### PR TITLE
fix(plugin): restore permission ask hook

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -6,6 +6,7 @@ import { Deferred, Effect, Layer, Context } from "effect"
 import os from "os"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Plugin } from "@/plugin"
 
 export const Event = PermissionV1.Event
 
@@ -43,6 +44,7 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service
+    const plugin = yield* Plugin.Service
     const state = yield* InstanceState.make<State>(
       Effect.fn("Permission.state")(function* (ctx) {
         void ctx
@@ -94,6 +96,24 @@ const layer = Layer.effect(
         tool: request.tool,
       }
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
+
+      const output: { status: "ask" | "allow" | "deny" } = { status: "ask" }
+      yield* plugin
+        .trigger(
+          "permission.ask",
+          { ...info, patterns: [...info.patterns], metadata: { ...info.metadata }, always: [...info.always] },
+          output,
+        )
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.sync(() => {
+              output.status = "ask"
+            }).pipe(Effect.tap(() => Effect.logError("permission ask plugin failed", { cause }))),
+          ),
+        )
+
+      if (output.status === "allow") return
+      if (output.status === "deny") return yield* new PermissionV1.DeniedError({ ruleset: [] })
 
       const deferred = yield* Deferred.make<void, PermissionV1.RejectedError | PermissionV1.CorrectedError>()
       pending.set(id, { info, deferred })
@@ -218,6 +238,6 @@ export function visibleTools<T>(tools: Record<string, T>, ruleset: PermissionV1.
   return Object.fromEntries(Object.entries(tools).filter(([name]) => !hidden.has(name)))
 }
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node] })
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node, Plugin.node] })
 
 export * as Permission from "."

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -12,11 +12,36 @@ import { testEffect } from "../lib/effect"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Plugin } from "../../src/plugin"
 
 const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+const pluginLayer = Layer.mock(Plugin.Service)({
+  trigger: <Input, Output>(name: string, input: Input, output: Output) =>
+    Effect.sync(() => {
+      if (name !== "permission.ask") return output
+      const request = input as PermissionV1.Request
+      const result = output as { status: "ask" | "allow" | "deny" }
+      if (request.metadata.plugin === "throw") throw new Error("plugin failed")
+      if (request.metadata.plugin === "mutate") {
+        ;(request.patterns as string[]).push("changed")
+        ;(request.metadata as Record<string, unknown>).changed = true
+        ;(request.always as string[]).push("changed")
+        return output
+      }
+      if (request.metadata.plugin === "allow" || request.metadata.plugin === "deny") {
+        result.status = request.metadata.plugin
+      }
+      return output
+    }),
+  list: () => Effect.succeed([]),
+  init: () => Effect.void,
+})
 const env = AppNodeBuilder.build(
-  LayerNode.group([Permission.node, EventV2Bridge.node, CrossSpawnSpawner.node, InstanceStore.node]),
-  [[InstanceStore.bootstrapNode, noopBootstrap]],
+  LayerNode.group([Permission.node, EventV2Bridge.node, CrossSpawnSpawner.node, InstanceStore.node, Plugin.node]),
+  [
+    [InstanceStore.bootstrapNode, noopBootstrap],
+    [Plugin.node, pluginLayer],
+  ],
 )
 const it = testEffect(env)
 
@@ -554,6 +579,87 @@ test("disabled - specific allow overrides wildcard deny", () => {
 })
 
 // ask tests
+
+it.instance(
+  "ask - resolves immediately when plugin allows",
+  () =>
+    Effect.gen(function* () {
+      const result = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: { plugin: "allow" },
+        always: [],
+        ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+      })
+      expect(result).toBeUndefined()
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - throws DeniedError when plugin denies",
+  () =>
+    Effect.gen(function* () {
+      const err = yield* fail(
+        ask({
+          sessionID: SessionID.make("session_test"),
+          permission: "bash",
+          patterns: ["ls"],
+          metadata: { plugin: "deny" },
+          always: [],
+          ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+        }),
+      )
+      expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+      expect((err as PermissionV1.DeniedError).ruleset).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - falls back to pending when plugin fails",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: { plugin: "throw" },
+        always: [],
+        ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      expect(yield* waitForPending(1)).toHaveLength(1)
+      yield* rejectAll()
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - protects pending request from plugin mutation",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: { plugin: "mutate" },
+        always: ["ls"],
+        ruleset: [{ permission: "bash", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      expect(pending[0].patterns).toEqual(["ls"])
+      expect(pending[0].metadata).toEqual({ plugin: "mutate" })
+      expect(pending[0].always).toEqual(["ls"])
+      yield* rejectAll()
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+)
 
 it.instance(
   "ask - resolves immediately when action is allow",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -4,13 +4,12 @@ import type {
   Project,
   Model,
   Provider,
-  Permission,
   UserMessage,
   Message,
   Part,
   Config as SDKConfig,
 } from "@opencode-ai/sdk"
-import type { Provider as ProviderV2, Model as ModelV2, Auth } from "@opencode-ai/sdk/v2"
+import type { Provider as ProviderV2, Model as ModelV2, Auth, PermissionRequest } from "@opencode-ai/sdk/v2"
 
 import type { BunShell } from "./shell.js"
 import { type ToolDefinition } from "./tool.js"
@@ -258,7 +257,7 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  "permission.ask"?: (input: PermissionRequest, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },


### PR DESCRIPTION
### Issue for this PR

Fixes #7006

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores the declared `permission.ask` plugin hook before OpenCode prompts the user. Plugins can allow or deny requests that static rules resolve to `ask`; plugin failures fall back to the normal prompt.

This rebases the approach from #30509 onto the current Effect/LayerNode service shape and credits @yohi's original implementation. The hook receives the current v2 `PermissionRequest` type and a copy of mutable request data.

### How did you verify your code works?

- Added tests for plugin allow, deny, failure fallback, and request mutation isolation.
- Ran the permission and plugin trigger tests: 85 passed.
- Ran the repository pre-push typecheck: 30 packages passed.
- Built a standalone binary and tested a real plugin round trip: allow suppressed the prompt, deny blocked execution, and a thrown hook fell back to the normal prompt.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
