### PR TITLE
fix(app): defer model variant selector

### DIFF
--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -55,6 +55,7 @@ export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
         controller={props.controller}
         borderUnderlay={props.borderUnderlay}
         class={props.class}
+        modelControlsVisible={!props.controller.model.loading}
         attachKeybind={command.keybindParts("file.attach")}
         attachShortcut={command.keybind("file.attach")}
         modelControl={
@@ -388,15 +389,11 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
             }
           : undefined
       },
-      get variant() {
-        if (props.controls.model.loading) return
-        return {
-          options: () => variants().map((value) => ({ id: value, label: value })),
-          current: () => props.controls.model.selection.variant.current() ?? "default",
-          onSelect: (value: string) =>
-            props.controls.model.selection.variant.set(value === "default" ? undefined : value),
-          keybind: () => command.keybindParts("model.variant.cycle"),
-        }
+      variant: {
+        options: () => variants().map((value) => ({ id: value, label: value })),
+        current: () => props.controls.model.selection.variant.current() ?? "default",
+        onSelect: (value) => props.controls.model.selection.variant.set(value === "default" ? undefined : value),
+        keybind: () => command.keybindParts("model.variant.cycle"),
       },
       submit: {
         stopping,

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -388,11 +388,15 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
             }
           : undefined
       },
-      variant: {
-        options: () => variants().map((value) => ({ id: value, label: value })),
-        current: () => props.controls.model.selection.variant.current() ?? "default",
-        onSelect: (value) => props.controls.model.selection.variant.set(value === "default" ? undefined : value),
-        keybind: () => command.keybindParts("model.variant.cycle"),
+      get variant() {
+        if (props.controls.model.loading) return
+        return {
+          options: () => variants().map((value) => ({ id: value, label: value })),
+          current: () => props.controls.model.selection.variant.current() ?? "default",
+          onSelect: (value: string) =>
+            props.controls.model.selection.variant.set(value === "default" ? undefined : value),
+          keybind: () => command.keybindParts("model.variant.cycle"),
+        }
       },
       submit: {
         stopping,

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -55,7 +55,7 @@ export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
         controller={props.controller}
         borderUnderlay={props.borderUnderlay}
         class={props.class}
-        modelControlsVisible={!props.controller.model.loading}
+        variantControlVisible={!props.controller.model.loading}
         attachKeybind={command.keybindParts("file.attach")}
         attachShortcut={command.keybind("file.attach")}
         modelControl={

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -39,6 +39,7 @@ export type PromptInputV2Props = {
   borderUnderlay?: boolean
   class?: string
   modelControl?: JSX.Element
+  modelControlsVisible?: boolean
   attachKeybind?: string[]
   attachShortcut?: string
 }
@@ -215,33 +216,35 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control()} />
               )}
             </Show>
-            <Show
-              when={props.modelControl}
-              fallback={
-                <Show when={view.model}>
-                  {(control) => (
+            <Show when={props.modelControlsVisible ?? true}>
+              <Show
+                when={props.modelControl}
+                fallback={
+                  <Show when={view.model}>
+                    {(control) => (
+                      <PromptInputV2ConfiguredSelect
+                        title="Choose model"
+                        keybind={["Mod", "M"]}
+                        control={control()}
+                        model
+                      />
+                    )}
+                  </Show>
+                }
+              >
+                {props.modelControl}
+              </Show>
+              <Show when={view.variant}>
+                {(control) => (
+                  <Show when={control().options().length > 1}>
                     <PromptInputV2ConfiguredSelect
-                      title="Choose model"
-                      keybind={["Mod", "M"]}
+                      title="Choose model variant"
+                      keybind={["Shift", "Mod", "D"]}
                       control={control()}
-                      model
                     />
-                  )}
-                </Show>
-              }
-            >
-              {props.modelControl}
-            </Show>
-            <Show when={view.variant}>
-              {(control) => (
-                <Show when={control().options().length > 1}>
-                  <PromptInputV2ConfiguredSelect
-                    title="Choose model variant"
-                    keybind={["Shift", "Mod", "D"]}
-                    control={control()}
-                  />
-                </Show>
-              )}
+                  </Show>
+                )}
+              </Show>
             </Show>
           </div>
           <PromptInputV2SubmitButton

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -39,7 +39,7 @@ export type PromptInputV2Props = {
   borderUnderlay?: boolean
   class?: string
   modelControl?: JSX.Element
-  modelControlsVisible?: boolean
+  variantControlVisible?: boolean
   attachKeybind?: string[]
   attachShortcut?: string
 }
@@ -216,35 +216,33 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control()} />
               )}
             </Show>
-            <Show when={props.modelControlsVisible ?? true}>
-              <Show
-                when={props.modelControl}
-                fallback={
-                  <Show when={view.model}>
-                    {(control) => (
-                      <PromptInputV2ConfiguredSelect
-                        title="Choose model"
-                        keybind={["Mod", "M"]}
-                        control={control()}
-                        model
-                      />
-                    )}
-                  </Show>
-                }
-              >
-                {props.modelControl}
-              </Show>
-              <Show when={view.variant}>
-                {(control) => (
-                  <Show when={control().options().length > 1}>
+            <Show
+              when={props.modelControl}
+              fallback={
+                <Show when={view.model}>
+                  {(control) => (
                     <PromptInputV2ConfiguredSelect
-                      title="Choose model variant"
-                      keybind={["Shift", "Mod", "D"]}
+                      title="Choose model"
+                      keybind={["Mod", "M"]}
                       control={control()}
+                      model
                     />
-                  </Show>
-                )}
-              </Show>
+                  )}
+                </Show>
+              }
+            >
+              {props.modelControl}
+            </Show>
+            <Show when={(props.variantControlVisible ?? true) && view.variant}>
+              {(control) => (
+                <Show when={control().options().length > 1}>
+                  <PromptInputV2ConfiguredSelect
+                    title="Choose model variant"
+                    keybind={["Shift", "Mod", "D"]}
+                    control={control()}
+                  />
+                </Show>
+              )}
             </Show>
           </div>
           <PromptInputV2SubmitButton


### PR DESCRIPTION
## Summary

- hide the model variant UI while model data is loading
- keep the variant controller available throughout loading

## Validation

- `bun typecheck` in `packages/app`
- `bun run typecheck` in `packages/session-ui`
- `bun test src/v2/components/prompt-input` in `packages/session-ui`
- `bun run test:e2e -- e2e/user-story/model-selection-flow.spec.ts` in `packages/app`
- repository pre-push typecheck