### PR TITLE
feat: emit permission_asked events in --format json mode for headless integrations

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -24,6 +24,7 @@ import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
+import { createInterface } from "node:readline"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
@@ -413,7 +414,8 @@ export const RunCommand = effectCmd({
         }
       }
 
-      const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
+      // In --format json mode, keep stdin open for permission replies from cc-connect
+      const piped = (process.stdin.isTTY || args.format === "json") ? undefined : await Bun.stdin.text()
       message = resolveRunInput(message, piped) ?? ""
       const initialInput = resolveRunInput(rawMessage, piped)
 
@@ -802,6 +804,25 @@ export const RunCommand = effectCmd({
                   requestID: permission.id,
                   reply: "once",
                 })
+              } else if (args.format === "json") {
+                emit("permission_asked", {
+                  permission: {
+                    id: permission.id,
+                    sessionID: permission.sessionID,
+                    permission: permission.permission,
+                    patterns: permission.patterns,
+                    metadata: permission.metadata,
+                    always: permission.always,
+                    tool: permission.tool,
+                  },
+                })
+                // Wait for permission reply from cc-connect via stdin
+                const reply = await readPermissionReply()
+                if (reply === "always") {
+                  await client.permission.reply({ requestID: permission.id, reply: "always" })
+                } else {
+                  await client.permission.reply({ requestID: permission.id, reply: reply === "once" ? "once" : "reject" })
+                }
               } else {
                 UI.println(
                   UI.Style.TEXT_WARNING_BOLD + "!",
@@ -816,6 +837,35 @@ export const RunCommand = effectCmd({
             }
           }
           return error
+        }
+
+        // Read a single JSON reply line from stdin and return the "reply" field.
+        // Used in --format json mode to receive permission responses from cc-connect.
+        // Times out after 120s if no valid reply received, defaulting to "reject".
+        async function readPermissionReply(): Promise<string> {
+          return new Promise((resolve) => {
+            const rl = createInterface({ input: process.stdin })
+            let resolved = false
+            const timeout = setTimeout(() => {
+              if (!resolved) {
+                resolved = true
+                rl.close()
+                resolve("reject")
+              }
+            }, 120000)
+            rl.on("line", (line: string) => {
+              if (resolved || !line.trim()) return
+              try {
+                const parsed = JSON.parse(line)
+                resolved = true
+                clearTimeout(timeout)
+                rl.close()
+                resolve(parsed.reply || "reject")
+              } catch {
+                // ignore invalid JSON, wait for next line
+              }
+            })
+          })
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk


### PR DESCRIPTION
## Problem

When OpenCode runs in `--format json` non-interactive mode (as used by external tools like cc-connect), all permission requests are automatically rejected internally. The `permission.asked` event is never emitted to stdout, so external tools cannot relay permission verification cards to users on messaging platforms (Telegram, Feishu, etc.).

See: https://github.com/chenhg5/cc-connect/issues/1420

## Solution

In `--format json` mode:

1. **Keep stdin open** for permission replies: stdin is no longer consumed for the prompt (the prompt is passed as a positional command-line argument), so it stays available as a reply channel
2. **Emit `permission_asked` JSON events** to stdout with full permission details (id, permission name, patterns, metadata, tool info)
3. **Read permission replies from stdin** via `readPermissionReply()` helper using `node:readline`, with a 120-second timeout defaulting to `"reject"`

## Data Flow

```
cc-connect → opencode run --format json "user message"
                ↓ (wants to call a tool)
                ↓ emits permission_asked JSON → stdout
                ↓ blocks reading stdin for reply
cc-connect receives JSON → shows permission card to user on Telegram
user clicks [Allow] / [Deny]
cc-connect writes {"requestID":"…","reply":"once"} → stdin
                ↓ opencode continues with approved tool call
```

## Changes

- `packages/opencode/src/cli/cmd/run.ts`: Modified stdin handling, `permission.asked` event handler, added `readPermissionReply()` helper

## Testing

Tested end-to-end with cc-connect + Telegram bot. Non-JSON-format mode behavior is unchanged.