### PR TITLE
fix(provider): preserve reasoning_content on interleaved normalization pass

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -341,7 +341,7 @@ function normalizeMessages(
             ...msg.providerOptions,
             openaiCompatible: {
               ...msg.providerOptions?.openaiCompatible,
-              [field]: reasoningText,
+              [field]: reasoningText || msg.providerOptions?.openaiCompatible?.[field] || "",
             },
           },
         }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1890,6 +1890,73 @@ describe("ProviderTransform.message - DeepSeek reasoning content", () => {
     expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("Let me think about this...")
   })
 
+  const deepseekModel2 = {
+    id: ModelV2.ID.make("deepseek/deepseek-chat"),
+    providerID: ProviderV2.ID.make("deepseek"),
+    api: { id: "deepseek-chat", url: "https://api.deepseek.com", npm: "@ai-sdk/openai-compatible" },
+    name: "DeepSeek Chat",
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: { field: "reasoning_content" },
+    },
+    cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+    limit: { context: 128000, output: 8192 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2023-04-01",
+  } as any
+
+  test("preserves existing reasoning_content from providerOptions when content has no reasoning parts", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+        providerOptions: {
+          openaiCompatible: {
+            reasoning_content: "Previous reasoning text that must be preserved",
+          },
+        },
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, deepseekModel2, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe(
+      "Previous reasoning text that must be preserved",
+    )
+    expect(result[0].content).toEqual([{ type: "text", text: "Hello" }])
+  })
+
+  test("prefers current reasoning text over existing providerOptions value", () => {
+    const msgs = [
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "New reasoning" },
+          { type: "text", text: "Answer" },
+        ],
+        providerOptions: {
+          openaiCompatible: {
+            reasoning_content: "Old reasoning from previous pass",
+          },
+        },
+      },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, deepseekModel2, {})
+
+    expect(result).toHaveLength(1)
+    expect(result[0].providerOptions?.openaiCompatible?.reasoning_content).toBe("New reasoning")
+    expect(result[0].content).toEqual([{ type: "text", text: "Answer" }])
+  })
+
   test("Non-DeepSeek providers leave reasoning content unchanged", () => {
     const msgs = [
       {


### PR DESCRIPTION
### Issue for this PR

Closes #35689
Ref #38749

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `normalizeMessages()` runs on a message that already has `reasoning_content` stored in `providerOptions` but no reasoning parts in its content, it overwrites the stored value with an empty string. This causes DeepSeek to reject the message on multi-turn thinking requests.

The fix preserves the existing `providerOptions.reasoning_content` when no reasoning parts are present in the current content, preventing the empty-string overwrite. This was reproducible by passing a normalized message through `ProviderTransform.message()` a second time.

### How did you verify your code works?

Two regression tests covering both the preservation scenario and the edge case where current reasoning should take priority over a stored value. 399 total tests pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this repository