### PR TITLE
feat(opencode): emit permission_asked events in --format json headless mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -24,6 +24,7 @@ import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
+import { createInterface } from "node:readline"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
@@ -413,7 +414,8 @@ export const RunCommand = effectCmd({
         }
       }
 
-      const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
+      // In --format json mode, keep stdin open for permission reply channel
+      const piped = (process.stdin.isTTY || args.format === "json") ? undefined : await Bun.stdin.text()
       message = resolveRunInput(message, piped) ?? ""
       const initialInput = resolveRunInput(rawMessage, piped)
 
@@ -802,6 +804,20 @@ export const RunCommand = effectCmd({
                   requestID: permission.id,
                   reply: "once",
                 })
+              } else if (args.format === "json") {
+                emit("permission_asked", {
+                  permission: {
+                    id: permission.id,
+                    sessionID: permission.sessionID,
+                    permission: permission.permission,
+                    patterns: permission.patterns,
+                    metadata: permission.metadata,
+                    always: permission.always,
+                    tool: permission.tool,
+                  },
+                })
+                const reply = await readPermissionReply()
+                await client.permission.reply({ requestID: permission.id, reply })
               } else {
                 UI.println(
                   UI.Style.TEXT_WARNING_BOLD + "!",
@@ -816,6 +832,25 @@ export const RunCommand = effectCmd({
             }
           }
           return error
+        }
+
+        // Read a single JSON reply line from stdin, return the "reply" field.
+        // Used in --format json mode to receive permission responses.
+        // Times out after 120s; defaults to "reject" on timeout or parse failure.
+        async function readPermissionReply(): Promise<string> {
+          return new Promise<string>((resolve) => {
+            const rl = createInterface({ input: process.stdin })
+            const timeout = setTimeout(() => {
+              rl.close()
+              resolve("reject")
+            }, 120000)
+            rl.on("line", (line: string) => {
+              if (!line.trim()) return
+              clearTimeout(timeout)
+              rl.close()
+              resolve(JSON.parse(line).reply || "reject")
+            })
+          }).catch(() => "reject")
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk


### PR DESCRIPTION
### Issue for this PR

Closes #39459

### Type of change

- [x] New feature

### What does this PR do?

When OpenCode runs in `--format json` non-interactive headless mode, it auto-rejects all permission requests without emitting them to stdout. External tools like cc-connect cannot relay permission verification cards to users.

This PR enables `permission_asked` NDJSON events in `--format json` mode:
- Skips reading the prompt from stdin (passed as positional arg instead), keeping stdin free for permission replies
- Emits `permission_asked` JSON event with full permission details (id, permission name, patterns, metadata)
- Reads JSON permission reply from stdin with 120s timeout (defaults to reject)

### How did you verify your code works?

Tested end-to-end with a patched cc-connect + Telegram bot. In non-yolo `--format json` mode, OpenCode now emits permission_asked events, waits for stdin replies, and correctly resumes tool execution after receiving allow/deny responses. Non-JSON-format mode behavior is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR