### PR TITLE
fix(app): use precise hostname match instead of substring for opencode.ai

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -100,7 +100,7 @@ if (!(root instanceof HTMLElement) && import.meta.env.DEV) {
 }
 
 const getCurrentUrl = () => {
-  if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
+  if (/(^|\.)opencode\.ai$/.test(location.hostname)) return "http://localhost:4096"
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
   return location.origin


### PR DESCRIPTION
### Issue for this PR

Closes #39479

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web frontend in `packages/app/src/entry.tsx` used `String.includes()` (substring match) to detect whether the page was served from an official `opencode.ai` domain. This caused a false positive on any domain that merely contains the substring `opencode.ai`.

When accessing the opencode web UI through a tunnel or reverse proxy using a domain like `opencode.aid.example.com`, the check `location.hostname.includes("opencode.ai")` returned `true`, so the frontend forced the backend URL to `http://localhost:4096` instead of `location.origin`. Since `localhost` refers to the remote browser's own machine (not the server behind the tunnel), all API requests failed.

The fix replaces the substring match with a regex that precisely matches `opencode.ai` and `*.opencode.ai`:

```ts
/(^|\.)opencode\.ai$/.test(location.hostname)
```

This is consistent with the CORS side (`packages/server/src/cors.ts`), which already uses a precise regex:

```ts
const opencodeOrigin = /^https:\/\/([a-z0-9-]+\.)*opencode\.ai$/
```

| Hostname | Before (`includes`) | After (regex) |
|---|:---:|:---:|
| `opencode.ai` | ✅ | ✅ |
| `app.opencode.ai` | ✅ | ✅ |
| `a.b.opencode.ai` | ✅ | ✅ |
| `opencode.aid.example.com` | ✅ false positive | ❌ correct |
| `myopencode.ai` | ✅ false positive | ❌ correct |

### How did you verify your code works?

Tested with a tunnel proxy using a domain containing the `opencode.ai` substring. Before the fix, the frontend connected to `localhost:4096` and all API requests failed. After the fix, the frontend correctly uses `location.origin` (the tunnel domain) as the backend URL.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
