### PR TITLE
feat(acp): expose recursive subagent sessions

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -24,7 +24,15 @@ import * as ACPService from "./service"
 export function init({ sdk: _sdk }: { sdk: OpencodeClient }) {
   return {
     create: (connection: AgentSideConnection) => {
-      return new Agent(ACPService.make({ sdk: _sdk, connection }))
+      const service = ACPService.make({ sdk: _sdk, connection })
+      // The SDK invokes this factory before AgentSideConnection finishes assigning
+      // its internal connection, so its lifecycle signal is readable next turn.
+      queueMicrotask(() => {
+        const close = () => service.close()
+        connection.signal.addEventListener("abort", close, { once: true })
+        if (connection.signal.aborted) close()
+      })
+      return new Agent(service)
     },
   }
 }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -83,6 +83,10 @@ export class Agent implements ACPAgent {
   cancel(params: CancelNotification) {
     return run(this.service.cancel(params))
   }
+
+  extMethod(method: string, params: Record<string, unknown>) {
+    return run(this.service.extension(method, params))
+  }
 }
 
 function run<A>(effect: Effect.Effect<A, ACPService.Error>) {

--- a/packages/opencode/src/acp/error.ts
+++ b/packages/opencode/src/acp/error.ts
@@ -43,6 +43,13 @@ export class UnsupportedOperationError extends Schema.TaggedErrorClass<Unsupport
   },
 ) {}
 
+export class InvalidExtensionParamsError extends Schema.TaggedErrorClass<InvalidExtensionParamsError>()(
+  "ACPInvalidExtensionParamsError",
+  {
+    params: Schema.Record(Schema.String, Schema.Unknown),
+  },
+) {}
+
 export class ServiceFailureError extends Schema.TaggedErrorClass<ServiceFailureError>()("ACPServiceFailureError", {
   safeMessage: Schema.String,
   service: Schema.optional(Schema.String),
@@ -58,6 +65,7 @@ export type Error =
   | AuthRequiredError
   | UnknownAuthMethodError
   | UnsupportedOperationError
+  | InvalidExtensionParamsError
   | ServiceFailureError
 
 export function toRequestError(error: Error) {
@@ -81,6 +89,8 @@ export function toRequestError(error: Error) {
       return RequestError.invalidParams({ methodId: error.methodId }, `unknown auth method: ${error.methodId}`)
     case "ACPUnsupportedOperationError":
       return RequestError.methodNotFound(error.method)
+    case "ACPInvalidExtensionParamsError":
+      return RequestError.invalidParams(error.params, "Invalid subagent extension params")
     case "ACPServiceFailureError":
       return RequestError.internalError(
         {

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -29,6 +29,7 @@ type GlobalEventEnvelope = {
 type GlobalEventStream = {
   stream: AsyncIterable<GlobalEventEnvelope>
 }
+type Listener = (event: Event) => Promise<void>
 
 export function start(input: { sdk: OpencodeClient; connection: Connection; session: ACPSession.Interface }) {
   const subscription = new Subscription(input)
@@ -41,6 +42,7 @@ export class Subscription {
   private readonly shellSnapshots = new Map<string, string>()
   private readonly toolStarts = new Set<string>()
   private readonly permission: ACPPermission.Handler
+  private readonly listeners = new Set<Listener>()
   private started = false
 
   constructor(
@@ -63,6 +65,11 @@ export class Subscription {
 
   stop() {
     this.abort.abort()
+  }
+
+  addListener(listener: Listener) {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
   }
 
   async handle(event: Event) {
@@ -123,6 +130,9 @@ export class Subscription {
         if (this.abort.signal.aborted) return
         if (!event.payload) continue
         await this.handle(event.payload).catch(() => {})
+        for (const listener of [...this.listeners]) {
+          await listener(event.payload).catch(() => {})
+        }
       }
       if (!this.abort.signal.aborted) await new Promise((resolve) => setTimeout(resolve, 1000))
     }

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -64,6 +64,10 @@ export class Subscription {
   }
 
   stop() {
+    this.close()
+  }
+
+  close() {
     this.abort.abort()
   }
 

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -70,6 +70,7 @@ export type Interface = {
   readonly prompt: (input: PromptRequest) => Effect.Effect<PromptResponse, Error>
   readonly cancel: (input: CancelNotification) => Effect.Effect<void, Error>
   readonly extension: (method: string, params: Record<string, unknown>) => Effect.Effect<Record<string, unknown>, Error>
+  readonly close: () => void
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ACP/Service") {}
@@ -98,6 +99,13 @@ export function make(input: {
           notify: (update) => extNotification("_opencode/subagents/update", update),
         })
       : undefined
+  let closed = false
+  const close = () => {
+    if (closed) return
+    closed = true
+    subagents?.close()
+    events?.close()
+  }
 
   const initialize = Effect.fn("ACP.initialize")(function* (params: InitializeRequest) {
     const started = performance.now()
@@ -603,13 +611,14 @@ export function make(input: {
     }),
     cancel,
     extension,
+    close,
   }
 }
 
 function decodeSubagentParams(params: Record<string, unknown>) {
   return Effect.try({
     try: () => Subagent.decodeListParams(params),
-    catch: (error) => ACPError.fromUnknownDefect(error, "Invalid subagent extension params"),
+    catch: () => new ACPError.InvalidExtensionParamsError({ params }),
   })
 }
 

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -41,6 +41,7 @@ import { ACPEvent } from "./event"
 import { ACPSession } from "./session"
 import { UsageService } from "./usage"
 import { ACPProfile } from "./profile"
+import { Subagent } from "./subagent"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { Provider } from "@/provider/provider"
@@ -50,7 +51,7 @@ export const AuthMethodID = "opencode-login"
 
 export type Error = ACPError.Error
 type ServiceConnection = Pick<AgentSideConnection, "sessionUpdate"> &
-  Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
+  Partial<Pick<AgentSideConnection, "extNotification" | "requestPermission" | "writeTextFile">>
 
 export type Interface = {
   readonly initialize: (input: InitializeRequest) => Effect.Effect<InitializeResponse, Error>
@@ -68,6 +69,7 @@ export type Interface = {
   readonly setSessionModel: (input: SetSessionModelRequest) => Effect.Effect<SetSessionModelResponse, Error>
   readonly prompt: (input: PromptRequest) => Effect.Effect<PromptResponse, Error>
   readonly cancel: (input: CancelNotification) => Effect.Effect<void, Error>
+  readonly extension: (method: string, params: Record<string, unknown>) => Effect.Effect<Record<string, unknown>, Error>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ACP/Service") {}
@@ -84,10 +86,18 @@ export function make(input: {
   const directoryService = input.directory ?? makeDirectoryService(input.sdk)
   const registeredMcp = new Map<string, Set<string>>()
   const sessionSnapshots = new Map<string, Directory.Snapshot>()
-  const events = input.connection
-    ? ACPEvent.start({ sdk: input.sdk, connection: input.connection, session })
-    : undefined
+  const connection = input.connection
+  const extNotification = connection?.extNotification?.bind(connection)
+  const events = connection ? ACPEvent.start({ sdk: input.sdk, connection, session }) : undefined
   if (events) input.eventSubscription?.(events)
+  const subagents =
+    extNotification && events
+      ? Subagent.make({
+          sdk: input.sdk,
+          events,
+          notify: (update) => extNotification("_opencode/subagents/update", update),
+        })
+      : undefined
 
   const initialize = Effect.fn("ACP.initialize")(function* (params: InitializeRequest) {
     const started = performance.now()
@@ -131,6 +141,17 @@ export function make(input: {
         name: "OpenCode",
         version: InstallationVersion,
       },
+      ...(subagents
+        ? {
+            _meta: {
+              "opencode.dev/subagents": {
+                version: 1,
+                list: true,
+                subscribe: true,
+              },
+            },
+          }
+        : {}),
     }
     ACPProfile.duration("acp.initialize", started)
     return response
@@ -477,6 +498,21 @@ export function make(input: {
     return {}
   })
 
+  const extension = Effect.fn("ACP.extension")(function* (method: string, params: Record<string, unknown>) {
+    if (!subagents) return yield* new ACPError.UnsupportedOperationError({ method })
+    if (method === "_opencode/subagents/list") {
+      const decoded = yield* decodeSubagentParams(params)
+      const snapshot = yield* subagentRequest(() => subagents.list(decoded))
+      return { ...Subagent.encodeSnapshot(snapshot) }
+    }
+    if (method === "_opencode/subagents/subscribe") {
+      const decoded = yield* decodeSubagentParams(params)
+      const snapshot = yield* subagentRequest(() => subagents.subscribe(decoded))
+      return { ...Subagent.encodeSnapshot(snapshot) }
+    }
+    return yield* new ACPError.UnsupportedOperationError({ method })
+  })
+
   return {
     initialize,
     authenticate,
@@ -566,7 +602,22 @@ export function make(input: {
       return yield* promptResponse(undefined, params.messageId)
     }),
     cancel,
+    extension,
   }
+}
+
+function decodeSubagentParams(params: Record<string, unknown>) {
+  return Effect.try({
+    try: () => Subagent.decodeListParams(params),
+    catch: (error) => ACPError.fromUnknownDefect(error, "Invalid subagent extension params"),
+  })
+}
+
+function subagentRequest<A>(run: () => Promise<A>) {
+  return Effect.tryPromise({
+    try: run,
+    catch: (error) => ACPError.fromUnknownDefect(error, "Subagent service failure"),
+  })
 }
 
 function makeSessionService() {

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -1,0 +1,208 @@
+import { Decimal } from "decimal.js"
+import type { Event } from "@opencode-ai/sdk/v2"
+import { Schema } from "effect"
+
+export const phases = ["queued", "running", "completed", "failed", "cancelled", "unknown"] as const
+export type Phase = (typeof phases)[number]
+
+export type DirectCost = {
+  amount: string
+  currency: string
+}
+
+export type Node = {
+  runId: string
+  sessionId: string
+  rootSessionId: string
+  parentSessionId?: string
+  agent?: string
+  title?: string
+  phase: Phase
+  createdAt?: string
+  updatedAt?: string
+  completedAt?: string
+  cwd: string
+  repository?: string
+  directCost?: DirectCost
+}
+
+export type Snapshot = {
+  generation: string
+  revision: number
+  nodes: Node[]
+}
+
+export type Update = {
+  generation: string
+  revision: number
+  upsert: Node[]
+  removedSessionIds: string[]
+}
+
+export type ListParams = {
+  rootSessionId?: string
+}
+
+export const ListParams = Schema.Struct({
+  rootSessionId: Schema.optional(Schema.String),
+})
+
+export const DirectCost = Schema.Struct({
+  amount: Schema.String,
+  currency: Schema.String,
+})
+
+export const Node = Schema.Struct({
+  runId: Schema.String,
+  sessionId: Schema.String,
+  rootSessionId: Schema.String,
+  parentSessionId: Schema.optional(Schema.String),
+  agent: Schema.optional(Schema.String),
+  title: Schema.optional(Schema.String),
+  phase: Schema.Literals(phases),
+  createdAt: Schema.optional(Schema.String),
+  updatedAt: Schema.optional(Schema.String),
+  completedAt: Schema.optional(Schema.String),
+  cwd: Schema.String,
+  repository: Schema.optional(Schema.String),
+  directCost: Schema.optional(DirectCost),
+})
+
+export const Snapshot = Schema.Struct({
+  generation: Schema.String,
+  revision: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  nodes: Schema.Array(Node),
+})
+
+export const Update = Schema.Struct({
+  generation: Schema.String,
+  revision: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  upsert: Schema.Array(Node),
+  removedSessionIds: Schema.Array(Schema.String),
+})
+
+export type Service = {
+  list(params: ListParams): Promise<Snapshot>
+  subscribe(params: ListParams): Promise<Snapshot>
+  handle(event: Event): Promise<void>
+  close(): void
+}
+
+const maxDepth = 8
+const maxDescendants = 300
+const decodeListParamsSchema = Schema.decodeUnknownSync(ListParams)
+const decodeSnapshotSchema = Schema.decodeUnknownSync(Snapshot)
+const decodeUpdateSchema = Schema.decodeUnknownSync(Update)
+
+export function decodeListParams(input: unknown): ListParams {
+  return decodeListParamsSchema(input)
+}
+
+export function decodeSnapshot(input: unknown): Snapshot {
+  return validateSnapshot(decodeSnapshotSchema(input))
+}
+
+export function encodeSnapshot(input: Snapshot): Snapshot {
+  return validateSnapshot(decodeSnapshotSchema(input))
+}
+
+export function decodeUpdate(input: unknown): Update {
+  return validateUpdate(decodeUpdateSchema(input))
+}
+
+export function encodeUpdate(input: Update): Update {
+  return validateUpdate(decodeUpdateSchema(input))
+}
+
+export function serializeDirectCost(amount: number, currency: string): DirectCost {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error("direct cost must be finite and nonnegative")
+  }
+  return { amount: new Decimal(amount).toString(), currency }
+}
+
+function validateSnapshot(input: Schema.Schema.Type<typeof Snapshot>): Snapshot {
+  const snapshot = {
+    generation: input.generation,
+    revision: input.revision,
+    nodes: input.nodes.map((node) => ({
+      ...node,
+      ...(node.directCost ? { directCost: { ...node.directCost } } : {}),
+    })),
+  }
+  snapshot.nodes.forEach(validateDirectCost)
+
+  const bySession = new Map(snapshot.nodes.map((node) => [node.sessionId, node]))
+  if (bySession.size !== snapshot.nodes.length) throw new Error("subagent session IDs must be unique")
+
+  const runIDs = new Set(snapshot.nodes.map((node) => node.runId))
+  if (runIDs.size !== snapshot.nodes.length) throw new Error("subagent run IDs must be unique")
+
+  snapshot.nodes.forEach((node) => {
+    if (!node.parentSessionId) {
+      if (node.rootSessionId !== node.sessionId) throw new Error("root node must match its root session ID")
+      return
+    }
+
+    const parent = bySession.get(node.parentSessionId)
+    if (!parent) throw new Error("subagent parent must be present in the snapshot")
+    if (parent.rootSessionId !== node.rootSessionId) throw new Error("subagent parent must share its root session ID")
+  })
+
+  snapshot.nodes.forEach((node) => {
+    const depth = depthOf(node, bySession, new Set())
+    if (depth > maxDepth) throw new Error(`subagent depth must not exceed ${maxDepth}`)
+  })
+
+  const descendants = snapshot.nodes.reduce((result, node) => {
+    result.set(node.rootSessionId, (result.get(node.rootSessionId) ?? 0) + 1)
+    return result
+  }, new Map<string, number>())
+  if ([...descendants.values()].some((count) => count - 1 > maxDescendants)) {
+    throw new Error(`subagent descendants must not exceed ${maxDescendants}`)
+  }
+
+  return snapshot
+}
+
+function validateUpdate(input: Schema.Schema.Type<typeof Update>): Update {
+  const update = {
+    generation: input.generation,
+    revision: input.revision,
+    upsert: input.upsert.map((node) => ({
+      ...node,
+      ...(node.directCost ? { directCost: { ...node.directCost } } : {}),
+    })),
+    removedSessionIds: [...input.removedSessionIds],
+  }
+  update.upsert.forEach(validateDirectCost)
+
+  const upserts = new Set(update.upsert.map((node) => node.sessionId))
+  if (upserts.size !== update.upsert.length) throw new Error("subagent update session IDs must be unique")
+
+  const removed = new Set(update.removedSessionIds)
+  if (removed.size !== update.removedSessionIds.length) throw new Error("removed subagent session IDs must be unique")
+  if (update.upsert.some((node) => removed.has(node.sessionId))) {
+    throw new Error("subagent update cannot upsert and remove the same session")
+  }
+
+  return update
+}
+
+function validateDirectCost(node: Node) {
+  if (!node.directCost) return
+
+  const amount = new Decimal(node.directCost.amount)
+  if (!amount.isFinite() || amount.isNegative()) throw new Error("direct cost must be finite and nonnegative")
+}
+
+function depthOf(node: Node, bySession: ReadonlyMap<string, Node>, visited: ReadonlySet<string>): number {
+  if (!node.parentSessionId) return 0
+  if (visited.has(node.sessionId)) throw new Error("subagent graph cannot contain cycles")
+
+  const parent = bySession.get(node.parentSessionId)
+  if (!parent) throw new Error("subagent parent must be present in the snapshot")
+  return depthOf(parent, bySession, new Set(visited).add(node.sessionId)) + 1
+}
+
+export * as Subagent from "./subagent"

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -89,6 +89,10 @@ export type Service = {
 }
 
 type SDK = Pick<OpencodeClient, "session">
+type EventSource = {
+  addListener(listener: (event: Event) => Promise<void>): () => void
+}
+type Notify = (update: Update) => Promise<void>
 
 const maxDepth = 8
 const maxDescendants = 300
@@ -123,30 +127,166 @@ export function serializeDirectCost(amount: number, currency: string): DirectCos
   return { amount: new Decimal(amount).toString(), currency }
 }
 
-export function make(input: { sdk: SDK }): Service {
+export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify }): Service {
   const generation = crypto.randomUUID()
   const failed = new Set<string>()
+  const deleted = new Set<string>()
+  const statuses = new Map<string, SessionStatus>()
+  const sessions = new Map<string, Session>()
+  const pending = new Set<string>()
+  const nodes = new Map<string, Node>()
+  let revision = 0
+  let params: ListParams = {}
+  let active = false
+  let initializing = false
+  let closed = false
+  let removeListener: (() => void) | undefined
+  let processing: Promise<void> | undefined
+
+  const handle = async (event: Event) => {
+    const sessionID = recordEvent({ event, failed, deleted, statuses, sessions })
+    if (!active || !sessionID) return
+
+    pending.add(sessionID)
+    if (initializing) return
+    await process()
+  }
+
+  const process = () => {
+    if (processing) return processing
+    processing = reconcile().finally(() => {
+      processing = undefined
+    })
+    return processing
+  }
+
+  const reconcile = async () => {
+    while (active && pending.size) {
+      const changed = [...pending]
+      pending.clear()
+      const roots = new Set(
+        changed.flatMap((sessionID) =>
+          affectedRoots({
+            sessionID,
+            nodes,
+            sessions,
+          }),
+        ),
+      )
+      if (params.rootSessionId) {
+        roots.forEach((rootSessionID) => {
+          if (rootSessionID !== params.rootSessionId) roots.delete(rootSessionID)
+        })
+      }
+
+      const upsert: Node[] = []
+      const removedSessionIds: string[] = []
+      for (const rootSessionId of roots) {
+        const next = await snapshot({
+          sdk: input.sdk,
+          generation,
+          revision,
+          params: { rootSessionId },
+          failed,
+          deleted,
+          statuses,
+          sessions,
+        })
+        if (!active) return
+
+        const previous = [...nodes.values()].filter((node) => node.rootSessionId === rootSessionId)
+        const bySession = new Map(next.nodes.map((node) => [node.sessionId, node]))
+        upsert.push(
+          ...next.nodes.filter((node) => {
+            const current = nodes.get(node.sessionId)
+            return !current || !sameNode(current, node)
+          }),
+        )
+        removedSessionIds.push(
+          ...previous.filter((node) => !bySession.has(node.sessionId)).map((node) => node.sessionId),
+        )
+        previous.forEach((node) => nodes.delete(node.sessionId))
+        next.nodes.forEach((node) => nodes.set(node.sessionId, node))
+      }
+      if (!upsert.length && !removedSessionIds.length) continue
+
+      const update = encodeUpdate({
+        generation,
+        revision: revision + 1,
+        upsert,
+        removedSessionIds,
+      })
+      // Reserve the revision before notification I/O so a failed send can never be reused.
+      revision = update.revision
+      await input.notify?.(update)
+    }
+  }
 
   return {
-    list: (params) => snapshot({ sdk: input.sdk, generation, params, failed }),
-    subscribe: (params) => snapshot({ sdk: input.sdk, generation, params, failed }),
-    handle: async (event) => {
-      if (event.type === "session.error" && event.properties.sessionID) {
-        failed.add(event.properties.sessionID)
-      }
+    list: (params) => snapshot({ sdk: input.sdk, generation, revision, params, failed, deleted, statuses, sessions }),
+    subscribe: async (nextParams) => {
+      if (!input.events || !input.notify) throw new Error("subagent subscription requires events and notify")
+      if (closed) throw new Error("subagent subscription is closed")
+
+      params = nextParams
+      active = true
+      initializing = true
+      removeListener ??= input.events.addListener(handle)
+      const initial = await snapshot({
+        sdk: input.sdk,
+        generation,
+        revision,
+        params,
+        failed,
+        deleted,
+        statuses,
+        sessions,
+      })
+      nodes.clear()
+      initial.nodes.forEach((node) => nodes.set(node.sessionId, node))
+      initializing = false
+      queueMicrotask(() => {
+        process().catch(() => {})
+      })
+      return initial
     },
-    close: () => failed.clear(),
+    handle,
+    close: () => {
+      closed = true
+      active = false
+      removeListener?.()
+      removeListener = undefined
+      pending.clear()
+      failed.clear()
+      deleted.clear()
+      statuses.clear()
+      sessions.clear()
+      nodes.clear()
+    },
   }
 }
 
-async function snapshot(input: { sdk: SDK; generation: string; params: ListParams; failed: ReadonlySet<string> }) {
+async function snapshot(input: {
+  sdk: SDK
+  generation: string
+  revision: number
+  params: ListParams
+  failed: ReadonlySet<string>
+  deleted: ReadonlySet<string>
+  statuses: ReadonlyMap<string, SessionStatus>
+  sessions: ReadonlyMap<string, Session>
+}) {
+  // Events after this boundary stay buffered for a successor revision.
+  const deleted = new Set(input.deleted)
+  const sessionOverrides = new Map(input.sessions)
+  const statusOverrides = new Map(input.statuses)
   const [rootsResponse, statusResponse] = await Promise.all([
     input.sdk.session.list({ roots: true }),
     input.sdk.session.status(),
   ])
-  const statuses = statusResponse.data ?? {}
+  const statuses = { ...(statusResponse.data ?? {}), ...Object.fromEntries(statusOverrides) }
   const nodes: Node[] = []
-  const roots = sortSessions(rootsResponse.data ?? []).filter(
+  const roots = mergeSessions(rootsResponse.data ?? [], sessionOverrides, deleted).filter(
     (session) => !input.params.rootSessionId || session.id === input.params.rootSessionId,
   )
 
@@ -161,10 +301,103 @@ async function snapshot(input: { sdk: SDK; generation: string; params: ListParam
       session: root,
       rootSessionId: root.id,
       depth: 0,
+      deleted,
+      sessions: sessionOverrides,
     })
   }
 
-  return encodeSnapshot({ generation: input.generation, revision: 0, nodes })
+  return encodeSnapshot({ generation: input.generation, revision: input.revision, nodes })
+}
+
+function recordEvent(input: {
+  event: Event
+  failed: Set<string>
+  deleted: Set<string>
+  statuses: Map<string, SessionStatus>
+  sessions: Map<string, Session>
+}) {
+  switch (input.event.type) {
+    case "session.created":
+      input.failed.delete(input.event.properties.sessionID)
+      input.deleted.delete(input.event.properties.sessionID)
+      input.sessions.set(input.event.properties.sessionID, input.event.properties.info)
+      return input.event.properties.sessionID
+    case "session.updated":
+      input.deleted.delete(input.event.properties.sessionID)
+      input.sessions.set(input.event.properties.sessionID, input.event.properties.info)
+      return input.event.properties.sessionID
+    case "session.deleted":
+      input.failed.delete(input.event.properties.sessionID)
+      input.deleted.add(input.event.properties.sessionID)
+      input.statuses.delete(input.event.properties.sessionID)
+      input.sessions.set(input.event.properties.sessionID, input.event.properties.info)
+      return input.event.properties.sessionID
+    case "session.status":
+      input.failed.delete(input.event.properties.sessionID)
+      input.statuses.set(input.event.properties.sessionID, input.event.properties.status)
+      return input.event.properties.sessionID
+    case "session.idle":
+      input.failed.delete(input.event.properties.sessionID)
+      input.statuses.set(input.event.properties.sessionID, { type: "idle" })
+      return input.event.properties.sessionID
+    case "session.error":
+      if (!input.event.properties.sessionID) return
+      input.failed.add(input.event.properties.sessionID)
+      return input.event.properties.sessionID
+  }
+}
+
+function mergeSessions(
+  source: Session[],
+  overrides: ReadonlyMap<string, Session>,
+  deleted: ReadonlySet<string>,
+  parentID?: string,
+) {
+  const merged = new Map<string, Session>()
+  source.forEach((session) => {
+    const current = overrides.get(session.id) ?? session
+    if (deleted.has(current.id) || current.parentID !== parentID) return
+    merged.set(current.id, current)
+  })
+  overrides.forEach((session) => {
+    if (deleted.has(session.id) || session.parentID !== parentID) return
+    merged.set(session.id, session)
+  })
+  return sortSessions([...merged.values()])
+}
+
+function affectedRoots(input: {
+  sessionID: string
+  nodes: ReadonlyMap<string, Node>
+  sessions: ReadonlyMap<string, Session>
+}) {
+  const roots = new Set<string>()
+  const current = input.nodes.get(input.sessionID)
+  if (current) roots.add(current.rootSessionId)
+
+  const root = rootOf(input.sessionID, input.nodes, input.sessions, new Set())
+  if (root) roots.add(root)
+  return [...roots]
+}
+
+function rootOf(
+  sessionID: string,
+  nodes: ReadonlyMap<string, Node>,
+  sessions: ReadonlyMap<string, Session>,
+  visited: ReadonlySet<string>,
+): string | undefined {
+  if (visited.has(sessionID)) return
+
+  const session = sessions.get(sessionID)
+  if (session) {
+    if (!session.parentID) return session.id
+    return rootOf(session.parentID, nodes, sessions, new Set(visited).add(sessionID))
+  }
+  return nodes.get(sessionID)?.rootSessionId
+}
+
+function sameNode(left: Node, right: Node) {
+  return JSON.stringify(left) === JSON.stringify(right)
 }
 
 async function readSession(input: {
@@ -177,6 +410,8 @@ async function readSession(input: {
   rootSessionId: string
   parentSessionId?: string
   depth: number
+  deleted: ReadonlySet<string>
+  sessions: ReadonlyMap<string, Session>
 }): Promise<void> {
   if (input.state.visited.has(input.session.id)) throw new Error("subagent graph cannot contain cycles")
   if (input.depth > maxDepth) throw new Error(`subagent depth must not exceed ${maxDepth}`)
@@ -204,7 +439,7 @@ async function readSession(input: {
   })
 
   const children = await input.sdk.session.children({ sessionID: input.session.id })
-  for (const child of sortSessions(children.data ?? [])) {
+  for (const child of mergeSessions(children.data ?? [], input.sessions, input.deleted, input.session.id)) {
     await readSession({
       ...input,
       session: child,

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -179,8 +179,9 @@ export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify })
         })
       }
 
-      const upsert: Node[] = []
-      const removedSessionIds: string[] = []
+      const staged = new Map(nodes)
+      const upsert = new Map<string, Node>()
+      const removed = new Set<string>()
       for (const rootSessionId of roots) {
         const next = await snapshot({
           sdk: input.sdk,
@@ -194,30 +195,29 @@ export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify })
         })
         if (!active) return
 
-        const previous = [...nodes.values()].filter((node) => node.rootSessionId === rootSessionId)
+        const previous = [...staged.values()].filter((node) => node.rootSessionId === rootSessionId)
         const bySession = new Map(next.nodes.map((node) => [node.sessionId, node]))
-        upsert.push(
-          ...next.nodes.filter((node) => {
-            const current = nodes.get(node.sessionId)
-            return !current || !sameNode(current, node)
-          }),
-        )
-        removedSessionIds.push(
-          ...previous.filter((node) => !bySession.has(node.sessionId)).map((node) => node.sessionId),
-        )
-        previous.forEach((node) => nodes.delete(node.sessionId))
-        next.nodes.forEach((node) => nodes.set(node.sessionId, node))
+        next.nodes.forEach((node) => {
+          const current = staged.get(node.sessionId)
+          if (!current || !sameNode(current, node)) upsert.set(node.sessionId, node)
+        })
+        previous.filter((node) => !bySession.has(node.sessionId)).forEach((node) => removed.add(node.sessionId))
+        previous.forEach((node) => staged.delete(node.sessionId))
+        next.nodes.forEach((node) => staged.set(node.sessionId, node))
       }
-      if (!upsert.length && !removedSessionIds.length) continue
+      const removedSessionIds = [...removed].filter((sessionID) => !upsert.has(sessionID))
+      if (!upsert.size && !removedSessionIds.length) continue
 
       const update = encodeUpdate({
         generation,
         revision: revision + 1,
-        upsert,
+        upsert: [...upsert.values()],
         removedSessionIds,
       })
       // Reserve the revision before notification I/O so a failed send can never be reused.
       revision = update.revision
+      nodes.clear()
+      staged.forEach((node) => nodes.set(node.sessionId, node))
       await input.notify?.(update)
     }
   }
@@ -228,27 +228,49 @@ export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify })
       if (!input.events || !input.notify) throw new Error("subagent subscription requires events and notify")
       if (closed) throw new Error("subagent subscription is closed")
 
+      const before = {
+        params,
+        failed: new Set(failed),
+        deleted: new Set(deleted),
+        statuses: new Map(statuses),
+        sessions: new Map(sessions),
+        pending: new Set(pending),
+      }
       params = nextParams
       active = true
       initializing = true
-      removeListener ??= input.events.addListener(handle)
-      const initial = await snapshot({
-        sdk: input.sdk,
-        generation,
-        revision,
-        params,
-        failed,
-        deleted,
-        statuses,
-        sessions,
-      })
-      nodes.clear()
-      initial.nodes.forEach((node) => nodes.set(node.sessionId, node))
-      initializing = false
-      queueMicrotask(() => {
-        process().catch(() => {})
-      })
-      return initial
+      try {
+        removeListener ??= input.events.addListener(handle)
+        const initial = await snapshot({
+          sdk: input.sdk,
+          generation,
+          revision,
+          params,
+          failed,
+          deleted,
+          statuses,
+          sessions,
+        })
+        nodes.clear()
+        initial.nodes.forEach((node) => nodes.set(node.sessionId, node))
+        initializing = false
+        queueMicrotask(() => {
+          process().catch(() => {})
+        })
+        return initial
+      } catch (error) {
+        active = false
+        initializing = false
+        removeListener?.()
+        removeListener = undefined
+        params = before.params
+        replaceSet(failed, before.failed)
+        replaceSet(deleted, before.deleted)
+        replaceMap(statuses, before.statuses)
+        replaceMap(sessions, before.sessions)
+        replaceSet(pending, before.pending)
+        throw error
+      }
     },
     handle,
     close: () => {
@@ -264,6 +286,16 @@ export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify })
       nodes.clear()
     },
   }
+}
+
+function replaceSet<T>(target: Set<T>, source: ReadonlySet<T>) {
+  target.clear()
+  source.forEach((item) => target.add(item))
+}
+
+function replaceMap<K, V>(target: Map<K, V>, source: ReadonlyMap<K, V>) {
+  target.clear()
+  source.forEach((value, key) => target.set(key, value))
 }
 
 async function snapshot(input: {

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -138,10 +138,6 @@ function validateSnapshot(input: Schema.Schema.Type<typeof Snapshot>): Snapshot 
   const runIDs = new Set(snapshot.nodes.map((node) => node.runId))
   if (runIDs.size !== snapshot.nodes.length) throw new Error("subagent run IDs must be unique")
 
-  if (snapshot.nodes.filter((node) => !node.parentSessionId).length !== 1) {
-    throw new Error("subagent snapshot must contain exactly one root node")
-  }
-
   snapshot.nodes.forEach((node) => {
     if (!node.parentSessionId) {
       if (node.rootSessionId !== node.sessionId) throw new Error("root node must match its root session ID")
@@ -153,18 +149,23 @@ function validateSnapshot(input: Schema.Schema.Type<typeof Snapshot>): Snapshot 
     if (parent.rootSessionId !== node.rootSessionId) throw new Error("subagent parent must share its root session ID")
   })
 
-  snapshot.nodes.forEach((node) => {
-    const depth = depthOf(node, bySession, new Set())
-    if (depth > maxDepth) throw new Error(`subagent depth must not exceed ${maxDepth}`)
-  })
-
-  const descendants = snapshot.nodes.reduce((result, node) => {
-    result.set(node.rootSessionId, (result.get(node.rootSessionId) ?? 0) + 1)
+  const nodesByRoot = snapshot.nodes.reduce((result, node) => {
+    result.set(node.rootSessionId, [...(result.get(node.rootSessionId) ?? []), node])
     return result
-  }, new Map<string, number>())
-  if ([...descendants.values()].some((count) => count - 1 > maxDescendants)) {
-    throw new Error(`subagent descendants must not exceed ${maxDescendants}`)
-  }
+  }, new Map<string, Node[]>())
+
+  nodesByRoot.forEach((nodes, rootSessionId) => {
+    const roots = nodes.filter((node) => !node.parentSessionId)
+    if (roots.length !== 1 || roots[0]?.sessionId !== rootSessionId) {
+      throw new Error("subagent root group must contain exactly one canonical root")
+    }
+    if (nodes.length - 1 > maxDescendants) throw new Error(`subagent descendants must not exceed ${maxDescendants}`)
+
+    nodes.forEach((node) => {
+      const depth = depthOf(node, bySession, new Set())
+      if (depth > maxDepth) throw new Error(`subagent depth must not exceed ${maxDepth}`)
+    })
+  })
 
   return snapshot
 }

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -138,6 +138,10 @@ function validateSnapshot(input: Schema.Schema.Type<typeof Snapshot>): Snapshot 
   const runIDs = new Set(snapshot.nodes.map((node) => node.runId))
   if (runIDs.size !== snapshot.nodes.length) throw new Error("subagent run IDs must be unique")
 
+  if (snapshot.nodes.filter((node) => !node.parentSessionId).length !== 1) {
+    throw new Error("subagent snapshot must contain exactly one root node")
+  }
+
   snapshot.nodes.forEach((node) => {
     if (!node.parentSessionId) {
       if (node.rootSessionId !== node.sessionId) throw new Error("root node must match its root session ID")

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -96,6 +96,11 @@ type Notify = (update: Update) => Promise<void>
 
 const maxDepth = 8
 const maxDescendants = 300
+const maxDirectCostAmountLength = 256
+const maxDirectCostSignificantDigits = 38
+const minDirectCostPower = -128
+const maxDirectCostPower = 127
+const directCostAmountPattern = /^([+-]?)(\d*)(?:\.(\d*))?(?:[eE]([+-]?\d+))?$/
 const decodeListParamsSchema = Schema.decodeUnknownSync(ListParams)
 const decodeSnapshotSchema = Schema.decodeUnknownSync(Snapshot)
 const decodeUpdateSchema = Schema.decodeUnknownSync(Update)
@@ -121,10 +126,12 @@ export function encodeUpdate(input: Update): Update {
 }
 
 export function serializeDirectCost(amount: number, currency: string): DirectCost {
-  if (!Number.isFinite(amount) || amount < 0) {
+  if (!Number.isFinite(amount) || amount < 0 || Object.is(amount, -0)) {
     throw new Error("direct cost must be finite and nonnegative")
   }
-  return { amount: new Decimal(amount).toString(), currency }
+  const serialized = new Decimal(amount).toString()
+  parseDirectCostAmount(serialized)
+  return { amount: serialized, currency }
 }
 
 export function make(input: { sdk: SDK; events?: EventSource; notify?: Notify }): Service {
@@ -568,8 +575,50 @@ function validateUpdate(input: Schema.Schema.Type<typeof Update>): Update {
 function validateDirectCost(node: Node) {
   if (!node.directCost) return
 
-  const amount = new Decimal(node.directCost.amount)
-  if (!amount.isFinite() || amount.isNegative()) throw new Error("direct cost must be finite and nonnegative")
+  parseDirectCostAmount(node.directCost.amount)
+}
+
+function parseDirectCostAmount(amount: string) {
+  if (!amount.length || amount.length > maxDirectCostAmountLength) {
+    invalidDirectCostAmount()
+  }
+
+  const match = directCostAmountPattern.exec(amount)
+  const integer = match?.[2] ?? ""
+  const fraction = match?.[3] ?? ""
+  if (!match || match[1] === "-" || (!integer.length && !fraction.length)) {
+    invalidDirectCostAmount()
+  }
+
+  const exponent = Number(match[4] ?? "0")
+  if (!Number.isSafeInteger(exponent)) {
+    invalidDirectCostAmount()
+  }
+
+  const coefficient = integer + fraction
+  const firstNonzero = coefficient.search(/[1-9]/)
+  if (firstNonzero === -1) {
+    if (exponent < minDirectCostPower || exponent > maxDirectCostPower) {
+      invalidDirectCostAmount()
+    }
+    return
+  }
+
+  const trailingZeroCount = coefficient.match(/0*$/)?.[0].length ?? 0
+  const significantDigits = coefficient.length - firstNonzero - trailingZeroCount
+  const power = exponent - fraction.length + trailingZeroCount
+  if (
+    significantDigits > maxDirectCostSignificantDigits ||
+    !Number.isSafeInteger(power) ||
+    power < minDirectCostPower ||
+    power > maxDirectCostPower
+  ) {
+    invalidDirectCostAmount()
+  }
+}
+
+function invalidDirectCostAmount(): never {
+  throw new Error("direct cost must be an exactly representable nonnegative decimal")
 }
 
 function depthOf(node: Node, bySession: ReadonlyMap<string, Node>, visited: ReadonlySet<string>): number {

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -127,10 +127,11 @@ export function encodeUpdate(input: Update): Update {
 
 export function serializeDirectCost(amount: number, currency: string): DirectCost {
   if (!Number.isFinite(amount) || amount < 0 || Object.is(amount, -0)) {
-    throw new Error("direct cost must be finite and nonnegative")
+    throw new InvalidDirectCostError("direct cost must be finite and nonnegative")
   }
   const serialized = new Decimal(amount).toString()
   parseDirectCostAmount(serialized)
+  validateDirectCostCurrency(currency)
   return { amount: serialized, currency }
 }
 
@@ -463,6 +464,7 @@ async function readSession(input: {
     }
   }
 
+  const directCost = serializeSessionDirectCost(input.session.cost)
   input.nodes.push({
     runId: input.session.id,
     sessionId: input.session.id,
@@ -474,7 +476,7 @@ async function readSession(input: {
     createdAt: new Date(input.session.time.created).toISOString(),
     updatedAt: new Date(input.session.time.updated).toISOString(),
     cwd: input.session.directory,
-    ...(input.session.cost === undefined ? {} : { directCost: serializeDirectCost(input.session.cost, "USD") }),
+    ...(directCost ? { directCost } : {}),
   })
 
   const children = await input.sdk.session.children({ sessionID: input.session.id })
@@ -576,6 +578,21 @@ function validateDirectCost(node: Node) {
   if (!node.directCost) return
 
   parseDirectCostAmount(node.directCost.amount)
+  validateDirectCostCurrency(node.directCost.currency)
+}
+
+function serializeSessionDirectCost(amount: number | undefined) {
+  if (amount === undefined) return
+  try {
+    return serializeDirectCost(amount, "USD")
+  } catch (error) {
+    if (error instanceof InvalidDirectCostError) return
+    throw error
+  }
+}
+
+function validateDirectCostCurrency(currency: string) {
+  if (!currency.trim().length) throw new InvalidDirectCostError("direct cost currency must not be blank")
 }
 
 function parseDirectCostAmount(amount: string) {
@@ -617,8 +634,10 @@ function parseDirectCostAmount(amount: string) {
   }
 }
 
+class InvalidDirectCostError extends Error {}
+
 function invalidDirectCostAmount(): never {
-  throw new Error("direct cost must be an exactly representable nonnegative decimal")
+  throw new InvalidDirectCostError("direct cost must be an exactly representable nonnegative decimal")
 }
 
 function depthOf(node: Node, bySession: ReadonlyMap<string, Node>, visited: ReadonlySet<string>): number {

--- a/packages/opencode/src/acp/subagent.ts
+++ b/packages/opencode/src/acp/subagent.ts
@@ -1,5 +1,5 @@
 import { Decimal } from "decimal.js"
-import type { Event } from "@opencode-ai/sdk/v2"
+import type { Event, OpencodeClient, Session, SessionStatus } from "@opencode-ai/sdk/v2"
 import { Schema } from "effect"
 
 export const phases = ["queued", "running", "completed", "failed", "cancelled", "unknown"] as const
@@ -88,6 +88,8 @@ export type Service = {
   close(): void
 }
 
+type SDK = Pick<OpencodeClient, "session">
+
 const maxDepth = 8
 const maxDescendants = 300
 const decodeListParamsSchema = Schema.decodeUnknownSync(ListParams)
@@ -119,6 +121,108 @@ export function serializeDirectCost(amount: number, currency: string): DirectCos
     throw new Error("direct cost must be finite and nonnegative")
   }
   return { amount: new Decimal(amount).toString(), currency }
+}
+
+export function make(input: { sdk: SDK }): Service {
+  const generation = crypto.randomUUID()
+  const failed = new Set<string>()
+
+  return {
+    list: (params) => snapshot({ sdk: input.sdk, generation, params, failed }),
+    subscribe: (params) => snapshot({ sdk: input.sdk, generation, params, failed }),
+    handle: async (event) => {
+      if (event.type === "session.error" && event.properties.sessionID) {
+        failed.add(event.properties.sessionID)
+      }
+    },
+    close: () => failed.clear(),
+  }
+}
+
+async function snapshot(input: { sdk: SDK; generation: string; params: ListParams; failed: ReadonlySet<string> }) {
+  const [rootsResponse, statusResponse] = await Promise.all([
+    input.sdk.session.list({ roots: true }),
+    input.sdk.session.status(),
+  ])
+  const statuses = statusResponse.data ?? {}
+  const nodes: Node[] = []
+  const roots = sortSessions(rootsResponse.data ?? []).filter(
+    (session) => !input.params.rootSessionId || session.id === input.params.rootSessionId,
+  )
+
+  for (const root of roots) {
+    const state = { descendants: 0, visited: new Set<string>() }
+    await readSession({
+      sdk: input.sdk,
+      statuses,
+      failed: input.failed,
+      nodes,
+      state,
+      session: root,
+      rootSessionId: root.id,
+      depth: 0,
+    })
+  }
+
+  return encodeSnapshot({ generation: input.generation, revision: 0, nodes })
+}
+
+async function readSession(input: {
+  sdk: SDK
+  statuses: Record<string, SessionStatus>
+  failed: ReadonlySet<string>
+  nodes: Node[]
+  state: { descendants: number; visited: Set<string> }
+  session: Session
+  rootSessionId: string
+  parentSessionId?: string
+  depth: number
+}): Promise<void> {
+  if (input.state.visited.has(input.session.id)) throw new Error("subagent graph cannot contain cycles")
+  if (input.depth > maxDepth) throw new Error(`subagent depth must not exceed ${maxDepth}`)
+
+  input.state.visited.add(input.session.id)
+  if (input.parentSessionId) {
+    input.state.descendants += 1
+    if (input.state.descendants > maxDescendants) {
+      throw new Error(`subagent descendants must not exceed ${maxDescendants}`)
+    }
+  }
+
+  input.nodes.push({
+    runId: input.session.id,
+    sessionId: input.session.id,
+    rootSessionId: input.rootSessionId,
+    ...(input.parentSessionId ? { parentSessionId: input.parentSessionId } : {}),
+    ...(input.session.agent ? { agent: input.session.agent } : {}),
+    ...(input.session.title ? { title: input.session.title } : {}),
+    phase: phaseOf(input.session.id, input.statuses[input.session.id], input.failed),
+    createdAt: new Date(input.session.time.created).toISOString(),
+    updatedAt: new Date(input.session.time.updated).toISOString(),
+    cwd: input.session.directory,
+    ...(input.session.cost === undefined ? {} : { directCost: serializeDirectCost(input.session.cost, "USD") }),
+  })
+
+  const children = await input.sdk.session.children({ sessionID: input.session.id })
+  for (const child of sortSessions(children.data ?? [])) {
+    await readSession({
+      ...input,
+      session: child,
+      parentSessionId: input.session.id,
+      depth: input.depth + 1,
+    })
+  }
+}
+
+function sortSessions(sessions: Session[]) {
+  return sessions.toSorted((a, b) => a.time.created - b.time.created || a.id.localeCompare(b.id))
+}
+
+function phaseOf(sessionId: string, status: SessionStatus | undefined, failed: ReadonlySet<string>): Phase {
+  if (failed.has(sessionId)) return "failed"
+  if (status?.type === "busy" || status?.type === "retry") return "running"
+  if (status?.type === "idle") return "completed"
+  return "unknown"
 }
 
 function validateSnapshot(input: Schema.Schema.Type<typeof Snapshot>): Snapshot {

--- a/packages/opencode/test/acp/agent-connection.test.ts
+++ b/packages/opencode/test/acp/agent-connection.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "bun:test"
+import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
+import type { Event, OpencodeClient, Session } from "@opencode-ai/sdk/v2"
+import { ACP } from "@/acp/agent"
+import { Subagent } from "@/acp/subagent"
+
+type Message = {
+  readonly jsonrpc: "2.0"
+  readonly id?: number
+  readonly method?: string
+  readonly result?: unknown
+  readonly error?: {
+    readonly code: number
+  }
+  readonly params?: unknown
+}
+
+describe("ACP agent connection", () => {
+  it("closes subagent extension attachments with the connection", async () => {
+    await using harness = makeHarness()
+    await harness.events.started.promise
+
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "_opencode/subagents/subscribe",
+      params: {},
+    })
+    const subscribed = await harness.output.next()
+    expect(Subagent.decodeSnapshot(subscribed.result).nodes.map((node) => node.sessionId)).toEqual(["root"])
+
+    const reads = harness.listReads()
+    const writes = harness.output.count()
+    await harness.close()
+    await harness.connection.closed
+
+    expect(harness.events.signal()?.aborted).toBe(true)
+    await harness.events.released.promise
+    await harness.events.emit(sessionStatus("root", { type: "busy" }))
+
+    expect(harness.listReads()).toBe(reads)
+    expect(harness.output.count()).toBe(writes)
+  })
+
+  it("preserves JSON-RPC error classes at the custom-method boundary", async () => {
+    await using harness = makeHarness()
+    await harness.events.started.promise
+
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "_opencode/subagents/list",
+      params: { rootSessionId: 42 },
+    })
+    expect((await harness.output.next()).error?.code).toBe(-32602)
+
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "_opencode/subagents/missing",
+      params: {},
+    })
+    expect((await harness.output.next()).error?.code).toBe(-32601)
+
+    harness.failList()
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "_opencode/subagents/list",
+      params: {},
+    })
+    expect((await harness.output.next()).error?.code).toBe(-32603)
+  })
+
+  it("writes the subscribe response before a buffered revision-1 update", async () => {
+    const snapshotStarted = Promise.withResolvers<void>()
+    const releaseSnapshot = Promise.withResolvers<void>()
+    await using harness = makeHarness({
+      holdFirstList: {
+        started: snapshotStarted,
+        release: releaseSnapshot.promise,
+      },
+    })
+    await harness.events.started.promise
+
+    await harness.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "_opencode/subagents/subscribe",
+      params: { rootSessionId: "root" },
+    })
+    await snapshotStarted.promise
+    await harness.events.emit(
+      sessionChanged(
+        "session.created",
+        session({
+          id: "child",
+          parentID: "root",
+          directory: "/workspace/child",
+          created: 2,
+          updated: 2,
+        }),
+      ),
+    )
+    releaseSnapshot.resolve()
+
+    const response = await harness.output.next()
+    const update = await harness.output.next()
+    expect(response).toMatchObject({ jsonrpc: "2.0", id: 1 })
+    Subagent.decodeSnapshot(response.result)
+    expect(update).toMatchObject({
+      jsonrpc: "2.0",
+      method: "_opencode/subagents/update",
+    })
+    expect(Subagent.decodeUpdate(update.params)).toMatchObject({
+      revision: 1,
+      upsert: [{ sessionId: "child", parentSessionId: "root" }],
+    })
+  })
+})
+
+function makeHarness(options?: {
+  holdFirstList?: {
+    started: PromiseWithResolvers<void>
+    release: Promise<void>
+  }
+}) {
+  const events = eventSource()
+  const output = outputCollector()
+  const input = new TransformStream<Uint8Array, Uint8Array>()
+  const writer = input.writable.getWriter()
+  const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+  let listReads = 0
+  let listFailure = false
+  let inputClosed = false
+  const sdk = {
+    global: {
+      event: (request?: { signal?: AbortSignal }) => {
+        events.capture(request?.signal)
+        return Promise.resolve({ stream: events.stream(request?.signal) })
+      },
+    },
+    session: {
+      list: async () => {
+        listReads += 1
+        if (listFailure) throw new Error("list failed")
+        if (listReads === 1 && options?.holdFirstList) {
+          options.holdFirstList.started.resolve()
+          await options.holdFirstList.release
+        }
+        return { data: [root] }
+      },
+      children: () => Promise.resolve({ data: [] }),
+      status: () => Promise.resolve({ data: { root: { type: "idle" as const } } }),
+    },
+  } as unknown as OpencodeClient
+  const connection = new AgentSideConnection(ACP.init({ sdk }).create, ndJsonStream(output.writable, input.readable))
+  const close = async () => {
+    if (inputClosed) return
+    inputClosed = true
+    await writer.close()
+  }
+
+  return {
+    connection,
+    events,
+    output,
+    send: (message: Message) => writer.write(new TextEncoder().encode(`${JSON.stringify(message)}\n`)),
+    close,
+    failList: () => {
+      listFailure = true
+    },
+    listReads: () => listReads,
+    [Symbol.asyncDispose]: async () => {
+      await close()
+      await connection.closed
+    },
+  }
+}
+
+function outputCollector() {
+  const decoder = new TextDecoder()
+  const queued: Message[] = []
+  const waiters: Array<(message: Message) => void> = []
+  let content = ""
+  let count = 0
+
+  const push = (message: Message) => {
+    count += 1
+    const waiter = waiters.shift()
+    if (waiter) {
+      waiter(message)
+      return
+    }
+    queued.push(message)
+  }
+
+  return {
+    writable: new WritableStream<Uint8Array>({
+      write(chunk) {
+        content += decoder.decode(chunk, { stream: true })
+        const lines = content.split("\n")
+        content = lines.pop() ?? ""
+        lines
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .forEach((line) => push(JSON.parse(line)))
+      },
+    }),
+    next: () => {
+      const message = queued.shift()
+      if (message) return Promise.resolve(message)
+      return new Promise<Message>((resolve) => waiters.push(resolve))
+    },
+    count: () => count,
+  }
+}
+
+function eventSource() {
+  type Envelope = {
+    readonly payload: Event
+    readonly delivered: PromiseWithResolvers<void>
+  }
+  const queued: Envelope[] = []
+  const waiters: Array<(envelope: Envelope | undefined) => void> = []
+  const started = Promise.withResolvers<void>()
+  const released = Promise.withResolvers<void>()
+  let signal: AbortSignal | undefined
+  let done = false
+
+  const stream = async function* (abort?: AbortSignal) {
+    started.resolve()
+    try {
+      while (!abort?.aborted) {
+        const queuedEvent = queued.shift()
+        const next =
+          queuedEvent ??
+          (await new Promise<Envelope | undefined>((resolve) => {
+            waiters.push(resolve)
+            abort?.addEventListener("abort", () => resolve(undefined), { once: true })
+          }))
+        if (!next) return
+        yield { payload: next.payload }
+        next.delivered.resolve()
+      }
+    } finally {
+      done = true
+      released.resolve()
+    }
+  }
+
+  return {
+    started,
+    released,
+    stream,
+    capture: (value?: AbortSignal) => {
+      signal = value
+    },
+    signal: () => signal,
+    emit: (event: Event) => {
+      if (done) return Promise.resolve()
+      const envelope = { payload: event, delivered: Promise.withResolvers<void>() }
+      const waiter = waiters.shift()
+      if (waiter) waiter(envelope)
+      else queued.push(envelope)
+      return envelope.delivered.promise
+    },
+  }
+}
+
+function session(input: {
+  id: string
+  directory: string
+  created: number
+  updated: number
+  parentID?: string
+}): Session {
+  return {
+    id: input.id,
+    slug: input.id,
+    projectID: "project",
+    directory: input.directory,
+    ...(input.parentID ? { parentID: input.parentID } : {}),
+    title: input.id,
+    agent: "build",
+    version: "1",
+    time: { created: input.created, updated: input.updated },
+  }
+}
+
+function sessionChanged(type: "session.created" | "session.updated", info: Session): Event {
+  return {
+    id: `event-${type}-${info.id}`,
+    type,
+    properties: { sessionID: info.id, info },
+  }
+}
+
+function sessionStatus(sessionID: string, status: { type: "busy" | "idle" }): Event {
+  return {
+    id: `event-status-${sessionID}`,
+    type: "session.status",
+    properties: { sessionID, status },
+  }
+}

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -40,6 +40,8 @@ function createEventStream() {
   const queue: GlobalEventEnvelope[] = []
   const waiters: Array<(value: GlobalEventEnvelope | undefined) => void> = []
   const state = { closed: false }
+  const ready = Promise.withResolvers<void>()
+  let opened = false
 
   const push = (event: GlobalEventEnvelope) => {
     const waiter = waiters.shift()
@@ -58,6 +60,10 @@ function createEventStream() {
   }
 
   const stream = async function* (signal?: AbortSignal) {
+    if (!opened) {
+      opened = true
+      ready.resolve()
+    }
     while (true) {
       if (signal?.aborted) return
       const next = queue.shift()
@@ -75,7 +81,7 @@ function createEventStream() {
     }
   }
 
-  return { push, close, stream }
+  return { push, close, ready: ready.promise, stream }
 }
 
 function createHarness(messages: Record<string, SessionMessageResponse> = {}) {
@@ -319,6 +325,44 @@ async function createKnownSession(
 }
 
 describe("acp event routing", () => {
+  it("delivers transcript and isolated listeners from the single global stream", async () => {
+    const harness = createHarness()
+    await createKnownSession(harness.session, "ses_listener", {
+      messageId: "msg_listener",
+      partId: "part_listener",
+      partType: "text",
+    })
+    const received = Promise.withResolvers<Event>()
+
+    harness.subscription.addListener(async () => {
+      throw new Error("listener failed")
+    })
+    harness.subscription.addListener(async (event) => {
+      received.resolve(event)
+    })
+    harness.subscription.start()
+    await harness.events.ready
+
+    const event = textDelta("ses_listener", "msg_listener", "part_listener", "hello")
+    harness.events.push({ payload: event })
+
+    expect(await received.promise).toEqual(event)
+    expect(harness.updates).toEqual([
+      {
+        sessionId: "ses_listener",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          messageId: "msg_listener",
+          content: { type: "text", text: "hello" },
+        },
+      },
+    ])
+    expect(harness.calls.eventSubscribe).toBe(1)
+
+    harness.subscription.stop()
+    harness.events.close()
+  })
+
   it("routes message.part.delta by sessionID without cross-session pollution", async () => {
     const harness = createHarness()
     await createKnownSession(harness.session, "ses_a", { messageId: "msg_a", partId: "part_a", partType: "text" })

--- a/packages/opencode/test/acp/fixtures/subagents-v1.json
+++ b/packages/opencode/test/acp/fixtures/subagents-v1.json
@@ -1,0 +1,40 @@
+{
+  "snapshot": {
+    "generation": "generation-a",
+    "revision": 7,
+    "nodes": [
+      {
+        "runId": "root",
+        "sessionId": "root",
+        "rootSessionId": "root",
+        "title": "Root",
+        "phase": "running",
+        "createdAt": "2026-07-29T00:00:00.000Z",
+        "updatedAt": "2026-07-29T00:01:00.000Z",
+        "cwd": "/workspace/repo",
+        "repository": "kosnet/repo",
+        "directCost": { "amount": "1.20", "currency": "USD" }
+      },
+      {
+        "runId": "child",
+        "sessionId": "child",
+        "rootSessionId": "root",
+        "parentSessionId": "root",
+        "agent": "explore",
+        "title": "Inspect ACP",
+        "phase": "completed",
+        "createdAt": "2026-07-29T00:00:10.000Z",
+        "updatedAt": "2026-07-29T00:00:50.000Z",
+        "completedAt": "2026-07-29T00:00:50.000Z",
+        "cwd": "/workspace/repo",
+        "directCost": { "amount": "0.35", "currency": "USD" }
+      }
+    ]
+  },
+  "update": {
+    "generation": "generation-a",
+    "revision": 8,
+    "upsert": [],
+    "removedSessionIds": ["child"]
+  }
+}

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -14,8 +14,10 @@ import type { AssistantMessage, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { Effect } from "effect"
+import { Agent } from "@/acp/agent"
 import * as ACPService from "@/acp/service"
 import * as ACPError from "@/acp/error"
+import { Subagent } from "@/acp/subagent"
 import { UsageService } from "@/acp/usage"
 import type { Provider } from "@/provider/provider"
 
@@ -196,6 +198,11 @@ describe("ACP service sessions", () => {
             data: input.directory ? sessions.filter((session) => session.directory === input.directory) : sessions,
           }),
         messages: () => Promise.resolve({ data: messages }),
+        children: () => Promise.resolve({ data: [] }),
+        status: () =>
+          Promise.resolve({
+            data: Object.fromEntries(sessions.map((item) => [item.id, { type: "idle" as const }])),
+          }),
         prompt:
           options?.prompt ??
           ((input: unknown) => {
@@ -245,13 +252,17 @@ describe("ACP service sessions", () => {
           return Promise.resolve({ data: {} })
         },
       },
+      global: {
+        event: () => new Promise(() => {}),
+      },
     } as unknown as OpencodeClient
     const connection = {
       sessionUpdate: (update: SessionNotification) => {
         updates.push(update)
         return Promise.resolve()
       },
-    } as Pick<AgentSideConnection, "sessionUpdate">
+      extNotification: () => Promise.resolve(),
+    } as Pick<AgentSideConnection, "sessionUpdate" | "extNotification">
     const usage = UsageService.Service.of({
       buildUsage: UsageService.buildUsage,
       latestAssistantMessage: UsageService.latestAssistantMessage,
@@ -275,6 +286,29 @@ describe("ACP service sessions", () => {
       usageUpdates,
     }
   }
+
+  it("advertises and dispatches the version-1 subagent extension", async () => {
+    const { service } = makeService()
+    const agent = new Agent(service)
+
+    const initialized = await agent.initialize({ protocolVersion: 1 })
+    expect(initialized._meta).toEqual({
+      "opencode.dev/subagents": {
+        version: 1,
+        list: true,
+        subscribe: true,
+      },
+    })
+
+    const listed = Subagent.decodeSnapshot(await agent.extMethod("_opencode/subagents/list", {}))
+    const subscribed = Subagent.decodeSnapshot(await agent.extMethod("_opencode/subagents/subscribe", {}))
+    expect(listed.nodes).toHaveLength(102)
+    expect(subscribed.nodes).toHaveLength(102)
+
+    await expect(agent.extMethod("_opencode/subagents/missing", {})).rejects.toMatchObject({
+      code: -32601,
+    })
+  })
 
   it("creates a backed session with config options and command update", async () => {
     const { service, updates, mcpAdds } = makeService()

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -42,7 +42,7 @@ describe("acp subagent wire contract", () => {
     })
   })
 
-  test("rejects a node whose root does not match its parent", () => {
+  test("rejects a cross-root parent", () => {
     const snapshot = structuredClone(fixture.snapshot)
     snapshot.nodes[1].rootSessionId = "other-root"
 
@@ -56,14 +56,14 @@ describe("acp subagent wire contract", () => {
     expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
   })
 
-  test("rejects a snapshot without a parentless root", () => {
+  test("accepts an empty collection of root graphs", () => {
     const snapshot = structuredClone(fixture.snapshot)
     snapshot.nodes = []
 
-    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+    expect(Subagent.decodeSnapshot(snapshot)).toEqual(snapshot)
   })
 
-  test("rejects a snapshot with multiple parentless roots", () => {
+  test("accepts multiple valid root graphs", () => {
     const snapshot = structuredClone(fixture.snapshot)
     snapshot.nodes.push({
       runId: "other-root",
@@ -72,6 +72,21 @@ describe("acp subagent wire contract", () => {
       phase: "completed",
       cwd: "/workspace/other-repo",
     })
+
+    expect(Subagent.decodeSnapshot(snapshot)).toEqual(snapshot)
+  })
+
+  test("rejects a root group without its canonical root", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes = [
+      {
+        runId: "root-alias",
+        sessionId: "root-alias",
+        rootSessionId: "root",
+        phase: "completed",
+        cwd: "/workspace/repo",
+      },
+    ]
 
     expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
   })

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -29,18 +29,75 @@ describe("acp subagent wire contract", () => {
     expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
   })
 
-  test.each(["-0.35", "NaN", "Infinity"])("rejects a non-serializable direct cost of %s", (amount) => {
+  test.each([
+    "-0.35",
+    "-0",
+    "NaN",
+    "Infinity",
+    "9".repeat(39),
+    "9".repeat(40),
+    "0".repeat(257),
+    "1e128",
+    "1.2e-128",
+    "1e-129",
+    "0e128",
+    "0e-129",
+    "1e9007199254740992",
+  ])("rejects an out-of-contract direct cost of %s from snapshots and updates", (amount) => {
     const snapshot = structuredClone(fixture.snapshot)
     snapshot.nodes[1].directCost.amount = amount
+    const update = structuredClone(fixture.update)
+    update.upsert = [structuredClone(snapshot.nodes[1])]
+    update.removedSessionIds = []
 
     expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+    expect(() => Subagent.decodeUpdate(update)).toThrow()
   })
 
-  test("serializes a finite direct cost as a decimal string", () => {
-    expect(Subagent.serializeDirectCost(1.2, "USD")).toEqual({ amount: "1.2", currency: "USD" })
+  test.each([
+    "12345678901234567890123456789012345678",
+    "1e127",
+    "1e-128",
+    "1.20",
+    "+1.20",
+    "12e-1",
+    "000001.2000",
+    "10e-129",
+    "0",
+    "0".repeat(256),
+    "0e127",
+    "0e-128",
+  ])("accepts an exactly representable direct cost of %s in snapshots and updates", (amount) => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].directCost.amount = amount
+    const update = structuredClone(fixture.update)
+    update.upsert = [structuredClone(snapshot.nodes[1])]
+    update.removedSessionIds = []
+
+    expect(Subagent.decodeSnapshot(snapshot).nodes[1]?.directCost?.amount).toBe(amount)
+    expect(Subagent.decodeUpdate(update).upsert[0]?.directCost?.amount).toBe(amount)
   })
-  ;[-0.35, Number.NaN, Number.POSITIVE_INFINITY].forEach((amount) => {
-    test(`rejects an unrepresentable direct cost of ${amount}`, () => {
+  ;[
+    { amount: 0, expected: "0" },
+    { amount: 1.2, expected: "1.2" },
+    { amount: 1e127, expected: "1e+127" },
+    { amount: 1e-128, expected: "1e-128" },
+  ].forEach(({ amount, expected }) => {
+    test(`serializes the finite direct cost ${amount} as ${expected}`, () => {
+      expect(Subagent.serializeDirectCost(amount, "USD")).toEqual({ amount: expected, currency: "USD" })
+    })
+  })
+  ;[
+    { label: "negative zero", amount: -0 },
+    { label: "-0.35", amount: -0.35 },
+    { label: "NaN", amount: Number.NaN },
+    { label: "positive infinity", amount: Number.POSITIVE_INFINITY },
+    { label: "1e+128", amount: 1e128 },
+    { label: "1.2e-128", amount: 1.2e-128 },
+    { label: "Number.MAX_VALUE (1.7976931348623157e+308)", amount: Number.MAX_VALUE },
+    { label: "Number.MIN_VALUE (5e-324)", amount: Number.MIN_VALUE },
+  ].forEach(({ label, amount }) => {
+    test(`rejects an unrepresentable direct cost of ${label}`, () => {
       expect(() => Subagent.serializeDirectCost(amount, "USD")).toThrow()
     })
   })

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test"
+import { Subagent } from "@/acp/subagent"
+
+const fixture = await Bun.file(`${import.meta.dir}/fixtures/subagents-v1.json`).json()
+
+describe("acp subagent wire contract", () => {
+  test("decodes and encodes the version-1 fixture", () => {
+    expect(Subagent.decodeSnapshot(fixture.snapshot)).toEqual(fixture.snapshot)
+    expect(Subagent.encodeSnapshot(fixture.snapshot)).toEqual(fixture.snapshot)
+    expect(Subagent.decodeUpdate(fixture.update)).toEqual(fixture.update)
+    expect(Subagent.encodeUpdate(fixture.update)).toEqual(fixture.update)
+  })
+
+  test("rejects an unsupported node phase", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].phase = "waiting"
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test("rejects a node without its workspace directory", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    delete snapshot.nodes[1].cwd
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test.each(["-0.35", "NaN", "Infinity"])("rejects a non-serializable direct cost of %s", (amount) => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].directCost.amount = amount
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test("serializes a finite direct cost as a decimal string", () => {
+    expect(Subagent.serializeDirectCost(1.2, "USD")).toEqual({ amount: "1.2", currency: "USD" })
+  })
+
+  ;[-0.35, Number.NaN, Number.POSITIVE_INFINITY].forEach((amount) => {
+    test(`rejects an unrepresentable direct cost of ${amount}`, () => {
+      expect(() => Subagent.serializeDirectCost(amount, "USD")).toThrow()
+    })
+  })
+
+  test("rejects a node whose root does not match its parent", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].rootSessionId = "other-root"
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test("rejects duplicate session identities", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].sessionId = "root"
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test("rejects a ninth descendant depth", () => {
+    expect(() =>
+      Subagent.decodeSnapshot({
+        generation: "generation-a",
+        revision: 0,
+        nodes: Array.from({ length: 10 }, (_, depth) => ({
+          runId: `node-${depth}`,
+          sessionId: `node-${depth}`,
+          rootSessionId: "node-0",
+          ...(depth > 0 ? { parentSessionId: `node-${depth - 1}` } : {}),
+          phase: "completed",
+          cwd: "/workspace/repo",
+        })),
+      }),
+    ).toThrow()
+  })
+
+  test("rejects a root with 301 descendants", () => {
+    expect(() =>
+      Subagent.decodeSnapshot({
+        generation: "generation-a",
+        revision: 0,
+        nodes: [
+          {
+            runId: "root",
+            sessionId: "root",
+            rootSessionId: "root",
+            phase: "running",
+            cwd: "/workspace/repo",
+          },
+          ...Array.from({ length: 301 }, (_, index) => ({
+            runId: `child-${index}`,
+            sessionId: `child-${index}`,
+            rootSessionId: "root",
+            parentSessionId: "root",
+            phase: "completed",
+            cwd: "/workspace/repo",
+          })),
+        ],
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -77,6 +77,29 @@ describe("acp subagent wire contract", () => {
     expect(Subagent.decodeSnapshot(snapshot).nodes[1]?.directCost?.amount).toBe(amount)
     expect(Subagent.decodeUpdate(update).upsert[0]?.directCost?.amount).toBe(amount)
   })
+
+  test.each(["", " ", "\t\n"])("rejects a blank direct cost currency from every public codec", (currency) => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].directCost.currency = currency
+    const update = structuredClone(fixture.update)
+    update.upsert = [structuredClone(snapshot.nodes[1])]
+    update.removedSessionIds = []
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+    expect(() => Subagent.decodeUpdate(update)).toThrow()
+    expect(() => Subagent.serializeDirectCost(1.2, currency)).toThrow()
+  })
+
+  test("rejects a non-string direct cost currency as a schema error", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes[1].directCost.currency = 123
+    const update = structuredClone(fixture.update)
+    update.upsert = [structuredClone(snapshot.nodes[1])]
+    update.removedSessionIds = []
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+    expect(() => Subagent.decodeUpdate(update)).toThrow()
+  })
   ;[
     { amount: 0, expected: "0" },
     { amount: 1.2, expected: "1.2" },
@@ -272,6 +295,50 @@ describe("acp subagent snapshots", () => {
     const service = Subagent.make({ sdk: descendantSDK(301) })
 
     await expect(service.list({})).rejects.toThrow("subagent descendants must not exceed 300")
+  })
+
+  test.each([
+    { label: "negative", cost: -0.35 },
+    { label: "nonfinite", cost: Number.POSITIVE_INFINITY },
+    { label: "out-of-contract", cost: 1e128 },
+  ])("retains list and subscription graphs while omitting a child with $label cost", async ({ cost }) => {
+    const root = session({ id: "root", directory: "/workspace/root", cost: 1.2, created: 1, updated: 3 })
+    const child = session({
+      id: "child",
+      parentID: "root",
+      directory: "/workspace/child",
+      cost,
+      created: 2,
+      updated: 2,
+    })
+    const grandchild = session({
+      id: "grandchild",
+      parentID: "child",
+      directory: "/workspace/grandchild",
+      cost: 0.1,
+      created: 3,
+      updated: 1,
+    })
+    const harness = await subscriptionHarness({
+      sessions: [root, child, grandchild],
+      status: { root: { type: "busy" }, child: { type: "idle" }, grandchild: { type: "idle" } },
+    })
+    const service = Subagent.make({ sdk: harness.sdk, events: harness.events, notify: () => Promise.resolve() })
+
+    const listed = await service.list({})
+    const subscribed = await service.subscribe({})
+
+    for (const snapshot of [listed, subscribed]) {
+      expect(snapshot.nodes.map((node) => node.sessionId)).toEqual(["root", "child", "grandchild"])
+      expect(snapshot.nodes.map((node) => node.directCost)).toEqual([
+        { amount: "1.2", currency: "USD" },
+        undefined,
+        { amount: "0.1", currency: "USD" },
+      ])
+    }
+
+    service.close()
+    harness.close()
   })
 })
 

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -348,6 +348,72 @@ describe("acp subagent subscriptions", () => {
     harness.close()
   })
 
+  test("publishes a cross-root move atomically before later updates", async () => {
+    const rootA = session({ id: "root-a", directory: "/workspace/root-a", created: 1, updated: 1 })
+    const rootB = session({ id: "root-b", directory: "/workspace/root-b", created: 2, updated: 2 })
+    const child = session({
+      id: "child",
+      parentID: "root-a",
+      directory: "/workspace/child",
+      created: 3,
+      updated: 3,
+    })
+    const harness = await subscriptionHarness({
+      sessions: [rootA, rootB, child],
+      status: { "root-a": { type: "idle" }, "root-b": { type: "idle" }, child: { type: "idle" } },
+    })
+    const updates: Subagent.Update[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        updates.push(update)
+      },
+    })
+    const snapshot = await service.subscribe({})
+    const moved = {
+      ...child,
+      parentID: "root-b",
+      title: "moved child",
+      time: { ...child.time, updated: 4 },
+    }
+
+    await harness.send(sessionChanged("session.updated", moved))
+    await harness.send(sessionStatus("child", { type: "busy" }))
+
+    expect(updates.map((update) => update.revision)).toEqual([1, 2])
+    expect(updates[0]).toEqual({
+      generation: snapshot.generation,
+      revision: 1,
+      upsert: [
+        {
+          runId: "child",
+          sessionId: "child",
+          rootSessionId: "root-b",
+          parentSessionId: "root-b",
+          agent: "build",
+          title: "moved child",
+          phase: "completed",
+          createdAt: "1970-01-01T00:00:00.003Z",
+          updatedAt: "1970-01-01T00:00:00.004Z",
+          cwd: "/workspace/child",
+        },
+      ],
+      removedSessionIds: [],
+    })
+    expect(updates[1]?.upsert).toMatchObject([
+      {
+        sessionId: "child",
+        rootSessionId: "root-b",
+        parentSessionId: "root-b",
+        phase: "running",
+      },
+    ])
+
+    service.close()
+    harness.close()
+  })
+
   test("does not reuse a revision after notification failure", async () => {
     const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
     const harness = await subscriptionHarness({ sessions: [root], status: { root: { type: "idle" } } })
@@ -389,6 +455,76 @@ describe("acp subagent subscriptions", () => {
 
     expect(updates).toEqual([])
 
+    harness.close()
+  })
+
+  test("rolls back a failed snapshot before a clean subscription retry", async () => {
+    const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+    const attemptChild = session({
+      id: "attempt-child",
+      parentID: "root",
+      directory: "/workspace/attempt-child",
+      created: 2,
+      updated: 2,
+    })
+    const detached = session({ id: "detached", directory: "/workspace/detached", created: 3, updated: 3 })
+    const listStarted = Promise.withResolvers<void>()
+    const rejectList = Promise.withResolvers<void>()
+    let listReads = 0
+    const harness = await subscriptionHarness({
+      sessions: [root],
+      status: { root: { type: "idle" } },
+      list: async (roots) => {
+        listReads += 1
+        if (listReads !== 1) return roots
+        listStarted.resolve()
+        await rejectList.promise
+        throw new Error("snapshot failed")
+      },
+    })
+    const updates: Subagent.Update[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        updates.push(update)
+      },
+    })
+
+    const first = service.subscribe({})
+    await listStarted.promise
+    const attemptDispatched = harness.afterNextEvent(() => rejectList.resolve())
+    harness.push(sessionChanged("session.created", attemptChild))
+    await attemptDispatched
+    await expect(first).rejects.toThrow("snapshot failed")
+
+    await harness.send(sessionChanged("session.created", detached))
+    const snapshot = await service.subscribe({})
+    await harness.send(sessionStatus("root", { type: "busy" }))
+
+    expect(snapshot.nodes.map((node) => node.sessionId)).toEqual(["root"])
+    expect(updates).toEqual([
+      {
+        generation: snapshot.generation,
+        revision: 1,
+        upsert: [
+          {
+            runId: "root",
+            sessionId: "root",
+            rootSessionId: "root",
+            agent: "build",
+            title: "root",
+            phase: "running",
+            createdAt: "1970-01-01T00:00:00.001Z",
+            updatedAt: "1970-01-01T00:00:00.001Z",
+            cwd: "/workspace/root",
+          },
+        ],
+        removedSessionIds: [],
+      },
+    ])
+
+    service.close()
     harness.close()
   })
 })
@@ -519,6 +655,7 @@ async function subscriptionHarness(input: {
   sessions: Session[]
   status: Record<string, SessionStatus>
   blockChildren?: { rootSessionId: string; started: PromiseWithResolvers<void>; release: Promise<void> }
+  list?: (roots: Session[]) => Promise<Session[]>
 }) {
   const queue: EventEnvelope[] = []
   const waiters: Array<(value: EventEnvelope | undefined) => void> = []
@@ -547,8 +684,10 @@ async function subscriptionHarness(input: {
       event: (options?: { signal?: AbortSignal }) => Promise.resolve({ stream: stream(options?.signal) }),
     },
     session: {
-      list: (params?: { roots?: boolean }) =>
-        Promise.resolve({ data: params?.roots ? input.sessions.filter((item) => !item.parentID) : input.sessions }),
+      list: async (params?: { roots?: boolean }) => {
+        const sessions = params?.roots ? input.sessions.filter((item) => !item.parentID) : input.sessions
+        return { data: input.list ? await input.list(sessions) : sessions }
+      },
       children: async ({ sessionID }: { sessionID: string }) => {
         const data = input.sessions.filter((item) => item.parentID === sessionID)
         if (input.blockChildren && !childrenBlocked && sessionID === input.blockChildren.rootSessionId) {

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import type { Event, OpencodeClient, Session, SessionStatus } from "@opencode-ai/sdk/v2"
+import { Effect } from "effect"
+import { ACPEvent } from "@/acp/event"
+import { ACPSession } from "@/acp/session"
 import { Subagent } from "@/acp/subagent"
 
 const fixture = await Bun.file(`${import.meta.dir}/fixtures/subagents-v1.json`).json()
@@ -36,7 +39,6 @@ describe("acp subagent wire contract", () => {
   test("serializes a finite direct cost as a decimal string", () => {
     expect(Subagent.serializeDirectCost(1.2, "USD")).toEqual({ amount: "1.2", currency: "USD" })
   })
-
   ;[-0.35, Number.NaN, Number.POSITIVE_INFINITY].forEach((amount) => {
     test(`rejects an unrepresentable direct cost of ${amount}`, () => {
       expect(() => Subagent.serializeDirectCost(amount, "USD")).toThrow()
@@ -216,6 +218,181 @@ describe("acp subagent snapshots", () => {
   })
 })
 
+describe("acp subagent subscriptions", () => {
+  test("registers before snapshot reads and reconciles an event omitted by the in-flight snapshot", async () => {
+    const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+    const child = session({
+      id: "child",
+      parentID: "root",
+      directory: "/workspace/child",
+      created: 2,
+      updated: 2,
+    })
+    const childrenStarted = Promise.withResolvers<void>()
+    const releaseChildren = Promise.withResolvers<void>()
+    const harness = await subscriptionHarness({
+      sessions: [root],
+      status: { root: { type: "busy" } },
+      blockChildren: { rootSessionId: "root", started: childrenStarted, release: releaseChildren.promise },
+    })
+    const updates: Subagent.Update[] = []
+    const notified = Promise.withResolvers<void>()
+    const order: string[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        updates.push(update)
+        order.push("update")
+        notified.resolve()
+      },
+    })
+
+    const subscribing = service.subscribe({ rootSessionId: "root" })
+    await childrenStarted.promise
+    const dispatched = harness.afterNextEvent(() => releaseChildren.resolve())
+    harness.push(sessionChanged("session.created", child))
+
+    const snapshot = await subscribing
+    order.push("snapshot")
+    await dispatched
+    await notified.promise
+
+    expect(snapshot.nodes.map((node) => node.sessionId)).toEqual(["root"])
+    expect(order).toEqual(["snapshot", "update"])
+    expect(updates).toEqual([
+      {
+        generation: snapshot.generation,
+        revision: snapshot.revision + 1,
+        upsert: [
+          {
+            runId: "child",
+            sessionId: "child",
+            rootSessionId: "root",
+            parentSessionId: "root",
+            agent: "build",
+            title: "child",
+            phase: "unknown",
+            createdAt: "1970-01-01T00:00:00.002Z",
+            updatedAt: "1970-01-01T00:00:00.002Z",
+            cwd: "/workspace/child",
+          },
+        ],
+        removedSessionIds: [],
+      },
+    ])
+
+    service.close()
+    harness.close()
+  })
+
+  test("projects session changes as bounded successor updates for only the affected root", async () => {
+    const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+    const child = session({
+      id: "child",
+      parentID: "root",
+      directory: "/workspace/child",
+      created: 2,
+      updated: 2,
+    })
+    const other = session({ id: "other", directory: "/workspace/other", created: 3, updated: 3 })
+    const harness = await subscriptionHarness({
+      sessions: [root, child, other],
+      status: { root: { type: "busy" }, child: { type: "idle" }, other: { type: "idle" } },
+    })
+    const updates: Subagent.Update[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        updates.push(update)
+      },
+    })
+    const snapshot = await service.subscribe({})
+
+    const updated = { ...child, title: "renamed child", time: { ...child.time, updated: 4 } }
+    await harness.send(sessionChanged("session.updated", updated))
+
+    await harness.send(sessionStatus("child", { type: "busy" }))
+
+    await harness.send(sessionIdle("child"))
+
+    await harness.send(sessionError("child"))
+
+    await harness.send(sessionChanged("session.deleted", updated))
+
+    expect(updates.map((update) => update.revision)).toEqual([1, 2, 3, 4, 5])
+    expect(updates.every((update) => update.generation === snapshot.generation)).toBe(true)
+    expect(updates.slice(0, 4).map((update) => update.upsert.map((node) => node.sessionId))).toEqual([
+      ["child"],
+      ["child"],
+      ["child"],
+      ["child"],
+    ])
+    expect(updates.slice(0, 4).map((update) => update.upsert[0]?.phase)).toEqual([
+      "completed",
+      "running",
+      "completed",
+      "failed",
+    ])
+    expect(updates[0]?.upsert[0]?.title).toBe("renamed child")
+    expect(updates[4]).toEqual({
+      generation: snapshot.generation,
+      revision: 5,
+      upsert: [],
+      removedSessionIds: ["child"],
+    })
+    expect(updates.flatMap((update) => update.upsert).some((node) => node.sessionId === "other")).toBe(false)
+
+    service.close()
+    harness.close()
+  })
+
+  test("does not reuse a revision after notification failure", async () => {
+    const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+    const harness = await subscriptionHarness({ sessions: [root], status: { root: { type: "idle" } } })
+    const revisions: number[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        revisions.push(update.revision)
+        if (update.revision === 1) throw new Error("notification failed")
+      },
+    })
+    await service.subscribe({})
+
+    await harness.send(sessionStatus("root", { type: "busy" }))
+    await harness.send(sessionIdle("root"))
+
+    expect(revisions).toEqual([1, 2])
+
+    service.close()
+    harness.close()
+  })
+
+  test("unregisters on close and prevents later notifications", async () => {
+    const root = session({ id: "root", directory: "/workspace/root", created: 1, updated: 1 })
+    const harness = await subscriptionHarness({ sessions: [root], status: { root: { type: "idle" } } })
+    const updates: Subagent.Update[] = []
+    const service = Subagent.make({
+      sdk: harness.sdk,
+      events: harness.events,
+      notify: async (update) => {
+        updates.push(update)
+      },
+    })
+    await service.subscribe({})
+    service.close()
+
+    await harness.send(sessionStatus("root", { type: "busy" }))
+
+    expect(updates).toEqual([])
+
+    harness.close()
+  })
+})
+
 function recursiveSDK() {
   const sessions = [
     session({ id: "root-a", directory: "/workspace/root-a", cost: 1.2, created: 1, updated: 10 }),
@@ -332,6 +509,125 @@ function sessionError(sessionID: string): Event {
   return {
     id: `event-${sessionID}`,
     type: "session.error",
+    properties: { sessionID },
+  }
+}
+
+type EventEnvelope = { payload?: Event }
+
+async function subscriptionHarness(input: {
+  sessions: Session[]
+  status: Record<string, SessionStatus>
+  blockChildren?: { rootSessionId: string; started: PromiseWithResolvers<void>; release: Promise<void> }
+}) {
+  const queue: EventEnvelope[] = []
+  const waiters: Array<(value: EventEnvelope | undefined) => void> = []
+  const streamReady = Promise.withResolvers<void>()
+  let closed = false
+  let childrenBlocked = false
+
+  const stream = async function* (signal?: AbortSignal) {
+    streamReady.resolve()
+    while (!closed && !signal?.aborted) {
+      const queued = queue.shift()
+      if (queued) {
+        yield queued
+        continue
+      }
+      const next = await new Promise<EventEnvelope | undefined>((resolve) => {
+        waiters.push(resolve)
+        signal?.addEventListener("abort", () => resolve(undefined), { once: true })
+      })
+      if (!next) return
+      yield next
+    }
+  }
+  const sdk = {
+    global: {
+      event: (options?: { signal?: AbortSignal }) => Promise.resolve({ stream: stream(options?.signal) }),
+    },
+    session: {
+      list: (params?: { roots?: boolean }) =>
+        Promise.resolve({ data: params?.roots ? input.sessions.filter((item) => !item.parentID) : input.sessions }),
+      children: async ({ sessionID }: { sessionID: string }) => {
+        const data = input.sessions.filter((item) => item.parentID === sessionID)
+        if (input.blockChildren && !childrenBlocked && sessionID === input.blockChildren.rootSessionId) {
+          childrenBlocked = true
+          input.blockChildren.started.resolve()
+          await input.blockChildren.release
+        }
+        return { data }
+      },
+      status: () => Promise.resolve({ data: input.status }),
+    },
+  } as unknown as OpencodeClient
+  const events = new ACPEvent.Subscription({
+    sdk,
+    connection: { sessionUpdate: () => Promise.resolve() },
+    session: {
+      tryGet: () => Effect.succeed(undefined),
+    } as unknown as ACPSession.Interface,
+  })
+  events.start()
+  await streamReady.promise
+
+  const push = (event: Event) => {
+    const envelope = { payload: event }
+    const waiter = waiters.shift()
+    if (waiter) {
+      waiter(envelope)
+      return
+    }
+    queue.push(envelope)
+  }
+  const afterNextEvent = (after?: () => void) => {
+    const delivered = Promise.withResolvers<void>()
+    const remove = events.addListener(async () => {
+      after?.()
+      remove()
+      delivered.resolve()
+    })
+    return delivered.promise
+  }
+
+  return {
+    sdk,
+    events,
+    push,
+    afterNextEvent,
+    send: (event: Event) => {
+      const delivered = afterNextEvent()
+      push(event)
+      return delivered
+    },
+    close: () => {
+      closed = true
+      events.stop()
+      waiters.splice(0).forEach((resolve) => resolve(undefined))
+    },
+  }
+}
+
+function sessionChanged(type: "session.created" | "session.updated" | "session.deleted", info: Session): Event {
+  return {
+    id: `event-${type}-${info.id}`,
+    type,
+    properties: { sessionID: info.id, info },
+  }
+}
+
+function sessionStatus(sessionID: string, status: SessionStatus): Event {
+  return {
+    id: `event-status-${sessionID}`,
+    type: "session.status",
+    properties: { sessionID, status },
+  }
+}
+
+function sessionIdle(sessionID: string): Event {
+  return {
+    id: `event-idle-${sessionID}`,
+    type: "session.idle",
     properties: { sessionID },
   }
 }

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -56,6 +56,26 @@ describe("acp subagent wire contract", () => {
     expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
   })
 
+  test("rejects a snapshot without a parentless root", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes = []
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
+  test("rejects a snapshot with multiple parentless roots", () => {
+    const snapshot = structuredClone(fixture.snapshot)
+    snapshot.nodes.push({
+      runId: "other-root",
+      sessionId: "other-root",
+      rootSessionId: "other-root",
+      phase: "completed",
+      cwd: "/workspace/other-repo",
+    })
+
+    expect(() => Subagent.decodeSnapshot(snapshot)).toThrow()
+  })
+
   test("rejects a ninth descendant depth", () => {
     expect(() =>
       Subagent.decodeSnapshot({

--- a/packages/opencode/test/acp/subagent.test.ts
+++ b/packages/opencode/test/acp/subagent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { Event, OpencodeClient, Session, SessionStatus } from "@opencode-ai/sdk/v2"
 import { Subagent } from "@/acp/subagent"
 
 const fixture = await Bun.file(`${import.meta.dir}/fixtures/subagents-v1.json`).json()
@@ -134,3 +135,203 @@ describe("acp subagent wire contract", () => {
     ).toThrow()
   })
 })
+
+describe("acp subagent snapshots", () => {
+  test("reads every root graph with direct costs and authoritative phases", async () => {
+    const fixture = recursiveSDK()
+    const service = Subagent.make({ sdk: fixture.sdk })
+    await service.handle(sessionError("child-completed"))
+
+    const snapshot = await service.list({})
+
+    expect(snapshot.nodes.map((node) => node.sessionId)).toEqual([
+      "root-a",
+      "child-running",
+      "grandchild-completed",
+      "child-completed",
+      "root-b",
+    ])
+    expect(snapshot.nodes.map((node) => node.runId)).toEqual([
+      "root-a",
+      "child-running",
+      "grandchild-completed",
+      "child-completed",
+      "root-b",
+    ])
+    expect(snapshot.nodes.map((node) => [node.sessionId, node.rootSessionId, node.parentSessionId])).toEqual([
+      ["root-a", "root-a", undefined],
+      ["child-running", "root-a", "root-a"],
+      ["grandchild-completed", "root-a", "child-running"],
+      ["child-completed", "root-a", "root-a"],
+      ["root-b", "root-b", undefined],
+    ])
+    expect(snapshot.nodes.map((node) => [node.sessionId, node.cwd])).toEqual([
+      ["root-a", "/workspace/root-a"],
+      ["child-running", "/workspace/child-running"],
+      ["grandchild-completed", "/workspace/grandchild-completed"],
+      ["child-completed", "/workspace/child-completed"],
+      ["root-b", "/workspace/root-b"],
+    ])
+    expect(snapshot.nodes.map((node) => [node.sessionId, node.phase])).toEqual([
+      ["root-a", "running"],
+      ["child-running", "running"],
+      ["grandchild-completed", "completed"],
+      ["child-completed", "failed"],
+      ["root-b", "completed"],
+    ])
+    expect(snapshot.nodes.find((node) => node.sessionId === "root-a")?.directCost).toEqual({
+      amount: "1.2",
+      currency: "USD",
+    })
+    expect(snapshot.nodes.find((node) => node.sessionId === "child-running")?.directCost).toEqual({
+      amount: "0.35",
+      currency: "USD",
+    })
+    expect(fixture.statusReads).toBe(1)
+  })
+
+  test("filters snapshots to the requested root graph", async () => {
+    const service = Subagent.make({ sdk: recursiveSDK().sdk })
+
+    const snapshot = await service.list({ rootSessionId: "root-a" })
+
+    expect(snapshot.nodes.map((node) => node.sessionId)).toEqual([
+      "root-a",
+      "child-running",
+      "grandchild-completed",
+      "child-completed",
+    ])
+  })
+
+  test("rejects a ninth descendant while reading the SDK graph", async () => {
+    const service = Subagent.make({ sdk: chainSDK(9) })
+
+    await expect(service.list({})).rejects.toThrow("subagent depth must not exceed 8")
+  })
+
+  test("rejects a root with 301 descendants while reading the SDK graph", async () => {
+    const service = Subagent.make({ sdk: descendantSDK(301) })
+
+    await expect(service.list({})).rejects.toThrow("subagent descendants must not exceed 300")
+  })
+})
+
+function recursiveSDK() {
+  const sessions = [
+    session({ id: "root-a", directory: "/workspace/root-a", cost: 1.2, created: 1, updated: 10 }),
+    session({
+      id: "child-running",
+      parentID: "root-a",
+      directory: "/workspace/child-running",
+      cost: 0.35,
+      created: 2,
+      updated: 9,
+    }),
+    session({
+      id: "grandchild-completed",
+      parentID: "child-running",
+      directory: "/workspace/grandchild-completed",
+      cost: 0.1,
+      created: 3,
+      updated: 8,
+    }),
+    session({
+      id: "child-completed",
+      parentID: "root-a",
+      directory: "/workspace/child-completed",
+      cost: 0.5,
+      created: 4,
+      updated: 7,
+    }),
+    session({ id: "root-b", directory: "/workspace/root-b", cost: 2, created: 5, updated: 6 }),
+  ]
+  const status: Record<string, SessionStatus> = {
+    "root-a": { type: "busy" },
+    "child-running": { type: "retry", attempt: 1, message: "retry", next: 11 },
+    "grandchild-completed": { type: "idle" },
+    "child-completed": { type: "busy" },
+    "root-b": { type: "idle" },
+  }
+  let statusReads = 0
+
+  return {
+    sdk: sdk({ sessions, status, onStatus: () => statusReads++ }),
+    get statusReads() {
+      return statusReads
+    },
+  }
+}
+
+function chainSDK(descendantDepth: number) {
+  const sessions = Array.from({ length: descendantDepth + 1 }, (_, index) =>
+    session({
+      id: `node-${index}`,
+      ...(index > 0 ? { parentID: `node-${index - 1}` } : {}),
+      directory: `/workspace/node-${index}`,
+      created: index,
+      updated: index,
+    }),
+  )
+  return sdk({ sessions, status: Object.fromEntries(sessions.map((item) => [item.id, { type: "idle" }])) })
+}
+
+function descendantSDK(count: number) {
+  const sessions = [
+    session({ id: "root", directory: "/workspace/root", created: 0, updated: 0 }),
+    ...Array.from({ length: count }, (_, index) =>
+      session({
+        id: `child-${index}`,
+        parentID: "root",
+        directory: `/workspace/child-${index}`,
+        created: index + 1,
+        updated: index + 1,
+      }),
+    ),
+  ]
+  return sdk({ sessions, status: Object.fromEntries(sessions.map((item) => [item.id, { type: "idle" }])) })
+}
+
+function sdk(input: { sessions: Session[]; status: Record<string, SessionStatus>; onStatus?: () => void }) {
+  return {
+    session: {
+      list: (params?: { roots?: boolean }) =>
+        Promise.resolve({ data: params?.roots ? input.sessions.filter((item) => !item.parentID) : input.sessions }),
+      children: ({ sessionID }: { sessionID: string }) =>
+        Promise.resolve({ data: input.sessions.filter((item) => item.parentID === sessionID) }),
+      status: () => {
+        input.onStatus?.()
+        return Promise.resolve({ data: input.status })
+      },
+    },
+  } as unknown as Pick<OpencodeClient, "session">
+}
+
+function session(input: {
+  id: string
+  directory: string
+  created: number
+  updated: number
+  parentID?: string
+  cost?: number
+}): Session {
+  return {
+    id: input.id,
+    slug: input.id,
+    projectID: "project",
+    directory: input.directory,
+    ...(input.parentID ? { parentID: input.parentID } : {}),
+    ...(input.cost === undefined ? {} : { cost: input.cost }),
+    title: input.id,
+    agent: "build",
+    version: "1",
+    time: { created: input.created, updated: input.updated },
+  }
+}
+
+function sessionError(sessionID: string): Event {
+  return {
+    id: `event-${sessionID}`,
+    type: "session.error",
+    properties: { sessionID },
+  }
+}

--- a/packages/opencode/test/cli/acp/subagents.test.ts
+++ b/packages/opencode/test/cli/acp/subagents.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect } from "bun:test"
+import type { LoadSessionResponse, PromptResponse } from "@agentclientprotocol/sdk"
+import { Duration, Effect } from "effect"
+import { Subagent } from "@/acp/subagent"
+import { cliIt } from "../../lib/cli-process"
+import { createAcpClient, expectOk } from "./acp-test-client"
+import { expectErrorCode, initialize, newSession, verifierConfig } from "./helpers"
+
+type Response<T = unknown> = {
+  readonly jsonrpc: "2.0"
+  readonly id: number
+  readonly result?: T
+  readonly error?: unknown
+}
+
+type Notification<T = unknown> = {
+  readonly jsonrpc: "2.0"
+  readonly method: string
+  readonly params?: T
+}
+
+describe("opencode acp subagent extension subprocess", () => {
+  cliIt.live(
+    "lists, subscribes, updates, and loads a child transcript over ndjson",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const handle = yield* opencode.acp({
+          env: {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify({
+              ...verifierConfig(llm.url),
+              permission: { task: "allow" },
+            }),
+          },
+        })
+        const acp = createAcpClient(handle)
+        const initialized = yield* initialize(acp)
+        expect(initialized._meta).toEqual({
+          "opencode.dev/subagents": {
+            version: 1,
+            list: true,
+            subscribe: true,
+          },
+        })
+
+        const empty = Subagent.decodeSnapshot(expectOk(yield* acp.request("_opencode/subagents/list", {})))
+        expect(empty.nodes).toEqual([])
+
+        const root = yield* newSession(acp, home)
+        const listed = Subagent.decodeSnapshot(expectOk(yield* acp.request("_opencode/subagents/list", {})))
+        expect(listed.nodes).toHaveLength(1)
+        expect(listed.nodes[0]).toMatchObject({
+          sessionId: root.sessionId,
+          rootSessionId: root.sessionId,
+        })
+        const rootCwd = listed.nodes[0]?.cwd
+        expect(rootCwd).toBeDefined()
+        if (!rootCwd) return
+
+        const missing = yield* acp.request("_opencode/subagents/missing", {})
+        expectErrorCode(missing.error, -32601)
+
+        yield* llm.tool("task", {
+          description: "inspect child",
+          prompt: "return the child transcript fixture",
+          subagent_type: "general",
+        })
+        yield* llm.text("child transcript fixture")
+        yield* llm.text("parent complete")
+
+        yield* handle.send({
+          jsonrpc: "2.0",
+          id: 100,
+          method: "_opencode/subagents/subscribe",
+          params: { rootSessionId: root.sessionId },
+        })
+        yield* handle.send({
+          jsonrpc: "2.0",
+          id: 101,
+          method: "session/prompt",
+          params: {
+            sessionId: root.sessionId,
+            prompt: [{ type: "text", text: "delegate this task" }],
+          },
+        })
+
+        const subscribed = yield* subscribeBeforeUpdate(handle.receive, 100, 101)
+        expect(subscribed.response.error).toBeUndefined()
+        Subagent.decodeSnapshot(subscribed.response.result)
+
+        const observed = yield* collectPromptAndChildUpdate(handle.receive, 101, root.sessionId, subscribed.prompt)
+        expect(observed.prompt.error).toBeUndefined()
+        expect(observed.prompt.result).toMatchObject({ stopReason: "end_turn" })
+        const update = Subagent.decodeUpdate(observed.update.params)
+        const child = update.upsert.find((node) => node.parentSessionId === root.sessionId)
+        expect(child).toBeDefined()
+        if (!child) return
+        expect(child.cwd).toBe(rootCwd)
+
+        yield* handle.send({
+          jsonrpc: "2.0",
+          id: 102,
+          method: "session/load",
+          params: {
+            cwd: child.cwd,
+            sessionId: child.sessionId,
+            mcpServers: [],
+          },
+        })
+        const loaded = yield* collectLoadAndTranscript(handle.receive, 102, child.sessionId)
+        expect(loaded.response.error).toBeUndefined()
+        expect(loaded.response.result?.configOptions).toBeDefined()
+        expect(loaded.transcript).toBe("child transcript fixture")
+      }),
+    60_000,
+  )
+})
+
+function subscribeBeforeUpdate(receive: Effect.Effect<unknown>, subscribeId: number, promptId: number) {
+  return Effect.gen(function* () {
+    let prompt: Response<PromptResponse> | undefined
+    while (true) {
+      const message = yield* receive.pipe(Effect.timeout(Duration.seconds(15)))
+      if (isNotification(message) && message.method === "_opencode/subagents/update") {
+        return yield* Effect.die(new Error("subagent update arrived before subscribe response"))
+      }
+      if (isResponse<PromptResponse>(message) && message.id === promptId) prompt = message
+      if (isResponse<Subagent.Snapshot>(message) && message.id === subscribeId) {
+        return { response: message, prompt }
+      }
+    }
+  })
+}
+
+function collectPromptAndChildUpdate(
+  receive: Effect.Effect<unknown>,
+  id: number,
+  rootSessionId: string,
+  initialPrompt?: Response<PromptResponse>,
+) {
+  return Effect.gen(function* () {
+    let prompt = initialPrompt
+    let update: Notification<Subagent.Update> | undefined
+    while (!prompt || !update) {
+      const message = yield* receive.pipe(Effect.timeout(Duration.seconds(15)))
+      if (isResponse<PromptResponse>(message) && message.id === id) prompt = message
+      if (
+        isNotification<Subagent.Update>(message) &&
+        message.method === "_opencode/subagents/update" &&
+        message.params?.upsert.some((node) => node.parentSessionId === rootSessionId)
+      ) {
+        update = message
+      }
+    }
+    return { prompt, update }
+  })
+}
+
+function collectLoadAndTranscript(receive: Effect.Effect<unknown>, id: number, sessionId: string) {
+  return Effect.gen(function* () {
+    let response: Response<LoadSessionResponse> | undefined
+    let transcript: string | undefined
+    while (!response || !transcript) {
+      const message = yield* receive.pipe(Effect.timeout(Duration.seconds(15)))
+      if (isResponse<LoadSessionResponse>(message) && message.id === id) response = message
+      if (
+        isNotification<{
+          sessionId: string
+          update: { sessionUpdate: string; content?: { type: string; text?: string } }
+        }>(message) &&
+        message.method === "session/update" &&
+        message.params?.sessionId === sessionId &&
+        message.params.update.sessionUpdate === "agent_message_chunk"
+      ) {
+        transcript = message.params.update.content?.text
+      }
+    }
+    return { response, transcript }
+  })
+}
+
+function isResponse<T>(input: unknown): input is Response<T> {
+  return !!input && typeof input === "object" && "jsonrpc" in input && "id" in input
+}
+
+function isNotification<T>(input: unknown): input is Notification<T> {
+  return !!input && typeof input === "object" && "jsonrpc" in input && "method" in input && !("id" in input)
+}


### PR DESCRIPTION
### Issue for this PR

Closes #21802

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP currently loses Task subagent activity because its session manager only knows root sessions. This routes descendant events and permission requests through the root session, and adds an opt-in, versioned ACP extension for clients that need the recursive child-session graph.

Standard ACP behavior remains compatible: `session/list` stays root-only and `session/load` remains the transcript API. The extension publishes bounded status, cwd/repository, and direct-cost metadata with ordered snapshot/update revisions.

### How did you verify your code works?

- `bunx bun@1.3.14 test --timeout 30000 --only-failures test/acp test/cli/acp` — 252 passed
- `bunx bun@1.3.14 run typecheck`
- CLI integration tests launch `opencode acp`, negotiate the extension, subscribe, create a child, and verify the ordered update.

### Screenshots / recordings

Not applicable; this changes the ACP server protocol and has no OpenCode UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
