### PR TITLE
[FEATURE]: Add welcome_message config option for TUI startup screen

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -102,6 +102,9 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   plugins: ConfigPlugin.Plugins.pipe(Schema.optional).annotate({
     description: "Ordered external plugin packages to load",
   }),
+  welcome_message: Schema.String.pipe(Schema.optional).annotate({
+    description: "Custom message displayed on the TUI home screen below the logo",
+  }),
   experimental: ConfigExperimental.Experimental.pipe(Schema.optional),
   providers: Schema.Record(Schema.String, ConfigProvider.Info).pipe(Schema.optional),
 }) {}

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -166,6 +166,9 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  welcome_message: Schema.optional(Schema.String).annotate({
+    description: "Custom message displayed on the TUI home screen below the logo",
+  }),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -30,6 +30,7 @@ export function Home() {
   const editor = useEditorContext()
   const dimensions = useTerminalDimensions()
   const tuiConfig = useTuiConfig()
+  const welcomeMessage = createMemo(() => sync.data.config.welcome_message)
   const promptMaxWidth = createMemo(() => {
     const configured = tuiConfig.prompt?.max_width
     if (configured === "auto") return Math.max(75, Math.floor(dimensions().width * 0.7))
@@ -83,6 +84,11 @@ export function Home() {
             <Prompt ref={bind} right={<pluginRuntime.Slot name="home_prompt_right" />} placeholders={placeholder} />
           </pluginRuntime.Slot>
         </box>
+        {welcomeMessage() && (
+          <box flexDirection="column" alignItems="center" paddingTop={1} flexShrink={0}>
+            <text color="secondary">{welcomeMessage()}</text>
+          </box>
+        )}
         <pluginRuntime.Slot name="home_bottom" />
         <box flexGrow={1} minHeight={0} />
         <Toast />


### PR DESCRIPTION
## Problem

Users want to display custom text (e.g., a quote, greeting, or reminder) on the TUI startup screen below the logo/prompt, but there is no config option to do so.

## Proposed Solution

Add a `welcome_message` field to `opencode.json` config:

```json
{
  "welcome_message": "Fly like a butterfly, sting like a bee"
}
```

This text renders on the home screen between the prompt and the footer.

## Use Cases

- Personal quotes or mottos
- Team reminders or conventions
- Project-specific context
- Fun个性化 touches

## Changes

| File | Change |
|------|--------|
| `packages/core/src/config.ts` | Added `welcome_message` field to current config schema |
| `packages/core/src/v1/config/config.ts` | Added `welcome_message` field to V1 config schema |
| `packages/tui/src/routes/home.tsx` | Renders message below prompt when set |

## Testing

1. Add `"welcome_message": "Your message"` to `opencode.json`
2. Run `opencode` TUI
3. Confirm message appears below the prompt on the home screen

Closes #39483
