### PR TITLE
refactor: Use $HOME in shell rc for better dotfile management

### DIFF
--- a/install
+++ b/install
@@ -411,28 +411,28 @@ if [[ "$no_modify_path" != "true" ]]; then
 
     if [[ -z $config_file ]]; then
         print_message warning "No config file found for $current_shell. You may need to manually add to PATH:"
-        print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+        print_message info "  export PATH=\$HOME/.opencode/bin:\$PATH"
     elif [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
         case $current_shell in
             fish)
-                add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
+                add_to_path "$config_file" "fish_add_path \$HOME/.opencode/bin"
             ;;
             zsh)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                add_to_path "$config_file" "export PATH=\$HOME/.opencode/bin:\$PATH"
             ;;
             bash)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                add_to_path "$config_file" "export PATH=\$HOME/.opencode/bin:\$PATH"
             ;;
             ash)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                add_to_path "$config_file" "export PATH=\$HOME/.opencode/bin:\$PATH"
             ;;
             sh)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                add_to_path "$config_file" "export PATH=\$HOME/.opencode/bin:\$PATH"
             ;;
             *)
                 export PATH=$INSTALL_DIR:$PATH
                 print_message warning "Manually add the directory to $config_file (or similar):"
-                print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+                print_message info "  export PATH=\$HOME/.opencode/bin:\$PATH"
             ;;
         esac
     fi


### PR DESCRIPTION
### Issue for this PR

Closes #39329

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It uses literally `$HOME` instead of the expanded home in the shell rc file for easier dot file management (for example, my vms have `cloud` as username while my laptop has `lquenti`.

### How did you verify your code works?
- Startup basic ubuntu container (with git and curl)
- `git clone` the repo
- `bash install`
- verify the bashrc manually

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._