### PR TITLE
fix(app): show task list scrollbar

### DIFF
--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -224,7 +224,7 @@ function TodoList(props: { todos: Todo[] }) {
   return (
     <div class="relative">
       <div
-        class="px-3 pb-11 flex flex-col gap-1.5 max-h-42 overflow-y-auto no-scrollbar"
+        class="px-3 pb-11 flex flex-col gap-1.5 max-h-42 overflow-y-auto"
         style={{ "overflow-anchor": "none" }}
         onScroll={(e) => {
           setStore("stuck", e.currentTarget.scrollTop > 0)


### PR DESCRIPTION
### Issue for this PR

Closes #39528

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The task list can scroll when its content overflows, but the `no-scrollbar` class hides the scrollbar.

This PR removes `no-scrollbar` from the task list's scroll container, allowing the existing platform scrollbar to remain visible without changing the scrolling behavior.

### How did you verify your code works?

- Tested the task list locally in the desktop app with enough items to overflow.
- Verified that the list remains scrollable and the scrollbar is visible.
- Ran `bun run --cwd packages/app typecheck`.
- Passed the repository pre-push typecheck.

### Screenshots / recordings

Attached a recording showing the task list scrollbar when the content overflows.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


https://github.com/user-attachments/assets/5ca0be0a-d851-439f-9375-434a99dc47da
