### PR TITLE
fix(core): align ChatGPT OAuth context limits

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -14,6 +14,7 @@ import { ConfigExternalPlugin } from "../config/plugin/external"
 import { ConfigProviderPlugin } from "../config/plugin/provider"
 import { ConfigReferencePlugin } from "../config/plugin/reference"
 import { ConfigSkillPlugin } from "../config/plugin/skill"
+import { Credential } from "../credential"
 import { EventV2 } from "../event"
 import { FileSystem } from "../filesystem"
 import { FSUtil } from "../fs-util"
@@ -39,6 +40,7 @@ export type Requirements =
   | Catalog.Service
   | CommandV2.Service
   | Config.Service
+  | Credential.Service
   | EventV2.Service
   | FileSystem.Service
   | FSUtil.Service
@@ -68,6 +70,7 @@ const layer = Layer.effectDiscard(
     const integration = yield* Integration.Service
     const agents = yield* AgentV2.Service
     const config = yield* Config.Service
+    const credential = yield* Credential.Service
     const location = yield* Location.Service
     const modelsDev = yield* ModelsDev.Service
     const npm = yield* Npm.Service
@@ -90,6 +93,7 @@ const layer = Layer.effectDiscard(
               Effect.provideService(Integration.Service, integration),
               Effect.provideService(AgentV2.Service, agents),
               Effect.provideService(Config.Service, config),
+              Effect.provideService(Credential.Service, credential),
               Effect.provideService(Location.Service, location),
               Effect.provideService(ModelsDev.Service, modelsDev),
               Effect.provideService(Npm.Service, npm),
@@ -139,6 +143,7 @@ export const node = makeLocationNode({
     Integration.node,
     AgentV2.node,
     Config.node,
+    Credential.node,
     Location.node,
     ModelsDev.node,
     Npm.node,

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -1,9 +1,10 @@
 import { createServer } from "node:http"
 import type { IntegrationOAuthMethodRegistration } from "@opencode-ai/plugin/v2/effect/integration"
 import { define } from "@opencode-ai/plugin/v2/effect/plugin"
-import { Deferred, Effect } from "effect"
+import { Deferred, Effect, Stream } from "effect"
 import type { Scope } from "effect"
 import { Credential } from "../../credential"
+import { EventV2 } from "../../event"
 import { InstallationVersion } from "../../installation/version"
 import { Integration } from "../../integration"
 import { ModelV2 } from "../../model"
@@ -154,15 +155,35 @@ const headless = {
 export const OpenAIPlugin = define({
   id: "openai",
   effect: Effect.fn(function* (ctx) {
+    const credentials = yield* Credential.Service
+    const events = yield* EventV2.Service
     yield* ctx.integration.transform((draft) => {
       draft.method.update(browser)
       draft.method.update(headless)
     })
     yield* ctx.catalog.transform(
       Effect.fn(function* (evt) {
+        const connection = yield* ctx.integration.connection.active("openai")
+        const credential =
+          connection?.type === "credential" ? yield* credentials.get(Credential.ID.make(connection.id)) : undefined
         for (const item of evt.provider.list()) {
           if (item.provider.api.type !== "aisdk") continue
           if (item.provider.api.package !== "@ai-sdk/openai") continue
+          if (item.provider.id === "openai" && credential?.value.type === "oauth") {
+            // ChatGPT's Codex backend exposes smaller windows than the public API catalog.
+            // Keep these limits aligned with the V1 Codex OAuth provider transform.
+            for (const model of item.models.values()) {
+              const limit = model.id.includes("gpt-5.5")
+                ? { context: 400_000, input: 272_000, output: 128_000 }
+                : model.id.includes("gpt-5.6")
+                  ? { context: 500_000, input: 372_000, output: 128_000 }
+                  : undefined
+              if (!limit) continue
+              evt.model.update(item.provider.id, model.id, (draft) => {
+                draft.limit = limit
+              })
+            }
+          }
           if (!item.models.has(ModelV2.ID.make("gpt-5-chat-latest"))) continue
           evt.model.update(item.provider.id, ModelV2.ID.make("gpt-5-chat-latest"), (model) => {
             // OpenAIPlugin sends OpenAI models through Responses; this alias is a
@@ -171,6 +192,11 @@ export const OpenAIPlugin = define({
           })
         }
       }),
+    )
+    yield* events.subscribe(Integration.Event.ConnectionUpdated).pipe(
+      Stream.filter((event) => event.data.integrationID === Integration.ID.make("openai")),
+      Stream.runForEach(() => ctx.catalog.reload()),
+      Effect.forkScoped({ startImmediately: true }),
     )
     yield* ctx.aisdk.sdk(
       Effect.fn(function* (evt) {

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from "bun:test"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { Effect } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { Credential } from "@opencode-ai/core/credential"
 import { Integration } from "@opencode-ai/core/integration"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { PluginV2 } from "@opencode-ai/core/plugin"
@@ -150,6 +151,76 @@ describe("OpenAIPlugin", () => {
       expect(
         required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5-chat-latest"))).enabled,
       ).toBe(false)
+    }),
+  )
+
+  it.effect("tracks ChatGPT OAuth context limits", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const credentials = yield* Credential.Service
+      yield* catalog.transform((catalog) => {
+        const item = ProviderV2.Info.make({
+          ...ProviderV2.Info.empty(ProviderV2.ID.openai),
+          api: { type: "aisdk", package: "@ai-sdk/openai" },
+        })
+        catalog.provider.update(item.id, (draft) => {
+          draft.api = item.api
+        })
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.5"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
+        })
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.6-sol"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
+        })
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.7-pro"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
+        })
+      })
+      yield* credentials.create({
+        integrationID: Integration.ID.make("openai"),
+        value: Credential.Key.make({ type: "key", key: "key" }),
+      })
+      yield* addPlugin()
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6-sol"))).limit).toEqual({
+        context: 1_050_000,
+        input: 922_000,
+        output: 128_000,
+      })
+
+      const oauth = yield* credentials.create({
+        integrationID: Integration.ID.make("openai"),
+        value: Credential.OAuth.make({
+          type: "oauth",
+          methodID: Integration.MethodID.make("chatgpt-browser"),
+          refresh: "refresh",
+          access: "access",
+          expires: 0,
+        }),
+      })
+      yield* catalog.reload()
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5"))).limit).toEqual({
+        context: 400_000,
+        input: 272_000,
+        output: 128_000,
+      })
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6-sol"))).limit).toEqual({
+        context: 500_000,
+        input: 372_000,
+        output: 128_000,
+      })
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.7-pro"))).limit).toEqual({
+        context: 1_050_000,
+        input: 922_000,
+        output: 128_000,
+      })
+
+      yield* credentials.remove(oauth.id)
+      yield* catalog.reload()
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6-sol"))).limit).toEqual({
+        context: 1_050_000,
+        input: 922_000,
+        output: 128_000,
+      })
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #38851

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Applies V1's ChatGPT OAuth-specific GPT-5.5/5.6 context limits in V2. Public API-key limits and other models remain unchanged. The catalog reloads when the OpenAI connection changes.

ChatGPT's Codex backend exposes smaller windows than Models.dev's public API catalog. Without this overlay, provider overflow recovery compacts GPT-5.6 Sol near 372k while the TUI reports about 35% of 1.05M.

Catalog inspection reads stored credential type without refreshing tokens, so token expiry or refresh failure cannot alter model metadata.

### How did you verify your code works?

- focused OpenAI plugin tests: 8 pass
- full Core suite: 1081 pass
- Core typecheck
- pre-push monorepo typecheck: 30 packages

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
