### PR TITLE
feat(tui): simulate tab lifecycle in playground

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -327,7 +327,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                               <TuiStartupProvider
                                 value={{
                                   initialRoute: process.env.OPENCODE_SCRAP
-                                    ? { type: "plugin", id: "scrap", name: "scrap" }
+                                    ? { type: "plugin", id: "opencode.scrap", name: "scrap" }
                                     : process.env.OPENCODE_ROUTE
                                       ? JSON.parse(process.env.OPENCODE_ROUTE)
                                       : undefined,

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1,5 +1,5 @@
 import { RGBA, TextAttributes } from "@opentui/core"
-import { For, Show, createEffect, createMemo, createSignal } from "solid-js"
+import { For, Show, createComputed, createEffect, createMemo, createSignal, untrack } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useConfig } from "../config"
 import { useSessionTabs } from "../context/session-tabs"
@@ -7,10 +7,11 @@ import { useTheme, useThemes } from "../context/theme"
 import {
   adaptiveSessionTabLayout,
   sessionTabComplete,
-  SESSION_TAB_OVERFLOW_WIDTH,
+  seedSessionTabMotion,
+  sessionTabOverflowWidth,
   type SessionTabUnread,
 } from "../context/session-tabs-model"
-import { createAnimatable, spring } from "../ui/animation"
+import { createAnimatable, spring, tween } from "../ui/animation"
 import { Locale } from "../util/locale"
 import { stringWidth } from "../util/string-width"
 import { TabPulse } from "./tab-pulse"
@@ -20,7 +21,7 @@ type ContextController = ReturnType<typeof useSessionTabs>
 export type SessionTabsStatus = Omit<ReturnType<ContextController["status"]>, "unread"> & {
   unread: SessionTabUnread | undefined
 }
-export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close"> & {
+export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
   status(sessionID: string): SessionTabsStatus
 }
 
@@ -32,12 +33,14 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const [hovered, setHovered] = createSignal<string>()
+  const [dragging, setDragging] = createSignal<string>()
+  let strip: { screenX: number } | undefined
   const hueStep = () => (mode() === "light" ? 800 : 200)
   const accent = () => theme.hue.accent[hueStep()]
-  const activeNumber = () => tint(theme.hue.interactive[hueStep()], theme.background.default, 0.25)
+  const activeNumber = () => theme.hue.interactive[hueStep()]
   const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
   const activeID = createMemo(tabs.current)
-  const items = tabs.tabs
+  const items = () => tabs.tabs()
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
     adaptiveSessionTabLayout(items(), activeID(), dimensions().width, previous?.start),
   )
@@ -73,13 +76,27 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   let signature = ""
   let total = 0
 
-  createEffect(() => {
+  // createComputed runs before render effects, so seeded widths are visible on the first frame
+  // of a membership change instead of flashing the final layout.
+  createComputed(() => {
     const next = targets()
     const nextSignature = identity()
-    const reset = (signature && signature !== nextSignature) || (total && total !== layout().total)
+    const changed = Boolean(signature) && signature !== nextSignature
+    const resized = Boolean(total) && total !== layout().total
+    const previous = signature ? signature.split(":") : []
     signature = nextSignature
     total = layout().total
-    if (reset) return motion.jump(next)
+    if (!changed && !resized) return motion.animate(next)
+    // Identity-stable total changes are terminal resizes and still jump.
+    if (!changed) return motion.jump(next)
+    const seeded = seedSessionTabMotion(
+      previous,
+      layout().tabs.map((tab) => tab.sessionID),
+      untrack(motion.value),
+      next,
+    )
+    if (!seeded) return motion.jump(next)
+    motion.jump(seeded)
     motion.animate(next)
   })
 
@@ -87,7 +104,9 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
     const current = signature === identity() && total === layout().total ? motion.value() : targets()
     const widths = current.widths.map((width) => Math.max(1, Math.round(width)))
     const active = layout().tabs.findIndex((tab) => tab.sessionID === activeID())
-    if (active !== -1) widths[active]! += layout().total - widths.reduce((sum, width) => sum + width, 0)
+    const remainder = layout().total - widths.reduce((sum, width) => sum + width, 0)
+    // Absorb only rounding slack; membership animations leave a real gap while widths grow into place.
+    if (active !== -1 && Math.abs(remainder) <= layout().tabs.length) widths[active]! += remainder
     return new Map(
       layout().tabs.map((tab, index) => [
         tab.sessionID,
@@ -100,8 +119,21 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
     )
   })
 
+  // Map an absolute pointer column to the items index of the visible slot beneath it.
+  const slotAt = (x: number) => {
+    if (!strip) return undefined
+    const stripX = x - strip.screenX
+    let edge = layout().before > 0 ? sessionTabOverflowWidth(layout().before) : 0
+    for (const [index, width] of layout().widths.entries()) {
+      edge += width
+      if (stripX < edge) return layout().before + index
+    }
+    return layout().before + layout().widths.length - 1
+  }
+
   return (
     <box
+      ref={(element) => (strip = element)}
       height={1}
       flexShrink={0}
       position="relative"
@@ -127,7 +159,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
       }}
     >
       <Show when={layout().before > 0}>
-        <text width={SESSION_TAB_OVERFLOW_WIDTH} fg={theme.text.subdued}>
+        <text width={sessionTabOverflowWidth(layout().before)} fg={theme.text.subdued} selectable={false}>
           ‹{layout().before}
         </text>
       </Show>
@@ -138,21 +170,53 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
           const width = () => visuals().get(tab.sessionID)?.width ?? 1
           const selection = () => visuals().get(tab.sessionID)?.selection ?? Number(selected())
           const activity = () => visuals().get(tab.sessionID)?.activity ?? Number(status().complete)
+          const dragged = () => dragging() === tab.sessionID
           const background = () => {
-            const base =
-              hovered() === tab.sessionID && !selected()
-                ? theme.background.action.primary.hovered
-                : theme.background.default
-            return tint(base, theme.raise(theme.background.surface.offset), selection())
+            const lifted = (hovered() === tab.sessionID || dragged()) && !selected()
+            const base = lifted ? theme.background.action.primary.hovered : theme.background.default
+            // A dragged tab lifts to full selected elevation while it is held.
+            return tint(base, theme.raise(theme.background.surface.offset), dragged() ? 1 : selection())
           }
           const pulseBackground = () => background()
           const pulseColor = () => tint(pulseBackground(), theme.text.default, 0.45)
+          const glowColor = () => {
+            if (status().attention) return theme.text.feedback.warning.default
+            if (status().unread === "error") return theme.text.feedback.error.default
+            return accent()
+          }
+          const glows = () => !selected() && (status().attention || (!status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
-          const availableTitleWidth = () => Math.max(1, width() - 3)
+          let currentTitle = title()
+          const [outgoingTitle, setOutgoingTitle] = createSignal<string>()
+          const wipe = createAnimatable({ front: 1 }, { enabled: animations, transition: tween({ duration: 0.3 }) })
+          createEffect(() => {
+            const next = title()
+            if (next === currentTitle) return
+            setOutgoingTitle(currentTitle)
+            currentTitle = next
+            wipe.jump({ front: 0 })
+            wipe.animate({ front: 1 })
+          })
+          const tabNumber = () => items().findIndex((item) => item.sessionID === tab.sessionID) + 1
+          // The number cell keeps one trailing space, even for double-digit tabs.
+          const numberWidth = () => String(tabNumber()).length + 1
+          // Hovering reveals the close mark, so the title's right bound shifts left of it.
+          const availableTitleWidth = () =>
+            Math.max(1, width() - 1 - numberWidth() - (hovered() === tab.sessionID ? 2 : 0))
           const visibleTitle = createMemo(() => Locale.takeWidth(title(), availableTitleWidth()))
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
-          const fadeWidth = () => (hovered() === tab.sessionID ? 6 : 4)
-          const fadedTitleParts = createMemo(() => visibleTitleParts().slice(-fadeWidth()))
+          // A new title wipes in from the left over the previous one.
+          const displayedParts = createMemo(() => {
+            const outgoing = outgoingTitle()
+            const front = wipe.value().front
+            const parts = visibleTitleParts()
+            if (outgoing === undefined || front >= 1) return parts
+            const previous = Locale.graphemes(Locale.takeWidth(outgoing, availableTitleWidth()))
+            const cut = Math.round(front * Math.max(parts.length, previous.length))
+            return [...parts.slice(0, cut), ...previous.slice(cut)]
+          })
+          const fadeWidth = () => 4
+          const fadedTitleParts = createMemo(() => displayedParts().slice(-fadeWidth()))
           const titleFades = createMemo(
             () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > fadeWidth(),
           )
@@ -178,33 +242,70 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
               backgroundColor={background()}
               onMouseOver={() => setHovered(tab.sessionID)}
               onMouseOut={() => setHovered(undefined)}
-              onMouseUp={() => tabs.select(tab.sessionID)}
+              onMouseDown={() => setDragging(tab.sessionID)}
+              onMouseUp={() => {
+                setDragging(undefined)
+                tabs.select(tab.sessionID)
+              }}
+              onMouseDrag={(event) => {
+                const slot = slotAt(event.x)
+                if (slot === undefined) return
+                if (slot !== items().findIndex((item) => item.sessionID === tab.sessionID)) {
+                  tabs.move(tab.sessionID, slot)
+                }
+              }}
+              onMouseDragEnd={() => {
+                // Releasing a drag selects the dragged tab, matching browser tab strips and
+                // keeping sloppy clicks indistinguishable from clean ones.
+                setDragging(undefined)
+                tabs.select(tab.sessionID)
+              }}
             >
               <TabPulse
                 enabled={animations()}
-                active={status().busy}
-                complete={status().complete}
-                glow={status().unread === "activity" && !status().busy && !selected() && !status().attention}
+                active={status().busy && !status().attention}
+                complete={status().complete && !status().attention}
+                glow={glows()}
+                breathe={status().attention}
                 color={pulseColor()}
-                glowColor={accent()}
+                glowColor={glowColor()}
                 completionColor={accent()}
                 backgroundColor={pulseBackground()}
               />
               <box zIndex={1} width="100%" flexDirection="row">
-                <text width={1}> </text>
-                <text width={2} fg={numberColor()} attributes={selected() ? TextAttributes.BOLD : undefined}>
-                  {items().findIndex((item) => item.sessionID === tab.sessionID) + 1}
+                <text width={1} selectable={false}>
+                  {" "}
+                </text>
+                <text
+                  width={numberWidth()}
+                  fg={numberColor()}
+                  selectable={false}
+                  attributes={selected() || dragged() ? TextAttributes.BOLD : undefined}
+                >
+                  {tabNumber()}
                 </text>
                 <Show
                   when={titleFades()}
                   fallback={
-                    <text width={availableTitleWidth()} fg={foreground()} wrapMode="none">
-                      {visibleTitle()}
+                    <text
+                      width={availableTitleWidth()}
+                      fg={foreground()}
+                      wrapMode="none"
+                      selectable={false}
+                      attributes={selected() || dragged() ? TextAttributes.BOLD : undefined}
+                    >
+                      {displayedParts().join("")}
                     </text>
                   }
                 >
-                  <text width={availableTitleWidth()} fg={foreground()} wrapMode="none">
-                    {visibleTitleParts().slice(0, -fadeWidth()).join("")}
+                  <text
+                    width={availableTitleWidth()}
+                    fg={foreground()}
+                    wrapMode="none"
+                    selectable={false}
+                    attributes={selected() || dragged() ? TextAttributes.BOLD : undefined}
+                  >
+                    {displayedParts().slice(0, -fadeWidth()).join("")}
                     <For each={fadedTitleParts()}>
                       {(character, index) => (
                         <span
@@ -228,6 +329,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
                   zIndex={2}
                   width={1}
                   fg={closeColor()}
+                  selectable={false}
                   onMouseUp={(event) => {
                     event.stopPropagation()
                     tabs.close(tab.sessionID)
@@ -241,8 +343,8 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
         }}
       </For>
       <Show when={layout().after > 0}>
-        <text width={SESSION_TAB_OVERFLOW_WIDTH} fg={theme.text.subdued}>
-          {layout().after}›
+        <text width={sessionTabOverflowWidth(layout().after)} fg={theme.text.subdued} selectable={false}>
+          {" " + layout().after}›
         </text>
       </Show>
     </box>

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -6,6 +6,7 @@ type TabPulseOptions = RenderableOptions<TabPulseRenderable> & {
   active?: boolean
   complete?: boolean
   glow?: boolean
+  breathe?: boolean
   color?: RGBA
   glowColor?: RGBA
   completionColor?: RGBA
@@ -20,6 +21,15 @@ const RUN_TAIL = 18
 const RUN_FADE_OUT = 500
 const COMPLETION_DURATION = 900
 const COMPLETION_ATTACK = 0.16
+const COMPLETION_OPACITY = 0.18
+const EDGE_FLASH_DURATION = 500
+const EDGE_FLASH_OPACITY = 0.1
+const GLOW_IGNITION_DURATION = 600
+const GLOW_IGNITION_PEAK = 1.5
+const GLOW_IGNITION_ATTACK = 0.3
+const GLOW_FADE_OUT = 200
+const GLOW_BREATHE_PERIOD = 3_600
+const GLOW_BREATHE_RISE = 0.25
 const GLOW_TAIL = 12
 const GLOW_OPACITY = 0.16
 const DEFAULT_FOREGROUND = RGBA.defaultForeground()
@@ -37,6 +47,11 @@ export const completionPulseOpacity = (progress: number) =>
   progress < COMPLETION_ATTACK
     ? smootherstep(clamp(progress / COMPLETION_ATTACK))
     : 1 - smootherstep(clamp((progress - COMPLETION_ATTACK) / (1 - COMPLETION_ATTACK)))
+export const glowIgnitionLevel = (progress: number) =>
+  progress < GLOW_IGNITION_ATTACK
+    ? GLOW_IGNITION_PEAK * smootherstep(clamp(progress / GLOW_IGNITION_ATTACK))
+    : GLOW_IGNITION_PEAK -
+      (GLOW_IGNITION_PEAK - 1) * smootherstep(clamp((progress - GLOW_IGNITION_ATTACK) / (1 - GLOW_IGNITION_ATTACK)))
 export const unreadGlowIntensity = (index: number, width: number) => {
   const tail = Math.min(GLOW_TAIL, Math.max(1, width - 2))
   return smootherstep(clamp(1 - Math.max(0, index - 1) / tail))
@@ -61,19 +76,61 @@ export function blendTabPulseColor(
   output.g += (completionColor.g - output.g) * completion
   output.b += (completionColor.b - output.b) * completion
 }
+
+/** A one-shot animation clock: level() follows shape over duration, scaled by the value passed to start. */
+class Envelope {
+  private clock: number | undefined
+  private scale = 1
+
+  constructor(
+    private duration: number,
+    private shape: (progress: number) => number,
+  ) {}
+
+  start(scale = 1) {
+    if (this.clock !== undefined) return
+    this.clock = 0
+    this.scale = scale
+  }
+
+  stop() {
+    this.clock = undefined
+  }
+
+  advance(delta: number) {
+    if (this.clock === undefined) return
+    this.clock += delta
+    if (this.clock >= this.duration) this.clock = undefined
+  }
+
+  get active() {
+    return this.clock !== undefined
+  }
+
+  level() {
+    return this.clock === undefined ? 0 : this.scale * this.shape(this.clock / this.duration)
+  }
+}
+
 class TabPulseRenderable extends Renderable {
   private _enabled: boolean
   private _active: boolean
   private _complete: boolean
   private _glow: boolean
+  private _breathe: boolean
   private _color: RGBA
   private _glowColor: RGBA
   private _completionColor: RGBA
   private _backgroundColor: RGBA
   private clock = 0
-  private fadeClock: number | undefined
-  private completionClock: number | undefined
+  private breatheClock = 0
   private completionPending = false
+  private runFade = new Envelope(RUN_FADE_OUT, (progress) => 1 - smootherstep(progress))
+  private completionPulse = new Envelope(COMPLETION_DURATION, completionPulseOpacity)
+  private edgeFlash = new Envelope(EDGE_FLASH_DURATION, completionPulseOpacity)
+  private ignition = new Envelope(GLOW_IGNITION_DURATION, glowIgnitionLevel)
+  private glowOff = new Envelope(GLOW_FADE_OUT, (progress) => 1 - smootherstep(progress))
+  private envelopes = [this.runFade, this.completionPulse, this.edgeFlash, this.ignition, this.glowOff]
   private renderColor = RGBA.fromInts(0, 0, 0)
 
   constructor(ctx: RenderContext, options: TabPulseOptions = {}) {
@@ -84,21 +141,36 @@ class TabPulseRenderable extends Renderable {
     this._active = active
     this._complete = options.complete ?? false
     this._glow = options.glow ?? false
+    this._breathe = options.breathe ?? false
     this._color = options.color ?? RGBA.defaultForeground()
     this._glowColor = options.glowColor ?? this._color
     this._completionColor = options.completionColor ?? this._color
     this._backgroundColor = options.backgroundColor ?? RGBA.defaultBackground()
   }
 
+  private get breathing() {
+    return this._enabled && this._glow && this._breathe
+  }
+
+  /** Resting glow is 1; ignition overshoots on arrival, breathing swells while pending, glowOff decays after. */
+  private glowLevel() {
+    if (!this._glow) return this.glowOff.level()
+    const base = this.ignition.active ? this.ignition.level() : 1
+    if (!this.breathing) return base
+    return (
+      base * (1 + GLOW_BREATHE_RISE * 0.5 * (1 - Math.cos((2 * Math.PI * this.breatheClock) / GLOW_BREATHE_PERIOD)))
+    )
+  }
+
   set enabled(value: boolean) {
     if (value === this._enabled) return
     this._enabled = value
     if (!value) {
-      this.fadeClock = undefined
-      this.completionClock = undefined
+      for (const envelope of this.envelopes) envelope.stop()
       this.completionPending = false
+      this.breatheClock = 0
       this.live = false
-    } else if (this._active) {
+    } else if (this._active || this.breathing) {
       this.live = true
     }
     this.requestRender()
@@ -109,15 +181,16 @@ class TabPulseRenderable extends Renderable {
     this._active = value
     if (!this._enabled) return
     if (value) {
-      this.fadeClock = undefined
-      this.completionClock = undefined
+      this.runFade.stop()
+      this.completionPulse.stop()
       this.completionPending = false
-      this.live = true
     } else {
-      this.fadeClock = 0
+      this.runFade.start()
       this.completionPending = true
-      this.live = true
     }
+    // The same neutral edge flash marks both the start and the finish of a run.
+    this.edgeFlash.start()
+    this.live = true
     this.requestRender()
   }
 
@@ -125,20 +198,38 @@ class TabPulseRenderable extends Renderable {
     if (value === this._complete) return
     this._complete = value
     if (!value) {
-      this.completionClock = undefined
+      this.completionPulse.stop()
       this.completionPending = false
     }
     if (value && this.completionPending) {
-      this.completionClock = 0
       this.completionPending = false
-      this.live = this._enabled
+      if (this._enabled) {
+        this.completionPulse.start()
+        this.live = true
+      }
     }
     this.requestRender()
   }
 
   set glow(value: boolean) {
     if (value === this._glow) return
+    if (this._enabled && !value) this.glowOff.start(this.glowLevel())
     this._glow = value
+    this.ignition.stop()
+    this.breatheClock = 0
+    if (this._enabled && value) {
+      this.glowOff.stop()
+      this.ignition.start()
+      this.live = true
+    }
+    this.requestRender()
+  }
+
+  set breathe(value: boolean) {
+    if (value === this._breathe) return
+    this._breathe = value
+    this.breatheClock = 0
+    if (this.breathing) this.live = true
     this.requestRender()
   }
 
@@ -168,40 +259,35 @@ class TabPulseRenderable extends Renderable {
 
   protected override onUpdate(deltaTime: number): void {
     if (!this._enabled) return
-    if (this._active || this.fadeClock !== undefined) this.clock += deltaTime
-    if (this.fadeClock !== undefined) {
-      this.fadeClock += deltaTime
-      if (this.fadeClock >= RUN_FADE_OUT) this.fadeClock = undefined
-    }
+    if (this._active || this.runFade.active) this.clock += deltaTime
+    if (this.breathing) this.breatheClock += deltaTime
+    for (const envelope of this.envelopes) envelope.advance(deltaTime)
     if (this.completionPending) {
       if (this._complete) {
-        this.completionClock = 0
         this.completionPending = false
-      } else if (this.fadeClock === undefined) {
+        this.completionPulse.start()
+      } else if (!this.runFade.active) {
         this.completionPending = false
       }
     }
-    if (this.completionClock !== undefined) {
-      this.completionClock += deltaTime
-      if (this.completionClock >= COMPLETION_DURATION) this.completionClock = undefined
-    }
-    this.live = this._active || this.fadeClock !== undefined || this.completionClock !== undefined
+    this.live =
+      this._active ||
+      this.breathing ||
+      this.runFade.active ||
+      this.completionPulse.active ||
+      this.edgeFlash.active ||
+      this.ignition.active ||
+      this.glowOff.active
   }
 
   protected override renderSelf(buffer: OptimizedBuffer): void {
     if (!this.visible || this.isDestroyed || this.width <= 0) return
-    const runningOpacity = !this._enabled
-      ? 0
-      : this._active
-        ? 1
-        : this.fadeClock === undefined
-          ? 0
-          : 1 - smootherstep(clamp(this.fadeClock / RUN_FADE_OUT))
-    const completionOpacity =
-      !this._enabled || this.completionClock === undefined
-        ? 0
-        : completionPulseOpacity(this.completionClock / COMPLETION_DURATION)
-    if (!this._glow && runningOpacity === 0 && completionOpacity === 0) return
+    const running = !this._enabled ? 0 : this._active ? 1 : this.runFade.level()
+    const completion = this.completionPulse.level() * COMPLETION_OPACITY
+    // The edge flash is a neutral wash on the running stage; the accent completion stage stays reserved for results.
+    const flash = this.edgeFlash.level() * EDGE_FLASH_OPACITY
+    const glowLevel = this.glowLevel()
+    if (glowLevel === 0 && running === 0 && completion === 0 && flash === 0) return
     const progress = (this.clock % RUN_DURATION) / RUN_DURATION
     const start = -RUN_HEAD
     const end = this.width - 1 + RUN_TAIL
@@ -212,17 +298,14 @@ class TabPulseRenderable extends Renderable {
         intensityAt(index, front, RUN_HEAD, RUN_TAIL),
         intensityAt(index, secondFront, RUN_HEAD, RUN_TAIL),
       )
-      const glow = this._glow ? unreadGlowIntensity(index, this.width) * GLOW_OPACITY : 0
-      const running = intensity * 0.14 * runningOpacity
-      const completion = completionOpacity * 0.18
       blendTabPulseColor(
         this.renderColor,
         this._backgroundColor,
         this._glowColor,
         this._color,
         this._completionColor,
-        glow,
-        running,
+        unreadGlowIntensity(index, this.width) * GLOW_OPACITY * glowLevel,
+        Math.max(intensity * 0.14 * running, flash),
         completion,
       )
       buffer.setCell(this.screenX + index, this.screenY, " ", DEFAULT_FOREGROUND, this.renderColor)
@@ -243,6 +326,7 @@ export function TabPulse(props: {
   active: boolean
   complete?: boolean
   glow?: boolean
+  breathe?: boolean
   color: RGBA
   glowColor?: RGBA
   completionColor?: RGBA
@@ -257,6 +341,7 @@ export function TabPulse(props: {
       active={props.active}
       complete={props.complete ?? false}
       glow={props.glow ?? false}
+      breathe={props.breathe ?? false}
       color={props.color}
       glowColor={props.glowColor ?? props.color}
       completionColor={props.completionColor ?? props.color}

--- a/packages/tui/src/context/session-tabs-model.ts
+++ b/packages/tui/src/context/session-tabs-model.ts
@@ -17,7 +17,8 @@ export function sessionTabComplete(unread: SessionTabUnread | undefined, busy: b
 export const SESSION_TAB_WIDTH = 22
 export const SESSION_TAB_MAX_WIDTH = 32
 export const SESSION_TAB_MIN_WIDTH = 8
-export const SESSION_TAB_OVERFLOW_WIDTH = 3
+// Overflow markers reserve one gap cell beside the arrow and count, e.g. "‹12 " and " 12›".
+export const sessionTabOverflowWidth = (count: number) => String(count).length + 2
 
 export function openSessionTab(tabs: SessionTab[], tab: SessionTab): SessionTab[] {
   const index = tabs.findIndex((item) => item.sessionID === tab.sessionID)
@@ -33,6 +34,15 @@ export function closeSessionTab(tabs: readonly SessionTab[], sessionID: string) 
     tabs: tabs.filter((tab) => tab.sessionID !== sessionID),
     next: tabs[index + 1]?.sessionID ?? tabs[index - 1]?.sessionID,
   }
+}
+
+export function moveSessionTab(tabs: readonly SessionTab[], sessionID: string, index: number): readonly SessionTab[] {
+  const from = tabs.findIndex((tab) => tab.sessionID === sessionID)
+  const to = Math.max(0, Math.min(tabs.length - 1, index))
+  if (from === -1 || from === to) return tabs
+  const next = tabs.filter((tab) => tab.sessionID !== sessionID)
+  next.splice(to, 0, tabs[from])
+  return next
 }
 
 export function cycleSessionTab(tabs: readonly SessionTab[], active: string | undefined, direction: 1 | -1) {
@@ -65,6 +75,40 @@ export function moveSessionTabHistory(
   )
   if (!target) return { history, sessionID: undefined }
   return { history: { ...history, index: target.index }, sessionID: target.sessionID }
+}
+
+export type SessionTabMotionValues = {
+  widths: number[]
+  selections: number[]
+  activities: number[]
+}
+
+/**
+ * Seed width motion for a visible-tab membership change: retained tabs keep their current animated
+ * values and first-seen tabs grow in from zero width. Returns undefined when nothing is retained,
+ * meaning the window was fully replaced and the strip should jump.
+ */
+export function seedSessionTabMotion(
+  previous: readonly string[],
+  ids: readonly string[],
+  current: SessionTabMotionValues,
+  next: SessionTabMotionValues,
+): SessionTabMotionValues | undefined {
+  if (!ids.some((id) => previous.includes(id))) return undefined
+  return {
+    widths: ids.map((id, index) => {
+      const position = previous.indexOf(id)
+      return position === -1 ? 0 : (current.widths[position] ?? next.widths[index] ?? 0)
+    }),
+    selections: ids.map((id, index) => {
+      const position = previous.indexOf(id)
+      return (position === -1 ? next.selections[index] : current.selections[position]) ?? 0
+    }),
+    activities: ids.map((id, index) => {
+      const position = previous.indexOf(id)
+      return (position === -1 ? next.activities[index] : current.activities[position]) ?? 0
+    }),
+  }
 }
 
 export function adaptiveSessionTabLayout(
@@ -102,8 +146,8 @@ export function adaptiveSessionTabLayout(
       tabs.length - count,
     )
     const markers =
-      (nextStart > 0 ? SESSION_TAB_OVERFLOW_WIDTH : 0) +
-      (nextStart + count < tabs.length ? SESSION_TAB_OVERFLOW_WIDTH : 0)
+      (nextStart > 0 ? sessionTabOverflowWidth(nextStart) : 0) +
+      (nextStart + count < tabs.length ? sessionTabOverflowWidth(tabs.length - nextStart - count) : 0)
     const nextCount = fit(available - markers)
     if (nextCount === count || attempts === 0) return { count, start: nextStart }
     return solve(nextCount, nextStart, attempts - 1)
@@ -114,7 +158,7 @@ export function adaptiveSessionTabLayout(
   const after = tabs.length - solved.start - solved.count
   const contentWidth = Math.max(
     1,
-    available - (before > 0 ? SESSION_TAB_OVERFLOW_WIDTH : 0) - (after > 0 ? SESSION_TAB_OVERFLOW_WIDTH : 0),
+    available - (before > 0 ? sessionTabOverflowWidth(before) : 0) - (after > 0 ? sessionTabOverflowWidth(after) : 0),
   )
   const roomy = contentWidth >= SESSION_TAB_WIDTH * visible.length
   const total = roomy ? Math.min(contentWidth, SESSION_TAB_MAX_WIDTH * visible.length) : contentWidth

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -10,6 +10,7 @@ import { useTuiPaths } from "./runtime"
 import {
   closeSessionTab,
   cycleSessionTab,
+  moveSessionTab,
   moveSessionTabHistory,
   openSessionTab,
   recordSessionTabHistory,
@@ -39,11 +40,14 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     const config = useConfig().data
     const paths = useTuiPaths()
     const enabled = () => config.tabs?.enabled ?? false
+    // Keyed reconcile keeps tab object identity across reorders, so strip rows move instead of
+    // mutating in place, which per-row animations and drag state depend on.
     const [store, updateStore] = useStorage().store<PersistedState>("tabs", {
       initial: {
         global: empty(),
         cwd: {},
       },
+      key: "sessionID",
     })
     const fallback = empty()
     let history: SessionTabHistory = { entries: [], index: -1 }
@@ -176,6 +180,14 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
           return
         }
         remove(target, true)
+      },
+      move(sessionID: string, index: number) {
+        if (!enabled()) return
+        const session = root(sessionID)
+        if (moveSessionTab(state().tabs, session, index) === state().tabs) return
+        update((draft) => {
+          draft.tabs = [...moveSessionTab(draft.tabs, session, index)]
+        })
       },
       cycle(direction: 1 | -1) {
         if (!enabled()) return

--- a/packages/tui/src/context/storage.tsx
+++ b/packages/tui/src/context/storage.tsx
@@ -8,6 +8,8 @@ import { useTuiApp, useTuiPaths } from "./runtime"
 
 type Options<Value extends object> = {
   readonly initial: Value
+  /** Reconcile key for arrays inside the stored value, preserving item identity across updates. */
+  readonly key?: string
 }
 
 type Entry<Value extends object> = readonly [Store<Value>, (mutation: (draft: Value) => void) => Promise<void>]
@@ -53,7 +55,8 @@ function createStorage(root: string, channel: string) {
         }
       }
       const [store, setStore] = createStore(load())
-      const reload = () => batch(() => setStore(reconcile(load())))
+      const merge = (next: Value) => reconcile(next, { key: options.key ?? "id" })
+      const reload = () => batch(() => setStore(merge(load())))
       const update = (mutation: (draft: Value) => void) =>
         Flock.withLock(
           file,
@@ -62,7 +65,7 @@ function createStorage(root: string, channel: string) {
             mutation(draft)
             const next = clone(draft)
             await writeJsonAtomic(file, next)
-            batch(() => setStore(reconcile(next)))
+            batch(() => setStore(merge(next)))
           },
           { dir: locks },
         )

--- a/packages/tui/src/feature-plugins/system/scrap.tsx
+++ b/packages/tui/src/feature-plugins/system/scrap.tsx
@@ -1,8 +1,9 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
-import { batch, createSignal } from "solid-js"
+import { batch, createSignal, onCleanup } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
 import { SessionTabs, type SessionTabsController } from "../../component/session-tabs"
-import { moveSessionTab, type SessionTab } from "../../context/session-tabs-model"
+import { moveSessionTab } from "../../context/session-tabs-model"
 
 type FixtureStatus = ReturnType<SessionTabsController["status"]>
 
@@ -22,6 +23,8 @@ const FIXTURE_TABS = [
 ]
 
 const EMPTY_STATUS: FixtureStatus = { unread: undefined, attention: false, busy: false }
+const RUN_DURATION = 1_800
+const RESUME_DURATION = 900
 
 function Commands(props: { context: Plugin.Context }) {
   props.context.keymap.layer(() => ({
@@ -46,27 +49,79 @@ function Scrap(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const theme = props.context.theme
   const elevatedTheme = theme.contextual.elevated
-  const [tabs, setTabs] = createSignal<SessionTab[]>(FIXTURE_TABS.slice(0, 6))
-  const [active, setActive] = createSignal<string | undefined>("fixture-2")
-  const [animations, setAnimations] = createSignal(true)
-  const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>({
-    "fixture-2": { ...EMPTY_STATUS, busy: true },
-    "fixture-3": { ...EMPTY_STATUS, unread: "activity" },
-    "fixture-4": { ...EMPTY_STATUS, unread: "error" },
-    "fixture-5": { ...EMPTY_STATUS, attention: true },
-    "fixture-6": { ...EMPTY_STATUS, busy: true, attention: true },
+  // A keyed store mirrors production: retitles mutate rows in place instead of remounting them.
+  const [tabStore, setTabStore] = createStore<{ items: { sessionID: string; title?: string }[] }>({
+    items: FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })),
   })
+  const tabs = () => tabStore.items
+  const setItems = (next: { sessionID: string; title?: string }[]) =>
+    setTabStore("items", reconcile(next, { key: "sessionID" }))
+  const [active, setActive] = createSignal<string | undefined>("fixture-1")
+  const [lastEvent, setLastEvent] = createSignal("press space to start a random tab")
+  const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>({})
+  const runs = new Map<string, ReturnType<typeof setTimeout>>()
+  onCleanup(() => runs.forEach(clearTimeout))
+
+  const number = (sessionID: string) => tabs().findIndex((tab) => tab.sessionID === sessionID) + 1
+
+  function finishRun(sessionID: string, resumed: boolean) {
+    runs.delete(sessionID)
+    if (!tabs().some((item) => item.sessionID === sessionID)) return
+    const roll = Math.random()
+    // A permission request pauses the still-busy run until the tab is selected.
+    if (!resumed && roll < 0.25) {
+      setStatuses((current) => ({
+        ...current,
+        [sessionID]: { ...(current[sessionID] ?? EMPTY_STATUS), attention: true },
+      }))
+      setLastEvent(`tab ${number(sessionID)} needs input; select it to resolve`)
+      return
+    }
+    const failed = roll >= 0.75
+    const unread = active() === sessionID ? undefined : failed ? ("error" as const) : ("activity" as const)
+    batch(() => {
+      setStatuses((current) => ({
+        ...current,
+        [sessionID]: { ...(current[sessionID] ?? EMPTY_STATUS), busy: false, unread },
+      }))
+      // An untitled session earns its title after its first completed run, like a real summarization.
+      const index = number(sessionID) - 1
+      const fixture = FIXTURE_TABS.find((tab) => tab.sessionID === sessionID)
+      if (!failed && fixture && tabs()[index]?.title === undefined) setTabStore("items", index, "title", fixture.title)
+    })
+    setLastEvent(
+      `tab ${number(sessionID)} ${failed ? "failed" : "completed"}${unread ? " (unread)" : " while selected"}`,
+    )
+  }
+
+  const select = (sessionID: string) => {
+    const status = statuses()[sessionID]
+    const resumes = status !== undefined && status.attention && status.busy && !runs.has(sessionID)
+    batch(() => {
+      setActive(sessionID)
+      if (status && (status.unread || status.attention))
+        setStatuses((current) => ({ ...current, [sessionID]: { ...status, unread: undefined, attention: false } }))
+    })
+    if (resumes) {
+      setLastEvent(`tab ${number(sessionID)} input resolved, resuming`)
+      runs.set(
+        sessionID,
+        setTimeout(() => finishRun(sessionID, true), RESUME_DURATION),
+      )
+    }
+  }
+
   const controller = {
     tabs,
     current: active,
     status(sessionID) {
       return statuses()[sessionID] ?? EMPTY_STATUS
     },
+    select,
     move(sessionID: string, index: number) {
-      setTabs((current) => [...moveSessionTab(current, sessionID, index)])
-    },
-    select(sessionID) {
-      setActive(sessionID)
+      const next = moveSessionTab(tabs(), sessionID, index)
+      if (next === tabs()) return
+      setItems(next.map((tab) => ({ ...tab })))
     },
     close(sessionID?: string) {
       const target = sessionID ?? active()
@@ -74,10 +129,19 @@ function Scrap(props: { context: Plugin.Context }) {
       const items = tabs()
       const index = items.findIndex((tab) => tab.sessionID === target)
       if (index === -1) return
-      const next = items.filter((tab) => tab.sessionID !== target)
+      const next = items.filter((tab) => tab.sessionID !== target).map((tab) => ({ ...tab }))
+      const selected = next[index]?.sessionID ?? next[index - 1]?.sessionID
+      clearTimeout(runs.get(target))
+      runs.delete(target)
       batch(() => {
-        setTabs(next)
-        if (active() === target) setActive(next[index]?.sessionID ?? next[index - 1]?.sessionID)
+        setItems(next)
+        setStatuses((current) => {
+          const updated = { ...current }
+          delete updated[target]
+          return updated
+        })
+        if (active() === target && selected) select(selected)
+        if (active() === target && !selected) setActive(undefined)
       })
     },
   } satisfies SessionTabsController
@@ -86,12 +150,29 @@ function Scrap(props: { context: Plugin.Context }) {
     const items = tabs()
     if (items.length === 0) return
     const index = items.findIndex((tab) => tab.sessionID === active())
-    controller.select(items[(index + direction + items.length) % items.length]!.sessionID)
+    select(items[(index + direction + items.length) % items.length].sessionID)
   }
-  const updateStatus = (update: (status: FixtureStatus) => FixtureStatus) => {
-    const sessionID = active()
-    if (!sessionID) return
-    setStatuses((current) => ({ ...current, [sessionID]: update(current[sessionID] ?? EMPTY_STATUS) }))
+  const randomInactiveTab = () => {
+    const candidates = tabs().filter((tab) => {
+      const status = controller.status(tab.sessionID)
+      return tab.sessionID !== active() && !status.busy && !status.unread && !status.attention
+    })
+    // Untitled sessions run first so their title arrival is easy to trigger.
+    const untitled = candidates.filter((tab) => tab.title === undefined)
+    const pool = untitled.length > 0 ? untitled : candidates
+    return pool[Math.floor(Math.random() * pool.length)]
+  }
+  const selectedState = () => {
+    const current = active()
+    const status = current ? controller.status(current) : EMPTY_STATUS
+    const activity = status.busy
+      ? "running"
+      : status.unread === "activity"
+        ? "completed (unread)"
+        : status.unread === "error"
+          ? "failed (unread)"
+          : "read"
+    return status.attention ? `${activity} + needs input` : activity
   }
 
   props.context.keymap.layer(() => ({
@@ -104,48 +185,68 @@ function Scrap(props: { context: Plugin.Context }) {
           props.context.ui.router.navigate({ type: "home" })
         },
       },
-      { bind: "h", title: "Previous tab", group: "Scrap", run: () => cycle(-1) },
-      { bind: "l", title: "Next tab", group: "Scrap", run: () => cycle(1) },
+      { bind: "left,h", title: "Previous tab", group: "Scrap", run: () => cycle(-1) },
+      { bind: "right,l", title: "Next tab", group: "Scrap", run: () => cycle(1) },
+      ...Array.from({ length: 10 }, (_, index) => ({
+        bind: String((index + 1) % 10),
+        title: `Select tab ${index + 1}`,
+        group: "Scrap",
+        run() {
+          const tab = tabs()[index]
+          if (tab) select(tab.sessionID)
+        },
+      })),
+      {
+        bind: "space",
+        title: "Start a random tab",
+        group: "Scrap",
+        run() {
+          const tab = randomInactiveTab()
+          if (!tab) {
+            setLastEvent("every tab is busy or unread; select tabs to read them, or press r")
+            return
+          }
+          setStatuses((current) => ({
+            ...current,
+            [tab.sessionID]: { ...(current[tab.sessionID] ?? EMPTY_STATUS), busy: true, unread: undefined },
+          }))
+          setLastEvent(`tab ${number(tab.sessionID)} running`)
+          runs.set(
+            tab.sessionID,
+            setTimeout(() => finishRun(tab.sessionID, false), RUN_DURATION),
+          )
+        },
+      },
       {
         bind: "t",
         title: "Add tab",
         group: "Scrap",
         run() {
           const next = FIXTURE_TABS.find((fixture) => !tabs().some((tab) => tab.sessionID === fixture.sessionID))
-          if (next) setTabs((current) => [...current, next])
+          if (!next) {
+            setLastEvent("all fixture tabs are open")
+            return
+          }
+          setItems([...tabs().map((tab) => ({ ...tab })), { sessionID: next.sessionID }])
+          select(next.sessionID)
+          setLastEvent(`tab ${number(next.sessionID)} opened untitled; run it to earn its title`)
         },
       },
       { bind: "d", title: "Close tab", group: "Scrap", run: () => controller.close() },
       {
-        bind: "b",
-        title: "Toggle busy",
+        bind: "r",
+        title: "Reset",
         group: "Scrap",
-        run: () =>
-          updateStatus((status) =>
-            status.busy ? { ...status, busy: false, unread: "activity" } : { ...status, busy: true, unread: undefined },
-          ),
-      },
-      {
-        bind: "u",
-        title: "Cycle unread",
-        group: "Scrap",
-        run: () =>
-          updateStatus((status) => ({
-            ...status,
-            unread: status.unread === undefined ? "activity" : status.unread === "activity" ? "error" : undefined,
-          })),
-      },
-      {
-        bind: "a",
-        title: "Toggle attention",
-        group: "Scrap",
-        run: () => updateStatus((status) => ({ ...status, attention: !status.attention })),
-      },
-      {
-        bind: "m",
-        title: "Toggle motion",
-        group: "Scrap",
-        run: () => setAnimations((enabled) => !enabled),
+        run() {
+          runs.forEach(clearTimeout)
+          runs.clear()
+          batch(() => {
+            setItems(FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })))
+            setStatuses({})
+            setActive("fixture-1")
+          })
+          setLastEvent("reset; press space to start a random tab")
+        },
       },
     ],
   }))
@@ -157,7 +258,7 @@ function Scrap(props: { context: Plugin.Context }) {
       flexDirection="column"
       backgroundColor={theme.background.default}
     >
-      <SessionTabs controller={controller} animations={animations()} />
+      <SessionTabs controller={controller} />
       <box
         height={1}
         flexShrink={0}
@@ -169,7 +270,16 @@ function Scrap(props: { context: Plugin.Context }) {
         <text fg={elevatedTheme.text.subdued}>tab playground</text>
         <box flexGrow={1} />
         <text fg={elevatedTheme.text.subdued}>
-          h/l select | t add | d close | b busy | u unread | a attention | m motion | esc home
+          space run | t add | d close | r reset | ←/→ 1-0 move | drag reorders | esc home
+        </text>
+      </box>
+      <box paddingTop={2} paddingLeft={2} flexDirection="column">
+        <text fg={theme.text.default}>
+          selected: {number(active() ?? "")} | state: {selectedState()}
+        </text>
+        <text fg={theme.text.default}>background: {lastEvent()}</text>
+        <text fg={theme.text.subdued}>
+          runs complete, fail, or request input; selecting a tab reads and resolves it
         </text>
       </box>
       <box flexGrow={1} />

--- a/packages/tui/src/feature-plugins/system/scrap.tsx
+++ b/packages/tui/src/feature-plugins/system/scrap.tsx
@@ -2,6 +2,7 @@ import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { batch, createSignal } from "solid-js"
 import { SessionTabs, type SessionTabsController } from "../../component/session-tabs"
+import { moveSessionTab, type SessionTab } from "../../context/session-tabs-model"
 
 type FixtureStatus = ReturnType<SessionTabsController["status"]>
 
@@ -45,7 +46,7 @@ function Scrap(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const theme = props.context.theme
   const elevatedTheme = theme.contextual.elevated
-  const [tabs, setTabs] = createSignal(FIXTURE_TABS.slice(0, 6))
+  const [tabs, setTabs] = createSignal<SessionTab[]>(FIXTURE_TABS.slice(0, 6))
   const [active, setActive] = createSignal<string | undefined>("fixture-2")
   const [animations, setAnimations] = createSignal(true)
   const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>({
@@ -60,6 +61,9 @@ function Scrap(props: { context: Plugin.Context }) {
     current: active,
     status(sessionID) {
       return statuses()[sessionID] ?? EMPTY_STATUS
+    },
+    move(sessionID: string, index: number) {
+      setTabs((current) => [...moveSessionTab(current, sessionID, index)])
     },
     select(sessionID) {
       setActive(sessionID)

--- a/packages/tui/test/component/tab-pulse.test.ts
+++ b/packages/tui/test/component/tab-pulse.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
-import { blendTabPulseColor, completionPulseOpacity, unreadGlowIntensity } from "../../src/component/tab-pulse"
+import {
+  blendTabPulseColor,
+  completionPulseOpacity,
+  glowIgnitionLevel,
+  unreadGlowIntensity,
+} from "../../src/component/tab-pulse"
 import { tint } from "../../src/theme/color"
 
 test("completion pulse rises quickly and fades over the remaining duration", () => {
@@ -9,6 +14,13 @@ test("completion pulse rises quickly and fades over the remaining duration", () 
   expect(completionPulseOpacity(0.16)).toBe(1)
   expect(completionPulseOpacity(0.58)).toBeCloseTo(0.5)
   expect(completionPulseOpacity(1)).toBe(0)
+})
+
+test("glow ignition overshoots the resting level and settles back to it", () => {
+  expect(glowIgnitionLevel(0)).toBe(0)
+  expect(glowIgnitionLevel(0.3)).toBeCloseTo(1.5)
+  expect(glowIgnitionLevel(0.6)).toBeGreaterThan(1)
+  expect(glowIgnitionLevel(1)).toBe(1)
 })
 
 test("unread glow peaks behind the tab number and fades to the normal background", () => {

--- a/packages/tui/test/context/session-tabs-model.test.ts
+++ b/packages/tui/test/context/session-tabs-model.test.ts
@@ -3,13 +3,65 @@ import {
   adaptiveSessionTabLayout,
   closeSessionTab,
   cycleSessionTab,
+  moveSessionTab,
   moveSessionTabHistory,
   openSessionTab,
   recordSessionTabHistory,
+  seedSessionTabMotion,
   sessionTabComplete,
+  sessionTabOverflowWidth,
 } from "../../src/context/session-tabs-model"
 
 describe("session tabs", () => {
+  test("moves a tab to a clamped index and returns the same tabs for no-ops", () => {
+    const tabs = ["a", "b", "c"].map((sessionID) => ({ sessionID }))
+    expect(moveSessionTab(tabs, "a", 2).map((tab) => tab.sessionID)).toEqual(["b", "c", "a"])
+    expect(moveSessionTab(tabs, "c", -5).map((tab) => tab.sessionID)).toEqual(["c", "a", "b"])
+    expect(moveSessionTab(tabs, "b", 99).map((tab) => tab.sessionID)).toEqual(["a", "c", "b"])
+    expect(moveSessionTab(tabs, "b", 1)).toBe(tabs)
+    expect(moveSessionTab(tabs, "missing", 0)).toBe(tabs)
+  })
+
+  test("open seeding keeps survivors and grows the new tab from zero", () => {
+    const seeded = seedSessionTabMotion(
+      ["a", "b"],
+      ["a", "b", "c"],
+      { widths: [35, 35], selections: [1, 0], activities: [0, 1] },
+      { widths: [24, 23, 23], selections: [1, 0, 0], activities: [0, 1, 0] },
+    )
+    expect(seeded).toEqual({ widths: [35, 35, 0], selections: [1, 0, 0], activities: [0, 1, 0] })
+  })
+
+  test("close seeding keeps survivors at their current animated widths", () => {
+    const seeded = seedSessionTabMotion(
+      ["a", "b", "c"],
+      ["a", "c"],
+      { widths: [24, 23, 23], selections: [1, 0, 0], activities: [0, 0, 1] },
+      { widths: [35, 35], selections: [1, 0], activities: [0, 1] },
+    )
+    expect(seeded).toEqual({ widths: [24, 23], selections: [1, 0], activities: [0, 1] })
+  })
+
+  test("window shifts keep retained tabs and grow revealed ones", () => {
+    const seeded = seedSessionTabMotion(
+      ["a", "b", "c"],
+      ["b", "c", "d"],
+      { widths: [22, 8, 8], selections: [1, 0, 0], activities: [0, 0, 0] },
+      { widths: [8, 8, 22], selections: [0, 0, 1], activities: [0, 0, 0] },
+    )
+    expect(seeded).toEqual({ widths: [8, 8, 0], selections: [0, 0, 1], activities: [0, 0, 0] })
+  })
+
+  test("fully replaced windows jump instead of seeding", () => {
+    const values = { widths: [22], selections: [1], activities: [0] }
+    expect(seedSessionTabMotion(["a"], ["z"], values, values)).toBeUndefined()
+  })
+
+  test("overflow markers reserve room for a gap beside their digits", () => {
+    expect(sessionTabOverflowWidth(5)).toBe(3)
+    expect(sessionTabOverflowWidth(12)).toBe(4)
+  })
+
   test("opens each session once and refreshes its title", () => {
     const tabs = openSessionTab([{ sessionID: "a", title: "Old" }], { sessionID: "a", title: "New" })
     expect(tabs).toEqual([{ sessionID: "a", title: "New" }])


### PR DESCRIPTION
## What

Turns the tab playground into a lifecycle simulation so every tab animation from the stacked base PR can be exercised deterministically, and fixes the `OPENCODE_SCRAP=1` shortcut, which navigated to an unknown plugin route.

The playground now behaves like a miniature of the real app:

- `space` starts a random read inactive tab; it runs for 1.8s and then randomly completes (accent unread glow), fails (red glow), or pauses needing input (breathing warning glow, still busy).
- Selecting a tab reads it and resolves pending input, resuming the paused run.
- New tabs open untitled and earn their fixture title with the left-to-right wipe on first completion; untitled tabs run first so the title arrival is easy to trigger.
- `t` add, `d` close, `r` reset, arrows and `1`-`0` to move, drag to reorder.

## How

- `feature-plugins/system/scrap.tsx`: fixture state moved to a keyed store (mirroring production identity semantics), timed background runs with random outcomes, selection as the universal resolver, and a status line narrating the last background event.
- `app.tsx`: the `OPENCODE_SCRAP` startup route uses `opencode.scrap`, the id the built-in plugin registers, instead of `scrap`, which rendered "Unknown plugin route".

## Scope

Stacked on the tab animation polish PR; contains only playground and debug-shortcut changes, no production component behavior.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`
- Prettier
- The demo video on the base PR was recorded through this simulation

## Demo

See the recording on the base PR: it drives this simulation end to end.
