### PR TITLE
test(cli): update ACP fork expectation

### DIFF
--- a/packages/cli/test/acp/service-lifecycle.test.ts
+++ b/packages/cli/test/acp/service-lifecycle.test.ts
@@ -136,7 +136,7 @@ describe("acp service lifecycle", () => {
       method: "POST",
       path: "/api/session/ses_loaded/fork",
       query: {},
-      body: {},
+      body: { boundary: { type: "through" } },
     })
   })
 


### PR DESCRIPTION
Updates the ACP lifecycle test to expect the complete-session fork boundary sent by the client.