### PR TITLE
fix(tui): support cd before session creation

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -233,17 +233,32 @@ export function Prompt(props: PromptProps) {
   })
   Keymap.createLayer(() => ({
     mode: "global",
-    enabled: props.sessionID !== undefined,
     commands: [
       {
         id: "session.cd",
         title: "Change working directory",
         slash: { name: "cd", arguments: true },
         run: async (input) => {
-          const sessionID = props.sessionID
-          if (!sessionID) return
           if (!input?.trim()) {
             toast.show({ message: "Directory is required", variant: "error" })
+            return
+          }
+          const sessionID = props.sessionID
+          if (!sessionID) {
+            const value = input.trim()
+            const expanded =
+              value === "~" ? paths.home : value.startsWith("~/") ? path.join(paths.home, value.slice(2)) : value
+            const directory = path.resolve(
+              currentLocation.current?.directory ?? data.location.default().directory,
+              expanded,
+            )
+            const location = await client.api.location.get({ location: { directory } }).catch((error) => {
+              toast.show({ title: "Failed to change directory", message: errorMessage(error), variant: "error" })
+              return undefined
+            })
+            if (!location) return
+            move.setDirectory(location.directory, location.directory !== location.project.directory)
+            currentLocation.set(location)
             return
           }
           await client.api.session

--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -158,6 +158,10 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     setCreating(false)
   }
 
+  function setDirectory(directory: string, subdirectory: boolean) {
+    setDestination({ type: "directory", directory, subdirectory })
+  }
+
   createEffect(() => {
     if (!creating()) {
       setCreatingDots(3)
@@ -176,6 +180,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     pending,
     pendingNew,
     progress,
+    setDirectory,
     startSubmit,
   }
 }


### PR DESCRIPTION
## What

Allow `/cd <directory>` to select the working directory from the V2 new-session screen. The selected location is shown immediately and is used when the first session is created.

## Before / After

**Before**

1. Start the TUI on the new-session screen.
2. Enter `/cd ..`.
3. Because `session.cd` was disabled without a session ID, the input was submitted as a normal model prompt and created a session in the original directory.

**After**

1. Start the TUI on the new-session screen.
2. Enter `/cd ..`.
3. The destination is resolved relative to the current location, validated by the server, and displayed without creating a session.
4. The first prompt creates its session in that selected directory.

Existing sessions continue to use the `session.move` endpoint.

## How

- `packages/tui/src/component/prompt/index.tsx` registers `session.cd` on both home and session prompts. The home path expands `~`, resolves relative paths, validates the location, and updates the current TUI location.
- `packages/tui/src/component/prompt/move.tsx` exposes the existing pending destination state so session creation consumes the directory selected by `/cd`.

## Scope

This only changes V2 TUI slash-command behavior. It does not change the session move API or other clients.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (543 passed, 5 skipped)
- Full repository typecheck from the pre-push hook (32 packages passed)
- Real PTY verification from a fresh screen: `/cd ..` changed `~/code` to `~` without creating a session, `!pwd` then returned `/Users/kit`, and active-session `/cd code` still moved to `~/code`
- Prettier and `git diff --check`

## Demo

The recording shows `/cd ..` changing the pending location on the new-session screen, followed by `!pwd` confirming the first session starts there.

https://github.com/user-attachments/assets/295bb911-2631-4da2-aafe-da15b201d64e

## Flow

```mermaid
flowchart TD
  A[User enters /cd path] --> B{Session exists?}
  B -->|Yes| C[Move existing session]
  B -->|No| D[Resolve path from current location]
  D --> E[Validate location through server]
  E --> F[Store pending destination]
  F --> G[Update home footer]
  G --> H[Create first session at destination]
```
