### PR TITLE
fix(tui): show context percentage relative to input limit

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -272,7 +272,8 @@ export function Prompt(props: PromptProps) {
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    const limit = model?.limit.input ?? model?.limit.context
+    const pct = limit ? `${Math.round((tokens / limit) * 100)}%` : undefined
     const cost = session?.cost ?? 0
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),


### PR DESCRIPTION
### Issue for this PR

Closes #38851

### Type of change

- [x] Bug fix

### What does this PR do?

TUI context indicator used limit.context as denominator, but compaction triggers based on limit.input. For gpt-5.6-sol (input=372K, context=500K) this meant compaction started when TUI showed ~30-35%. Now uses limit.input when present, falling back to limit.context.

### How did you verify your code works?

Ran bun typecheck in packages/tui — passes cleanly.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR