### PR TITLE
feat(tui): make session tab switching fast for long transcripts

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -98,6 +98,13 @@ addDefaultParsers(parsers.parsers)
 // Exclude temporary bottom space when measuring the real transcript height.
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
 
+// Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
+// The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
+// in a few hundred milliseconds without a perceptible pause.
+const TRANSCRIPT_TAIL_ROWS = 40
+const TRANSCRIPT_BACKFILL_CHUNK = 60
+const TRANSCRIPT_BACKFILL_DELAY = 120
+
 const context = createContext<{
   width: number
   sessionID: string
@@ -296,6 +303,49 @@ export function Session() {
     r.set(route.prompt)
   }
 
+  /** Runs after layout has settled (two frames), unless the transcript was torn down. */
+  const afterLayout = (continuation: () => void) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!scroll || scroll.isDestroyed) return
+        continuation()
+      })
+    })
+  }
+
+  // Tail-first transcript mounting: only the newest rows mount when the session opens, and the
+  // rest backfill in chunks shortly after, so switching to a long session costs the visible tail
+  // instead of the whole transcript. Until backfill pins the count, the hidden span derives from
+  // the row count, so it needs no effect ordering; the clamp keeps at least a tail visible when a
+  // re-reduce shrinks the transcript. Streaming appends land at the end of the visible slice.
+  const [hiddenRows, setHiddenRows] = createSignal<number>()
+  const hidden = createMemo(() => Math.max(0, Math.min(hiddenRows() ?? Infinity, rows.length - TRANSCRIPT_TAIL_ROWS)))
+  const visibleRows = createMemo(() => (hidden() === 0 ? rows : rows.slice(hidden())))
+  createEffect(() => {
+    const current = hidden()
+    if (current === 0) return
+    // Until the first chunk pins hiddenRows, appends change hidden() and reset this timer, so
+    // backfill waits for a pause in streaming before starting. Once pinned, it drains on a fixed
+    // cadence undisturbed by appends.
+    const timer = setTimeout(() => {
+      const before = scroll && !scroll.isDestroyed ? scroll.scrollHeight : undefined
+      const viewportBottom = before === undefined ? 0 : scroll.scrollTop + scroll.viewport.height
+      setHiddenRows(Math.max(0, current - TRANSCRIPT_BACKFILL_CHUNK))
+      if (before === undefined) return
+      // Sticky scroll holds bottom-anchored readers through the mount; compensation is only for
+      // readers who have scrolled up.
+      if (viewportBottom >= before - 1) return
+      afterLayout(() => scroll.scrollBy(scroll.scrollHeight - before))
+    }, TRANSCRIPT_BACKFILL_DELAY)
+    onCleanup(() => clearTimeout(timer))
+  })
+  /** Message navigation needs the full transcript mounted before walking or jumping. */
+  const ensureAllRows = (continuation: () => void) => {
+    if (hidden() === 0) return continuation()
+    setHiddenRows(0)
+    afterLayout(continuation)
+  }
+
   createEffect(() => {
     const current = prompt()
     if (sent || !current || !synced() || !local.model.ready) return
@@ -322,41 +372,36 @@ export function Session() {
         currentSlack: scroll.getRenderable(NAVIGATION_SLACK_ID)?.height ?? 0,
       }),
     )
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (scroll.isDestroyed || navigationMessage() !== messageID) return
-        scroll.scrollTo(top)
+    afterLayout(() => {
+      if (navigationMessage() !== messageID) return
+      scroll.scrollTo(top)
+    })
+  }
+
+  const scrollToMessage = (direction: "next" | "prev", dialog: ReturnType<typeof useDialog>, userOnly = false) =>
+    ensureAllRows(() => {
+      const target = findMessageBoundary({
+        direction,
+        children: scroll.getChildren(),
+        messages: messages(),
+        scrollTop: scroll.scrollTop,
+        viewportY: scroll.viewport.y,
+        currentID: navigationMessage(),
+        userOnly,
       })
-    })
-  }
 
-  const scrollToMessage = (direction: "next" | "prev", dialog: ReturnType<typeof useDialog>, userOnly = false) => {
-    const target = findMessageBoundary({
-      direction,
-      children: scroll.getChildren(),
-      messages: messages(),
-      scrollTop: scroll.scrollTop,
-      viewportY: scroll.viewport.y,
-      currentID: navigationMessage(),
-      userOnly,
-    })
-
-    if (!target) {
+      if (target) alignMessage(target.id, target.top)
       dialog.clear()
-      return
-    }
+    })
 
-    alignMessage(target.id, target.top)
-    dialog.clear()
-  }
-
-  const jumpToMessage = (messageID: string) => {
-    const child = scroll.getRenderable(messageID)
-    if (!child) return
-    const y = scroll.scrollTop + child.y - scroll.viewport.y
-    const message = data.session.message.get(route.sessionID, messageID)
-    alignMessage(messageID, Math.max(0, y - (message?.type === "assistant" ? 1 : 0)))
-  }
+  const jumpToMessage = (messageID: string) =>
+    ensureAllRows(() => {
+      const child = scroll.getRenderable(messageID)
+      if (!child) return
+      const y = scroll.scrollTop + child.y - scroll.viewport.y
+      const message = data.session.message.get(route.sessionID, messageID)
+      alignMessage(messageID, Math.max(0, y - (message?.type === "assistant" ? 1 : 0)))
+    })
 
   function toBottom() {
     clearMessageNavigation()
@@ -932,12 +977,12 @@ export function Session() {
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}
             >
-              <For each={rows}>
+              <For each={visibleRows()}>
                 {(row, index) => (
                   <SessionRowView
                     row={row}
                     message={(messageID) => data.session.message.get(route.sessionID, messageID)}
-                    boundaryID={boundaries()[index()]}
+                    boundaryID={boundaries()[index() + hidden()]}
                   />
                 )}
               </For>

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -97,11 +97,16 @@ export function createSessionRows(sessionID: Accessor<string>) {
     }),
   )
 
-  // Re-reduce when the revert boundary changes (stage/clear/commit).
+  // Re-reduce when the revert boundary changes (stage/clear/commit). These reactions defer
+  // their first run: the mount effect above has already reduced the same state.
   createEffect(
-    on(revertBoundary, () => {
-      setRows(reconcile(reduce()))
-    }),
+    on(
+      revertBoundary,
+      () => {
+        setRows(reconcile(reduce()))
+      },
+      { defer: true },
+    ),
   )
 
   createEffect(
@@ -112,6 +117,7 @@ export function createSessionRows(sessionID: Accessor<string>) {
           .filter((item) => item.type === "compaction")
           .map((item) => item.id),
       () => setRows(reconcile(reduce())),
+      { defer: true },
     ),
   )
 
@@ -137,12 +143,11 @@ export function createSessionRows(sessionID: Accessor<string>) {
               : [],
         ),
       () => setRows(reconcile(reduce())),
+      { defer: true },
     ),
   )
 
-  createEffect(
-    on(turnTokens, () => setRows(reconcile(reduce()))),
-  )
+  createEffect(on(turnTokens, () => setRows(reconcile(reduce())), { defer: true }))
 
   const appendMessage = (messageID: string) =>
     setRows(


### PR DESCRIPTION
## What

Switching session tabs could visibly stall on long transcripts. This PR makes tab switching roughly constant-time — the visible switch mounts a fixed-size tail regardless of transcript size.

Front-end only by design: an earlier revision also added data-context prefetch and sync-dedup plumbing, but paging/prefetch on the data layer deserves its own API design (and is being looked at separately), so this version touches nothing outside the session route.

## Before / After

Measured with an isolated opencode-drive harness (three sessions of 51 / 123 / 243 transcript rows with realistic markdown + code-fence content, 160×45 viewport; sync = blocked main thread inside the switch, paint = next flushed frame):

| rows | before (warm switch) | after (warm switch) |
|---|---|---|
| 51 | ~47ms | ~38ms |
| 123 | ~91ms | ~38ms |
| 243 | **~167ms** | **~43ms** |

Warm-switch numbers were measured with an earlier revision that also skipped a post-sync re-reduce; this version keeps that re-reduce (it needs a data-context change), adding ~6–23ms of CPU *after* the switch paints — the visible switch is unaffected.

**Before**: every switch tore down and rebuilt the entire `<Session />` tree under the keyed route `Show`, eagerly mounting every transcript row — markdown parsing, tree-sitter highlighting, wrapping, and layout for up to 200 messages, scaling ~0.65ms/row.

**After**: a switch mounts only the newest 40 rows and backfills the rest in 60-row chunks shortly after, invisibly (bottom-anchored readers are held by sticky scroll; scrolled-up readers get scroll compensation). The switch cost no longer depends on transcript length.

Cold first visits still fetch inside the switch gesture (unchanged from before); hiding that behind prefetch is the data-layer follow-up.

## How

- `packages/tui/src/routes/session/index.tsx` — tail-first transcript mounting. `hidden` derives from the row count until backfill pins it (no effect-ordering dependence), clamped so a shrinking re-reduce always leaves a tail visible. A 120ms timer drains 60 rows per chunk, pausing while streaming appends reset it. `afterLayout` consolidates the existing double-rAF “wait for layout” pattern (also adopted by `alignMessage`). `jumpToMessage`/`scrollToMessage` wrap in `ensureAllRows`, which force-mounts the full transcript before message navigation walks or jumps.
- `packages/tui/src/routes/session/rows.ts` — defers the first run of the four reactive re-reduce effects, which each duplicated the mount reduce.

```mermaid
sequenceDiagram
    participant U as user
    participant T as SessionTabs
    participant S as Session route
    participant D as DataProvider

    Note over U,S: on tab switch
    U->>T: leader+digit / click
    T->>S: route.navigate (keyed remount)
    S->>D: rows from store (cached if visited)
    S->>S: mount newest 40 rows (~40ms)
    loop every 120ms until drained
        S->>S: mount 60 older rows above viewport
    end
```

## Scope

- No data-context changes: no prefetch, no sync return-type change, no plugin `Data` type change. Paging/prefetch belongs in a designed data-layer API (follow-up).
- No virtualization: rows above the viewport still mount (after backfill). Bounded by the 200-message fetch limit, so permanent windowing wasn’t warranted.
- One accepted edge: switching into an actively-streaming session before its rows settle can mount fully once (the pre-change behavior).
- The `boundaryID` index mapping stays positional; backfill briefly re-evaluates it per mounted row per chunk (bounded small at the message cap).
- The measurement harness (perf marks + opencode-drive benchmark scripts) is deliberately not included.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 562 pass, 5 skip, 1 fail — `restores queued compaction from durable pending input` fails identically on clean `v2` HEAD (`3c259fc552`), pre-existing and unrelated
- oxlint + repo-pinned Prettier clean on changed files
- Benchmarked end-to-end with an isolated opencode-drive instance and JSONL perf marks (numbers above; light/heavy/scale content sweeps)
- Dogfooded against a live six-tab setup with 200–450-message sessions — switches read as instant
- Screenshot-verified: switch paints the bottom-anchored tail immediately and identically through backfill; a full row re-reduce mid-backfill renders correctly
- Review-verified (not exercised e2e — drive couldn’t transmit the needed keys): scroll-compensation during backfill for scrolled-up readers, and `ensureAllRows` under message navigation

## Demo

https://assets.kitlangton.dev/anomalyco/opencode/pr-39568/tab-switch-demo-e5c2cbf8eb06.mp4

Recorded from the PR branch: cycling `<leader>1/2/3` between three sessions (150 / 60 / 250 tool-call transcripts with heavy markdown) — every switch paints instantly.
