### PR TITLE
fix(session): publish overflow error when recovery is abandoned, not attempted

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -402,6 +402,9 @@ const layer = Layer.effect(
       })
 
       if (result === "compact") {
+        // Recovery abandoned: this is where overflow becomes an outcome, so
+        // the error event fires here rather than on the recoverable 413 in
+        // processor.halt.
         processor.message.error = new SessionV1.ContextOverflowError({
           message: replay
             ? "Conversation history too large to compact - exceeds model context limit"
@@ -409,6 +412,10 @@ const layer = Layer.effect(
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
+        yield* events.publish(Session.Event.Error, {
+          sessionID: input.sessionID,
+          error: processor.message.error,
+        })
         return "stop"
       }
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -612,8 +612,13 @@ const layer = Layer.effect(
             yield* status.set(ctx.sessionID, { type: "idle" })
             return
           }
+          // Recovery attempt, not an outcome: auto-compaction will retry, so
+          // nothing is published here. The durable message carries no error
+          // either; announcing one on the error channel made every consumer
+          // (CLI exit code, TUI toast, orchestrators) fail runs that recover.
+          // If compaction cannot shrink the session, compaction.ts publishes
+          // the terminal error.
           ctx.needsCompaction = true
-          yield* events.publish(Session.Event.Error, { sessionID: ctx.sessionID, error })
           return
         }
         ctx.assistantMessage.error = error

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -242,6 +242,63 @@ describe("opencode run (non-interactive subprocess)", () => {
   )
 
   cliIt.concurrent(
+    "recovers from a provider size error via compaction without emitting an error event",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.error(413, {
+          error: { type: "request_too_large", message: "Request exceeds the maximum size" },
+        })
+        yield* llm.text("compacted history")
+        yield* llm.text("recovered output")
+
+        const result = yield* opencode.run("recover after overflow", {
+          format: "json",
+          env: { OPENCODE_DISABLE_AUTOCOMPACT: "0" },
+        })
+
+        opencode.expectExit(result, 0)
+        const events = opencode.parseJsonEvents(result.stdout)
+        expect(events.some((event) => event.type === "error")).toBe(false)
+        expect(
+          events.some(
+            (event) =>
+              event.type === "text" &&
+              typeof event.part === "object" &&
+              event.part !== null &&
+              "text" in event.part &&
+              event.part.text === "recovered output",
+          ),
+        ).toBe(true)
+      }),
+    60_000,
+  )
+
+  cliIt.concurrent(
+    "exits nonzero with an error event when compaction cannot shrink the session",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.error(413, {
+          error: { type: "request_too_large", message: "Request exceeds the maximum size" },
+        })
+        yield* llm.error(413, {
+          error: { type: "request_too_large", message: "Request exceeds the maximum size" },
+        })
+
+        const result = yield* opencode.run("overflow beyond recovery", {
+          format: "json",
+          env: { OPENCODE_DISABLE_AUTOCOMPACT: "0" },
+        })
+
+        opencode.expectExit(result, 1)
+        const events = opencode.parseJsonEvents(result.stdout)
+        const errors = events.filter((event) => event.type === "error")
+        expect(errors.length).toBe(1)
+        expect(JSON.stringify(errors[0])).toContain("too large to compact")
+      }),
+    60_000,
+  )
+
+  cliIt.concurrent(
     "rejects requested permissions by default and allows them with the dangerous flag",
     ({ home, llm, opencode }) =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #39573

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a provider rejects a request for size (413 / `ContextOverflowError`) and auto-compaction is enabled, the halt path in `processor.ts` publishes `Session.Event.Error` and then recovers (compact, retry, succeed). Every consumer of that event treats it as the run's outcome — `opencode run` exits 1, the TUI shows an error toast, the desktop app fires an OS notification — so a run that produced a correct result is reported as failed.

That publish is the outlier among `session.error` producers: it's the only one that doesn't set `message.error` (so the event contradicts the stored message), the only one not followed by idle or a throw, and nothing consumes it — compaction is triggered by the `"compact"` return value, not the event. Recoverable provider errors elsewhere are already silent: retried 429s never publish, and the proactive overflow check just sets `needsCompaction`.

The fix moves the announcement from "overflow occurred" to "recovery abandoned":

- `processor.ts`: remove the publish in the auto-compact branch.
- `compaction.ts`: publish in the `result === "compact"` branch ("too large to compact even after stripping media"), which already writes `message.error` / `finish = "error"` but emitted no event. Without this half, failed recovery would exit 0 silently — before this PR, that case only got its error event as a side effect of the halt re-entering during summary generation, carrying the raw 413 text instead of the clearer compaction message.

Net effect: `session.error` fires when the outcome is affected. Recovered overflow is quiet (the compaction message still shows in the transcript and `session.compacted` still fires); abandoned recovery still fails loudly, now with the better message. No consumer changes needed.

### How did you verify your code works?

Two new subprocess tests in `test/cli/run/run-process.test.ts` using the existing TestLLMServer harness:

- 413 → compact → retry: exit 0, no `error` event on the `--format json` stream, recovered output present.
- 413 → compaction itself also 413s: exit 1, exactly one `error` event, containing "too large to compact".

Both fail with the source change reverted (checked by stashing `src/` and re-running). Full `run-process.test.ts` passes 15/15, and `bun typecheck` from `packages/opencode` is clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
