### PR TITLE
refactor(core): simplify formatter selection

### DIFF
--- a/packages/core/src/formatter.ts
+++ b/packages/core/src/formatter.ts
@@ -54,9 +54,6 @@ const layer = Layer.effect(
         })
         formatters = builtIns
         if (configured === true) return
-        if (configured.ruff?.disabled || configured.uv?.disabled) {
-          formatters = formatters.filter((formatter) => formatter.name !== "ruff" && formatter.name !== "uv")
-        }
 
         for (const [name, entry] of Object.entries(configured)) {
           const index = formatters.findIndex((formatter) => formatter.name === name)

--- a/packages/core/src/formatter/builtins.ts
+++ b/packages/core/src/formatter/builtins.ts
@@ -18,7 +18,6 @@ export function make(input: {
   readonly fs: FSUtil.Interface
   readonly npm: Npm.Interface
   readonly processes: AppProcess.Interface
-  readonly experimentalOxfmt?: boolean
 }) {
   const disabled = false as const
   const findUp = (target: string) => input.fs.findUp(target, input.directory, input.worktree)


### PR DESCRIPTION
## Summary
- remove the unused `experimentalOxfmt` built-in parameter
- remove linked Ruff/UV disable handling so formatter entries are configured independently

## Verification
- `bun typecheck` in `packages/core`
- `bun test test/formatter.test.ts` in `packages/core` (9 passed)