### PR TITLE
fix(opencode): await stdout drain so piped output is not truncated

### DIFF
--- a/packages/opencode/src/cli/cmd/db.ts
+++ b/packages/opencode/src/cli/cmd/db.ts
@@ -1,9 +1,15 @@
+import { EOL } from "os"
 import type { Argv } from "yargs"
 import { spawn } from "child_process"
 import { Database } from "@opencode-ai/core/database/database"
 import { Effect } from "effect"
 import { sql } from "drizzle-orm"
 import { effectCmd } from "../effect-cmd"
+import { writeStdout } from "../../util/stdout"
+
+// Matches the 64 KiB pipe buffer: large enough that a flush rarely blocks, small
+// enough that the rendered text never becomes a second copy of the result set.
+const CHUNK_SIZE = 64 * 1024
 
 const QueryCommand = effectCmd({
   command: "$0 [query]",
@@ -27,11 +33,23 @@ const QueryCommand = effectCmd({
     if (query) {
       const { db } = yield* Database.Service
       const result = yield* db.all<Record<string, unknown>>(sql.raw(query)).pipe(Effect.orDie)
-      if (args.format === "json") console.log(JSON.stringify(result, null, 2))
-      else if (result.length > 0) {
+      if (args.format === "json") {
+        yield* Effect.promise(() => writeStdout(JSON.stringify(result, null, 2) + EOL))
+      } else if (result.length > 0) {
         const keys = Object.keys(result[0])
-        console.log(keys.join("\t"))
-        for (const row of result) console.log(keys.map((key) => row[key]).join("\t"))
+        // Flush in chunks rather than joining the whole table first: `db.all()`
+        // has already materialized every row, so buffering the rendered text on
+        // top of that doubles the footprint on large results.
+        let chunk = keys.join("\t") + EOL
+        for (const row of result) {
+          chunk += keys.map((key) => row[key]).join("\t") + EOL
+          if (chunk.length >= CHUNK_SIZE) {
+            const pending = chunk
+            chunk = ""
+            yield* Effect.promise(() => writeStdout(pending))
+          }
+        }
+        if (chunk.length > 0) yield* Effect.promise(() => writeStdout(chunk))
       }
       return
     }

--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -6,6 +6,7 @@ import { effectCmd, fail } from "../effect-cmd"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
 import { EOL } from "os"
+import { writeStdout } from "../../util/stdout"
 import { Effect } from "effect"
 
 function redact(kind: string, id: string, value: string) {
@@ -286,7 +287,8 @@ const run = Effect.fn("Cli.export.body")(function* (args: { sessionID?: string; 
 
     const exportData = { info: sessionInfo, messages }
 
-    process.stdout.write(JSON.stringify(args.sanitize ? sanitize(exportData) : exportData, null, 2))
-    process.stdout.write(EOL)
+    yield* Effect.promise(() =>
+      writeStdout(JSON.stringify(args.sanitize ? sanitize(exportData) : exportData, null, 2) + EOL),
+    )
   }).pipe(Effect.catchCause(() => fail(`Session not found: ${sessionID!}`)))
 })

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -11,6 +11,7 @@ import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 import { NotFoundError } from "@/storage/storage"
 import { EOL } from "os"
+import { writeStdout } from "../../util/stdout"
 import path from "path"
 import { which } from "@opencode-ai/core/util/which"
 
@@ -101,7 +102,7 @@ export const SessionListCommand = effectCmd({
         })
 
         if (!proc.stdin) {
-          console.log(output)
+          await writeStdout(output + EOL)
           return
         }
 
@@ -110,7 +111,7 @@ export const SessionListCommand = effectCmd({
         await proc.exited
       })
     } else {
-      console.log(output)
+      yield* Effect.promise(() => writeStdout(output + EOL))
     }
   }),
 })

--- a/packages/opencode/src/util/stdout.ts
+++ b/packages/opencode/src/util/stdout.ts
@@ -1,0 +1,33 @@
+/**
+ * Write `text` to stdout and resolve once the stream has accepted all of it.
+ *
+ * `process.stdout.write()` returns false when the destination (typically a
+ * pipe) cannot take the whole payload at once. The remainder is queued on the
+ * stream, and anything still queued when the process exits is discarded, so
+ * large output is silently truncated at the pipe buffer boundary while the
+ * command still exits 0. Awaiting `drain` before returning keeps the write
+ * intact.
+ *
+ * A downstream reader that goes away (`| head`) raises EPIPE and never emits
+ * `drain`, so that case resolves rather than hanging forever. Any other write
+ * error rejects: attaching a listener suppresses the default crash, and
+ * reporting success after a failed write is the same silent-truncation trap
+ * this function exists to close.
+ */
+export function writeStdout(text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (process.stdout.write(text)) return resolve()
+    const settle = (err?: NodeJS.ErrnoException) => {
+      process.stdout.off("drain", onDrain)
+      process.stdout.off("error", onError)
+      process.stdout.off("close", onDrain)
+      if (err && err.code !== "EPIPE") reject(err)
+      else resolve()
+    }
+    const onDrain = () => settle()
+    const onError = (err: NodeJS.ErrnoException) => settle(err)
+    process.stdout.on("drain", onDrain)
+    process.stdout.on("error", onError)
+    process.stdout.on("close", onDrain)
+  })
+}

--- a/packages/opencode/test/util/stdout.test.ts
+++ b/packages/opencode/test/util/stdout.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const STDOUT_MODULE = path.join(import.meta.dir, "../../src/util/stdout.ts")
+
+// 200 KB is comfortably past the 64 KiB pipe buffer where the truncation bit.
+const SIZE = 200_000
+
+/**
+ * Runs a writer in a child process behind a *slow* reader and returns the byte
+ * count that survived.
+ *
+ * The delay matters. With a reader that drains immediately the pipe never fills,
+ * write() never reports backpressure, and even a broken writer looks correct;
+ * that false pass is what let this bug survive an earlier fix attempt. Sleeping
+ * first guarantees the buffer is full before anything is consumed.
+ */
+async function survivingBytes(writer: string, delaySeconds = 1) {
+  const proc = Bun.spawn(
+    ["sh", "-c", `${process.execPath} -e '${writer.replace(/'/g, `'\\''`)}' | { sleep ${delaySeconds}; cat; } | wc -c`],
+    { stdout: "pipe", stderr: "pipe" },
+  )
+  const out = await new Response(proc.stdout).text()
+  await proc.exited
+  return Number(out.trim())
+}
+
+const awaited = `const { writeStdout } = await import(${JSON.stringify(STDOUT_MODULE)}); await writeStdout("x".repeat(${SIZE})); process.exit(0)`
+const unawaited = `process.stdout.write("x".repeat(${SIZE})); process.exit(0)`
+
+describe("writeStdout", () => {
+  test("delivers a payload larger than the pipe buffer to a slow reader", async () => {
+    expect(await survivingBytes(awaited)).toBe(SIZE)
+  })
+
+  test("an unawaited write truncates under the same conditions", async () => {
+    // Guards the guard: if this ever passes, the test above proves nothing.
+    expect(await survivingBytes(unawaited)).toBeLessThan(SIZE)
+  })
+
+  test("resolves instead of hanging when the reader goes away", async () => {
+    // `| head` closes the pipe early. Waiting for a drain that never arrives
+    // would hang the command forever.
+    const proc = Bun.spawn(["sh", "-c", `${process.execPath} -e '${awaited.replace(/'/g, `'\\''`)}' | head -c 10`], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const out = await new Response(proc.stdout).text()
+    await proc.exited
+    expect(out.length).toBe(10)
+  })
+
+  test("short payloads are unaffected", async () => {
+    const proc = Bun.spawn(
+      [
+        process.execPath,
+        "-e",
+        `const { writeStdout } = await import(${JSON.stringify(STDOUT_MODULE)}); await writeStdout("hello"); process.exit(0)`,
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    )
+    const out = await new Response(proc.stdout).text()
+    await proc.exited
+    expect(out).toBe("hello")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29330

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode db`, `session list`, and `export` silently lose output past 64 KiB when piped. Exit code stays 0, so it looks like it worked.

`process.stdout.write()` returns `false` once the pipe buffer is full. The rest is queued on the stream and thrown away when the process exits. `console.log` does the same thing and gives you nothing to await. That is why #3049 didn't fix it: it moved `export` to `process.stdout.write` but never waited for the write to be accepted.

This adds a small `writeStdout()` that waits for `drain` when the write is refused, and routes the three commands through it. EPIPE resolves instead of waiting for a drain that will never come, so `| head` still works.

`db` also renders TSV in 64 KiB chunks now. Building the whole table as one string first was a second copy of a result set `db.all()` had already materialized.

Worth noting the accepted explanation on #29330 is that `process.exit()` in `src/index.ts` fires before stdout drains. I don't think that's it: removing the `process.exit()` and waiting 2s still truncated at exactly 65536. Backpressure is the part that matters, so I left `process.exit()` alone.

### How did you verify your code works?

Repro needs no existing sessions:

```bash
Q="with recursive t(n) as (select 1 union all select n+1 from t where n < 5000)
   select n as n, '0123456789012345678901234567890123456789' as pad from t"

bun dev db --format json "$Q" | wc -c    # before: 65536   after: 388896
bun dev db --format json "$Q" > f; wc -c f   # 388896 both
```

Also checked, before -> after:

- tsv, one 200 KB row, piped: 65541 -> 200006
- tsv, 5000 rows through a slow reader: 65536 -> 228899
- 19 MB result: piped output now byte-identical to a file redirect
- `| head -c 20` returns 20 bytes and doesn't hang
- small results, empty results, `db path`, exit codes (0 ok / 1 bad SQL) unchanged
- 400k rows: 1.0s / 520 MB vs 1.2-1.3s / 423-477 MB on dev. Faster, ~10% more peak RSS, `db.all()` dominates either way.

`bun typecheck` clean. `bun test` in `packages/opencode` has the same 7 failures before and after (5s timeouts in workspace/snapshot/httpapi/revert tests). New `test/util/stdout.test.ts` covers the large-payload, EPIPE, and short-payload cases, plus a control asserting an unawaited write still truncates so the test can't quietly stop testing anything.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
