### PR TITLE
fix(tui): focus palette settings after layout

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -1,10 +1,10 @@
-import { InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { CliRenderEvents, InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { Keymap, type KeymapCommand } from "../context/keymap"
 import { useTheme, useThemes } from "../context/theme"
 import { entries, filter, flatMap, groupBy, pipe } from "remeda"
 import { batch, createEffect, createMemo, createSignal, For, Show, type JSX, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
-import { useTerminalDimensions } from "@opentui/solid"
+import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "./dialog"
@@ -100,6 +100,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const mode = themes.mode
   const config = useConfig().data
   const scrollAcceleration = createMemo(() => getScrollAcceleration(config))
+  const renderer = useRenderer()
 
   const [store, setStore] = createStore({
     selected: 0,
@@ -110,7 +111,17 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const actionFocused = createMemo(() => focusedAction() !== undefined)
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
-  let visibilityGeneration = 0
+  let pendingVisibility: (() => void) | undefined
+
+  function scheduleVisibility(callback: () => void) {
+    if (pendingVisibility) renderer.off(CliRenderEvents.FRAME, pendingVisibility)
+    pendingVisibility = () => {
+      pendingVisibility = undefined
+      callback()
+    }
+    renderer.once(CliRenderEvents.FRAME, pendingVisibility)
+    renderer.requestRender()
+  }
 
   createEffect(
     on(
@@ -265,14 +276,10 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           selection = option
           if (!moved) return
           const value = option.value
-          const generation = ++visibilityGeneration
-          requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-              if (generation !== visibilityGeneration) return
-              if (!props.preserveSelection || store.filter.length > 0) return
-              if (!isDeepEqual(selected()?.value, value)) return
-              scrollToSelection(false)
-            })
+          scheduleVisibility(() => {
+            if (!props.preserveSelection || store.filter.length > 0) return
+            if (!isDeepEqual(selected()?.value, value)) return
+            scrollToSelection(false)
           })
           return
         }
@@ -284,23 +291,23 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     ),
   )
   onCleanup(() => {
-    visibilityGeneration++
+    if (!pendingVisibility) return
+    renderer.off(CliRenderEvents.FRAME, pendingVisibility)
+    pendingVisibility = undefined
   })
 
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
       if (filter.length > 0) resetSelection = true
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (filter.length > 0) {
-            moveTo(0, true, false)
-            return
-          }
-          if (current && props.focusCurrent !== false) {
-            const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
-            if (currentIndex >= 0) moveTo(currentIndex, true)
-          }
-        })
+      scheduleVisibility(() => {
+        if (filter.length > 0) {
+          moveTo(0, true, false)
+          return
+        }
+        if (current && props.focusCurrent !== false) {
+          const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
+          if (currentIndex >= 0) moveTo(currentIndex, true)
+        }
       })
     }),
   )

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -111,15 +111,16 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const actionFocused = createMemo(() => focusedAction() !== undefined)
   let selection: { value: T; category?: string } | undefined
   let resetSelection = false
-  let pendingVisibility: (() => void) | undefined
+  let pendingScroll: (() => void) | undefined
 
-  function scheduleVisibility(callback: () => void) {
-    if (pendingVisibility) renderer.off(CliRenderEvents.FRAME, pendingVisibility)
-    pendingVisibility = () => {
-      pendingVisibility = undefined
-      callback()
+  function scrollAfterLayout(center: boolean, value: T) {
+    if (pendingScroll) renderer.off(CliRenderEvents.FRAME, pendingScroll)
+    pendingScroll = () => {
+      pendingScroll = undefined
+      if (!isDeepEqual(selected()?.value, value)) return
+      scrollToSelection(center)
     }
-    renderer.once(CliRenderEvents.FRAME, pendingVisibility)
+    renderer.once(CliRenderEvents.FRAME, pendingScroll)
     renderer.requestRender()
   }
 
@@ -275,12 +276,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           setStore("selected", index)
           selection = option
           if (!moved) return
-          const value = option.value
-          scheduleVisibility(() => {
-            if (!props.preserveSelection || store.filter.length > 0) return
-            if (!isDeepEqual(selected()?.value, value)) return
-            scrollToSelection(false)
-          })
+          if (!props.preserveSelection || store.filter.length > 0) return
+          scrollAfterLayout(false, option.value)
           return
         }
         const next = reconcileSelection(store.selected, flat().length)
@@ -291,24 +288,26 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     ),
   )
   onCleanup(() => {
-    if (!pendingVisibility) return
-    renderer.off(CliRenderEvents.FRAME, pendingVisibility)
-    pendingVisibility = undefined
+    if (!pendingScroll) return
+    renderer.off(CliRenderEvents.FRAME, pendingScroll)
+    pendingScroll = undefined
   })
 
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
       if (filter.length > 0) resetSelection = true
-      scheduleVisibility(() => {
-        if (filter.length > 0) {
-          moveTo(0, true, false)
-          return
-        }
-        if (current && props.focusCurrent !== false) {
-          const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
-          if (currentIndex >= 0) moveTo(currentIndex, true)
-        }
-      })
+      if (filter.length > 0) {
+        const option = flat()[0]
+        if (!option) return
+        moveTo(0, true, false)
+        scrollAfterLayout(true, option.value)
+        return
+      }
+      if (!current || props.focusCurrent === false) return
+      const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
+      if (currentIndex < 0) return
+      moveTo(currentIndex, true)
+      scrollAfterLayout(true, current)
     }),
   )
 

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -290,16 +290,18 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
       if (filter.length > 0) resetSelection = true
-      setTimeout(() => {
-        if (filter.length > 0) {
-          moveTo(0, true, false)
-        } else if (current && props.focusCurrent !== false) {
-          const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
-          if (currentIndex >= 0) {
-            moveTo(currentIndex, true)
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (filter.length > 0) {
+            moveTo(0, true, false)
+            return
           }
-        }
-      }, 0)
+          if (current && props.focusCurrent !== false) {
+            const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
+            if (currentIndex >= 0) moveTo(currentIndex, true)
+          }
+        })
+      })
     }),
   )
 

--- a/packages/tui/test/cli/tui/command-palette.test.tsx
+++ b/packages/tui/test/cli/tui/command-palette.test.tsx
@@ -73,16 +73,11 @@ test("searches settings globally and opens the matching setting", async () => {
     expect(app.captureCharFrame()).not.toContain("Animations")
     await app.waitFor(() => app.renderer.currentFocusedEditor instanceof InputRenderable)
 
-    for (const key of "side") app.mockInput.pressKey(key)
-    await app.waitForFrame((frame) => frame.includes("Sidebar"))
-    expect(app.captureCharFrame()).not.toContain("New session")
-    expect(app.captureCharFrame()).not.toContain("Switch model")
-    expect(app.captureCharFrame()).not.toContain("Markdown")
-
+    for (const key of "sounds") app.mockInput.pressKey(key)
     app.mockInput.pressEnter()
-    await app.waitForFrame((frame) => frame.includes("Settings") && frame.includes("Color mode"))
+    await app.waitForFrame((frame) => frame.includes("Settings") && frame.includes("Sounds"))
     app.mockInput.pressEnter()
-    await app.waitFor(() => current.session?.sidebar === "hide")
+    await app.waitFor(() => current.attention?.sound === false)
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/cli/tui/command-palette.test.tsx
+++ b/packages/tui/test/cli/tui/command-palette.test.tsx
@@ -73,6 +73,7 @@ test("searches settings globally and opens the matching setting", async () => {
     expect(app.captureCharFrame()).not.toContain("Animations")
     await app.waitFor(() => app.renderer.currentFocusedEditor instanceof InputRenderable)
 
+    app.mockInput.pressArrow("down")
     for (const key of "sounds") app.mockInput.pressKey(key)
     app.mockInput.pressEnter()
     await app.waitForFrame((frame) => frame.includes("Settings") && frame.includes("Sounds"))


### PR DESCRIPTION
**What**

Make settings opened from command-palette search visible and active immediately, including off-screen results such as Sounds.

**Before / After**

**Before:** Type `sounds` in the command palette and press Enter immediately. The Settings dialog selects Sounds internally, but its scrollbox remains at Appearance because the scroll runs before OpenTUI has completed layout.

**After:** Selection updates synchronously, so immediate input targets Sounds. The layout-dependent scroll runs after OpenTUI completes the frame, centering Sounds in the viewport.

**How**

- `packages/tui/src/ui/dialog-select.tsx` keeps selection updates synchronous and coalesces only the pending scroll onto `CliRenderEvents.FRAME`. It requests the layout frame, ignores stale selections, and removes the pending listener during cleanup.
- `packages/tui/test/cli/tui/command-palette.test.tsx` first moves away from index zero, then searches for the off-screen Sounds setting and submits immediately. This covers both synchronous selection reset and post-layout scrolling.

**Scope**

This only changes selection-visibility scheduling in `DialogSelect`. Filtering, selection reconciliation, and setting mutation behavior are unchanged.

**Testing**

- `cd packages/tui && bun run test test/cli/tui/dialog-select.test.tsx test/cli/tui/command-palette.test.tsx test/ui/select-controller.test.ts` (11 passed)
- `cd packages/tui && bun typecheck`
- Repository pre-push typecheck: 33 packages passed
- Full TUI suite: 562 passed, 5 skipped; one pre-existing timeout remains in `restores queued compaction from durable pending input` and reproduces unchanged on `origin/v2`

**Demo**

This six-second crop uses the OpenTUI regression harness to preserve the immediate type-and-submit timing. The first half shows the baseline dialog at Appearance; the second shows the fixed dialog centered on Sounds.

https://github.com/user-attachments/assets/03a1325f-3049-4e0d-8e0c-f606f3bb733f
