### PR TITLE
feat(tui): prefetch open session tabs after connect

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -1,6 +1,7 @@
-import { createEffect, onCleanup } from "solid-js"
+import { createEffect, createMemo, onCleanup } from "solid-js"
 import { isDeepEqual } from "remeda"
 import { createSimpleContext } from "./helper"
+import { useClient } from "./client"
 import { useData } from "./data"
 import { useEvent } from "./event"
 import { useRoute } from "./route"
@@ -31,10 +32,14 @@ type PersistedState = {
 
 const empty = (): TabsState => ({ tabs: [], unread: {} })
 
+// Deliberately after connect settles: the visible session's mount syncs win the first slots.
+const TAB_PREFETCH_DELAY = 300
+
 export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimpleContext({
   name: "SessionTabs",
   init: () => {
     const route = useRoute()
+    const client = useClient()
     const data = useData()
     const event = useEvent()
     const config = useConfig().data
@@ -126,6 +131,45 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
           result[sessionID] = result[sessionID] === "error" ? "error" : entry[1]
           return result
         }, {})
+      })
+    })
+
+    // Warm open tabs' session data so first switches render from cache instead of fetching inside
+    // the switch gesture. Uses only existing sync methods (each dedupes internally), so reruns on
+    // tab-set or connection changes are no-ops for already-warm sessions, and reconnects double as
+    // a cache refresh after an SSE gap. The delay lets the current session's own mount syncs get
+    // the first connection slots. The effect tracks only the id set: reorders, tab switches, and
+    // title updates neither restart the timer nor an in-flight warm pass; the timer callback
+    // itself runs untracked, where the current session is skipped.
+    const openTabSessions = createMemo(() =>
+      state()
+        .tabs.map((tab) => tab.sessionID)
+        .sort()
+        .join("\n"),
+    )
+    createEffect(() => {
+      if (!enabled()) return
+      if (client.connection.status() !== "connected") return
+      if (openTabSessions() === "") return
+      let stale = false
+      const timer = setTimeout(async () => {
+        const sessions = state()
+          .tabs.map((tab) => tab.sessionID)
+          .filter((sessionID) => sessionID !== current())
+        for (const sessionID of sessions) {
+          if (stale) return
+          await Promise.allSettled([
+            data.session.sync(sessionID),
+            data.session.message.sync(sessionID),
+            data.session.pending.sync(sessionID),
+            data.session.permission.sync(sessionID),
+            data.session.form.sync(sessionID),
+          ])
+        }
+      }, TAB_PREFETCH_DELAY)
+      onCleanup(() => {
+        stale = true
+        clearTimeout(timer)
       })
     })
 


### PR DESCRIPTION
## What

The first visit to an open session tab showed an empty transcript while `message.list` and its sibling fetches ran inside the switch gesture — a few hundred ms of blank screen on long transcripts. This PR warms open tabs' session data in the background after the client connects, so first switches render from cache like revisits do.

**Before**: click a never-visited tab → keyed remount → mount syncs fire → blank transcript until the fetches resolve (the 200-message `message.list` alone measured ~276ms on a heavy session).

**After**: 300ms after connect, tabs warm sequentially in the background. By the time you click, the store already holds the data and the switch renders immediately. Clicking faster than the warm-up degrades to exactly the old behavior.

## How

One effect in `packages/tui/src/context/session-tabs.tsx`. For each open tab except the current session, it runs the five syncs a session route reads on mount (`session`, `message`, `pending`, `permission`, `form`), sequentially per session, deferred 300ms so the visible session's own mount syncs get the first connection slots.

- Uses only existing `data.*.sync` methods — no data-context or plugin API changes. Each sync dedupes internally, so effect reruns (tab changes, reconnects) are no-ops for already-warm sessions, and a reconnect doubles as a cache refresh after an SSE gap.
- Cancellation: tab-set or connection changes flag the pass stale and clear the timer; an in-flight pass stops at the next session boundary.

## Scope

- Deliberately not a data-layer prefetch/paging API — sync-what-mount-syncs is the whole design, so this can be deleted wholesale when a designed data-layer prefetch or partial-page fetch lands.
- Memory is bounded by open-tab count (same data any visit would cache).
- Complements #39568 (tail-first mounting) but is independent of it: that PR makes warm switches cheap to *mount*; this one makes first switches warm.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 563 pass, 5 skip, 0 fail
- oxlint and repo-pinned Prettier clean on the changed file
- Behavior previously verified end-to-end in the earlier revision of #39568 (same effect shape against a `data.session.prefetch` bundle): cold first visits measured 43–61ms with zero fetches inside the switch window, vs ~230ms+ unprefetched
