### PR TITLE
feat(plugin): add ui.tabs API for session tab control

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -346,6 +346,25 @@ export interface UI {
     navigate(destination: Destination): void
     current(): Route
   }
+  readonly tabs: {
+    /** Returns whether session tabs are enabled for this TUI. */
+    enabled(): boolean
+    /** Returns the currently open root-session tabs. Reactive when read in a Solid computation. */
+    list(): readonly {
+      readonly sessionID: string
+      readonly title?: string
+      readonly active: boolean
+      readonly busy: boolean
+      readonly attention: boolean
+      readonly unread?: "activity" | "error"
+    }[]
+    /** Opens (or focuses) a tab for a session, adding it when not already open. Returns false when tabs are disabled. */
+    open(sessionID: string): boolean
+    /** Focuses an already-open tab and returns false when it is not open. */
+    focus(sessionID: string): boolean
+    /** Closes an open tab, or the active tab when omitted, and returns false when no tab matched. */
+    close(sessionID?: string): boolean
+  }
   readonly slot: <Name extends SlotName>(name: Name, render: Slot<Name>) => () => void
 }
 

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -33,6 +33,7 @@ import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 import { useAttention } from "../context/attention"
 import { useStorage } from "../context/storage"
+import { useSessionTabs } from "../context/session-tabs"
 import { abbreviateHome } from "../util/path-format"
 import { builtins } from "./builtins"
 import { discoverTuiPlugins } from "./discovery"
@@ -94,6 +95,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver }>
   const toast = useToast()
   const attention = useAttention()
   const storage = useStorage()
+  const sessionTabs = useSessionTabs()
   const directory = config.path ? path.dirname(config.path) : process.cwd()
   const [store, setStore] = createStore({
     ready: false,
@@ -276,6 +278,33 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver }>
           },
           current() {
             return route.data
+          },
+        },
+        tabs: {
+          enabled: sessionTabs.enabled,
+          list: () =>
+            sessionTabs.tabs().map((tab) => ({
+              ...tab,
+              active: sessionTabs.current() === tab.sessionID,
+              ...sessionTabs.status(tab.sessionID),
+            })),
+          open(sessionID) {
+            if (!sessionTabs.enabled()) return false
+            sessionTabs.select(sessionID)
+            return true
+          },
+          focus(sessionID) {
+            if (!sessionTabs.enabled()) return false
+            if (!sessionTabs.tabs().some((tab) => tab.sessionID === sessionID)) return false
+            sessionTabs.select(sessionID)
+            return true
+          },
+          close(sessionID) {
+            if (!sessionTabs.enabled()) return false
+            const target = sessionID ?? sessionTabs.current()
+            if (!target || !sessionTabs.tabs().some((tab) => tab.sessionID === target)) return false
+            sessionTabs.close(target)
+            return true
           },
         },
         slot(name, render) {


### PR DESCRIPTION
## What

Adds a `ui.tabs` API to the TUI plugin context so plugins can observe and control session tabs. Until now, tabs were purely internal to the TUI: a plugin could render into slots and navigate routes, but had no way to know which tabs are open, which one is focused, or to open/close them.

First consumer is the voice-control plugin, where the assistant answers "what tabs do I have open?", focuses a tab by name, opens a session as a new tab, and closes finished ones.

```ts
context.ui.tabs.enabled()          // tabs feature on for this TUI?
context.ui.tabs.list()             // [{ sessionID, title, active, busy, attention, unread }]
context.ui.tabs.open(sessionID)    // open (or focus) a tab for any session
context.ui.tabs.focus(sessionID)   // focus an already-open tab; false when not open
context.ui.tabs.close(sessionID?)  // close a tab, or the active one when omitted
```

## How

- `packages/plugin/src/tui/context.ts` — the `UI` interface gains `tabs` with doc comments; `list()` is reactive when read inside a Solid computation.
- `packages/tui/src/plugin/context.tsx` — implementation delegates to the existing `useSessionTabs` context: `list()` joins tab entries with `status()` (busy/attention/unread) and the current route; `open()` uses `select()`, which navigates and lets the route effect add the tab; `focus()`/`close()` validate membership first and report success as a boolean.

All verbs are no-ops returning `false` when tabs are disabled, so plugins degrade gracefully in TUIs running without tabs.

## Scope

- Read + open/focus/close only. No reorder, rename, or unread manipulation — happy to add when a consumer needs them.
- No plugin-facing events for tab changes; `list()` reactivity covers the current use cases.

## Testing

- `bun typecheck` in `packages/plugin` and `packages/tui`
- `bun run test` in `packages/tui`: 568 pass, 0 fail
- End-to-end via the voice plugin on this API shape: listing, focusing, opening, and closing tabs by voice against a live TUI