### PR TITLE
fix(core): retry lazy initializer after it throws

### DIFF
--- a/packages/core/src/util/lazy.ts
+++ b/packages/core/src/util/lazy.ts
@@ -4,8 +4,11 @@ export function lazy<T>(fn: () => T) {
 
   return (): T => {
     if (loaded) return value as T
+    // Only memoize once fn() returns. Marking loaded up front caches `undefined`
+    // forever when the initializer throws, so a transient failure is permanent.
+    const next = fn()
+    value = next
     loaded = true
-    value = fn()
-    return value as T
+    return next
   }
 }

--- a/packages/core/test/util/lazy.test.ts
+++ b/packages/core/test/util/lazy.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import { lazy } from "@opencode-ai/core/util/lazy"
+
+test("lazy caches the resolved value and calls fn once", () => {
+  let calls = 0
+  const get = lazy(() => {
+    calls++
+    return { id: calls }
+  })
+
+  const first = get()
+  expect(get()).toBe(first)
+  expect(calls).toBe(1)
+})
+
+test("lazy retries after the initializer throws", () => {
+  let calls = 0
+  const get = lazy(() => {
+    calls++
+    if (calls === 1) throw new Error("transient")
+    return "value"
+  })
+
+  expect(() => get()).toThrow("transient")
+  expect(get()).toBe("value")
+  expect(calls).toBe(2)
+})
+
+test("lazy keeps rethrowing while the initializer keeps failing", () => {
+  let calls = 0
+  const get = lazy(() => {
+    calls++
+    throw new Error("always")
+  })
+
+  expect(() => get()).toThrow("always")
+  expect(() => get()).toThrow("always")
+  expect(calls).toBe(2)
+})
+
+test("lazy caches an undefined result without re-running fn", () => {
+  let calls = 0
+  const get = lazy(() => {
+    calls++
+    return undefined
+  })
+
+  expect(get()).toBeUndefined()
+  expect(get()).toBeUndefined()
+  expect(calls).toBe(1)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39596

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`lazy()` set `loaded = true` before calling `fn()`. If the initializer throws, `loaded` is already true but `value` was never assigned, so every later call takes the `if (loaded)` fast path and returns `undefined` forever. The real error is swallowed and a transient failure becomes permanent.

Moving the assignment after `fn()` returns fixes it: a throw now leaves `loaded` false, so the next call retries. Success path is unchanged - still one `fn()` call, still caches an `undefined` result.

### How did you verify your code works?

Added `packages/core/test/util/lazy.test.ts` (4 tests: caching, retry after throw, repeated failure, cached `undefined`).

Checked the tests actually catch the bug - reverted the src change and the two retry tests fail (`Received function did not throw`, received `undefined`); with the fix 4/4 pass.

`bun typecheck` clean in `packages/core`; `bun test test/util/` 31/31 pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
