### PR TITLE
fix(core): correct path helpers for delimiter-less input

### DIFF
--- a/packages/core/src/util/path.ts
+++ b/packages/core/src/util/path.ts
@@ -9,13 +9,18 @@ export function getDirectory(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[/\\]+$/, "")
   const parts = trimmed.split(/[/\\]/)
+  // A path with no separator has no parent directory, so there is nothing to show.
+  if (parts.length <= 1) return ""
   return parts.slice(0, parts.length - 1).join("/") + "/"
 }
 
 export function getFileExtension(path: string | undefined) {
   if (!path) return ""
-  const parts = path.split(".")
-  return parts[parts.length - 1]
+  const filename = getFilename(path)
+  // A leading dot marks a hidden file, not an extension.
+  const lastDot = filename.lastIndexOf(".")
+  if (lastDot <= 0) return ""
+  return filename.slice(lastDot + 1)
 }
 
 export function getFilenameTruncated(path: string | undefined, maxLength: number = 20) {
@@ -30,8 +35,11 @@ export function getFilenameTruncated(path: string | undefined, maxLength: number
 
 export function truncateMiddle(text: string, maxLength: number = 20) {
   if (text.length <= maxLength) return text
+  if (maxLength <= 1) return "…"
   const available = maxLength - 1 // -1 for ellipsis
   const start = Math.ceil(available / 2)
   const end = Math.floor(available / 2)
+  // slice(-0) returns the whole string, so an empty tail has to be handled explicitly.
+  if (end === 0) return text.slice(0, start) + "…"
   return text.slice(0, start) + "…" + text.slice(-end)
 }

--- a/packages/core/test/util/path.test.ts
+++ b/packages/core/test/util/path.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { getDirectory, getFileExtension, getFilename, truncateMiddle } from "@opencode-ai/core/util/path"
+
+test("getFilename returns the last segment", () => {
+  expect(getFilename("a/b/c.txt")).toBe("c.txt")
+  expect(getFilename("C:\\x\\y.txt")).toBe("y.txt")
+  expect(getFilename("a/b/")).toBe("b")
+  expect(getFilename(undefined)).toBe("")
+})
+
+test("getDirectory returns the parent directory", () => {
+  expect(getDirectory("src/file.txt")).toBe("src/")
+  expect(getDirectory("a/b/c.txt")).toBe("a/b/")
+  expect(getDirectory("C:\\x\\y.txt")).toBe("C:/x/")
+})
+
+test("getDirectory returns empty for a path with no parent", () => {
+  expect(getDirectory("README.md")).toBe("")
+  expect(getDirectory("file.txt")).toBe("")
+  expect(getDirectory(undefined)).toBe("")
+  expect(getDirectory("")).toBe("")
+})
+
+test("getDirectory keeps the root for absolute paths", () => {
+  expect(getDirectory("/abs.txt")).toBe("/")
+})
+
+test("getFileExtension returns the extension without the dot", () => {
+  expect(getFileExtension("a.txt")).toBe("txt")
+  expect(getFileExtension("src/index.test.ts")).toBe("ts")
+  expect(getFileExtension("archive.TAR.GZ")).toBe("GZ")
+})
+
+test("getFileExtension returns empty when there is no extension", () => {
+  expect(getFileExtension("Makefile")).toBe("")
+  expect(getFileExtension("LICENSE")).toBe("")
+  expect(getFileExtension("src/Dockerfile")).toBe("")
+  expect(getFileExtension(undefined)).toBe("")
+})
+
+test("getFileExtension treats a leading dot as a hidden file, not an extension", () => {
+  expect(getFileExtension(".gitignore")).toBe("")
+  expect(getFileExtension("src/.env")).toBe("")
+  expect(getFileExtension(".eslintrc.json")).toBe("json")
+})
+
+test("getFileExtension ignores dots in parent directories", () => {
+  expect(getFileExtension("my.dir/Makefile")).toBe("")
+})
+
+test("truncateMiddle never exceeds maxLength", () => {
+  for (const maxLength of [1, 2, 3, 4, 5, 10]) {
+    const result = truncateMiddle("abcdefghij", maxLength)
+    expect(result.length).toBeLessThanOrEqual(maxLength)
+  }
+})
+
+test("truncateMiddle keeps both ends when there is room", () => {
+  expect(truncateMiddle("abcdefghij", 5)).toBe("ab…ij")
+  expect(truncateMiddle("abcdefghij", 4)).toBe("ab…j")
+  expect(truncateMiddle("abcdefghij", 3)).toBe("a…j")
+})
+
+test("truncateMiddle degrades to a prefix when no tail fits", () => {
+  expect(truncateMiddle("abcdefghij", 2)).toBe("a…")
+  expect(truncateMiddle("abcdefghij", 1)).toBe("…")
+})
+
+test("truncateMiddle returns short input unchanged", () => {
+  expect(truncateMiddle("abc", 20)).toBe("abc")
+  expect(truncateMiddle("", 20)).toBe("")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39598

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Three helpers in `packages/core/src/util/path.ts` assumed their delimiter was always present:

- `getDirectory()` appended `"/"` unconditionally, so a root-level file reported `"/"` as its parent and the command palette rendered `/README.md`. Now returns `""` when there is no separator; absolute paths keep their `"/"` root.
- `getFileExtension()` split on `.` and took the last part, so `"Makefile"` returned `"Makefile"` and `".gitignore"` returned `"gitignore"`. Now resolves the filename first and treats a leading dot as a hidden file.
- `truncateMiddle()` hit `slice(-0)` when `maxLength <= 2`, which returns the whole string, so output came back longer than the limit. Now degrades to a prefix or a bare ellipsis.

Normal input is unaffected: `getDirectory("a/b/c.txt")` is still `"a/b/"`, `getFileExtension("a.txt")` still `"txt"`, `truncateMiddle` unchanged for `maxLength >= 3`.

### How did you verify your code works?

Added `packages/core/test/util/path.test.ts` (12 tests).

Checked they catch the bugs - against the unfixed source 6 of 12 fail; with the fix 12/12 pass.

`bun typecheck` clean in `packages/core`; oxlint 0 warnings on both files.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
