### PR TITLE
fix(tui): resolve filetype case-insensitively for suffix and bare names

### DIFF
--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -8,11 +8,10 @@ import {
   type DiffRenderable,
   type ScrollBoxRenderable,
 } from "@opentui/core"
-import { LANGUAGE_EXTENSIONS } from "../../util/filetype"
+import { filetype } from "../../util/filetype"
 import { useBindings, useCommandShortcut } from "../../keymap"
 import { useTheme } from "../../context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
-import path from "path"
 import { createEffect, createMemo, createResource, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js"
 import { DiffViewerFileTree } from "./diff-viewer-file-tree"
 import { Panel, PanelGroup, Separator } from "./diff-viewer-ui"
@@ -70,13 +69,6 @@ const normalizeDiffs = (diffs: readonly (VcsFileDiff | SnapshotFileDiff)[]): Dif
         ]
       : [],
   )
-
-function filetype(input?: string) {
-  if (!input) return "none"
-  const language = LANGUAGE_EXTENSIONS[path.extname(input)]
-  if (["typescriptreact", "javascriptreact", "javascript"].includes(language)) return "typescript"
-  return language
-}
 
 function storedView(value: unknown): DiffView | undefined {
   if (value === "split" || value === "unified") return value

--- a/packages/tui/src/util/filetype.ts
+++ b/packages/tui/src/util/filetype.ts
@@ -122,9 +122,22 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".typc": "typst",
 }
 
+function lookup(input: string) {
+  const name = path.basename(input).toLowerCase()
+  // Keys like ".html.erb" and bare "makefile" never equal path.extname(), so match
+  // the longest suffix first and fall back to the whole name for extensionless files.
+  let dot = name.indexOf(".")
+  while (dot !== -1) {
+    const found = LANGUAGE_EXTENSIONS[name.slice(dot)]
+    if (found) return found
+    dot = name.indexOf(".", dot + 1)
+  }
+  return LANGUAGE_EXTENSIONS[name]
+}
+
 export function filetype(input?: string) {
   if (!input) return "none"
-  const language = LANGUAGE_EXTENSIONS[path.extname(input)]
+  const language = lookup(input)
   if (["typescriptreact", "javascriptreact", "javascript"].includes(language)) return "typescript"
   return language
 }

--- a/packages/tui/test/util/filetype.test.ts
+++ b/packages/tui/test/util/filetype.test.ts
@@ -13,4 +13,39 @@ describe("util.filetype", () => {
     expect(filetype()).toBe("none")
     expect(filetype("")).toBe("none")
   })
+
+  test("ignores extension casing", () => {
+    expect(filetype("COMPONENT.TSX")).toBe("typescript")
+    expect(filetype("main.PY")).toBe("python")
+    expect(filetype("Program.CS")).toBe("csharp")
+    expect(filetype("notes.Md")).toBe("markdown")
+  })
+
+  test("matches extensionless names", () => {
+    expect(filetype("Makefile")).toBe("makefile")
+    expect(filetype("makefile")).toBe("makefile")
+    expect(filetype("build/Makefile")).toBe("makefile")
+  })
+
+  test("matches compound extensions", () => {
+    expect(filetype("index.html.erb")).toBe("erb")
+    expect(filetype("views/show.json.erb")).toBe("erb")
+    expect(filetype("app.css.erb")).toBe("erb")
+  })
+
+  test("prefers the longest matching suffix", () => {
+    // ".json.erb" wins over ".erb", and neither is shadowed by ".json"
+    expect(filetype("data.json")).toBe("json")
+    expect(filetype("data.json.erb")).toBe("erb")
+  })
+
+  test("resolves extensions on paths", () => {
+    expect(filetype("src/util/filetype.ts")).toBe("typescript")
+    expect(filetype("a.b/main.rs")).toBe("rust")
+  })
+
+  test("stays undefined for unmapped names", () => {
+    expect(filetype("LICENSE")).toBeUndefined()
+    expect(filetype("archive.xyz")).toBeUndefined()
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #39601

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`filetype()` indexed `LANGUAGE_EXTENSIONS` with `path.extname()`, an exact case-sensitive lookup. Uppercase extensions (`COMPONENT.TSX`, `main.PY`) and extensionless names (`Makefile`) missed entirely, so those files rendered with no syntax highlighting. It also left five map keys unreachable, since `path.extname()` only ever returns the final `.xxx`: `makefile`, `.html.erb`, `.js.erb`, `.css.erb`, `.json.erb`.

Now it lowercases the basename and tries each dot-suffix longest-first, falling back to the whole name. That reaches the compound and bare-name keys without adding entries to the map.

`diff-viewer.tsx` had a byte-identical private copy of the helper with the same bug - it now imports the shared one, dropping 8 lines and an unused `path` import.

### How did you verify your code works?

Extended `packages/tui/test/util/filetype.test.ts` from 2 to 8 tests: casing, extensionless names, compound suffixes, longest-suffix precedence (`data.json` -> json but `data.json.erb` -> erb), paths.

Checked they catch the bugs - against the unfixed source the casing and extensionless tests fail; with the fix 8/8 pass. The two original assertions are unchanged and still pass.

`packages/tui`: `bun typecheck` clean, `bun test test/util/` 52/52 pass, oxlint warning count identical before and after.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
