### PR TITLE
fix(core): sanitize frontmatter keys containing hyphens and dots

### DIFF
--- a/packages/core/src/config/markdown.ts
+++ b/packages/core/src/config/markdown.ts
@@ -25,7 +25,9 @@ export function sanitize(content: string) {
   const frontmatter = match[1]
   const result = frontmatter.split(/\r?\n/).flatMap((line) => {
     if (line.trim().startsWith("#") || line.trim() === "" || /^\s+/.test(line)) return [line]
-    const entry = line.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\s*:\s*(.*)$/)
+    // Keys may contain hyphens and dots — `allowed-tools` is the common case in
+    // other agents' command files, and it is exactly what needs sanitizing.
+    const entry = line.match(/^([a-zA-Z_][a-zA-Z0-9_.-]*)\s*:\s*(.*)$/)
     if (!entry) return [line]
     const value = entry[2].trim()
     if (value === "" || value === ">" || value === "|" || value.startsWith('"') || value.startsWith("'")) return [line]

--- a/packages/opencode/test/config/fixtures/frontmatter.md
+++ b/packages/opencode/test/config/fixtures/frontmatter.md
@@ -16,6 +16,8 @@ single_quoted_colon: 'Single quoted: also fine'
 mixed: He said "hello: world" and then left
 empty:
 dollar: Use $' and $& for special patterns
+allowed-tools: Read: every file
+dotted.key: Has a colon: here
 ---
 
 Content that should not be parsed:

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -159,6 +159,14 @@ describe("ConfigMarkdown: frontmatter parsing", async () => {
     expect(parsed.data.dollar).toBe("Use $' and $& for special patterns")
   })
 
+  test("should extract hyphenated keys with colons in the value", () => {
+    expect(parsed.data["allowed-tools"]).toBe("Read: every file")
+  })
+
+  test("should extract dotted keys with colons in the value", () => {
+    expect(parsed.data["dotted.key"]).toBe("Has a colon: here")
+  })
+
   test("should not parse fake yaml from content", () => {
     expect(parsed.data.fake_field).toBeUndefined()
     expect(parsed.data.another).toBeUndefined()


### PR DESCRIPTION
### Issue for this PR

Closes #39603

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The sanitizer's key pattern was `[a-zA-Z_][a-zA-Z0-9_]*`, which excludes hyphens. A hyphenated key never matched, so the line was returned unsanitized and the retry `matter(sanitize(content))` threw exactly as the first parse did.

`allowed-tools` is the most common such key in other agents' command files, which is the compatibility case `sanitize()` exists for. Because `parseOption()` swallows the error, it failed silently: commands ran with the raw YAML header pasted into the prompt, and agents lost `description`, `mode`, `model`, `steps` and `permissions`.

Added `-` and `.` to the key character class. Every other key shape behaves as before.

### How did you verify your code works?

Added `allowed-tools: Read: every file` and `dotted.key: Has a colon: here` to the existing `frontmatter.md` fixture, plus two assertions.

Checked the fixture catches the bug - without the fix `parse()` throws `Failed to parse YAML frontmatter: incomplete explicit mapping pair` on the `allowed-tools` line and the whole describe block aborts, so 19 tests run instead of 39. With the fix 39/39 pass.

Also confirmed the underscore control case (`allowed_tools`) sanitizes correctly both before and after, so that path is untouched.

`bun typecheck` clean in `packages/core` and `packages/opencode`; `packages/core` `bun test test/config/` 50/50 pass; oxlint 0 warnings.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
