### PR TITLE
fix(console): emit valid cost chunks

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -386,7 +386,7 @@ export async function handler(
                   await trackUsage(sessionId, billingSource, authInfo, modelInfo, providerInfo, usageInfo, costInfo)
                   await reload(billingSource, authInfo, costInfo)
                   const cost = calculateOccurredCost(billingSource, costInfo)
-                  c.enqueue(encoder.encode(buildCostChunk(opts.format, cost)))
+                  c.enqueue(encoder.encode(buildCostChunk(opts.format, cost, model)))
                 }
                 c.close()
                 return

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -166,14 +166,21 @@ export interface CommonChunk {
   }
 }
 
-export function buildCostChunk(format: ZenData.Format, cost: string): string {
+export function buildCostChunk(format: ZenData.Format, cost: string, model: string): string {
   switch (format) {
     case "anthropic":
       return `event: ping\ndata: ${JSON.stringify({ type: "ping", cost })}\n\n`
     case "openai":
       return `event: ping\ndata: ${JSON.stringify({ type: "ping", cost })}\n\n`
     case "oa-compat":
-      return `data: ${JSON.stringify({ choices: [], cost })}\n\n`
+      return `data: ${JSON.stringify({
+        id: `chatcmpl-${crypto.randomUUID()}`,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model,
+        choices: [],
+        cost,
+      })}\n\n`
     default:
       return `data: ${JSON.stringify({ type: "ping", cost })}\n\n`
   }

--- a/packages/console/app/test/provider.test.ts
+++ b/packages/console/app/test/provider.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { buildCostChunk } from "../src/routes/zen/util/provider/provider"
+
+describe("buildCostChunk", () => {
+  test("builds a valid OpenAI-compatible chat completion chunk", () => {
+    const chunk = buildCostChunk("oa-compat", "0.001", "test-model")
+    const data = JSON.parse(chunk.slice("data: ".length))
+
+    expect(data).toMatchObject({
+      object: "chat.completion.chunk",
+      model: "test-model",
+      choices: [],
+      cost: "0.001",
+    })
+    expect(data.id).toStartWith("chatcmpl-")
+    expect(data.created).toBeInteger()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39061

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Zen appended `oa-compat` cost events without required OpenAI chunk fields. This adds `id`, `object`, `created`, and `model` while preserving `cost`, so strict clients can deserialize the event.

### How did you verify your code works?

- Ran `bun test test/provider.test.ts` from `packages/console/app` with Bun 1.3.14.
- `@opencode-ai/console-app` typecheck passed during the pre-push check. Full repo typecheck remains blocked by an unrelated existing error in `packages/opencode/src/bus/global.ts`.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR