### PR TITLE
fix(cli): share the Solid runtime with externally loaded TUI plugins

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import "@opentui/solid/runtime-plugin-support"
 import { NodeRuntime, NodeServices } from "@effect/platform-node"
 import { Effect } from "effect"
 import { Commands } from "./commands/commands"


### PR DESCRIPTION
## What

Externally loaded TUI plugins (installed from npm or a local path, e.g. the voice-control plugin) currently resolve their own copy of `solid-js` from their own `node_modules`. Two Solid instances means reactivity primitives and context providers from the host TUI don't work inside plugin components — external Solid plugins can't render at all.

## How

One import at the CLI entrypoint: `@opentui/solid/runtime-plugin-support` is opentui's official (Bun-only) integration point for exactly this. It registers a Bun loader plugin that:

- maps `solid-js`, `solid-js/store`, `@opentui/solid`, `@opentui/solid/components`, and the JSX runtime specifiers to the host's already-loaded module instances, so plugins share one runtime
- installs the Solid JSX transform for externally loaded `.tsx` entrypoints

Installation is idempotent behind a global symbol and throws on incompatible double-install, so it is safe at the top of the entrypoint before anything else loads.

## Scope

- No behavior change for built-in plugins or TUIs without external Solid plugins; the loader plugin only rewrites the listed specifiers.
- Companion to #39591 (`ui.tabs`): together they are the only host-side requirements for shipping TUI plugins as standalone packages.

## Testing

- Verified end-to-end with the voice-control plugin loaded from an external path: without this import its Solid components fail to render; with it the plugin renders and shares host context.