### PR TITLE
fix(app): guard optional model.limit.context access in context metrics and tooltip

### DIFF
--- a/packages/app/src/components/model-tooltip.tsx
+++ b/packages/app/src/components/model-tooltip.tsx
@@ -18,7 +18,7 @@ type ModelInfo = {
     input: Array<string>
   }
   reasoning?: boolean
-  limit: {
+  limit?: {
     context: number
   }
 }
@@ -90,8 +90,9 @@ export const ModelTooltip: Component<{ model: ModelInfo; latest?: boolean; free?
       ? language.t("model.tooltip.reasoning.allowed")
       : language.t("model.tooltip.reasoning.none")
   }
-  const context = () => language.t("model.tooltip.context", { limit: props.model.limit.context.toLocaleString() })
-  const contextLimit = () => props.model.limit.context.toLocaleString(language.intl())
+  const context = () =>
+    language.t("model.tooltip.context", { limit: props.model.limit?.context?.toLocaleString() ?? "—" })
+  const contextLimit = () => props.model.limit?.context?.toLocaleString(language.intl()) ?? "—"
 
   if (props.v2) {
     return (

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -96,4 +96,26 @@ describe("getSessionContext", () => {
 
     expect(ctx).toBeUndefined()
   })
+
+  test("falls back to null usage when the matched model has no limit field", () => {
+    const messages = [assistant("a1", { input: 40, output: 10, reasoning: 0, read: 0, write: 0 }, 0.1)]
+    const providers = [
+      {
+        id: "openai",
+        name: "OpenAI",
+        models: {
+          "gpt-4.1": {
+            name: "GPT-4.1",
+          },
+        },
+      },
+    ]
+
+    const ctx = getSessionContext(messages, providers)
+
+    expect(ctx?.providerLabel).toBe("OpenAI")
+    expect(ctx?.modelLabel).toBe("GPT-4.1")
+    expect(ctx?.limit).toBeUndefined()
+    expect(ctx?.usage).toBeNull()
+  })
 })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -8,7 +8,7 @@ type Provider = {
 
 type Model = {
   name?: string
-  limit: {
+  limit?: {
     context: number
   }
 }
@@ -44,7 +44,7 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
 
   const provider = providers.find((item) => item.id === message.providerID)
   const model = provider?.models[message.modelID]
-  const limit = model?.limit.context
+  const limit = model?.limit?.context
   const total = tokenTotal(message)
 
   return {


### PR DESCRIPTION
Fixes #39595

## Bug

`model.limit` is typed as required in both `session-context-metrics.ts` and `model-tooltip.tsx`, but a matched model can legitimately have no `limit` field (e.g. server omits it for a given provider/model). This causes:

- `session-context-metrics.ts`: `model?.limit.context` throws `TypeError: undefined is not an object` instead of degrading to `usage: null` the way the surrounding code clearly intends (there's already a `limit ? ... : null` fallback a few lines below \u2014 the crash happens before it's reached).
- `model-tooltip.tsx`: same unguarded `props.model.limit.context.toLocaleString()` pattern in two places, crashing the tooltip render.

## Fix

Made `limit` optional on both local `Model`/`ModelInfo` types and optional-chained the three access sites, falling back to the em-dash (`\u2014`) convention already used elsewhere in this codebase for missing values (see `session-context-format.ts`).

## Verification

Added a regression test (`falls back to null usage when the matched model has no limit field`) that reproduces the exact crash reported in the issue. Confirmed it fails without the fix:

```
TypeError: undefined is not an object (evaluating 'model?.limit.context')
    at build (session-context-metrics.ts:47:24)
(fail) getSessionContext > falls back to null usage when the matched model has no limit field
```

...and passes with it. Also ran, all green:
- `bun test src/components/session/session-context-metrics.test.ts` (5/5 pass)
- `bun run typecheck` in `packages/app` (tsgo -b, no errors)
- `bun run lint` on changed files (0 errors, 4 pre-existing warnings unrelated to this change)
- full monorepo `bun turbo typecheck` via the repo's pre-push hook (30/30 packages pass)

Related: #37456 reported the same root-cause unsafe access pattern for a different UI surface (Context tab em-dash), closed as an AI-generated issue but the underlying code defect is real and still present \u2014 this PR fixes the unsafe-access root cause directly.

---
AI-assisted: this fix was drafted and verified end-to-end (repro, fix, tests, typecheck, lint) with an AI coding assistant (Atlas) under my direction and review before opening this PR.