### PR TITLE
docs: add Modal provider setup

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1505,6 +1505,30 @@ To use Kimi K2 from Moonshot AI:
 
 ---
 
+### Modal
+
+1. Create a [managed Auto Endpoint](https://modal.com/endpoints) for the model you want to use.
+
+2. Create a [proxy token](https://modal.com/docs/guide/endpoints#proxy-tokens), then join its ID and secret with a period:
+
+   ```txt
+   wk-<id>.ws-<secret>
+   ```
+
+3. Run the `/connect` command, search for **Modal**, and enter the combined proxy token.
+
+   ```txt
+   /connect
+   ```
+
+4. Run the `/models` command to select one of the endpoints in your Modal workspace.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### NVIDIA
 
 NVIDIA provides access to Nemotron models and many other open models through [build.nvidia.com](https://build.nvidia.com) for free.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1507,7 +1507,7 @@ To use Kimi K2 from Moonshot AI:
 
 ### Modal
 
-1. Create a [managed Auto Endpoint](https://modal.com/endpoints) for the model you want to use.
+1. Create a [shared Endpoint](https://modal.com/endpoints) for the model you want to use.
 
 2. Create a [proxy token](https://modal.com/docs/guide/endpoints#proxy-tokens), then join its ID and secret with a period:
 


### PR DESCRIPTION
## Summary

- add Modal to the provider directory
- document creating a managed endpoint and combining its proxy token
- show the `/connect` and `/models` flow for discovered workspace endpoints

## Context

Modal model discovery landed in #39066, but the provider directory is maintained separately and did not include setup instructions.

## Testing

- `prettier --check packages/web/src/content/docs/providers.mdx`
- `git diff --check`
