### PR TITLE
docs: add PPT Design Skill to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -63,6 +63,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                       | Description                                                      |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
+| [PPT Design Skill](https://github.com/sunchaokun/PPT-Design-Skill)                         | AI-powered PPT generation — 40,000+ styles, 3 modes, fully editable .pptx |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |


### PR DESCRIPTION
## PPT Design Skill

AI-powered PPT generation skill compatible with OpenCode and 13+ AI coding platforms.

- Three modes: FreeStyle (one-liner), Build Script (pixel-perfect), VI Build (enterprise template)
- 40,000+ style combinations via natural language (`--style "dark cyberpunk"`)
- 5 AI image engines, 10 diagram types, fully editable .pptx output
- Installable via `python install.py --platform opencode`

### Entry added to
- `ecosystem.mdx` ? Projects section

### Checklist
- [x] Public repository with active maintenance
- [x] Directly related to OpenCode (installable as skill)
- [x] Entry follows existing table format