### PR TITLE
fix(app): resolve a session's project by directory, not by shared ID

### DIFF
--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -18,6 +18,7 @@ import {
   homeProjectDirectories,
   homeSessionServerStatus,
   latestRootSession,
+  projectForSession,
   toggleHomeProjectSelection,
 } from "./helpers"
 import { pathKey } from "@/utils/path-key"
@@ -317,5 +318,62 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+})
+
+describe("projectForSession", () => {
+  // Project.resolve keys the ID off the git remote, so directories that share a
+  // repo identity - separate clones, sibling worktrees, or one nested inside the
+  // other's repo - all carry the same one.
+  const projectB = { id: "github.com/me/repo", worktree: "/home/me/projects/beta" }
+  const projectT = { id: "github.com/me/repo", worktree: "/home/me/projects/tango" }
+
+  test("resolves each project by directory when they share a repo identity", () => {
+    const projects = [projectB, projectT]
+    const id = "github.com/me/repo"
+
+    expect(
+      projectForSession(session({ id: "ses_b", directory: "/home/me/projects/beta", projectID: id }), projects),
+    ).toBe(projectB)
+    expect(
+      projectForSession(session({ id: "ses_t", directory: "/home/me/projects/tango", projectID: id }), projects),
+    ).toBe(projectT)
+  })
+
+  test("resolves each project by directory when they share the global ID", () => {
+    const outsideA = { id: "global", worktree: "/home/me/notes" }
+    const outsideB = { id: "global", worktree: "/home/me/scratch" }
+    const projects = [outsideA, outsideB]
+
+    expect(
+      projectForSession(session({ id: "ses_a", directory: "/home/me/notes", projectID: "global" }), projects),
+    ).toBe(outsideA)
+    expect(
+      projectForSession(session({ id: "ses_b", directory: "/home/me/scratch", projectID: "global" }), projects),
+    ).toBe(outsideB)
+  })
+
+  test("falls back to the ID for a session below a repo root", () => {
+    const repo = { id: "prj_repo", worktree: "/home/me/repo" }
+
+    expect(
+      projectForSession(session({ id: "ses_nested", directory: "/home/me/repo/packages/app", projectID: "prj_repo" }), [
+        repo,
+      ]),
+    ).toBe(repo)
+  })
+
+  test("matches a sandbox directory", () => {
+    const project = { id: "prj_one", worktree: "/home/me/repo", sandboxes: ["/home/me/sandbox"] }
+
+    expect(
+      projectForSession(session({ id: "ses_sb", directory: "/home/me/sandbox", projectID: "other" }), [project]),
+    ).toBe(project)
+  })
+
+  test("returns undefined when nothing matches", () => {
+    expect(
+      projectForSession(session({ id: "ses_x", directory: "/home/me/elsewhere", projectID: "nope" }), [projectB]),
+    ).toBeUndefined()
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -106,13 +106,21 @@ export function projectForSession<T extends { id?: string; worktree: string; san
   projects: T[],
   byID: Map<string, T> = new Map(projects.flatMap((project) => (project.id ? [[project.id, project] as const] : []))),
 ) {
-  const direct = byID.get(session.projectID)
-  if (direct) return direct
+  // Match the directory before the ID. A project ID does not identify an opened
+  // directory: Project.resolve keys it off the git remote (falling back to the
+  // repo's root commit), so separate clones, sibling worktrees, and a directory
+  // nested inside another's repo all share one — as does everything outside a
+  // repo, under the global ID. Keying off the ID first collapses every session
+  // in those directories onto whichever was opened first. A worktree or sandbox
+  // path identifies an opened project on its own; the ID is only needed for
+  // sessions below a repo root, where no path matches exactly.
   const directory = pathKey(session.directory)
-  return projects.find(
+  const byPath = projects.find(
     (project) =>
       pathKey(project.worktree) === directory || project.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
   )
+  if (byPath) return byPath
+  return byID.get(session.projectID)
 }
 
 export const errorMessage = (err: unknown, fallback: string) => {


### PR DESCRIPTION
### Issue for this PR

Closes #39667

The root cause is #36233 — project identity derived solely from the git remote is what makes two distinct directories collide on one ID, and #35714 reports the same collision causing wrong-project redirects. This PR deliberately does not close either: it does not change how identity is derived, it stops the UI misattributing sessions once a collision already exists.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

With two projects open, every session tab showed the *first* project's name and avatar — a chat in project B and a chat in project T both rendered as B.

A project ID does not identify an opened directory. `Project.resolve` keys it off the git remote, falling back to a cached ID and then the repo's root commit:

```js
const id = (yield* remote(repo)) ?? previous ?? (yield* root(repo))
```

So separate clones, sibling worktrees, and a directory nested inside another's repo all resolve to the same ID — as does every directory outside a repo, under the global ID.

`projectForSession` looked that ID up before the directory, so every session across those directories resolved to whichever project was opened first. It isn't only cosmetic: the same helper feeds the command palette and the home session list, so sessions were attributed to the wrong project there too. The server compounds it — `worktree: projectID === ID.global ? worktree : existing.worktree` keeps the first directory's worktree on the shared row.

The fix matches the worktree or a sandbox path first, since either identifies an opened project on its own, and falls back to the ID only for sessions below a repo root where no path matches exactly. Repo setups are unaffected: a session in a subdirectory still resolves through the ID, which is exactly the fallback case.

### How did you verify your code works?

- Reproduced with two projects open in the web UI: a session in the second project rendered the first project's avatar. Applied the fix and it resolved correctly; reverted the build and it came back; reapplied and it went away again.
- Unit tests for `projectForSession` covering both collision routes (directories sharing a repo identity, and directories outside a repo sharing the global ID), plus the repo-subdirectory fallback, sandbox matching, and the no-match case. Both collision tests were checked against the pre-fix implementation to confirm they actually fail there.
- `bun test` for the app package and typecheck are clean. The only failing test is the pre-existing `ar` i18n parity gap, which fails identically on `dev`.

### Screenshots / recordings

Not a visual change beyond the corrected label: tabs for a second project now show that project's own name and avatar instead of the first project's.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
