### PR TITLE
fix(tui): truncate project picker paths

### DIFF
--- a/packages/tui/src/component/dialog-project.tsx
+++ b/packages/tui/src/component/dialog-project.tsx
@@ -8,6 +8,9 @@ import { abbreviateHome } from "../runtime"
 import { useTuiPaths } from "../context/runtime"
 import { useLocation } from "../context/location"
 import { useToast } from "../ui/toast"
+import { useTerminalDimensions } from "@opentui/solid"
+import { truncateFilePath } from "../ui/file-path"
+import { stringWidth } from "../util/string-width"
 
 export function DialogProject() {
   const dialog = useDialog()
@@ -16,6 +19,7 @@ export function DialogProject() {
   const paths = useTuiPaths()
   const location = useLocation()
   const toast = useToast()
+  const dimensions = useTerminalDimensions()
 
   data.project.invalidate()
   void data.project.sync().catch(toast.error)
@@ -36,12 +40,19 @@ export function DialogProject() {
         if (b.id === current()?.id) return 1
         return 0
       })
-      .map((project) => ({
-        title: project.name ?? path.basename(project.canonical),
-        description: abbreviateHome(project.canonical, paths.home),
-        value: project.canonical,
-        category: project.id === current()?.id ? "Current" : "Projects",
-      }))
+      .map((project) => {
+        const title = project.name ?? path.basename(project.canonical)
+        const description = abbreviateHome(project.canonical, paths.home)
+        // Dialog padding, the current marker, title padding, and the separating space use nine columns.
+        const width = Math.min(60, dimensions().width - 2) - 9 - stringWidth(title)
+        return {
+          title,
+          description: truncateFilePath(description, width),
+          searchText: description,
+          value: project.canonical,
+          category: project.id === current()?.id ? "Current" : "Projects",
+        }
+      })
   })
 
   return (

--- a/packages/tui/src/ui/file-path.tsx
+++ b/packages/tui/src/ui/file-path.tsx
@@ -62,9 +62,14 @@ export function truncateFilePath(value: string, maxWidth: number) {
   const separatorWidth = stringWidth(separator)
   let width = stringWidth(prefix + basename)
   for (let index = segments.length - 2; index >= 0; index--) {
-    const next = stringWidth(segments[index]!) + separatorWidth
-    if (width + next > maxWidth) break
-    selected.unshift(segments[index]!)
+    const segment = segments[index]!
+    const next = stringWidth(segment) + separatorWidth
+    if (width + next > maxWidth) {
+      const available = maxWidth - width - separatorWidth
+      if (available > 1) selected.unshift(takeStart(segment, available - 1) + "…")
+      break
+    }
+    selected.unshift(segment)
     width += next
   }
   return prefix + selected.join(separator)

--- a/packages/tui/test/ui/file-path.test.ts
+++ b/packages/tui/test/ui/file-path.test.ts
@@ -14,6 +14,11 @@ describe("truncateFilePath", () => {
     expect(truncateFilePath(path, 19)).toBe("…/dialog-select.tsx")
   })
 
+  test("uses remaining width for part of a long parent segment", () => {
+    const path = "/private/var/folders/run-17f048ec-dbb2-4b36-860c-98637bb51a8d/files"
+    expect(truncateFilePath(path, 40)).toBe("/…/run-17f048ec-dbb2-4b36-860c-98…/files")
+  })
+
   test("preserves the extension when the basename must shrink", () => {
     expect(truncateFilePath(path, 16)).toBe("…/dialog-se….tsx")
     expect(truncateFilePath("dialog-select.tsx", 12)).toBe("dialog-….tsx")


### PR DESCRIPTION
## What

Uses the existing path-aware truncation helper for project paths in the `/projects` picker, and improves that helper to use leftover columns for part of a long parent directory. Long paths now preserve both useful parent context and their basename instead of being clipped or over-collapsed.

## Before / After

**Before**

`DialogSelect` rendered each project description as an unbounded plain string, so OpenTUI clipped long paths on the right. Passing the same path through `truncateFilePath` exposed another edge case: when the nearest parent segment did not fit in full, the helper dropped it entirely despite having room for most of it.

```text
files /…/files
```

**After**

The picker calculates the description width from the responsive dialog width and project title, then calls `truncateFilePath`. The helper fills remaining columns with a partially truncated parent segment:

```text
files /…/run-0e709f66-1f1b-4c76-9671-095fa915…/files
```

The first ellipsis represents omitted ancestors; the second marks the truncated parent segment. Shorter project paths remain unchanged.

## How

- `packages/tui/src/component/dialog-project.tsx` calculates the available description columns for the 60-column medium dialog.
- Paths are abbreviated relative to home, then passed through `truncateFilePath`; the full description remains in `searchText`, so truncation does not reduce fuzzy-search coverage.
- `packages/tui/src/ui/file-path.tsx` keeps adding complete parent segments from right to left. When the next parent does not fit in full, it now uses the remaining columns for that segment's prefix plus an ellipsis before stopping.
- `packages/tui/test/ui/file-path.test.ts` covers the long-parent case alongside the existing maximum-width invariant.

## Testing

- `bun typecheck` in `packages/tui`: clean.
- `bun run test test/ui/file-path.test.ts` in `packages/tui`: 9 passed.
- Full repository typecheck via pre-push hook: 33 tasks passed.
- OpenCode Drive at 100×30: opened `/projects` with a long temporary current-project path, verified partial-parent truncation consumed the available row, and completed a switch to `~/tmp/demo-code/blog`.

## Demo

The long current-project path uses the available width while shorter project paths remain intact:

![Project picker with partial parent path truncation](https://github.com/user-attachments/assets/8875135a-9725-4307-bab6-b0111f6a4fb1)
