### PR TITLE
fix(tui): cap session tab pulse frame rate

### DIFF
--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -123,6 +123,37 @@ class Envelope {
 
 // Hoisted so the per-frame liveness check allocates no closure.
 const envelopeActive = (envelope: Envelope) => envelope.active
+const activePulses = new Set<TabPulseRenderable>()
+let pulseTimer: ReturnType<typeof setInterval> | undefined
+let pulseTime = 0
+
+function animatePulse(pulse: TabPulseRenderable, value: boolean) {
+  if (!value) {
+    activePulses.delete(pulse)
+    if (activePulses.size === 0 && pulseTimer) clearInterval(pulseTimer)
+    if (activePulses.size === 0) pulseTimer = undefined
+    return
+  }
+  activePulses.add(pulse)
+  if (pulseTimer) return
+  pulseTime = performance.now()
+  pulseTimer = setInterval(() => {
+    const now = performance.now()
+    const delta = now - pulseTime
+    pulseTime = now
+    for (const active of activePulses) {
+      if (active.isDestroyed) {
+        activePulses.delete(active)
+        continue
+      }
+      active.updateAnimation(delta)
+      active.requestRender()
+    }
+    if (activePulses.size > 0 || !pulseTimer) return
+    clearInterval(pulseTimer)
+    pulseTimer = undefined
+  }, 1000 / 60)
+}
 
 class TabPulseRenderable extends Renderable {
   private _enabled: boolean
@@ -151,7 +182,7 @@ class TabPulseRenderable extends Renderable {
   constructor(ctx: RenderContext, options: TabPulseOptions = {}) {
     const enabled = options.enabled ?? true
     const active = options.active ?? false
-    super(ctx, { ...options, height: 1, live: enabled && active })
+    super(ctx, { ...options, height: 1, live: false })
     this._enabled = enabled
     this._active = active
     this._complete = options.complete ?? false
@@ -163,6 +194,11 @@ class TabPulseRenderable extends Renderable {
     this._completionColor = options.completionColor ?? this._color
     this._backgroundColor = options.backgroundColor ?? RGBA.defaultBackground()
     this._onLevel = options.onLevel
+    this.setAnimating(enabled && (active || this.breathing))
+  }
+
+  private setAnimating(value: boolean) {
+    animatePulse(this, value)
   }
 
   set onLevel(value: ((level: number) => void) | undefined) {
@@ -197,9 +233,9 @@ class TabPulseRenderable extends Renderable {
       for (const envelope of this.envelopes) envelope.stop()
       this.completionPending = false
       this.breatheClock = 0
-      this.live = false
+      this.setAnimating(false)
     } else if (this._active || this.breathing) {
-      this.live = true
+      this.setAnimating(true)
     }
     this.requestRender()
   }
@@ -218,7 +254,7 @@ class TabPulseRenderable extends Renderable {
     }
     // The same neutral edge flash marks both the start and the finish of a run.
     this.edgeFlash.start()
-    this.live = true
+    this.setAnimating(true)
     this.requestRender()
   }
 
@@ -233,7 +269,7 @@ class TabPulseRenderable extends Renderable {
       this.completionPending = false
       if (this._enabled) {
         this.completionPulse.start()
-        this.live = true
+        this.setAnimating(true)
       }
     }
     this.requestRender()
@@ -248,7 +284,7 @@ class TabPulseRenderable extends Renderable {
     if (this._enabled && value) {
       this.glowOff.stop()
       this.ignition.start()
-      this.live = true
+      this.setAnimating(true)
     }
     this.requestRender()
   }
@@ -257,7 +293,7 @@ class TabPulseRenderable extends Renderable {
     if (value === this._breathe) return
     this._breathe = value
     this.breatheClock = 0
-    if (this.breathing) this.live = true
+    if (this.breathing) this.setAnimating(true)
     this.requestRender()
   }
 
@@ -291,7 +327,7 @@ class TabPulseRenderable extends Renderable {
     this.requestRender()
   }
 
-  protected override onUpdate(deltaTime: number): void {
+  updateAnimation(deltaTime: number): void {
     if (!this._enabled) return
     if (this._active || this.runFade.active) this.clock += deltaTime
     if (this.breathing) this.breatheClock += deltaTime
@@ -304,7 +340,11 @@ class TabPulseRenderable extends Renderable {
         this.completionPending = false
       }
     }
-    this.live = this._active || this.breathing || this.envelopes.some(envelopeActive)
+    this.setAnimating(this._active || this.breathing || this.envelopes.some(envelopeActive))
+  }
+
+  protected override destroySelf(): void {
+    this.setAnimating(false)
   }
 
   protected override renderSelf(buffer: OptimizedBuffer): void {


### PR DESCRIPTION
## What

Cap animated session tabs at one shared 60 Hz clock instead of marking every `TabPulseRenderable` as OpenTUI `live`.

The visual animation is unchanged, but a busy tab no longer drives the renderer thousands of times per second.

## Before / After

**Before**: the first busy tab set `live: true`. Although OpenCode creates one global renderer with `targetFps: 60` and OpenTUI reports `maxFps: 60`, a pulse-only benchmark measured 1,000–3,500 renderer-reported FPS (typically 1,600–1,900). The request stayed busy for 20 seconds without emitting text or tool deltas, so this isolates the animation loop from session traffic.

**After**: active pulses join one module-global 60 Hz clock. The clock advances every active pulse, requests rendering through the existing global renderer, and stops when the last pulse finishes. The same benchmark measures 51–55 frames/sec with OpenTUI reporting a stable 55–56 FPS.

## How

`packages/tui/src/component/tab-pulse.tsx`:

- Keep `TabPulseRenderable.live` disabled, avoiding the uncapped OpenTUI live loop.
- Maintain one `Set` of active pulse renderables and one 60 Hz timer for the process.
- Advance all active envelopes from the same measured delta.
- Remove stopped/destroyed pulses and clear the timer when none remain.

```mermaid
sequenceDiagram
    participant S as Session status
    participant P as Active pulses
    participant C as Shared 60 Hz clock
    participant R as Global renderer

    S->>P: tab becomes busy
    P->>C: join clock
    loop while any pulse is active
        C->>P: advance(delta)
        P->>R: requestRender()
    end
    S->>P: pulse/fade completes
    P->>C: leave clock
```

## Scope

- This is a localized workaround for the OpenTUI `live` scheduling path. It does not change the global renderer configuration.
- No animation timing, easing, color, glow, or completion behavior changes.
- CPU improves only modestly because the excess frames were cheap: pulse-only steady-state samples moved from roughly 20–32% to 18–22%. The important invariant is that renderer work is now bounded.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 566 pass, 5 skip, 0 fail
- `bun run test test/component/tab-pulse.test.ts`: 5 pass, 0 fail
- Repo-pinned Prettier and oxlint clean on the changed file
- Isolated opencode-drive pulse benchmark, 160×45 viewport, busy background session with zero streamed deltas:
  - before: typically 1,600–1,900 FPS, renderer-reported peaks above 3,000
  - after: 51–55 measured FPS, renderer-reported 55–56 FPS
