### PR TITLE
fix(tui): hide redundant session directory labels

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -133,9 +133,7 @@ export function DialogSessionList() {
       const project = data.project.get(session.projectID)
       const footer = allProjects()
         ? Locale.truncate(project?.name || path.basename(project?.canonical ?? directory), 20)
-        : directory !== data.location.info()?.project.directory
-          ? Locale.truncate(path.basename(directory), 20)
-          : ""
+        : undefined
       const slot = sessionTabs.enabled() ? undefined : slotByID.get(session.id)
       const deleting = toDelete() === session.id
       return {


### PR DESCRIPTION
## What

Removes redundant directory labels from the session picker when it is scoped to the current directory.

## Before / After

**Before**

Current-directory mode already filters every session to `session.location.directory === current.directory`, but each row compared that directory against the project root. When the current directory was below the root, every row repeated the same basename on the right:

```text
Verify OpenCode V2 Location boot profiling    kit
Parent directory navigation                  kit
Emergency storage cleanup                    kit
```

**After**

Current-directory mode omits the redundant row footer. The dialog title communicates the current project scope.

All-projects mode is unchanged and continues to show each session's project name, where the label distinguishes mixed-project rows:

```text
Local transcription stuck             voice-control
Project switcher                       opencode
```

## How

- `packages/tui/src/component/dialog-session-list.tsx` now returns no footer in current-directory mode.
- The existing all-projects project-name lookup and truncation remain unchanged.
- Query scoping, search, grouping, selection, and the `ctrl+a` mode toggle are untouched.

## Testing

- `bun typecheck` in `packages/tui`: clean.
- Full repository typecheck via pre-push hook: 33 tasks passed.
