### PR TITLE
refactor(core): skip redundant worktree lookup

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -246,12 +246,13 @@ const layer = Layer.effect(
       if (repo) {
         const previous = yield* cached(repo.commonDirectory)
         const id = (yield* remote(repo)) ?? previous ?? (yield* root(repo))
-        const canonical = yield* git.worktree
-          .list(repo)
-          .pipe(
-            Effect.map((items) => items.find((item) => item.kind === "main")?.directory ?? repo.worktree),
-            Effect.catch(() => Effect.succeed(repo.worktree)),
-          )
+        const canonical =
+          repo.gitDirectory === repo.commonDirectory
+            ? repo.worktree
+            : yield* git.worktree.list(repo).pipe(
+                Effect.map((items) => items.find((item) => item.kind === "main")?.directory ?? repo.worktree),
+                Effect.catch(() => Effect.succeed(repo.worktree)),
+              )
         return yield* persist({
           previous,
           id: id ?? ID.global,

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -143,6 +143,7 @@ describe("Project.resolve", () => {
 
       expect(result.id).toBe(Project.ID.make(yield* Effect.promise(() => rootCommit(tmp.path))))
       expect(result.directory).toBe(yield* real(tmp.path))
+      expect(result.canonical).toBe(result.directory)
       expect(result.previous).toBeUndefined()
       expect(result.vcs?.type).toBe("git")
     }),


### PR DESCRIPTION
## What

Avoid the redundant `git worktree list --porcelain` subprocess when `Project.resolve` discovers an ordinary main checkout.

Controlled local benchmark on the same M2 Max:

| Path | Median | p95 | Samples |
| --- | ---: | ---: | ---: |
| Ordinary main checkout, always list | 61.077 ms | 69.659 ms | 18 pooled |
| Ordinary main checkout, skip list | 28.919 ms | 33.468 ms | 18 pooled |

This is a 32.157 ms median reduction, or 52.6%. The benchmark is an engineering comparison from one local machine, not an SLA.

## How

- Use the discovered `repo.worktree` as canonical when `repo.gitDirectory === repo.commonDirectory`, which identifies the ordinary main-worktree case.
- Preserve the existing `git.worktree.list` fallback for linked worktrees, where the git directory differs from the common directory.
- Assert that a committed main checkout remains its own canonical directory; retain the existing linked-worktree coverage proving that a linked checkout resolves canonical to the main checkout.

## Scope

- Includes only the `Project.resolve` fast path and focused test coverage.
- Excludes profiling instrumentation, benchmark scripts, performance reports, raw data, direct-rev-parse experiments, and concurrency experiments.
- Linked-worktree behavior is intentionally unchanged.
- No visual demo is needed because this has no visual surface.

## Testing

From `packages/core`:

- `bunx prettier --write src/project.ts test/project.test.ts`
- `bun typecheck`
- `bun run test test/git.test.ts test/project.test.ts` (18 passed, 1 skipped)
- `git diff --check`

The normal push hook also completed the repository-wide Turbo typecheck successfully.