### PR TITLE
feat(tui): open session list with ctrl+l

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -87,7 +87,7 @@ export const Definitions = {
   session_copy: keybind("none", "Copy session transcript"),
   session_move: keybind("none", "Move session"),
   session_new: keybind("<leader>n", "Create a new session"),
-  session_list: keybind("<leader>l", "List all sessions"),
+  session_list: keybind("ctrl+l,<leader>l", "List all sessions"),
   session_timeline: keybind("<leader>g", "Show session timeline"),
   session_fork: keybind("none", "Fork session from message"),
   session_rename: keybind("ctrl+r", "Rename session"),

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -55,7 +55,7 @@ test("resolves host-neutral defaults", () => {
   expect(config.leader_timeout).toBe(LeaderTimeoutDefault)
   expect(config.mouse).toBe(true)
   expect(config.keybinds.has("terminal.suspend")).toBe(true)
-  expect(config.keybinds.has("session.list")).toBe(true)
+  expect(config.keybinds.get("session.list")).toMatchObject([{ key: "ctrl+l,<leader>l" }])
 })
 
 test("resolves overrides without mutating input", () => {

--- a/packages/tui/test/keymap.test.tsx
+++ b/packages/tui/test/keymap.test.tsx
@@ -125,10 +125,10 @@ test("mode-less bindings stay active when opencode mode changes", async () => {
   const app = await testRender(() => <Harness />)
   try {
     expect(counts).toEqual({
-      base: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 1 },
-      question: { "session.list": 1, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 0 },
+      base: { "session.list": 2, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 1 },
+      question: { "session.list": 2, "session.new": 1, "session.page.up": 2, "session.first": 2, "model.list": 0 },
       autocomplete: {
-        "session.list": 1,
+        "session.list": 2,
         "session.new": 1,
         "session.page.up": 2,
         "session.first": 2,


### PR DESCRIPTION
## What

Make `Ctrl+L` open the existing session list directly in the V2 TUI. The existing `<leader>l` sequence remains available as a secondary binding.

Before, the session list only had the two-stroke `<leader>l` default, so getting there through the command palette could make `Ctrl+L` feel palette-like rather than direct. After, `Ctrl+L` dispatches `session.list` and opens `DialogSessionList` immediately.

## How

- Add `ctrl+l` as the primary default for `session_list` in `packages/tui/src/config/keybind.ts`.
- Preserve `<leader>l` as the secondary default.
- Assert the resolved config and both active runtime keymap sequences, including question and autocomplete modes.

## Scope

This PR does not change Ctrl+O/Ctrl+I tab history, Option-bracket dogfood bindings, session pagination, or background-tab rendering.

## Testing

- `bun run test test/config.test.tsx test/keymap.test.tsx` from `packages/tui` (11 passed)
- `bun run test` from `packages/tui` (191 passed, 1 skipped)
- `bun typecheck` from `packages/tui`
- `bunx prettier --check packages/tui/src/config/keybind.ts packages/tui/test/config.test.tsx packages/tui/test/keymap.test.tsx`
- `bunx oxlint packages/tui/src/config/keybind.ts packages/tui/test/config.test.tsx packages/tui/test/keymap.test.tsx` (0 errors; 5 existing warnings in `keybind.ts`)
- Hermetic V2 TUI run: pressing Ctrl+L from an open provider dialog directly opened the Sessions dialog.

## Demo

https://github.com/user-attachments/assets/5092d76f-a667-47c0-a7d8-7d3c4fccc4c6
