### PR TITLE
fix(plugin): skip mismatched kind in readV1Plugin detect mode

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -281,6 +281,8 @@ export function readV1Plugin(
     throw new TypeError(`Plugin ${spec} must default export an object with ${kind}()`)
   }
   if (mode === "detect" && !("id" in value) && !("server" in value) && !("tui" in value)) return
+  if (mode === "detect" && kind === "server" && !("server" in value)) return
+  if (mode === "detect" && kind === "tui" && !("tui" in value)) return
 
   const server = "server" in value ? value.server : undefined
   const tui = "tui" in value ? value.tui : undefined

--- a/packages/opencode/test/plugin/read-v1-plugin.test.ts
+++ b/packages/opencode/test/plugin/read-v1-plugin.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { readV1Plugin } from "../../src/plugin/shared"
+
+// Regression coverage for #31610:
+// readV1Plugin in "detect" mode must not throw when the plugin module
+// exports a default object that does not include the requested kind's
+// entrypoint (e.g. a TUI-only plugin scanned by the server loader).
+
+describe("plugin.shared.readV1Plugin detect mode", () => {
+  test("returns undefined when a TUI-only plugin is scanned for kind=server", () => {
+    // Given a plugin that only exports `tui` (no `server`)
+    const mod = {
+      default: {
+        id: "tui-only",
+        tui: () => ({}) as unknown,
+      },
+    }
+
+    // When the server loader asks to detect whether this is a server plugin
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "tui-only-plugin",
+      "server",
+      "detect",
+    )
+
+    // Then it should silently skip instead of throwing
+    expect(result).toBeUndefined()
+  })
+
+  test("returns undefined when a server-only plugin is scanned for kind=tui", () => {
+    const mod = {
+      default: {
+        id: "server-only",
+        server: () => ({}) as unknown,
+      },
+    }
+
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "server-only-plugin",
+      "tui",
+      "detect",
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  test("returns the value when the requested kind is present", () => {
+    const server = () => ({ ok: true })
+    const mod = {
+      default: {
+        id: "has-both-but-server",
+        server,
+      },
+    }
+
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "plugin",
+      "server",
+      "detect",
+    )
+
+    expect(result).toEqual({ id: "has-both-but-server", server })
+  })
+
+  test("strict mode still throws for TUI-only plugins loaded as server", () => {
+    // Sanity check: strict mode is unchanged.
+    const mod = {
+      default: {
+        id: "tui-only",
+        tui: () => ({}) as unknown,
+      },
+    }
+
+    expect(() =>
+      readV1Plugin(
+        mod as unknown as Record<string, unknown>,
+        "tui-only-plugin",
+        "server",
+        "strict",
+      ),
+    ).toThrow(/must default export an object with server/)
+  })
+})


### PR DESCRIPTION
## What
Add two short-circuit guards in `readV1Plugin` (`packages/opencode/src/plugin/shared.ts`) so that in `mode="detect"`, a plugin module that does not export the requested kind's entrypoint is silently skipped instead of throwing.

## Why
The server plugin loader (`packages/opencode/src/plugin/index.ts:applyPlugin`) calls
`readV1Plugin(load.mod, load.spec, "server", "detect")` to discover V1 plugins.
For a plugin that exports only `tui`, the existing "all fields missing" guard did
not fire (because `id` and `tui` are present), so control fell through to the
kind-specific check and threw
`TypeError: Plugin ... must default export an object with server()`.
That error was caught and logged at ERROR level on every startup of users with
TUI-only plugins, producing noisy and misleading logs.

The same symmetric issue exists for `kind === "tui"`, so the fix adds two
guards (one per kind).

## Verification
- `bun test packages/opencode/test/plugin/read-v1-plugin.test.ts` -> 4/4 pass
- New regression test (`test/plugin/read-v1-plugin.test.ts`) covers:
  - TUI-only plugin scanned by server loader in detect mode -> undefined (was throw)
  - server-only plugin scanned by TUI loader in detect mode -> undefined (was throw)
  - plugin that exposes the requested kind -> value returned
  - strict mode still throws for mismatched kinds (behavior unchanged)

Fixes #31610