### PR TITLE
fix(tui): flash tabs on prompt admission

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -283,6 +283,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
               <TabPulse
                 enabled={animations()}
                 active={status().busy && !status().attention}
+                promptPulse={status().promptPulse}
                 complete={status().complete && !status().attention}
                 glow={glows()}
                 breathe={status().attention}

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -4,6 +4,7 @@ import { extend } from "@opentui/solid"
 type TabPulseOptions = RenderableOptions<TabPulseRenderable> & {
   enabled?: boolean
   active?: boolean
+  promptPulse?: number
   complete?: boolean
   glow?: boolean
   breathe?: boolean
@@ -102,6 +103,11 @@ class Envelope {
     this.scale = scale
   }
 
+  restart(scale = 1) {
+    this.clock = 0
+    this.scale = scale
+  }
+
   stop() {
     this.clock = undefined
   }
@@ -127,6 +133,7 @@ const envelopeActive = (envelope: Envelope) => envelope.active
 class TabPulseRenderable extends Renderable {
   private _enabled: boolean
   private _active: boolean
+  private _promptPulse: number
   private _complete: boolean
   private _glow: boolean
   private _breathe: boolean
@@ -154,6 +161,7 @@ class TabPulseRenderable extends Renderable {
     super(ctx, { ...options, height: 1, live: enabled && active })
     this._enabled = enabled
     this._active = active
+    this._promptPulse = options.promptPulse ?? 0
     this._complete = options.complete ?? false
     this._glow = options.glow ?? false
     this._breathe = options.breathe ?? false
@@ -218,6 +226,15 @@ class TabPulseRenderable extends Renderable {
     }
     // The same neutral edge flash marks both the start and the finish of a run.
     this.edgeFlash.start()
+    this.live = true
+    this.requestRender()
+  }
+
+  set promptPulse(value: number) {
+    if (value === this._promptPulse) return
+    this._promptPulse = value
+    if (!this._enabled) return
+    this.edgeFlash.restart()
     this.live = true
     this.requestRender()
   }
@@ -368,6 +385,7 @@ extend({ tab_pulse: TabPulseRenderable })
 export function TabPulse(props: {
   enabled?: boolean
   active: boolean
+  promptPulse?: number
   complete?: boolean
   glow?: boolean
   breathe?: boolean
@@ -385,6 +403,7 @@ export function TabPulse(props: {
       width="100%"
       enabled={props.enabled ?? true}
       active={props.active}
+      promptPulse={props.promptPulse ?? 0}
       complete={props.complete ?? false}
       glow={props.glow ?? false}
       breathe={props.breathe ?? false}

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -29,6 +29,7 @@ const COMPLETION_OPACITY = 0.18
 const EDGE_FLASH_DURATION = 800
 const EDGE_FLASH_ATTACK = 0.1
 const EDGE_FLASH_OPACITY = 0.1
+const PROMPT_FLASH_SCALE = 2
 const GLOW_IGNITION_DURATION = 600
 const GLOW_IGNITION_PEAK = 1.5
 const GLOW_IGNITION_ATTACK = 0.3
@@ -234,7 +235,7 @@ class TabPulseRenderable extends Renderable {
     if (value === this._promptPulse) return
     this._promptPulse = value
     if (!this._enabled) return
-    this.edgeFlash.restart()
+    this.edgeFlash.restart(PROMPT_FLASH_SCALE)
     this.live = true
     this.requestRender()
   }

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { isDeepEqual } from "remeda"
 import { createSimpleContext } from "./helper"
 import { useClient } from "./client"
@@ -55,6 +55,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       key: "sessionID",
     })
     const fallback = empty()
+    const [promptPulses, setPromptPulses] = createSignal<Record<string, number>>({})
     let history: SessionTabHistory = { entries: [], index: -1 }
 
     function state() {
@@ -77,6 +78,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       const family = members.length > 0 ? members : [session]
       return {
         unread: state().unread[session],
+        promptPulse: promptPulses()[session] ?? 0,
         attention: family.some(
           (id) => (data.session.permission.list(id)?.length ?? 0) > 0 || (data.session.form.list(id)?.length ?? 0) > 0,
         ),
@@ -177,6 +179,14 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     onCleanup(event.on("session.execution.interrupted", (evt) => markUnread(evt.data.sessionID, "activity")))
     onCleanup(event.on("session.execution.failed", (evt) => markUnread(evt.data.sessionID, "error")))
     onCleanup(
+      event.on("session.input.admitted", (evt) => {
+        if (!enabled() || evt.data.input.type !== "user") return
+        const sessionID = root(evt.data.sessionID)
+        if (current() === sessionID || !state().tabs.some((tab) => tab.sessionID === sessionID)) return
+        setPromptPulses((pulses) => ({ ...pulses, [sessionID]: (pulses[sessionID] ?? 0) + 1 }))
+      }),
+    )
+    onCleanup(
       event.on("session.error", (evt) => {
         if (evt.data.sessionID) markUnread(evt.data.sessionID, "error")
       }),
@@ -200,6 +210,12 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       update((draft) => {
         draft.tabs = closeSessionTab(draft.tabs, target).tabs
         delete draft.unread[target]
+      })
+      setPromptPulses((pulses) => {
+        if (pulses[target] === undefined) return pulses
+        const next = { ...pulses }
+        delete next[target]
+        return next
       })
       if (selected) route.navigate(next ? { type: "session", sessionID: next } : { type: "home" })
     }

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -23,7 +23,7 @@ const FIXTURE_TABS = [
   { sessionID: "fixture-12", title: "Prepare review" },
 ]
 
-const EMPTY_STATUS: FixtureStatus = { unread: undefined, attention: false, busy: false }
+const EMPTY_STATUS: FixtureStatus = { unread: undefined, promptPulse: 0, attention: false, busy: false }
 const RUN_DURATION = 1_800
 const RESUME_DURATION = 900
 

--- a/packages/tui/test/component/tab-pulse.test.tsx
+++ b/packages/tui/test/component/tab-pulse.test.tsx
@@ -41,6 +41,7 @@ test("a prompt pulse restarts the neutral edge flash while the tab remains busy"
     await Bun.sleep(80)
     await app.renderOnce()
     expect(firstBackground()?.equals(background)).toBeFalse()
+    expect(firstBackground()?.r ?? 0).toBeGreaterThan(0.17)
 
     await Bun.sleep(800)
     await app.renderOnce()

--- a/packages/tui/test/component/tab-pulse.test.tsx
+++ b/packages/tui/test/component/tab-pulse.test.tsx
@@ -1,12 +1,59 @@
+/** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { createSignal } from "solid-js"
 import {
+  TabPulse,
   blendTabPulseColor,
   completionPulseOpacity,
   glowIgnitionLevel,
   unreadGlowIntensity,
 } from "../../src/component/tab-pulse"
 import { tint } from "../../src/theme/color"
+
+test("a prompt pulse restarts the neutral edge flash while the tab remains busy", async () => {
+  const background = RGBA.fromHex("#101010")
+  const flash = RGBA.fromHex("#f0f0f0")
+  const [promptPulse, setPromptPulse] = createSignal(0)
+  const app = await testRender(
+    () => (
+      <box width={8} height={1} backgroundColor={background}>
+        <TabPulse
+          active={true}
+          promptPulse={promptPulse()}
+          color={background}
+          flashColor={flash}
+          backgroundColor={background}
+        />
+      </box>
+    ),
+    { width: 8, height: 1 },
+  )
+
+  const firstBackground = () => app.captureSpans().lines[0]?.spans[0]?.bg
+
+  try {
+    await app.renderOnce()
+    expect(firstBackground()?.equals(background)).toBeTrue()
+
+    setPromptPulse(1)
+    await Bun.sleep(80)
+    await app.renderOnce()
+    expect(firstBackground()?.equals(background)).toBeFalse()
+
+    await Bun.sleep(800)
+    await app.renderOnce()
+    expect(firstBackground()?.equals(background)).toBeTrue()
+
+    setPromptPulse(2)
+    await Bun.sleep(80)
+    await app.renderOnce()
+    expect(firstBackground()?.equals(background)).toBeFalse()
+  } finally {
+    app.renderer.destroy()
+  }
+})
 
 test("completion pulse rises quickly and fades over the remaining duration", () => {
   expect(completionPulseOpacity(0)).toBe(0)

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -1,0 +1,110 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import type { OpenCodeEvent } from "@opencode-ai/client"
+import { testRender } from "@opentui/solid"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+import { ConfigProvider } from "../../src/config"
+import { ClientProvider, useClient } from "../../src/context/client"
+import { DataProvider } from "../../src/context/data"
+import { RouteProvider, useRoute } from "../../src/context/route"
+import { TuiAppProvider } from "../../src/context/runtime"
+import { SessionTabsProvider, useSessionTabs } from "../../src/context/session-tabs"
+import { StorageProvider } from "../../src/context/storage"
+import { createApi, createEventStream, createFetch, directory } from "../fixture/tui-client"
+import { TestTuiContexts } from "../fixture/tui-environment"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+
+async function wait(fn: () => boolean, timeout = 2_000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+test("user prompt admissions pulse an already-busy background tab", async () => {
+  const state = mkdtempSync(path.join(tmpdir(), "opencode-session-tabs-"))
+  const events = createEventStream()
+  const calls = createFetch(undefined, events)
+  let tabs!: ReturnType<typeof useSessionTabs>
+  let route!: ReturnType<typeof useRoute>
+  let client!: ReturnType<typeof useClient>
+
+  function Probe() {
+    tabs = useSessionTabs()
+    route = useRoute()
+    client = useClient()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts paths={{ state }}>
+      <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
+        <StorageProvider>
+          <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
+            <RouteProvider initialRoute={{ type: "session", sessionID: "background" }}>
+              <ClientProvider api={createApi(calls.fetch)}>
+                <DataProvider>
+                  <SessionTabsProvider>
+                    <Probe />
+                  </SessionTabsProvider>
+                </DataProvider>
+              </ClientProvider>
+            </RouteProvider>
+          </ConfigProvider>
+        </StorageProvider>
+      </TuiAppProvider>
+    </TestTuiContexts>
+  ))
+
+  const emit = (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } })
+  const admitted = (sessionID: string, inputID: string): OpenCodeEvent => ({
+    id: `evt_${inputID}`,
+    created: Date.now(),
+    type: "session.input.admitted",
+    durable: { aggregateID: sessionID, seq: Number(inputID.replace(/\D/g, "")), version: 1 },
+    data: {
+      sessionID,
+      inputID,
+      input: { type: "user", data: { text: inputID }, delivery: "steer" },
+    },
+  })
+
+  try {
+    await wait(
+      () => client.connection.status() === "connected" && tabs.tabs().some((tab) => tab.sessionID === "background"),
+    )
+    route.navigate({ type: "session", sessionID: "active" })
+    await wait(() => tabs.current() === "active" && tabs.tabs().length === 2)
+
+    emit({
+      id: "evt_context",
+      created: Date.now(),
+      type: "session.input.admitted",
+      durable: { aggregateID: "background", seq: 0, version: 1 },
+      data: {
+        sessionID: "background",
+        inputID: "msg_context",
+        input: { type: "synthetic", data: { text: "editor context" }, delivery: "steer" },
+      },
+    })
+    await Bun.sleep(20)
+    expect(tabs.status("background").promptPulse).toBe(0)
+
+    emit(admitted("background", "msg_1"))
+    await wait(() => tabs.status("background").promptPulse === 1 && tabs.status("background").busy)
+
+    emit(admitted("background", "msg_2"))
+    await wait(() => tabs.status("background").promptPulse === 2)
+
+    emit(admitted("active", "msg_3"))
+    await Bun.sleep(20)
+    expect(tabs.status("active").promptPulse).toBe(0)
+    expect(tabs.status("background")).toMatchObject({ promptPulse: 2, busy: true })
+  } finally {
+    app.renderer.destroy()
+    rmSync(state, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What

Flash an open background session tab whenever another user prompt is admitted, including when that session is already busy.

## Before / After

**Before:** The neutral edge flash was driven only by idle-to-busy and busy-to-idle transitions. Steering or queueing another prompt into a session that was already running left its background tab visually unchanged, so the admission had no acknowledgement.

**After:** Each admitted user prompt increments an ephemeral pulse for its open background root tab. `TabPulse` restarts a stronger neutral edge flash for every prompt pulse while the busy state remains unchanged, keeping it visible over the running sweep. Active tabs and hidden synthetic context admissions do not receive this extra acknowledgement.

## How

- `packages/tui/src/context/session-tabs.tsx` listens to the existing durable `session.input.admitted` event and emits a per-tab prompt nonce only for open background user inputs.
- `packages/tui/src/component/tab-pulse.tsx` restarts the existing edge-flash envelope when that nonce changes instead of manufacturing a session status transition.
- Prompt admissions use twice the standard edge-flash intensity so the acknowledgement remains visible while the busy sweep continues.
- Pulse state is ephemeral and removed when its tab closes.
- Regression coverage drives both the real client event stream into `SessionTabsProvider` and the actual OpenTUI renderable color output.

## Scope

- No protocol or server changes.
- No V1 `packages/opencode` changes.
- No pagination, OpenTUI scheduler, or keybinding changes.

## Testing

- `cd packages/tui && bun run test` (568 passed, 5 skipped)
- `cd packages/tui && bun typecheck`
- Repository-wide Turbo typecheck via the push hook (33 tasks passed)
- `bunx prettier --check` on all changed files
- `bunx oxlint` on changed implementation and test files (0 errors; one pre-existing warning on the session-tabs context export)
- OpenCode Drive recording against this branch with two cue-labeled background prompt admissions while the tab remains continuously busy

## Demo

The composer labels each direct background admission. The enlarged strip at the top makes both independent tab flashes visible while tab 1 remains continuously busy.

https://github.com/user-attachments/assets/6eb65970-bf17-4adb-8864-5cccebf3776c

## Flow

```mermaid
sequenceDiagram
    participant Server
    participant Tabs as SessionTabsProvider
    participant Pulse as TabPulse

    Server->>Tabs: session.input.admitted (user)
    Tabs->>Tabs: confirm open background root tab
    Tabs->>Tabs: increment promptPulse
    Tabs->>Pulse: new promptPulse, busy unchanged
    Pulse->>Pulse: restart stronger neutral edge flash
```
