### PR TITLE
refactor(core): cache canonical worktree lookup

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,6 +1,6 @@
 export * as Project from "./project"
 
-import { Context, Effect, Layer, Schema } from "effect"
+import { Cache, Context, Duration, Effect, Exit, Layer, Schema } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { asc, desc, isNotNull, isNull, ne, or } from "drizzle-orm"
 import path from "path"
@@ -106,6 +106,14 @@ const layer = Layer.effect(
     const proc = yield* AppProcess.Service
     const db = (yield* Database.Service).db
     const projectDirectories = yield* ProjectDirectories.Service
+    const findCanonicalWorktree = (repo: Git.Repository) =>
+      git.worktree
+        .list(repo)
+        .pipe(Effect.map((items) => items.find((item) => item.kind === "main")?.directory ?? repo.worktree))
+    const canonicalWorktrees = yield* Cache.makeWith(findCanonicalWorktree, {
+      capacity: 128,
+      timeToLive: (exit) => (Exit.isSuccess(exit) ? "60 minutes" : Duration.zero),
+    })
 
     const persist = Effect.fnUntraced(function* (project: Resolved) {
       yield* db
@@ -249,10 +257,7 @@ const layer = Layer.effect(
         const canonical =
           repo.gitDirectory === repo.commonDirectory
             ? repo.worktree
-            : yield* git.worktree.list(repo).pipe(
-                Effect.map((items) => items.find((item) => item.kind === "main")?.directory ?? repo.worktree),
-                Effect.catch(() => Effect.succeed(repo.worktree)),
-              )
+            : yield* Cache.get(canonicalWorktrees, repo).pipe(Effect.catch(() => Effect.succeed(repo.worktree)))
         return yield* persist({
           previous,
           id: id ?? ID.global,

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -5,6 +5,7 @@ import path from "path"
 import { Effect, Layer, Schema } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Database } from "@opencode-ai/core/database/database"
+import { Git } from "@opencode-ai/core/git"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -371,5 +372,38 @@ describe("Project.resolve", () => {
         { directory: yield* real(worktree), strategy: "git_worktree" },
       ])
     }),
+  )
+
+  testEffect(Layer.empty).live("reuses the canonical worktree lookup", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const worktree = `${tmp.path}-worktree`
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(() => fs.rm(worktree, { recursive: true, force: true })).pipe(Effect.ignore),
+          )
+          yield* Effect.promise(() => initRepo(tmp.path, { commit: true, remote: "git@github.com:owner/repo.git" }))
+          yield* Effect.promise(() => $`git worktree add ${worktree} -b cache-${Date.now()}`.cwd(tmp.path).quiet())
+          const git = yield* Git.Service.pipe(Effect.provide(AppNodeBuilder.build(Git.node)))
+          let lists = 0
+          const instrumented = Git.Service.of({
+            ...git,
+            worktree: {
+              ...git.worktree,
+              list: (repo) => Effect.sync(() => lists++).pipe(Effect.andThen(git.worktree.list(repo))),
+            },
+          })
+          const layer = AppNodeBuilder.build(Project.node, [[Git.node, Layer.succeed(Git.Service, instrumented)]])
+
+          yield* Effect.gen(function* () {
+            const project = yield* Project.Service
+            expect((yield* project.resolve(abs(worktree))).canonical).toBe(yield* real(tmp.path))
+            expect((yield* project.resolve(abs(worktree))).canonical).toBe(yield* real(tmp.path))
+            expect(lists).toBe(1)
+          }).pipe(Effect.provide(layer))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
   )
 })


### PR DESCRIPTION
## What

Avoid rerunning `git worktree list --porcelain` whenever multiple Locations resolve inside the same linked checkout. Successful canonical-worktree lookups are reused by the process-global Project service.

In the controlled linked-worktree benchmark, repeated `Project.resolve` calls improved from 48.903 ms median / 55.672 ms p95 to 29.301 ms median / 35.576 ms p95.

## How

- `packages/core/src/project.ts` owns a bounded Effect `Cache` for canonical worktree lookups.
- Successful lookups live for 60 minutes; failures receive zero TTL so degraded fallbacks are retried.
- Concurrent misses for the same structurally equal Git repository are deduplicated by Effect `Cache`.
- Ordinary main checkouts retain the fast path merged in #39692 and never enter the cache.
- `packages/core/test/project.test.ts` wraps the real Git service and verifies that two separately discovered linked-worktree resolutions perform one `worktree.list` call while preserving the canonical main checkout.

## Scope

- The cache is process-local and starts empty after restart.
- Different linked checkouts currently use distinct repository keys and each pay their first lookup.
- This does not replace documented Git behavior with path heuristics or private metadata parsing.
- Profiling instrumentation, benchmark scripts, and raw results are not included.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/git.test.ts test/project.test.ts` from `packages/core`: 19 passed, 1 skipped
- `git diff --check`
- Push-hook repository-wide Turbo typecheck

Full Location A/B, two interleaved nine-run batches per side on the same M2 Max:

| New linked-worktree Location | Baseline | Cached | Change |
| --- | ---: | ---: | ---: |
| Graph boot median | 66.598 ms | 43.587 ms | -34.6% |
| Graph boot p95 | 78.265 ms | 46.132 ms | -41.1% |
| Plugin-ready median | 231.702 ms | 201.742 ms | -12.9% |
| Plugin-ready p95 | 252.417 ms | 207.302 ms | -17.9% |

These are controlled local engineering comparisons, not a cross-machine SLA.