### PR TITLE
fix(core): stop repository discovery at nearest marker

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -200,11 +200,19 @@ const layer = Layer.effect(
     const locked = <A, E, R>(repository: Repository, effect: Effect.Effect<A, E, R>) =>
       locks.withLock(repository.gitDirectory)(effect)
 
+    const findGitDirectory = Effect.fnUntraced(function* (input: AbsolutePath) {
+      let current: string = input
+      while (true) {
+        const dotgit = path.join(current, ".git")
+        if (yield* fs.exists(dotgit)) return dotgit
+        const parent = path.dirname(current)
+        if (parent === current) return undefined
+        current = parent
+      }
+    })
+
     const discover = Effect.fn("Git.repo.discover")(function* (input: AbsolutePath) {
-      const dotgit = yield* fs.up({ targets: [".git"], start: input }).pipe(
-        Effect.map((matches) => matches[0]),
-        Effect.catch(() => Effect.succeed(undefined)),
-      )
+      const dotgit = yield* findGitDirectory(input).pipe(Effect.catch(() => Effect.succeed(undefined)))
       if (!dotgit) return undefined
 
       const cwd = path.dirname(dotgit)

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -200,19 +200,11 @@ const layer = Layer.effect(
     const locked = <A, E, R>(repository: Repository, effect: Effect.Effect<A, E, R>) =>
       locks.withLock(repository.gitDirectory)(effect)
 
-    const findGitDirectory = Effect.fnUntraced(function* (input: AbsolutePath) {
-      let current: string = input
-      while (true) {
-        const dotgit = path.join(current, ".git")
-        if (yield* fs.exists(dotgit)) return dotgit
-        const parent = path.dirname(current)
-        if (parent === current) return undefined
-        current = parent
-      }
-    })
-
     const discover = Effect.fn("Git.repo.discover")(function* (input: AbsolutePath) {
-      const dotgit = yield* findGitDirectory(input).pipe(Effect.catch(() => Effect.succeed(undefined)))
+      const dotgit = yield* fs.up({ targets: [".git"], start: input, mode: "first" }).pipe(
+        Effect.map((matches) => matches[0]),
+        Effect.catch(() => Effect.succeed(undefined)),
+      )
       if (!dotgit) return undefined
 
       const cwd = path.dirname(dotgit)

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -49,7 +49,7 @@ export const root = Effect.fn("Project.root")(function* (
   fs: FSUtil.Interface,
   input: AbsolutePath,
 ) {
-  return yield* fs.up({ targets: [".git", ".hg"], start: input }).pipe(
+  return yield* fs.up({ targets: [".git", ".hg"], start: input, mode: "first" }).pipe(
     Effect.map((matches) => matches[0] ? AbsolutePath.make(path.dirname(matches[0])) : undefined),
     Effect.catch(() => Effect.succeed(undefined)),
   )
@@ -224,7 +224,7 @@ const layer = Layer.effect(
     })
 
     const hgDiscover = Effect.fnUntraced(function* (input: AbsolutePath) {
-      const dotHg = yield* fs.up({ targets: [".hg"], start: input }).pipe(
+      const dotHg = yield* fs.up({ targets: [".hg"], start: input, mode: "first" }).pipe(
         Effect.map((matches) => matches[0]),
         Effect.catch(() => Effect.succeed(undefined)),
       )

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test"
-import { Effect, FileSystem } from "effect"
+import { Effect, FileSystem, Layer } from "effect"
 import { LayerNodePlatform } from "@opencode-ai/util/effect/app-node-platform"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
@@ -271,15 +271,27 @@ describe("FSUtil", () => {
     it(
       "stops at the first match when requested",
       Effect.gen(function* () {
-        const fs = yield* FSUtil.Service
         const filesys = yield* FileSystem.FileSystem
         const tmp = yield* filesys.makeTempDirectoryScoped()
         yield* filesys.writeFileString(path.join(tmp, "marker"), "root")
         const child = path.join(tmp, "sub")
         yield* filesys.makeDirectory(child)
         yield* filesys.writeFileString(path.join(child, "marker"), "child")
+        const checked: string[] = []
+        const instrumented = FileSystem.FileSystem.of({
+          ...filesys,
+          exists: (target) => Effect.sync(() => checked.push(target)).pipe(Effect.andThen(filesys.exists(target))),
+        })
+        const search = yield* FSUtil.Service.pipe(
+          Effect.provide(
+            FSUtil.layer.pipe(Layer.fresh, Layer.provide(Layer.succeed(FileSystem.FileSystem, instrumented))),
+          ),
+        )
 
-        expect(yield* fs.up({ targets: ["marker"], start: child, mode: "first" })).toEqual([path.join(child, "marker")])
+        expect(yield* search.up({ targets: ["marker", "other"], start: child, mode: "first" })).toEqual([
+          path.join(child, "marker"),
+        ])
+        expect(checked).toEqual([path.join(child, "marker")])
       }),
     )
   })

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -267,6 +267,21 @@ describe("FSUtil", () => {
         expect(result).toContain(path.join(tmp, "b.txt"))
       }),
     )
+
+    it(
+      "stops at the first match when requested",
+      Effect.gen(function* () {
+        const fs = yield* FSUtil.Service
+        const filesys = yield* FileSystem.FileSystem
+        const tmp = yield* filesys.makeTempDirectoryScoped()
+        yield* filesys.writeFileString(path.join(tmp, "marker"), "root")
+        const child = path.join(tmp, "sub")
+        yield* filesys.makeDirectory(child)
+        yield* filesys.writeFileString(path.join(child, "marker"), "child")
+
+        expect(yield* fs.up({ targets: ["marker"], start: child, mode: "first" })).toEqual([path.join(child, "marker")])
+      }),
+    )
   })
 
   describe("glob", () => {

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -2,10 +2,8 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, Layer } from "effect"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Effect } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { branch, commit, gitRemote } from "./fixture/git"
@@ -15,36 +13,6 @@ import { testEffect } from "./lib/effect"
 const it = testEffect(LayerNode.compile(Git.node))
 
 describe("Git", () => {
-  testEffect(Layer.empty).live("stops discovery at the nearest Git directory", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (root) =>
-        Effect.gen(function* () {
-          yield* Effect.promise(() => initRepo(root.path))
-          const nested = path.join(root.path, "a", "b")
-          yield* Effect.promise(() => fs.mkdir(nested, { recursive: true }))
-          const filesystem = yield* FSUtil.Service.pipe(Effect.provide(AppNodeBuilder.build(FSUtil.node)))
-          const parentDotGit = path.join(path.dirname(root.path), ".git")
-          let checkedParent = false
-          const instrumented = FSUtil.Service.of({
-            ...filesystem,
-            exists: (target) => {
-              if (target === parentDotGit) checkedParent = true
-              return filesystem.exists(target)
-            },
-          })
-          const layer = AppNodeBuilder.build(Git.node, [[FSUtil.node, Layer.succeed(FSUtil.Service, instrumented)]])
-          const git = yield* Git.Service.pipe(Effect.provide(layer))
-
-          expect((yield* git.repo.discover(AbsolutePath.make(nested)))?.worktree).toBe(
-            AbsolutePath.make(yield* Effect.promise(() => fs.realpath(root.path))),
-          )
-          expect(checkedParent).toBe(false)
-        }),
-      (root) => Effect.promise(() => root[Symbol.asyncDispose]()),
-    ),
-  )
-
   it.live("discovers repository metadata without a work tree", () =>
     Effect.gen(function* () {
       const root = yield* Effect.acquireRelease(

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -2,8 +2,10 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { branch, commit, gitRemote } from "./fixture/git"
@@ -13,6 +15,36 @@ import { testEffect } from "./lib/effect"
 const it = testEffect(LayerNode.compile(Git.node))
 
 describe("Git", () => {
+  testEffect(Layer.empty).live("stops discovery at the nearest Git directory", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (root) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => initRepo(root.path))
+          const nested = path.join(root.path, "a", "b")
+          yield* Effect.promise(() => fs.mkdir(nested, { recursive: true }))
+          const filesystem = yield* FSUtil.Service.pipe(Effect.provide(AppNodeBuilder.build(FSUtil.node)))
+          const parentDotGit = path.join(path.dirname(root.path), ".git")
+          let checkedParent = false
+          const instrumented = FSUtil.Service.of({
+            ...filesystem,
+            exists: (target) => {
+              if (target === parentDotGit) checkedParent = true
+              return filesystem.exists(target)
+            },
+          })
+          const layer = AppNodeBuilder.build(Git.node, [[FSUtil.node, Layer.succeed(FSUtil.Service, instrumented)]])
+          const git = yield* Git.Service.pipe(Effect.provide(layer))
+
+          expect((yield* git.repo.discover(AbsolutePath.make(nested)))?.worktree).toBe(
+            AbsolutePath.make(yield* Effect.promise(() => fs.realpath(root.path))),
+          )
+          expect(checkedParent).toBe(false)
+        }),
+      (root) => Effect.promise(() => root[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("discovers repository metadata without a work tree", () =>
     Effect.gen(function* () {
       const root = yield* Effect.acquireRelease(

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -28,6 +28,13 @@ export namespace FSUtil {
     readonly type: "file" | "directory" | "symlink" | "other"
   }
 
+  export interface UpOptions {
+    readonly targets: string[]
+    readonly start: string
+    readonly stop?: string
+    readonly mode?: "all" | "first"
+  }
+
   export interface Interface extends FileSystem.FileSystem {
     readonly isDir: (path: string) => Effect.Effect<boolean>
     readonly isFile: (path: string) => Effect.Effect<boolean>
@@ -40,12 +47,7 @@ export namespace FSUtil {
     readonly readDirectoryEntries: (path: string) => Effect.Effect<DirEntry[], Error>
     readonly resolve: (path: string) => Effect.Effect<string>
     readonly findUp: (target: string, start: string, stop?: string) => Effect.Effect<string[], Error>
-    readonly up: (options: {
-      targets: string[]
-      start: string
-      stop?: string
-      mode?: "all" | "first"
-    }) => Effect.Effect<string[], Error>
+    readonly up: (options: UpOptions) => Effect.Effect<string[], Error>
     readonly globUp: (pattern: string, start: string, stop?: string) => Effect.Effect<string[], Error>
     readonly scan: (pattern: string, options?: Glob.Options) => Effect.Effect<string[], Error>
     readonly globMatch: (pattern: string, filepath: string) => boolean
@@ -158,26 +160,7 @@ export namespace FSUtil {
         })
       })
 
-      const findUp = Effect.fn("FileSystem.findUp")(function* (target: string, start: string, stop?: string) {
-        const result: string[] = []
-        let current = start
-        while (true) {
-          const search = join(current, target)
-          if (yield* fs.exists(search)) result.push(search)
-          if (stop === current) break
-          const parent = dirname(current)
-          if (parent === current) break
-          current = parent
-        }
-        return result
-      })
-
-      const up = Effect.fn("FileSystem.up")(function* (options: {
-        targets: string[]
-        start: string
-        stop?: string
-        mode?: "all" | "first"
-      }) {
+      const up = Effect.fn("FileSystem.up")(function* (options: UpOptions) {
         const result: string[] = []
         let current = options.start
         while (true) {
@@ -195,6 +178,10 @@ export namespace FSUtil {
         }
         return result
       })
+
+      const findUp = Effect.fn("FileSystem.findUp")((target: string, start: string, stop?: string) =>
+        up({ targets: [target], start, stop }),
+      )
 
       const globUp = Effect.fn("FileSystem.globUp")(function* (pattern: string, start: string, stop?: string) {
         const result: string[] = []

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -40,7 +40,12 @@ export namespace FSUtil {
     readonly readDirectoryEntries: (path: string) => Effect.Effect<DirEntry[], Error>
     readonly resolve: (path: string) => Effect.Effect<string>
     readonly findUp: (target: string, start: string, stop?: string) => Effect.Effect<string[], Error>
-    readonly up: (options: { targets: string[]; start: string; stop?: string }) => Effect.Effect<string[], Error>
+    readonly up: (options: {
+      targets: string[]
+      start: string
+      stop?: string
+      mode?: "all" | "first"
+    }) => Effect.Effect<string[], Error>
     readonly globUp: (pattern: string, start: string, stop?: string) => Effect.Effect<string[], Error>
     readonly scan: (pattern: string, options?: Glob.Options) => Effect.Effect<string[], Error>
     readonly globMatch: (pattern: string, filepath: string) => boolean
@@ -167,13 +172,21 @@ export namespace FSUtil {
         return result
       })
 
-      const up = Effect.fn("FileSystem.up")(function* (options: { targets: string[]; start: string; stop?: string }) {
+      const up = Effect.fn("FileSystem.up")(function* (options: {
+        targets: string[]
+        start: string
+        stop?: string
+        mode?: "all" | "first"
+      }) {
         const result: string[] = []
         let current = options.start
         while (true) {
           for (const target of options.targets) {
             const search = join(current, target)
-            if (yield* fs.exists(search)) result.push(search)
+            if (yield* fs.exists(search)) {
+              result.push(search)
+              if (options.mode === "first") return result
+            }
           }
           if (options.stop === current) break
           const parent = dirname(current)


### PR DESCRIPTION
## What

Make ancestor traversal semantics explicit: `FSUtil.up` still collects all matches by default, while callers that need only the nearest repository marker can opt into `mode: "first"` and stop immediately.

## Before / After

**Before:** Git discovery, filesystem-only project-root detection, and Mercurial discovery called the collect-all traversal and selected `matches[0]`. They still probed every ancestor up to the filesystem root even though later matches could not affect their result.

**After:** Those three repository-discovery paths request first-match traversal and stop at the nearest `.git` or `.hg`. Collect-all consumers retain their existing behavior.

## How

- `packages/util/src/fs-util.ts` adds an optional `mode: "all" | "first"` to `up`; omitted mode remains collect-all.
- `packages/core/src/git.ts` requests first-match traversal for `.git`.
- `packages/core/src/project.ts` requests first-match traversal for filesystem project-root and Mercurial discovery.
- `packages/core/test/filesystem/filesystem.test.ts` verifies both existing collect-all semantics and the opt-in nearest-match behavior.

Audited collect-all consumers remain unchanged:

- Config discovery collects `.opencode`, `.claude`, `.agents`, and config files from multiple ancestors.
- Ambient and read-tool instruction discovery collect every applicable `AGENTS.md`.
- Formatter discovery scans ancestor manifests/configuration and intentionally uses the existing collect-all `findUp`.

## Scope

This is a semantic cleanup, not a material startup optimization. Prior profiling measured repository-marker ascent at roughly 0.44 ms median. The default `FSUtil.up` behavior is unchanged, and no configuration, instruction, tool, or formatter traversal is shortened.

## Testing

- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/util`
- `bun run test test/filesystem/filesystem.test.ts test/git.test.ts test/project.test.ts` from `packages/core`: 46 passed, 1 skipped
- `git diff --check`
- Repository-wide Turbo typecheck through the pre-push hook: 33 packages passed