### PR TITLE
fix(plugin): report in-process server URL accurately

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -141,8 +141,12 @@ const layer = Layer.effect(
         const { Server } = yield* Effect.promise(() => import("../server/server"))
 
         const serverUrl = Server.url
+        // When no HTTP listener is bound (the default in-process TUI transport),
+        // there is no reachable loopback URL. Report the in-process placeholder
+        // ("http://opencode.internal") rather than a fabricated localhost:4096,
+        // which would falsely imply a live TCP server that plugins can dial.
         const client = createOpencodeClient({
-          baseUrl: serverUrl?.toString() ?? "http://localhost:4096",
+          baseUrl: serverUrl?.toString() ?? "http://opencode.internal",
           directory: ctx.directory,
           headers: ServerAuth.headers(),
           ...(serverUrl ? {} : { fetch: async (...args) => Server.Default().app.fetch(...args) }),
@@ -159,7 +163,10 @@ const layer = Layer.effect(
             },
           },
           get serverUrl(): URL {
-            return Server.url ?? new URL("http://localhost:4096")
+            // Reflect the bound listener when one exists; otherwise surface the
+            // in-process placeholder so plugins can detect there is no external
+            // TCP server instead of being handed a dead localhost:4096 URL.
+            return Server.url ?? new URL("http://opencode.internal")
           },
           // @ts-expect-error
           $: typeof Bun === "undefined" ? undefined : Bun.$,


### PR DESCRIPTION
### Issue for this PR

Closes #39561

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The default TUI uses an in-process transport and does not bind an HTTP listener, but `PluginInput.serverUrl` fell back to `http://localhost:4096`. That URL implies a reachable server that does not exist, so plugins attempting to connect to it fail.

This changes the no-listener fallback to `http://opencode.internal`, which is already the in-process transport placeholder in `tui.ts` and `run.ts`. The plugin client still uses `Server.Default().app.fetch` when no listener exists; only the reported placeholder changes.

### How did you verify your code works?

Confirmed the default TUI has no TCP listener and `--port 4096` does bind one. The change makes the default plugin URL report the in-process placeholder instead of the unreachable localhost URL. I also rebased the branch on the latest `dev` and ran `git diff --check`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
