### PR TITLE
feat(tui): page older session messages

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -2,6 +2,9 @@
 // Prefer straightforward projection. Do not add generation counters, stale-response
 // merges, live/history overlays, or other race machinery here—last write wins.
 // Reconnect invalidates cached reads; active UI owners decide what to sync again.
+// One sanctioned exception: message.older drops a continuation whose cursor no longer
+// matches the current window edge, because applying it would poison the cursor and
+// leave a permanent unfetchable gap rather than a recoverable stale view.
 
 import type {
   AgentInfo,
@@ -788,14 +791,21 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             event.data.sessionID,
             (store.session.input[event.data.sessionID] ?? []).filter((id) => id < event.data.to),
           )
-          message.update(event.data.sessionID, (draft, index) => {
-            const position = draft.findIndex((item) => item.id >= event.data.to)
-            if (position === -1) return
-            for (const item of draft.splice(position)) index.delete(item.id)
-          })
-          if (store.session.message[event.data.sessionID]?.length === 0) {
-            result.session.message.invalidate(event.data.sessionID)
-            void result.session.message.sync(event.data.sessionID)
+          {
+            let emptied = false
+            message.update(event.data.sessionID, (draft, index) => {
+              const position = draft.findIndex((item) => item.id >= event.data.to)
+              if (position === -1) return
+              emptied = position === 0
+              for (const item of draft.splice(position)) index.delete(item.id)
+            })
+            // A fully reverted window keeps no anchor for older paging, so refetch to make
+            // history below the revert point the new tail. Only a window that actually held
+            // messages needs this; never-loaded sessions must not start speculative fetches.
+            if (emptied) {
+              result.session.message.invalidate(event.data.sessionID)
+              void result.session.message.sync(event.data.sessionID).catch(() => {})
+            }
           }
           break
         case "session.compaction.delta":
@@ -1046,13 +1056,17 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           hasOlder(sessionID: string) {
             return messageCursor.has(sessionID)
           },
-          older(sessionID: string, count: number) {
+          paging(sessionID: string) {
+            return messagePaging.has(sessionID)
+          },
+          /** Resolves with the number of messages prepended, which can exceed the limit (turn-root extension) or undershoot it (dedupe). */
+          older(sessionID: string, limit: number) {
             const cursor = messageCursor.get(sessionID)
             if (!cursor) return Promise.resolve(0)
             const active = messagePaging.get(sessionID)
             if (active) return active
             const pending = (async () => {
-              const page = await fetchMessagePage(sessionID, count, cursor)
+              const page = await fetchMessagePage(sessionID, limit, cursor)
               // Invalidate or a fresh sync may have replaced the window mid-flight. Apply the
               // continuation only while it still extends the current window edge; prepending it
               // onto a replaced window would leave a permanent unfetchable gap in the transcript.

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -41,6 +41,19 @@ export type DataSessionStatus = "idle" | "running"
 
 const messageIDFromEvent = (eventID: string) => eventID.replace(/^evt_/, "msg_")
 
+// A window whose oldest turn-significant message is an assistant reply starts mid-turn:
+// its user or shell prompt sits on an older page. Matches the desktop client's invariant.
+function needsOlderTurnRoot(source: readonly SessionMessageInfo[]) {
+  const boundary = source.find(
+    (message) =>
+      message.type === "user" ||
+      message.type === "shell" ||
+      message.type === "assistant" ||
+      (message.type === "synthetic" && message.description?.trim()),
+  )
+  return boundary?.type === "assistant"
+}
+
 // Global MCP elicitations temporarily use "global" instead of a real session ID, so the
 // server cannot recover their Location when settling them. Preserve the event Location
 // until MCP elicitations carry session ownership.
@@ -154,6 +167,23 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     const messageIndex = new Map<string, Map<string, number>>()
     const messageCursor = new Map<string, string | undefined>()
     const messagePaging = new Map<string, Promise<number>>()
+    // Fetch one descending page, following the cursor while the window would open on a
+    // dangling assistant reply, so the oldest loaded message always starts its turn.
+    const fetchMessagePage = async (sessionID: string, limit: number, cursor?: string) => {
+      const request = (cursor?: string) =>
+        client.api.message.list(cursor ? { sessionID, limit, cursor } : { sessionID, limit, order: "desc" })
+      const pages = [await request(cursor)]
+      while (pages.at(-1)!.cursor.next && needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) {
+        const response = await request(pages.at(-1)!.cursor.next ?? undefined)
+        pages.push(response)
+        if (!response.data.length) break
+      }
+      const last = pages.at(-1)!
+      return {
+        messages: pages.flatMap((page) => page.data).toReversed(),
+        cursor: last.data.length < limit ? undefined : (last.cursor.next ?? undefined),
+      }
+    }
     const sync = createSync()
 
     function setSessionActive(sessionID: string, status: DataSessionStatus) {
@@ -1002,11 +1032,10 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           sync(sessionID: string) {
             return sync.run(`session.message:${sessionID}`, async () => {
-              const page = await client.api.message.list({ sessionID, limit: 20, order: "desc" })
-              const messages = page.data.toReversed()
-              messageCursor.set(sessionID, page.data.length < 20 ? undefined : (page.cursor.next ?? undefined))
-              messageIndex.set(sessionID, new Map(messages.map((message, index) => [message.id, index])))
-              setStore("session", "message", sessionID, reconcile(messages))
+              const page = await fetchMessagePage(sessionID, 20)
+              messageCursor.set(sessionID, page.cursor)
+              messageIndex.set(sessionID, new Map(page.messages.map((message, index) => [message.id, index])))
+              setStore("session", "message", sessionID, reconcile(page.messages))
             })
           },
           older(sessionID: string, count: number) {
@@ -1015,10 +1044,10 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             const active = messagePaging.get(sessionID)
             if (active) return active
             const pending = (async () => {
-              const page = await client.api.message.list({ sessionID, limit: count, cursor })
-              messageCursor.set(sessionID, page.data.length < count ? undefined : (page.cursor.next ?? undefined))
+              const page = await fetchMessagePage(sessionID, count, cursor)
+              messageCursor.set(sessionID, page.cursor)
               const loaded = index(sessionID)
-              const older = page.data.toReversed().filter((item) => !loaded.has(item.id))
+              const older = page.messages.filter((item) => !loaded.has(item.id))
               if (older.length === 0) return 0
               message.update(sessionID, (draft, index) => {
                 draft.unshift(...older)

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -152,6 +152,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       directory: process.cwd(),
     })
     const messageIndex = new Map<string, Map<string, number>>()
+    const messageCursor = new Map<string, string | undefined>()
+    const messagePaging = new Map<string, Promise<number>>()
     const sync = createSync()
 
     function setSessionActive(sessionID: string, status: DataSessionStatus) {
@@ -275,6 +277,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
 
     function removeSession(sessionID: string) {
       messageIndex.delete(sessionID)
+      messageCursor.delete(sessionID)
+      messagePaging.delete(sessionID)
       sync.invalidate(`session:${sessionID}`)
       sync.invalidate(`session.pending:${sessionID}`)
       sync.invalidate(`session.message:${sessionID}`)
@@ -310,6 +314,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           // hydration can load pending and projected messages atomically.
           sync.complete(`session.pending:${event.data.sessionID}`)
           sync.complete(`session.message:${event.data.sessionID}`)
+          messageCursor.set(event.data.sessionID, undefined)
           break
         case "session.deleted":
           removeSession(event.data.sessionID)
@@ -754,6 +759,10 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             if (position === -1) return
             for (const item of draft.splice(position)) index.delete(item.id)
           })
+          if (store.session.message[event.data.sessionID]?.length === 0) {
+            result.session.message.invalidate(event.data.sessionID)
+            void result.session.message.sync(event.data.sessionID)
+          }
           break
         case "session.compaction.delta":
           message.update(event.data.sessionID, (draft) => {
@@ -993,14 +1002,39 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           sync(sessionID: string) {
             return sync.run(`session.message:${sessionID}`, async () => {
-              const messages = (
-                await client.api.message.list({ sessionID, limit: 200, order: "desc" })
-              ).data.toReversed()
+              const page = await client.api.message.list({ sessionID, limit: 20, order: "desc" })
+              const messages = page.data.toReversed()
+              messageCursor.set(sessionID, page.data.length < 20 ? undefined : (page.cursor.next ?? undefined))
               messageIndex.set(sessionID, new Map(messages.map((message, index) => [message.id, index])))
               setStore("session", "message", sessionID, reconcile(messages))
             })
           },
+          older(sessionID: string, count: number) {
+            const cursor = messageCursor.get(sessionID)
+            if (!cursor) return Promise.resolve(0)
+            const active = messagePaging.get(sessionID)
+            if (active) return active
+            const pending = (async () => {
+              const page = await client.api.message.list({ sessionID, limit: count, cursor })
+              messageCursor.set(sessionID, page.data.length < count ? undefined : (page.cursor.next ?? undefined))
+              const loaded = index(sessionID)
+              const older = page.data.toReversed().filter((item) => !loaded.has(item.id))
+              if (older.length === 0) return 0
+              message.update(sessionID, (draft, index) => {
+                draft.unshift(...older)
+                index.clear()
+                draft.forEach((item, position) => index.set(item.id, position))
+              })
+              return older.length
+            })().finally(() => {
+              if (messagePaging.get(sessionID) === pending) messagePaging.delete(sessionID)
+            })
+            messagePaging.set(sessionID, pending)
+            return pending
+          },
           invalidate(sessionID: string) {
+            messageCursor.delete(sessionID)
+            messagePaging.delete(sessionID)
             sync.invalidate(`session.message:${sessionID}`)
           },
         },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -41,10 +41,14 @@ export type DataSessionStatus = "idle" | "running"
 
 const messageIDFromEvent = (eventID: string) => eventID.replace(/^evt_/, "msg_")
 
+const initialMessagePageSize = 20
+
 // A window whose oldest turn-significant message is an assistant reply starts mid-turn:
-// its user or shell prompt sits on an older page. Matches the desktop client's invariant.
-function needsOlderTurnRoot(source: readonly SessionMessageInfo[]) {
-  const boundary = source.find(
+// its user or shell prompt sits on an older page. Input is descending (newest first) as
+// served, so the oldest boundary is found from the end. Matches the desktop client's
+// invariant in packages/app/src/context/server-session.ts.
+function needsOlderTurnRoot(descending: readonly SessionMessageInfo[]) {
+  const boundary = descending.findLast(
     (message) =>
       message.type === "user" ||
       message.type === "shell" ||
@@ -165,23 +169,24 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       directory: process.cwd(),
     })
     const messageIndex = new Map<string, Map<string, number>>()
-    const messageCursor = new Map<string, string | undefined>()
+    // Continuation cursor per session; absence means no older history is known to remain.
+    const messageCursor = new Map<string, string>()
     const messagePaging = new Map<string, Promise<number>>()
     // Fetch one descending page, following the cursor while the window would open on a
     // dangling assistant reply, so the oldest loaded message always starts its turn.
     const fetchMessagePage = async (sessionID: string, limit: number, cursor?: string) => {
       const request = (cursor?: string) =>
         client.api.message.list(cursor ? { sessionID, limit, cursor } : { sessionID, limit, order: "desc" })
-      const pages = [await request(cursor)]
-      while (pages.at(-1)!.cursor.next && needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) {
-        const response = await request(pages.at(-1)!.cursor.next ?? undefined)
-        pages.push(response)
-        if (!response.data.length) break
+      let response = await request(cursor)
+      const descending = [...response.data]
+      while (response.data.length > 0 && response.cursor.next && needsOlderTurnRoot(descending)) {
+        response = await request(response.cursor.next)
+        descending.push(...response.data)
       }
-      const last = pages.at(-1)!
       return {
-        messages: pages.flatMap((page) => page.data).toReversed(),
-        cursor: last.data.length < limit ? undefined : (last.cursor.next ?? undefined),
+        messages: descending.toReversed(),
+        // The server returns a cursor even on the final page; a short page is the exhaustion signal.
+        cursor: response.data.length < limit ? undefined : (response.cursor.next ?? undefined),
       }
     }
     const sync = createSync()
@@ -344,7 +349,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           // hydration can load pending and projected messages atomically.
           sync.complete(`session.pending:${event.data.sessionID}`)
           sync.complete(`session.message:${event.data.sessionID}`)
-          messageCursor.set(event.data.sessionID, undefined)
           break
         case "session.deleted":
           removeSession(event.data.sessionID)
@@ -1032,11 +1036,15 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           sync(sessionID: string) {
             return sync.run(`session.message:${sessionID}`, async () => {
-              const page = await fetchMessagePage(sessionID, 20)
-              messageCursor.set(sessionID, page.cursor)
+              const page = await fetchMessagePage(sessionID, initialMessagePageSize)
+              if (page.cursor) messageCursor.set(sessionID, page.cursor)
+              else messageCursor.delete(sessionID)
               messageIndex.set(sessionID, new Map(page.messages.map((message, index) => [message.id, index])))
               setStore("session", "message", sessionID, reconcile(page.messages))
             })
+          },
+          hasOlder(sessionID: string) {
+            return messageCursor.has(sessionID)
           },
           older(sessionID: string, count: number) {
             const cursor = messageCursor.get(sessionID)
@@ -1045,7 +1053,12 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             if (active) return active
             const pending = (async () => {
               const page = await fetchMessagePage(sessionID, count, cursor)
-              messageCursor.set(sessionID, page.cursor)
+              // Invalidate or a fresh sync may have replaced the window mid-flight. Apply the
+              // continuation only while it still extends the current window edge; prepending it
+              // onto a replaced window would leave a permanent unfetchable gap in the transcript.
+              if (messageCursor.get(sessionID) !== cursor) return 0
+              if (page.cursor) messageCursor.set(sessionID, page.cursor)
+              else messageCursor.delete(sessionID)
               const loaded = index(sessionID)
               const older = page.messages.filter((item) => !loaded.has(item.id))
               if (older.length === 0) return 0

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -358,35 +358,42 @@ export function Session() {
     if (!data.session.message.hasOlder(sessionID)) return Promise.resolve(0)
     const viewport = scroll
     const before = viewport.scrollHeight
-    const first = messages()[0]?.id
+    // Anchor on the oldest message that actually rendered: the window can open on rows the
+    // reducer skips (e.g. description-less synthetics), and the height fallback would fold
+    // concurrent bottom appends into the compensation.
+    const first = messages().find((message) => viewport.getRenderable(message.id))?.id
     const anchor = first ? viewport.getRenderable(first) : undefined
     const anchorTop = anchor ? anchor.y - viewport.viewport.y : undefined
     const request = data.session.message
       .older(sessionID, HISTORY_PAGE_SIZE)
-      .then(
-        async (added) => {
-          if (added === 0 || route.sessionID !== sessionID || messages()[0]?.id === first) return added
-          await settleLayout()
-          if (route.sessionID !== sessionID || scroll !== viewport || viewport.isDestroyed) return added
-          const nextAnchor = first ? viewport.getRenderable(first) : undefined
-          // Message boundaries exclude bottom appends from the compensation; height is a fallback for notice rows.
-          viewport.scrollBy(
-            anchorTop !== undefined && nextAnchor
-              ? nextAnchor.y - viewport.viewport.y - anchorTop
-              : viewport.scrollHeight - before,
-          )
-          return added
-        },
-        () => 0,
-      )
+      .then(async (added) => {
+        // An unchanged first id after a positive count means the window was replaced
+        // mid-microtask (reconnect resync) and the prepend was discarded; skip compensation.
+        if (added === 0 || route.sessionID !== sessionID || messages()[0]?.id === first) return added
+        await settleLayout()
+        if (route.sessionID !== sessionID || scroll !== viewport || viewport.isDestroyed) return added
+        const nextAnchor = first ? viewport.getRenderable(first) : undefined
+        // Message boundaries exclude bottom appends from the compensation; height is a fallback for notice rows.
+        viewport.scrollBy(
+          anchorTop !== undefined && nextAnchor
+            ? nextAnchor.y - viewport.viewport.y - anchorTop
+            : viewport.scrollHeight - before,
+        )
+        return added
+      })
       .finally(() => {
         if (historyRequests.get(sessionID) === request) historyRequests.delete(sessionID)
       })
     historyRequests.set(sessionID, request)
     return request
   }
+  /** Rejects when a page fetch fails, so full-history consumers can report truncation instead of proceeding silently. */
   const loadAllOlder = async () => {
     const sessionID = route.sessionID
+    // The cursor only exists after the initial sync; await it (deduped) so an early
+    // call cannot mistake "not loaded yet" for "no older history".
+    await data.session.message.sync(sessionID)
+    if (route.sessionID !== sessionID) return
     if (hidden() !== 0) {
       setHiddenRows(0)
       await settleLayout()
@@ -397,7 +404,8 @@ export function Session() {
   }
   const loadOlderAtTop = () => {
     if (!scroll || scroll.isDestroyed || scroll.scrollTop > 0) return
-    void loadOlder()
+    // Scroll-driven paging swallows failures; the cursor survives, so the next tick retries.
+    void loadOlder().catch(() => {})
   }
   createEffect(
     on(
@@ -407,8 +415,11 @@ export function Session() {
         const sessionID = route.sessionID
         afterLayout(() => {
           if (route.sessionID !== sessionID) return
+          // Adopt a page left in flight by a previous mount of this session so its prepend
+          // lands with anchor compensation instead of shifting the restored viewport.
+          if (data.session.message.paging(sessionID)) return void loadOlder().catch(() => {})
           if (scroll.scrollHeight > scroll.viewport.height && scroll.scrollTop > 0) return
-          void loadOlder()
+          void loadOlder().catch(() => {})
         })
       },
     ),
@@ -471,11 +482,13 @@ export function Session() {
       }
       if (direction === "prev") {
         const sessionID = route.sessionID
-        void loadOlder().then((added) => {
-          if (route.sessionID !== sessionID) return
-          if (added > 0) return scrollToMessage(direction, dialog, userOnly)
-          dialog.clear()
-        })
+        void loadOlder()
+          .catch(() => 0)
+          .then((added) => {
+            if (route.sessionID !== sessionID) return
+            if (added > 0) return scrollToMessage(direction, dialog, userOnly)
+            dialog.clear()
+          })
         return
       }
       dialog.clear()
@@ -581,8 +594,15 @@ export function Session() {
         clearMessageNavigation()
         // loadAllOlder pins hidden rows to zero before paging, so the transcript is fully
         // mounted here and no ensureAllRows wrapper is needed.
-        await loadAllOlder()
+        const complete = await loadAllOlder().then(
+          () => true,
+          () => false,
+        )
         if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+        if (!complete) {
+          toast.show({ message: "Failed to load full session history", variant: "error", duration: 3000 })
+          return
+        }
         scroll.scrollTo(0)
         dialog.clear()
       },
@@ -623,8 +643,18 @@ export function Session() {
       slash: { name: "timeline" },
       run: async () => {
         const sessionID = route.sessionID
-        await loadAllOlder()
-        if (route.sessionID !== sessionID) return
+        const complete = await loadAllOlder().then(
+          () => true,
+          () => false,
+        )
+        // The Session component remounts per session; a stale instance must not open
+        // dialogs whose callbacks close over its destroyed scroll renderable.
+        if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+        if (!complete) {
+          toast.show({ message: "Failed to load full session history", variant: "error", duration: 3000 })
+          dialog.clear()
+          return
+        }
         dialog.replace(() => (
           <DialogTimeline
             sessionID={route.sessionID}
@@ -641,8 +671,16 @@ export function Session() {
       slash: { name: "fork" },
       run: async () => {
         const sessionID = route.sessionID
-        await loadAllOlder()
-        if (route.sessionID !== sessionID) return
+        const complete = await loadAllOlder().then(
+          () => true,
+          () => false,
+        )
+        if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+        if (!complete) {
+          toast.show({ message: "Failed to load full session history", variant: "error", duration: 3000 })
+          dialog.clear()
+          return
+        }
         dialog.replace(() => (
           <DialogFork
             sessionID={route.sessionID}
@@ -680,12 +718,17 @@ export function Session() {
       id: "session.undo",
       group: "Session",
       slash: { name: "undo" },
-      run: () => {
+      run: async () => {
         const boundary = session()?.revert?.messageID
-        const message = messages().findLast(
-          (message): message is SessionMessageUser =>
-            message.type === "user" && !!message.text.trim() && (!boundary || message.id < boundary),
-        )
+        const candidate = () =>
+          messages().findLast(
+            (message): message is SessionMessageUser =>
+              message.type === "user" && !!message.text.trim() && (!boundary || message.id < boundary),
+          )
+        // Repeated undo can walk past the loaded window; page older history until a
+        // candidate appears or history is exhausted.
+        let message = candidate()
+        while (!message && (await loadOlder().catch(() => 0)) > 0) message = candidate()
         if (!message) {
           toast.show({ message: "Nothing to undo", variant: "error", duration: 3000 })
           dialog.clear()
@@ -1070,6 +1113,8 @@ export function Session() {
               ref={(r) => (scroll = r)}
               onMouseScroll={(event) => {
                 if (event.modifiers.shift || event.scroll?.direction !== "up") return
+                // The scrollbox applies the wheel delta after this handler returns; defer one
+                // microtask so loadOlderAtTop reads the post-scroll scrollTop.
                 queueMicrotask(loadOlderAtTop)
               }}
               viewportOptions={{

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -105,6 +105,8 @@ const TRANSCRIPT_TAIL_ROWS = 40
 const TRANSCRIPT_BACKFILL_CHUNK = 60
 const TRANSCRIPT_BACKFILL_DELAY = 120
 // Cold-open stays small for latency; once the user asks for history, page like desktop.
+// 200 is also the server's maximum message page size (protocol session.messages limit);
+// raising it past the cap would make requests fail validation.
 const HISTORY_PAGE_SIZE = 200
 
 const context = createContext<{
@@ -305,13 +307,16 @@ export function Session() {
     r.set(route.prompt)
   }
 
-  /** Runs after layout has settled (two frames), unless the transcript was torn down. */
+  /** Resolves after layout has settled (two frames). */
+  const settleLayout = () =>
+    new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+  /** Runs after layout has settled, unless the transcript was torn down. */
   const afterLayout = (continuation: () => void) => {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (!scroll || scroll.isDestroyed) return
-        continuation()
-      })
+    void settleLayout().then(() => {
+      if (!scroll || scroll.isDestroyed) return
+      continuation()
     })
   }
 
@@ -342,16 +347,15 @@ export function Session() {
     onCleanup(() => clearTimeout(timer))
   })
   const historyRequests = new Map<string, Promise<number>>()
-  const settleLayout = () =>
-    new Promise<void>((resolve) => {
-      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
-    })
   // Keep each fetch locked through layout so the next page cannot overlap anchor restoration.
   const loadOlder = () => {
     const sessionID = route.sessionID
     if (!scroll || scroll.isDestroyed || hidden() !== 0) return Promise.resolve(0)
     const active = historyRequests.get(sessionID)
     if (active) return active
+    // Exhausted history: skip the anchor snapshot and promise plumbing entirely, so
+    // fully-loaded sessions pay one map lookup per scroll or row change.
+    if (!data.session.message.hasOlder(sessionID)) return Promise.resolve(0)
     const viewport = scroll
     const before = viewport.scrollHeight
     const first = messages()[0]?.id
@@ -382,11 +386,14 @@ export function Session() {
     return request
   }
   const loadAllOlder = async () => {
+    const sessionID = route.sessionID
     if (hidden() !== 0) {
       setHiddenRows(0)
       await settleLayout()
     }
-    while ((await loadOlder()) > 0) {}
+    // Stop on session switch: loadOlder re-reads the route, so continuing would
+    // exhaustively page the newly opened session instead.
+    while (route.sessionID === sessionID && (await loadOlder()) > 0) {}
   }
   const loadOlderAtTop = () => {
     if (!scroll || scroll.isDestroyed || scroll.scrollTop > 0) return
@@ -463,7 +470,9 @@ export function Session() {
         return
       }
       if (direction === "prev") {
+        const sessionID = route.sessionID
         void loadOlder().then((added) => {
+          if (route.sessionID !== sessionID) return
           if (added > 0) return scrollToMessage(direction, dialog, userOnly)
           dialog.clear()
         })
@@ -570,12 +579,12 @@ export function Session() {
       run: async () => {
         const sessionID = route.sessionID
         clearMessageNavigation()
+        // loadAllOlder pins hidden rows to zero before paging, so the transcript is fully
+        // mounted here and no ensureAllRows wrapper is needed.
         await loadAllOlder()
-        if (route.sessionID !== sessionID) return
-        ensureAllRows(() => {
-          scroll.scrollTo(0)
-          dialog.clear()
-        })
+        if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+        scroll.scrollTo(0)
+        dialog.clear()
       },
     },
     {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -104,6 +104,7 @@ const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const TRANSCRIPT_TAIL_ROWS = 40
 const TRANSCRIPT_BACKFILL_CHUNK = 60
 const TRANSCRIPT_BACKFILL_DELAY = 120
+const HISTORY_PAGE_SIZE = 20
 
 const context = createContext<{
   width: number
@@ -339,6 +340,71 @@ export function Session() {
     }, TRANSCRIPT_BACKFILL_DELAY)
     onCleanup(() => clearTimeout(timer))
   })
+  const historyRequests = new Map<string, Promise<number>>()
+  const settleLayout = () =>
+    new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+  // Keep each fetch locked through layout so the next page cannot overlap anchor restoration.
+  const loadOlder = (count = HISTORY_PAGE_SIZE) => {
+    const sessionID = route.sessionID
+    if (!scroll || scroll.isDestroyed || hidden() !== 0) return Promise.resolve(0)
+    const active = historyRequests.get(sessionID)
+    if (active) return active
+    const viewport = scroll
+    const before = viewport.scrollHeight
+    const first = messages()[0]?.id
+    const anchor = first ? viewport.getRenderable(first) : undefined
+    const anchorTop = anchor ? anchor.y - viewport.viewport.y : undefined
+    const request = data.session.message
+      .older(sessionID, count)
+      .then(
+        async (added) => {
+          if (added === 0 || route.sessionID !== sessionID || messages()[0]?.id === first) return added
+          await settleLayout()
+          if (route.sessionID !== sessionID || scroll !== viewport || viewport.isDestroyed) return added
+          const nextAnchor = first ? viewport.getRenderable(first) : undefined
+          // Message boundaries exclude bottom appends from the compensation; height is a fallback for notice rows.
+          viewport.scrollBy(
+            anchorTop !== undefined && nextAnchor
+              ? nextAnchor.y - viewport.viewport.y - anchorTop
+              : viewport.scrollHeight - before,
+          )
+          return added
+        },
+        () => 0,
+      )
+      .finally(() => {
+        if (historyRequests.get(sessionID) === request) historyRequests.delete(sessionID)
+      })
+    historyRequests.set(sessionID, request)
+    return request
+  }
+  const loadAllOlder = async () => {
+    if (hidden() !== 0) {
+      setHiddenRows(0)
+      await settleLayout()
+    }
+    while ((await loadOlder(200)) > 0) {}
+  }
+  const loadOlderAtTop = () => {
+    if (!scroll || scroll.isDestroyed || scroll.scrollTop > 0) return
+    void loadOlder()
+  }
+  createEffect(
+    on(
+      () => [synced(), hidden(), rows.length] as const,
+      ([ready, hidden]) => {
+        if (!ready || hidden !== 0) return
+        const sessionID = route.sessionID
+        afterLayout(() => {
+          if (route.sessionID !== sessionID) return
+          if (scroll.scrollHeight > scroll.viewport.height && scroll.scrollTop > 0) return
+          void loadOlder()
+        })
+      },
+    ),
+  )
   /** Message navigation needs the full transcript mounted before walking or jumping. */
   const ensureAllRows = (continuation: () => void) => {
     if (hidden() === 0) return continuation()
@@ -390,7 +456,18 @@ export function Session() {
         userOnly,
       })
 
-      if (target) alignMessage(target.id, target.top)
+      if (target) {
+        alignMessage(target.id, target.top)
+        dialog.clear()
+        return
+      }
+      if (direction === "prev") {
+        void loadOlder().then((added) => {
+          if (added > 0) return scrollToMessage(direction, dialog, userOnly)
+          dialog.clear()
+        })
+        return
+      }
       dialog.clear()
     })
 
@@ -420,6 +497,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-scroll.height / 2)
+        loadOlderAtTop()
         dialog.clear()
       },
     },
@@ -442,6 +520,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-1)
+        loadOlderAtTop()
         dialog.clear()
       },
     },
@@ -464,6 +543,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-scroll.height / 4)
+        loadOlderAtTop()
         dialog.clear()
       },
     },
@@ -486,10 +566,15 @@ export function Session() {
       title: "First message",
       group: "Session",
       palette: undefined,
-      run: () => {
+      run: async () => {
+        const sessionID = route.sessionID
         clearMessageNavigation()
-        scroll.scrollTo(0)
-        dialog.clear()
+        await loadAllOlder()
+        if (route.sessionID !== sessionID) return
+        ensureAllRows(() => {
+          scroll.scrollTo(0)
+          dialog.clear()
+        })
       },
     },
     {
@@ -526,7 +611,10 @@ export function Session() {
       id: "session.timeline",
       group: "Session",
       slash: { name: "timeline" },
-      run: () => {
+      run: async () => {
+        const sessionID = route.sessionID
+        await loadAllOlder()
+        if (route.sessionID !== sessionID) return
         dialog.replace(() => (
           <DialogTimeline
             sessionID={route.sessionID}
@@ -541,7 +629,10 @@ export function Session() {
       id: "session.fork",
       group: "Session",
       slash: { name: "fork" },
-      run: () => {
+      run: async () => {
+        const sessionID = route.sessionID
+        await loadAllOlder()
+        if (route.sessionID !== sessionID) return
         dialog.replace(() => (
           <DialogFork
             sessionID={route.sessionID}
@@ -785,6 +876,8 @@ export function Session() {
         try {
           const sessionData = session()
           if (!sessionData) return
+          await loadAllOlder()
+          if (route.sessionID !== sessionData.id) return
           const transcript = formatSessionTranscript(sessionData, messages(), showThinking())
           await clipboard.write?.(transcript)
           toast.show({ message: "Session transcript copied to clipboard!", variant: "success" })
@@ -809,6 +902,10 @@ export function Session() {
           const options = await DialogExportOptions.show(dialog, showThinking())
 
           if (options === null) return
+          if (options.format === "markdown") {
+            await loadAllOlder()
+            if (route.sessionID !== sessionData.id) return
+          }
 
           const content =
             options.format === "markdown"
@@ -961,6 +1058,10 @@ export function Session() {
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}
+              onMouseScroll={(event) => {
+                if (event.modifiers.shift || event.scroll?.direction !== "up") return
+                queueMicrotask(loadOlderAtTop)
+              }}
               viewportOptions={{
                 paddingRight: showScrollbar() ? 1 : 0,
               }}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -104,7 +104,8 @@ const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const TRANSCRIPT_TAIL_ROWS = 40
 const TRANSCRIPT_BACKFILL_CHUNK = 60
 const TRANSCRIPT_BACKFILL_DELAY = 120
-const HISTORY_PAGE_SIZE = 20
+// Cold-open stays small for latency; once the user asks for history, page like desktop.
+const HISTORY_PAGE_SIZE = 200
 
 const context = createContext<{
   width: number
@@ -346,7 +347,7 @@ export function Session() {
       requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
     })
   // Keep each fetch locked through layout so the next page cannot overlap anchor restoration.
-  const loadOlder = (count = HISTORY_PAGE_SIZE) => {
+  const loadOlder = () => {
     const sessionID = route.sessionID
     if (!scroll || scroll.isDestroyed || hidden() !== 0) return Promise.resolve(0)
     const active = historyRequests.get(sessionID)
@@ -357,7 +358,7 @@ export function Session() {
     const anchor = first ? viewport.getRenderable(first) : undefined
     const anchorTop = anchor ? anchor.y - viewport.viewport.y : undefined
     const request = data.session.message
-      .older(sessionID, count)
+      .older(sessionID, HISTORY_PAGE_SIZE)
       .then(
         async (added) => {
           if (added === 0 || route.sessionID !== sessionID || messages()[0]?.id === first) return added
@@ -385,7 +386,7 @@ export function Session() {
       setHiddenRows(0)
       await settleLayout()
     }
-    while ((await loadOlder(200)) > 0) {}
+    while ((await loadOlder()) > 0) {}
   }
   const loadOlderAtTop = () => {
     if (!scroll || scroll.isDestroyed || scroll.scrollTop > 0) return

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -316,6 +316,90 @@ test("refreshes resources into reactive getters", async () => {
   }
 })
 
+test("loads older session messages through a private cursor", async () => {
+  const events = createEventStream()
+  const sessionID = "ses_paged"
+  const requests: URL[] = []
+  const item = (value: number) => ({
+    id: `msg_${value.toString().padStart(3, "0")}`,
+    type: "user" as const,
+    text: `Message ${value}`,
+    time: { created: value },
+  })
+  const switched = (value: number) => ({
+    id: `msg_${value.toString().padStart(3, "0")}`,
+    type: "model-switched" as const,
+    model: { id: "model", providerID: "provider" },
+    time: { created: value },
+  })
+  const calls = createFetch((url) => {
+    if (url.pathname === `/api/session/${sessionID}/pending`) return json({ data: [] })
+    if (url.pathname !== `/api/session/${sessionID}/message`) return undefined
+    requests.push(url)
+    if (url.searchParams.get("cursor") === "older-page") {
+      return json({
+        data: [item(21), item(20), item(19), item(18), switched(17)],
+        cursor: { next: "unused" },
+      })
+    }
+    return json({
+      data: Array.from({ length: 20 }, (_, index) => item(40 - index)),
+      cursor: { next: "older-page" },
+    })
+  }, events)
+  let data!: ReturnType<typeof useData>
+  let rows!: ReturnType<typeof createSessionRows>
+
+  function Probe() {
+    data = useData()
+    rows = createSessionRows(() => sessionID)
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ClientProvider api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </ClientProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await data.session.message.sync(sessionID)
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 20 }, (_, index) => item(index + 21).id),
+    )
+    await wait(() => rows.length === 20)
+
+    const loaded = await Promise.all([
+      data.session.message.older(sessionID, 10),
+      data.session.message.older(sessionID, 10),
+    ])
+    expect(loaded).toEqual([4, 4])
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 24 }, (_, index) => item(index + 17).id),
+    )
+    expect(data.session.message.get(sessionID, "msg_017")?.id).toBe("msg_017")
+    expect(data.session.message.get(sessionID, "msg_040")?.id).toBe("msg_040")
+    await wait(() => rows.length === 24)
+    expect(rows[0]).toEqual({ type: "message", messageID: "msg_017" })
+
+    expect(await data.session.message.older(sessionID, 10)).toBe(0)
+    expect(requests).toHaveLength(2)
+    expect(requests[0]?.searchParams.get("limit")).toBe("20")
+    expect(requests[0]?.searchParams.get("order")).toBe("desc")
+    expect(requests[1]?.searchParams.get("limit")).toBe("10")
+    expect(requests[1]?.searchParams.get("cursor")).toBe("older-page")
+    expect(requests[1]?.searchParams.has("order")).toBeFalse()
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("applies absolute usage events to session info", async () => {
   const events = createEventStream()
   const sessionID = "ses_usage_refresh"

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -433,6 +433,7 @@ test("extends message pages until they start at a turn root", async () => {
     text: "note",
     time: { created: value },
   })
+  const described = (value: number) => ({ ...synthetic(value), description: "Reverted" })
   const range = (newest: number, oldest: number) =>
     Array.from({ length: newest - oldest + 1 }, (_, index) => item(newest - index))
   const calls = createFetch((url) => {
@@ -443,7 +444,8 @@ test("extends message pages until they start at a turn root", async () => {
     // Initial window ends on a description-less synthetic (not turn-significant) below an
     // assistant reply whose prompt is on the next page.
     if (cursor === null) return json({ data: [...range(60, 43), assistant(42), synthetic(41)], cursor: { next: "c1" } })
-    if (cursor === "c1") return json({ data: range(40, 21), cursor: { next: "c2" } })
+    // A described synthetic is a valid turn root, so this extension stops here.
+    if (cursor === "c1") return json({ data: [...range(40, 22), described(21)], cursor: { next: "c2" } })
     // Older page also ends on an assistant reply.
     if (cursor === "c2") return json({ data: [...range(20, 13), shell(12), assistant(11)], cursor: { next: "c3" } })
     // A shell message is a valid turn root, so the extension stops here.
@@ -516,6 +518,8 @@ test("drops a stale older page when the window is replaced mid-flight", async ()
     if (cursor === "stale") return new Promise<Response>((resolve) => (release = resolve))
     if (cursor === "fresh")
       return json({ data: Array.from({ length: 10 }, (_, index) => item(20 - index)), cursor: { next: "unused" } })
+    // A request with the poisoned (or any unexpected) cursor must fail loudly.
+    if (cursor !== null) throw new Error(`unexpected cursor: ${cursor}`)
     initialLoads += 1
     return json({ data: window, cursor: { next: initialLoads === 1 ? "stale" : "fresh" } })
   }, events)
@@ -546,16 +550,15 @@ test("drops a stale older page when the window is replaced mid-flight", async ()
     // The window is replaced while the older page is still in flight.
     data.session.message.invalidate(sessionID)
     await data.session.message.sync(sessionID)
+
+    // Invalidate cleared the paging slot, so a fresh page can start before the stale one lands.
+    const fresh = data.session.message.older(sessionID, 10)
     release!(json({ data: Array.from({ length: 10 }, (_, index) => item(20 - index)), cursor: { next: "poison" } }))
 
-    // The stale continuation no longer extends the current window edge and must be dropped.
+    // The stale continuation no longer extends the current window edge and must be dropped;
+    // the fresh page applies from the fresh cursor, not the poisoned one.
+    expect(await fresh).toBe(10)
     expect(await stale).toBe(0)
-    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
-      Array.from({ length: 20 }, (_, index) => id(index + 21)),
-    )
-
-    // Paging resumes from the fresh cursor, not the poisoned one.
-    expect(await data.session.message.older(sessionID, 10)).toBe(10)
     expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
       Array.from({ length: 30 }, (_, index) => id(index + 11)),
     )

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -419,6 +419,20 @@ test("extends message pages until they start at a turn root", async () => {
     content: [],
     time: { created: value },
   })
+  const shell = (value: number) => ({
+    id: id(value),
+    type: "shell" as const,
+    shellID: "sh_test",
+    command: "ls",
+    status: "exited" as const,
+    time: { created: value },
+  })
+  const synthetic = (value: number) => ({
+    id: id(value),
+    type: "synthetic" as const,
+    text: "note",
+    time: { created: value },
+  })
   const range = (newest: number, oldest: number) =>
     Array.from({ length: newest - oldest + 1 }, (_, index) => item(newest - index))
   const calls = createFetch((url) => {
@@ -426,12 +440,14 @@ test("extends message pages until they start at a turn root", async () => {
     if (url.pathname !== `/api/session/${sessionID}/message`) return undefined
     requests.push(url)
     const cursor = url.searchParams.get("cursor")
-    // Initial window ends on an assistant reply whose prompt is on the next page.
-    if (cursor === null) return json({ data: [...range(60, 42), assistant(41)], cursor: { next: "c1" } })
+    // Initial window ends on a description-less synthetic (not turn-significant) below an
+    // assistant reply whose prompt is on the next page.
+    if (cursor === null) return json({ data: [...range(60, 43), assistant(42), synthetic(41)], cursor: { next: "c1" } })
     if (cursor === "c1") return json({ data: range(40, 21), cursor: { next: "c2" } })
     // Older page also ends on an assistant reply.
-    if (cursor === "c2") return json({ data: [...range(20, 12), assistant(11)], cursor: { next: "c3" } })
-    if (cursor === "c3") return json({ data: [item(10)], cursor: { next: "c4" } })
+    if (cursor === "c2") return json({ data: [...range(20, 13), shell(12), assistant(11)], cursor: { next: "c3" } })
+    // A shell message is a valid turn root, so the extension stops here.
+    if (cursor === "c3") return json({ data: [shell(10)], cursor: { next: "c4" } })
     throw new Error(`unexpected cursor: ${cursor}`)
   }, events)
   let data!: ReturnType<typeof useData>
@@ -474,6 +490,75 @@ test("extends message pages until they start at a turn root", async () => {
     // The short extension page exhausted history despite the returned cursor.
     expect(await data.session.message.older(sessionID, 10)).toBe(0)
     expect(requests).toHaveLength(4)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("drops a stale older page when the window is replaced mid-flight", async () => {
+  const events = createEventStream()
+  const sessionID = "ses_stale_page"
+  const id = (value: number) => `msg_${value.toString().padStart(3, "0")}`
+  const item = (value: number) => ({
+    id: id(value),
+    type: "user" as const,
+    text: `Message ${value}`,
+    time: { created: value },
+  })
+  const window = Array.from({ length: 20 }, (_, index) => item(40 - index))
+  let release: ((response: Response) => void) | undefined
+  let initialLoads = 0
+  const calls = createFetch((url) => {
+    if (url.pathname === `/api/session/${sessionID}/pending`) return json({ data: [] })
+    if (url.pathname !== `/api/session/${sessionID}/message`) return undefined
+    const cursor = url.searchParams.get("cursor")
+    // The stale continuation stays in flight until the test releases it.
+    if (cursor === "stale") return new Promise<Response>((resolve) => (release = resolve))
+    if (cursor === "fresh")
+      return json({ data: Array.from({ length: 10 }, (_, index) => item(20 - index)), cursor: { next: "unused" } })
+    initialLoads += 1
+    return json({ data: window, cursor: { next: initialLoads === 1 ? "stale" : "fresh" } })
+  }, events)
+  let data!: ReturnType<typeof useData>
+
+  function Probe() {
+    data = useData()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ClientProvider api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </ClientProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await data.session.message.sync(sessionID)
+    const stale = data.session.message.older(sessionID, 10)
+    await wait(() => release !== undefined)
+
+    // The window is replaced while the older page is still in flight.
+    data.session.message.invalidate(sessionID)
+    await data.session.message.sync(sessionID)
+    release!(json({ data: Array.from({ length: 10 }, (_, index) => item(20 - index)), cursor: { next: "poison" } }))
+
+    // The stale continuation no longer extends the current window edge and must be dropped.
+    expect(await stale).toBe(0)
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 20 }, (_, index) => id(index + 21)),
+    )
+
+    // Paging resumes from the fresh cursor, not the poisoned one.
+    expect(await data.session.message.older(sessionID, 10)).toBe(10)
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 30 }, (_, index) => id(index + 11)),
+    )
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -400,6 +400,85 @@ test("loads older session messages through a private cursor", async () => {
   }
 })
 
+test("extends message pages until they start at a turn root", async () => {
+  const events = createEventStream()
+  const sessionID = "ses_turn_root"
+  const requests: URL[] = []
+  const id = (value: number) => `msg_${value.toString().padStart(3, "0")}`
+  const item = (value: number) => ({
+    id: id(value),
+    type: "user" as const,
+    text: `Message ${value}`,
+    time: { created: value },
+  })
+  const assistant = (value: number) => ({
+    id: id(value),
+    type: "assistant" as const,
+    agent: "build",
+    model: { id: "model", providerID: "provider" },
+    content: [],
+    time: { created: value },
+  })
+  const range = (newest: number, oldest: number) =>
+    Array.from({ length: newest - oldest + 1 }, (_, index) => item(newest - index))
+  const calls = createFetch((url) => {
+    if (url.pathname === `/api/session/${sessionID}/pending`) return json({ data: [] })
+    if (url.pathname !== `/api/session/${sessionID}/message`) return undefined
+    requests.push(url)
+    const cursor = url.searchParams.get("cursor")
+    // Initial window ends on an assistant reply whose prompt is on the next page.
+    if (cursor === null) return json({ data: [...range(60, 42), assistant(41)], cursor: { next: "c1" } })
+    if (cursor === "c1") return json({ data: range(40, 21), cursor: { next: "c2" } })
+    // Older page also ends on an assistant reply.
+    if (cursor === "c2") return json({ data: [...range(20, 12), assistant(11)], cursor: { next: "c3" } })
+    if (cursor === "c3") return json({ data: [item(10)], cursor: { next: "c4" } })
+    throw new Error(`unexpected cursor: ${cursor}`)
+  }, events)
+  let data!: ReturnType<typeof useData>
+
+  function Probe() {
+    data = useData()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ClientProvider api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </ClientProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await data.session.message.sync(sessionID)
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 40 }, (_, index) => id(index + 21)),
+    )
+    expect(requests).toHaveLength(2)
+    expect(requests[1]?.searchParams.get("cursor")).toBe("c1")
+    expect(requests[1]?.searchParams.get("limit")).toBe("20")
+
+    expect(await data.session.message.older(sessionID, 10)).toBe(11)
+    expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(
+      Array.from({ length: 51 }, (_, index) => id(index + 10)),
+    )
+    expect(requests).toHaveLength(4)
+    expect(requests[2]?.searchParams.get("cursor")).toBe("c2")
+    expect(requests[3]?.searchParams.get("cursor")).toBe("c3")
+    expect(requests[3]?.searchParams.get("limit")).toBe("10")
+
+    // The short extension page exhausted history despite the returned cursor.
+    expect(await data.session.message.older(sessionID, 10)).toBe(0)
+    expect(requests).toHaveLength(4)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("applies absolute usage events to session info", async () => {
   const events = createEventStream()
   const sessionID = "ses_usage_refresh"


### PR DESCRIPTION
## What

Load only the newest 20 messages when opening a V2 TUI session, then page older history into the transcript as the user scrolls upward.

On the measured 200-message session, the initial API request dropped from 1.66 MB / 111.9 ms median to 72 KB / 12.7 ms median. Across four open tabs, that is about 86% fewer bytes and 5.3x less sequential server time before client decoding, row reduction, and rendering.

## Before / After

**Before:** Every session switch fetched up to 200 projected messages before reducing the transcript. Opening several long tabs repeatedly paid for history that was not visible.

**After:** A session opens from its newest 20 messages. Reaching the top fetches the next page through a private cursor, prepends it chronologically, and preserves the visible message anchor. Short pages continue loading until the viewport is filled.

Commands that require complete history still behave completely: First message, previous-message navigation, timeline, fork, transcript copy, and Markdown export load the remaining pages before acting.

## How

- `packages/tui/src/context/data.tsx` keeps the opaque server cursor private and adds `data.session.message.older(sessionID, count)`.
- Older requests coalesce per session, deduplicate overlap, prepend in chronological order, and rebuild the message index.
- Exhaustion stays internal: `older(...)` returns the number of newly loaded messages and becomes a zero-result no-op once the cursor is exhausted.
- `packages/tui/src/routes/session/index.tsx` requests history at the viewport top and serializes each fetch through layout restoration.
- Anchor restoration prefers the existing visible message boundary, so concurrent bottom appends do not affect compensation; total-height growth remains the fallback for notice rows.
- The existing full `rows.ts` reduction runs after each prepend so reasoning, exploration, and usage groups may cross page boundaries safely.

## Scope

- No protocol, server, generated client, or plugin `Data` API changes.
- No incremental row-prepend optimization or transcript virtualization.
- JSON export retains its existing direct ascending API pagination.

## Testing

- `cd packages/tui && bun run test` (570 passed, 5 skipped)
- `cd packages/tui && bun typecheck`
- Repository-wide push-hook typecheck (33 tasks passed)
- Changed-file oxlint (0 errors; baseline warnings remain)
- OpenCode Drive: seeded a 15-turn session, opened it in a fresh TUI, verified newest-20 startup, upward prepend with request 6 held at the same viewport position, and First message landing on request 1

## Demo

The recording uses OpenCode Drive's simulated model. It opens the fresh 20-message tail, pages upward while request 6 remains anchored, then invokes First message and lands on request 1.

https://github.com/user-attachments/assets/7537d27f-d522-4ef6-a9be-6e01d2872db4

Anchor after the prepend:

![Request 6 remains at the top after loading older history](https://github.com/user-attachments/assets/a962db2d-f214-4e5b-bdbc-a81b789d0a44)

## Flow

```mermaid
sequenceDiagram
    participant View as Session view
    participant Data as TUI data layer
    participant API as Message API

    View->>Data: sync(sessionID)
    Data->>API: newest 20, order=desc
    API-->>Data: messages + opaque older cursor
    Data-->>View: chronological loaded window
    View->>View: user reaches transcript top
    View->>Data: older(sessionID, 20)
    Data->>API: cursor page
    API-->>Data: older messages + next cursor
    Data->>Data: dedupe, prepend, rebuild index
    Data-->>View: enlarged chronological window
    View->>View: full row reduction + anchor restore
```
