### PR TITLE
refactor(tui): flatten project picker list

### DIFF
--- a/packages/tui/src/component/dialog-project.tsx
+++ b/packages/tui/src/component/dialog-project.tsx
@@ -50,7 +50,6 @@ export function DialogProject() {
           description: truncateFilePath(description, width),
           searchText: description,
           value: project.canonical,
-          category: project.id === current()?.id ? "Current" : "Projects",
         }
       })
   })


### PR DESCRIPTION
## What

Flatten the project picker into one continuous list. The active project remains sorted first and marked with the existing dot, so the `Current` and `Projects` category headings add spacing without adding information.

## Before / After

**Before**

The active project and remaining projects are split into two labeled groups.

![Grouped project picker](https://github.com/user-attachments/assets/9ba821f3-4bda-4424-a741-f0e7ff31e1f9)

**After**

Projects share one compact list; the active project is still identified by the dot.

![Flat project picker](https://github.com/user-attachments/assets/b45af3fe-037f-4811-8654-7b3d758217ff)

## How

- Stop assigning project-picker options to `Current` and `Projects` categories.
- Keep the existing current-project sort order, marker, filtering, and path truncation.

## Scope

This only changes project-picker grouping and spacing. Project discovery and location switching are unchanged.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/cli/tui/dialog-select.test.tsx` in `packages/tui`: 8 passed
- Full repository typecheck through the pre-push hook: 33 tasks passed
- Terminal Control end-to-end run against a matching V2 server with synthetic `atlas`, `beacon`, and `compass` repositories; verified the flat render and a Home switch from `atlas` to `beacon`

## Demo

The screenshots above come from the real TUI connected to a local V2 server populated only with synthetic repositories.
