### PR TITLE
fix(workflows): skip maintenance jobs on forks

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   close:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/close-prs.yml
+++ b/.github/workflows/close-prs.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   close:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     permissions:


### PR DESCRIPTION
### Issue for this PR

Closes #35666

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `if: github.repository == 'anomalyco/opencode'` to the `close-issues` and `close-prs` jobs. Forks otherwise run these scheduled workflows with a fork-scoped `GITHUB_TOKEN`, while the scripts target the canonical repository, causing 403 responses. The guard keeps these repository-maintenance jobs running only in the canonical repository.

### How did you verify your code works?

Reviewed the workflow diff and ran `git diff --check`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._