### PR TITLE
fix(app): make New Session and the project picker work with no project open

### DIFF
--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -175,6 +175,58 @@ test("searches from an absolute root without a default base", async () => {
   expect(directories).toEqual(["/"])
 })
 
+test("lists the base directory when the filter is empty", async () => {
+  const listed: string[] = []
+  let found = 0
+  const sdk = {
+    api: {
+      file: {
+        list: (input: { location?: { directory?: string } }) => {
+          listed.push(input.location?.directory ?? "")
+          return Promise.resolve({
+            data: [
+              { path: "projects/", type: "directory" },
+              { path: "notes.txt", type: "file" },
+              { path: "work/", type: "directory" },
+            ],
+          })
+        },
+        // `find` is index-backed and returns nothing for an empty query in a home
+        // directory or the filesystem root, so the empty filter must not use it.
+        find: () => {
+          found++
+          return Promise.resolve({ data: [] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/home/luke" })
+
+  expect(await search("")).toEqual(["/home/luke/projects", "/home/luke/work"])
+  expect(listed).toEqual(["/home/luke"])
+  expect(found).toBe(0)
+})
+
+test("still fuzzy-finds once the filter is non-empty", async () => {
+  let found = 0
+  const sdk = {
+    api: {
+      file: {
+        list: () => Promise.resolve({ data: [] }),
+        find: (input: { query?: string }) => {
+          found++
+          expect(input.query).toBe("proj")
+          return Promise.resolve({ data: [{ path: "projects/" }] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/home/luke" })
+
+  expect(await search("proj")).toEqual(["/home/luke/projects"])
+  expect(found).toBe(1)
+})
+
 test("identifies the next directory level to preload", () => {
   expect(
     preloadTreeDirectories("src/", [

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -374,6 +374,16 @@ export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string
     const pathInput = raw.startsWith("~") || !!pickerRoot(raw) || raw.includes("/")
     const query = normalizePickerDrive(input.path)
     if (!pathInput) {
+      // An empty filter has nothing to fuzzy-match on, and `file.find` is backed by an
+      // index that declines to run in the home directory or the filesystem root - which
+      // are exactly the directories the picker opens on by default. That returns an empty
+      // list and the dialog reads "No folders found" until something is typed. List the
+      // directory instead so the first open shows its folders.
+      if (!query) {
+        const listed = await match(input.directory, "", 50)
+        if (!active()) return []
+        return listed.slice(0, 50)
+      }
       const results = await args.sdk.api.file
         .find({ location: { directory: input.directory }, query, type: "directory", limit: 50 })
         .then((result) => result.data.map((entry) => entry.path))

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -292,9 +292,23 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                 const project = global.ensureServerCtx(conn).projects.list()[0]
                 return project ? [{ server: ServerConnection.key(conn), project }] : []
               })[0]
-              if (!fallback) return
+              if (fallback) {
+                tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
+                return
+              }
 
-              tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
+              // No project has been opened in this browser yet. Without this the button
+              // silently does nothing on a fresh profile. The server already reports the
+              // directory it was started in, so use that and remember it as an open project.
+              const connection = global.servers.list()[0] ?? server.current
+              if (!connection) return
+              const ctx = global.ensureServerCtx(connection)
+              const directory = ctx.sync.data.path.directory
+              if (!directory) return
+
+              ctx.projects.open(directory)
+              ctx.projects.touch(directory)
+              tabs.newDraft({ server: ServerConnection.key(connection), directory }, "")
             }
             const toggleHome = () => tabs.toggleHome({ home: layout.route().type === "home", current: currentTab() })
 


### PR DESCRIPTION
### Issue for this PR

Closes #37606
Closes #37611

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two one-line-ish fixes that together make `opencode web` usable from a browser profile that has never opened a project. They are separate commits and can be split if you'd rather take them individually.

**1. Titlebar New Session does nothing (#37606)**

`openNewTab()` in `titlebar.tsx` ends with:

```ts
const fallback = global.servers.list().flatMap(...)[0]
if (!fallback) return
```

On a fresh profile `layout.projects.list()` and every server's `projects.list()` are empty, so it returns before creating a draft — no draft, no navigation, and no network request, which is why it reads as a dead button rather than an error.

The server already reports its startup directory via `/path`, so I use that as the last fallback and call `projects.open`/`touch` so the directory is remembered as the opened and last project (otherwise the next click would take the same dead path again).

**2. Project picker shows "No folders found" until you type (#37611)**

In `createDirectorySearch`, an empty filter is not `pathInput`, so it goes to `file.find`; anything containing `/` goes to `file.list` via `match()`. That asymmetry is the bug — `file.find` is index-backed and declines to run in a home directory or the filesystem root, which is exactly where the picker opens (`sync.data.path.home || sync.data.path.directory`). The server logs `Failed to init file picker: Can not run certain FFF features in a file system root or home directories`, and the request returns 200 with `[]`.

Same server, only the directory differs:

```
/find/file?query=&dirs=true&limit=50&directory=%2Fhome%2Fipzero  ->  []
/find/file?query=&dirs=true&limit=50&directory=%2Fmnt%2Fdata     ->  ["chat/...", ...]
```

So I list the directory when the filter is empty. `match(dir, "", 50)` already handles that and routes through `file.list`. A non-empty filter still uses `file.find` unchanged. This also explains the workaround people keep finding — typing `~/x` or an absolute path switches to the working path.

These two mask each other: with the picker broken, the titlebar button is the only way to open anything, so a fresh browser can't get in at all. That's likely why #37606 keeps getting refiled (#39100, #38411, #37227).

Note on #37607, which fixes the same thing: its approach is right, but the `home.tsx` hunk no longer applies to `dev` (`newSessionProject` isn't there in that form). Happy to close this if you'd rather revive that one.

### How did you verify your code works?

Reproduced on 1.18.9, arm64 (Jetson, Ubuntu 20.04), `opencode serve --hostname 0.0.0.0`.

- Ran the dev app (`VITE_OPENCODE_SERVER_HOST/PORT`) against a live server started in `/mnt/data/chat`, driven headlessly over CDP with an empty-`localStorage` profile.
- Before: clicking New Session produced 0 network requests. After: 31 requests, navigates to `/new-session?draftId=...`, composer renders, and `localStorage` records the directory as opened + last project.
- Before: Add Project showed "No folders found". After: it lists the home directory's folders and `/mnt/data/chat` under Recent projects.
- Added two tests to `directory-picker-domain.test.ts` — the empty filter lists via `file.list` and never calls `file.find`; a non-empty filter still fuzzy-finds. The first fails on unmodified `dev`.
- `bun run test:unit` in `packages/app`: 692 -> 694 passing, no new failures. The one `i18n parity` failure reproduces on clean `dev` and is unrelated.
- `bun run typecheck`: clean.

### Screenshots / recordings

No visual change to capture — the difference is an inert control becoming functional. Concretely, on a fresh profile the home screen goes from "Nothing here yet / Create a session to get started" with a non-responding `+`, to opening a draft composer for the server's directory.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
