### PR TITLE
fix(tui): register storybook only for story runs

### DIFF
--- a/packages/tui/src/plugin/builtins.ts
+++ b/packages/tui/src/plugin/builtins.ts
@@ -18,6 +18,8 @@ export const builtins = [
   SidebarFooter,
   Notifications,
   Plugins,
-  Storybook,
+  // The storybook is a development tool; keep its route and palette commands out of
+  // normal launches and register it only for OPENCODE_STORY runs.
+  ...(process.env.OPENCODE_STORY ? [Storybook] : []),
   DiffViewer,
 ]


### PR DESCRIPTION
## What

The component storybook (#39548) is a development tool, but it registered as an always-on builtin plugin — every user saw **Open storybook** and **Storybook: Session tabs** in their command palette (Debug group).

## Before / After

**Before**: typing "story" (or browsing) in any user's command palette surfaced the storybook entries, and the `storybook` plugin route was navigable in every session.

**After**: normal launches register no storybook plugin at all — no palette entries, no route, no keymap layer. Launching with `OPENCODE_STORY=1` (index) or `OPENCODE_STORY=<story>` (direct) registers it exactly as before.

## How

`packages/tui/src/plugin/builtins.ts`: include `Storybook` in the builtin list only when `process.env.OPENCODE_STORY` is set — the same variable the boot route already keys on, so story runs remain self-contained. The module stays statically imported (a few component definitions, no module-scope effects); the gate removes the meaningful cost: plugin activation, its keymap layer, and per-palette-query command evaluation.

## Testing

- `cd packages/tui && bun typecheck`
- `cd packages/tui && bun run test` — 569 pass / 5 skip / 0 fail