### PR TITLE
feat(tui): add temporary new session tab

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1219,7 +1219,13 @@ function App(props: { pair?: DialogPairCredentials }) {
         <box flexGrow={1} minWidth={0} flexDirection="column">
           <Show when={plugins.ready()}>
             <box flexGrow={1} minHeight={0} flexDirection="column">
-              <Show when={sessionTabs.enabled() && sessionTabs.tabs().length > 0 && route.data.type !== "plugin"}>
+              <Show
+                when={
+                  sessionTabs.enabled() &&
+                  (sessionTabs.tabs().length > 0 || sessionTabs.newTab()) &&
+                  route.data.type !== "plugin"
+                }
+              >
                 <SessionTabs />
               </Show>
               <Switch>

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -6,10 +6,10 @@ import { useSessionTabs } from "../context/session-tabs"
 import { useTheme, useThemes } from "../context/theme"
 import {
   adaptiveSessionTabLayout,
-  NEW_SESSION_TAB_ID,
   sessionTabComplete,
   seedSessionTabMotion,
   sessionTabOverflowWidth,
+  type SessionTab,
   type SessionTabUnread,
 } from "../context/session-tabs-model"
 import { createAnimatable, spring, tween } from "../ui/animation"
@@ -25,10 +25,18 @@ type ContextController = ReturnType<typeof useSessionTabs>
 export type SessionTabsStatus = Omit<ReturnType<ContextController["status"]>, "unread"> & {
   unread: SessionTabUnread | undefined
 }
+export const EMPTY_SESSION_TAB_STATUS: SessionTabsStatus = {
+  unread: undefined,
+  promptPulse: 0,
+  attention: false,
+  busy: false,
+}
 export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
   newTab?: () => boolean
   status(sessionID: string): SessionTabsStatus
 }
+
+const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: "New session" }
 
 export function SessionTabs(props: { controller?: SessionTabsController; animations?: boolean } = {}) {
   const tabs = props.controller ?? useSessionTabs()
@@ -45,10 +53,8 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   const activeNumber = () => theme.hue.interactive[hueStep()]
   const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
   const newTab = () => tabs.newTab?.() ?? false
-  const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB_ID : tabs.current()))
-  const items = createMemo(() =>
-    newTab() ? [...tabs.tabs(), { sessionID: NEW_SESSION_TAB_ID, title: "New session" }] : tabs.tabs(),
-  )
+  const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB.sessionID : tabs.current()))
+  const items = createMemo(() => (newTab() ? [...tabs.tabs(), NEW_SESSION_TAB] : tabs.tabs()))
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
     adaptiveSessionTabLayout(items(), activeID(), dimensions().width, previous?.start),
   )
@@ -56,10 +62,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
     () =>
       new Map(
         layout().tabs.map((tab) => {
-          const status =
-            tab.sessionID === NEW_SESSION_TAB_ID
-              ? { unread: undefined, promptPulse: 0, attention: false, busy: false }
-              : tabs.status(tab.sessionID)
+          const status = tab === NEW_SESSION_TAB ? EMPTY_SESSION_TAB_STATUS : tabs.status(tab.sessionID)
           return [
             tab.sessionID,
             {
@@ -270,7 +273,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
           // keeping sloppy clicks indistinguishable from clean ones.
           const release = () => {
             setDragging(undefined)
-            if (tab.sessionID === NEW_SESSION_TAB_ID) return
+            if (tab === NEW_SESSION_TAB) return
             tabs.select(tab.sessionID)
           }
           return (
@@ -284,7 +287,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
               onMouseDown={() => setDragging(tab.sessionID)}
               onMouseUp={release}
               onMouseDrag={(event) => {
-                if (tab.sessionID === NEW_SESSION_TAB_ID) return
+                if (tab === NEW_SESSION_TAB) return
                 const slot = slotAt(event.x)
                 if (slot !== undefined && slot !== tabNumber() - 1) tabs.move(tab.sessionID, slot)
               }}
@@ -333,7 +336,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
                   selectable={false}
                   onMouseUp={(event) => {
                     event.stopPropagation()
-                    tabs.close(tab.sessionID === NEW_SESSION_TAB_ID ? undefined : tab.sessionID)
+                    tabs.close(tab === NEW_SESSION_TAB ? undefined : tab.sessionID)
                   }}
                 >
                   {hovered() === tab.sessionID ? "×" : ""}

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -6,6 +6,7 @@ import { useSessionTabs } from "../context/session-tabs"
 import { useTheme, useThemes } from "../context/theme"
 import {
   adaptiveSessionTabLayout,
+  NEW_SESSION_TAB_ID,
   sessionTabComplete,
   seedSessionTabMotion,
   sessionTabOverflowWidth,
@@ -25,6 +26,7 @@ export type SessionTabsStatus = Omit<ReturnType<ContextController["status"]>, "u
   unread: SessionTabUnread | undefined
 }
 export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
+  newTab?: () => boolean
   status(sessionID: string): SessionTabsStatus
 }
 
@@ -42,8 +44,11 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   const accent = () => theme.hue.accent[hueStep()]
   const activeNumber = () => theme.hue.interactive[hueStep()]
   const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
-  const activeID = createMemo(tabs.current)
-  const items = tabs.tabs
+  const newTab = () => tabs.newTab?.() ?? false
+  const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB_ID : tabs.current()))
+  const items = createMemo(() =>
+    newTab() ? [...tabs.tabs(), { sessionID: NEW_SESSION_TAB_ID, title: "New session" }] : tabs.tabs(),
+  )
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
     adaptiveSessionTabLayout(items(), activeID(), dimensions().width, previous?.start),
   )
@@ -51,7 +56,10 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
     () =>
       new Map(
         layout().tabs.map((tab) => {
-          const status = tabs.status(tab.sessionID)
+          const status =
+            tab.sessionID === NEW_SESSION_TAB_ID
+              ? { unread: undefined, promptPulse: 0, attention: false, busy: false }
+              : tabs.status(tab.sessionID)
           return [
             tab.sessionID,
             {
@@ -262,6 +270,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
           // keeping sloppy clicks indistinguishable from clean ones.
           const release = () => {
             setDragging(undefined)
+            if (tab.sessionID === NEW_SESSION_TAB_ID) return
             tabs.select(tab.sessionID)
           }
           return (
@@ -275,6 +284,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
               onMouseDown={() => setDragging(tab.sessionID)}
               onMouseUp={release}
               onMouseDrag={(event) => {
+                if (tab.sessionID === NEW_SESSION_TAB_ID) return
                 const slot = slotAt(event.x)
                 if (slot !== undefined && slot !== tabNumber() - 1) tabs.move(tab.sessionID, slot)
               }}
@@ -323,7 +333,7 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
                   selectable={false}
                   onMouseUp={(event) => {
                     event.stopPropagation()
-                    tabs.close(tab.sessionID)
+                    tabs.close(tab.sessionID === NEW_SESSION_TAB_ID ? undefined : tab.sessionID)
                   }}
                 >
                   {hovered() === tab.sessionID ? "×" : ""}

--- a/packages/tui/src/context/session-tabs-model.ts
+++ b/packages/tui/src/context/session-tabs-model.ts
@@ -5,8 +5,6 @@ export type SessionTab = {
 
 export type SessionTabUnread = "activity" | "error"
 
-export const NEW_SESSION_TAB_ID = "new"
-
 export type SessionTabHistory = {
   entries: readonly string[]
   index: number

--- a/packages/tui/src/context/session-tabs-model.ts
+++ b/packages/tui/src/context/session-tabs-model.ts
@@ -5,6 +5,8 @@ export type SessionTab = {
 
 export type SessionTabUnread = "activity" | "error"
 
+export const NEW_SESSION_TAB_ID = "new"
+
 export type SessionTabHistory = {
   entries: readonly string[]
   index: number

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -225,6 +225,9 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       tabs() {
         return state().tabs
       },
+      newTab() {
+        return route.data.type === "home"
+      },
       current,
       status,
       select(sessionID: string) {
@@ -235,8 +238,10 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         if (!enabled()) return
         const target = sessionID ? root(sessionID) : current()
         if (!target) {
-          const previous = state().tabs.at(-1)
-          if (route.data.type === "home" && previous) route.navigate({ type: "session", sessionID: previous.sessionID })
+          const previous = moveSessionTabHistory(history, state().tabs, undefined, -1)
+          history = previous.history
+          const session = previous.sessionID ?? state().tabs.at(-1)?.sessionID
+          if (route.data.type === "home" && session) route.navigate({ type: "session", sessionID: session })
           return
         }
         remove(target, true)

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -2,7 +2,11 @@ import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { batch, createSignal, For, onCleanup } from "solid-js"
 import { createStore, reconcile } from "solid-js/store"
-import { SessionTabs, type SessionTabsController } from "../../../component/session-tabs"
+import {
+  EMPTY_SESSION_TAB_STATUS,
+  SessionTabs,
+  type SessionTabsController,
+} from "../../../component/session-tabs"
 import { moveSessionTab } from "../../../context/session-tabs-model"
 import type { Story } from "./index"
 
@@ -23,7 +27,6 @@ const FIXTURE_TABS = [
   { sessionID: "fixture-12", title: "Prepare review" },
 ]
 
-const EMPTY_STATUS: FixtureStatus = { unread: undefined, promptPulse: 0, attention: false, busy: false }
 const RUN_DURATION = 1_800
 const RESUME_DURATION = 900
 
@@ -66,7 +69,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     if (!resumed && roll < 0.25) {
       setStatuses((current) => ({
         ...current,
-        [sessionID]: { ...(current[sessionID] ?? EMPTY_STATUS), attention: true },
+        [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), attention: true },
       }))
       setLastEvent(`tab ${number(sessionID)} needs input; select it to resolve`)
       return
@@ -77,7 +80,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       setOutcomes((current) => ({ ...current, [sessionID]: failed ? "failed" : "completed" }))
       setStatuses((current) => ({
         ...current,
-        [sessionID]: { ...(current[sessionID] ?? EMPTY_STATUS), busy: false, unread },
+        [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), busy: false, unread },
       }))
       // An untitled session earns its title after its first completed run, like a real summarization.
       const index = number(sessionID) - 1
@@ -110,7 +113,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     tabs,
     current: active,
     status(sessionID) {
-      return statuses()[sessionID] ?? EMPTY_STATUS
+      return statuses()[sessionID] ?? EMPTY_SESSION_TAB_STATUS
     },
     select,
     move(sessionID: string, index: number) {
@@ -150,7 +153,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const startRun = (sessionID: string) => {
     setStatuses((current) => ({
       ...current,
-      [sessionID]: { ...(current[sessionID] ?? EMPTY_STATUS), busy: true, unread: undefined },
+      [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), busy: true, unread: undefined },
     }))
     setOutcomes((current) => {
       const next = { ...current }
@@ -223,7 +226,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
 
   const selectedState = () => {
     const current = active()
-    const status = current ? controller.status(current) : EMPTY_STATUS
+    const status = current ? controller.status(current) : EMPTY_SESSION_TAB_STATUS
     const activity = status.busy
       ? "running"
       : status.unread === "activity"

--- a/packages/tui/test/context/session-tabs-model.test.ts
+++ b/packages/tui/test/context/session-tabs-model.test.ts
@@ -151,12 +151,12 @@ describe("session tabs", () => {
     expect(layout.widths.reduce((total, width) => total + width, 0)).toBe(76)
   })
 
-  test("does not reserve an active tab slot on the new session page", () => {
-    const tabs = ["a", "b", "c", "d", "e"].map((sessionID) => ({ sessionID }))
-    const layout = adaptiveSessionTabLayout(tabs, "dummy", 40)
+  test("reserves an active tab slot for the new session page", () => {
+    const tabs = ["a", "b", "c", "d", "new"].map((sessionID) => ({ sessionID }))
+    const layout = adaptiveSessionTabLayout(tabs, "new", 54)
 
     expect(layout.tabs).toEqual(tabs)
-    expect(layout.widths).toEqual([8, 8, 8, 8, 8])
+    expect(layout.widths).toEqual([8, 8, 8, 8, 22])
     expect(layout.widths.reduce((total, width) => total + width, 0)).toBe(layout.total)
   })
 

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -24,7 +24,7 @@ async function wait(fn: () => boolean, timeout = 2_000) {
   }
 }
 
-test("user prompt admissions pulse an already-busy background tab", async () => {
+async function renderSessionTabs(initialSessionID: string) {
   const state = mkdtempSync(path.join(tmpdir(), "opencode-session-tabs-"))
   const events = createEventStream()
   const calls = createFetch(undefined, events)
@@ -44,7 +44,7 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
       <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
         <StorageProvider>
           <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
-            <RouteProvider initialRoute={{ type: "session", sessionID: "background" }}>
+            <RouteProvider initialRoute={{ type: "session", sessionID: initialSessionID }}>
               <ClientProvider api={createApi(calls.fetch)}>
                 <DataProvider>
                   <SessionTabsProvider>
@@ -59,7 +59,20 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
     </TestTuiContexts>
   ))
 
-  const emit = (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } })
+  await wait(() => client.connection.status() === "connected")
+  return {
+    tabs,
+    route,
+    emit: (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } }),
+    destroy() {
+      app.renderer.destroy()
+      rmSync(state, { recursive: true, force: true })
+    },
+  }
+}
+
+test("user prompt admissions pulse an already-busy background tab", async () => {
+  const setup = await renderSessionTabs("background")
   const admitted = (sessionID: string, inputID: string): OpenCodeEvent => ({
     id: `evt_${inputID}`,
     created: Date.now(),
@@ -73,13 +86,11 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
   })
 
   try {
-    await wait(
-      () => client.connection.status() === "connected" && tabs.tabs().some((tab) => tab.sessionID === "background"),
-    )
-    route.navigate({ type: "session", sessionID: "active" })
-    await wait(() => tabs.current() === "active" && tabs.tabs().length === 2)
+    await wait(() => setup.tabs.tabs().some((tab) => tab.sessionID === "background"))
+    setup.route.navigate({ type: "session", sessionID: "active" })
+    await wait(() => setup.tabs.current() === "active" && setup.tabs.tabs().length === 2)
 
-    emit({
+    setup.emit({
       id: "evt_context",
       created: Date.now(),
       type: "session.input.admitted",
@@ -91,82 +102,52 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
       },
     })
     await Bun.sleep(20)
-    expect(tabs.status("background").promptPulse).toBe(0)
+    expect(setup.tabs.status("background").promptPulse).toBe(0)
 
-    emit(admitted("background", "msg_1"))
-    await wait(() => tabs.status("background").promptPulse === 1 && tabs.status("background").busy)
+    setup.emit(admitted("background", "msg_1"))
+    await wait(
+      () => setup.tabs.status("background").promptPulse === 1 && setup.tabs.status("background").busy,
+    )
 
-    emit(admitted("background", "msg_2"))
-    await wait(() => tabs.status("background").promptPulse === 2)
+    setup.emit(admitted("background", "msg_2"))
+    await wait(() => setup.tabs.status("background").promptPulse === 2)
 
-    emit(admitted("active", "msg_3"))
+    setup.emit(admitted("active", "msg_3"))
     await Bun.sleep(20)
-    expect(tabs.status("active").promptPulse).toBe(0)
-    expect(tabs.status("background")).toMatchObject({ promptPulse: 2, busy: true })
+    expect(setup.tabs.status("active").promptPulse).toBe(0)
+    expect(setup.tabs.status("background")).toMatchObject({ promptPulse: 2, busy: true })
   } finally {
-    app.renderer.destroy()
-    rmSync(state, { recursive: true, force: true })
+    setup.destroy()
   }
 })
 
 test("tracks a temporary new session tab across close and creation", async () => {
-  const state = mkdtempSync(path.join(tmpdir(), "opencode-session-tabs-"))
-  const events = createEventStream()
-  const calls = createFetch(undefined, events)
-  let tabs!: ReturnType<typeof useSessionTabs>
-  let route!: ReturnType<typeof useRoute>
-  let client!: ReturnType<typeof useClient>
-
-  function Probe() {
-    tabs = useSessionTabs()
-    route = useRoute()
-    client = useClient()
-    return <box />
-  }
-
-  const app = await testRender(() => (
-    <TestTuiContexts paths={{ state }}>
-      <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
-        <StorageProvider>
-          <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
-            <RouteProvider initialRoute={{ type: "session", sessionID: "first" }}>
-              <ClientProvider api={createApi(calls.fetch)}>
-                <DataProvider>
-                  <SessionTabsProvider>
-                    <Probe />
-                  </SessionTabsProvider>
-                </DataProvider>
-              </ClientProvider>
-            </RouteProvider>
-          </ConfigProvider>
-        </StorageProvider>
-      </TuiAppProvider>
-    </TestTuiContexts>
-  ))
+  const setup = await renderSessionTabs("first")
 
   try {
-    await wait(() => client.connection.status() === "connected" && tabs.current() === "first")
-    route.navigate({ type: "session", sessionID: "second" })
-    await wait(() => tabs.current() === "second" && tabs.tabs().length === 2)
-    route.navigate({ type: "session", sessionID: "first" })
-    await wait(() => tabs.current() === "first")
+    await wait(() => setup.tabs.current() === "first")
+    setup.route.navigate({ type: "session", sessionID: "second" })
+    await wait(() => setup.tabs.current() === "second" && setup.tabs.tabs().length === 2)
+    setup.route.navigate({ type: "session", sessionID: "first" })
+    await wait(() => setup.tabs.current() === "first")
 
-    route.navigate({ type: "home" })
-    await wait(() => tabs.newTab() && tabs.current() === undefined)
-    expect(tabs.tabs().map((tab) => tab.sessionID)).toEqual(["first", "second"])
-    tabs.close()
-    await wait(() => route.data.type === "session")
+    setup.route.navigate({ type: "home" })
+    await wait(() => setup.tabs.newTab() && setup.tabs.current() === undefined)
+    expect(setup.tabs.tabs().map((tab) => tab.sessionID)).toEqual(["first", "second"])
+    setup.tabs.close()
+    await wait(() => setup.route.data.type === "session")
 
-    expect(route.data).toEqual({ type: "session", sessionID: "first" })
+    expect(setup.route.data).toEqual({ type: "session", sessionID: "first" })
 
-    route.navigate({ type: "home" })
-    await wait(() => tabs.newTab())
-    route.navigate({ type: "session", sessionID: "third" })
-    await wait(() => tabs.current() === "third" && tabs.tabs().some((tab) => tab.sessionID === "third"))
+    setup.route.navigate({ type: "home" })
+    await wait(() => setup.tabs.newTab())
+    setup.route.navigate({ type: "session", sessionID: "third" })
+    await wait(
+      () => setup.tabs.current() === "third" && setup.tabs.tabs().some((tab) => tab.sessionID === "third"),
+    )
 
-    expect(tabs.newTab()).toBe(false)
+    expect(setup.tabs.newTab()).toBe(false)
   } finally {
-    app.renderer.destroy()
-    rmSync(state, { recursive: true, force: true })
+    setup.destroy()
   }
 })

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -108,3 +108,65 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
     rmSync(state, { recursive: true, force: true })
   }
 })
+
+test("tracks a temporary new session tab across close and creation", async () => {
+  const state = mkdtempSync(path.join(tmpdir(), "opencode-session-tabs-"))
+  const events = createEventStream()
+  const calls = createFetch(undefined, events)
+  let tabs!: ReturnType<typeof useSessionTabs>
+  let route!: ReturnType<typeof useRoute>
+  let client!: ReturnType<typeof useClient>
+
+  function Probe() {
+    tabs = useSessionTabs()
+    route = useRoute()
+    client = useClient()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts paths={{ state }}>
+      <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
+        <StorageProvider>
+          <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
+            <RouteProvider initialRoute={{ type: "session", sessionID: "first" }}>
+              <ClientProvider api={createApi(calls.fetch)}>
+                <DataProvider>
+                  <SessionTabsProvider>
+                    <Probe />
+                  </SessionTabsProvider>
+                </DataProvider>
+              </ClientProvider>
+            </RouteProvider>
+          </ConfigProvider>
+        </StorageProvider>
+      </TuiAppProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await wait(() => client.connection.status() === "connected" && tabs.current() === "first")
+    route.navigate({ type: "session", sessionID: "second" })
+    await wait(() => tabs.current() === "second" && tabs.tabs().length === 2)
+    route.navigate({ type: "session", sessionID: "first" })
+    await wait(() => tabs.current() === "first")
+
+    route.navigate({ type: "home" })
+    await wait(() => tabs.newTab() && tabs.current() === undefined)
+    expect(tabs.tabs().map((tab) => tab.sessionID)).toEqual(["first", "second"])
+    tabs.close()
+    await wait(() => route.data.type === "session")
+
+    expect(route.data).toEqual({ type: "session", sessionID: "first" })
+
+    route.navigate({ type: "home" })
+    await wait(() => tabs.newTab())
+    route.navigate({ type: "session", sessionID: "third" })
+    await wait(() => tabs.current() === "third" && tabs.tabs().some((tab) => tab.sessionID === "third"))
+
+    expect(tabs.newTab()).toBe(false)
+  } finally {
+    app.renderer.destroy()
+    rmSync(state, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What

Represent the unsaved `/new` screen as a selected, temporary `New session` tab.

Closing that tab now restores the previously active session from selection history. If the user submits a prompt instead, the temporary tab disappears as the created session takes its place in the strip.

## Before / After

**Before**

1. Start on `First task` with `Second task` also open.
2. Run `leader+n`; the TUI moves to Home, but no tab represents that screen.
3. Run `leader+w`; because Home has no active tab, Close selects the last tab in strip order (`Second task`) rather than the previously active tab (`First task`).

**After**

```text
1 First task  2 Second task
                          leader+n
1 First task  2 Second task  3 New session
                          leader+w
1 First task  2 Second task
^ restored
```

## How

- Derive a non-persisted `New session` display tab whenever the active route is Home.
- Keep the placeholder outside the persisted session-tab collection and plugin tab API.
- Render the placeholder as selected and inert except for Close.
- Resolve Home-close through session selection history, falling back to strip order only when no open history entry remains.
- Let the existing session-route effect replace the placeholder with the real session tab after creation.

## Scope

This changes only the TUI session tab strip. It does not create a durable session before prompt submission or expose a synthetic session ID through the plugin API.

## Testing

- `bun run test test/context/session-tabs.test.tsx test/context/session-tabs-model.test.ts` in `packages/tui`: 26 passed
- `bun typecheck` in `packages/tui`
- Full repository typecheck through the pre-push hook: 33 tasks passed
- Terminal Control end-to-end run against a hermetic V2 server with synthetic `First task` and `Second task` sessions

## Demo

The recording shows `leader+n` opening the temporary tab and `leader+w` closing it back to the previously active tab.

https://github.com/user-attachments/assets/5834e38c-fbe8-4308-8f62-948491f8d252
