### PR TITLE
fix(simulation): mirror kitty keyboard protocol

### DIFF
--- a/packages/simulation/src/frontend/renderer.ts
+++ b/packages/simulation/src/frontend/renderer.ts
@@ -41,6 +41,7 @@ export const create = Effect.fn("SimulationRenderer.create")(function* (
         ...options,
         width: cols,
         height: rows,
+        kittyKeyboard: Boolean(options.useKittyKeyboard),
         ...(recording
           ? {
               stdout: recording as unknown as NodeJS.WriteStream,

--- a/packages/simulation/test/actions.test.ts
+++ b/packages/simulation/test/actions.test.ts
@@ -43,6 +43,25 @@ test("normalizes named keys for OpenTUI", async () => {
   ])
 })
 
+test("headless input mirrors the configured kitty keyboard protocol", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const renderer = yield* SimulationRenderer.create({ useKittyKeyboard: {} })
+        const harness = createHarness(renderer)
+        let key: { readonly name: string; readonly source: string } | undefined
+        renderer.keyInput.once("keypress", (event) => {
+          key = event
+        })
+
+        yield* execute(harness, { type: "ui.press", key: "escape" })
+
+        expect(key).toMatchObject({ name: "escape", source: "kitty" })
+      }),
+    ),
+  )
+})
+
 test("clicks a target at relative coordinates through descendant text", async () => {
   await Effect.runPromise(
     Effect.scoped(


### PR DESCRIPTION
## What

Keep headless simulation input on the same keyboard protocol configured for the TUI. This makes simulated keys behave like keys sent to the corresponding OpenTUI renderer.

## Before / After

**Before:** `SimulationRenderer.create({ useKittyKeyboard: ... })` forwarded the option to the application but created the headless OpenTUI renderer without `kittyKeyboard`. A simulated Escape was therefore emitted as legacy input, which could enter OpenTUI's escape-sequence disambiguation path instead of behaving like the configured Kitty key.

**After:** the headless renderer receives `kittyKeyboard: true` whenever `useKittyKeyboard` is configured. Simulated Escape is emitted immediately with `source: "kitty"`, matching the application's keyboard mode.

## How

- `packages/simulation/src/frontend/renderer.ts` mirrors `useKittyKeyboard` into `createTestRenderer`.
- `packages/simulation/test/actions.test.ts` verifies that `ui.press("escape")` emits a Kitty keyboard event.

## Scope

This only aligns the existing headless renderer with the existing application option. It does not change key normalization, terminal input parsing, or the simulation protocol.

## Testing

- `bun test` in `packages/simulation` (39 tests)
- `bun run typecheck` in `packages/simulation`
- Repository pre-push typecheck (33 packages)

## Flow

```mermaid
sequenceDiagram
    participant App as Simulated TUI
    participant Renderer as Headless OpenTUI renderer
    participant Drive as Simulation client

    App->>Renderer: configure Kitty keyboard mode
    Drive->>Renderer: press Escape
    Renderer-->>App: keypress source=kitty
```
