### PR TITLE
feat(tui): delete current session

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -51,6 +51,7 @@ import { useClient } from "../../context/client"
 import { useEditorContext } from "../../context/editor"
 import { openEditor } from "../../editor"
 import { useDialog } from "../../ui/dialog"
+import { DialogConfirm } from "../../ui/dialog-confirm"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
 import { DialogMessage } from "./dialog-message"
 import { DialogFork } from "./dialog-fork"
@@ -520,6 +521,32 @@ export function Session() {
       group: "Session",
       slash: { name: "rename" },
       run: () => DialogSessionRename.show(dialog, route.sessionID, session()?.title),
+    },
+    {
+      title: "Delete session",
+      id: "session.delete",
+      group: "Session",
+      slash: { name: "delete" },
+      run: async () => {
+        const current = session()
+        if (!current) return
+        const confirmed = await DialogConfirm.show(
+          dialog,
+          "Delete Session",
+          `Delete "${current.title}"? This action cannot be undone.`,
+        )
+        if (confirmed !== true) return
+        const error = await client.api.session.remove({ sessionID: route.sessionID }).then(
+          () => undefined,
+          (error) => error,
+        )
+        if (!error) return
+        toast.show({
+          message: `Failed to delete session: ${errorMessage(error)}`,
+          variant: "error",
+          duration: 5000,
+        })
+      },
     },
     {
       title: "Jump to message",


### PR DESCRIPTION
## What

Add a `Delete session` command for the active V2 TUI session. It is available from the command palette and as `/delete`; the existing `session_delete` binding also makes `Ctrl-D` open the confirmation while viewing a session.

The confirmation starts on **Confirm**, so the full keyboard flow is `Ctrl-D`, then `Enter`. `Escape` cancels without deleting anything.

## Before / After

**Before:** Deleting the active session required opening the session list, finding the current session, and pressing `Ctrl-D` twice.

**After:** The active session can be deleted in place. The TUI asks for confirmation, removes the session on the second keypress, and returns home through the existing `session.deleted` event flow.

## How

- Register `session.delete` with the session route in `packages/tui/src/routes/session/index.tsx`.
- Reuse `DialogConfirm` for the destructive confirmation instead of introducing another dialog.
- Call the existing session removal API after confirmation and surface failures as an error toast.
- Leave successful navigation and notification handling to the existing `session.deleted` listener.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (573 passed, 5 skipped)
- Push hook: workspace typecheck across 33 packages
- OpenCode Drive `v1.4.1` against this worktree with required protocol negotiation: created one simulated session, pressed `Ctrl-D`, asserted the confirmation, pressed `Enter`, asserted the deleted-session toast, and verified the session API returned zero sessions

## Demo

OpenCode Drive recording with a simulated model and isolated project. It shows `Ctrl-D` opening the confirmation and `Enter` deleting the session and returning home.

https://github.com/user-attachments/assets/38700eca-e7c3-4947-8ea8-c011aec3e8c4

![Delete session confirmation](https://github.com/user-attachments/assets/ba2ddff0-b717-43eb-aebf-8c3c57ea9d8f)

## Flow

```mermaid
flowchart LR
  A[Active session] -->|Ctrl-D, palette, or /delete| B[Delete confirmation]
  B -->|Escape or Cancel| A
  B -->|Enter on Confirm| C[Remove session]
  C -->|session.deleted| D[Home]
  C -->|API error| E[Error toast]
```
