### PR TITLE
feat(tui): inherit session directory when creating a new session

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -646,6 +646,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         run: () => {
           route.navigate({
             type: "home",
+            location: route.data.type === "session" ? data.session.get(route.data.sessionID)?.location : undefined,
           })
           dialog.clear()
         },

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -240,7 +240,6 @@ export function Prompt(props: PromptProps) {
               return undefined
             })
             if (!location) return
-            move.setDirectory(location.directory, location.directory !== location.project.directory)
             currentLocation.set(location)
             return
           }
@@ -963,7 +962,10 @@ export function Prompt(props: PromptProps) {
       const directory = await move.getDirectory()
       if (move.pending() && !directory) return false
       finishMoveProgress = Boolean(move.progress())
-      const location = data.location.default()
+      // The location context is where the next session is created: seeded by the home
+      // route (launch cwd, inherited session location, or picked project) and updated
+      // by /cd before a session exists.
+      const location = currentLocation.ref ?? data.location.default()
 
       const created = await client.api.session
         .create({
@@ -1299,7 +1301,12 @@ export function Prompt(props: PromptProps) {
     return `Ask anything... "${list()[store.placeholder % list().length]}"`
   })
   const locationLabel = createMemo(() => {
-    if (!props.sessionID || status() !== "idle") return
+    if (!props.sessionID) {
+      // No session yet: show where the next session will be created.
+      const directory = currentLocation.ref?.directory ?? data.location.default().directory
+      return abbreviateHome(directory, paths.home)
+    }
+    if (status() !== "idle") return
     const directory = data.session.get(props.sessionID)?.location.directory
     return directory ? abbreviateHome(directory, paths.home) : undefined
   })

--- a/packages/tui/src/context/location.tsx
+++ b/packages/tui/src/context/location.tsx
@@ -5,6 +5,8 @@ import { useData } from "./data"
 
 const context = createContext<{
   readonly current: LocationGetOutput | undefined
+  // The target location as set, available before the server-synced info in `current` arrives.
+  readonly ref: LocationRef | undefined
   set: (location?: LocationRef) => void
 }>()
 
@@ -36,6 +38,9 @@ export function LocationProvider(props: ParentProps) {
       value={{
         get current() {
           return current()
+        },
+        get ref() {
+          return ref()
         },
         set,
       }}

--- a/packages/tui/src/context/route.tsx
+++ b/packages/tui/src/context/route.tsx
@@ -7,6 +7,7 @@ import { useTuiStartup } from "./runtime"
 export type HomeRoute = {
   type: "home"
   prompt?: PromptInfo
+  // Location carried over from the previous session or project picker so a new session lands there.
   location?: LocationRef
 }
 

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "../component/prompt"
-import { createEffect, createMemo, createSignal, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, onMount, Show, untrack } from "solid-js"
 import { Logo } from "../component/logo"
 import { useArgs } from "../context/args"
 import { useRouteData } from "../context/route"
@@ -31,7 +31,13 @@ export function Home() {
   const forms = createMemo(() => data.session.form.list("global", currentLocation()) ?? [])
   let sent = false
 
-  createEffect(() => location.set(currentLocation()))
+  // Track only the route location and (when absent) the default location; location.set
+  // reads other signals internally and tracking them would re-assert the route location
+  // after the user overrides it with /cd.
+  createEffect(() => {
+    const target = currentLocation()
+    untrack(() => location.set(target))
+  })
 
   onMount(() => {
     editor.clearSelection()


### PR DESCRIPTION
## What

In the V2 TUI, `/new` always created the next session in the directory the TUI was launched from, even when the current session lived in a different project. Now the home route inherits the previous session's location — matching the desktop app's new-tab behavior — and the label under the prompt always shows where the next session will be created.

**Before:** launch in `~/a`, open a session in `~/b`, hit `/new`, submit → session created in `~/a`, with no indication anywhere.
**After:** same steps → home shows `~/b` under the prompt and the session is created in `~/b`. `/cd` on home overrides it (and the label updates), and a plain launch keeps using the launch cwd.

This also fixes the open menu / project picker: it already navigated home with `route.location`, but the next session was still created in the launch cwd.

## How

The design principle: **the location context is where the next session is created.** Home seeds it (launch cwd, inherited session location, or picked project), `/cd` updates it, `session.create` reads it. No parallel staging state.

- `context/location.tsx` — the provider exposes `ref` (the target location as set) alongside `current` (the server-synced info), so creation and display can honor a location before its sync completes.
- `app.tsx` — `session.new` passes the active session's `location` when navigating home.
- `component/prompt/index.tsx` — `session.create` falls back to `currentLocation.ref` instead of `data.location.default()`; `/cd` before a session exists now only sets the context (its extra move-staging call is gone); the under-prompt location label always renders on home.
- `routes/home.tsx` — the seeding effect tracks only the route location (and, when absent, the default) and calls `location.set` inside `untrack`: `location.set` reads other signals internally, and tracking them re-asserted the route location after a user `/cd`, silently changing where the session would be created.
- `context/route.tsx` — documents `HomeRoute.location` as the carried-over location.

## Flow

```mermaid
sequenceDiagram
    participant S as Session route (~/b)
    participant H as Home route
    participant L as Location context
    participant P as Prompt
    participant API as Server

    S->>H: /new — navigate({ type: "home", location: session.location })
    H->>L: location.set({ directory: "~/b" })
    Note over P: label shows ~/b
    opt user overrides
        P->>L: /cd ~/elsewhere — location.set(...)
        Note over P: label shows ~/elsewhere
    end
    P->>API: session.create({ location: currentLocation.ref })
```

## Scope

- `/move`'s "new working copy" staging is untouched and still takes precedence at submit when explicitly selected.
- Error-path navigations to home (session not found) intentionally do not carry a location.
- Closing the last session tab lands on home with the launch cwd (deliberate: closing is a "done" gesture, not a "continue" gesture).
- No changes to the desktop app, which already inherits the active tab's directory.

## Testing

- `bun typecheck` and `bun test` in `packages/tui` (573 pass).
- End-to-end against a hermetic `serve` instance with `termctrl`, verified via the server API: launched the TUI in project A with a session in project B; `/new` showed B on home and created the next session in B; `/cd` after `/new` updated the label and created in A instead; plain launch kept the cwd.

## Demo

Real end-to-end run (hermetic server, real TUI): session in `newtab-b`, `/new` inherits it and the label shows it, new session created there, then `/new` + `/cd` overrides back to `newtab-a`.

https://github.com/user-attachments/assets/24d184db-b69e-49de-9654-8b352e34c854
