### PR TITLE
fix(session): preserve execution start time in tool metadata updates

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -74,7 +74,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             metadata: val.metadata,
             status: "running",
             input: args,
-            time: { start: Date.now() },
+            time: match.state.status === "running" ? match.state.time : { start: Date.now() },
           },
         }
       }),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1861,6 +1861,59 @@ unixNoLLMServer(
 )
 
 unix(
+  "tool metadata updates preserve the execution start time",
+  () =>
+    withSh(() =>
+      Effect.gen(function* () {
+        const { dir, llm } = yield* useServerConfig(providerCfg)
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({
+          title: "Tool timing",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+
+        yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          noReply: true,
+          parts: [{ type: "text", text: "run bash" }],
+        })
+        yield* llm.tool("bash", {
+          command: "printf first; sleep 0.2; printf second",
+          timeout: 30_000,
+          workdir: path.resolve(dir),
+        })
+        yield* llm.text("done")
+
+        const run = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        const started = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+            const tool = msgs
+              .flatMap((item) => item.parts)
+              .find((part): part is SessionV1.ToolPart => part.type === "tool")
+            if (tool?.state.status !== "running" || !tool.state.metadata?.output.includes("first")) return
+            return tool.state.time.start
+          }),
+          "timed out waiting for the first shell metadata update",
+        )
+
+        const exit = yield* Fiber.await(run)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+        const tool = msgs.flatMap((item) => item.parts).find((part): part is SessionV1.ToolPart => part.type === "tool")
+        expect(tool?.state.status).toBe("completed")
+        if (tool?.state.status !== "completed") return
+        expect(tool.state.time.start).toBe(started)
+        expect(tool.state.time.end).toBeGreaterThan(started)
+      }),
+    ),
+  { config: cfg },
+  30_000,
+)
+
+unix(
   "cancel finalizes interrupted bash tool output through normal truncation",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #39754

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tool metadata updates rebuilt the running state with a new `time.start`. Tools that stream metadata, such as the shell tool, therefore recorded a start time near their final output update instead of when execution began.

This change reuses the existing running state's `time` value and only initializes `time.start` when a pending tool first transitions to running. Completion and failure continue to add the terminal end time as before.

### How did you verify your code works?

Added an end-to-end regression test that captures the start time after the first streamed shell update, waits for another update and completion, and verifies that the original start time is retained.

Ran:

```sh
bun --cwd packages/opencode test test/session/prompt.test.ts
```

```sh
bun test v1.3.14 (0d9b296a)

 57 pass
 1 skip
 0 fail
 225 expect() calls
Ran 58 tests across 1 file. [24.53s]
```

### Screenshots / recordings

Not applicable; this change has no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
