### PR TITLE
feat: make webfetch tool's User-Agent no longer lie and respect robots.txt

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -25,6 +25,7 @@ import { ConfigToolOutput } from "./config/tool-output"
 import { ConfigWatcher } from "./config/watcher"
 import { ConfigV1 } from "./v1/config/config"
 import { ConfigMigrateV1 } from "./v1/config/migrate"
+import { InstallationVersion } from "./installation/version"
 
 export class Info extends Schema.Class<Info>("Config.Info")({
   $schema: Schema.optional(Schema.String).annotate({
@@ -104,6 +105,15 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   }),
   experimental: ConfigExperimental.Experimental.pipe(Schema.optional),
   providers: Schema.Record(Schema.String, ConfigProvider.Info).pipe(Schema.optional),
+  fetch_user_agent: Schema.optional(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed(`OpenCode/${InstallationVersion}`)),
+  ),
+  does_input_mean_training: Schema.optional(Schema.Boolean).pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
+  respect_robots_txt: Schema.optional(Schema.Boolean).pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+  ),
 }) {}
 
 export class Document extends Schema.Class<Document>("Config.Document")({

--- a/packages/core/src/tool/robots-txt.ts
+++ b/packages/core/src/tool/robots-txt.ts
@@ -1,0 +1,212 @@
+import { Duration, Effect } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+
+interface Rule {
+  type: "allow" | "disallow"
+  pattern: string
+}
+
+interface Group {
+  agents: string[]
+  rules: Rule[]
+  disallowAiTraining: string[]
+  disallowAiInput: string[]
+  contentUsageBlockAi: boolean
+  contentSignalAiInput: boolean
+  contentSignalAiTrain: boolean
+}
+
+type RobotsRules = Group[]
+
+let cache = new Map<string, { rules: RobotsRules; expiresAt: number }>()
+
+export function clearCache() {
+  cache = new Map<string, { rules: RobotsRules; expiresAt: number }>()
+}
+
+const CACHE_TTL_MINUTES = 45
+
+function originFrom(url: string): string | undefined {
+  try {
+    const u = new URL(url)
+    if (u.protocol !== "http:" && u.protocol !== "https:") return undefined
+    return `${u.protocol}//${u.hostname}${u.port ? `:${u.port}` : ""}`
+  } catch {
+    return undefined
+  }
+}
+
+function pathMatch(pattern: string, path: string): boolean {
+  pattern = pattern.trim()
+  if (pattern === "/") return true
+  const hasEnd = pattern.endsWith("$")
+  const pat = hasEnd ? pattern.slice(0, -1) : pattern
+  if (pat === "") return true
+  const parts = pat.split("*")
+  let pos = 0
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]
+    if (part === "") continue
+    if (i === 0 && !path.startsWith(part)) return false
+    const idx = path.indexOf(part, i === 0 ? 0 : pos)
+    if (idx === -1) return false
+    pos = idx + part.length
+  }
+  if (hasEnd) {
+    if (parts[parts.length - 1] !== "") return pos === path.length
+    return true
+  }
+  return true
+}
+
+function findMatchingGroup(groups: RobotsRules, userAgent: string): Group | undefined {
+  let exactMatch: Group | undefined
+  let wildcardMatch: Group | undefined
+  for (const group of groups) {
+    for (const agent of group.agents) {
+      if (agent.toLowerCase() === userAgent.toLowerCase()) {
+        exactMatch = group
+      } else if (agent.toLowerCase() === "*") {
+        wildcardMatch = group
+      }
+    }
+  }
+  return exactMatch ?? wildcardMatch
+}
+
+function isPathAllowed(path: string, group: Group): boolean {
+  let bestRule: Rule | undefined
+  for (const rule of group.rules) {
+    if (pathMatch(rule.pattern, path)) {
+      if (!bestRule || rule.pattern.length > bestRule.pattern.length) {
+        bestRule = rule
+      } else if (rule.pattern.length === bestRule.pattern.length && rule.type === "allow" && bestRule.type === "disallow") {
+        bestRule = rule
+      }
+    }
+  }
+  if (!bestRule) return true
+  return bestRule.type === "allow"
+}
+
+export function parseRobotsTxt(text: string): RobotsRules {
+  const groups: Group[] = []
+  let currentGroup: Group | undefined
+
+  const agents: string[] = []
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim()
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      if (trimmed === "") {
+        if (currentGroup && agents.length > 0) {
+          currentGroup.agents = [...agents]
+          groups.push(currentGroup)
+        }
+        currentGroup = undefined
+        agents.length = 0
+      }
+      continue
+    }
+    const colonIdx = trimmed.indexOf(":")
+    if (colonIdx === -1) continue
+    const field = trimmed.slice(0, colonIdx).trim().toLowerCase()
+    const value = trimmed.slice(colonIdx + 1).trim()
+    if (value === "") continue
+    if (field === "user-agent") {
+      if (currentGroup && currentGroup.rules.length > 0) {
+        currentGroup.agents = [...agents]
+        groups.push(currentGroup)
+        agents.length = 0
+        currentGroup = { agents: [], rules: [], disallowAiTraining: [], disallowAiInput: [], contentUsageBlockAi: false, contentSignalAiInput: false, contentSignalAiTrain: false }
+      } else if (!currentGroup) {
+        currentGroup = { agents: [], rules: [], disallowAiTraining: [], disallowAiInput: [], contentUsageBlockAi: false, contentSignalAiInput: false, contentSignalAiTrain: false }
+      }
+      agents.push(value)
+    } else if (field === "disallow" && currentGroup) {
+      currentGroup.rules.push({ type: "disallow", pattern: value })
+    } else if (field === "allow" && currentGroup) {
+      currentGroup.rules.push({ type: "allow", pattern: value })
+    } else if (field === "disallowaitraining" && currentGroup) {
+      currentGroup.disallowAiTraining.push(value)
+    } else if (field === "disallowaiinput" && currentGroup) {
+      currentGroup.disallowAiInput.push(value)
+    } else if (field === "content-usage" && currentGroup) {
+      if (value.toLowerCase().trim() === "ai=n") currentGroup.contentUsageBlockAi = true
+    } else if (field === "content-signal" && currentGroup) {
+      for (const part of value.split(",")) {
+        const trimmed = part.trim().toLowerCase()
+        if (trimmed === "ai-train=no") currentGroup.contentSignalAiTrain = true
+        else if (trimmed === "ai-input=no") currentGroup.contentSignalAiInput = true
+      }
+    }
+  }
+  if (currentGroup && agents.length > 0) {
+    currentGroup.agents = [...agents]
+    groups.push(currentGroup)
+  }
+  return groups
+}
+
+export function isAllowed(path: string, groups: RobotsRules, userAgent: string): boolean {
+  if (groups.length === 0) return true
+  const group = findMatchingGroup(groups, userAgent)
+  if (!group) return true
+  return isPathAllowed(path, group)
+}
+
+export function checkAiOptOut(groups: RobotsRules, path: string, inputMeansTraining: boolean, userAgent: string): boolean {
+  const group = findMatchingGroup(groups, userAgent)
+  if (!group) return false
+  for (const p of group.disallowAiInput) {
+    if (pathMatch(p, path)) return true
+  }
+  if (group.contentSignalAiInput) return true
+  if (inputMeansTraining) {
+    for (const p of group.disallowAiTraining) {
+      if (pathMatch(p, path)) return true
+    }
+    if (group.contentUsageBlockAi) return true
+    if (group.contentSignalAiTrain) return true
+  }
+  return false
+}
+
+export const fetchRobotsTxt = (http: HttpClient.HttpClient, url: string, userAgent: string) =>
+  Effect.gen(function* () {
+    if (cache.size > 500) {
+      const now = Date.now()
+      for (const [key, entry] of cache) {
+        if (entry.expiresAt <= now) cache.delete(key)
+      }
+    }
+    const origin = originFrom(url)
+    if (!origin) return undefined
+    const cached = cache.get(origin)
+    if (cached && cached.expiresAt > Date.now()) return cached.rules
+    const robotsUrl = `${origin}/robots.txt`
+    const response = yield* http
+      .execute(
+        HttpClientRequest.get(robotsUrl).pipe(
+          HttpClientRequest.setHeaders({
+            "User-Agent": userAgent,
+            Accept: "text/plain",
+          }),
+        ),
+      )
+      .pipe(
+        Effect.catch(() => Effect.succeed(undefined as HttpClientResponse.HttpClientResponse | undefined)),
+        Effect.timeoutOrElse({
+          duration: Duration.seconds(10),
+          orElse: () => Effect.succeed(undefined),
+        }),
+      )
+    if (!response) return undefined
+    if (response.status !== 200) return undefined
+    const text = yield* response.text.pipe(
+      Effect.catch(() => Effect.succeed("")),
+    )
+    const rules = parseRobotsTxt(text)
+    cache.set(origin, { rules, expiresAt: Date.now() + CACHE_TTL_MINUTES * 60 * 1000 })
+    return rules
+  })

--- a/packages/core/src/tool/webfetch.ts
+++ b/packages/core/src/tool/webfetch.ts
@@ -12,6 +12,9 @@ import { collectBoundedResponseBody } from "./http-body"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
+import * as RobotsTxt from "./robots-txt"
+import { Config } from "../config"
+import { InstallationVersion } from "../installation/version"
 
 export const name = "webfetch"
 export const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
@@ -61,32 +64,14 @@ const headers = (format: Format, userAgent: string) => ({
   "Accept-Language": "en-US,en;q=0.9",
 })
 
-const browserUserAgent =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
-
-const isCloudflareChallenge = (error: unknown) => {
-  if (!error || typeof error !== "object" || !("reason" in error)) return false
-  const reason = error.reason
-  if (
-    !reason ||
-    typeof reason !== "object" ||
-    !("_tag" in reason) ||
-    reason._tag !== "StatusCodeError" ||
-    !("response" in reason)
-  )
-    return false
-  const response = reason.response as HttpClientResponse.HttpClientResponse
-  return response.status === 403 && response.headers["cf-mitigated"] === "challenge"
-}
-
-const request = (url: string, format: Format, userAgent = browserUserAgent) =>
+const request = (url: string, format: Format, userAgent: string) =>
   HttpClientRequest.get(url).pipe(HttpClientRequest.setHeaders(headers(format, userAgent)))
 
 const assertHttpUrl = (url: URL) => {
   if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("URL must use http:// or https://")
 }
 
-const execute = (http: HttpClient.HttpClient, url: string, format: Format, userAgent = browserUserAgent) =>
+const execute = (http: HttpClient.HttpClient, url: string, format: Format, userAgent: string) =>
   http.execute(request(url, format, userAgent)).pipe(Effect.flatMap(HttpClientResponse.filterStatusOk))
 
 const collectBody = (response: HttpClientResponse.HttpClientResponse) =>
@@ -120,6 +105,11 @@ const layer = Layer.effectDiscard(
     const tools = yield* Tools.Service
     const http = yield* HttpClient.HttpClient
     const permission = yield* PermissionV2.Service
+    const config = yield* Config.Service
+    const entries = yield* config.entries()
+    const userAgent = Config.latest(entries, "fetch_user_agent") ?? `OpenCode/${InstallationVersion}`
+    const inputMeansTraining = Config.latest(entries, "does_input_mean_training") ?? false
+    const respectRobotsTxt = Config.latest(entries, "respect_robots_txt") ?? true
 
     yield* tools
       .register({
@@ -145,10 +135,18 @@ const layer = Layer.effectDiscard(
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
 
+              if (respectRobotsTxt) {
+                const urlObj = new URL(input.url)
+                const rules = yield* RobotsTxt.fetchRobotsTxt(http, input.url, userAgent).pipe(Effect.catch(() => Effect.succeed(undefined)))
+                if (rules) {
+                  if (!RobotsTxt.isAllowed(urlObj.pathname, rules, userAgent) || RobotsTxt.checkAiOptOut(rules, urlObj.pathname, inputMeansTraining, userAgent)) {
+                    return yield* Effect.fail(new Error(`${urlObj.origin}/robots.txt forbids this request`))
+                  }
+                }
+              }
+
               const { body, contentType } = yield* Effect.gen(function* () {
-                const response = yield* execute(http, input.url, input.format).pipe(
-                  Effect.catchIf(isCloudflareChallenge, () => execute(http, input.url, input.format, "opencode")),
-                )
+                const response = yield* execute(http, input.url, input.format, userAgent)
                 const contentType = response.headers["content-type"] || ""
                 const mime = mimeFrom(contentType)
                 if (isImageAttachment(mime))
@@ -183,7 +181,7 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/webfetch",
   layer,
-  deps: [ToolRegistry.node, PermissionV2.node, LayerNodePlatform.httpClient],
+  deps: [ToolRegistry.node, PermissionV2.node, LayerNodePlatform.httpClient, Config.node],
 })
 
 export function extractTextFromHTML(html: string) {

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -166,6 +166,16 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  fetch_user_agent: Schema.optional(Schema.String).annotate({
+    description: "User-Agent header value for the webfetch tool. Defaults to OpenCode/<version>",
+  }),
+  respect_robots_txt: Schema.optional(Schema.Boolean).annotate({
+    description: "Whether to respect robots.txt when fetching URLs. Defaults to true",
+  }),
+  does_input_mean_training: Schema.optional(Schema.Boolean).annotate({
+    description:
+      "Whether user input may be used for AI training. When true, DisallowAITraining, Content-Usage: ai=n, and Content-Signal: ai-train=no in robots.txt are respected as AI opt-out signals. Defaults to false",
+  }),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -5,6 +5,9 @@ import * as Tool from "./tool"
 import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
+import { Config } from "@/config/config"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import { fetchRobotsTxt, isAllowed, checkAiOptOut } from "@opencode-ai/core/tool/robots-txt"
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
@@ -26,6 +29,7 @@ export const WebFetchTool = Tool.define(
   Effect.gen(function* () {
     const http = yield* HttpClient.HttpClient
     const httpOk = HttpClient.filterStatusOk(http)
+    const configSvc = yield* Config.Service
 
     return {
       description: DESCRIPTION,
@@ -47,6 +51,22 @@ export const WebFetchTool = Tool.define(
             },
           })
 
+          const cfg = yield* configSvc.get()
+          const userAgent = cfg.fetch_user_agent ?? `OpenCode/${InstallationVersion}`
+          const inputMeansTraining = cfg.does_input_mean_training ?? false
+
+          if (cfg.respect_robots_txt ?? true) {
+            const urlObj = new URL(params.url)
+            const rules = yield* fetchRobotsTxt(http, params.url, userAgent).pipe(
+              Effect.catch(() => Effect.succeed(undefined)),
+            )
+            if (rules) {
+              if (!isAllowed(urlObj.pathname, rules, userAgent) || checkAiOptOut(rules, urlObj.pathname, inputMeansTraining, userAgent)) {
+                throw new Error(`${urlObj.origin}/robots.txt forbids this request`)
+              }
+            }
+          }
+
           const timeout = Math.min((params.timeout ?? DEFAULT_TIMEOUT / 1000) * 1000, MAX_TIMEOUT)
 
           // Build Accept header based on requested format with q parameters for fallbacks
@@ -67,28 +87,14 @@ export const WebFetchTool = Tool.define(
                 "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
           }
           const headers = {
-            "User-Agent":
-              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+            "User-Agent": userAgent,
             Accept: acceptHeader,
             "Accept-Language": "en-US,en;q=0.9",
           }
 
           const request = HttpClientRequest.get(params.url).pipe(HttpClientRequest.setHeaders(headers))
 
-          // Retry with honest UA if blocked by Cloudflare bot detection (TLS fingerprint mismatch)
           const response = yield* httpOk.execute(request).pipe(
-            Effect.catchIf(
-              (err) =>
-                err.reason._tag === "StatusCodeError" &&
-                err.reason.response.status === 403 &&
-                err.reason.response.headers["cf-mitigated"] === "challenge",
-              () =>
-                httpOk.execute(
-                  HttpClientRequest.get(params.url).pipe(
-                    HttpClientRequest.setHeaders({ ...headers, "User-Agent": "opencode" }),
-                  ),
-                ),
-            ),
             Effect.timeoutOrElse({ duration: timeout, orElse: () => Effect.die(new Error("Request timed out")) }),
           )
 

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -9,11 +9,12 @@ import { WebFetchTool } from "../../src/tool/webfetch"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { Tool } from "@/tool/tool"
 import { testEffect } from "../lib/effect"
+import { TestConfig } from "../fixture/config"
 
 const it = testEffect(
   LayerNode.compile(LayerNode.group([httpClient, Truncate.node, Agent.node]), [
     [httpClient, FetchHttpClient.layer as Layer.Layer<HttpClient.HttpClient>],
-  ]),
+  ]).pipe(Layer.provideMerge(TestConfig.layer())),
 )
 
 const ctx = {


### PR DESCRIPTION
### Issue for this PR

Closes #14453

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Make the web fetch tool's User-Agent be "OpenCode/${InstallationVersion}" by default and can be changed in the config. Before sending a request, it checks the domain's robots.txt and fails if it disallows the user-agent or has unofficial instructions to disallow AI input in general. Can optionally be configured to also block the request if it disallows AI training (if your LLM provider trains on your queries). Can also be disabled entirely in the config. robots.txt files are cached in RAM for up to 45 minutes, purged when more than 500 entries are present.

### How did you verify your code works?

Asked Big Pickle to check his User-Agent and if he can access various websites.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._
Not a UI change

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
