### PR TITLE
feat(opencode): add Claude subscription authentication

### DIFF
--- a/packages/opencode/src/plugin/anthropic/claude.ts
+++ b/packages/opencode/src/plugin/anthropic/claude.ts
@@ -1,0 +1,743 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import type { Model } from "@opencode-ai/sdk/v2"
+import { Global } from "@opencode-ai/core/global"
+import { OauthCallbackPage } from "@opencode-ai/core/oauth/page"
+import { Flock } from "@opencode-ai/core/util/flock"
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises"
+import { createServer, type ServerResponse } from "node:http"
+import path from "node:path"
+import { OAUTH_DUMMY_KEY } from "../../auth"
+import { isRecord } from "@/util/record"
+
+export const CLAUDE_CODE_VERSION = "2.1.220"
+export const CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+export const AUTHORIZE_ENDPOINT = "https://claude.com/cai/oauth/authorize"
+export const TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token"
+export const PROFILE_ENDPOINT = "https://api.anthropic.com/api/oauth/profile"
+export const API_ENDPOINT = "https://api.anthropic.com/v1/messages"
+export const SUCCESS_ENDPOINT = "https://platform.claude.com/oauth/code/success?app=claude-code"
+export const REFRESH_SCOPES = [
+  "user:profile",
+  "user:inference",
+  "user:sessions:claude_code",
+  "user:mcp_servers",
+  "user:file_upload",
+] as const
+export const AUTHORIZE_SCOPES = ["org:create_api_key", ...REFRESH_SCOPES] as const
+export const SUBSCRIPTION_MODELS = ["claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-fable-5"] as const
+export const ANTHROPIC_VERSION = "2023-06-01"
+export const CLAUDE_CODE_BILLING =
+  "x-anthropic-billing-header: cc_version=2.1.220.205; cc_entrypoint=sdk-cli; cch=00000;"
+export const CLAUDE_CODE_AUXILIARY_BILLING =
+  "x-anthropic-billing-header: cc_version=2.1.220.aa8; cc_entrypoint=sdk-cli; cch=00000;"
+export const CLAUDE_AGENT_IDENTITY = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+export const ANTHROPIC_BETA = [
+  "claude-code-20250219",
+  "oauth-2025-04-20",
+  "interleaved-thinking-2025-05-14",
+  "thinking-token-count-2026-05-13",
+  "context-management-2025-06-27",
+  "prompt-caching-scope-2026-01-05",
+  "mid-conversation-system-2026-04-07",
+  "advisor-tool-2026-03-01",
+  "effort-2025-11-24",
+  "extended-cache-ttl-2025-04-11",
+  "cache-diagnosis-2026-04-07",
+].join(",")
+export const ANTHROPIC_AUXILIARY_BETA = [
+  "oauth-2025-04-20",
+  "interleaved-thinking-2025-05-14",
+  "thinking-token-count-2026-05-13",
+  "context-management-2025-06-27",
+  "prompt-caching-scope-2026-01-05",
+  "advisor-tool-2026-03-01",
+  "structured-outputs-2025-12-15",
+  "cache-diagnosis-2026-04-07",
+].join(",")
+
+const USER_AGENT = `claude-cli/${CLAUDE_CODE_VERSION} (external, sdk-cli)`
+const REFRESH_WINDOW_MS = 5 * 60 * 1000
+const TOKEN_TIMEOUT_MS = 30 * 1000
+const PROFILE_TIMEOUT_MS = 10 * 1000
+const DEFAULT_MAX_OUTPUT_TOKENS = 64_000
+const STAINLESS_PACKAGE_VERSION = "0.94.0"
+const STAINLESS_RUNTIME_VERSION = "v26.3.0"
+const UTILITY_MODELS = ["claude-haiku-4-5-20251001", "claude-haiku-4-5"]
+const DEVICE_ID_PATTERN = /^[0-9a-f]{64}$/
+const DEVICE_ID_FILE = path.join(Global.Path.data, "anthropic-device-id")
+
+export interface PkceCodes {
+  verifier: string
+  challenge: string
+}
+
+export interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+  refresh_token_expires_in?: number
+  scope?: string
+}
+
+export interface ClaudeAuthPluginOptions {
+  authorizeEndpoint?: string
+  tokenEndpoint?: string
+  profileEndpoint?: string
+  apiEndpoint?: string
+  httpFetch?: typeof fetch
+  now?: () => number
+  deviceID?: () => Promise<string>
+}
+
+interface OAuthCallback {
+  redirectUri: string
+  code: Promise<string>
+  complete: () => void
+  cancel: (error: Error) => void
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  return Buffer.from(bytes).toString("base64url")
+}
+
+function stainlessOS() {
+  if (process.platform === "darwin") return "MacOS"
+  if (process.platform === "win32") return "Windows"
+  if (process.platform === "linux") return "Linux"
+  return `Other:${process.platform}`
+}
+
+export async function generatePKCE(): Promise<PkceCodes> {
+  const verifier = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)))
+  const challenge = base64UrlEncode(
+    new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier))),
+  )
+  return { verifier, challenge }
+}
+
+export function buildAuthorizeUrl(input: { redirectUri: string; challenge: string; state: string; endpoint?: string }) {
+  const url = new URL(input.endpoint ?? AUTHORIZE_ENDPOINT)
+  url.search = new URLSearchParams({
+    code: "true",
+    client_id: CLIENT_ID,
+    response_type: "code",
+    redirect_uri: input.redirectUri,
+    scope: AUTHORIZE_SCOPES.join(" "),
+    code_challenge: input.challenge,
+    code_challenge_method: "S256",
+    state: input.state,
+  }).toString()
+  return url.toString()
+}
+
+export async function exchangeAuthorizationCode(input: {
+  code: string
+  redirectUri: string
+  verifier: string
+  state: string
+  endpoint?: string
+  httpFetch?: typeof fetch
+}) {
+  return requestTokens({
+    operation: "exchange",
+    endpoint: input.endpoint ?? TOKEN_ENDPOINT,
+    httpFetch: input.httpFetch ?? fetch,
+    requireRefresh: true,
+    body: {
+      grant_type: "authorization_code",
+      code: input.code,
+      redirect_uri: input.redirectUri,
+      client_id: CLIENT_ID,
+      code_verifier: input.verifier,
+      state: input.state,
+    },
+  })
+}
+
+export async function refreshAccessToken(input: { refresh: string; endpoint?: string; httpFetch?: typeof fetch }) {
+  return requestTokens({
+    operation: "refresh",
+    endpoint: input.endpoint ?? TOKEN_ENDPOINT,
+    httpFetch: input.httpFetch ?? fetch,
+    requireRefresh: false,
+    body: {
+      grant_type: "refresh_token",
+      refresh_token: input.refresh,
+      client_id: CLIENT_ID,
+      scope: REFRESH_SCOPES.join(" "),
+    },
+  })
+}
+
+export async function requestProfile(input: { access: string; endpoint?: string; httpFetch?: typeof fetch }) {
+  const response = await (input.httpFetch ?? fetch)(input.endpoint ?? PROFILE_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${input.access}`,
+      "Cache-Control": "no-cache",
+      "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
+    },
+    signal: AbortSignal.timeout(PROFILE_TIMEOUT_MS),
+  })
+  if (!response.ok) throw new Error(`Claude profile request failed: ${response.status}`)
+  const value = await response.json()
+  if (!isRecord(value) || !isRecord(value.account) || typeof value.account.uuid !== "string" || !value.account.uuid) {
+    throw new Error("Claude profile response is missing account.uuid")
+  }
+  return value.account.uuid
+}
+
+async function requestTokens(input: {
+  operation: "exchange" | "refresh"
+  endpoint: string
+  httpFetch: typeof fetch
+  requireRefresh: boolean
+  body: Record<string, string>
+}) {
+  const response = await input.httpFetch(input.endpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": USER_AGENT,
+    },
+    body: JSON.stringify(input.body),
+    signal: AbortSignal.timeout(TOKEN_TIMEOUT_MS),
+  })
+  if (!response.ok) throw new Error(`Claude token ${input.operation} failed: ${response.status}`)
+  return parseTokenResponse(await response.json(), input.requireRefresh)
+}
+
+function parseTokenResponse(value: unknown, requireRefresh: boolean): TokenResponse {
+  if (!isRecord(value)) throw new Error("Claude token response is invalid")
+  if (typeof value.access_token !== "string" || !value.access_token) {
+    throw new Error("Claude token response is missing access_token")
+  }
+  if (typeof value.expires_in !== "number" || !Number.isFinite(value.expires_in) || value.expires_in <= 0) {
+    throw new Error("Claude token response is missing expires_in")
+  }
+  if (requireRefresh && (typeof value.refresh_token !== "string" || !value.refresh_token)) {
+    throw new Error("Claude token response is missing refresh_token")
+  }
+
+  return {
+    access_token: value.access_token,
+    expires_in: value.expires_in,
+    ...(typeof value.refresh_token === "string" && value.refresh_token ? { refresh_token: value.refresh_token } : {}),
+    ...(typeof value.refresh_token_expires_in === "number"
+      ? { refresh_token_expires_in: value.refresh_token_expires_in }
+      : {}),
+    ...(typeof value.scope === "string" ? { scope: value.scope } : {}),
+  }
+}
+
+async function startOAuthCallback(state: string): Promise<OAuthCallback> {
+  let resolveCode: (code: string) => void
+  let rejectCode: (error: Error) => void
+  let codeResolved = false
+  let closed = false
+  let pendingResponse: ServerResponse | undefined
+  const code = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve
+    rejectCode = reject
+  })
+  code.catch(() => {})
+
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://localhost")
+    if (url.pathname !== "/callback") {
+      response.writeHead(404)
+      response.end("Not found")
+      return
+    }
+
+    if (url.searchParams.get("state") !== state) {
+      const message = "Invalid state parameter"
+      response.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
+      response.end(OauthCallbackPage.error(message, { provider: "Claude" }))
+      reject(new Error(message))
+      return
+    }
+
+    const error = url.searchParams.get("error")
+    if (error) {
+      const message = url.searchParams.get("error_description") ?? error
+      response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
+      response.end(OauthCallbackPage.error(message, { provider: "Claude" }))
+      reject(new Error(message))
+      return
+    }
+
+    const authorizationCode = url.searchParams.get("code")
+    if (!authorizationCode) {
+      const message = "Authorization code not found"
+      response.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
+      response.end(OauthCallbackPage.error(message, { provider: "Claude" }))
+      reject(new Error(message))
+      return
+    }
+
+    if (codeResolved) {
+      response.writeHead(409)
+      response.end("Authorization callback already received")
+      return
+    }
+
+    codeResolved = true
+    pendingResponse = response
+    resolveCode!(authorizationCode)
+  })
+
+  function close() {
+    server.close(() => {})
+  }
+
+  function complete() {
+    if (closed) return
+    closed = true
+    if (pendingResponse && !pendingResponse.writableEnded) {
+      pendingResponse.writeHead(302, { Location: SUCCESS_ENDPOINT })
+      pendingResponse.end()
+    }
+    close()
+  }
+
+  function reject(error: Error) {
+    if (closed) return
+    if (codeResolved) {
+      complete()
+      return
+    }
+    closed = true
+    close()
+    rejectCode!(error)
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const fail = (error: Error) => reject(error)
+    server.once("error", fail)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", fail)
+      resolve()
+    })
+  })
+
+  const address = server.address()
+  if (!address || typeof address === "string") {
+    server.close(() => {})
+    throw new Error("Failed to start Claude OAuth callback server")
+  }
+
+  return {
+    redirectUri: `http://localhost:${address.port}/callback`,
+    code,
+    complete,
+    cancel: reject,
+  }
+}
+
+export async function ClaudeAuthPlugin(input: PluginInput, options: ClaudeAuthPluginOptions = {}): Promise<Hooks> {
+  const authorizeEndpoint = options.authorizeEndpoint ?? AUTHORIZE_ENDPOINT
+  const tokenEndpoint = options.tokenEndpoint ?? TOKEN_ENDPOINT
+  const profileEndpoint = options.profileEndpoint ?? PROFILE_ENDPOINT
+  const apiEndpoint = options.apiEndpoint ?? API_ENDPOINT
+  const httpFetch = options.httpFetch ?? fetch
+  const now = options.now ?? Date.now
+  const deviceID = options.deviceID ?? loadClaudeDeviceID
+  const callbacks = new Set<OAuthCallback>()
+  let utilityModel: Model | undefined
+
+  return {
+    async dispose() {
+      for (const callback of callbacks) callback.cancel(new Error("Claude OAuth login cancelled"))
+      callbacks.clear()
+    },
+    provider: {
+      id: "anthropic",
+      async models(provider, ctx) {
+        if (ctx.auth?.type !== "oauth") {
+          utilityModel = undefined
+          return provider.models
+        }
+        utilityModel = UTILITY_MODELS.map((id) =>
+          Object.values(provider.models).find((model) => model.api.id === id),
+        ).find((model) => model !== undefined)
+        const models = { ...provider.models }
+        const opus = models["claude-opus-4-8"]
+        if (!models["claude-opus-5"] && opus) {
+          models["claude-opus-5"] = {
+            ...opus,
+            id: "claude-opus-5",
+            name: "Claude Opus 5",
+            family: "claude-opus",
+            api: {
+              ...opus.api,
+              id: "claude-opus-5",
+            },
+            release_date: "2026-07-24",
+          }
+        }
+        return Object.fromEntries(
+          SUBSCRIPTION_MODELS.flatMap((modelID) => {
+            const model = models[modelID]
+            if (!model) return []
+            return [
+              [
+                modelID,
+                {
+                  ...model,
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cache: { read: 0, write: 0 },
+                  },
+                },
+              ] as const,
+            ]
+          }),
+        )
+      },
+    },
+    auth: {
+      provider: "anthropic",
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "oauth") return {}
+
+        let refreshPromise:
+          | Promise<{
+              access: string
+              refresh: string
+              expires: number
+            }>
+          | undefined
+        let accountID = (auth as typeof auth & { accountId?: string }).accountId
+        let profilePromise: Promise<string> | undefined
+        let deviceIDPromise: Promise<string> | undefined
+        const sessions = new Map<string, string>()
+
+        const refresh = (refreshToken: string) =>
+          refreshPromise ??
+          (refreshPromise = refreshAccessToken({
+            refresh: refreshToken,
+            endpoint: tokenEndpoint,
+            httpFetch,
+          })
+            .then(async (tokens) => {
+              const next = {
+                access: tokens.access_token,
+                refresh: tokens.refresh_token ?? refreshToken,
+                expires: now() + tokens.expires_in * 1000,
+              }
+              await input.client.auth.set({
+                path: { id: "anthropic" },
+                body: {
+                  type: "oauth",
+                  refresh: next.refresh,
+                  access: next.access,
+                  expires: next.expires,
+                  ...(accountID && { accountId: accountID }),
+                },
+              })
+              return next
+            })
+            .finally(() => {
+              refreshPromise = undefined
+            }))
+
+        return {
+          apiKey: OAUTH_DUMMY_KEY,
+          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+            const source = new Request(requestInput, init)
+            if (!new URL(source.url).pathname.endsWith("/v1/messages")) return httpFetch(requestInput, init)
+
+            const currentAuth = await getAuth()
+            if (currentAuth.type !== "oauth") return httpFetch(requestInput, init)
+            const authWithAccount = currentAuth as typeof currentAuth & { accountId?: string }
+            accountID ??= authWithAccount.accountId
+
+            const credentials =
+              currentAuth.access && currentAuth.expires > now() + REFRESH_WINDOW_MS
+                ? {
+                    access: currentAuth.access,
+                    refresh: currentAuth.refresh,
+                    expires: currentAuth.expires,
+                  }
+                : await refresh(currentAuth.refresh)
+
+            const target = new URL(apiEndpoint)
+            target.searchParams.set("beta", "true")
+            const auxiliary = source.headers.get("x-opencode-claude-request") === "title"
+            const sourceSessionID =
+              source.headers.get("x-claude-code-session-id") ??
+              source.headers.get("x-session-id") ??
+              crypto.randomUUID()
+            const sessionID = sessions.get(sourceSessionID) ?? crypto.randomUUID()
+            sessions.set(sourceSessionID, sessionID)
+            const sourceParentSessionID = source.headers.get("x-parent-session-id")
+            const parentSessionID = sourceParentSessionID
+              ? (sessions.get(sourceParentSessionID) ?? crypto.randomUUID())
+              : undefined
+            if (sourceParentSessionID && parentSessionID) sessions.set(sourceParentSessionID, parentSessionID)
+            const resolvedAccountID =
+              accountID ??
+              (await (profilePromise ??= requestProfile({
+                access: credentials.access,
+                endpoint: profileEndpoint,
+                httpFetch,
+              }).then(async (value) => {
+                accountID = value
+                const latest = await getAuth()
+                if (latest.type === "oauth") {
+                  await input.client.auth.set({
+                    path: { id: "anthropic" },
+                    body: {
+                      type: "oauth",
+                      refresh: latest.refresh,
+                      access: latest.access,
+                      expires: latest.expires,
+                      ...(value && { accountId: value }),
+                    },
+                  })
+                }
+                return value
+              })))
+            const resolvedDeviceID = await (deviceIDPromise ??= deviceID())
+            const body = await rewriteMessageBody(source, {
+              accountID: resolvedAccountID,
+              auxiliary,
+              deviceID: resolvedDeviceID,
+              parentSessionID,
+              sessionID,
+            })
+
+            const send = (access: string) => {
+              const headers = new Headers(source.headers)
+              headers.delete("x-api-key")
+              headers.delete("authorization")
+              headers.delete("x-session-affinity")
+              headers.delete("x-session-id")
+              headers.delete("x-parent-session-id")
+              headers.delete("x-opencode-claude-request")
+              headers.delete("x-stainless-helper-method")
+              headers.set("authorization", `Bearer ${access}`)
+              headers.set("anthropic-version", ANTHROPIC_VERSION)
+              headers.set("anthropic-beta", auxiliary ? ANTHROPIC_AUXILIARY_BETA : ANTHROPIC_BETA)
+              headers.set("anthropic-dangerous-direct-browser-access", "true")
+              headers.set("x-app", "cli")
+              headers.set("x-claude-code-session-id", sessionID)
+              headers.set("x-client-request-id", crypto.randomUUID())
+              headers.set("accept", "application/json")
+              headers.set("user-agent", USER_AGENT)
+              headers.set("x-stainless-arch", process.arch)
+              headers.set("x-stainless-lang", "js")
+              headers.set("x-stainless-os", stainlessOS())
+              headers.set("x-stainless-package-version", STAINLESS_PACKAGE_VERSION)
+              headers.set("x-stainless-retry-count", "0")
+              headers.set("x-stainless-runtime", "node")
+              headers.set("x-stainless-runtime-version", STAINLESS_RUNTIME_VERSION)
+              headers.set("x-stainless-timeout", "600")
+              return httpFetch(new Request(new Request(target, source.clone()), { headers, ...(body ? { body } : {}) }))
+            }
+
+            const response = await send(credentials.access)
+            const rejected =
+              response.status === 401 ||
+              (response.status === 403 && (await response.clone().text()).includes("OAuth token has been revoked"))
+            if (!rejected) return response
+
+            const latest = await getAuth()
+            if (latest.type !== "oauth") return response
+            await response.body?.cancel()
+            return send((await refresh(latest.refresh)).access)
+          },
+        }
+      },
+      methods: [
+        {
+          label: "Claude Pro/Max",
+          type: "oauth",
+          authorize: async () => {
+            const pkce = await generatePKCE()
+            const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)))
+            const callback = await startOAuthCallback(state)
+            callbacks.add(callback)
+
+            return {
+              url: buildAuthorizeUrl({
+                redirectUri: callback.redirectUri,
+                challenge: pkce.challenge,
+                state,
+                endpoint: authorizeEndpoint,
+              }),
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              method: "auto" as const,
+              callback: async () => {
+                try {
+                  const tokens = await exchangeAuthorizationCode({
+                    code: await callback.code,
+                    redirectUri: callback.redirectUri,
+                    verifier: pkce.verifier,
+                    state,
+                    endpoint: tokenEndpoint,
+                    httpFetch,
+                  })
+                  const accountID = await requestProfile({
+                    access: tokens.access_token,
+                    endpoint: profileEndpoint,
+                    httpFetch,
+                  })
+                  return {
+                    type: "success" as const,
+                    refresh: tokens.refresh_token!,
+                    access: tokens.access_token,
+                    expires: now() + tokens.expires_in * 1000,
+                    accountId: accountID,
+                  }
+                } finally {
+                  callback.complete()
+                  callbacks.delete(callback)
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "Manually enter API Key",
+          type: "api",
+        },
+      ],
+    },
+    "experimental.provider.small_model": async (request, output) => {
+      if (request.provider.id !== "anthropic") return
+      output.model = utilityModel
+    },
+    "chat.params": async (request, output) => {
+      if (request.model.providerID !== "anthropic") return
+      if (request.provider.options.apiKey !== OAUTH_DUMMY_KEY) return
+      if (request.agent === "title") {
+        output.maxOutputTokens = 32_000
+        output.options.thinking = { type: "disabled" }
+        delete output.options.effort
+        return
+      }
+      output.maxOutputTokens = DEFAULT_MAX_OUTPUT_TOKENS
+      output.options.thinking ??= { type: "adaptive" }
+      output.options.effort ??= "medium"
+    },
+    "chat.headers": async (request, output) => {
+      if (request.model.providerID !== "anthropic") return
+      if (request.provider.options.apiKey !== OAUTH_DUMMY_KEY) return
+      if (request.agent === "title") output.headers["x-opencode-claude-request"] = "title"
+    },
+  }
+}
+
+export async function loadClaudeDeviceID(filepath = DEVICE_ID_FILE) {
+  return Flock.withLock(`anthropic-device-id:${filepath}`, async () => {
+    const existing = await readClaudeDeviceID(filepath)
+    if (existing) {
+      await chmod(filepath, 0o600)
+      return existing
+    }
+
+    await mkdir(path.dirname(filepath), { recursive: true })
+    const value = Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("hex")
+    const pending = `${filepath}.${process.pid}.${crypto.randomUUID()}.tmp`
+    await writeFile(pending, value, { flag: "wx", mode: 0o600 })
+    await rename(pending, filepath).finally(() => unlink(pending).catch(() => undefined))
+    return value
+  })
+}
+
+async function readClaudeDeviceID(filepath: string) {
+  const value = await readFile(filepath, "utf8").catch((error) => {
+    if (hasErrorCode(error, "ENOENT")) return undefined
+    throw error
+  })
+  if (value === undefined) return undefined
+  const result = value.trim()
+  if (!DEVICE_ID_PATTERN.test(result)) return undefined
+  return result
+}
+
+function hasErrorCode(error: unknown, code: string) {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code
+}
+
+async function rewriteMessageBody(
+  request: Request,
+  input: {
+    accountID: string
+    auxiliary: boolean
+    deviceID: string
+    parentSessionID?: string
+    sessionID: string
+  },
+) {
+  const value = await request
+    .clone()
+    .json()
+    .catch(() => undefined)
+  if (!isRecord(value)) return undefined
+  const system = Array.isArray(value.system)
+    ? value.system
+    : typeof value.system === "string"
+      ? [{ type: "text", text: value.system }]
+      : []
+  const messages = Array.isArray(value.messages) ? value.messages : []
+  const metadata = {
+    user_id: JSON.stringify({
+      device_id: input.deviceID,
+      account_uuid: input.accountID,
+      session_id: input.sessionID,
+      ...(input.parentSessionID && { parent_session_id: input.parentSessionID }),
+    }),
+  }
+  const rewrittenSystem = [
+    { type: "text", text: input.auxiliary ? CLAUDE_CODE_AUXILIARY_BILLING : CLAUDE_CODE_BILLING },
+    { type: "text", text: CLAUDE_AGENT_IDENTITY },
+    ...system,
+  ]
+  if (input.auxiliary) {
+    return JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      messages,
+      system: rewrittenSystem,
+      tools: [],
+      metadata,
+      max_tokens: 32_000,
+      thinking: { type: "disabled" },
+      temperature: 1,
+      output_config: {
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            properties: { title: { type: "string" } },
+            required: ["title"],
+            additionalProperties: false,
+          },
+        },
+      },
+      stream: true,
+    })
+  }
+  return JSON.stringify({
+    model: value.model,
+    messages,
+    system: rewrittenSystem,
+    tools: Array.isArray(value.tools) ? value.tools : [],
+    metadata,
+    max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+    thinking: { type: "adaptive" },
+    context_management: {
+      edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+    },
+    output_config: { effort: "medium" },
+    diagnostics: {
+      previous_message_id: null,
+    },
+    stream: true,
+  })
+}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -10,6 +10,7 @@ import { Config } from "@/config/config"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { ServerAuth } from "@/server/auth"
 import { CodexAuthPlugin } from "./openai/codex"
+import { ClaudeAuthPlugin } from "./anthropic/claude"
 import { Session } from "@/session/session"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { CopilotAuthPlugin } from "./github-copilot/copilot"
@@ -70,6 +71,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
       CodexAuthPlugin(input, {
         experimentalWebSockets: experimentalWebSocketsEnabled({ enabled: flags.experimentalWebSockets }),
       }),
+    ClaudeAuthPlugin,
     CopilotAuthPlugin,
     ModalPlugin,
     GitlabAuthPlugin,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -62,6 +62,7 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 
 const decodeMessageInfo = Schema.decodeUnknownExit(SessionV1.Info)
 const decodeMessagePart = Schema.decodeUnknownExit(SessionV1.Part)
+const decodeGeneratedTitle = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 const MAX_MCP_RESOURCE_BLOB_BYTES = 10 * 1024 * 1024
 const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
   "application/pdf",
@@ -80,6 +81,19 @@ IMPORTANT:
 - This tool provides your final answer - no further actions are taken after calling it`
 
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
+
+export function cleanGeneratedTitle(text: string) {
+  const parsed = Option.getOrUndefined(decodeGeneratedTitle(text))
+  const value =
+    typeof parsed === "object" && parsed !== null && "title" in parsed && typeof parsed.title === "string"
+      ? parsed.title
+      : text
+  return value
+    .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0)
+}
 
 function mcpResourceBase64Size(value: string) {
   const trimmed = value.replace(/\s/g, "")
@@ -240,11 +254,7 @@ const layer = Layer.effect(
           Stream.mkString,
           Effect.orDie,
         )
-      const cleaned = text
-        .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
-        .split("\n")
-        .map((line) => line.trim())
-        .find((line) => line.length > 0)
+      const cleaned = cleanGeneratedTitle(text)
       if (!cleaned) return
       const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
       yield* sessions

--- a/packages/opencode/test/plugin/anthropic.test.ts
+++ b/packages/opencode/test/plugin/anthropic.test.ts
@@ -1,0 +1,1074 @@
+import { describe, expect, test } from "bun:test"
+import { stat } from "node:fs/promises"
+import path from "node:path"
+import {
+  ANTHROPIC_AUXILIARY_BETA,
+  ANTHROPIC_BETA,
+  ANTHROPIC_VERSION,
+  AUTHORIZE_SCOPES,
+  CLAUDE_AGENT_IDENTITY,
+  CLAUDE_CODE_AUXILIARY_BILLING,
+  CLAUDE_CODE_BILLING,
+  CLIENT_ID,
+  ClaudeAuthPlugin,
+  REFRESH_SCOPES,
+  SUCCESS_ENDPOINT,
+  buildAuthorizeUrl,
+  exchangeAuthorizationCode,
+  generatePKCE,
+  loadClaudeDeviceID,
+  refreshAccessToken,
+  requestProfile,
+} from "../../src/plugin/anthropic/claude"
+import { tmpdir } from "../fixture/fixture"
+
+type AuthUpdate = {
+  path: { id: string }
+  body: {
+    type: "oauth"
+    refresh: string
+    access: string
+    expires: number
+    accountId?: string
+  }
+}
+
+function pluginInput(set: (input: AuthUpdate) => Promise<void> = async () => {}) {
+  return {
+    client: {
+      auth: { set },
+    },
+    project: {},
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {},
+  } as never
+}
+
+describe("plugin.anthropic", () => {
+  test("builds the captured PKCE authorization request", async () => {
+    const pkce = await generatePKCE()
+    const url = new URL(
+      buildAuthorizeUrl({
+        redirectUri: "http://localhost:3210/callback",
+        challenge: pkce.challenge,
+        state: "state-test",
+      }),
+    )
+    const expectedChallenge = Buffer.from(
+      await crypto.subtle.digest("SHA-256", new TextEncoder().encode(pkce.verifier)),
+    ).toString("base64url")
+
+    expect(pkce.verifier).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(pkce.challenge).toBe(expectedChallenge)
+    expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize")
+    expect(url.searchParams.get("code")).toBe("true")
+    expect(url.searchParams.get("client_id")).toBe(CLIENT_ID)
+    expect(url.searchParams.get("response_type")).toBe("code")
+    expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:3210/callback")
+    expect(url.searchParams.get("scope")).toBe(AUTHORIZE_SCOPES.join(" "))
+    expect(AUTHORIZE_SCOPES.join(" ")).toBe(
+      "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+    )
+    expect(REFRESH_SCOPES.join(" ")).toBe(
+      "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+    )
+    expect(ANTHROPIC_VERSION).toBe("2023-06-01")
+    expect(ANTHROPIC_BETA).toBe(
+      "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24,extended-cache-ttl-2025-04-11,cache-diagnosis-2026-04-07",
+    )
+    expect(url.searchParams.get("code_challenge")).toBe(pkce.challenge)
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(url.searchParams.get("state")).toBe("state-test")
+  })
+
+  test("sends captured JSON token exchange and refresh payloads", async () => {
+    const requests: Array<{
+      body: Record<string, string>
+      contentType: string | null
+      userAgent: string | null
+    }> = []
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const body = (await request.json()) as Record<string, string>
+        requests.push({
+          body,
+          contentType: request.headers.get("content-type"),
+          userAgent: request.headers.get("user-agent"),
+        })
+        if (body.grant_type === "authorization_code") {
+          return Response.json({
+            access_token: "access-initial",
+            refresh_token: "refresh-initial",
+            expires_in: 3600,
+            refresh_token_expires_in: 2_592_000,
+            scope: AUTHORIZE_SCOPES.join(" "),
+          })
+        }
+        return Response.json({
+          access_token: "access-refreshed",
+          expires_in: 1800,
+          scope: REFRESH_SCOPES.join(" "),
+        })
+      },
+    })
+
+    const endpoint = new URL("/v1/oauth/token", server.url).toString()
+    const exchanged = await exchangeAuthorizationCode({
+      code: "authorization-code",
+      redirectUri: "http://localhost:3210/callback",
+      verifier: "pkce-verifier",
+      state: "oauth-state",
+      endpoint,
+    })
+    const refreshed = await refreshAccessToken({
+      refresh: "refresh-initial",
+      endpoint,
+    })
+
+    expect(exchanged).toEqual({
+      access_token: "access-initial",
+      refresh_token: "refresh-initial",
+      expires_in: 3600,
+      refresh_token_expires_in: 2_592_000,
+      scope: AUTHORIZE_SCOPES.join(" "),
+    })
+    expect(refreshed).toEqual({
+      access_token: "access-refreshed",
+      expires_in: 1800,
+      scope: REFRESH_SCOPES.join(" "),
+    })
+    expect(requests).toEqual([
+      {
+        body: {
+          grant_type: "authorization_code",
+          code: "authorization-code",
+          redirect_uri: "http://localhost:3210/callback",
+          client_id: CLIENT_ID,
+          code_verifier: "pkce-verifier",
+          state: "oauth-state",
+        },
+        contentType: "application/json",
+        userAgent: "claude-cli/2.1.220 (external, sdk-cli)",
+      },
+      {
+        body: {
+          grant_type: "refresh_token",
+          refresh_token: "refresh-initial",
+          client_id: CLIENT_ID,
+          scope: REFRESH_SCOPES.join(" "),
+        },
+        contentType: "application/json",
+        userAgent: "claude-cli/2.1.220 (external, sdk-cli)",
+      },
+    ])
+  })
+
+  test("persists Claude Code's random 64-hex device ID with private permissions", async () => {
+    await using tmp = await tmpdir()
+    const filepath = path.join(tmp.path, "claude-device-id")
+    const [first, second] = await Promise.all([loadClaudeDeviceID(filepath), loadClaudeDeviceID(filepath)])
+    const seededPath = path.join(tmp.path, "seeded-device-id")
+    const seeded = "f".repeat(64)
+    await Bun.write(seededPath, seeded)
+    const corruptPath = path.join(tmp.path, "corrupt-device-id")
+    await Bun.write(corruptPath, "not-a-device-id")
+    const repaired = await loadClaudeDeviceID(corruptPath)
+
+    expect(first).toMatch(/^[0-9a-f]{64}$/)
+    expect(second).toBe(first)
+    expect(await Bun.file(filepath).text()).toBe(first)
+    expect(await loadClaudeDeviceID(seededPath)).toBe(seeded)
+    expect(repaired).toMatch(/^[0-9a-f]{64}$/)
+    expect(repaired).not.toBe("not-a-device-id")
+    expect(await Bun.file(corruptPath).text()).toBe(repaired)
+    if (process.platform !== "win32") {
+      expect((await stat(filepath)).mode & 0o777).toBe(0o600)
+      expect((await stat(seededPath)).mode & 0o777).toBe(0o600)
+      expect((await stat(corruptPath)).mode & 0o777).toBe(0o600)
+    }
+  })
+
+  test("loads the OAuth profile with the captured request headers", async () => {
+    const requests: Array<{
+      method: string
+      authorization: string | null
+      cacheControl: string | null
+      contentType: string | null
+      userAgent: string | null
+    }> = []
+
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        requests.push({
+          method: request.method,
+          authorization: request.headers.get("authorization"),
+          cacheControl: request.headers.get("cache-control"),
+          contentType: request.headers.get("content-type"),
+          userAgent: request.headers.get("user-agent"),
+        })
+        return Response.json({ account: { uuid: "account-test" } })
+      },
+    })
+
+    const accountID = await requestProfile({
+      access: "access-profile",
+      endpoint: new URL("/api/oauth/profile", server.url).toString(),
+    })
+
+    expect(accountID).toBe("account-test")
+    expect(requests).toEqual([
+      {
+        method: "GET",
+        authorization: "Bearer access-profile",
+        cacheControl: "no-cache",
+        contentType: "application/json",
+        userAgent: "claude-cli/2.1.220 (external, sdk-cli)",
+      },
+    ])
+  })
+
+  test("rejects an OAuth profile without an account UUID", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ account: {} })
+      },
+    })
+
+    await expect(
+      requestProfile({
+        access: "access-profile",
+        endpoint: new URL("/api/oauth/profile", server.url).toString(),
+      }),
+    ).rejects.toThrow("Claude profile response is missing account.uuid")
+  })
+
+  test("loads and persists a missing account ID before the first Messages request", async () => {
+    let auth = {
+      type: "oauth" as const,
+      refresh: "refresh-token",
+      access: "access-token",
+      expires: Date.now() + 60 * 60 * 1000,
+      accountId: undefined as string | undefined,
+    }
+    const updates: AuthUpdate[] = []
+    const bodies: string[] = []
+    let profiles = 0
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        if (new URL(request.url).pathname === "/api/oauth/profile") {
+          profiles += 1
+          return Response.json({ account: { uuid: "account-profile" } })
+        }
+        bodies.push(await request.text())
+        return new Response("{}", { status: 200 })
+      },
+    })
+    const hooks = await ClaudeAuthPlugin(
+      pluginInput(async (update) => {
+        updates.push(update)
+        auth = {
+          type: "oauth",
+          refresh: update.body.refresh,
+          access: update.body.access,
+          expires: update.body.expires,
+          accountId: update.body.accountId,
+        }
+      }),
+      {
+        profileEndpoint: new URL("/api/oauth/profile", server.url).toString(),
+        apiEndpoint: new URL("/v1/messages", server.url).toString(),
+      },
+    )
+    const loaded = await hooks.auth!.loader!(async () => auth as never, {} as never)
+
+    await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: { "X-Session-Id": "session-test" },
+      body: JSON.stringify({ model: "claude-sonnet-5" }),
+    })
+    await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: { "X-Session-Id": "session-test" },
+      body: JSON.stringify({ model: "claude-sonnet-5" }),
+    })
+
+    expect(profiles).toBe(1)
+    expect(updates).toEqual([
+      {
+        path: { id: "anthropic" },
+        body: {
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: auth.expires,
+          accountId: "account-profile",
+        },
+      },
+    ])
+    const first = JSON.parse(bodies[0]).metadata.user_id
+    const second = JSON.parse(bodies[1]).metadata.user_id
+    expect(JSON.parse(first)).toEqual({
+      device_id: expect.stringMatching(/^[0-9a-f]{64}$/),
+      account_uuid: "account-profile",
+      session_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+    })
+    expect(second).toBe(first)
+  })
+
+  test("keeps the callback listener open until it is explicitly cancelled", async () => {
+    const hooks = await ClaudeAuthPlugin(pluginInput())
+    const authorize = await hooks.auth!.methods[0].authorize!({})
+    if (!("callback" in authorize) || authorize.method !== "auto") {
+      throw new Error("Expected automatic OAuth authorization result")
+    }
+    const callback = authorize.callback()
+    let settled = false
+    callback.finally(() => (settled = true)).catch(() => {})
+
+    await Bun.sleep(20)
+    expect(settled).toBe(false)
+
+    await hooks.dispose!()
+    await expect(callback).rejects.toThrow("Claude OAuth login cancelled")
+  })
+
+  test("exchanges a loopback callback and redirects after login succeeds", async () => {
+    const requests: string[] = []
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url)
+        requests.push(url.pathname)
+        if (url.pathname === "/v1/oauth/token") {
+          return Response.json({
+            access_token: "access-initial",
+            refresh_token: "refresh-initial",
+            expires_in: 3600,
+          })
+        }
+        return Response.json({ account: { uuid: "account-test" } })
+      },
+    })
+    const hooks = await ClaudeAuthPlugin(pluginInput(), {
+      tokenEndpoint: new URL("/v1/oauth/token", server.url).toString(),
+      profileEndpoint: new URL("/api/oauth/profile", server.url).toString(),
+    })
+    const authorize = await hooks.auth!.methods[0].authorize!({})
+    if (!("callback" in authorize) || authorize.method !== "auto" || !authorize.url) {
+      throw new Error("Expected automatic OAuth authorization result")
+    }
+    const authorizeUrl = new URL(authorize.url)
+    const redirectUri = authorizeUrl.searchParams.get("redirect_uri")!
+    const state = authorizeUrl.searchParams.get("state")!
+    const callback = authorize.callback()
+    const browser = fetch(`${redirectUri}?code=authorization-code&state=${encodeURIComponent(state)}`, {
+      redirect: "manual",
+    })
+    const [result, response] = await Promise.all([callback, browser])
+
+    expect(result).toEqual({
+      type: "success",
+      refresh: "refresh-initial",
+      access: "access-initial",
+      expires: expect.any(Number),
+      accountId: "account-test",
+    })
+    expect(requests).toEqual(["/v1/oauth/token", "/api/oauth/profile"])
+    expect(response.status).toBe(302)
+    expect(response.headers.get("location")).toBe(SUCCESS_ENDPOINT)
+  })
+
+  test("filters OAuth models to the current subscription catalog with zero cost", async () => {
+    const hooks = await ClaudeAuthPlugin(pluginInput())
+    const provider = {
+      models: Object.fromEntries(
+        [
+          "claude-sonnet-5",
+          "claude-opus-4-8",
+          "claude-opus-4-8-fast",
+          "claude-fable-5",
+          "claude-haiku-4-5",
+          "claude-haiku-4-5-20251001",
+          "claude-api-only",
+        ].map((id) => [
+          id,
+          {
+            id,
+            api: { id },
+            cost: {
+              input: 3,
+              output: 15,
+              cache: { read: 0.3, write: 3.75 },
+            },
+          },
+        ]),
+      ),
+    }
+    provider.models["claude-opus-4-8-fast"].api.id = "claude-opus-4-8"
+
+    const models = await hooks.provider!.models!(provider as never, { auth: { type: "oauth" } } as never)
+
+    expect(Object.keys(models)).toEqual(["claude-sonnet-5", "claude-opus-5", "claude-opus-4-8", "claude-fable-5"])
+    expect(models["claude-opus-5"]).toMatchObject({
+      id: "claude-opus-5",
+      name: "Claude Opus 5",
+      family: "claude-opus",
+      api: { id: "claude-opus-5" },
+      release_date: "2026-07-24",
+    })
+    expect(models["claude-sonnet-5"].cost).toEqual({
+      input: 0,
+      output: 0,
+      cache: { read: 0, write: 0 },
+    })
+    const small: { model?: unknown } = {}
+    await hooks["experimental.provider.small_model"]!({ provider: { id: "anthropic" } } as never, small as never)
+    expect(small.model).toEqual(provider.models["claude-haiku-4-5-20251001"])
+    expect(await hooks.provider!.models!(provider as never, { auth: { type: "api" } } as never)).toBe(
+      provider.models as never,
+    )
+  })
+
+  test("uses the captured Claude Code body defaults for subscription requests", async () => {
+    const hooks = await ClaudeAuthPlugin(pluginInput())
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60 * 60 * 1000,
+          accountId: "account-test",
+        }) as never,
+      {} as never,
+    )
+    const output = {
+      temperature: undefined,
+      topP: undefined,
+      topK: undefined,
+      maxOutputTokens: 32_000,
+      options: {},
+    }
+
+    await hooks["chat.params"]!(
+      {
+        agent: "build",
+        model: { providerID: "anthropic" },
+        provider: { options: loaded },
+      } as never,
+      output as never,
+    )
+
+    expect(output.maxOutputTokens).toBe(64_000)
+    expect(output.options).toEqual({
+      thinking: { type: "adaptive" },
+      effort: "medium",
+    })
+
+    const title = {
+      temperature: undefined,
+      topP: undefined,
+      topK: undefined,
+      maxOutputTokens: 64_000,
+      options: { effort: "low" } as Record<string, unknown>,
+    }
+    await hooks["chat.params"]!(
+      {
+        agent: "title",
+        model: { providerID: "anthropic" },
+        provider: { options: loaded },
+      } as never,
+      title as never,
+    )
+    expect(title.maxOutputTokens).toBe(32_000)
+    expect(title.options).toEqual({
+      thinking: { type: "disabled" },
+    })
+
+    const headers = { headers: {} as Record<string, string> }
+    await hooks["chat.headers"]!(
+      {
+        agent: "title",
+        model: { providerID: "anthropic" },
+        provider: { options: loaded },
+      } as never,
+      headers,
+    )
+    expect(headers.headers).toEqual({
+      "x-opencode-claude-request": "title",
+    })
+  })
+
+  test("leaves non-Messages requests untouched", async () => {
+    const url = "https://api.anthropic.com/v1/models?source=opencode"
+    const init: RequestInit = {
+      method: "POST",
+      headers: {
+        Authorization: "Basic original",
+        "X-Api-Key": "original-key",
+        "X-Custom": "original-value",
+      },
+      body: "original-body",
+    }
+    let capturedInput: RequestInfo | URL | undefined
+    let capturedInit: RequestInit | undefined
+    const httpFetch = Object.assign(
+      async (input: RequestInfo | URL, requestInit?: RequestInit) => {
+        capturedInput = input
+        capturedInit = requestInit
+        return new Response("untouched")
+      },
+      { preconnect() {} },
+    )
+    const hooks = await ClaudeAuthPlugin(pluginInput(), {
+      httpFetch,
+      deviceID: async () => {
+        throw new Error("device ID should not be loaded")
+      },
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: 0,
+          accountId: "account-test",
+        }) as never,
+      {} as never,
+    )
+
+    expect(await (await loaded.fetch!(url, init)).text()).toBe("untouched")
+    expect(capturedInput).toBe(url)
+    expect(capturedInit).toBe(init)
+  })
+
+  test("rewrites Messages requests with the captured Claude Code headers", async () => {
+    const requests: Array<{
+      url: string
+      method: string
+      body: string
+      authorization: string | null
+      apiKey: string | null
+      version: string | null
+      beta: string | null
+      browserAccess: string | null
+      app: string | null
+      sessionID: string | null
+      clientRequestID: string | null
+      sessionAffinity: string | null
+      opencodeSessionID: string | null
+      parentSessionID: string | null
+      userAgent: string | null
+      accept: string | null
+      stainlessArch: string | null
+      stainlessHelperMethod: string | null
+      stainlessLang: string | null
+      stainlessOS: string | null
+      stainlessPackageVersion: string | null
+      stainlessRetryCount: string | null
+      stainlessRuntime: string | null
+      stainlessRuntimeVersion: string | null
+      stainlessTimeout: string | null
+    }> = []
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        requests.push({
+          url: request.url,
+          method: request.method,
+          body: await request.text(),
+          authorization: request.headers.get("authorization"),
+          apiKey: request.headers.get("x-api-key"),
+          version: request.headers.get("anthropic-version"),
+          beta: request.headers.get("anthropic-beta"),
+          browserAccess: request.headers.get("anthropic-dangerous-direct-browser-access"),
+          app: request.headers.get("x-app"),
+          sessionID: request.headers.get("x-claude-code-session-id"),
+          clientRequestID: request.headers.get("x-client-request-id"),
+          sessionAffinity: request.headers.get("x-session-affinity"),
+          opencodeSessionID: request.headers.get("x-session-id"),
+          parentSessionID: request.headers.get("x-parent-session-id"),
+          userAgent: request.headers.get("user-agent"),
+          accept: request.headers.get("accept"),
+          stainlessArch: request.headers.get("x-stainless-arch"),
+          stainlessHelperMethod: request.headers.get("x-stainless-helper-method"),
+          stainlessLang: request.headers.get("x-stainless-lang"),
+          stainlessOS: request.headers.get("x-stainless-os"),
+          stainlessPackageVersion: request.headers.get("x-stainless-package-version"),
+          stainlessRetryCount: request.headers.get("x-stainless-retry-count"),
+          stainlessRuntime: request.headers.get("x-stainless-runtime"),
+          stainlessRuntimeVersion: request.headers.get("x-stainless-runtime-version"),
+          stainlessTimeout: request.headers.get("x-stainless-timeout"),
+        })
+        return new Response("event: message_stop\ndata: {}\n\n", {
+          headers: { "Content-Type": "text/event-stream" },
+        })
+      },
+    })
+
+    const hooks = await ClaudeAuthPlugin(pluginInput(), {
+      apiEndpoint: new URL("/v1/messages", server.url).toString(),
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60 * 60 * 1000,
+          accountId: "account-test",
+        }) as never,
+      {} as never,
+    )
+    const response = await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        Accept: "text/event-stream",
+        "Content-Type": "application/json",
+        "X-Api-Key": "api-key-must-be-removed",
+        Authorization: "Basic must-be-replaced",
+        "Anthropic-Version": "old",
+        "X-Session-Affinity": "session-test",
+        "X-Session-Id": "session-test",
+        "X-Parent-Session-Id": "parent-test",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-5",
+        messages: [{ role: "user", content: "hello" }],
+        stream: true,
+        system: [{ type: "text", text: "OpenCode system" }],
+        temperature: 0.5,
+        top_k: 10,
+        top_p: 0.9,
+      }),
+    })
+
+    expect(await response.text()).toBe("event: message_stop\ndata: {}\n\n")
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toEqual({
+      url: new URL("/v1/messages?beta=true", server.url).toString(),
+      method: "POST",
+      body: expect.any(String),
+      authorization: "Bearer access-token",
+      apiKey: null,
+      version: ANTHROPIC_VERSION,
+      beta: ANTHROPIC_BETA,
+      browserAccess: "true",
+      app: "cli",
+      sessionID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      clientRequestID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      sessionAffinity: null,
+      opencodeSessionID: null,
+      parentSessionID: null,
+      userAgent: "claude-cli/2.1.220 (external, sdk-cli)",
+      accept: "application/json",
+      stainlessArch: process.arch,
+      stainlessHelperMethod: null,
+      stainlessLang: "js",
+      stainlessOS:
+        process.platform === "darwin"
+          ? "MacOS"
+          : process.platform === "win32"
+            ? "Windows"
+            : process.platform === "linux"
+              ? "Linux"
+              : `Other:${process.platform}`,
+      stainlessPackageVersion: "0.94.0",
+      stainlessRetryCount: "0",
+      stainlessRuntime: "node",
+      stainlessRuntimeVersion: "v26.3.0",
+      stainlessTimeout: "600",
+    })
+    const body = JSON.parse(requests[0].body)
+    const userID = JSON.parse(body.metadata.user_id)
+    expect(Object.keys(body)).toEqual([
+      "model",
+      "messages",
+      "system",
+      "tools",
+      "metadata",
+      "max_tokens",
+      "thinking",
+      "context_management",
+      "output_config",
+      "diagnostics",
+      "stream",
+    ])
+    expect(body).toEqual({
+      model: "claude-sonnet-5",
+      messages: [{ role: "user", content: "hello" }],
+      stream: true,
+      max_tokens: 64_000,
+      thinking: { type: "adaptive" },
+      context_management: {
+        edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+      },
+      output_config: { effort: "medium" },
+      diagnostics: {
+        previous_message_id: null,
+      },
+      tools: [],
+      metadata: {
+        user_id: expect.any(String),
+      },
+      system: [
+        { type: "text", text: CLAUDE_CODE_BILLING },
+        { type: "text", text: CLAUDE_AGENT_IDENTITY },
+        { type: "text", text: "OpenCode system" },
+      ],
+    })
+    expect(userID).toEqual({
+      device_id: expect.stringMatching(/^[0-9a-f]{64}$/),
+      account_uuid: "account-test",
+      session_id: requests[0].sessionID,
+      parent_session_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+    })
+  })
+
+  test("uses the captured Claude Code auxiliary envelope for title requests", async () => {
+    const requests: Array<{
+      beta: string | null
+      helperMethod: string | null
+      marker: string | null
+      body: Record<string, unknown>
+    }> = []
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        requests.push({
+          beta: request.headers.get("anthropic-beta"),
+          helperMethod: request.headers.get("x-stainless-helper-method"),
+          marker: request.headers.get("x-opencode-claude-request"),
+          body: (await request.json()) as Record<string, unknown>,
+        })
+        return new Response("{}", { status: 200 })
+      },
+    })
+    const hooks = await ClaudeAuthPlugin(pluginInput(), {
+      apiEndpoint: new URL("/v1/messages", server.url).toString(),
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60 * 60 * 1000,
+          accountId: "account-test",
+        }) as never,
+      {} as never,
+    )
+
+    await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-OpenCode-Claude-Request": "title",
+      },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5",
+        messages: [{ role: "user", content: "Generate a title" }],
+        max_tokens: 64_000,
+        output_config: { effort: "low" },
+        stream: true,
+        system: [{ type: "text", text: "OpenCode title prompt" }],
+        temperature: 0.5,
+        thinking: { type: "adaptive", display: "omitted" },
+        top_k: 10,
+        top_p: 0.9,
+      }),
+    })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0].beta).toBe(ANTHROPIC_AUXILIARY_BETA)
+    expect(requests[0].helperMethod).toBeNull()
+    expect(requests[0].marker).toBeNull()
+    expect(Object.keys(requests[0].body)).toEqual([
+      "model",
+      "messages",
+      "system",
+      "tools",
+      "metadata",
+      "max_tokens",
+      "thinking",
+      "temperature",
+      "output_config",
+      "stream",
+    ])
+    expect(requests[0].body).toEqual({
+      model: "claude-haiku-4-5-20251001",
+      messages: [{ role: "user", content: "Generate a title" }],
+      max_tokens: 32_000,
+      stream: true,
+      system: [
+        { type: "text", text: CLAUDE_CODE_AUXILIARY_BILLING },
+        { type: "text", text: CLAUDE_AGENT_IDENTITY },
+        { type: "text", text: "OpenCode title prompt" },
+      ],
+      thinking: { type: "disabled" },
+      temperature: 1,
+      tools: [],
+      output_config: {
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            properties: { title: { type: "string" } },
+            required: ["title"],
+            additionalProperties: false,
+          },
+        },
+      },
+      metadata: {
+        user_id: expect.any(String),
+      },
+    })
+  })
+
+  for (const rejection of [
+    { name: "401", status: 401, body: '{"error":{"message":"unauthorized"}}' },
+    { name: "revoked-token 403", status: 403, body: '{"error":{"message":"OAuth token has been revoked"}}' },
+  ]) {
+    test(`refreshes and retries once after ${rejection.name}`, async () => {
+      const now = 1_800_000_000_000
+      let auth = {
+        type: "oauth" as const,
+        refresh: "refresh-old",
+        access: "access-rejected",
+        expires: now + 60 * 60 * 1000,
+        accountId: "account-test",
+      }
+      const updates: AuthUpdate[] = []
+      const apiRequests: Array<{
+        authorization: string | null
+        clientRequestID: string | null
+        sessionID: string | null
+        body: string
+      }> = []
+      let refreshRequests = 0
+
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/v1/oauth/token") {
+            refreshRequests += 1
+            return Response.json({
+              access_token: "access-new",
+              refresh_token: "refresh-new",
+              expires_in: 3600,
+            })
+          }
+
+          apiRequests.push({
+            authorization: request.headers.get("authorization"),
+            clientRequestID: request.headers.get("x-client-request-id"),
+            sessionID: request.headers.get("x-claude-code-session-id"),
+            body: await request.text(),
+          })
+          if (apiRequests.length === 1) {
+            return new Response(rejection.body, { status: rejection.status })
+          }
+          return new Response("{}", { status: 200 })
+        },
+      })
+
+      const hooks = await ClaudeAuthPlugin(
+        pluginInput(async (update) => {
+          updates.push(update)
+          auth = {
+            type: "oauth",
+            refresh: update.body.refresh,
+            access: update.body.access,
+            expires: update.body.expires,
+            accountId: update.body.accountId ?? "account-test",
+          }
+        }),
+        {
+          tokenEndpoint: new URL("/v1/oauth/token", server.url).toString(),
+          apiEndpoint: new URL("/v1/messages", server.url).toString(),
+          now: () => now,
+        },
+      )
+      const loaded = await hooks.auth!.loader!(async () => auth as never, {} as never)
+      const body = JSON.stringify({ model: "claude-sonnet-5", messages: [{ role: "user", content: "hello" }] })
+      const response = await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      })
+
+      expect(response.status).toBe(200)
+      expect(refreshRequests).toBe(1)
+      expect(updates).toEqual([
+        {
+          path: { id: "anthropic" },
+          body: {
+            type: "oauth",
+            refresh: "refresh-new",
+            access: "access-new",
+            expires: now + 3600 * 1000,
+            accountId: "account-test",
+          },
+        },
+      ])
+      expect(apiRequests).toEqual([
+        {
+          authorization: "Bearer access-rejected",
+          clientRequestID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          sessionID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          body: expect.any(String),
+        },
+        {
+          authorization: "Bearer access-new",
+          clientRequestID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          sessionID: expect.stringMatching(/^[0-9a-f-]{36}$/),
+          body: expect.any(String),
+        },
+      ])
+      expect(apiRequests[0].body).toBe(apiRequests[1].body)
+      expect(apiRequests[0].sessionID).toBe(apiRequests[1].sessionID)
+      expect(apiRequests[0].clientRequestID).not.toBe(apiRequests[1].clientRequestID)
+    })
+  }
+
+  test("does not refresh an unrelated 403 response", async () => {
+    let requests = 0
+    const httpFetch = Object.assign(
+      async () => {
+        requests += 1
+        return new Response('{"error":{"message":"permission denied"}}', { status: 403 })
+      },
+      { preconnect() {} },
+    )
+    const hooks = await ClaudeAuthPlugin(pluginInput(), {
+      httpFetch,
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh-token",
+          access: "access-token",
+          expires: Date.now() + 60 * 60 * 1000,
+          accountId: "account-test",
+        }) as never,
+      {} as never,
+    )
+
+    const response = await loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      body: "{}",
+    })
+
+    expect(response.status).toBe(403)
+    expect(requests).toBe(1)
+  })
+
+  test("refreshes five minutes early, keeps an unrotated refresh token, and deduplicates requests", async () => {
+    const now = 1_800_000_000_000
+    let auth = {
+      type: "oauth" as const,
+      refresh: "refresh-old",
+      access: "access-expiring",
+      expires: now + 4 * 60 * 1000,
+      accountId: "account-test",
+    }
+    const updates: AuthUpdate[] = []
+    const apiAuthorizations: Array<string | null> = []
+    let refreshRequests = 0
+    let releaseRefresh: () => void
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve
+    })
+    let signalRefresh: () => void
+    const refreshStarted = new Promise<void>((resolve) => {
+      signalRefresh = resolve
+    })
+
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname === "/v1/oauth/token") {
+          refreshRequests += 1
+          signalRefresh!()
+          expect(await request.json()).toEqual({
+            grant_type: "refresh_token",
+            refresh_token: "refresh-old",
+            client_id: CLIENT_ID,
+            scope: REFRESH_SCOPES.join(" "),
+          })
+          await refreshGate
+          return Response.json({
+            access_token: "access-new",
+            expires_in: 3600,
+          })
+        }
+
+        apiAuthorizations.push(request.headers.get("authorization"))
+        return new Response("{}", { status: 200 })
+      },
+    })
+
+    const hooks = await ClaudeAuthPlugin(
+      pluginInput(async (update) => {
+        updates.push(update)
+        auth = {
+          type: "oauth",
+          refresh: update.body.refresh,
+          access: update.body.access,
+          expires: update.body.expires,
+          accountId: update.body.accountId ?? "account-test",
+        }
+      }),
+      {
+        tokenEndpoint: new URL("/v1/oauth/token", server.url).toString(),
+        apiEndpoint: new URL("/v1/messages", server.url).toString(),
+        now: () => now,
+      },
+    )
+    const loaded = await hooks.auth!.loader!(async () => auth as never, {} as never)
+    const first = loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      body: "{}",
+    })
+    const second = loaded.fetch!("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      body: "{}",
+    })
+
+    await refreshStarted
+    expect(refreshRequests).toBe(1)
+    expect(apiAuthorizations).toHaveLength(0)
+    releaseRefresh!()
+    await Promise.all([first, second])
+
+    expect(refreshRequests).toBe(1)
+    expect(updates).toEqual([
+      {
+        path: { id: "anthropic" },
+        body: {
+          type: "oauth",
+          refresh: "refresh-old",
+          access: "access-new",
+          expires: now + 3600 * 1000,
+          accountId: "account-test",
+        },
+      },
+    ])
+    expect(apiAuthorizations).toEqual(["Bearer access-new", "Bearer access-new"])
+  })
+})

--- a/packages/opencode/test/session/prompt-title.test.ts
+++ b/packages/opencode/test/session/prompt-title.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { cleanGeneratedTitle } from "../../src/session/prompt"
+
+describe("session.prompt title", () => {
+  test("unwraps Claude Code structured title responses", () => {
+    expect(cleanGeneratedTitle('{"title":"Subscription usage implementation"}')).toBe(
+      "Subscription usage implementation",
+    )
+  })
+
+  test("preserves plain-text title responses", () => {
+    expect(cleanGeneratedTitle("<think>hidden</think>\nPlain title\nIgnored line")).toBe("Plain title")
+  })
+})


### PR DESCRIPTION
## Summary

Add Anthropic Claude subscription authentication through an integrated OAuth flow and adapt Claude API requests for subscription-backed usage.

## Changes

- Add PKCE-based Claude OAuth authorization, callback handling, token exchange, refresh, and profile lookup.
- Persist Claude account and device identifiers with safe concurrent access.
- Expose supported subscription models with zero usage cost and Claude-compatible request metadata.
- Transform Anthropic message requests for subscription authentication, session tracking, billing headers, beta features, and utility-model routing.
- Register the Anthropic authentication plugin.
- Clean generated session titles before use.
- Add coverage for OAuth, token refresh, request transformation, model filtering, device identity, and title cleanup.