### PR TITLE
refactor(core): isolate AI SDK native mappings

### DIFF
--- a/packages/ai/src/provider-package.ts
+++ b/packages/ai/src/provider-package.ts
@@ -1,6 +1,7 @@
 import type { Model, ProviderOptions } from "./schema"
 
 export interface Settings extends Readonly<Record<string, unknown>> {
+  readonly baseURL?: string
   readonly headers?: Readonly<Record<string, string>>
   readonly body?: Readonly<Record<string, unknown>>
   readonly limits?: {

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -6,13 +6,14 @@ export interface Mapping {
 }
 
 export function map(packageName: string | undefined, settings: Readonly<Record<string, unknown>>): Mapping | undefined {
-  const sharedSettings = mapSharedSettings(settings)
+  const baseSettings = mapBaseSettings(settings)
   switch (packageName) {
     case "@ai-sdk/google":
       return {
         package: "@opencode-ai/ai/providers/google",
         settings: {
-          ...sharedSettings,
+          ...baseSettings,
+          ...mapAPIKey(settings),
           ...mapProviderOptions("gemini", settings),
         },
       }
@@ -20,7 +21,8 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/openrouter",
         settings: {
-          ...sharedSettings,
+          ...baseSettings,
+          ...mapAPIKey(settings),
           ...mapProviderOptions("openrouter", settings),
         },
       }
@@ -28,18 +30,22 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/xai",
         settings: {
-          ...sharedSettings,
+          ...baseSettings,
+          ...mapAPIKey(settings),
           ...mapProviderOptions("xai", settings),
         },
       }
   }
 }
 
-function mapSharedSettings(settings: Readonly<Record<string, unknown>>) {
+function mapBaseSettings(settings: Readonly<Record<string, unknown>>) {
   return {
-    ...(typeof settings.apiKey === "string" ? { apiKey: settings.apiKey } : {}),
     ...(typeof settings.baseURL === "string" ? { baseURL: settings.baseURL } : {}),
   }
+}
+
+function mapAPIKey(settings: Readonly<Record<string, unknown>>) {
+  return typeof settings.apiKey === "string" ? { apiKey: settings.apiKey } : {}
 }
 
 function mapProviderOptions(namespace: string, settings: Readonly<Record<string, unknown>>) {

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -1,0 +1,45 @@
+export * as AISDKNative from "./aisdk-native"
+
+export interface Mapping {
+  readonly package: string
+  readonly settings: Readonly<Record<string, unknown>>
+}
+
+export function map(packageName: string | undefined, settings: Readonly<Record<string, unknown>>): Mapping | undefined {
+  switch (packageName) {
+    case "@ai-sdk/google":
+      return {
+        package: "@opencode-ai/ai/providers/google",
+        settings: {
+          ...settings,
+          ...mapProviderOptions("gemini", settings),
+        },
+      }
+    case "@openrouter/ai-sdk-provider":
+      return {
+        package: "@opencode-ai/ai/providers/openrouter",
+        settings: {
+          ...settings,
+          ...mapProviderOptions("openrouter", settings),
+        },
+      }
+    case "@ai-sdk/xai":
+      return {
+        package: "@opencode-ai/ai/providers/xai",
+        settings: {
+          ...settings,
+          ...mapProviderOptions("xai", settings),
+        },
+      }
+  }
+}
+
+function mapProviderOptions(namespace: string, settings: Readonly<Record<string, unknown>>) {
+  const values = Object.fromEntries(
+    Object.entries(settings).filter(
+      ([key]) => !["apiKey", "authToken", "baseURL", "chunkTimeout", "fetch", "timeout"].includes(key),
+    ),
+  )
+  if (Object.keys(values).length === 0) return {}
+  return { providerOptions: { [namespace]: values } }
+}

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -6,12 +6,13 @@ export interface Mapping {
 }
 
 export function map(packageName: string | undefined, settings: Readonly<Record<string, unknown>>): Mapping | undefined {
+  const sharedSettings = mapSharedSettings(settings)
   switch (packageName) {
     case "@ai-sdk/google":
       return {
         package: "@opencode-ai/ai/providers/google",
         settings: {
-          ...mapProviderSettings(settings),
+          ...sharedSettings,
           ...mapProviderOptions("gemini", settings),
         },
       }
@@ -19,7 +20,7 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/openrouter",
         settings: {
-          ...mapProviderSettings(settings),
+          ...sharedSettings,
           ...mapProviderOptions("openrouter", settings),
         },
       }
@@ -27,14 +28,14 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/xai",
         settings: {
-          ...mapProviderSettings(settings),
+          ...sharedSettings,
           ...mapProviderOptions("xai", settings),
         },
       }
   }
 }
 
-function mapProviderSettings(settings: Readonly<Record<string, unknown>>) {
+function mapSharedSettings(settings: Readonly<Record<string, unknown>>) {
   return {
     ...(typeof settings.apiKey === "string" ? { apiKey: settings.apiKey } : {}),
     ...(typeof settings.baseURL === "string" ? { baseURL: settings.baseURL } : {}),

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -11,7 +11,7 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/google",
         settings: {
-          ...settings,
+          ...mapProviderSettings(settings),
           ...mapProviderOptions("gemini", settings),
         },
       }
@@ -19,7 +19,7 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/openrouter",
         settings: {
-          ...settings,
+          ...mapProviderSettings(settings),
           ...mapProviderOptions("openrouter", settings),
         },
       }
@@ -27,10 +27,17 @@ export function map(packageName: string | undefined, settings: Readonly<Record<s
       return {
         package: "@opencode-ai/ai/providers/xai",
         settings: {
-          ...settings,
+          ...mapProviderSettings(settings),
           ...mapProviderOptions("xai", settings),
         },
       }
+  }
+}
+
+function mapProviderSettings(settings: Readonly<Record<string, unknown>>) {
+  return {
+    ...(typeof settings.apiKey === "string" ? { apiKey: settings.apiKey } : {}),
+    ...(typeof settings.baseURL === "string" ? { baseURL: settings.baseURL } : {}),
   }
 }
 

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -12,6 +12,7 @@ import { Auth, type AnyRoute } from "@opencode-ai/ai/route"
 import { Context, Effect, Layer, Schema } from "effect"
 import { produce } from "immer"
 import { AISDK } from "./aisdk"
+import { AISDKNative } from "./aisdk-native"
 import { Catalog } from "./catalog"
 import { Credential } from "./credential"
 import { Integration } from "./integration"
@@ -182,8 +183,10 @@ export const fromCatalogModel = (
         .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
     )
   }
-  const native = Provider.isAISDK(resolved.package) ? nativePackage(packageName) : resolved.package
-  if (Provider.isAISDK(resolved.package) && !native) {
+  const configured = { ...resolved.settings, ...credential?.metadata }
+  const mapping = Provider.isAISDK(resolved.package) ? AISDKNative.map(packageName, configured) : undefined
+  const native = mapping?.package ?? resolved.package
+  if (Provider.isAISDK(resolved.package) && !mapping) {
     if (!dependencies?.loadAISDK) return Effect.fail(unsupported(resolved))
     const runtime = produce(resolved, (draft) => {
       draft.settings = Provider.mergeOverlay(draft.settings, {
@@ -201,15 +204,13 @@ export const fromCatalogModel = (
     const module = yield* (dependencies?.loadPackage ?? Provider.loadPackage)(specifier).pipe(
       Effect.mapError(() => unsupported(resolved)),
     )
-    const configured = { ...resolved.settings, ...credential?.metadata }
-    const providerOptions = nativeProviderOptions(packageName, configured)
+    const mapped = mapping?.settings ?? configured
     const settings = {
-      ...(credential ? withoutNativeAuthSettings(configured) : configured),
+      ...(credential ? withoutNativeAuthSettings(mapped) : mapped),
       ...nativeCredentialSettings(specifier, credential),
       headers: resolved.headers,
       body: resolved.body,
       limits: { context: resolved.limit.context, output: resolved.limit.output },
-      ...(providerOptions ? { providerOptions } : {}),
     }
     return yield* Effect.try({
       try: () => {
@@ -224,26 +225,6 @@ export const fromCatalogModel = (
       catch: () => unsupported(resolved),
     })
   })
-}
-
-const nativePackage = (packageName: string | undefined) => {
-  if (packageName === "@ai-sdk/google") return "@opencode-ai/ai/providers/google"
-  if (packageName === "@openrouter/ai-sdk-provider") return "@opencode-ai/ai/providers/openrouter"
-  if (packageName === "@ai-sdk/xai") return "@opencode-ai/ai/providers/xai"
-  return undefined
-}
-
-const nativeProviderOptions = (packageName: string | undefined, settings: Readonly<Record<string, unknown>>) => {
-  const values = Object.fromEntries(
-    Object.entries(settings).filter(
-      ([key]) => !["apiKey", "authToken", "baseURL", "chunkTimeout", "fetch", "timeout"].includes(key),
-    ),
-  )
-  if (Object.keys(values).length === 0) return undefined
-  if (packageName === "@ai-sdk/google") return { gemini: values }
-  if (packageName === "@openrouter/ai-sdk-provider") return { openrouter: values }
-  if (packageName === "@ai-sdk/xai") return { xai: values }
-  return undefined
 }
 
 const isNativeOpenAI = (packageName: string | undefined) =>


### PR DESCRIPTION
## Summary
- move AI SDK-to-native package mapping into a dedicated module
- make each supported package an explicit switch branch
- return the mapped native package and settings as one conversion result
- preserve the current option projection behavior as a starting point for provider-specific mappings

## Testing
- `bun typecheck` in `packages/core`
- `bun test test/model-resolver.test.ts test/generate.test.ts` in `packages/core` (28 pass)