### PR TITLE
fix(app): prevent stale session tab reads

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -289,9 +289,9 @@ export function SessionHeader() {
 
   return (
     <>
-      <Show when={search() && centerMount()}>
+      <Show when={search() && centerMount()} keyed>
         {(mount) => (
-          <Portal mount={mount()}>
+          <Portal mount={mount}>
             <Button
               type="button"
               variant="ghost"
@@ -308,10 +308,10 @@ export function SessionHeader() {
                 </span>
               </div>
 
-              <Show when={hotkey()}>
+              <Show when={hotkey()} keyed>
                 {(keybind) => (
                   <Keybind class="shrink-0 !border-0 !bg-transparent !shadow-none px-0 text-text-weaker">
-                    {keybind()}
+                    {keybind}
                   </Keybind>
                 )}
               </Show>
@@ -319,9 +319,9 @@ export function SessionHeader() {
           </Portal>
         )}
       </Show>
-      <Show when={rightMount()}>
+      <Show when={rightMount()} keyed>
         {(mount) => (
-          <Portal mount={mount()}>
+          <Portal mount={mount}>
             <Show
               when={isV2}
               fallback={

--- a/packages/app/src/components/titlebar-tab-nav.tsx
+++ b/packages/app/src/components/titlebar-tab-nav.tsx
@@ -224,6 +224,7 @@ export function TabNavItem(props: {
         <span data-slot="project-avatar-slot" class="flex size-4 shrink-0 items-center justify-center">
           <Show
             when={props.session()}
+            keyed
             fallback={
               <span class="block size-4 rounded-[3px] border border-v2-border-border-muted" aria-hidden="true" />
             }
@@ -231,8 +232,8 @@ export function TabNavItem(props: {
             {(session) => (
               <SessionTabAvatar
                 project={project()}
-                directory={session().directory}
-                sessionId={session().id}
+                directory={session.directory}
+                sessionId={session.id}
                 server={props.server}
               />
             )}

--- a/packages/app/src/pages/new-session/new-session-view.tsx
+++ b/packages/app/src/pages/new-session/new-session-view.tsx
@@ -78,9 +78,9 @@ export function NewSessionStatus(props: { mount: Accessor<HTMLElement | null>; v
   const language = useLanguage()
 
   return (
-    <Show when={props.mount()}>
+    <Show when={props.mount()} keyed>
       {(mount) => (
-        <Portal mount={mount()}>
+        <Portal mount={mount}>
           <Show when={props.visible()}>
             <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
               <StatusPopoverV2 />


### PR DESCRIPTION
### Issue for this PR

Closes #39766
Closes #39704

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Session and project navigation could update titlebar content while Solid was transitioning away from the previous view. Several callback-form `<Show>` components exposed guarded accessors to titlebar avatars and portals, allowing their children to read those accessors after the conditions were disposed and crash the desktop renderer with `Stale read from <Show>`.

This keys those `<Show>` boundaries and passes their captured values directly to the avatar, portals, and keybind. The titlebar children now receive stable values during teardown instead of reading disposed narrowing accessors.

### How did you verify your code works?

- Reproduced the original crash on desktop 1.18.10 by opening an existing session from another project.
- Confirmed the original session-tab crash no longer occurs.
- Ran `bun typecheck` in `packages/app`.
- Ran `bun test --conditions=browser --preload ./happydom.ts ./test-browser/solid-router-cleanup.test.ts` in `packages/app`.
- The repository commit-hook typecheck completed successfully across 30 packages.
- Ran `git diff --check`.

### Screenshots / recordings

Not applicable; this fixes renderer crashes without changing the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR