### PR TITLE
fix(tui): name deleted session in toast

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -525,8 +525,11 @@ function App(props: { pair?: DialogPairCredentials }) {
     renderer.useMouse = config.data.mouse
   })
 
+  let active: { id: string; title: string } | undefined
   // Update terminal window title based on current route and session
   createEffect(() => {
+    const session = route.data.type === "session" ? data.session.get(route.data.sessionID) : undefined
+    if (session) active = { id: session.id, title: session.title }
     if (!terminalTitleEnabled()) return
 
     if (route.data.type === "home") {
@@ -535,7 +538,6 @@ function App(props: { pair?: DialogPairCredentials }) {
     }
 
     if (route.data.type === "session") {
-      const session = data.session.get(route.data.sessionID)
       if (!session || isDefaultTitle(session.title)) {
         renderer.setTerminalTitle("OpenCode")
         return
@@ -1160,10 +1162,11 @@ function App(props: { pair?: DialogPairCredentials }) {
 
   event.on("session.deleted", (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.data.sessionID) {
+      const title = active?.id === evt.data.sessionID ? active.title : undefined
       route.navigate({ type: "home" })
       toast.show({
         variant: "info",
-        message: "The current session was deleted",
+        message: title ? `Session "${title}" was deleted` : "The current session was deleted",
       })
     }
   })


### PR DESCRIPTION
## What

Name the deleted session in the TUI toast introduced by #39750.

**Before:** `The current session was deleted`

**After:** `Session "OpenCode Drive" was deleted`

## How

Retain the last loaded active session ID and title before the deletion event removes it from the data store. The existing `session.deleted` handler uses that retained title, with the generic text as a fallback if the session was never loaded.

The cache updates independently of terminal-title preferences, so disabling terminal window titles does not affect the toast.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (573 passed, 5 skipped)
- Push hook: workspace typecheck across 33 packages
- OpenCode Drive `v1.4.1` with required protocol negotiation: deleted the active simulated session, asserted `Session "OpenCode Drive" was deleted`, and verified zero sessions remained

## Demo

https://github.com/user-attachments/assets/c210e2d8-db93-4687-a5b7-862cef58d07e

![Named deleted-session toast](https://github.com/user-attachments/assets/c6b6aea4-a83e-4071-9491-58e98ca7fec9)
