### PR TITLE
fix(app): prevent file tree tab clipping

### DIFF
--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -59,6 +59,7 @@ import { SessionFileBrowserTab, type SessionFileBrowserState } from "@/pages/ses
 
 type ReviewDiff = FileDiffInfo | SnapshotFileDiff | VcsFileDiff
 type RenderDiff = FileDiffInfo | (SnapshotFileDiff & { file: string }) | VcsFileDiff
+const FILE_TREE_WIDTH_MIN = 240
 
 function renderDiff(value: ReviewDiff): value is RenderDiff {
   return typeof value.file === "string"
@@ -104,13 +105,14 @@ export function SessionSidePanel(props: {
       }),
   )
   const open = createMemo(() => reviewOpen() || fileOpen())
+  const fileTreeWidth = createMemo(() => Math.max(FILE_TREE_WIDTH_MIN, layout.fileTree.width()))
   const reviewTab = createMemo(() => isDesktop())
   const panelWidth = createMemo(() => {
     if (!open()) return "0px"
     if (reviewOpen()) return "auto"
-    return `${layout.fileTree.width()}px`
+    return `${fileTreeWidth()}px`
   })
-  const treeWidth = createMemo(() => (fileOpen() ? `${layout.fileTree.width()}px` : "0px"))
+  const treeWidth = createMemo(() => (fileOpen() ? `${fileTreeWidth()}px` : "0px"))
 
   const diffs = createMemo(() => props.diffs().filter(renderDiff))
   const diffFiles = createMemo(() => diffs().map((d) => d.file))
@@ -845,8 +847,8 @@ export function SessionSidePanel(props: {
                     <ResizeHandle
                       direction="horizontal"
                       edge="start"
-                      size={layout.fileTree.width()}
-                      min={200}
+                      size={fileTreeWidth()}
+                      min={FILE_TREE_WIDTH_MIN}
                       max={480}
                       onResize={(width) => {
                         props.size.touch()


### PR DESCRIPTION
### Issue for this PR

Closes #39765

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop file tree could be resized narrow enough to clip the Files Changed tab. This raises its minimum width to 240px and applies the same minimum when rendering persisted widths, so panels previously saved below the limit also recover correctly.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/app`
- Ran the repository typecheck commit hook
- Ran `git diff --check`
- Verified the file tree tabs remain visible at the minimum width

### Screenshots / recordings

**BEFORE**

https://github.com/user-attachments/assets/392ecc42-2ab7-48a9-be0f-d0b4a5e879e4

**AFTER**

https://github.com/user-attachments/assets/744861d9-bbe1-4448-be95-7e1ed293658d

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR