### PR TITLE
fix(tui): preserve current selection across list updates

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -240,7 +240,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     on(
       () => props.options,
       () => {
-        if (!props.preserveSelection) {
+        if (!props.preserveSelection && props.current === undefined) {
           const count = flat().length
           if (count === 0) return
           const next = reconcileSelection(store.selected, count)
@@ -276,7 +276,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           setStore("selected", index)
           selection = option
           if (!moved) return
-          if (!props.preserveSelection || store.filter.length > 0) return
+          if ((!props.preserveSelection && props.current === undefined) || store.filter.length > 0) return
           scrollAfterLayout(false, option.value)
           return
         }

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -79,7 +79,7 @@ async function renderSelect(
   return app
 }
 
-async function mountSelect(root: string, initial: DialogSelectOption<string>[]) {
+async function mountSelect(root: string, initial: DialogSelectOption<string>[], current?: string) {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
   const config = createTuiResolvedConfig()
@@ -114,6 +114,7 @@ async function mountSelect(root: string, initial: DialogSelectOption<string>[]) 
           <DialogSelect
             title="Mutable options"
             options={options()}
+            current={current}
             onMove={(option) => moved.push(option.value)}
             onSelect={(option) => selected.push(option.value)}
           />
@@ -305,6 +306,23 @@ test("keeps the cursor index while options are temporarily empty", async () => {
     await select.app.waitFor(() => select.selected.length === 1)
 
     expect(select.selected).toEqual(["third"])
+  } finally {
+    select.app.renderer.destroy()
+  }
+})
+
+test("keeps the current option selected when options reorder", async () => {
+  await using tmp = await tmpdir()
+  const options = ["first", "current", "third"].map((value) => ({ title: value, value }))
+  const select = await mountSelect(tmp.path, options, "current")
+
+  try {
+    select.replaceOptions([options[1], options[2], options[0]])
+    await select.app.waitForFrame((frame) => frame.indexOf("current") < frame.indexOf("third"))
+    select.app.mockInput.pressEnter()
+    await select.app.waitFor(() => select.selected.length === 1)
+
+    expect(select.selected).toEqual(["current"])
   } finally {
     select.app.renderer.destroy()
   }


### PR DESCRIPTION
## What

Keep a dialog's blue selection attached to its current item when asynchronously loaded options are inserted or reordered.

This fixes the session picker showing the current-session dot on one row while Enter would select a different blue-highlighted row.

## Before / After

**Before:** The session picker rendered cached sessions and selected the current session by numeric index. When the server response replaced that list with more sessions or a different order, the index stayed fixed and silently pointed at another session. The dot still followed the current session ID, so the dot and blue selection diverged.

**After:** A dialog with a `current` value reconciles selection by option value across list updates. Reordering the options moves the selected index with the same session, keeping the current marker, blue highlight, and Enter behavior aligned.

## How

- `packages/tui/src/ui/dialog-select.tsx` treats `current` selections as value-preserving during option reconciliation and post-layout scrolling.
- `packages/tui/test/cli/tui/dialog-select.test.tsx` replaces `[first, current, third]` with `[current, third, first]` and verifies Enter still submits `current`.

## Scope

Dialogs without a `current` item retain their existing index-based reconciliation behavior. Filtering and explicit `preserveSelection` behavior are unchanged.

## Testing

- `bun run typecheck` from `packages/tui`
- `bun run test` from `packages/tui`: 574 passed, 5 skipped
- Full repository typecheck passed during push
- OpenCode Drive simulated seven sessions against the latest V2 source checkout, switched from Golf to Charlie, and reopened the picker with the dot and blue selection aligned

## Demo

Simulated sessions driven through the real V2 TUI in a PTY using the Drive startup fix in anomalyco/opencode-drive#50. The blue selection first moves independently while Golf remains current; after switching to Charlie and reopening, the dot and selection are aligned on Charlie.

https://github.com/user-attachments/assets/93eefbcf-634d-4436-9eab-f83ecc445c61

## Flow

```mermaid
sequenceDiagram
  participant User
  participant SessionPicker
  participant DialogSelect
  participant Server
  User->>SessionPicker: open session list
  SessionPicker->>DialogSelect: current session ID + cached options
  Server-->>SessionPicker: refreshed options
  SessionPicker->>DialogSelect: replace/reorder options
  DialogSelect->>DialogSelect: find selected session by value
  DialogSelect-->>User: dot, highlight, and Enter target stay aligned
```
