### PR TITLE
fix(tui): clarify open menu project labels

### DIFF
--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -76,7 +76,7 @@ export function DialogOpen() {
           .slice(0, RECENT_LIMIT)
     const sessionOptions = recent.map((session) => {
       const project = data.project.get(session.projectID)
-      const name = project?.name || path.basename(project?.canonical ?? "") || path.basename(session.location.directory)
+      const name = project?.canonical === "/" ? undefined : project?.name || path.basename(project?.canonical ?? "")
       const running = data.session.family(session.id).some((id) => data.session.status(id) === "running")
       return {
         title: session.title,
@@ -101,17 +101,14 @@ export function DialogOpen() {
         return true
       })
       .map((project) => {
-        const title = abbreviateHome(project.canonical, paths.home)
-        const footer =
-          project.name && project.name !== path.basename(project.canonical)
-            ? Locale.truncate(project.name, 20)
-            : undefined
-        // Dialog padding, the gutter column, title padding, the gap, and the footer use this space.
-        const width = Math.min(60, dimensions().width - 2) - 9 - (footer ? stringWidth(footer) + 1 : 0)
+        const title = project.name ?? path.basename(project.canonical)
+        const footer = abbreviateHome(project.canonical, paths.home)
+        // Dialog padding, the gutter column, title padding, and the separating space use nine columns.
+        const width = Math.min(60, dimensions().width - 2) - 9 - stringWidth(title)
         return {
-          title: truncateFilePath(title, width),
-          footer,
-          searchText: [title, project.name].filter(Boolean).join(" "),
+          title,
+          footer: truncateFilePath(footer, width),
+          searchText: footer,
           value: { type: "project", directory: project.canonical } as OpenTarget,
           category: "Projects",
         }

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -76,13 +76,13 @@ export function DialogOpen() {
           .slice(0, RECENT_LIMIT)
     const sessionOptions = recent.map((session) => {
       const project = data.project.get(session.projectID)
-      const name = project?.name || path.basename(project?.canonical ?? session.location.directory)
+      const name = project?.name || path.basename(project?.canonical ?? "") || path.basename(session.location.directory)
       const running = data.session.family(session.id).some((id) => data.session.status(id) === "running")
       return {
         title: session.title,
         value: { type: "session", sessionID: session.id } as OpenTarget,
         category: "Sessions",
-        footer: `${Locale.truncate(name, 20)} · ${timeAgo(session.time.updated)}`,
+        footer: `${name ? `${Locale.truncate(name, 20)} · ` : ""}${timeAgo(session.time.updated)}`,
         gutter: running
           ? () => <Spinner />
           : tabs.has(session.id)
@@ -101,14 +101,17 @@ export function DialogOpen() {
         return true
       })
       .map((project) => {
-        const title = project.name ?? path.basename(project.canonical)
-        const description = abbreviateHome(project.canonical, paths.home)
-        // Dialog padding, the gutter column, title padding, and the separating space use nine columns.
-        const width = Math.min(60, dimensions().width - 2) - 9 - stringWidth(title)
+        const title = abbreviateHome(project.canonical, paths.home)
+        const footer =
+          project.name && project.name !== path.basename(project.canonical)
+            ? Locale.truncate(project.name, 20)
+            : undefined
+        // Dialog padding, the gutter column, title padding, the gap, and the footer use this space.
+        const width = Math.min(60, dimensions().width - 2) - 9 - (footer ? stringWidth(footer) + 1 : 0)
         return {
-          title,
-          description: truncateFilePath(description, width),
-          searchText: description,
+          title: truncateFilePath(title, width),
+          footer,
+          searchText: [title, project.name].filter(Boolean).join(" "),
           value: { type: "project", directory: project.canonical } as OpenTarget,
           category: "Projects",
         }


### PR DESCRIPTION
## What

Make project identity clearer in the TUI's Open dialog:

- keep concise project names as the primary, left-hand label
- align each project's subdued path on the right
- show only the age for sessions without a project instead of an orphan separator

## Before / After

**Before:** Sessions outside a VCS project resolve through the global project, whose canonical path is `/`. Taking its basename produced an empty project label, but the footer still rendered ` · 7m`. Project paths also appeared immediately after their names instead of forming a consistent right-hand metadata column.

**After:** Sessions without a project show only their age. Sessions with projects retain `project · age`. Project options keep their concise names on the left and align their abbreviated paths on the right.

## How

- Update `packages/tui/src/component/dialog-open.tsx` to treat the global `/` project as having no display name.
- Build the session footer conditionally so an empty label cannot leave punctuation behind.
- Render each project's existing name as its title and its abbreviated, path-aware-truncated path as the right-hand footer.
- Preserve the full path as supplemental search text.

## Scope

This only changes labels in the combined Open dialog. It does not change project identity, persistence, ordering, or the dedicated session list.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (574 passed, 5 skipped)
- `bunx prettier --check packages/tui/src/component/dialog-open.tsx`
- `bunx oxlint packages/tui/src/component/dialog-open.tsx`
- pre-push full-workspace typecheck (33 tasks passed)
- OpenCode Drive v1.4.1 against this checkout, with three Git projects and one global-project session; opened the dialog with `ctrl+o` and captured the rendered result

## Demo

The selected `Review scratch notes` session has no project and therefore shows only `now`. The rows below retain project names on the left, with paths aligned on the right.

![Open dialog showing project names on the left, paths on the right, and no orphan separator for a session without a project](https://github.com/user-attachments/assets/b04cd332-824f-4029-a3d5-4c3b8984c5f7)
