### PR TITLE
fix(tui): default tabs to global scope

### DIFF
--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -105,7 +105,7 @@ export const settings: Setting[] = [
     title: "Scope",
     category: "Tabs",
     path: ["tabs", "scope"],
-    default: "cwd",
+    default: "global",
     values: ["cwd", "global"],
     labels: ["current directory", "global"],
   },

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -66,12 +66,12 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     let closedTabs: ClosedSessionTab[] = []
 
     function state() {
-      if (config.tabs?.scope === "global") return store.global
-      return store.cwd[paths.cwd] ?? fallback
+      if (config.tabs?.scope === "cwd") return store.cwd[paths.cwd] ?? fallback
+      return store.global
     }
 
     function update(mutation: (draft: TabsState) => void) {
-      const scope = config.tabs?.scope ?? "cwd"
+      const scope = config.tabs?.scope ?? "global"
       void updateStore((draft) => mutation(scope === "cwd" ? (draft.cwd[paths.cwd] ??= empty()) : draft.global)).catch(
         () => {},
       )

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -64,6 +64,7 @@ async function renderSessionTabs(initialSessionID: string) {
   return {
     tabs,
     route,
+    state,
     emit: (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } }),
     destroy() {
       app.renderer.destroy()
@@ -71,6 +72,21 @@ async function renderSessionTabs(initialSessionID: string) {
     },
   }
 }
+
+test("stores session tabs globally by default", async () => {
+  const setup = await renderSessionTabs("first")
+
+  try {
+    const file = path.join(setup.state, "test", "tui", "tabs.json")
+    await wait(() => Bun.file(file).size > 0)
+    expect(await Bun.file(file).json()).toEqual({
+      global: { tabs: [{ sessionID: "first" }], unread: {} },
+      cwd: {},
+    })
+  } finally {
+    setup.destroy()
+  }
+})
 
 test("user prompt admissions pulse an already-busy background tab", async () => {
   const setup = await renderSessionTabs("background")
@@ -106,9 +122,7 @@ test("user prompt admissions pulse an already-busy background tab", async () => 
     expect(setup.tabs.status("background").promptPulse).toBe(0)
 
     setup.emit(admitted("background", "msg_1"))
-    await wait(
-      () => setup.tabs.status("background").promptPulse === 1 && setup.tabs.status("background").busy,
-    )
+    await wait(() => setup.tabs.status("background").promptPulse === 1 && setup.tabs.status("background").busy)
 
     setup.emit(admitted("background", "msg_2"))
     await wait(() => setup.tabs.status("background").promptPulse === 2)
@@ -144,9 +158,7 @@ test("tracks a temporary new session tab across close and creation", async () =>
     await wait(() => setup.tabs.newTab())
     setup.route.navigate({ type: "session", sessionID: "third" })
     expect(setup.tabs.newTab()).toBe(true)
-    await wait(
-      () => setup.tabs.current() === "third" && setup.tabs.tabs().some((tab) => tab.sessionID === "third"),
-    )
+    await wait(() => setup.tabs.current() === "third" && setup.tabs.tabs().some((tab) => tab.sessionID === "third"))
 
     expect(setup.tabs.newTab()).toBe(false)
     expect(setup.tabs.tabs().find((tab) => tab.sessionID === "third")?.title).toBe(NEW_SESSION_TAB_TITLE)


### PR DESCRIPTION
**What**

Session tabs now use one global tab set by default. Users can still choose `current directory` in TUI settings when they want separate tab sets per working directory.

**Before / After**

**Before:** With tabs enabled and no explicit scope, each working directory had an independent tab set, and the settings dialog identified `current directory` as the default.

**After:** With no explicit scope, all working directories share the global tab set. An explicit `tabs.scope: "cwd"` continues to select per-directory storage, and the settings dialog identifies `global` as the default.

**How**

- Updates the runtime fallback in `packages/tui/src/context/session-tabs.tsx` to select global storage unless `cwd` is explicit.
- Updates the Tabs > Scope setting metadata in `packages/tui/src/component/dialog-config.tsx`.
- Adds a persistence regression test proving an unspecified scope writes the opened session into the global bucket.

**Scope**

This PR changes only the tab-strip scope default. The session picker default will follow in a separate PR.

**Testing**

- `bun run test test/context/session-tabs.test.tsx`
- `bun typecheck` from `packages/tui`
- Full workspace typecheck run by the pre-push hook
- `bunx prettier --check src/context/session-tabs.tsx src/component/dialog-config.tsx test/context/session-tabs.test.tsx`