### PR TITLE
fix(tui): align session picker scope

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -19,6 +19,7 @@ import { errorMessage } from "../util/error"
 import { useSessionTabs } from "../context/session-tabs"
 import { useStorage } from "../context/storage"
 import { sessionTitle } from "../util/session"
+import { useConfig } from "../config"
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -30,12 +31,15 @@ export function DialogSessionList() {
   const client = useClient()
   const local = useLocal()
   const sessionTabs = useSessionTabs()
+  const config = useConfig().data
   const toast = useToast()
   const [filter, setFilter] = createSignal("")
   const shortcuts = Keymap.useShortcuts()
   const [search, setSearch] = createDebouncedSignal("", 150)
   const [toDelete, setToDelete] = createSignal<string>()
-  const [prefs, updatePrefs] = useStorage().store("session-list", { initial: { allProjects: false } })
+  const [prefs, updatePrefs] = useStorage().store("session-list", {
+    initial: { allProjects: config.tabs?.scope !== "cwd" },
+  })
   const allProjects = () => prefs.allProjects
 
   const [searchResults, { mutate: setSearchResults }] = createResource(
@@ -236,7 +240,9 @@ export function DialogSessionList() {
               .remove({ sessionID: option.value })
               .then(() => {
                 setSearchResults((result) =>
-                  result ? { ...result, sessions: result.sessions.filter((session) => session.id !== option.value) } : result,
+                  result
+                    ? { ...result, sessions: result.sessions.filter((session) => session.id !== option.value) }
+                    : result,
                 )
               })
               .catch((error) => {


### PR DESCRIPTION
**What**

The session picker now derives its initial project scope from the Tabs > Scope setting. Global tabs start the picker in `all projects`; per-directory tabs start it in `current directory`.

A picker scope changed with `ctrl+a` remains persisted and continues to override the initial default on later opens.

**Before / After**

**Before:** A user with global tabs opened the session picker in current-directory mode until they manually toggled `ctrl+a`.

**After:** A fresh picker preference follows the configured tab scope, while an explicit picker toggle remains remembered.

**How**

`packages/tui/src/component/dialog-session-list.tsx` reads the resolved TUI config and seeds `session-list.allProjects` from whether `tabs.scope` is global.

**Scope**

This is stacked on #39783, which changes the tab-scope default itself. This PR only aligns the session picker’s initial scope; it does not remove the picker’s independent persisted override.

**Testing**

- `bun typecheck` from `packages/tui`
- Full workspace typecheck run by the pre-push hook
- `bunx prettier --check src/component/dialog-session-list.tsx`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #39783
2. **#39784** 👈 current
<!-- stack:links:end -->