### PR TITLE
fix(app): register new workspace and open project shortcuts in the new layout

### DIFF
--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -2,19 +2,61 @@ import { createEffect, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { DebugBar } from "@/components/debug-bar"
+import { useDirectoryPicker } from "@/components/directory-picker"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { useCommand } from "@/context/command"
+import { useGlobal } from "@/context/global"
+import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
+import { ServerConnection, useServer } from "@/context/server"
+import { useTabs } from "@/context/tabs"
+import { homeProjectDirectories } from "@/pages/layout/helpers"
 import { setNavigate } from "@/utils/notification-click"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
   const navigate = useNavigate()
+  const command = useCommand()
+  const global = useGlobal()
+  const language = useLanguage()
+  const server = useServer()
+  const tabs = useTabs()
+  const pickDirectory = useDirectoryPicker()
   setNavigate(navigate)
   const [state, setState] = createStore({ debugTools: true })
 
   createEffect(() => setV2Toast(true))
+
+  const chooseProject = () => {
+    const conn = server.current
+    if (!conn) return
+    pickDirectory({
+      server: conn,
+      title: language.t("command.project.open"),
+      multiple: true,
+      onSelect: (result) => {
+        const directories = homeProjectDirectories(result)
+        const directory = directories[0]
+        if (!directory) return
+        const ctx = global.ensureServerCtx(conn)
+        directories.forEach((entry) => ctx.projects.open(entry))
+        ctx.projects.touch(directory)
+        void tabs.newDraft({ server: ServerConnection.key(conn), directory })
+      },
+    })
+  }
+
+  command.register("layout-new", () => [
+    {
+      id: "project.open",
+      title: language.t("command.project.open"),
+      category: language.t("command.category.project"),
+      keybind: "mod+o",
+      onSelect: chooseProject,
+    },
+  ])
 
   const update: TitlebarUpdate = {
     version: () => {

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -26,6 +26,10 @@ export default function NewSessionPage() {
       empty: project.empty,
       open: () => project.setOpen(true),
     },
+    workspace: {
+      enabled: workspace.bar.visible,
+      create: () => workspace.selection.set("create"),
+    },
   })
   createEffect(() => {
     if (!draft.prompt.ready()) return

--- a/packages/app/src/pages/new-session/use-new-session-commands.tsx
+++ b/packages/app/src/pages/new-session/use-new-session-commands.tsx
@@ -9,6 +9,10 @@ export function useNewSessionCommands(input: {
     empty: () => boolean
     open: () => void
   }
+  workspace: {
+    enabled: () => boolean
+    create: () => void
+  }
 }) {
   const command = useCommand()
   const dialog = useDialog()
@@ -39,6 +43,17 @@ export function useNewSessionCommands(input: {
       keybind: "mod+shift+o",
       disabled: input.project.empty(),
       onSelect: input.project.open,
+    },
+    {
+      id: "workspace.new",
+      title: language.t("workspace.new"),
+      category: language.t("command.category.workspace"),
+      keybind: "mod+shift+w",
+      disabled: !input.workspace.enabled(),
+      onSelect: () => {
+        input.workspace.create()
+        input.restoreFocus()
+      },
     },
   ])
 }


### PR DESCRIPTION
### Issue for this PR

Closes #39785

supersedes #37830, which fixed the same two shortcuts but was written against `new-session.tsx` before that page's commands were extracted, so it no longer merges.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

two shortcuts do nothing in the new layout, and their commands are missing from the palette:

- `mod+shift+w` (new workspace) on the new session page
- `mod+o` (open project) anywhere in the new layout

both are registered in one place, `packages/app/src/pages/layout.tsx`, which only mounts inside `LegacyServerLayout`. in `Routes` the draft page is a sibling of that tree rather than a child of it, and new layout session routes go through `TargetSessionRoute`, also outside it:

```
<Route component={LegacyServerLayout}>
  <Route path="/:dir" component={DirectoryLayout}>...</Route>
</Route>
<Route path="/new-session" component={DraftRoute} />
```

so in the new layout that shell never mounts and neither command exists.

`workspace.new` now registers in `use-new-session-commands.tsx`, wired to the workspace controller. selecting it sets the workspace chip to create, the same thing picking new workspace from the chip menu does, then restores focus to the prompt. it is gated on `bar.visible()`, mirroring how the legacy registration is gated on its workspace setting, and a disabled option is dropped from the keymap so the binding stays inert while the bar is hidden. it had been registered here in c9a5556 before the extraction dropped it.

`project.open` now registers in `layout-new.tsx`. that is the shell mounted for the new layout and only for it, so it mirrors where the legacy layout registers its copy and cannot collide with it. the titlebar would have been the other candidate, but it renders in both layouts, which would have produced a duplicate id in the legacy one. the handler opens the picked directories through the server context and opens a draft tab for the first, since the new layout is tab and draft based rather than sidebar based.

worth noting what this was not. the command context suppresses keybinds while a contenteditable has focus, but only when no modifier is held. both shortcuts hold one, so the prompt editor was never swallowing them.

session pages in the new layout still have no `workspace.new`. giving them one means reproducing `createWorkspace` from `layout.tsx` along with its busy state, naming and navigation, which is a bigger change and better kept separate.

### How did you verify your code works?

- traced the route tree and command registry to confirm the draft page and new layout session routes mount outside `LegacyServerLayout`, and that neither command has another registration
- confirmed `layout-new.tsx` mounts only in the new layout, so `project.open` cannot duplicate the legacy registration, and checked the desktop log for duplicate id warnings after the change
- confirmed neither keybind is claimed by an electron menu accelerator or bound by another command
- confirmed every string used already exists in all 17 locales, so no new i18n keys are needed
- typecheck passes in app
- app unit tests match the base, one pre-existing i18n parity failure on unrelated keys, unchanged by this pr
- ran the desktop app and confirmed both shortcuts work and both commands appear in the palette

### Screenshots / recordings

before

after

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
