### PR TITLE
fix(session): stop retrying fixed-window usage quotas

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -119,6 +119,13 @@ export function retryable(error: Err, provider: string) {
         },
       }
     }
+    const quota = `${error.data.message}\n${error.data.responseBody ?? ""}`.toLowerCase()
+    if (
+      status === 429 &&
+      /(?:5[- ]hour|weekly|monthly) usage quota/.test(quota) &&
+      (quota.includes("will reset at") || quota.includes("will reset in"))
+    )
+      return undefined
     return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
   }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -254,6 +254,52 @@ describe("session.retry.retryable", () => {
     expect(retryable).toEqual({ message: "Response decompression failed" })
   })
 
+  test("does not retry fixed-window usage quota errors", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message:
+          "You have exceeded the 5-hour usage quota. It will reset at 2026-07-30 16:11:46 +0800 CST. We recommend upgrading your plan for more quota, or waiting for the reset.",
+        isRetryable: true,
+        statusCode: 429,
+        responseHeaders: { "content-type": "application/json" },
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
+  })
+
+  test("does not retry fixed-window usage quota errors from the response body", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "Too many requests",
+        isRetryable: true,
+        statusCode: 429,
+        responseBody: JSON.stringify({
+          error: {
+            message: "You have exceeded the weekly usage quota. It will reset in 6 days.",
+          },
+        }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
+  })
+
+  test("retries short-window usage quota errors", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "You have exceeded the per-minute usage quota. It will reset in 20 seconds.",
+        isRetryable: true,
+        statusCode: 429,
+        responseHeaders: { "retry-after": "20" },
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "You have exceeded the per-minute usage quota. It will reset in 20 seconds.",
+    })
+  })
+
   test("maps free limits to Go upsell action", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #39790

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops retrying 429 responses for known long-window usage quotas (5-hour, weekly, or monthly) because another request cannot succeed before the reset. The check uses both the provider message and retained response body.

Short-window rate limits continue through the existing retry path. This complements the general retry cap proposed in #38958 by ending known terminal quota responses immediately.

### How did you verify your code works?

- `bun test test/session/retry.test.ts`: 36 passed, 0 failed
- `bun typecheck`: passed in `packages/opencode`
- `bunx prettier --check src/session/retry.ts test/session/retry.test.ts`: passed
- Push hook `bun turbo typecheck`: 30 tasks passed
- Full `bun test` was attempted but did not complete because existing snapshot and permission tests timed out or failed while initializing temporary Git repositories; the focused retry tests remained green

The regression tests cover the observed 5-hour response, quota text retained only in `responseBody`, and a per-minute quota that must remain retryable.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR