### PR TITLE
fix(opencode): spawn configured posix shell directly on Windows

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -291,13 +291,24 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
 })
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
-  if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
-      cwd,
-      env,
-      stdin: "ignore",
-      detached: false,
-    })
+  if (process.platform === "win32") {
+    if (Shell.ps(shell)) {
+      return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+        cwd,
+        env,
+        stdin: "ignore",
+        detached: false,
+      })
+    }
+
+    if (Shell.posix(shell)) {
+      return ChildProcess.make(shell, ["-c", command], {
+        cwd,
+        env,
+        stdin: "ignore",
+        detached: false,
+      })
+    }
   }
 
   return ChildProcess.make(command, [], {


### PR DESCRIPTION
### Issue for this PR

Closes #38799

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, configuring a POSIX shell (e.g. `"shell": "C:/msys64/usr/bin/bash.exe"`) doesn't work for the bash tool. `cmd()` in `packages/opencode/src/tool/shell.ts` spawns non-PowerShell commands via `ChildProcess.make(command, [], { shell })`, and Node's `child_process.spawn` on Windows always passes `cmd.exe`-style `/d /s /c` args to whatever binary is given via the `shell` option. MSYS2/Git Bash expect `-c`, so the invocation breaks.

PowerShell was already special-cased to spawn the binary directly with its own flags; POSIX shells were not. This adds the matching branch: on Windows, when the selected shell is POSIX (`Shell.posix()`, which covers bash/sh/zsh/dash/ksh via the `META` table), the shell binary is spawned directly with `["-c", command]`. PowerShell, cmd.exe, and non-Windows behavior are unchanged.

### How did you verify your code works?

Traced the spawn path on Windows and confirmed Node injects `/d /s /c` for any `{ shell }` binary; verified `Shell.posix()` returns true for MSYS2 bash paths and false for cmd/powershell from the existing `META` table. Relying on CI for the package test suite (first-time contributor, workflows pending approval).

bun typecheck clean. Ran full test/tool/shell.test.ts from MSYS2 shell, 91/91 passed.

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR