### PR TITLE
fix(core): respect model input limits

### DIFF
--- a/packages/ai/src/provider-package.ts
+++ b/packages/ai/src/provider-package.ts
@@ -6,6 +6,7 @@ export interface Settings extends Readonly<Record<string, unknown>> {
   readonly body?: Readonly<Record<string, unknown>>
   readonly limits?: {
     readonly context: number
+    readonly input?: number
     readonly output: number
   }
 }

--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -123,6 +123,7 @@ export const mergeGenerationOptions = (...items: ReadonlyArray<GenerationOptions
 
 export class ModelLimits extends Schema.Class<ModelLimits>("LLM.ModelLimits")({
   context: Schema.optional(Schema.Number),
+  input: Schema.optional(Schema.Number),
   output: Schema.optional(Schema.Number),
 }) {}
 

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -332,7 +332,7 @@ function modelFromLanguage(info: Info, language: LanguageModelV3) {
               body: projected.body === undefined ? undefined : { ...projected.body },
               headers: info.headers,
             },
-      limits: { context: info.limit.context, output: info.limit.output },
+      limits: { context: info.limit.context, input: info.limit.input, output: info.limit.output },
       providerOptions,
     },
     body: {

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -81,7 +81,7 @@ const withDefaults = (model: Info, route: AnyRoute) =>
     headers: providerHeaders(model),
     providerOptions: providerOptions(model),
     http: model.body === undefined ? undefined : { body: model.body },
-    limits: { context: model.limit.context, output: model.limit.output },
+    limits: { context: model.limit.context, input: model.limit.input, output: model.limit.output },
   })
 
 const providerHeaders = (model: Info) => {
@@ -204,7 +204,7 @@ export const fromCatalogModel = (
       ...nativeCredentialSettings(specifier, credential),
       headers: resolved.headers,
       body: resolved.body,
-      limits: { context: resolved.limit.context, output: resolved.limit.output },
+      limits: { context: resolved.limit.context, input: resolved.limit.input, output: resolved.limit.output },
     }
     return yield* Effect.try({
       try: () => {

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -220,12 +220,7 @@ export const OpenAIPlugin = define({
             return
           }
           draft.cost = []
-          if (draft.id.includes("gpt-5.5")) {
-            draft.limit = { context: 400_000, input: 272_000, output: 128_000 }
-          }
-          if (draft.id.includes("gpt-5.6")) {
-            draft.limit = { context: 500_000, input: 372_000, output: 128_000 }
-          }
+          draft.limit = { ...draft.limit, context: 272_000, input: 272_000 }
         })
       }
     })

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -220,6 +220,7 @@ export const OpenAIPlugin = define({
             return
           }
           draft.cost = []
+          // Match Codex CLI so context consumption and subscription usage stay consistent between clients.
           draft.limit = { ...draft.limit, context: 272_000, input: 272_000 }
         })
       }

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -152,14 +152,11 @@ const settings = (documents: readonly Config.Entry[]) => {
   const configured = documents
     .filter((entry): entry is Config.Document => entry.type === "document")
     .flatMap((entry) => (entry.info.compaction ? [entry.info.compaction] : []))
-  return configured.reduce<Settings>(
-    (result, current) => ({
-      auto: current.auto ?? result.auto,
-      buffer: current.buffer ?? result.buffer,
-      tokens: current.keep?.tokens ?? result.tokens,
-    }),
-    { auto: true, buffer: DEFAULT_BUFFER, tokens: DEFAULT_KEEP_TOKENS },
-  )
+  return {
+    auto: configured.findLast((value) => value.auto !== undefined)?.auto ?? true,
+    buffer: configured.findLast((value) => value.buffer !== undefined)?.buffer ?? DEFAULT_BUFFER,
+    tokens: configured.findLast((value) => value.keep?.tokens !== undefined)?.keep?.tokens ?? DEFAULT_KEEP_TOKENS,
+  }
 }
 
 const select = (

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -351,10 +351,14 @@ const make = (dependencies: Dependencies) => {
     )
     if (!last) return false
     const output = Math.min(input.model.route.defaults.limits?.output ?? 0, OUTPUT_TOKEN_MAX)
+    const limit = Math.min(
+      input.model.route.defaults.limits?.input ?? Number.POSITIVE_INFINITY,
+      context - (output || config.buffer),
+    )
     const used =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     if (used <= 0) return false
-    return used >= context - (output || config.buffer)
+    return used >= limit
   }
   const compactManual = Effect.fn("SessionCompaction.compactManual")(function* (input: ManualInput) {
     const content = planContent(input.messages, config.tokens)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -350,16 +350,16 @@ const make = (dependencies: Dependencies) => {
         message.type === "assistant" && message.tokens !== undefined,
     )
     if (!last) return false
-    const output = Math.min(input.model.route.defaults.limits?.output ?? 0, OUTPUT_TOKEN_MAX)
+    const limits = input.model.route.defaults.limits
+    const output = Math.min(limits?.output ?? 0, OUTPUT_TOKEN_MAX)
     const promptCeiling = Math.min(
-      input.model.route.defaults.limits?.input ?? Number.POSITIVE_INFINITY,
-      context - output,
+      limits?.input === undefined ? Number.POSITIVE_INFINITY : limits.input - config.buffer,
+      context - Math.max(output, config.buffer),
     )
-    const limit = promptCeiling - config.buffer
     const used =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     if (used <= 0) return false
-    return used >= limit
+    return used >= promptCeiling
   }
   const compactManual = Effect.fn("SessionCompaction.compactManual")(function* (input: ManualInput) {
     const content = planContent(input.messages, config.tokens)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -351,10 +351,11 @@ const make = (dependencies: Dependencies) => {
     )
     if (!last) return false
     const output = Math.min(input.model.route.defaults.limits?.output ?? 0, OUTPUT_TOKEN_MAX)
-    const limit = Math.min(
+    const promptCeiling = Math.min(
       input.model.route.defaults.limits?.input ?? Number.POSITIVE_INFINITY,
-      context - (output || config.buffer),
+      context - output,
     )
+    const limit = promptCeiling - config.buffer
     const used =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     if (used <= 0) return false

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -17,6 +17,7 @@ interface ModelOptions {
   readonly headers?: Info["headers"]
   readonly body?: Info["body"]
   readonly variants?: Info["variants"]
+  readonly limit?: Info["limit"]
 }
 
 const model = (packageName: string | undefined, options: ModelOptions = {}) =>
@@ -36,7 +37,7 @@ const model = (packageName: string | undefined, options: ModelOptions = {}) =>
     cost: [],
     status: "active",
     enabled: true,
-    limit: { context: 100, output: 20 },
+    limit: options.limit ?? { context: 100, output: 20 },
   })
 
 describe("ModelResolver", () => {
@@ -44,6 +45,7 @@ describe("ModelResolver", () => {
     Effect.gen(function* () {
       const catalog = model(Provider.aisdk("@ai-sdk/openai"), {
         settings: { baseURL: "https://openai.example/v1" },
+        limit: { context: 100, input: 80, output: 20 },
       })
       const resolved = yield* ModelResolver.fromCatalogModel(catalog)
 
@@ -55,7 +57,7 @@ describe("ModelResolver", () => {
         endpoint: { baseURL: "https://openai.example/v1" },
         defaults: {
           headers: { "x-test": "header" },
-          limits: { context: 100, output: 20 },
+          limits: { context: 100, input: 80, output: 20 },
           http: { body: { custom_extension: { enabled: true } } },
         },
       })

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -74,6 +74,9 @@ describe("OpenAIPlugin", () => {
           ]
         })
         catalog.model.update(item.id, Model.ID.make("gpt-5.5-pro"), () => {})
+        catalog.model.update(item.id, Model.ID.make("gpt-5.4"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 64_000 }
+        })
         catalog.model.update(item.id, Model.ID.make("gpt-5.4-pro"), (model) => {
           model.modelID = Model.ID.make("gpt-5.4")
           model.body = { reasoning: { mode: "pro" } }
@@ -137,7 +140,7 @@ describe("OpenAIPlugin", () => {
       const eligible = required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))
       expect(eligible.package).toBe("@opencode-ai/ai/providers/openai")
       expect(eligible.cost).toEqual([])
-      expect(eligible.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
+      expect(eligible.limit).toEqual({ context: 272_000, input: 272_000, output: 128_000 })
       expect(eligible.enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5-pro"))).enabled).toBe(
         false,
@@ -145,10 +148,15 @@ describe("OpenAIPlugin", () => {
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4-pro"))).enabled).toBe(
         false,
       )
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4"))).limit).toEqual({
+        context: 272_000,
+        input: 272_000,
+        output: 64_000,
+      })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6"))).enabled).toBe(false)
       const gpt56 = required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6-sol")))
       expect(gpt56.enabled).toBe(true)
-      expect(gpt56.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
+      expect(gpt56.limit).toEqual({ context: 272_000, input: 272_000, output: 128_000 })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.1"))).enabled).toBe(false)
     }),
   )

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -132,7 +132,7 @@ test("compaction prompt requires the checkpoint headings in order", () => {
   expect(prompt).toContain("Keep every section, even when empty.")
 })
 
-it.effect("auto compaction respects explicit model input limits", () =>
+it.effect("auto compaction reserves a buffer below the prompt ceiling", () =>
   Effect.gen(function* () {
     const compaction = yield* SessionCompaction.Service
     const session = Session.Info.make({
@@ -143,12 +143,12 @@ it.effect("auto compaction respects explicit model input limits", () =>
       time: { created: DateTime.makeUnsafe(0), updated: DateTime.makeUnsafe(0) },
       location: Location.Ref.make({ directory: AbsolutePath.make("/tmp") }),
     })
-    const input = (tokens: number) => ({
+    const input = (tokens: number, limits: { context: number; input?: number; output: number }) => ({
       session,
       model: Model.make({
         id: "test-model",
         provider: "test-provider",
-        route: OpenAIChat.route.with({ limits: { context: 1_000, input: 100, output: 100 } }),
+        route: OpenAIChat.route.with({ limits }),
       }),
       cost: [],
       messages: [
@@ -164,8 +164,13 @@ it.effect("auto compaction respects explicit model input limits", () =>
       ],
     })
 
-    expect(compaction.required(input(99))).toBe(false)
-    expect(compaction.required(input(100))).toBe(true)
+    const inputLimited = { context: 400_000, input: 272_000, output: 128_000 }
+    expect(compaction.required(input(251_999, inputLimited))).toBe(false)
+    expect(compaction.required(input(252_000, inputLimited))).toBe(true)
+
+    const contextLimited = { context: 100_000, output: 10_000 }
+    expect(compaction.required(input(69_999, contextLimited))).toBe(false)
+    expect(compaction.required(input(70_000, contextLimited))).toBe(true)
   }),
 )
 

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -169,8 +169,12 @@ it.effect("auto compaction reserves a buffer below the prompt ceiling", () =>
     expect(compaction.required(input(252_000, inputLimited))).toBe(true)
 
     const contextLimited = { context: 100_000, output: 10_000 }
-    expect(compaction.required(input(69_999, contextLimited))).toBe(false)
-    expect(compaction.required(input(70_000, contextLimited))).toBe(true)
+    expect(compaction.required(input(79_999, contextLimited))).toBe(false)
+    expect(compaction.required(input(80_000, contextLimited))).toBe(true)
+
+    const outputLimited = { context: 100_000, output: 30_000 }
+    expect(compaction.required(input(69_999, outputLimited))).toBe(false)
+    expect(compaction.required(input(70_000, outputLimited))).toBe(true)
   }),
 )
 

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -19,9 +19,11 @@ import { Session } from "@opencode-ai/core/session"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { App } from "@opencode-ai/core/app"
+import { Agent } from "@opencode-ai/core/agent"
+import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Money } from "@opencode-ai/schema/money"
-import { DateTime, Effect, Fiber, Layer, Stream } from "effect"
+import { DateTime, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { asc, eq } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
 
@@ -129,6 +131,43 @@ test("compaction prompt requires the checkpoint headings in order", () => {
   expect(prompt).toContain("next action if known")
   expect(prompt).toContain("Keep every section, even when empty.")
 })
+
+it.effect("auto compaction respects explicit model input limits", () =>
+  Effect.gen(function* () {
+    const compaction = yield* SessionCompaction.Service
+    const session = Session.Info.make({
+      id: Session.ID.make("ses_input_limit"),
+      projectID: Project.ID.global,
+      cost: Money.USD.zero,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: DateTime.makeUnsafe(0), updated: DateTime.makeUnsafe(0) },
+      location: Location.Ref.make({ directory: AbsolutePath.make("/tmp") }),
+    })
+    const input = (tokens: number) => ({
+      session,
+      model: Model.make({
+        id: "test-model",
+        provider: "test-provider",
+        route: OpenAIChat.route.with({ limits: { context: 1_000, input: 100, output: 100 } }),
+      }),
+      cost: [],
+      messages: [
+        Schema.decodeUnknownSync(SessionMessage.Assistant)({
+          id: SessionMessage.ID.make("msg_assistant"),
+          type: "assistant",
+          agent: Agent.defaultID,
+          model: { id: "test-model", providerID: "test-provider" },
+          content: [],
+          tokens: { input: tokens, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 0, completed: 0 },
+        }),
+      ],
+    })
+
+    expect(compaction.required(input(99))).toBe(false)
+    expect(compaction.required(input(100))).toBe(true)
+  }),
+)
 
 it.effect("manual compaction summarizes short context instead of no-op", () =>
   Effect.gen(function* () {

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -95,7 +95,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
 | `auto` | `true` | Runs the preflight context-size check. It does not disable manual compaction or one-shot provider-overflow recovery. |
 | `prune` | None | Accepted by the V2 schema, but currently has no runtime effect. V2 does not prune old tool outputs in place. |
 | `keep.tokens` | `8000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
-| `buffer` | `20000` | Safety reserve subtracted from the model's usable prompt ceiling when calculating the automatic threshold. |
+| `buffer` | `20000` | Safety reserve below an explicit input limit. Without one, it is the minimum context reserve and the model output allowance wins when larger. |
 
 `keep.tokens` and `buffer` accept non-negative integers. Larger `keep.tokens`
 preserves more recent detail but leaves less room for future work. Larger

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -95,7 +95,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
 | `auto` | `true` | Runs the preflight context-size check. It does not disable manual compaction or one-shot provider-overflow recovery. |
 | `prune` | None | Accepted by the V2 schema, but currently has no runtime effect. V2 does not prune old tool outputs in place. |
 | `keep.tokens` | `8000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
-| `buffer` | `20000` | Token reserve used by the automatic threshold. The requested model output allowance wins when it is larger. |
+| `buffer` | `20000` | Safety reserve subtracted from the model's usable prompt ceiling when calculating the automatic threshold. |
 
 `keep.tokens` and `buffer` accept non-negative integers. Larger `keep.tokens`
 preserves more recent detail but leaves less room for future work. Larger


### PR DESCRIPTION
## Summary
- add `input` to executable native and AI SDK model limits
- preserve catalog input limits through model resolution and provider-package settings
- compact against the tighter of the explicit input limit and context-minus-output budget
- align eligible ChatGPT OAuth GPT-5.4, GPT-5.5, and GPT-5.6 models with Codex's current 272k context window metadata

## Validation
- `bun typecheck` in `packages/ai` and `packages/core`
- `bun test test/compile.test.ts` in `packages/ai`
- `bun test test/model-resolver.test.ts test/plugin/provider-openai.test.ts test/session-compaction.test.ts` in `packages/core`