### PR TITLE
feat(tui): show optional daily session cost

### DIFF
--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -57,20 +57,14 @@ const Endpoint3_0 = (raw: RawClient["server.session"]) => (input?: Endpoint3_0In
     },
   }).pipe(Effect.mapError(mapClientError))
 
-const Endpoint3_1 = (raw: RawClient["server.session"]) => () =>
-  raw["session.cost"]({}).pipe(
-    Effect.mapError(mapClientError),
-    Effect.map((value) => value.data),
-  )
-
-type Endpoint3_2Request = Parameters<RawClient["server.session"]["session.create"]>[0]
-type Endpoint3_2Input = {
-  readonly id?: Endpoint3_2Request["payload"]["id"]
-  readonly agent?: Endpoint3_2Request["payload"]["agent"]
-  readonly model?: Endpoint3_2Request["payload"]["model"]
-  readonly location?: Endpoint3_2Request["payload"]["location"]
+type Endpoint3_1Request = Parameters<RawClient["server.session"]["session.create"]>[0]
+type Endpoint3_1Input = {
+  readonly id?: Endpoint3_1Request["payload"]["id"]
+  readonly agent?: Endpoint3_1Request["payload"]["agent"]
+  readonly model?: Endpoint3_1Request["payload"]["model"]
+  readonly location?: Endpoint3_1Request["payload"]["location"]
 }
-const Endpoint3_2 = (raw: RawClient["server.session"]) => (input?: Endpoint3_2Input) =>
+const Endpoint3_1 = (raw: RawClient["server.session"]) => (input?: Endpoint3_1Input) =>
   raw["session.create"]({
     payload: { id: input?.["id"], agent: input?.["agent"], model: input?.["model"], location: input?.["location"] },
   }).pipe(
@@ -78,49 +72,49 @@ const Endpoint3_2 = (raw: RawClient["server.session"]) => (input?: Endpoint3_2In
     Effect.map((value) => value.data),
   )
 
-const Endpoint3_3 = (raw: RawClient["server.session"]) => () =>
+const Endpoint3_2 = (raw: RawClient["server.session"]) => () =>
   raw["session.active"]({}).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.get"]>[0]
-type Endpoint3_4Input = { readonly sessionID: Endpoint3_4Request["params"]["sessionID"] }
-const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
+type Endpoint3_3Request = Parameters<RawClient["server.session"]["session.get"]>[0]
+type Endpoint3_3Input = { readonly sessionID: Endpoint3_3Request["params"]["sessionID"] }
+const Endpoint3_3 = (raw: RawClient["server.session"]) => (input: Endpoint3_3Input) =>
   raw["session.get"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
-type Endpoint3_5Input = {
-  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
-  readonly agent: Endpoint3_5Request["payload"]["agent"]
+type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
+type Endpoint3_4Input = {
+  readonly sessionID: Endpoint3_4Request["params"]["sessionID"]
+  readonly agent: Endpoint3_4Request["payload"]["agent"]
 }
-const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
+const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
   raw["session.switchAgent"]({ params: { sessionID: input["sessionID"] }, payload: { agent: input["agent"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
-type Endpoint3_6Input = {
-  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
-  readonly model: Endpoint3_6Request["payload"]["model"]
+type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
+type Endpoint3_5Input = {
+  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
+  readonly model: Endpoint3_5Request["payload"]["model"]
 }
-const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
+const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
   raw["session.switchModel"]({ params: { sessionID: input["sessionID"] }, payload: { model: input["model"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
-type Endpoint3_7Input = {
-  readonly sessionID: Endpoint3_7Request["params"]["sessionID"]
-  readonly id?: Endpoint3_7Request["payload"]["id"]
-  readonly prompt: Endpoint3_7Request["payload"]["prompt"]
-  readonly delivery?: Endpoint3_7Request["payload"]["delivery"]
-  readonly resume?: Endpoint3_7Request["payload"]["resume"]
+type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint3_6Input = {
+  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
+  readonly id?: Endpoint3_6Request["payload"]["id"]
+  readonly prompt: Endpoint3_6Request["payload"]["prompt"]
+  readonly delivery?: Endpoint3_6Request["payload"]["delivery"]
+  readonly resume?: Endpoint3_6Request["payload"]["resume"]
 }
-const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
+const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
@@ -129,23 +123,23 @@ const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint3_8Input = { readonly sessionID: Endpoint3_8Request["params"]["sessionID"] }
-const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
+type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint3_7Input = { readonly sessionID: Endpoint3_7Request["params"]["sessionID"] }
+const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
   raw["session.compact"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-type Endpoint3_9Input = { readonly sessionID: Endpoint3_9Request["params"]["sessionID"] }
-const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
+type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint3_8Input = { readonly sessionID: Endpoint3_8Request["params"]["sessionID"] }
+const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
   raw["session.wait"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint3_10Input = {
-  readonly sessionID: Endpoint3_10Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_10Request["payload"]["messageID"]
-  readonly files?: Endpoint3_10Request["payload"]["files"]
+type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint3_9Input = {
+  readonly sessionID: Endpoint3_9Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_9Request["payload"]["messageID"]
+  readonly files?: Endpoint3_9Request["payload"]["files"]
 }
-const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
+const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input["sessionID"] },
     payload: { messageID: input["messageID"], files: input["files"] },
@@ -154,42 +148,42 @@ const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10I
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint3_11Input = { readonly sessionID: Endpoint3_11Request["params"]["sessionID"] }
-const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
+type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
+type Endpoint3_10Input = { readonly sessionID: Endpoint3_10Request["params"]["sessionID"] }
+const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
   raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
-type Endpoint3_12Input = { readonly sessionID: Endpoint3_12Request["params"]["sessionID"] }
-const Endpoint3_12 = (raw: RawClient["server.session"]) => (input: Endpoint3_12Input) =>
+type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint3_11Input = { readonly sessionID: Endpoint3_11Request["params"]["sessionID"] }
+const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
   raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.context"]>[0]
-type Endpoint3_13Input = { readonly sessionID: Endpoint3_13Request["params"]["sessionID"] }
-const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
+type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_12Input = { readonly sessionID: Endpoint3_12Request["params"]["sessionID"] }
+const Endpoint3_12 = (raw: RawClient["server.session"]) => (input: Endpoint3_12Input) =>
   raw["session.context"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.history"]>[0]
-type Endpoint3_14Input = {
-  readonly sessionID: Endpoint3_14Request["params"]["sessionID"]
-  readonly limit?: Endpoint3_14Request["query"]["limit"]
-  readonly after?: Endpoint3_14Request["query"]["after"]
+type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.history"]>[0]
+type Endpoint3_13Input = {
+  readonly sessionID: Endpoint3_13Request["params"]["sessionID"]
+  readonly limit?: Endpoint3_13Request["query"]["limit"]
+  readonly after?: Endpoint3_13Request["query"]["after"]
 }
-const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
+const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
   raw["session.history"]({
     params: { sessionID: input["sessionID"] },
     query: { limit: input["limit"], after: input["after"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.events"]>[0]
-type Endpoint3_15Input = {
-  readonly sessionID: Endpoint3_15Request["params"]["sessionID"]
-  readonly after?: Endpoint3_15Request["query"]["after"]
+type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.events"]>[0]
+type Endpoint3_14Input = {
+  readonly sessionID: Endpoint3_14Request["params"]["sessionID"]
+  readonly after?: Endpoint3_14Request["query"]["after"]
 }
-const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
+const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
   Stream.unwrap(
     raw["session.events"]({ params: { sessionID: input["sessionID"] }, query: { after: input["after"] } }).pipe(
       Effect.mapError(mapClientError),
@@ -197,41 +191,47 @@ const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15I
     ),
   )
 
-type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint3_16Input = { readonly sessionID: Endpoint3_16Request["params"]["sessionID"] }
-const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
+type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
+type Endpoint3_15Input = { readonly sessionID: Endpoint3_15Request["params"]["sessionID"] }
+const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
   raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_17Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint3_17Input = {
-  readonly sessionID: Endpoint3_17Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_17Request["params"]["messageID"]
+type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint3_16Input = {
+  readonly sessionID: Endpoint3_16Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_16Request["params"]["messageID"]
 }
-const Endpoint3_17 = (raw: RawClient["server.session"]) => (input: Endpoint3_17Input) =>
+const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
   raw["session.message"]({ params: { sessionID: input["sessionID"], messageID: input["messageID"] } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+const Endpoint3_17 = (raw: RawClient["server.session"]) => () =>
+  raw["session.cost"]({}).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
 const adaptGroup3 = (raw: RawClient["server.session"]) => ({
   list: Endpoint3_0(raw),
-  cost: Endpoint3_1(raw),
-  create: Endpoint3_2(raw),
-  active: Endpoint3_3(raw),
-  get: Endpoint3_4(raw),
-  switchAgent: Endpoint3_5(raw),
-  switchModel: Endpoint3_6(raw),
-  prompt: Endpoint3_7(raw),
-  compact: Endpoint3_8(raw),
-  wait: Endpoint3_9(raw),
-  stage: Endpoint3_10(raw),
-  clear: Endpoint3_11(raw),
-  commit: Endpoint3_12(raw),
-  context: Endpoint3_13(raw),
-  history: Endpoint3_14(raw),
-  events: Endpoint3_15(raw),
-  interrupt: Endpoint3_16(raw),
-  message: Endpoint3_17(raw),
+  create: Endpoint3_1(raw),
+  active: Endpoint3_2(raw),
+  get: Endpoint3_3(raw),
+  switchAgent: Endpoint3_4(raw),
+  switchModel: Endpoint3_5(raw),
+  prompt: Endpoint3_6(raw),
+  compact: Endpoint3_7(raw),
+  wait: Endpoint3_8(raw),
+  stage: Endpoint3_9(raw),
+  clear: Endpoint3_10(raw),
+  commit: Endpoint3_11(raw),
+  context: Endpoint3_12(raw),
+  history: Endpoint3_13(raw),
+  events: Endpoint3_14(raw),
+  interrupt: Endpoint3_15(raw),
+  message: Endpoint3_16(raw),
+  cost: Endpoint3_17(raw),
 })
 
 type Endpoint4_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]

--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -57,14 +57,20 @@ const Endpoint3_0 = (raw: RawClient["server.session"]) => (input?: Endpoint3_0In
     },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_1Request = Parameters<RawClient["server.session"]["session.create"]>[0]
-type Endpoint3_1Input = {
-  readonly id?: Endpoint3_1Request["payload"]["id"]
-  readonly agent?: Endpoint3_1Request["payload"]["agent"]
-  readonly model?: Endpoint3_1Request["payload"]["model"]
-  readonly location?: Endpoint3_1Request["payload"]["location"]
+const Endpoint3_1 = (raw: RawClient["server.session"]) => () =>
+  raw["session.cost"]({}).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint3_2Request = Parameters<RawClient["server.session"]["session.create"]>[0]
+type Endpoint3_2Input = {
+  readonly id?: Endpoint3_2Request["payload"]["id"]
+  readonly agent?: Endpoint3_2Request["payload"]["agent"]
+  readonly model?: Endpoint3_2Request["payload"]["model"]
+  readonly location?: Endpoint3_2Request["payload"]["location"]
 }
-const Endpoint3_1 = (raw: RawClient["server.session"]) => (input?: Endpoint3_1Input) =>
+const Endpoint3_2 = (raw: RawClient["server.session"]) => (input?: Endpoint3_2Input) =>
   raw["session.create"]({
     payload: { id: input?.["id"], agent: input?.["agent"], model: input?.["model"], location: input?.["location"] },
   }).pipe(
@@ -72,49 +78,49 @@ const Endpoint3_1 = (raw: RawClient["server.session"]) => (input?: Endpoint3_1In
     Effect.map((value) => value.data),
   )
 
-const Endpoint3_2 = (raw: RawClient["server.session"]) => () =>
+const Endpoint3_3 = (raw: RawClient["server.session"]) => () =>
   raw["session.active"]({}).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_3Request = Parameters<RawClient["server.session"]["session.get"]>[0]
-type Endpoint3_3Input = { readonly sessionID: Endpoint3_3Request["params"]["sessionID"] }
-const Endpoint3_3 = (raw: RawClient["server.session"]) => (input: Endpoint3_3Input) =>
+type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.get"]>[0]
+type Endpoint3_4Input = { readonly sessionID: Endpoint3_4Request["params"]["sessionID"] }
+const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
   raw["session.get"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
-type Endpoint3_4Input = {
-  readonly sessionID: Endpoint3_4Request["params"]["sessionID"]
-  readonly agent: Endpoint3_4Request["payload"]["agent"]
+type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
+type Endpoint3_5Input = {
+  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
+  readonly agent: Endpoint3_5Request["payload"]["agent"]
 }
-const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
+const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
   raw["session.switchAgent"]({ params: { sessionID: input["sessionID"] }, payload: { agent: input["agent"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
-type Endpoint3_5Input = {
-  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
-  readonly model: Endpoint3_5Request["payload"]["model"]
+type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
+type Endpoint3_6Input = {
+  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
+  readonly model: Endpoint3_6Request["payload"]["model"]
 }
-const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
+const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
   raw["session.switchModel"]({ params: { sessionID: input["sessionID"] }, payload: { model: input["model"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
-type Endpoint3_6Input = {
-  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
-  readonly id?: Endpoint3_6Request["payload"]["id"]
-  readonly prompt: Endpoint3_6Request["payload"]["prompt"]
-  readonly delivery?: Endpoint3_6Request["payload"]["delivery"]
-  readonly resume?: Endpoint3_6Request["payload"]["resume"]
+type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint3_7Input = {
+  readonly sessionID: Endpoint3_7Request["params"]["sessionID"]
+  readonly id?: Endpoint3_7Request["payload"]["id"]
+  readonly prompt: Endpoint3_7Request["payload"]["prompt"]
+  readonly delivery?: Endpoint3_7Request["payload"]["delivery"]
+  readonly resume?: Endpoint3_7Request["payload"]["resume"]
 }
-const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
+const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
@@ -123,23 +129,23 @@ const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint3_7Input = { readonly sessionID: Endpoint3_7Request["params"]["sessionID"] }
-const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
-  raw["session.compact"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
 type Endpoint3_8Input = { readonly sessionID: Endpoint3_8Request["params"]["sessionID"] }
 const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
+  raw["session.compact"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint3_9Input = { readonly sessionID: Endpoint3_9Request["params"]["sessionID"] }
+const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
   raw["session.wait"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint3_9Input = {
-  readonly sessionID: Endpoint3_9Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_9Request["payload"]["messageID"]
-  readonly files?: Endpoint3_9Request["payload"]["files"]
+type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint3_10Input = {
+  readonly sessionID: Endpoint3_10Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_10Request["payload"]["messageID"]
+  readonly files?: Endpoint3_10Request["payload"]["files"]
 }
-const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
+const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input["sessionID"] },
     payload: { messageID: input["messageID"], files: input["files"] },
@@ -148,42 +154,42 @@ const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint3_10Input = { readonly sessionID: Endpoint3_10Request["params"]["sessionID"] }
-const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
-  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 type Endpoint3_11Input = { readonly sessionID: Endpoint3_11Request["params"]["sessionID"] }
 const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
-  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
 type Endpoint3_12Input = { readonly sessionID: Endpoint3_12Request["params"]["sessionID"] }
 const Endpoint3_12 = (raw: RawClient["server.session"]) => (input: Endpoint3_12Input) =>
+  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_13Input = { readonly sessionID: Endpoint3_13Request["params"]["sessionID"] }
+const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
   raw["session.context"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.history"]>[0]
-type Endpoint3_13Input = {
-  readonly sessionID: Endpoint3_13Request["params"]["sessionID"]
-  readonly limit?: Endpoint3_13Request["query"]["limit"]
-  readonly after?: Endpoint3_13Request["query"]["after"]
+type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.history"]>[0]
+type Endpoint3_14Input = {
+  readonly sessionID: Endpoint3_14Request["params"]["sessionID"]
+  readonly limit?: Endpoint3_14Request["query"]["limit"]
+  readonly after?: Endpoint3_14Request["query"]["after"]
 }
-const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
+const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
   raw["session.history"]({
     params: { sessionID: input["sessionID"] },
     query: { limit: input["limit"], after: input["after"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.events"]>[0]
-type Endpoint3_14Input = {
-  readonly sessionID: Endpoint3_14Request["params"]["sessionID"]
-  readonly after?: Endpoint3_14Request["query"]["after"]
+type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.events"]>[0]
+type Endpoint3_15Input = {
+  readonly sessionID: Endpoint3_15Request["params"]["sessionID"]
+  readonly after?: Endpoint3_15Request["query"]["after"]
 }
-const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
+const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
   Stream.unwrap(
     raw["session.events"]({ params: { sessionID: input["sessionID"] }, query: { after: input["after"] } }).pipe(
       Effect.mapError(mapClientError),
@@ -191,17 +197,17 @@ const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14I
     ),
   )
 
-type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint3_15Input = { readonly sessionID: Endpoint3_15Request["params"]["sessionID"] }
-const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
+type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
+type Endpoint3_16Input = { readonly sessionID: Endpoint3_16Request["params"]["sessionID"] }
+const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
   raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint3_16Input = {
-  readonly sessionID: Endpoint3_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_16Request["params"]["messageID"]
+type Endpoint3_17Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint3_17Input = {
+  readonly sessionID: Endpoint3_17Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_17Request["params"]["messageID"]
 }
-const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
+const Endpoint3_17 = (raw: RawClient["server.session"]) => (input: Endpoint3_17Input) =>
   raw["session.message"]({ params: { sessionID: input["sessionID"], messageID: input["messageID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
@@ -209,22 +215,23 @@ const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16I
 
 const adaptGroup3 = (raw: RawClient["server.session"]) => ({
   list: Endpoint3_0(raw),
-  create: Endpoint3_1(raw),
-  active: Endpoint3_2(raw),
-  get: Endpoint3_3(raw),
-  switchAgent: Endpoint3_4(raw),
-  switchModel: Endpoint3_5(raw),
-  prompt: Endpoint3_6(raw),
-  compact: Endpoint3_7(raw),
-  wait: Endpoint3_8(raw),
-  stage: Endpoint3_9(raw),
-  clear: Endpoint3_10(raw),
-  commit: Endpoint3_11(raw),
-  context: Endpoint3_12(raw),
-  history: Endpoint3_13(raw),
-  events: Endpoint3_14(raw),
-  interrupt: Endpoint3_15(raw),
-  message: Endpoint3_16(raw),
+  cost: Endpoint3_1(raw),
+  create: Endpoint3_2(raw),
+  active: Endpoint3_3(raw),
+  get: Endpoint3_4(raw),
+  switchAgent: Endpoint3_5(raw),
+  switchModel: Endpoint3_6(raw),
+  prompt: Endpoint3_7(raw),
+  compact: Endpoint3_8(raw),
+  wait: Endpoint3_9(raw),
+  stage: Endpoint3_10(raw),
+  clear: Endpoint3_11(raw),
+  commit: Endpoint3_12(raw),
+  context: Endpoint3_13(raw),
+  history: Endpoint3_14(raw),
+  events: Endpoint3_15(raw),
+  interrupt: Endpoint3_16(raw),
+  message: Endpoint3_17(raw),
 })
 
 type Endpoint4_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -6,7 +6,6 @@ import type {
   AgentsListOutput,
   SessionsListInput,
   SessionsListOutput,
-  SessionsCostOutput,
   SessionsCreateInput,
   SessionsCreateOutput,
   SessionsActiveOutput,
@@ -38,6 +37,7 @@ import type {
   SessionsInterruptOutput,
   SessionsMessageInput,
   SessionsMessageOutput,
+  SessionsCostOutput,
   MessagesListInput,
   MessagesListOutput,
   ModelsListInput,
@@ -305,11 +305,6 @@ export function make(options: ClientOptions) {
           },
           requestOptions,
         ),
-      cost: (requestOptions?: RequestOptions) =>
-        request<{ readonly data: SessionsCostOutput }>(
-          { method: "GET", path: `/api/session/cost`, successStatus: 200, declaredStatuses: [401, 400], empty: false },
-          requestOptions,
-        ).then((value) => value.data),
       create: (input?: SessionsCreateInput, requestOptions?: RequestOptions) =>
         request<{ readonly data: SessionsCreateOutput }>(
           {
@@ -496,6 +491,11 @@ export function make(options: ClientOptions) {
             declaredStatuses: [404, 400, 401],
             empty: false,
           },
+          requestOptions,
+        ).then((value) => value.data),
+      cost: (requestOptions?: RequestOptions) =>
+        request<{ readonly data: SessionsCostOutput }>(
+          { method: "GET", path: `/api/session/cost`, successStatus: 200, declaredStatuses: [401, 400], empty: false },
           requestOptions,
         ).then((value) => value.data),
     },

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -6,6 +6,7 @@ import type {
   AgentsListOutput,
   SessionsListInput,
   SessionsListOutput,
+  SessionsCostOutput,
   SessionsCreateInput,
   SessionsCreateOutput,
   SessionsActiveOutput,
@@ -304,6 +305,11 @@ export function make(options: ClientOptions) {
           },
           requestOptions,
         ),
+      cost: (requestOptions?: RequestOptions) =>
+        request<{ readonly data: SessionsCostOutput }>(
+          { method: "GET", path: `/api/session/cost`, successStatus: 200, declaredStatuses: [401, 400], empty: false },
+          requestOptions,
+        ).then((value) => value.data),
       create: (input?: SessionsCreateInput, requestOptions?: RequestOptions) =>
         request<{ readonly data: SessionsCreateOutput }>(
           {

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -266,6 +266,8 @@ export type SessionsListOutput = {
   readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
 }
 
+export type SessionsCostOutput = { readonly data: number }["data"]
+
 export type SessionsCreateInput = {
   readonly id?: {
     readonly id?: string | null

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -266,8 +266,6 @@ export type SessionsListOutput = {
   readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
 }
 
-export type SessionsCostOutput = { readonly data: number }["data"]
-
 export type SessionsCreateInput = {
   readonly id?: {
     readonly id?: string | null
@@ -1754,6 +1752,8 @@ export type SessionsMessageOutput = {
         readonly time: { readonly created: number }
       }
 }["data"]
+
+export type SessionsCostOutput = { readonly data: number }["data"]
 
 export type MessagesListInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,7 +3,7 @@ export * from "./session/schema"
 
 import { DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
-import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, like, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -101,6 +101,10 @@ export class OperationUnavailableError extends Schema.TaggedErrorClass<Operation
 
 export { ContextSnapshotDecodeError, MessageDecodeError } from "./session/error"
 
+export function sumSessionCosts(sessions: readonly { readonly cost?: number }[]) {
+  return sessions.reduce((total, session) => total + (session.cost ?? 0), 0)
+}
+
 export class PromptConflictError extends Schema.TaggedErrorClass<PromptConflictError>()("Session.PromptConflictError", {
   sessionID: SessionSchema.ID,
   messageID: SessionMessage.ID,
@@ -112,6 +116,7 @@ export type Error = NotFoundError | MessageDecodeError | OperationUnavailableErr
 
 export interface Interface {
   readonly list: (input?: ListInput) => Effect.Effect<SessionSchema.Info[]>
+  readonly todayCost: Effect.Effect<number>
   readonly create: (input: CreateInput) => Effect.Effect<SessionSchema.Info>
   readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info, NotFoundError>
   readonly messages: (input: {
@@ -205,6 +210,17 @@ const layer = Layer.effect(
       )
 
     const result = Service.of({
+      todayCost: Effect.gen(function* () {
+        const start = new Date()
+        start.setHours(0, 0, 0, 0)
+        const rows = yield* db
+          .select({ cost: SessionTable.cost })
+          .from(SessionTable)
+          .where(gte(SessionTable.time_updated, start.getTime()))
+          .all()
+          .pipe(Effect.orDie)
+        return sumSessionCosts(rows)
+      }),
       create: Effect.fn("V2Session.create")(function* (input) {
         const sessionID = input.id ?? SessionSchema.ID.create()
         const recorded = yield* store.get(sessionID)

--- a/packages/core/test/session-cost.test.ts
+++ b/packages/core/test/session-cost.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "bun:test"
+import { sumSessionCosts } from "@opencode-ai/core/session"
+
+test("sums session costs and treats missing costs as zero", () => {
+  expect(sumSessionCosts([{ cost: 0.05 }, {}, { cost: 10.29 }])).toBeCloseTo(10.34)
+})

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -6,7 +6,6 @@ import { Database } from "@opencode-ai/core/database/database"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { Project } from "@/project/project"
 import { InstanceRef } from "@/effect/instance-ref"
-import { sumSessionCosts } from "@opencode-ai/core/session"
 
 interface SessionStats {
   totalSessions: number
@@ -125,7 +124,7 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
   const stats: SessionStats = {
     totalSessions: filteredSessions.length,
     totalMessages: 0,
-    totalCost: sumSessionCosts(filteredSessions),
+    totalCost: 0,
     totalTokens: {
       input: 0,
       output: 0,
@@ -169,6 +168,7 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
           .messages({ sessionID: session.id })
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])))
 
+        const sessionCost = session.cost ?? 0
         const sessionTokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
         let sessionToolUsage: Record<string, number> = {}
         let sessionModelUsage: Record<
@@ -211,6 +211,7 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
 
         return {
           messageCount: messages.length,
+          sessionCost,
           sessionTokens,
           sessionTotalTokens:
             sessionTokens.input +
@@ -233,6 +234,7 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
     sessionTotalTokens.push(result.sessionTotalTokens)
 
     stats.totalMessages += result.messageCount
+    stats.totalCost += result.sessionCost
     stats.totalTokens.input += result.sessionTokens.input
     stats.totalTokens.output += result.sessionTokens.output
     stats.totalTokens.reasoning += result.sessionTokens.reasoning

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -6,6 +6,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { Project } from "@/project/project"
 import { InstanceRef } from "@/effect/instance-ref"
+import { sumSessionCosts } from "@opencode-ai/core/session"
 
 interface SessionStats {
   totalSessions: number
@@ -124,7 +125,7 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
   const stats: SessionStats = {
     totalSessions: filteredSessions.length,
     totalMessages: 0,
-    totalCost: 0,
+    totalCost: sumSessionCosts(filteredSessions),
     totalTokens: {
       input: 0,
       output: 0,
@@ -168,7 +169,6 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
           .messages({ sessionID: session.id })
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])))
 
-        const sessionCost = session.cost ?? 0
         const sessionTokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
         let sessionToolUsage: Record<string, number> = {}
         let sessionModelUsage: Record<
@@ -211,7 +211,6 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
 
         return {
           messageCount: messages.length,
-          sessionCost,
           sessionTokens,
           sessionTotalTokens:
             sessionTokens.input +
@@ -234,7 +233,6 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
     sessionTotalTokens.push(result.sessionTotalTokens)
 
     stats.totalMessages += result.messageCount
-    stats.totalCost += result.sessionCost
     stats.totalTokens.input += result.sessionTokens.input
     stats.totalTokens.output += result.sessionTokens.output
     stats.totalTokens.reasoning += result.sessionTokens.reasoning

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -419,6 +419,7 @@ type TuiAttentionConfigView = {
 type TuiConfigView = Pick<PluginConfig, "$schema" | "theme" | "plugin"> &
   NonNullable<PluginConfig["tui"]> & {
     leader_timeout: number
+    show_today_cost: boolean
     attention: TuiAttentionConfigView
     plugin_enabled?: Record<string, boolean>
     keybinds: TuiBindingLookupView

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -126,6 +126,17 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
       ),
     )
     .add(
+      HttpApiEndpoint.get("session.cost", "/api/session/cost", {
+        success: Schema.Struct({ data: Schema.Finite }),
+      }).annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.session.cost",
+          summary: "Get today's session cost",
+          description: "Get the total cost of sessions updated since local midnight.",
+        }),
+      ),
+    )
+    .add(
       HttpApiEndpoint.post("session.create", "/api/session", {
         payload: Schema.Struct({
           id: Session.ID.pipe(Schema.optional),

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -126,17 +126,6 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
       ),
     )
     .add(
-      HttpApiEndpoint.get("session.cost", "/api/session/cost", {
-        success: Schema.Struct({ data: Schema.Finite }),
-      }).annotateMerge(
-        OpenApi.annotations({
-          identifier: "v2.session.cost",
-          summary: "Get today's session cost",
-          description: "Get the total cost of sessions updated since local midnight.",
-        }),
-      ),
-    )
-    .add(
       HttpApiEndpoint.post("session.create", "/api/session", {
         payload: Schema.Struct({
           id: Session.ID.pipe(Schema.optional),
@@ -381,6 +370,17 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
             description: "Retrieve one projected message owned by the Session.",
           }),
         ),
+    )
+    .add(
+      HttpApiEndpoint.get("session.cost", "/api/session/cost", {
+        success: Schema.Struct({ data: Schema.Finite }),
+      }).annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.session.cost",
+          summary: "Get today's session cost",
+          description: "Get the total cost of sessions updated since local midnight.",
+        }),
+      ),
     )
     .annotateMerge(
       OpenApi.annotations({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -339,6 +339,8 @@ import type {
   V2SessionCompactResponses,
   V2SessionContextErrors,
   V2SessionContextResponses,
+  V2SessionCostErrors,
+  V2SessionCostResponses,
   V2SessionCreateErrors,
   V2SessionCreateResponses,
   V2SessionEventsErrors,
@@ -5463,6 +5465,18 @@ export class Session3 extends HeyApiClient {
       url: "/api/session",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Get today's session cost
+   *
+   * Get the total cost of sessions updated since local midnight.
+   */
+  public cost<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+    return (options?.client ?? this.client).get<V2SessionCostResponses, V2SessionCostErrors, ThrowOnError>({
+      url: "/api/session/cost",
+      ...options,
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -11370,6 +11370,28 @@ export type V2SessionListResponses = {
 
 export type V2SessionListResponse = V2SessionListResponses[keyof V2SessionListResponses]
 
+export type V2SessionCostData = {
+  body?: never
+  path?: never
+  query?: never
+  url: "/api/session/cost"
+}
+
+export type V2SessionCostErrors = {
+  400: InvalidRequestError
+  401: UnauthorizedError
+}
+
+export type V2SessionCostError = V2SessionCostErrors[keyof V2SessionCostErrors]
+
+export type V2SessionCostResponses = {
+  200: {
+    data: number
+  }
+}
+
+export type V2SessionCostResponse = V2SessionCostResponses[keyof V2SessionCostResponses]
+
 export type V2SessionCreateData = {
   body: {
     id?: string

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -22,6 +22,12 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
 
     return handlers
       .handle(
+        "session.cost",
+        Effect.fn(function* () {
+          return { data: yield* session.todayCost }
+        }),
+      )
+      .handle(
         "session.list",
         Effect.fn(function* (ctx) {
           const query =

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -72,10 +72,14 @@ export const Info = Schema.Struct({
   diff_style: Schema.optional(DiffStyle),
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  show_today_cost: Schema.optional(Schema.Boolean).annotate({
+    description: "Show today's session cost in the footer (default: false)",
+  }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
 export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "cursor"> & {
+  show_today_cost: boolean
   attention: {
     enabled: boolean
     notifications: boolean
@@ -132,6 +136,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
           blinking: input.cursor.blinking ?? true,
         }
       : undefined,
+    show_today_cost: input.show_today_cost ?? false,
   }
 }
 

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -73,7 +73,7 @@ export const Info = Schema.Struct({
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
   show_today_cost: Schema.optional(Schema.Boolean).annotate({
-    description: "Show today's session cost in the footer (default: false)",
+    description: "Show today's session cost in the sidebar Context section (default: false)",
   }),
 })
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createEffect, createMemo, createSignal, onCleanup, onMount, Show } from "solid-js"
+import { createMemo, createResource, onCleanup, onMount, Show } from "solid-js"
 
 const id = "internal:sidebar-context"
 
@@ -14,27 +14,18 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
-  const [sessionCost, setSessionCost] = createSignal<number>()
-  const cost = createMemo(() => sessionCost() ?? session()?.cost ?? 0)
-  const [todayCost, setTodayCost] = createSignal<number>()
-
-  const refreshCosts = async () => {
-    const [sessionResult, todayResult] = await Promise.all([
-      props.api.client.v2.session.get({ sessionID: props.session_id }).catch(() => undefined),
-      props.api.tuiConfig.show_today_cost ? props.api.client.v2.session.cost().catch(() => undefined) : undefined,
-    ])
-    const currentSessionCost = sessionResult?.data?.data.cost
-    if (currentSessionCost !== undefined) setSessionCost(currentSessionCost)
-    if (todayResult?.data?.data !== undefined) setTodayCost(todayResult.data.data)
-  }
-
-  createEffect(() => {
-    session()
-    void refreshCosts()
-  })
+  const cost = createMemo(() => session()?.cost ?? 0)
+  const enabled = () => props.api.tuiConfig.show_today_cost
+  // Today's cost spans every session, so it comes from the server rather than the local session store.
+  const [todayCost, { refetch }] = createResource(
+    () => (enabled() ? cost() : undefined),
+    () => props.api.client.v2.session.cost().then((result) => result.data?.data).catch(() => undefined),
+  )
 
   onMount(() => {
-    const interval = setInterval(refreshCosts, 30_000)
+    const interval = setInterval(() => {
+      if (enabled()) void refetch()
+    }, 30_000)
     onCleanup(() => clearInterval(interval))
   })
 
@@ -64,7 +55,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
-      <Show when={props.api.tuiConfig.show_today_cost && todayCost() !== undefined}>
+      <Show when={enabled() && todayCost() !== undefined}>
         <text fg={theme().textMuted}>{money.format(todayCost()!)} today</text>
       </Show>
     </box>

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup, onMount, Show } from "solid-js"
 
 const id = "internal:sidebar-context"
 
@@ -14,7 +14,29 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
-  const cost = createMemo(() => session()?.cost ?? 0)
+  const [sessionCost, setSessionCost] = createSignal<number>()
+  const cost = createMemo(() => sessionCost() ?? session()?.cost ?? 0)
+  const [todayCost, setTodayCost] = createSignal<number>()
+
+  const refreshCosts = async () => {
+    const [sessionResult, todayResult] = await Promise.all([
+      props.api.client.v2.session.get({ sessionID: props.session_id }).catch(() => undefined),
+      props.api.tuiConfig.show_today_cost ? props.api.client.v2.session.cost().catch(() => undefined) : undefined,
+    ])
+    const currentSessionCost = sessionResult?.data?.data.cost
+    if (currentSessionCost !== undefined) setSessionCost(currentSessionCost)
+    if (todayResult?.data?.data !== undefined) setTodayCost(todayResult.data.data)
+  }
+
+  createEffect(() => {
+    session()
+    void refreshCosts()
+  })
+
+  onMount(() => {
+    const interval = setInterval(refreshCosts, 30_000)
+    onCleanup(() => clearInterval(interval))
+  })
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
@@ -42,6 +64,9 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
       <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <Show when={props.api.tuiConfig.show_today_cost && todayCost() !== undefined}>
+        <text fg={theme().textMuted}>{money.format(todayCost()!)} today</text>
+      </Show>
     </box>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Related to #39740. Session cost is already visible in the sidebar Context section, but users also need an optional total for all sessions updated today without running `opencode stats --days 1`.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional Today cost below the existing session spend in the sidebar Context section. The footer is unchanged. The display is:

```text
$0.21 spent
$0.56 today
```

When the current session's model has no pricing information (e.g. a custom model without a `cost` entry in the catalog or config), the spent line reads `N/A spent` instead of `$0.00 spent`, since the true cost cannot be derived. The footer session-cost display is unchanged.

Today is calculated from every session in the shared local database updated since local midnight. It is therefore shared across concurrently running OpenCode terminals and each Context view refreshes it every 30 seconds. The current session spend is fetched from the persisted session record as well. If a value cannot be fetched, it is omitted.

The Today line is disabled by default and appears only when `show_today_cost` is set to `true`. Create `~/.config/opencode/tui.json` if it does not exist:

```json
{
  "$schema": "https://opencode.ai/tui.json",
  "show_today_cost": true
}
```

A project-local `.opencode/tui.json` can also be used. The daily aggregation is exposed through the typed session API and does not shell out to `opencode stats --days 1`.

### Why the diff touches so many files

The hand-written change is small: the endpoint (`packages/protocol/src/groups/session.ts`, `packages/server/src/handlers/session.ts`, `packages/core/src/session.ts`), the TUI config flag, and the sidebar Context view (including the `N/A spent` fallback). Everything else is regenerated output:

- `packages/client/src/generated-effect/client.ts` and `packages/client/src/generated/*.ts` — generated by `@opencode-ai/httpapi-codegen` (`// Do not edit` header), adding the typed `session.cost` client method. The endpoint is registered last in the session group so the generator's positional `Endpoint3_N` constants keep their existing names and the generated diff is append-only. Route matching is unaffected: the router (`find-my-way-ts`) prioritizes the static `/api/session/cost` segment over `/api/session/:sessionID` regardless of registration order.
- `packages/sdk/js/src/v2/gen/*.ts` — the hey-api codegen adding the same `cost()` method to the SDK.
- `packages/plugin/src/tui.ts` — the `TuiConfigView` type gains the resolved `show_today_cost` field so plugins see the setting.
- `packages/opencode/src/cli/cmd/stats.ts` — refactored to reuse the new `sumSessionCosts` helper instead of accumulating cost inline (same output, one code path for cost summation).

Note on attribution: the total sums the full `cost` of every session with `time_updated` since local midnight. A long-running session that started yesterday and is touched today counts its entire cost toward today. This is a deliberate simplification for a glanceable stat; exact per-day attribution would require message-level aggregation.

### How did you verify your code works?

- `bun typecheck` passed in `packages/plugin`, `packages/sdk/js`, and `packages/tui`.
- The focused session-cost test passed.
- Built and smoke-tested the local Linux binary with `--version`.
- Rebased onto the latest `origin/dev` before updating this PR.
- Confirmed the sidebar shows `N/A spent` when the session model has no pricing and the currency amount when it does.

The repository-wide pre-push typecheck is currently blocked by unrelated AWS stats client type errors and a Bun/tsgo segmentation fault.

### Screenshots / recordings

This is a terminal UI change. Expected sidebar Context output with the setting enabled:

```text
Context
12,345 tokens
42% used
$0.21 spent
$0.56 today
```

For a model without pricing information:

```text
Context
12,345 tokens
42% used
N/A spent
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
