### PR TITLE
feat(app): add project file explorer sidebar and build/plan mode bar

### DIFF
--- a/packages/app/src/components/file-tree-v2.tsx
+++ b/packages/app/src/components/file-tree-v2.tsx
@@ -1,4 +1,5 @@
 import { useFile } from "@/context/file"
+import type { ExplorerTree } from "@/context/explorer"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import "@opencode-ai/ui/v2/file-tree-v2.css"
 import {
@@ -126,17 +127,18 @@ export default function FileTreeV2(props: {
   allowed?: readonly string[]
   kinds?: ReadonlyMap<string, Kind>
   draggable?: boolean
+  tree?: ExplorerTree
   onFileClick?: (file: FileNode) => void
   onFileDoubleClick?: (file: FileNode) => void
 }) {
-  const file = useFile()
+  const tree = () => props.tree ?? useFile().tree
   const live = () => props.allowed === undefined
   const draggable = () => props.draggable ?? true
   const active = () => normalizeFileTreeV2Path(props.active ?? "")
   const model = createMemo(() => (live() ? undefined : buildFileTreeV2Model(props.allowed ?? [])))
-  const expanded = (path: string) => file.tree.state(path)?.expanded ?? !live()
+  const expanded = (path: string) => tree().state(path)?.expanded ?? !live()
   const rows = createMemo(() => {
-    if (live()) return flattenLiveFileTreeV2((path) => file.tree.children(path), expanded)
+    if (live()) return flattenLiveFileTreeV2((path) => tree().children(path), expanded)
     return flattenFileTreeV2(model()!, expanded)
   })
   const [root, setRoot] = createSignal<HTMLDivElement>()
@@ -165,7 +167,7 @@ export default function FileTreeV2(props: {
 
   createEffect(() => {
     if (!live()) return
-    void file.tree.list("")
+    void tree().list("")
   })
 
   // Only scroll when the active path changes (or first appears in the tree).
@@ -199,10 +201,10 @@ export default function FileTreeV2(props: {
 
   const toggleDirectory = (path: string, originalPath: string) => {
     if (expanded(path)) {
-      file.tree.collapse(originalPath)
+      tree().collapse(originalPath)
       return
     }
-    file.tree.expand(originalPath, live() ? undefined : { list: false })
+    tree().expand(originalPath, live() ? undefined : { list: false })
   }
 
   const rowByKey = createMemo(() => new Map(rows().map((row) => [row.node.path, row] as const)))

--- a/packages/app/src/context/explorer.tsx
+++ b/packages/app/src/context/explorer.tsx
@@ -1,0 +1,98 @@
+import { createSimpleContext } from "@opencode-ai/ui/context"
+import { useParams } from "@solidjs/router"
+import { createEffect, createMemo } from "solid-js"
+import { useLanguage } from "./language"
+import { useLayout } from "./layout"
+import { useServerSDK } from "./server-sdk"
+import { useServer } from "./server"
+import { createFileTreeStore } from "./file/tree-store"
+import type { FileNode } from "@opencode-ai/sdk/v2"
+import { decode64 } from "@/utils/base64"
+import { showToast } from "@/utils/toast"
+
+export type ExplorerTree = {
+  list: (path: string) => Promise<void>
+  refresh: (path: string) => Promise<void>
+  state: (path: string) => { expanded?: boolean; loaded?: boolean; loading?: boolean } | undefined
+  children: (path: string) => readonly FileNode[]
+  expand: (path: string, behavior?: { list?: boolean }) => void
+  collapse: (path: string) => void
+  toggle: (path: string) => void
+}
+
+const normalizeDir = (input: string) =>
+  input
+    .replaceAll("\\", "/")
+    .replace(/\/+$/, "")
+
+export const { use: useExplorer, provider: ExplorerProvider } = createSimpleContext({
+  name: "Explorer",
+  init: () => {
+    const params = useParams()
+    const serverSDK = useServerSDK()
+    const server = useServer()
+    const layout = useLayout()
+    const language = useLanguage()
+
+    const routeDir = createMemo(() => {
+      const slug = params.dir
+      if (!slug) return
+      return decode64(slug)
+    })
+
+    const directory = createMemo(() => {
+      const routed = routeDir()
+      if (routed) return routed
+      const last = server.projects.last()
+      if (last) return last
+      return layout.projects.list()[0]?.worktree
+    })
+
+    const client = createMemo(() => {
+      const dir = directory()
+      if (!dir) return
+      return serverSDK().createClient({ directory: dir, throwOnError: true })
+    })
+
+    const tree = createFileTreeStore({
+      scope: directory,
+      normalizeDir,
+      list: (path) => {
+        const c = client()
+        if (!c) return Promise.resolve([])
+        return c.file.list({ path }).then((x) => x.data ?? [])
+      },
+      onError: (message) => {
+        showToast({
+          variant: "error",
+          title: language.t("toast.file.listFailed.title"),
+          description: message,
+        })
+      },
+    })
+
+    createEffect(() => {
+      directory()
+      tree.reset()
+    })
+
+    return {
+      directory,
+      tree: {
+        list: tree.listDir,
+        refresh: (path: string) => tree.listDir(path, { force: true }),
+        state: tree.dirState,
+        children: tree.children,
+        expand: tree.expandDir,
+        collapse: tree.collapseDir,
+        toggle(path: string) {
+          if (tree.dirState(path)?.expanded) {
+            tree.collapseDir(path)
+            return
+          }
+          tree.expandDir(path)
+        },
+      } satisfies ExplorerTree,
+    }
+  },
+})

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -29,6 +29,7 @@ export type { ProjectAvatarVariant }
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 const DEFAULT_SIDEBAR_WIDTH = 344
 const DEFAULT_FILE_TREE_WIDTH = 200
+const DEFAULT_EXPLORER_WIDTH = 280
 const DEFAULT_SESSION_WIDTH = 600
 const DEFAULT_TERMINAL_HEIGHT = 280
 const DEFAULT_REVIEW_PANEL_OPENED = false
@@ -289,6 +290,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           opened: false,
           width: DEFAULT_FILE_TREE_WIDTH,
           tab: "changes" as "changes" | "all",
+        },
+        explorer: {
+          opened: true,
+          width: DEFAULT_EXPLORER_WIDTH,
         },
         session: {
           width: DEFAULT_SESSION_WIDTH,
@@ -739,6 +744,22 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             return
           }
           setStore("fileTree", "width", width)
+        },
+      },
+      explorer: {
+        opened: createMemo(() => store.explorer?.opened ?? true),
+        width: createMemo(() => store.explorer?.width ?? DEFAULT_EXPLORER_WIDTH),
+        open() {
+          setStore("explorer", "opened", true)
+        },
+        close() {
+          setStore("explorer", "opened", false)
+        },
+        toggle() {
+          setStore("explorer", "opened", (x) => !x)
+        },
+        resize(width: number) {
+          setStore("explorer", "width", width)
         },
       },
       session: {

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -184,7 +184,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       list,
       visible: agentsVisible,
       current() {
-        return pickAgent(agentsVisible() ? (scope()?.agent ?? store.current) : "build")
+        const selected = scope()?.agent ?? store.current
+        if (agentsVisible()) return pickAgent(selected)
+        if (selected === "build" || selected === "plan") return pickAgent(selected)
+        return pickAgent("build")
       },
       set(name: string | undefined) {
         const item = pickAgent(name)

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,12 +1,17 @@
-import { createEffect, Suspense, type ParentProps } from "solid-js"
+import { createEffect, Show, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useNavigate } from "@solidjs/router"
 import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
 import { usePlatform } from "@/context/platform"
+import { useCommand } from "@/context/command"
+import { useExplorer, ExplorerProvider } from "@/context/explorer"
+import { useLayout } from "@/context/layout"
+import { useLanguage } from "@/context/language"
 import { setNavigate } from "@/utils/notification-click"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
+import { ProjectExplorerSidebar } from "@/pages/layout/explorer-sidebar"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
@@ -42,12 +47,38 @@ export default function NewLayout(props: ParentProps) {
             : undefined
         }
       />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
+      <ExplorerProvider>
+        <ProjectExplorerShell>{props.children}</ProjectExplorerShell>
+      </ExplorerProvider>
       {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
       <TabsInfoPopup />
       <ToastRegion v2 />
+    </div>
+  )
+}
+
+function ProjectExplorerShell(props: ParentProps) {
+  const explorer = useExplorer()
+  const layout = useLayout()
+  const language = useLanguage()
+  const command = useCommand()
+
+  command.register("explorer", () => [
+    {
+      id: "explorer.toggle",
+      title: language.t("command.fileTree.toggle"),
+      category: language.t("command.category.view"),
+      keybind: "mod+shift+e",
+      onSelect: () => layout.explorer.toggle(),
+    },
+  ])
+
+  return (
+    <div class="flex flex-1 min-h-0 min-w-0 gap-2">
+      <ProjectExplorerSidebar />
+      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
+        <Suspense>{props.children}</Suspense>
+      </main>
     </div>
   )
 }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -83,6 +83,8 @@ import {
 } from "./layout/sidebar-workspace"
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
+import { ExplorerProvider, useExplorer } from "@/context/explorer"
+import { ProjectExplorerSidebar } from "./layout/explorer-sidebar"
 
 export default function LegacyLayout(props: ParentProps) {
   const serverSDK = useServerSDK()
@@ -905,6 +907,13 @@ export default function LegacyLayout(props: ParentProps) {
         category: language.t("command.category.view"),
         keybind: "mod+b",
         onSelect: () => layout.sidebar.toggle(),
+      },
+      {
+        id: "explorer.toggle",
+        title: language.t("command.fileTree.toggle"),
+        category: language.t("command.category.view"),
+        keybind: "mod+shift+e",
+        onSelect: () => layout.explorer.toggle(),
       },
       {
         id: "project.open",
@@ -2273,6 +2282,9 @@ export default function LegacyLayout(props: ParentProps) {
         <UpdateAvailableToast version={updateVersion() ?? ""} install={installUpdate} language={language} />
       </Show>
       <div class="flex-1 min-h-0 min-w-0 flex">
+        <ExplorerProvider>
+          <ProjectExplorerShell />
+        </ExplorerProvider>
         <div class="flex-1 min-h-0 relative">
           <div class="size-full relative overflow-x-hidden">
             <nav
@@ -2453,4 +2465,13 @@ function UpdateAvailableToast(props: {
   })
 
   return null
+}
+
+function ProjectExplorerShell() {
+  const explorer = useExplorer()
+  return (
+    <Show when={explorer.directory() !== undefined}>
+      <ProjectExplorerSidebar />
+    </Show>
+  )
 }

--- a/packages/app/src/pages/layout/explorer-sidebar.css
+++ b/packages/app/src/pages/layout/explorer-sidebar.css
@@ -1,0 +1,59 @@
+[data-component="project-explorer"] {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-sidebar"] {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  min-height: 0;
+  overflow: hidden;
+  transition: width 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-filter"] {
+  padding: 0 8px 4px;
+  flex-shrink: 0;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-filter"] [data-component="text-input-v2"] {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  margin-top: 3px;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-tree"] {
+  flex: 1;
+  min-height: 0;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-tree"] .scroll-view__viewport {
+  padding: 4px 8px 12px;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-tree"] .scroll-view__thumb {
+  width: 16px;
+}
+
+[data-component="project-explorer"] [data-slot="project-explorer-tree"] .scroll-view__thumb::after {
+  width: 6px;
+  background-color: var(--v2-border-border-muted, var(--border-weak-base));
+}
+
+[data-component="project-explorer"]
+  [data-slot="project-explorer-tree"]
+  .scroll-view__thumb:hover::after,
+[data-component="project-explorer"]
+  [data-slot="project-explorer-tree"]
+  .scroll-view__thumb[data-dragging="true"]::after {
+  background-color: var(--v2-border-border-strong, var(--border-strong-base));
+}

--- a/packages/app/src/pages/layout/explorer-sidebar.tsx
+++ b/packages/app/src/pages/layout/explorer-sidebar.tsx
@@ -1,0 +1,211 @@
+import { createEffect, createMemo, createSignal, Show } from "solid-js"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import { useNavigate } from "@solidjs/router"
+import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
+import { ScrollView } from "@opencode-ai/ui/scroll-view"
+import { TextInputV2 } from "@opencode-ai/ui/v2/text-input-v2"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { Icon } from "@opencode-ai/ui/v2/icon"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { createQuery } from "@tanstack/solid-query"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
+import { useExplorer } from "@/context/explorer"
+import { useServerSDK } from "@/context/server-sdk"
+import { SessionRouteKey, SessionStateKey } from "@/utils/server-scope"
+import { setSessionHandoff } from "@/pages/session/handoff"
+import { displayName } from "./helpers"
+import FileTreeV2 from "@/components/file-tree-v2"
+import { SessionFileListV2, applyFileListKeyDown } from "@/pages/session/v2/session-file-list-v2"
+import "./explorer-sidebar.css"
+
+const emptyFiles: string[] = []
+
+export function ProjectExplorerSidebar(props: { mobile?: boolean }) {
+  const language = useLanguage()
+  const layout = useLayout()
+  const explorer = useExplorer()
+  const navigate = useNavigate()
+  const serverSDK = useServerSDK()
+
+  const [filter, setFilter] = createSignal("")
+  const [explicitHighlight, setExplicitHighlight] = createSignal<string>()
+  const [resizing, setResizing] = createSignal(false)
+  const hasDirectory = createMemo(() => explorer.directory() !== undefined)
+  const opened = createMemo(() => (layout.explorer.opened() || props.mobile) && hasDirectory())
+  const query = createMemo(() => filter().trim())
+
+  createEffect(() => {
+    if (!resizing()) return
+    const stop = () => setResizing(false)
+    makeEventListener(document, "pointerup", stop)
+    makeEventListener(document, "pointercancel", stop)
+  })
+
+  const project = createMemo(() => {
+    const directory = explorer.directory()
+    if (!directory) return
+    return layout.projects
+      .list()
+      .find((item) => item.worktree === directory || item.sandboxes?.includes(directory))
+  })
+
+  const title = createMemo(() => displayName(project() ?? { worktree: explorer.directory() ?? "" }))
+
+  const search = createQuery(() => {
+    const value = query()
+    const directory = explorer.directory()
+    return {
+      queryKey: ["explorer-files", serverSDK().url, value] as const,
+      enabled: value.length > 0 && !!directory,
+      queryFn: ({ signal }) =>
+        serverSDK()
+          .api.file.find({
+            location: { directory },
+            query: value,
+            type: "file",
+            limit: 200,
+          })
+          .then((x) => x.data.map((entry) => entry.path)),
+    }
+  })
+
+  const files = createMemo(() => {
+    if (!query() || search.isPending) return emptyFiles
+    return [...new Set(search.data ?? emptyFiles)]
+  })
+
+  const highlighted = createMemo(() => {
+    const values = files()
+    if (values.length === 0) return undefined
+    const explicit = explicitHighlight()
+    if (explicit && values.includes(explicit)) return explicit
+    return values[0]
+  })
+
+  const loading = createMemo(() => query().length > 0 && search.isPending)
+
+  const openFile = (path: string) => {
+    const directory = explorer.directory()
+    if (!directory) return
+    const slug = base64Encode(directory)
+    const sessionKey = SessionStateKey.from(serverSDK().scope, SessionRouteKey.fromRoute(slug))
+    setSessionHandoff(sessionKey, { files: { [path]: null } })
+    navigate(`/${slug}/session`)
+  }
+
+  const onFilterKeyDown = (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => {
+    if (event.key === "Escape" && query()) {
+      event.preventDefault()
+      setFilter("")
+      return
+    }
+    if (!query()) return
+    applyFileListKeyDown(event, files(), highlighted(), {
+      onHighlight: setExplicitHighlight,
+      onSelect: openFile,
+    })
+  }
+
+  return (
+    <div data-component="project-explorer" class="flex h-full min-w-0">
+      <aside
+        data-slot="project-explorer-sidebar"
+        class="my-2 ml-2 h-[calc(100%-1rem)] shrink-0 overflow-hidden rounded-[10px] bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]"
+        classList={{ hidden: !opened() }}
+        style={{ width: opened() ? `${layout.explorer.width()}px` : "0px" }}
+      >
+        <div class="flex h-full flex-col overflow-hidden">
+          <div data-slot="project-explorer-header" class="flex shrink-0 items-center justify-between gap-2 px-2 pt-3 pb-1">
+            <div
+              data-slot="project-explorer-title"
+              class="min-w-0 truncate pl-1 text-[13px] font-[500] text-v2-text-text-base"
+            >
+              {title()}
+            </div>
+            <Show when={!props.mobile}>
+              <TooltipV2 value={language.t("common.close")}>
+                <IconButtonV2
+                  variant="ghost-muted"
+                  size="small"
+                  class="hover-reveal"
+                  icon={<Icon name="xmark-small" />}
+                  aria-label={language.t("common.close")}
+                  onClick={() => layout.explorer.close()}
+                />
+              </TooltipV2>
+            </Show>
+          </div>
+          <div data-slot="project-explorer-filter" class="shrink-0 px-2 pb-2">
+            <TextInputV2
+              type="search"
+              value={filter()}
+              onInput={(event) => setFilter(event.currentTarget.value)}
+              onKeyDown={onFilterKeyDown}
+              showClearButton={filter().length > 0}
+              clearLabel={language.t("ui.list.clearFilter")}
+              onClearClick={() => setFilter("")}
+              placeholder={language.t("ui.sessionReviewV2.filterFiles")}
+              aria-label={language.t("ui.sessionReviewV2.filterFiles")}
+              leadingIcon={<Icon name="magnifying-glass" />}
+            />
+          </div>
+          <ScrollView
+            data-slot="project-explorer-tree"
+            class="min-h-0 flex-1 group/file-tree-v2"
+            thumbVisibility="scroll"
+          >
+            <Show
+              when={query()}
+              fallback={<FileTreeV2 tree={explorer.tree} onFileClick={(node) => openFile(node.path)} />}
+            >
+              <Show
+                when={!loading()}
+                fallback={
+                  <div role="status" class="px-2 py-2 text-12-regular text-text-weak">
+                    {language.t("common.loading")}
+                    {language.t("common.loading.ellipsis")}
+                  </div>
+                }
+              >
+                <Show
+                  when={files().length > 0}
+                  fallback={
+                    <div role="status" class="px-2 py-2 text-12-regular text-text-weak">
+                      {language.t("palette.empty")}
+                    </div>
+                  }
+                >
+                  <SessionFileListV2
+                    files={files()}
+                    highlighted={highlighted()}
+                    onFileClick={(path) => {
+                      setExplicitHighlight(path)
+                      openFile(path)
+                    }}
+                    onFileDoubleClick={openFile}
+                  />
+                </Show>
+              </Show>
+            </Show>
+          </ScrollView>
+        </div>
+      </aside>
+      <Show when={opened() && !props.mobile}>
+        <div class="my-2 flex shrink-0" onPointerDown={() => setResizing(true)}>
+          <ResizeHandle
+            direction="horizontal"
+            edge="start"
+            size={layout.explorer.width()}
+            min={240}
+            max={640}
+            onResize={(width) => {
+              layout.explorer.resize(width)
+            }}
+          />
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/pages/new-session/new-session-view.tsx
+++ b/packages/app/src/pages/new-session/new-session-view.tsx
@@ -9,6 +9,7 @@ import { Portal } from "solid-js/web"
 import createPresence from "solid-presence"
 import { PromptInputV2Composer } from "@/components/prompt-input-v2"
 import { PromptGitStatus, PromptWorkspaceSelector } from "@/components/prompt-workspace-selector"
+import { AgentModeBar } from "@/pages/session/composer/agent-mode-bar"
 import {
   PromptProjectAddButton,
   PromptProjectSelector,
@@ -42,6 +43,7 @@ export function NewSessionView(props: {
             <WordmarkV2 class="h-auto w-full text-v2-background-bg-inverse" />
             <div class="mt-8 flex flex-col gap-8">
               <PromptInputV2Composer controller={props.input} />
+              <AgentModeBar />
               <Show when={props.project.empty()}>
                 <PromptProjectAddButton controller={props.project} />
               </Show>

--- a/packages/app/src/pages/session/composer/agent-mode-bar.tsx
+++ b/packages/app/src/pages/session/composer/agent-mode-bar.tsx
@@ -1,0 +1,43 @@
+import { createMemo, For, Show } from "solid-js"
+import { SegmentedControlV2, SegmentedControlItemV2 } from "@opencode-ai/ui/v2/segmented-control-v2"
+import { useLocal } from "@/context/local"
+
+const MODES = ["build", "plan"] as const
+
+export function AgentModeBar() {
+  const local = useLocal()
+
+  const modes = createMemo(() => {
+    const names = new Set(local.agent.list().map((agent) => agent.name))
+    return MODES.filter((mode) => names.has(mode))
+  })
+
+  const current = createMemo(() => local.agent.current()?.name)
+  const visible = createMemo(() => modes().length > 0)
+
+  return (
+    <Show when={visible()}>
+      <div data-component="agent-mode-bar" class="flex w-full items-center">
+        <SegmentedControlV2
+          value={current()}
+          onChange={(value) => {
+            if (value === "build" || value === "plan") local.agent.set(value)
+          }}
+          class="gap-0.5 rounded-[6px] bg-v2-overlay-simple-overlay p-0.5"
+          aria-label="Agent mode"
+        >
+          <For each={modes()}>
+            {(mode) => (
+              <SegmentedControlItemV2
+                value={mode}
+                class="h-6 min-w-14 rounded-[4px] px-2 text-[12px] font-medium uppercase tracking-[0.06em] text-v2-text-text-muted transition-colors data-[pressed]:bg-v2-background-bg-base data-[pressed]:text-v2-text-text-base data-[pressed]:shadow-[var(--v2-elevation-raised)]"
+              >
+                {mode}
+              </SegmentedControlItemV2>
+            )}
+          </For>
+        </SegmentedControlV2>
+      </div>
+    </Show>
+  )
+}

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -6,6 +6,7 @@ import { SessionQuestionDock } from "@/pages/session/composer/session-question-d
 import { SessionFollowupDock } from "@/pages/session/composer/session-followup-dock"
 import { SessionRevertDock } from "@/pages/session/composer/session-revert-dock"
 import { SessionTodoDock } from "@/pages/session/composer/session-todo-dock"
+import { AgentModeBar } from "@/pages/session/composer/agent-mode-bar"
 import type { SessionComposerRegionController } from "./session-composer-region-controller"
 
 export function SessionComposerRegion(props: {
@@ -131,6 +132,9 @@ export function SessionComposerRegion(props: {
                 "margin-top": `${-controller.lift()}px`,
               }}
             >
+              <div class="flex justify-center pb-2">
+                <AgentModeBar />
+              </div>
               <Show when={controller.followup()?.items.length}>
                 <SessionFollowupDock
                   items={controller.followup()!.items}

--- a/packages/desktop/.gitignore
+++ b/packages/desktop/.gitignore
@@ -1,6 +1,7 @@
 # Logs
 logs
 *.log
+*.log.err
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary

Adds a persistent left sidebar showing the current project's file tree on all screens (new and legacy layouts), with a searchable file listing and adjustable width. Adds a BUILD/PLAN segmented control below the chat that switches the active agent mode.

## Changes

- **ExplorerProvider** (new): resolves the current project directory globally and exposes a file tree built from the server file API, so the sidebar works on every screen.
- **FileTreeV2**: accepts an optional external \	ree\ so the same component powers both the session side panel and the new explorer sidebar.
- **ProjectExplorerSidebar** (new): project name header, search filter, navigable file tree, resizable width (240-640px), rounded v2 styling.
- **AgentModeBar** (new): BUILD/PLAN segmented control below the chat that calls \local.agent.set(...)\, matching the agent mode behavior of the CLI.
- **\local.agent.current()\**: respects \uild\/\plan\ selection even when custom agents are not visible.
- Mounted in both \NewLayout\ and the legacy \Layout\, with a \mod+shift+e\ toggle.

## Testing

- Ran \un typecheck\ in \packages/app\ and \packages/desktop\ (only pre-existing \custom-elements.d.ts\ error).
- Ran file tree unit tests (\ile-tree-v2-model.test.ts\, \ile-tree.test.ts\) - all passing.
- Tested interactively in the desktop app.