### PR TITLE
feat(session-ui): render ordered tool media

### DIFF
--- a/packages/session-ui/src/components/message-media.test.ts
+++ b/packages/session-ui/src/components/message-media.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { mediaLabel, supportedImageMime } from "./message-media"
+
+describe("supportedImageMime", () => {
+  test("accepts the ordered-media conformance profile", () => {
+    expect(["image/png", "image/jpeg", "image/webp", "image/gif"].every(supportedImageMime)).toBe(true)
+  })
+
+  test("rejects unsupported and active image formats", () => {
+    expect(supportedImageMime("image/svg+xml")).toBe(false)
+    expect(supportedImageMime("application/pdf")).toBe(false)
+  })
+})
+
+describe("mediaLabel", () => {
+  test("prefers the filename and falls back to the MIME type", () => {
+    expect(mediaLabel({ filename: "diagram.png", mime: "image/png" })).toBe("diagram.png")
+    expect(mediaLabel({ mime: "image/webp" })).toBe("image/webp")
+  })
+})

--- a/packages/session-ui/src/components/message-media.ts
+++ b/packages/session-ui/src/components/message-media.ts
@@ -1,0 +1,9 @@
+const supportedImageMimes = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"])
+
+export function supportedImageMime(mime: string) {
+  return supportedImageMimes.has(mime.toLowerCase())
+}
+
+export function mediaLabel(file: { filename?: string; mime: string }) {
+  return file.filename || file.mime || "Attachment"
+}

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -713,6 +713,66 @@
   width: 100%;
 }
 
+[data-slot="agent-media-attachments"] {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
+  gap: 12px;
+  width: 100%;
+  margin-top: 8px;
+}
+
+[data-slot="agent-media-image"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  max-height: min(70vh, 720px);
+  padding: 0;
+  overflow: hidden;
+  border: 0.5px solid var(--v2-border-border-base);
+  border-radius: 8px;
+  background: var(--v2-background-bg-layer-02);
+  cursor: zoom-in;
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--v2-border-border-strong);
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: min(70vh, 720px);
+    object-fit: contain;
+  }
+}
+
+[data-slot="agent-media-fallback"] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 48px;
+  padding: 8px 10px;
+  color: var(--v2-text-text-muted);
+  border: 0.5px solid var(--v2-border-border-base);
+  border-radius: 8px;
+  background: var(--v2-background-bg-layer-02);
+
+  [data-component="file-icon"] {
+    flex: none;
+  }
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
 [data-component="dock-prompt"][data-kind="permission"] {
   position: relative;
   display: flex;

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -66,6 +66,7 @@ import { useLocation } from "@solidjs/router"
 import { attached, inline, kind, typeLabel } from "./message-file"
 import { readPartText } from "./message-part-text"
 import { SessionProgressIndicatorV2 } from "../v2/components/session-progress-indicator-v2"
+import { mediaLabel, supportedImageMime } from "./message-media"
 
 async function writeClipboard(text: string): Promise<boolean> {
   const body = typeof document === "undefined" ? undefined : document.body
@@ -1142,6 +1143,11 @@ export function ContextToolGroup(props: {
               const running = createMemo(
                 () => partAccessor().state.status === "pending" || partAccessor().state.status === "running",
               )
+              const attachments = createMemo(() => {
+                const state = partAccessor().state
+                if (state.status !== "completed") return []
+                return state.attachments ?? []
+              })
               return (
                 <div data-slot="context-tool-group-item">
                   <div data-component="tool-trigger">
@@ -1165,6 +1171,9 @@ export function ContextToolGroup(props: {
                       </div>
                     </div>
                   </div>
+                  <Show when={attachments().length > 0}>
+                    <MediaAttachments files={attachments()} provenance={partAccessor().tool} />
+                  </Show>
                 </div>
               )
             }}
@@ -1585,6 +1594,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   })
 
   const render = createMemo(() => ToolRegistry.render(part().tool) ?? GenericTool)
+  const attachments = createMemo(() => {
+    const state = part().state
+    if (state.status !== "completed") return []
+    return state.attachments ?? []
+  })
   const controlledOpen = () => (props.onToolOpenChange ? (props.toolOpen ?? props.defaultOpen) : undefined)
   const handleToolOpenChange = (open: boolean) => props.onToolOpenChange?.(open)
 
@@ -1619,26 +1633,74 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
             }}
           </Match>
           <Match when={true}>
-            <Dynamic
-              component={render()}
-              input={input()}
-              tool={part().tool}
-              sessionID={part().sessionID}
-              metadata={partMetadata()}
-              // @ts-expect-error
-              output={part().state.output}
-              status={part().state.status}
-              hideDetails={props.hideDetails}
-              defaultOpen={props.defaultOpen}
-              open={controlledOpen()}
-              onOpenChange={props.onToolOpenChange ? handleToolOpenChange : undefined}
-              deferContent={props.deferToolContent}
-              virtualizeDiff={props.virtualizeDiff}
-              onContentRendered={props.onContentRendered}
-            />
+            <>
+              <Dynamic
+                component={render()}
+                input={input()}
+                tool={part().tool}
+                sessionID={part().sessionID}
+                metadata={partMetadata()}
+                // @ts-expect-error
+                output={part().state.output}
+                status={part().state.status}
+                hideDetails={props.hideDetails}
+                defaultOpen={props.defaultOpen}
+                open={controlledOpen()}
+                onOpenChange={props.onToolOpenChange ? handleToolOpenChange : undefined}
+                deferContent={props.deferToolContent}
+                virtualizeDiff={props.virtualizeDiff}
+                onContentRendered={props.onContentRendered}
+              />
+              <Show when={attachments().length > 0}>
+                <MediaAttachments files={attachments()} provenance={part().tool} />
+              </Show>
+            </>
           </Match>
         </Switch>
       </div>
+    </Show>
+  )
+}
+
+PART_MAPPING["file"] = function FilePartDisplay(props) {
+  const part = () => props.part as FilePart
+  return <MediaAttachments files={[part()]} />
+}
+
+function MediaAttachments(props: { files: FilePart[]; provenance?: string }) {
+  return (
+    <Show when={props.files.length > 0}>
+      <div data-slot="agent-media-attachments" data-provenance={props.provenance}>
+        <For each={props.files}>{(file) => <MediaAttachment file={file} />}</For>
+      </div>
+    </Show>
+  )
+}
+
+function MediaAttachment(props: { file: FilePart }) {
+  const dialog = useDialog()
+  const [failed, setFailed] = createSignal(false)
+  const name = () => mediaLabel(props.file)
+  const image = () => supportedImageMime(props.file.mime)
+
+  const open = () => {
+    if (!image() || failed()) return
+    dialog.show(() => <ImagePreview src={props.file.url} alt={name()} />)
+  }
+
+  return (
+    <Show
+      when={image() && !failed()}
+      fallback={
+        <div data-slot="agent-media-fallback" role="status" title={name()}>
+          <FileIcon node={{ path: name(), type: "file" }} />
+          <span>{name()}</span>
+        </div>
+      }
+    >
+      <button type="button" data-slot="agent-media-image" aria-label={name()} title={name()} onClick={open}>
+        <img src={props.file.url} alt={name()} loading="lazy" onError={() => setFailed(true)} />
+      </button>
     </Show>
   )
 }

--- a/packages/session-ui/src/components/timeline-playground.stories.tsx
+++ b/packages/session-ui/src/components/timeline-playground.stories.tsx
@@ -265,6 +265,8 @@ Here's what the output looks like:
 And below is the final result.`,
 }
 
+const MEDIA_FIXTURE = new URL("../../../ui/src/assets/images/social-share.png", import.meta.url).href
+
 const REASONING_SAMPLES = [
   `**Analyzing the request**
 
@@ -293,6 +295,29 @@ This should be straightforward given the existing component architecture.`,
 ]
 
 const TOOL_SAMPLES = {
+  "read image": {
+    tool: "read",
+    input: { filePath: "packages/ui/src/assets/images/social-share.png" },
+    output: "Image Size: 1200x630.",
+    title: "Read packages/ui/src/assets/images/social-share.png",
+    metadata: {},
+    attachments: [
+      {
+        id: "ordered-media-fixture",
+        type: "file",
+        mime: "image/png",
+        filename: "social-share.png",
+        url: MEDIA_FIXTURE,
+      } as FilePart,
+      {
+        id: "ordered-media-unsupported",
+        type: "file",
+        mime: "application/pdf",
+        filename: "unsupported.pdf",
+        url: "data:application/pdf;base64,",
+      } as FilePart,
+    ],
+  },
   read: {
     tool: "read",
     input: { filePath: "src/components/session-turn.tsx", offset: 1, limit: 50 },
@@ -561,6 +586,7 @@ function toolPart(sample: (typeof TOOL_SAMPLES)[keyof typeof TOOL_SAMPLES], stat
         title: sample.title,
         metadata: sample.metadata ?? {},
         time: { start: Date.now(), end: Date.now() + 1000 },
+        attachments: "attachments" in sample ? sample.attachments : undefined,
       },
     } as ToolPart
   }


### PR DESCRIPTION
### Issue for this PR

Closes #39815

Linear surface: [AES-29](https://linear.app/rt88/issue/AES-29/render-tool-graphics-and-mermaid-diagrams-in-the-opencode-frontend)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Renders supported tool-result images in provider order, opens them in the existing image preview, and gives unsupported media a labeled fallback. It covers both normal tools and context-grouped read tools.

Related: #38846 covers clickable tool image thumbnails. This patch additionally preserves provider ordering, renders unsupported attachments as labeled fallbacks, supports top-level assistant file parts, and adds deterministic coverage.

### How did you verify your code works?

Ran the session-ui typecheck and focused tests (9 passing), plus the workspace typecheck (30 packages). In Storybook, verified ordered image/fallback rendering, preview open/close, and a 480px viewport without horizontal overflow.

### Screenshots / recordings

Validated in the visible Browser against a real OpenCode web session and backend. The included `Playground/Timeline` story lets reviewers reproduce the image, fallback, and preview states locally.

![Real OpenCode chat rendering an ordered tool image](https://uploads.linear.app/e7159f61-7b61-4844-86c9-23b552fe1895/a2d4c0fb-be27-4fed-9502-ecce4639148f/a5deee0a-48ae-4f26-bc93-aeb72d17dd2b)

![Real OpenCode image preview](https://uploads.linear.app/e7159f61-7b61-4844-86c9-23b552fe1895/053c79e8-f905-4d00-b65f-d027b8eb7f64/3373d2a2-8d91-48ff-b538-1a69f0471d02)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
