### PR TITLE
fix(app): prevent stale prompt control reads

### DIFF
--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -212,20 +212,20 @@ export function PromptInputV2(props: PromptInputV2Props) {
               onContext={props.controller.openContext}
               onShell={props.controller.openShell}
             />
-            <Show when={view.agent}>
+            <Show when={view.agent} keyed>
               {(control) => (
-                <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control()} />
+                <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control} />
               )}
             </Show>
             <Show
               when={props.modelControl}
               fallback={
-                <Show when={view.model}>
+                <Show when={view.model} keyed>
                   {(control) => (
                     <PromptInputV2ConfiguredSelect
                       title="Choose model"
                       keybind={["Mod", "M"]}
-                      control={control()}
+                      control={control}
                       model
                     />
                   )}
@@ -234,13 +234,13 @@ export function PromptInputV2(props: PromptInputV2Props) {
             >
               {props.modelControl}
             </Show>
-            <Show when={(props.variantControlVisible ?? true) && view.variant}>
+            <Show when={(props.variantControlVisible ?? true) && view.variant} keyed>
               {(control) => (
-                <Show when={control().options().length > 1}>
+                <Show when={control.options().length > 1}>
                   <PromptInputV2ConfiguredSelect
                     title="Choose model variant"
                     keybind={["Shift", "Mod", "D"]}
-                    control={control()}
+                    control={control}
                   />
                 </Show>
               )}


### PR DESCRIPTION
### Issue for this PR

- Closes #39840
- Related to #39766 and #39704

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Fixes a desktop renderer crash when opening an existing session from another project for the first time.
- Fixes the same crash when switching projects from a new-session tab.
- An instrumented stack traced the crash to the prompt input variant control reading the accessor from an outer `<Show>` after that control was unmounted.
- Makes the agent, model, and variant control boundaries keyed because all three use the same lifecycle pattern.
- Passes each control directly to its selector instead of retaining a narrowing accessor that can become stale during project navigation.

### How did you verify your code works?

- Reproduced both project-navigation crashes on desktop 1.18.10 before the change.
- Confirmed both paths no longer crash after the change.
- Ran `bun typecheck` in `packages/session-ui`.
- Ran `bun typecheck` in `packages/app`.
- Ran the prompt-input machine and store tests: 16 passed.
- The repository pre-push typecheck completed successfully across 30 packages.

### Screenshots / recordings

- **Before:**

https://github.com/user-attachments/assets/070dc37b-8949-4f19-93dc-b308d127cf46

- **After:**

https://github.com/user-attachments/assets/a3d81703-8e91-4a8f-a4ef-7a766cf72803

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR