### PR TITLE
fix(desktop): debounce persisted store writes

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -47,6 +47,7 @@ import { registerWslIpcHandlers } from "./wsl/ipc"
 import { spawnWslSidecar } from "./wsl/sidecar"
 import { migrate } from "./migrate"
 import { cleanupStoreFiles } from "./store-cleanup"
+import { flushAllStores } from "./store"
 import { startBackgroundCli } from "./background-cli"
 
 const APP_NAMES: Record<string, string> = {
@@ -222,11 +223,13 @@ const main = Effect.gen(function* () {
 
   app.on("before-quit", () => {
     setAppQuitting()
+    flushAllStores()
     void stopSidecars()
   })
 
   app.on("will-quit", () => {
     setAppQuitting()
+    flushAllStores()
     void stopSidecars()
   })
 

--- a/packages/desktop/src/main/store.test.ts
+++ b/packages/desktop/src/main/store.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test, vi } from "bun:test"
+import { BufferedStore } from "./store"
+
+class MemoryStore {
+  writes = 0
+  private value: Record<string, unknown> = {}
+
+  get store() {
+    return { ...this.value }
+  }
+
+  set store(value: Record<string, unknown>) {
+    this.writes++
+    this.value = { ...value }
+  }
+
+  get(key: string) {
+    return this.value[key]
+  }
+
+  has(key: string) {
+    return key in this.value
+  }
+}
+
+describe("BufferedStore", () => {
+  test("makes pending changes available immediately", () => {
+    const target = new MemoryStore()
+    const store = new BufferedStore(target)
+
+    store.set("theme", "dark")
+
+    expect(store.get("theme")).toBe("dark")
+    expect(store.has("theme")).toBe(true)
+    expect(store.store).toEqual({ theme: "dark" })
+    expect(target.store).toEqual({})
+    store.flush()
+  })
+
+  test("batches changes into one physical write", () => {
+    const target = new MemoryStore()
+    const store = new BufferedStore(target)
+
+    store.set("prompt", "first")
+    store.set("prompt", "latest")
+    store.set("cursor", 6)
+    store.flush()
+
+    expect(target.writes).toBe(1)
+    expect(target.store).toEqual({ prompt: "latest", cursor: 6 })
+  })
+
+  test("debounces writes from the latest change", () => {
+    vi.useFakeTimers()
+    try {
+      const target = new MemoryStore()
+      const store = new BufferedStore(target, 100)
+
+      store.set("prompt", "first")
+      vi.advanceTimersByTime(99)
+      store.set("prompt", "latest")
+      vi.advanceTimersByTime(99)
+      expect(target.writes).toBe(0)
+
+      vi.advanceTimersByTime(1)
+      expect(target.writes).toBe(1)
+      expect(target.store).toEqual({ prompt: "latest" })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test("batches deletes and clears", () => {
+    const target = new MemoryStore()
+    target.store = { first: 1, second: 2 }
+    target.writes = 0
+    const store = new BufferedStore(target)
+
+    store.delete("first")
+    expect(store.has("first")).toBe(false)
+    expect(store.store).toEqual({ second: 2 })
+
+    store.clear()
+    store.set("latest", 3)
+    store.flush()
+
+    expect(target.writes).toBe(1)
+    expect(target.store).toEqual({ latest: 3 })
+  })
+})

--- a/packages/desktop/src/main/store.ts
+++ b/packages/desktop/src/main/store.ts
@@ -6,7 +6,82 @@ import { join } from "node:path"
 import { SETTINGS_STORE } from "./store-keys"
 import { deleteStoreFileIfEmpty } from "./store-cleanup"
 
-const cache = new Map<string, Store>()
+const DELETED = Symbol("deleted")
+const WRITE_DELAY = 500
+
+type StoreTarget = {
+  get(key: string): unknown
+  has(key: string): boolean
+  store: Record<string, unknown>
+}
+
+export class BufferedStore {
+  private pending = new Map<string, unknown>()
+  private cleared = false
+  private timer: ReturnType<typeof setTimeout> | undefined
+
+  constructor(
+    private target: StoreTarget,
+    private delay = WRITE_DELAY,
+  ) {}
+
+  get store() {
+    const next = this.cleared ? {} : { ...this.target.store }
+    for (const [key, value] of this.pending) {
+      if (value === DELETED) delete next[key]
+      else next[key] = value
+    }
+    return next
+  }
+
+  get(key: string) {
+    if (this.pending.has(key)) {
+      const value = this.pending.get(key)
+      return value === DELETED ? undefined : value
+    }
+    if (this.cleared) return undefined
+    return this.target.get(key)
+  }
+
+  has(key: string) {
+    if (this.pending.has(key)) return this.pending.get(key) !== DELETED
+    if (this.cleared) return false
+    return this.target.has(key)
+  }
+
+  set(key: string, value: unknown) {
+    this.pending.set(key, value)
+    this.schedule()
+  }
+
+  delete(key: string) {
+    this.pending.set(key, DELETED)
+    this.schedule()
+  }
+
+  clear() {
+    this.cleared = true
+    this.pending.clear()
+    this.schedule()
+  }
+
+  flush() {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
+    if (!this.cleared && this.pending.size === 0) return
+
+    this.target.store = this.store
+    this.cleared = false
+    this.pending.clear()
+  }
+
+  private schedule() {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.flush(), this.delay)
+  }
+}
+
+const cache = new Map<string, BufferedStore>()
 
 // We cannot instantiate the electron-store at module load time because
 // module import hoisting causes this to run before app.setPath("userData", ...)
@@ -15,21 +90,31 @@ const cache = new Map<string, Store>()
 export function getStore(name = SETTINGS_STORE) {
   const cached = cache.get(name)
   if (cached) return cached
-  const next = new Store({
-    name,
-    cwd: electron.app.getPath("userData"),
-    fileExtension: "",
-    accessPropertiesByDotNotation: false,
-  })
+  const next = new BufferedStore(
+    new Store({
+      name,
+      cwd: electron.app.getPath("userData"),
+      fileExtension: "",
+      accessPropertiesByDotNotation: false,
+    }),
+  )
   cache.set(name, next)
   return next
 }
 
+export function flushAllStores() {
+  for (const store of cache.values()) store.flush()
+}
+
 export async function removeStoreFileIfEmpty(name: string) {
-  if (await deleteStoreFileIfEmpty(electron.app.getPath("userData"), name)) cache.delete(name)
+  const store = cache.get(name)
+  store?.flush()
+  if (!(await deleteStoreFileIfEmpty(electron.app.getPath("userData"), name))) return
+  if (!store || Object.keys(store.store).length === 0) cache.delete(name)
 }
 
 export function removeStoreFile(name: string) {
+  cache.get(name)?.flush()
   rmSync(join(electron.app.getPath("userData"), name), { force: true })
   cache.delete(name)
 }


### PR DESCRIPTION
## Summary
- buffer Electron store mutations behind a 500 ms trailing debounce
- merge pending mutations into one physical store replacement per flush
- keep buffered values immediately readable and flush all stores during shutdown
- flush before scoped store cleanup or removal

## Verification
- `bun test src/main/store.test.ts src/main/store-cleanup.test.ts` from `packages/desktop`
- `bun typecheck` from `packages/desktop`
- pre-push workspace typecheck