### PR TITLE
fix(tui): show N/A spent for models without pricing

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo } from "solid-js"
+import { modelHasPricing } from "./cost"
 
 const id = "internal:sidebar-context"
 
@@ -15,6 +16,12 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
   const cost = createMemo(() => session()?.cost ?? 0)
+  const model = createMemo(() => {
+    const ref = session()?.model
+    if (!ref) return undefined
+    return props.api.state.provider.find((item) => item.id === ref.providerID)?.models[ref.id]
+  })
+  const priced = createMemo(() => modelHasPricing(model()))
 
   const state = createMemo(() => {
     const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
@@ -41,7 +48,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <text fg={theme().textMuted}>{priced() ? `${money.format(cost())} spent` : "N/A spent"}</text>
     </box>
   )
 }

--- a/packages/tui/src/feature-plugins/sidebar/cost.ts
+++ b/packages/tui/src/feature-plugins/sidebar/cost.ts
@@ -1,0 +1,7 @@
+import type { Model } from "@opencode-ai/sdk/v2"
+
+export function modelHasPricing(model: Model | undefined): boolean {
+  const cost = model?.cost
+  if (cost === undefined) return false
+  return cost.input !== 0 || cost.output !== 0
+}

--- a/packages/tui/test/feature-plugins/sidebar-context-cost.test.ts
+++ b/packages/tui/test/feature-plugins/sidebar-context-cost.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { modelHasPricing } from "../../src/feature-plugins/sidebar/cost"
+
+describe("modelHasPricing", () => {
+  test("returns false when the model is undefined", () => {
+    expect(modelHasPricing(undefined)).toBe(false)
+  })
+
+  test("returns false when the model has no cost entry", () => {
+    expect(modelHasPricing({} as never)).toBe(false)
+  })
+
+  test("returns false when input and output are zero", () => {
+    expect(modelHasPricing({ cost: { input: 0, output: 0, cache: { read: 0, write: 0 } } } as never)).toBe(false)
+  })
+
+  test("returns true when input is non-zero", () => {
+    expect(
+      modelHasPricing({ cost: { input: 0.14, output: 0, cache: { read: 0.028, write: 0 } } } as never),
+    ).toBe(true)
+  })
+
+  test("returns true when output is non-zero", () => {
+    expect(
+      modelHasPricing({ cost: { input: 0, output: 0.28, cache: { read: 0, write: 0 } } } as never),
+    ).toBe(true)
+  })
+
+  test("returns false when only cache pricing is non-zero", () => {
+    expect(
+      modelHasPricing({ cost: { input: 0, output: 0, cache: { read: 0.028, write: 0 } } } as never),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39869. Related to #17223 (runtime cost tracking for custom providers — this PR addresses only the misleading display for unpriced models, not the runtime cost calculation or usage handling).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the TUI sidebar Context section, the spent line now reads `N/A spent` when the current session's model has no pricing instead of `$0.00 spent`.

A model is considered priced only when its `cost` entry has at least one of `input`/`output` non-zero. For example, a custom model added to `opencode.json` **with** pricing:

```json
"models": {
  "deepseek/deepseek-v4-flash-0731": {
    "name": "DeepSeek V4 Flash 0731",
    "cost": { "input": 0.14, "output": 0.28, "cache_read": 0.028 }
  }
}
```

shows `$0.21 spent` in the sidebar Context, whereas the same model added **without** a `cost` entry:

```json
"models": {
  "deepseek/deepseek-v4-flash-0731": {
    "name": "DeepSeek V4 Flash 0731"
  }
}
```

now shows `N/A spent` instead of a misleading `$0.00 spent`. The terminal UI footer is unchanged; when cost is not set for a model, no session amount displays there.

The pricing decision is extracted into a small pure helper (`modelHasPricing`) so the display logic is unit-testable without mounting the TUI.

### How did you verify your code works?

- `bun typecheck` passed in `packages/tui`.
- Added a focused unit test covering the pricing decision (no `cost` entry, zero input/output, non-zero input, non-zero output).
- Confirmed the sidebar shows `N/A spent` when the session model has no pricing and the currency amount when it does.

### Screenshots / recordings

This is a terminal UI change. Expected sidebar Context output for a model without pricing:

```
Context
12,345 tokens
42% used
N/A spent
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
