### PR TITLE
fix(server): surface session creation errors

### DIFF
--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -467,7 +467,7 @@ export function make(options: ClientOptions) {
               location: input?.["location"],
             },
             successStatus: 200,
-            declaredStatuses: [401, 400],
+            declaredStatuses: [500, 401, 400],
             empty: false,
           },
           requestOptions,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -2349,6 +2349,14 @@ export type InvalidCursorError = { readonly _tag: "InvalidCursorError"; readonly
 export const isInvalidCursorError = (value: unknown): value is InvalidCursorError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "InvalidCursorError"
 
+export type UnknownError = {
+  readonly _tag: "UnknownError"
+  readonly message: string
+  readonly ref?: string | undefined
+}
+export const isUnknownError = (value: unknown): value is UnknownError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnknownError"
+
 export type SessionNotFoundError = {
   readonly _tag: "SessionNotFoundError"
   readonly sessionID: string
@@ -2413,14 +2421,6 @@ export type SessionBusyError = {
 }
 export const isSessionBusyError = (value: unknown): value is SessionBusyError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "SessionBusyError"
-
-export type UnknownError = {
-  readonly _tag: "UnknownError"
-  readonly message: string
-  readonly ref?: string | undefined
-}
-export const isUnknownError = (value: unknown): value is UnknownError =>
-  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnknownError"
 
 export type InstructionEntryValueTooLargeError = {
   readonly _tag: "InstructionEntryValueTooLargeError"

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { isSessionNotFoundError, isUnauthorizedError, OpenCode } from "../src/promise/index"
+import { isSessionNotFoundError, isUnauthorizedError, isUnknownError, OpenCode } from "../src/promise/index"
 
 test("exposes every standard HTTP API group", () => {
   const client = OpenCode.make({ baseUrl: "http://localhost:3000" })
@@ -503,6 +503,25 @@ test("middleware errors remain declared client errors", async () => {
     throw new Error("Expected request to fail")
   } catch (error) {
     expect(isUnauthorizedError(error)).toBe(true)
+  }
+})
+
+test("session.create preserves server errors", async () => {
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async () =>
+      Response.json(
+        { _tag: "UnknownError", message: "Unexpected server error. Check server logs for details.", ref: "err_test" },
+        { status: 500 },
+      ),
+  })
+
+  try {
+    await client.session.create({ location: { directory: "/tmp/project" } })
+    throw new Error("Expected request to fail")
+  } catch (error) {
+    expect(isUnknownError(error)).toBe(true)
+    expect(error).toMatchObject({ ref: "err_test" })
   }
 })
 

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -154,6 +154,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           location: Location.Ref.pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: Session.Info }),
+        error: UnknownError,
       }).annotateMerge(
         OpenApi.annotations({
           identifier: "v2.session.create",

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -81,7 +81,22 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                 model: ctx.payload.model,
                 location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
               })
-              .pipe(Effect.orDie),
+              .pipe(
+                Effect.catchCause((cause) => {
+                  const ref = `err_${crypto.randomUUID().slice(0, 8)}`
+                  return Effect.logError("failed to create session", { cause }).pipe(
+                    Effect.annotateLogs({ ref }),
+                    Effect.andThen(
+                      Effect.fail(
+                        new UnknownError({
+                          message: "Unexpected server error. Check server logs for details.",
+                          ref,
+                        }),
+                      ),
+                    ),
+                  )
+                }),
+              ),
           }
         }),
       )

--- a/packages/server/test/process.test.ts
+++ b/packages/server/test/process.test.ts
@@ -1,7 +1,11 @@
+import { Database } from "bun:sqlite"
 import { expect } from "bun:test"
 import { Effect } from "effect"
 import { HttpServer } from "effect/unstable/http"
+import path from "node:path"
 import { it } from "../../core/test/lib/effect"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { ServerAuth } from "../src/auth"
 import { ServerProcess } from "../src/process"
 
 it.live("allows browser preflight requests without credentials", () =>
@@ -40,5 +44,48 @@ it.live("allows browser preflight requests without credentials", () =>
     expect(health.status).toBe(200)
     expect(health.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
     expect(yield* Effect.promise(() => health.json())).toMatchObject({ version: "test-version" })
+  }),
+)
+
+it.live("returns a structured error when session creation hits a database error", () =>
+  Effect.gen(function* () {
+    const tmp = yield* Effect.acquireRelease(
+      Effect.promise(() => tmpdir("opencode-server-test-")),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    )
+    const database = path.join(tmp.path, "opencode.db")
+    const server = yield* ServerProcess.start<never, never>({
+      hostname: "127.0.0.1",
+      port: 0,
+      password: "secret",
+      app: { version: "test-version" },
+      database: { path: database },
+    })
+
+    yield* Effect.sync(() => {
+      const sqlite = new Database(database)
+      sqlite.run("ALTER TABLE session DROP COLUMN title")
+      sqlite.close()
+    })
+
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/session", HttpServer.formatAddress(server.address)), {
+        method: "POST",
+        headers: {
+          authorization: ServerAuth.header({ password: "secret" })!,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ location: { directory: tmp.path } }),
+      }),
+    )
+    const body = yield* Effect.promise(() => response.json())
+
+    expect(response.status).toBe(500)
+    expect(body).toMatchObject({
+      _tag: "UnknownError",
+      message: "Unexpected server error. Check server logs for details.",
+    })
+    if (typeof body !== "object" || body === null || !("ref" in body)) throw new Error("Expected an error reference")
+    expect(body.ref).toMatch(/^err_[0-9a-f-]{8}$/)
   }),
 )

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -977,20 +977,24 @@ export function Prompt(props: PromptProps) {
             variant,
           },
         })
-        .catch(() => undefined)
+        .then(
+          (data) => ({ data }),
+          (error) => ({ error }),
+        )
 
-      if (!created) {
+      if ("error" in created) {
         if (finishMoveProgress) move.finishSubmit()
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          title: "Creating a session failed",
+          message: errorMessage(created.error),
           variant: "error",
         })
 
         return true
       }
 
-      sessionID = created.id
-      session = created
+      sessionID = created.data.id
+      session = created.data
     }
 
     const inputText = expandTrackedPastedText(


### PR DESCRIPTION
### Issue for this PR

Closes #39775

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session.create` used `orDie`, turning database failures such as schema drift into defects. The HTTP layer returned an empty 500, and the TUI discarded the rejected client error.

This declares `UnknownError` for the endpoint, logs the full cause with a short reference returned in the response, regenerates the Promise client so the 500 is decoded, and shows the returned message in the session creation toast. Server and client regression tests cover the failure path.

### How did you verify your code works?

- `bun test` in `packages/server`: 17 passed
- `bun test` in `packages/protocol`: 2 passed
- `bun test` in `packages/client`: 46 passed
- `bun test` in `packages/tui`: 575 passed, 5 skipped
- `bun typecheck` in all four affected packages
- pre-push workspace typecheck: 33/33 tasks passed

### Screenshots / recordings

Not included. The visible change is limited to replacing the generic failure copy with the error message returned by the server.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
