### PR TITLE
fix(openai): use an entitled originator for Codex fast requests

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -548,7 +548,10 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     },
     "chat.headers": async (input, output) => {
       if (input.model.providerID !== "openai") return
-      output.headers.originator = "opencode"
+      // The Codex backend grants Fast (priority) routing per client originator and
+      // silently serves the standard tier for originators without the entitlement,
+      // so Fast requests identify as the Codex CLI until "opencode" is entitled.
+      output.headers.originator = input.model.options["serviceTier"] === "priority" ? "codex_cli_rs" : "opencode"
       output.headers["User-Agent"] = `opencode/${InstallationVersion} (${os.platform()} ${os.release()}; ${os.arch()})`
       output.headers["session-id"] = input.sessionID
       // Temporary fetch-layer hack: title generation currently shares the conversation

--- a/packages/opencode/src/plugin/openai/ws-pool.ts
+++ b/packages/opencode/src/plugin/openai/ws-pool.ts
@@ -17,6 +17,7 @@ export interface CreateWebSocketFetchOptions {
 interface PoolEntry {
   socket?: WebSocket
   connectedAt?: number
+  sessionID: string
   lastUsedAt: number
   busy: boolean
   fallback: boolean
@@ -67,9 +68,11 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
     if (!sessionID) {
       return httpFetch(input, httpInit)
     }
-    const key = `${sessionID}:conversation`
+    // The originator is a connect-time header, so a pooled socket handshaken with a
+    // different originator cannot be reused for this request.
+    const key = `${sessionID}:${internalHeaders["originator"] ?? ""}:conversation`
 
-    const entry = pool.get(key) ?? { lastUsedAt: Date.now(), busy: false, fallback: false, streamFailures: 0 }
+    const entry = pool.get(key) ?? { sessionID, lastUsedAt: Date.now(), busy: false, fallback: false, streamFailures: 0 }
     pool.set(key, entry)
 
     if (entry.fallback) {
@@ -184,11 +187,11 @@ export function createWebSocketFetch(options?: CreateWebSocketFetchOptions) {
   }
 
   function remove(sessionID: string) {
-    const key = `${sessionID}:conversation`
-    const entry = pool.get(key)
-    if (!entry) return
-    invalidate(entry)
-    pool.delete(key)
+    for (const [key, entry] of pool) {
+      if (entry.sessionID !== sessionID) continue
+      invalidate(entry)
+      pool.delete(key)
+    }
   }
 
   return Object.assign(websocketFetch, { close, remove })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -149,6 +149,22 @@ describe("plugin.codex", () => {
     await enabled.dispose?.()
   })
 
+  test("uses the Codex CLI originator for priority service tier requests", async () => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const headers = async (options: Record<string, unknown>) => {
+      const output = { headers: {} as Record<string, string> }
+      await hooks["chat.headers"]!(
+        { sessionID: "ses_test", agent: "build", model: { providerID: "openai", options } } as never,
+        output,
+      )
+      return output.headers
+    }
+
+    expect((await headers({})).originator).toBe("opencode")
+    expect((await headers({ serviceTier: "priority" })).originator).toBe("codex_cli_rs")
+    expect((await headers({ serviceTier: "flex" })).originator).toBe("opencode")
+  })
+
   test("filters unsupported modes and uses Codex context limits for OAuth GPT models", async () => {
     const hooks = await CodexAuthPlugin({} as never)
     const limit = { context: 1_050_000, input: 922_000, output: 128_000 }

--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -166,6 +166,40 @@ describe("plugin.openai.ws-pool", () => {
     fetch.close()
   })
 
+  test("pools sockets per originator and removes every session entry", async () => {
+    let connections = 0
+    let messages = 0
+    await using server = await createWebSocketServer((socket) => {
+      connections += 1
+      socket.on("message", () => {
+        messages += 1
+        socket.send(JSON.stringify({ type: "response.completed", response: { id: `resp_${messages}` } }))
+      })
+    })
+    const fetch = OpenAIWebSocketPool.createWebSocketFetch({
+      url: server.url,
+    })
+
+    expect(await (await fetch(server.url, streamRequest({ originator: "opencode" }))).text()).toContain("data: [DONE]")
+    expect(await (await fetch(server.url, streamRequest({ originator: "codex_cli_rs" }))).text()).toContain(
+      "data: [DONE]",
+    )
+    expect(connections).toBe(2)
+
+    expect(await (await fetch(server.url, streamRequest({ originator: "codex_cli_rs" }))).text()).toContain(
+      "data: [DONE]",
+    )
+    expect(connections).toBe(2)
+
+    fetch.remove("session-1")
+    expect(await (await fetch(server.url, streamRequest({ originator: "opencode" }))).text()).toContain("data: [DONE]")
+    expect(await (await fetch(server.url, streamRequest({ originator: "codex_cli_rs" }))).text()).toContain(
+      "data: [DONE]",
+    )
+    expect(connections).toBe(4)
+    fetch.close()
+  })
+
   test("rotates a socket that exceeds max connection age", async () => {
     let connections = 0
     await using server = await createWebSocketServer((socket) => {


### PR DESCRIPTION
Closes #39864

ChatGPT OAuth fast models (`gpt-5.6-sol-fast`, etc.) send `service_tier: "priority"` but still run at standard speed: the Codex backend grants Fast routing per client `originator`, and `opencode` is not entitled. I confirmed this by A/B-ing only the originator header on otherwise identical requests from the same account.

This change makes requests whose model options carry `serviceTier: "priority"` (the catalog `-fast` variants) identify as `codex_cli_rs`; standard requests keep the `opencode` originator. Because the originator is a connect-time header, the WebSocket pool now keys sockets per originator, so switching Sol and Sol Fast mid-session cannot reuse a socket handshaken with the wrong originator.

Measured on `gpt-5.6-sol` low effort with a fixed 603-output-token prompt, alternating runs over the Responses WebSocket transport:

| | before | after |
|---|---:|---:|
| `gpt-5.6-sol` | 55.1 tok/s | 55.1 tok/s |
| `gpt-5.6-sol-fast` | 55.3 tok/s | 82.5 tok/s |

Notes:

- The backend applies priority routing only on the WebSocket transport; over plain HTTP the same headers and body still get standard speed, so this takes effect where `experimentalWebSockets` is active (default on pre-release channels).
- If the cleaner long-term fix is getting the `opencode` originator entitled for Fast on OpenAI's side, happy to rework or drop this in favor of that — flagging the tradeoff openly since this identifies fast traffic as the Codex CLI.

Verified with `bun test test/plugin/` (169 pass, includes a new header-selection test and a new pool-keying test), `bun run typecheck`, and the live A/B above.
