### PR TITLE
fix(tui): stabilize open picker

### DIFF
--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -78,7 +78,7 @@ export function DialogOpen() {
     const sessionOptions = recent.map((session) => {
       const project = data.project.get(session.projectID)
       const name = project?.canonical === "/" ? undefined : project?.name || path.basename(project?.canonical ?? "")
-      const running = data.session.family(session.id).some((id) => data.session.status(id) === "running")
+      const running = data.session.running(session.id)
       return {
         title: withTimestampedFallback(session),
         value: { type: "session", sessionID: session.id } as OpenTarget,

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,10 +1,12 @@
 import path from "path"
 import { createMemo, createResource, createSignal, onMount } from "solid-js"
+import type { SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
 import { dialogWidth, useDialog } from "../ui/dialog"
 import { DialogSelect, dialogSelectContentWidth } from "../ui/dialog-select"
 import { useRoute } from "../context/route"
 import { useData } from "../context/data"
+import { useClient } from "../context/client"
 import { useLocation } from "../context/location"
 import { useSessionTabs } from "../context/session-tabs"
 import { useTheme, useThemes } from "../context/theme"
@@ -25,6 +27,7 @@ export function DialogOpen() {
   const dialog = useDialog()
   const route = useRoute()
   const data = useData()
+  const client = useClient()
   const location = useLocation()
   const sessionTabs = useSessionTabs()
   const themes = useThemes()
@@ -34,6 +37,7 @@ export function DialogOpen() {
   const dimensions = useTerminalDimensions()
   const shortcuts = Keymap.useShortcuts()
   const [filter, setFilter] = createSignal("")
+  const [selectionMoved, setSelectionMoved] = createSignal(false)
 
   void data.project.sync().catch(() => {})
 
@@ -41,10 +45,10 @@ export function DialogOpen() {
   // immediately from the local store and never blocks on the network.
   const [fetched] = createResource(
     () =>
-      data.session.recent
-        .sync()
-        .then(() => data.session.recent.list())
-        .catch(() => []),
+      client.api.session
+        .list({ limit: 50, order: "desc", parentID: null })
+        .then((response) => response.data)
+        .catch(() => [] as SessionInfo[]),
     { initialValue: [] },
   )
 
@@ -78,7 +82,9 @@ export function DialogOpen() {
     const sessionOptions = recent.map((session) => {
       const project = data.project.get(session.projectID)
       const name = project?.canonical === "/" ? undefined : project?.name || path.basename(project?.canonical ?? "")
-      const running = data.session.running(session.id)
+      const running =
+        data.session.status(session.id) === "running" ||
+        data.session.family(session.id).some((id) => data.session.status(id) === "running")
       return {
         title: withTimestampedFallback(session),
         value: { type: "session", sessionID: session.id } as OpenTarget,
@@ -132,6 +138,8 @@ export function DialogOpen() {
       options={options()}
       current={currentSessionID() ? ({ type: "session", sessionID: currentSessionID()! } as OpenTarget) : undefined}
       focusCurrent={false}
+      preserveSelection={selectionMoved()}
+      onMove={() => setSelectionMoved(true)}
       onFilter={setFilter}
       noMatchView={
         <box paddingLeft={4} paddingRight={4}>

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,12 +1,10 @@
 import path from "path"
 import { createMemo, createResource, createSignal, onMount } from "solid-js"
-import type { SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
 import { dialogWidth, useDialog } from "../ui/dialog"
 import { DialogSelect, dialogSelectContentWidth } from "../ui/dialog-select"
 import { useRoute } from "../context/route"
 import { useData } from "../context/data"
-import { useClient } from "../context/client"
 import { useLocation } from "../context/location"
 import { useSessionTabs } from "../context/session-tabs"
 import { useTheme, useThemes } from "../context/theme"
@@ -27,7 +25,6 @@ export function DialogOpen() {
   const dialog = useDialog()
   const route = useRoute()
   const data = useData()
-  const client = useClient()
   const location = useLocation()
   const sessionTabs = useSessionTabs()
   const themes = useThemes()
@@ -38,22 +35,25 @@ export function DialogOpen() {
   const shortcuts = Keymap.useShortcuts()
   const [filter, setFilter] = createSignal("")
 
-  data.project.invalidate()
   void data.project.sync().catch(() => {})
 
   // One background fetch fills in recent sessions from other projects; the menu renders
   // immediately from the local store and never blocks on the network.
   const [fetched] = createResource(
     () =>
-      client.api.session
-        .list({ limit: 50, order: "desc", parentID: null })
-        .then((response) => response.data)
-        .catch(() => [] as SessionInfo[]),
+      data.session.recent
+        .sync()
+        .then(() => data.session.recent.list())
+        .catch(() => []),
     { initialValue: [] },
   )
 
-  const openTabs = createMemo(() => new Set(sessionTabs.tabs().map((tab) => tab.sessionID)))
-  const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
+  const openTabs = createMemo(
+    () => new Set(sessionTabs.enabled() ? sessionTabs.tabs().map((tab) => tab.sessionID) : []),
+  )
+  const currentSessionID = createMemo(() =>
+    route.data.type === "session" ? data.session.root(route.data.sessionID) : undefined,
+  )
   const sessions = createMemo(() => {
     const seen = new Set<string>()
     return [...data.session.list(), ...fetched()]
@@ -69,7 +69,7 @@ export function DialogOpen() {
     const tabs = openTabs()
     // With an empty query the menu shows what is not already one keystroke away: open tabs are
     // visible in the strip, so recents exclude them. Typing widens the pool to every session so
-    // matching a tab by name still switches to it.
+    // matching a loaded tab by name still switches to it.
     const recent = filter().trim()
       ? sessions()
       : sessions()
@@ -98,7 +98,7 @@ export function DialogOpen() {
     const projectOptions = data.project
       .list()
       .filter((project) => {
-        if (project.canonical === "/" || project.id === current?.id || seen.has(project.canonical)) return false
+        if (project.canonical === "/" || seen.has(project.canonical)) return false
         seen.add(project.canonical)
         return true
       })
@@ -113,6 +113,10 @@ export function DialogOpen() {
           searchText: footer,
           value: { type: "project", directory: project.canonical } as OpenTarget,
           category: "Projects",
+          gutter:
+            project.canonical === current?.canonical
+              ? () => <text fg={theme.text.formfield.selected}>●</text>
+              : undefined,
         }
       })
 

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -49,6 +49,10 @@ export function DialogSessionList() {
         if (!data.location.info()) await data.location.sync()
         const current = data.location.info()
         if (!current) throw new Error("Location unavailable")
+        if (allProjects && !query) {
+          await data.session.recent.sync()
+          return { query, allProjects, sessions: data.session.recent.list(), error: undefined }
+        }
         const response = await client.api.session.list({
           ...(allProjects
             ? {}

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -93,7 +93,8 @@ export function DialogSessionList() {
   const sessions = createMemo(() => {
     const query = filter().trim()
     const local = localSessions()
-    if (query !== search().trim() || searchResults.loading) return searchResults.latest?.sessions ?? local
+    if (query !== search().trim()) return searchResults.latest?.sessions ?? local
+    if (searchResults.loading) return searchResults.latest?.sessions ?? []
     const result = searchResults()
     if (result?.query !== query || result.allProjects !== allProjects() || result.error) return local
     return result.sessions
@@ -158,7 +159,7 @@ export function DialogSessionList() {
         footer,
         bg: deleting ? theme.background.action.destructive.focused : undefined,
         fg: deleting ? theme.text.action.destructive.focused : undefined,
-        gutter: data.session.family(session.id).some((id) => data.session.status(id) === "running")
+        gutter: data.session.running(session.id)
           ? () => <Spinner />
           : slot === undefined
             ? undefined

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -49,10 +49,6 @@ export function DialogSessionList() {
         if (!data.location.info()) await data.location.sync()
         const current = data.location.info()
         if (!current) throw new Error("Location unavailable")
-        if (allProjects && !query) {
-          await data.session.recent.sync()
-          return { query, allProjects, sessions: data.session.recent.list(), error: undefined }
-        }
         const response = await client.api.session.list({
           ...(allProjects
             ? {}
@@ -159,11 +155,13 @@ export function DialogSessionList() {
         footer,
         bg: deleting ? theme.background.action.destructive.focused : undefined,
         fg: deleting ? theme.text.action.destructive.focused : undefined,
-        gutter: data.session.running(session.id)
-          ? () => <Spinner />
-          : slot === undefined
-            ? undefined
-            : () => <text fg={theme.hue.accent[mode() === "light" ? 800 : 200]}>{slot}</text>,
+        gutter:
+          data.session.status(session.id) === "running" ||
+          data.session.family(session.id).some((id) => data.session.status(id) === "running")
+            ? () => <Spinner />
+            : slot === undefined
+              ? undefined
+              : () => <text fg={theme.hue.accent[mode() === "light" ? 800 : 200]}>{slot}</text>,
       }
     }
 

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -967,6 +967,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         status(sessionID: string) {
           return store.session.active[sessionID] ?? "idle"
         },
+        running(sessionID: string) {
+          const root = resolveRoot(sessionID)
+          const family = store.session.family[root]
+          return (family?.length ? family : [root]).some((id) => store.session.active[id] === "running")
+        },
         input: {
           list(sessionID: string) {
             return store.session.input[sessionID] ?? []

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -69,7 +69,6 @@ type LocationData = {
 type Store = {
   session: {
     info: Record<string, SessionInfo>
-    recent: SessionInfo[]
     // Family index keyed by a family's root (or furthest-known-ancestor when the
     // true root is not yet loaded). The value is a flat deduplicated list of every
     // session ID in that family, including the key itself once its info arrives.
@@ -134,7 +133,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     const [store, setStore] = createStore<Store>({
       session: {
         info: {},
-        recent: [],
         family: {},
         active: {},
         message: {},
@@ -293,7 +291,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           delete draft.input[sessionID]
           delete draft.permission[sessionID]
           delete draft.form[sessionID]
-          draft.recent = draft.recent.filter((session) => session.id !== sessionID)
           for (const [rootID, family] of Object.entries(draft.family)) {
             const next = family.filter((id) => id !== sessionID)
             if (next.length === 0) delete draft.family[rootID]
@@ -306,7 +303,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     function handleEvent(event: OpenCodeEvent) {
       switch (event.type) {
         case "session.created":
-          result.session.recent.invalidate()
           result.session.invalidate(event.data.sessionID)
           void result.session.sync(event.data.sessionID)
           // Band-aid: a newly created session starts empty, so live events can be its source of truth.
@@ -317,7 +313,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           sync.complete(`session.message:${event.data.sessionID}`)
           break
         case "session.deleted":
-          result.session.recent.invalidate()
           removeSession(event.data.sessionID)
           break
         case "session.usage.updated":
@@ -385,7 +380,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             if (store.session.info[event.data.sessionID])
               setStore("session", "info", event.data.sessionID, "title", event.data.title)
           })
-          setStore("session", "recent", (session) => session.id === event.data.sessionID, "title", event.data.title)
           break
         case "session.moved":
           if (store.session.info[event.data.sessionID]) {
@@ -394,16 +388,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               setStore("session", "info", event.data.sessionID, "projectID", event.data.projectID)
             setStore("session", "info", event.data.sessionID, "subpath", event.data.subpath)
           }
-          setStore(
-            "session",
-            "recent",
-            (session) => session.id === event.data.sessionID,
-            produce((session) => {
-              session.location = event.data.location
-              if (event.data.projectID) session.projectID = event.data.projectID
-              session.subpath = event.data.subpath
-            }),
-          )
           break
         case "session.input.promoted": {
           removePending(event.data.sessionID, event.data.inputID)
@@ -745,7 +729,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         case "session.execution.succeeded":
         case "session.execution.failed":
         case "session.execution.interrupted":
-          result.session.recent.invalidate()
           setSessionActive(event.data.sessionID, "idle")
           message.update(event.data.sessionID, (draft) => {
             const currentAssistant = message.activeAssistant(draft)
@@ -932,20 +915,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         list() {
           return Object.values(store.session.info).toSorted((a, b) => b.time.updated - a.time.updated)
         },
-        recent: {
-          list() {
-            return store.session.recent
-          },
-          sync() {
-            return sync.run("session.recent", async () => {
-              const response = await client.api.session.list({ limit: 50, order: "desc", parentID: null })
-              setStore("session", "recent", reconcile(response.data))
-            })
-          },
-          invalidate() {
-            sync.invalidate("session.recent")
-          },
-        },
         get(sessionID: string) {
           return store.session.info[sessionID]
         },
@@ -966,11 +935,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         },
         status(sessionID: string) {
           return store.session.active[sessionID] ?? "idle"
-        },
-        running(sessionID: string) {
-          const root = resolveRoot(sessionID)
-          const family = store.session.family[root]
-          return (family?.length ? family : [root]).some((id) => store.session.active[id] === "running")
         },
         input: {
           list(sessionID: string) {

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -69,6 +69,7 @@ type LocationData = {
 type Store = {
   session: {
     info: Record<string, SessionInfo>
+    recent: SessionInfo[]
     // Family index keyed by a family's root (or furthest-known-ancestor when the
     // true root is not yet loaded). The value is a flat deduplicated list of every
     // session ID in that family, including the key itself once its info arrives.
@@ -133,6 +134,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     const [store, setStore] = createStore<Store>({
       session: {
         info: {},
+        recent: [],
         family: {},
         active: {},
         message: {},
@@ -291,6 +293,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           delete draft.input[sessionID]
           delete draft.permission[sessionID]
           delete draft.form[sessionID]
+          draft.recent = draft.recent.filter((session) => session.id !== sessionID)
           for (const [rootID, family] of Object.entries(draft.family)) {
             const next = family.filter((id) => id !== sessionID)
             if (next.length === 0) delete draft.family[rootID]
@@ -303,6 +306,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     function handleEvent(event: OpenCodeEvent) {
       switch (event.type) {
         case "session.created":
+          result.session.recent.invalidate()
           result.session.invalidate(event.data.sessionID)
           void result.session.sync(event.data.sessionID)
           // Band-aid: a newly created session starts empty, so live events can be its source of truth.
@@ -313,6 +317,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           sync.complete(`session.message:${event.data.sessionID}`)
           break
         case "session.deleted":
+          result.session.recent.invalidate()
           removeSession(event.data.sessionID)
           break
         case "session.usage.updated":
@@ -380,6 +385,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             if (store.session.info[event.data.sessionID])
               setStore("session", "info", event.data.sessionID, "title", event.data.title)
           })
+          setStore("session", "recent", (session) => session.id === event.data.sessionID, "title", event.data.title)
           break
         case "session.moved":
           if (store.session.info[event.data.sessionID]) {
@@ -388,6 +394,16 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               setStore("session", "info", event.data.sessionID, "projectID", event.data.projectID)
             setStore("session", "info", event.data.sessionID, "subpath", event.data.subpath)
           }
+          setStore(
+            "session",
+            "recent",
+            (session) => session.id === event.data.sessionID,
+            produce((session) => {
+              session.location = event.data.location
+              if (event.data.projectID) session.projectID = event.data.projectID
+              session.subpath = event.data.subpath
+            }),
+          )
           break
         case "session.input.promoted": {
           removePending(event.data.sessionID, event.data.inputID)
@@ -729,6 +745,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         case "session.execution.succeeded":
         case "session.execution.failed":
         case "session.execution.interrupted":
+          result.session.recent.invalidate()
           setSessionActive(event.data.sessionID, "idle")
           message.update(event.data.sessionID, (draft) => {
             const currentAssistant = message.activeAssistant(draft)
@@ -914,6 +931,20 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       session: {
         list() {
           return Object.values(store.session.info).toSorted((a, b) => b.time.updated - a.time.updated)
+        },
+        recent: {
+          list() {
+            return store.session.recent
+          },
+          sync() {
+            return sync.run("session.recent", async () => {
+              const response = await client.api.session.list({ limit: 50, order: "desc", parentID: null })
+              setStore("session", "recent", reconcile(response.data))
+            })
+          },
+          invalidate() {
+            sync.invalidate("session.recent")
+          },
         },
         get(sessionID: string) {
           return store.session.info[sessionID]

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -115,12 +115,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
   let selection: { value: T; category?: string } | undefined
-  let selectionExplicit = false
   let resetSelection = false
   let pendingScroll: (() => void) | undefined
-
-  const preserveSelection = () =>
-    props.preserveSelection || selectionExplicit || (props.current !== undefined && props.focusCurrent !== false)
 
   function scrollAfterLayout(center: boolean, value: T) {
     if (pendingScroll) renderer.off(CliRenderEvents.FRAME, pendingScroll)
@@ -249,7 +245,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     on(
       () => props.options,
       () => {
-        if (!preserveSelection()) {
+        if (!props.preserveSelection && (props.current === undefined || props.focusCurrent === false)) {
           const count = flat().length
           if (count === 0) return
           const next = reconcileSelection(store.selected, count)
@@ -285,7 +281,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           setStore("selected", index)
           selection = option
           if (!moved) return
-          if (!preserveSelection() || store.filter.length > 0) return
+          if (
+            (!props.preserveSelection && (props.current === undefined || props.focusCurrent === false)) ||
+            store.filter.length > 0
+          )
+            return
           scrollAfterLayout(false, option.value)
           return
         }
@@ -323,7 +323,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   function move(direction: number) {
     if (props.locked) return
     if (flat().length === 0) return
-    selectionExplicit = true
     moveTo(moveSelection(store.selected, { count: flat().length, delta: direction, policy: "wrap" }), true)
   }
 
@@ -446,7 +445,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
-            selectionExplicit = true
             moveTo(0)
           },
         },
@@ -457,7 +455,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
-            selectionExplicit = true
             moveTo(flat().length - 1)
           },
         },
@@ -504,10 +501,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     },
     moveTo(value) {
       const index = flat().findIndex((option) => isDeepEqual(option.value, value))
-      if (index >= 0) {
-        selectionExplicit = true
-        moveTo(index, true)
-      }
+      if (index >= 0) moveTo(index, true)
     },
   }
   props.ref?.(ref)
@@ -607,7 +601,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             <input
               onInput={(e) => {
                 if (props.locked) return
-                selectionExplicit = false
                 batch(() => {
                   setStore("filter", e)
                   props.onFilter?.(e)
@@ -701,14 +694,12 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                             if (store.input !== "mouse") return
                             const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                             if (index === -1) return
-                            selectionExplicit = true
                             moveTo(index)
                           }}
                           onMouseDown={() => {
                             if (props.locked) return
                             const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                             if (index === -1) return
-                            selectionExplicit = true
                             moveTo(index)
                           }}
                         >

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -115,8 +115,12 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
   let selection: { value: T; category?: string } | undefined
+  let selectionExplicit = false
   let resetSelection = false
   let pendingScroll: (() => void) | undefined
+
+  const preserveSelection = () =>
+    props.preserveSelection || selectionExplicit || (props.current !== undefined && props.focusCurrent !== false)
 
   function scrollAfterLayout(center: boolean, value: T) {
     if (pendingScroll) renderer.off(CliRenderEvents.FRAME, pendingScroll)
@@ -134,7 +138,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       () => props.current,
       (current) => {
         if (props.focusCurrent === false) return
-        if (current) {
+        if (current !== undefined) {
           const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
           if (currentIndex >= 0) {
             setStore("selected", currentIndex)
@@ -245,7 +249,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     on(
       () => props.options,
       () => {
-        if (!props.preserveSelection && props.current === undefined) {
+        if (!preserveSelection()) {
           const count = flat().length
           if (count === 0) return
           const next = reconcileSelection(store.selected, count)
@@ -281,7 +285,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           setStore("selected", index)
           selection = option
           if (!moved) return
-          if ((!props.preserveSelection && props.current === undefined) || store.filter.length > 0) return
+          if (!preserveSelection() || store.filter.length > 0) return
           scrollAfterLayout(false, option.value)
           return
         }
@@ -308,7 +312,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         scrollAfterLayout(true, option.value)
         return
       }
-      if (!current || props.focusCurrent === false) return
+      if (current === undefined || props.focusCurrent === false) return
       const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
       if (currentIndex < 0) return
       moveTo(currentIndex, true)
@@ -319,6 +323,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   function move(direction: number) {
     if (props.locked) return
     if (flat().length === 0) return
+    selectionExplicit = true
     moveTo(moveSelection(store.selected, { count: flat().length, delta: direction, policy: "wrap" }), true)
   }
 
@@ -441,6 +446,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
+            selectionExplicit = true
             moveTo(0)
           },
         },
@@ -451,6 +457,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
+            selectionExplicit = true
             moveTo(flat().length - 1)
           },
         },
@@ -497,7 +504,10 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     },
     moveTo(value) {
       const index = flat().findIndex((option) => isDeepEqual(option.value, value))
-      if (index >= 0) moveTo(index, true)
+      if (index >= 0) {
+        selectionExplicit = true
+        moveTo(index, true)
+      }
     },
   }
   props.ref?.(ref)
@@ -597,6 +607,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             <input
               onInput={(e) => {
                 if (props.locked) return
+                selectionExplicit = false
                 batch(() => {
                   setStore("filter", e)
                   props.onFilter?.(e)
@@ -690,12 +701,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                             if (store.input !== "mouse") return
                             const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                             if (index === -1) return
+                            selectionExplicit = true
                             moveTo(index)
                           }}
                           onMouseDown={() => {
                             if (props.locked) return
                             const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                             if (index === -1) return
+                            selectionExplicit = true
                             moveTo(index)
                           }}
                         >

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -134,7 +134,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       () => props.current,
       (current) => {
         if (props.focusCurrent === false) return
-        if (current !== undefined) {
+        if (current) {
           const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
           if (currentIndex >= 0) {
             setStore("selected", currentIndex)
@@ -312,7 +312,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         scrollAfterLayout(true, option.value)
         return
       }
-      if (current === undefined || props.focusCurrent === false) return
+      if (!current || props.focusCurrent === false) return
       const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
       if (currentIndex < 0) return
       moveTo(currentIndex, true)

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -169,10 +169,12 @@ test("proactively syncs project metadata newest first", async () => {
   }
 })
 
-test("caches recent sessions until invalidated", async () => {
+test("caches recent sessions and reports unhydrated running sessions", async () => {
   const events = createEventStream()
   let requests = 0
   const calls = createFetch((url) => {
+    if (url.pathname === "/api/session/active")
+      return json({ data: { ses_recent: { type: "running" } } })
     if (url.pathname !== "/api/session" || url.searchParams.get("parentID") !== "null") return
     requests++
     return json({ data: [sessionInfo("ses_recent", undefined)], cursor: {} })
@@ -201,6 +203,8 @@ test("caches recent sessions until invalidated", async () => {
     await data.session.recent.sync()
     expect(requests).toBe(1)
     expect(data.session.recent.list().map((session) => session.id)).toEqual(["ses_recent"])
+
+    await wait(() => data.session.running("ses_recent"))
 
     data.session.recent.invalidate()
     await data.session.recent.sync()

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -106,11 +106,18 @@ test("does not preload session summaries into the data context", async () => {
   }
 })
 
-test("proactively syncs project metadata", async () => {
+test("proactively syncs project metadata newest first", async () => {
   const events = createEventStream()
   const calls = createFetch((url) => {
     if (url.pathname !== "/api/project") return
     return json([
+      {
+        id: "proj_old",
+        canonical: "/old/project",
+        name: "Old project",
+        time: { created: 1, updated: 1 },
+        sandboxes: [],
+      },
       {
         id: "proj_test",
         canonical: worktree,
@@ -149,7 +156,55 @@ test("proactively syncs project metadata", async () => {
         time: { created: 1, updated: 2 },
         sandboxes: [],
       },
+      {
+        id: "proj_old",
+        canonical: "/old/project",
+        name: "Old project",
+        time: { created: 1, updated: 1 },
+        sandboxes: [],
+      },
     ])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("caches recent sessions until invalidated", async () => {
+  const events = createEventStream()
+  let requests = 0
+  const calls = createFetch((url) => {
+    if (url.pathname !== "/api/session" || url.searchParams.get("parentID") !== "null") return
+    requests++
+    return json({ data: [sessionInfo("ses_recent", undefined)], cursor: {} })
+  }, events)
+  let data!: ReturnType<typeof useData>
+
+  function Probe() {
+    data = useData()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ClientProvider api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </ClientProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await data.session.recent.sync()
+    await data.session.recent.sync()
+    expect(requests).toBe(1)
+    expect(data.session.recent.list().map((session) => session.id)).toEqual(["ses_recent"])
+
+    data.session.recent.invalidate()
+    await data.session.recent.sync()
+    expect(requests).toBe(2)
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -169,51 +169,6 @@ test("proactively syncs project metadata newest first", async () => {
   }
 })
 
-test("caches recent sessions and reports unhydrated running sessions", async () => {
-  const events = createEventStream()
-  let requests = 0
-  const calls = createFetch((url) => {
-    if (url.pathname === "/api/session/active")
-      return json({ data: { ses_recent: { type: "running" } } })
-    if (url.pathname !== "/api/session" || url.searchParams.get("parentID") !== "null") return
-    requests++
-    return json({ data: [sessionInfo("ses_recent", undefined)], cursor: {} })
-  }, events)
-  let data!: ReturnType<typeof useData>
-
-  function Probe() {
-    data = useData()
-    return <box />
-  }
-
-  const app = await testRender(() => (
-    <TestTuiContexts>
-      <ClientProvider api={createApi(calls.fetch)}>
-        <ProjectProvider>
-          <DataProvider>
-            <Probe />
-          </DataProvider>
-        </ProjectProvider>
-      </ClientProvider>
-    </TestTuiContexts>
-  ))
-
-  try {
-    await data.session.recent.sync()
-    await data.session.recent.sync()
-    expect(requests).toBe(1)
-    expect(data.session.recent.list().map((session) => session.id)).toEqual(["ses_recent"])
-
-    await wait(() => data.session.running("ses_recent"))
-
-    data.session.recent.invalidate()
-    await data.session.recent.sync()
-    expect(requests).toBe(2)
-  } finally {
-    app.renderer.destroy()
-  }
-})
-
 test("bootstraps MCP data for the TUI location", async () => {
   const events = createEventStream()
   const requests: URL[] = []

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -18,16 +18,14 @@ import { StorageProvider } from "../../../src/context/storage"
 import { ThemeProvider } from "../../../src/context/theme"
 import { DialogProvider, useDialog } from "../../../src/ui/dialog"
 import { ToastProvider } from "../../../src/ui/toast"
-import { createApi, createEventStream, createFetch, json } from "../../fixture/tui-client"
+import { createApi, createEventStream, createFetch, json, type FetchHandler } from "../../fixture/tui-client"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 
 test("selecting an unhydrated session preserves its location", async () => {
-  const state = mkdtempSync(path.join(tmpdir(), "opencode-dialog-open-"))
-  const events = createEventStream()
   const remote = { directory: "/tmp/opencode/remote", workspaceID: "ws_remote" }
-  const calls = createFetch((url) => {
-    if (url.pathname !== "/api/session") return
+  const fixture = await renderOpen((url) => {
+    if (url.pathname !== "/api/session") return undefined
     return json({
       data: [
         {
@@ -42,7 +40,74 @@ test("selecting an unhydrated session preserves its location", async () => {
       ],
       cursor: {},
     })
-  }, events)
+  })
+
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Remote session"))
+    expect(fixture.data.session.get("ses_remote")).toBeUndefined()
+
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "session")
+
+    expect(fixture.route.data).toEqual({ type: "session", sessionID: "ses_remote" })
+    expect(fixture.location.ref).toEqual(remote)
+  } finally {
+    fixture.dispose()
+  }
+})
+
+test("shows the current project and opens its root", async () => {
+  const root = "/tmp/opencode/project"
+  const subfolder = `${root}/packages/tui`
+  const fixture = await renderOpen(
+    (url) => {
+      if (url.pathname === "/api/project")
+        return json([
+          {
+            id: "proj_current",
+            canonical: root,
+            name: "OpenCode",
+            time: { created: 1, updated: 2 },
+            sandboxes: [],
+          },
+        ])
+      if (url.pathname === "/api/location")
+        return json({
+          directory: subfolder,
+          project: { id: "proj_current", directory: root, canonical: root },
+        })
+      return undefined
+    },
+    async ({ data, location }) => {
+      await data.location.sync({ directory: subfolder })
+      location.set({ directory: subfolder })
+    },
+  )
+
+  try {
+    const frame = await fixture.app.waitForFrame((value) => value.includes("OpenCode") && value.includes("●"))
+    expect(frame).toContain(root)
+
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "home")
+
+    expect(fixture.route.data).toEqual({ type: "home", location: { directory: root } })
+    expect(fixture.location.ref).toEqual({ directory: root })
+  } finally {
+    fixture.dispose()
+  }
+})
+
+async function renderOpen(
+  handler: FetchHandler,
+  beforeOpen?: (contexts: {
+    data: ReturnType<typeof useData>
+    location: ReturnType<typeof useLocation>
+  }) => void | Promise<void>,
+) {
+  const state = mkdtempSync(path.join(tmpdir(), "opencode-dialog-open-"))
+  const events = createEventStream()
+  const calls = createFetch(handler, events)
   let route!: ReturnType<typeof useRoute>
   let location!: ReturnType<typeof useLocation>
   let data!: ReturnType<typeof useData>
@@ -52,7 +117,9 @@ test("selecting an unhydrated session preserves its location", async () => {
     route = useRoute()
     location = useLocation()
     data = useData()
-    onMount(() => dialog.replace(() => <DialogOpen />))
+    onMount(
+      () => void Promise.resolve(beforeOpen?.({ data, location })).then(() => dialog.replace(() => <DialogOpen />)),
+    )
     return null
   }
 
@@ -90,17 +157,20 @@ test("selecting an unhydrated session preserves its location", async () => {
   )
   app.renderer.start()
 
-  try {
-    await app.waitForFrame((frame) => frame.includes("Remote session"))
-    expect(data.session.get("ses_remote")).toBeUndefined()
-
-    app.mockInput.pressEnter()
-    await app.waitFor(() => route.data.type === "session")
-
-    expect(route.data).toEqual({ type: "session", sessionID: "ses_remote" })
-    expect(location.ref).toEqual(remote)
-  } finally {
-    app.renderer.destroy()
-    rmSync(state, { recursive: true, force: true })
+  return {
+    app,
+    get route() {
+      return route
+    },
+    get location() {
+      return location
+    },
+    get data() {
+      return data
+    },
+    dispose() {
+      app.renderer.destroy()
+      rmSync(state, { recursive: true, force: true })
+    },
   }
-})
+}

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -98,6 +98,61 @@ test("shows the current project and opens its root", async () => {
   }
 })
 
+test("preserves a moved project when sessions arrive", async () => {
+  let resolveSessions!: (response: Response) => void
+  const sessions = new Promise<Response>((resolve) => (resolveSessions = resolve))
+  const fixture = await renderOpen((url) => {
+    if (url.pathname === "/api/session") return sessions
+    if (url.pathname === "/api/project")
+      return json([
+        {
+          id: "proj_first",
+          canonical: "/tmp/opencode/first",
+          name: "First project",
+          time: { created: 1, updated: 2 },
+          sandboxes: [],
+        },
+        {
+          id: "proj_second",
+          canonical: "/tmp/opencode/second",
+          name: "Second project",
+          time: { created: 1, updated: 1 },
+          sandboxes: [],
+        },
+      ])
+    return undefined
+  })
+
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Second project"))
+    fixture.app.mockInput.pressArrow("down")
+
+    resolveSessions(
+      json({
+        data: [
+          {
+            id: "ses_recent",
+            projectID: "proj_first",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: 2, updated: 3 },
+            title: "Recent session",
+            location: { directory: "/tmp/opencode/first" },
+          },
+        ],
+        cursor: {},
+      }),
+    )
+    await fixture.app.waitForFrame((frame) => frame.includes("Recent session"))
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "home")
+
+    expect(fixture.route.data).toEqual({ type: "home", location: { directory: "/tmp/opencode/second" } })
+  } finally {
+    fixture.dispose()
+  }
+})
+
 async function renderOpen(
   handler: FetchHandler,
   beforeOpen?: (contexts: {

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -379,23 +379,3 @@ test("keeps the first row selected when current is only a marker", async () => {
     select.app.renderer.destroy()
   }
 })
-
-test("focuses a falsy current value", async () => {
-  await using tmp = await tmpdir()
-  const select = await mountSelect(
-    tmp.path,
-    [
-      { title: "other", value: "other" },
-      { title: "empty", value: "" },
-    ],
-    "",
-  )
-
-  try {
-    select.app.mockInput.pressEnter()
-    await select.app.waitFor(() => select.selected.length === 1)
-    expect(select.selected).toEqual([""])
-  } finally {
-    select.app.renderer.destroy()
-  }
-})

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -380,37 +380,6 @@ test("keeps the first row selected when current is only a marker", async () => {
   }
 })
 
-test("keeps an explicitly moved selection when options are prepended", async () => {
-  await using tmp = await tmpdir()
-  const project = { title: "project", value: "project" }
-  const select = await mountSelect(
-    tmp.path,
-    [
-      { title: "first project", value: "first-project" },
-      project,
-    ],
-    "current",
-    false,
-  )
-
-  try {
-    select.app.mockInput.pressArrow("down")
-    await select.app.waitFor(() => select.moved.at(-1) === "project")
-    select.replaceOptions([
-      { title: "recent session", value: "recent" },
-      { title: "first project", value: "first-project" },
-      project,
-    ])
-    await select.app.waitForFrame((frame) => frame.includes("recent session"))
-    select.app.mockInput.pressEnter()
-    await select.app.waitFor(() => select.selected.length === 1)
-
-    expect(select.selected).toEqual(["project"])
-  } finally {
-    select.app.renderer.destroy()
-  }
-})
-
 test("focuses a falsy current value", async () => {
   await using tmp = await tmpdir()
   const select = await mountSelect(

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -82,7 +82,12 @@ async function renderSelect(
   return app
 }
 
-async function mountSelect(root: string, initial: DialogSelectOption<string>[], current?: string) {
+async function mountSelect(
+  root: string,
+  initial: DialogSelectOption<string>[],
+  current?: string,
+  focusCurrent?: boolean,
+) {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
   const config = createTuiResolvedConfig()
@@ -118,6 +123,7 @@ async function mountSelect(root: string, initial: DialogSelectOption<string>[], 
             title="Mutable options"
             options={options()}
             current={current}
+            focusCurrent={focusCurrent}
             onMove={(option) => moved.push(option.value)}
             onSelect={(option) => selected.push(option.value)}
           />
@@ -348,6 +354,78 @@ test("keeps the current option selected when options reorder", async () => {
     await select.app.waitFor(() => select.selected.length === 1)
 
     expect(select.selected).toEqual(["current"])
+  } finally {
+    select.app.renderer.destroy()
+  }
+})
+
+test("keeps the first row selected when current is only a marker", async () => {
+  await using tmp = await tmpdir()
+  const project = { title: "project", value: "project" }
+  const select = await mountSelect(tmp.path, [project], "current", false)
+
+  try {
+    select.replaceOptions([
+      { title: "recent session", value: "recent" },
+      project,
+      { title: "current session", value: "current" },
+    ])
+    await select.app.waitForFrame((frame) => frame.includes("recent session"))
+    select.app.mockInput.pressEnter()
+    await select.app.waitFor(() => select.selected.length === 1)
+
+    expect(select.selected).toEqual(["recent"])
+  } finally {
+    select.app.renderer.destroy()
+  }
+})
+
+test("keeps an explicitly moved selection when options are prepended", async () => {
+  await using tmp = await tmpdir()
+  const project = { title: "project", value: "project" }
+  const select = await mountSelect(
+    tmp.path,
+    [
+      { title: "first project", value: "first-project" },
+      project,
+    ],
+    "current",
+    false,
+  )
+
+  try {
+    select.app.mockInput.pressArrow("down")
+    await select.app.waitFor(() => select.moved.at(-1) === "project")
+    select.replaceOptions([
+      { title: "recent session", value: "recent" },
+      { title: "first project", value: "first-project" },
+      project,
+    ])
+    await select.app.waitForFrame((frame) => frame.includes("recent session"))
+    select.app.mockInput.pressEnter()
+    await select.app.waitFor(() => select.selected.length === 1)
+
+    expect(select.selected).toEqual(["project"])
+  } finally {
+    select.app.renderer.destroy()
+  }
+})
+
+test("focuses a falsy current value", async () => {
+  await using tmp = await tmpdir()
+  const select = await mountSelect(
+    tmp.path,
+    [
+      { title: "other", value: "other" },
+      { title: "empty", value: "" },
+    ],
+    "",
+  )
+
+  try {
+    select.app.mockInput.pressEnter()
+    await select.app.waitFor(() => select.selected.length === 1)
+    expect(select.selected).toEqual([""])
   } finally {
     select.app.renderer.destroy()
   }


### PR DESCRIPTION
## What

Stabilize the Ctrl-O open picker and make the current project explicit.

- Keep the first session selected when async results arrive.
- Preserve an explicit keyboard or mouse selection across later option updates.
- List projects newest-first and include the current project with a dot.
- Open the current project's canonical root, including when the TUI is inside a subfolder.
- Show running indicators for unhydrated session summaries.
- Avoid forcibly refetching already-cached project metadata on every open.

## Before / After

**Before:** Ctrl-O could render cached projects first, select a project, then prepend recent sessions while preserving the project by identity. The highlight therefore appeared partway down the final list. A late response could also replace a project the user had explicitly selected. The current project was omitted entirely.

**After:** Async initialization stays on the first row until the user moves. Once the user moves, `DialogOpen` enables the existing selection-preservation behavior. The current project remains in recency order with a dot and opens its canonical root. Project metadata reuses the existing data cache; each session dialog retains its existing bounded local query.

## How

- `packages/tui/src/ui/dialog-select.tsx` treats `focusCurrent={false}` as a marker-only current value and handles falsy `current` values consistently.
- `packages/tui/src/component/dialog-open.tsx` owns the narrow `selectionMoved` state, respects disabled tabs, resolves child routes to root sessions, includes the current project root, and checks both root and family running status.
- `packages/tui/src/component/dialog-session-list.tsx` uses its loading state on the first uncached open instead of replacing an already-rendered local list, and applies the same root-plus-family running check.
- TUI integration tests cover delayed option insertion, explicit project movement, project ordering, unhydrated session handoff, and opening the current project root.

## Scope

Ctrl-O remains a bounded recents-and-projects picker. Older session search continues to live in the full session dialog rather than turning Ctrl-O into an unbounded search surface. This PR does not add a new shared data cache or change `DataProvider`.

## Testing

- `bun run test` from `packages/tui`: 582 passed, 5 skipped.
- `bun typecheck` from `packages/tui`.
- Pre-push repository typecheck: 33 packages passed.
- OpenCode Drive run against this worktree with three concurrent running sessions, opening Ctrl-O and observing their live spinners.

## Demo

OpenCode Drive launches three concurrent simulated sessions and records Ctrl-O showing their live animated spinners, stable initial selection, and the current-project dot.

https://github.com/user-attachments/assets/72bdb07d-6dda-48fb-939a-29871bb9eb8f

## Flow

```mermaid
flowchart TD
  Open[Ctrl-O opens picker] --> Local[Render local sessions and cached projects]
  Open --> Recent[Load bounded recent sessions]
  Recent --> Options[Reconcile options]
  Local --> Options
  Options --> Moved{User moved selection?}
  Moved -- No --> First[Keep first row selected]
  Moved -- Yes --> Value[Preserve selected value]
  First --> Choose{Selected target}
  Value --> Choose
  Choose -- Session --> Session[Restore session location and navigate]
  Choose -- Project --> Root[Open canonical project root]
```

