### PR TITLE
fix(core): fence runtime MCP tool reconciliation

### DIFF
--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -2,7 +2,7 @@ export * as McpTool from "./mcp"
 
 import { ToolFailure } from "@opencode-ai/ai"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
-import { Effect, Exit, type JsonSchema, Layer, Scope, Semaphore, Stream } from "effect"
+import { Context, Effect, Exit, type JsonSchema, Layer, Scope, Semaphore, Stream } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "../bus"
 
@@ -16,7 +16,14 @@ import { Tool } from "../tool"
 export const namespace = (server: string) => server.replace(/[^a-zA-Z0-9_-]/g, "_")
 export const name = (server: string, tool: string) => `${namespace(server)}_${tool.replace(/[^a-zA-Z0-9_-]/g, "_")}`
 
-export const layer = Layer.effectDiscard(
+export interface Interface {
+  readonly reconcile: Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/McpTool") {}
+
+export const layer = Layer.effect(
+  Service,
   Effect.gen(function* () {
     const mcp = yield* MCP.Service
     const tools = yield* Tool.Service
@@ -118,11 +125,12 @@ export const layer = Layer.effectDiscard(
       Stream.runForEach(() => reconcile),
       Effect.forkScoped({ startImmediately: true }),
     )
+    return Service.of({ reconcile })
   }),
 )
 
 export const node = makeLocationNode({
-  name: "mcp-tools",
+  service: Service,
   layer,
   deps: [Tool.node, MCP.node, Bus.node, Permission.node],
 })

--- a/packages/core/test/mcp-tool-reconciliation.test.ts
+++ b/packages/core/test/mcp-tool-reconciliation.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Bus } from "@opencode-ai/core/bus"
+import { Image } from "@opencode-ai/core/image"
+import { MCP } from "@opencode-ai/core/mcp/index"
+import { Permission } from "@opencode-ai/core/permission"
+import { McpTool } from "@opencode-ai/core/tool/mcp"
+import { Tool } from "@opencode-ai/core/tool"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Deferred, Effect, Fiber, Layer, PubSub, Stream } from "effect"
+import { imagePassthrough } from "./lib/image"
+
+test("explicitly fences asynchronous MCP tool reconciliation", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const initialRead = yield* Deferred.make<void>()
+        const reconcileStarted = yield* Deferred.make<void>()
+        const releaseReconcile = yield* Deferred.make<void>()
+        const updates = yield* PubSub.unbounded<void>()
+        let reads = 0
+        let catalog: Array<MCP.Tool> = []
+
+        const layer = AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node]), [
+          [
+            MCP.node,
+            Layer.mock(MCP.Service, {
+              tools: () =>
+                Effect.gen(function* () {
+                  reads += 1
+                  if (reads === 1) {
+                    const current = catalog
+                    yield* Deferred.succeed(initialRead, undefined)
+                    return current
+                  }
+                  yield* Deferred.succeed(reconcileStarted, undefined)
+                  yield* Deferred.await(releaseReconcile)
+                  return catalog
+                }),
+            }),
+          ],
+          [Bus.node, Layer.mock(Bus.Service, { subscribe: () => Stream.fromPubSub(updates) as never })],
+          [Permission.node, Layer.mock(Permission.Service, {})],
+          [Image.node, imagePassthrough],
+        ])
+
+        yield* Effect.gen(function* () {
+          const registry = yield* Tool.Service
+          const adapter = yield* McpTool.Service
+          yield* Deferred.await(initialRead)
+          catalog = [
+            new MCP.Tool({
+              server: MCP.ServerName.make("voice"),
+              name: "list_open_tabs",
+              inputSchema: { type: "object", properties: {} },
+            }),
+          ]
+
+          yield* PubSub.publish(updates, undefined)
+          yield* Deferred.await(reconcileStarted)
+
+          const stale = yield* registry.snapshot()
+          expect(stale.codeModeCatalog?.some((entry) => entry.path === "voice.list_open_tabs")).toBe(false)
+
+          const fence = yield* Effect.forkChild(adapter.reconcile, { startImmediately: true })
+          expect(fence.pollUnsafe()).toBeUndefined()
+          yield* Deferred.succeed(releaseReconcile, undefined)
+          yield* Fiber.join(fence)
+          const current = yield* registry.snapshot()
+          expect(current.codeModeCatalog?.some((entry) => entry.path === "voice.list_open_tabs")).toBe(true)
+        }).pipe(Effect.provide(layer))
+      }),
+    ),
+  )
+})

--- a/packages/server/src/handlers/mcp.ts
+++ b/packages/server/src/handlers/mcp.ts
@@ -1,4 +1,5 @@
 import { MCP } from "@opencode-ai/core/mcp/index"
+import { McpTool } from "@opencode-ai/core/tool/mcp"
 import { McpServerNotFoundError } from "@opencode-ai/protocol/errors"
 import { Effect } from "effect"
 import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
@@ -30,7 +31,9 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
         "mcp.add",
         Effect.fn(function* (ctx) {
           const service = yield* MCP.Service
+          const tools = yield* McpTool.Service
           yield* service.add(ctx.params.server, ctx.payload.config)
+          yield* tools.reconcile
           return HttpApiSchema.NoContent.make()
         }),
       )
@@ -38,7 +41,9 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
         "mcp.remove",
         Effect.fn(function* (ctx) {
           const service = yield* MCP.Service
+          const tools = yield* McpTool.Service
           yield* notFound(service.remove(ctx.params.server))
+          yield* tools.reconcile
           return HttpApiSchema.NoContent.make()
         }),
       )
@@ -46,7 +51,9 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
         "mcp.connect",
         Effect.fn(function* (ctx) {
           const service = yield* MCP.Service
+          const tools = yield* McpTool.Service
           yield* notFound(service.connect(ctx.params.server))
+          yield* tools.reconcile
           return HttpApiSchema.NoContent.make()
         }),
       )
@@ -54,7 +61,9 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
         "mcp.disconnect",
         Effect.fn(function* (ctx) {
           const service = yield* MCP.Service
+          const tools = yield* McpTool.Service
           yield* notFound(service.disconnect(ctx.params.server))
+          yield* tools.reconcile
           return HttpApiSchema.NoContent.make()
         }),
       )


### PR DESCRIPTION
## What

Make runtime MCP lifecycle mutations read-your-writes consistent with the ToolRegistry and Code Mode catalog. After an MCP add, remove, connect, or disconnect request returns, the next session tool snapshot now reflects that mutation.

## Before / After

**Before:** `MCP.add` connected the server, discovered its tools, published `mcp.tools.changed`, and returned. `McpTool` consumed that event on an asynchronously forked stream, so an immediate session request could snapshot the previous direct-tool or Code Mode catalog while reconciliation was still in flight.

**After:** runtime MCP handlers await an explicit `McpTool.reconcile` fence after mutating MCP state. The fence serializes behind any event-driven reconciliation and returns only after the complete current MCP tool set has replaced the prior registry scope.

## How

- `packages/core/src/tool/mcp.ts` exposes the existing serialized reconciliation effect as a Location-scoped service while retaining asynchronous reconciliation for server-originated tool-list updates.
- `packages/server/src/handlers/mcp.ts` awaits that service after runtime add, remove, connect, and disconnect operations.
- `packages/core/test/mcp-tool-reconciliation.test.ts` blocks event-driven reconciliation to prove publication can complete while a snapshot is stale, then verifies the explicit fence waits and makes the Code Mode path immediately visible.

## Scope

This does not make all event-bus subscribers synchronous and does not change server-originated MCP list-change behavior. The stronger guarantee applies at the runtime MCP HTTP lifecycle boundary.

## Testing

- `bun typecheck` in `packages/core`
- `bun run test test/mcp.test.ts test/mcp-tool-reconciliation.test.ts` in `packages/core`: 23 tests, 67 expectations
- `bun typecheck` in `packages/server`
- `bun run test` in `packages/server`: 16 tests, 39 expectations
- Repository pre-push typecheck: 33 package tasks passed

## Flow

```mermaid
sequenceDiagram
  participant Client
  participant MCP
  participant McpTool
  participant Registry as ToolRegistry / Code Mode

  Client->>MCP: add / remove / connect / disconnect
  MCP-->>McpTool: mcp.tools.changed (async)
  Client->>McpTool: reconcile fence
  McpTool->>MCP: read complete current tool set
  McpTool->>Registry: register replacement scope
  McpTool->>Registry: close previous scope
  McpTool-->>Client: mutation is observable
```