### PR TITLE
fix(core): exclude deleted projects from listing

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -148,7 +148,7 @@ const layer = Layer.effect(
         .orderBy(desc(ProjectTable.time_updated), asc(ProjectTable.id))
         .all()
         .pipe(Effect.orDie)
-      return rows.map(fromRow)
+      return yield* Effect.filter(rows.map(fromRow), (project) => fs.existsSafe(project.canonical))
     })
 
     const directories = Effect.fn("Project.directories")(function* (input: DirectoriesInput) {

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -15,8 +15,16 @@ import { testEffect } from "./lib/effect"
 const it = testEffect(Layer.merge(AppNodeBuilder.build(Project.node), AppNodeBuilder.build(Database.node)))
 
 describe("Project.list", () => {
-  it.effect("returns complete projects ordered by recent update", () =>
+  it.live("returns existing projects ordered by recent update", () =>
     Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const older = abs(path.join(tmp.path, "older"))
+      const newer = abs(path.join(tmp.path, "newer"))
+      const deleted = abs(path.join(tmp.path, "deleted"))
+      yield* Effect.promise(() => Promise.all([fs.mkdir(older), fs.mkdir(newer)]))
       const db = (yield* Database.Service).db
       const project = yield* Project.Service
       yield* db
@@ -24,22 +32,29 @@ describe("Project.list", () => {
         .values([
           {
             id: Project.ID.make("older"),
-            worktree: abs("/older"),
+            worktree: older,
             vcs: "git",
             name: "Older",
             icon_color: "#000000",
             commands: { start: "bun dev" },
-            sandboxes: [abs("/older/sandbox")],
+            sandboxes: [abs(path.join(older, "sandbox"))],
             time_created: 1,
             time_updated: 1,
           },
           {
             id: Project.ID.make("newer"),
-            worktree: abs("/newer"),
+            worktree: newer,
             sandboxes: [],
             time_created: 2,
             time_updated: 2,
             time_initialized: 3,
+          },
+          {
+            id: Project.ID.make("deleted"),
+            worktree: deleted,
+            sandboxes: [],
+            time_created: 3,
+            time_updated: 3,
           },
         ])
         .run()
@@ -47,19 +62,19 @@ describe("Project.list", () => {
       expect(yield* project.list()).toEqual([
         {
           id: Project.ID.make("newer"),
-          canonical: abs("/newer"),
+          canonical: newer,
           time: { created: 2, updated: 2, initialized: 3 },
           sandboxes: [],
         },
         {
           id: Project.ID.make("older"),
-          canonical: abs("/older"),
+          canonical: older,
           vcs: "git",
           name: "Older",
           icon: { color: "#000000" },
           commands: { start: "bun dev" },
           time: { created: 1, updated: 1 },
-          sandboxes: [abs("/older/sandbox")],
+          sandboxes: [abs(path.join(older, "sandbox"))],
         },
       ])
     }),


### PR DESCRIPTION
## What

Prevent deleted projects from appearing as selectable targets in the V2 project picker.

## Before / After

**Before:** `Project.list()` returned every persisted project row, including projects whose canonical directory had been deleted. The TUI project picker exposed that stale path; selecting it could leave the prompt location and footer out of sync, and submitting a prompt failed because the directory no longer existed.

**After:** project listing verifies each canonical directory still exists before returning it. Deleted project rows remain persisted, but clients no longer receive them as selectable projects.

## How

- `packages/core/src/project.ts` filters the ordered project rows through the filesystem service before returning them.
- `packages/core/test/project.test.ts` covers existing and deleted canonical directories while preserving metadata and recency ordering assertions.

## Scope

This does not delete stale rows from the database or change project identity and persistence behavior. It only prevents unavailable projects from being exposed by the project listing API.

## Testing

- `bun run test test/project.test.ts` from `packages/core`: 13 passed, 1 skipped
- `bun typecheck` from `packages/core`: passed
- Pre-push `bun turbo typecheck --concurrency=3`: 33 packages passed
- `bun run test` from `packages/core`: 1,523 passed, 6 skipped, 1 unrelated failure because `~/.config/opencode/plugins/voice.ts` was discovered by the plugin-isolation test
