### PR TITLE
fix(cli): deduplicate Node asset destinations

### DIFF
--- a/packages/cli/script/node-assets.ts
+++ b/packages/cli/script/node-assets.ts
@@ -58,8 +58,9 @@ export async function collectNodeAssets(target: NodeTarget) {
         source: path.join(ptyRoot, relative),
       })),
   ]
-  await Promise.all(assets.map((asset) => stat(asset.source)))
-  return assets
+  const unique = [...new Map(assets.map((asset) => [asset.key, asset])).values()]
+  await Promise.all(unique.map((asset) => stat(asset.source)))
+  return unique
 }
 
 export async function hashNodeAssets(assets: readonly NodeAsset[]) {

--- a/packages/cli/test/node-assets.test.ts
+++ b/packages/cli/test/node-assets.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+import { collectNodeAssets } from "../script/node-assets"
+import { nodeTarget, shellParserWasmAssets } from "../src/node/target"
+
+test("collects each SEA asset key once", async () => {
+  const assets = await collectNodeAssets(nodeTarget(process.platform, process.arch))
+  const keys = assets.map((asset) => asset.key)
+
+  expect(new Set(keys).size).toBe(keys.length)
+  expect(assets.filter((asset) => asset.key === shellParserWasmAssets.runtime)).toEqual([
+    {
+      key: shellParserWasmAssets.runtime,
+      source: fileURLToPath(import.meta.resolve(shellParserWasmAssets.runtime)),
+    },
+  ])
+})


### PR DESCRIPTION
## What
Prevent Node SEA builds from copying the same asset key to one destination concurrently. This removes the intermittent Windows `EBUSY` failure while preserving the CLI-owned shell parser assets.

## Before / After
**Before:** OpenTUI and the CLI shell parser manifest both emitted `web-tree-sitter/tree-sitter.wasm`. `copyNodeAssets` launched both copies concurrently against the same destination, which Windows intermittently rejected as busy or locked.

**After:** `collectNodeAssets` emits exactly one entry per SEA asset key. Later explicit CLI entries take precedence, so each destination receives one copy and the shell parser remains bound to the CLI dependency version.

## How
- Deduplicate collected assets by stable SEA key before source validation and copying.
- Add a regression test for unique keys and explicit shell parser source precedence.

## Scope
This changes Node SEA asset collection only. It does not add generic filesystem retries or alter runtime asset extraction.

## Testing
- `bun run test -- test/node-assets.test.ts`
- `bun typecheck`
- `bun run build:node` (all Linux, macOS, and Windows targets)
- Push hook: monorepo typecheck, 33/33 tasks passed