### PR TITLE
test(app): restore stable offset observer ordering

### DIFF
--- a/packages/app/src/pages/session/timeline/observe-element-offset.test.ts
+++ b/packages/app/src/pages/session/timeline/observe-element-offset.test.ts
@@ -38,15 +38,15 @@ test("reports a divergent native offset once and ignores equal offsets and unrel
     instance.scrollOffset = offset
   })
 
-  document.body.append(unrelated)
-  unrelated.remove()
-  await frames(2)
-  expect(calls).toEqual([])
-
   route.remove()
   document.body.append(route)
   await new Promise((resolve) => setTimeout(resolve, 0))
   await frames(3)
+  expect(calls).toEqual([[0, false]])
+
+  document.body.append(unrelated)
+  unrelated.remove()
+  await frames(2)
   expect(calls).toEqual([[0, false]])
 
   route.remove()

--- a/packages/app/src/pages/session/timeline/observe-element-offset.test.ts
+++ b/packages/app/src/pages/session/timeline/observe-element-offset.test.ts
@@ -44,11 +44,13 @@ test("reports a divergent native offset once and ignores equal offsets and unrel
   await frames(3)
   expect(calls).toEqual([[0, false]])
 
+  instance.scrollOffset = 79_400
   document.body.append(unrelated)
   unrelated.remove()
   await frames(2)
   expect(calls).toEqual([[0, false]])
 
+  instance.scrollOffset = 0
   route.remove()
   document.body.append(route)
   await new Promise((resolve) => setTimeout(resolve, 0))


### PR DESCRIPTION
## What
Restore the stable ordering for the reconnect-aware offset observer test that was previously landed in #38044 and later lost during a branch merge.

## Before / After
**Before:** The test performed unrelated DOM mutations and awaited animation frames before its first reconnect. Happy DOM stores mutation callbacks weakly, so GC could collect the callback during that asynchronous gap and leave the reconnect assertion with no calls.

**After:** The test verifies the reconnect first, then performs unrelated DOM churn and confirms it adds no callback. Production behavior and coverage remain unchanged, without exposing the test to Happy DOM's weak-callback artifact before its positive assertion.

## How
Reorder the existing test phases to match the proven ordering from #38044. A second reconnect still verifies equal offsets are ignored after the unrelated-mutation check.

## Scope
Test-only change. No App runtime or timeline implementation changes.

## Testing
- Focused suite repeated 500 times: 3,500/3,500 tests passed
- `bun test --preload ./happydom.ts ./src/pages/session/timeline/observe-element-offset.test.ts`
- `bun typecheck`
- Push hook: monorepo typecheck, 33/33 tasks passed
- Full App unit suite: 684 passed; one unrelated existing i18n parity failure for missing Arabic keys