### PR TITLE
feat(opencode): add system prompt debug command

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -15,6 +15,7 @@ import { SnapshotCommand } from "./snapshot"
 import { AgentCommand } from "./agent"
 import { StartupCommand } from "./startup"
 import { V2Command } from "./v2"
+import { PromptCommand } from "./prompt"
 
 export const DebugCommand = cmd({
   command: "debug",
@@ -30,6 +31,7 @@ export const DebugCommand = cmd({
       .command(SnapshotCommand)
       .command(StartupCommand)
       .command(AgentCommand)
+      .command(PromptCommand)
       .command(V2Command)
       .command(InfoCommand)
       .command(PathsCommand)

--- a/packages/opencode/src/cli/cmd/debug/prompt.ts
+++ b/packages/opencode/src/cli/cmd/debug/prompt.ts
@@ -1,0 +1,67 @@
+import { EOL } from "os"
+import { Effect } from "effect"
+import { Agent } from "@/agent/agent"
+import { Instruction } from "@/session/instruction"
+import { Plugin } from "@/plugin"
+import { Provider } from "@/provider/provider"
+import { SystemPrompt } from "@/session/system"
+import { errorMessage } from "@/util/error"
+import { effectCmd, fail } from "../../effect-cmd"
+
+export const PromptCommand = effectCmd({
+  command: "prompt",
+  describe: "export resolved system prompt",
+  builder: (yargs) =>
+    yargs
+      .option("agent", {
+        type: "string",
+        describe: "agent name to resolve the prompt for",
+      })
+      .option("model", {
+        type: "string",
+        describe: "model in provider/model format",
+      }),
+  handler: Effect.fn("Cli.debug.prompt")(function* (args) {
+    const agents = yield* Agent.Service
+    const provider = yield* Provider.Service
+    const sys = yield* SystemPrompt.Service
+    const instruction = yield* Instruction.Service
+    const plugin = yield* Plugin.Service
+
+    const agent = args.agent ? yield* agents.get(args.agent) : yield* agents.defaultInfo()
+    const modelRef = yield* (args.model ? Effect.succeed(Provider.parseModel(args.model)) : provider.defaultModel()).pipe(
+      Effect.catch((error) => fail(errorMessage(error))),
+    )
+    const model = yield* provider
+      .getModel(modelRef.providerID, modelRef.modelID)
+      .pipe(Effect.catch((error) => fail(errorMessage(error))))
+    const [env, instructions, mcpInstructions, skills] = yield* Effect.all([
+      sys.environment(model),
+      instruction.system().pipe(Effect.orDie),
+      sys.mcp(agent),
+      sys.skills(agent),
+    ])
+
+    const system = [
+      [
+        ...(agent.prompt ? [agent.prompt] : SystemPrompt.provider(model)),
+        ...env,
+        ...instructions,
+        ...(mcpInstructions ? [mcpInstructions] : []),
+        ...(skills ? [skills] : []),
+      ]
+        .filter((item) => item)
+        .join("\n"),
+    ]
+
+    const header = system[0]
+    yield* plugin.trigger("experimental.chat.system.transform", { sessionID: "debug-prompt", model }, { system })
+    if (system.length > 2 && system[0] === header) {
+      const rest = system.slice(1)
+      system.length = 0
+      system.push(header, rest.join("\n"))
+    }
+
+    process.stdout.write(system.join("\n") + EOL)
+  }),
+})

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -29,6 +29,7 @@ import { SessionCompaction } from "@/session/compaction"
 import { SessionRevert } from "@/session/revert"
 import { SessionSummary } from "@/session/summary"
 import { SessionPrompt } from "@/session/prompt"
+import { SystemPrompt } from "@/session/system"
 import { Instruction } from "@/session/instruction"
 import { LLM } from "@/session/llm"
 import { LSP } from "@/lsp/lsp"
@@ -87,6 +88,7 @@ export const AppLayer = AppNodeBuilderV1.build(
     SessionCompaction.node,
     SessionRevert.node,
     SessionSummary.node,
+    SystemPrompt.node,
     SessionPrompt.node,
     Instruction.node,
     LLM.node,


### PR DESCRIPTION
### Issue for this PR

Related to #24990, #39033, and #33333.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a local CLI debug command:

```bash
opencode debug prompt
```

The command prints the resolved effective system prompt for the current project, agent, and model. It supports optional `--agent` and `--model` flags.

This is useful when debugging prompt-affecting customization layers such as `AGENTS.md`, `opencode.json` `instructions`, skills, MCP instructions, custom agents, and `experimental.chat.system.transform` plugins.

The implementation uses the same existing system prompt services used by normal request assembly:

- `SystemPrompt.provider(model)` for the model-family base prompt
- `SystemPrompt.environment(model)` for environment context
- `Instruction.system()` for `AGENTS.md` and configured instruction files
- `SystemPrompt.mcp(agent)` for MCP instructions
- `SystemPrompt.skills(agent)` for the available skills block
- `experimental.chat.system.transform` for plugin transformations

This is intentionally narrower than a full context dump or export feature. It does not persist anything to `opencode.db`, does not change transcript export behavior, does not add a TUI surface, and does not dump the full request/message array.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode`
- Ran `bun --conditions=browser ./src/index.ts debug prompt --help`
- Ran `bun --conditions=browser ./src/index.ts --pure debug prompt --model opencode/big-pickle`
- Verified the real command output included the environment block, instruction files, and available skills block
- Ran `bun run build --single --skip-install --skip-embed-web-ui`
- Ran built binary smoke test: `dist/opencode-darwin-arm64/bin/opencode --version`
- Ran built binary command check: `dist/opencode-darwin-arm64/bin/opencode debug prompt --help`
- Pre-push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

N/A. CLI-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
