### PR TITLE
feat: add X-Opencode-Session-Id header for session identification

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -196,6 +196,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
         : {
             "x-session-affinity": input.sessionID,
             "X-Session-Id": input.sessionID,
+            "X-Opencode-Session-Id": input.sessionID,
             ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
             "User-Agent": USER_AGENT,
           }),


### PR DESCRIPTION
### Issue for this PR

Closes #39912

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode already sends `X-Session-Id` with LLM requests, but the header name doesn't
follow the `x-<vendor>-session-id` convention that tools like LiteLLM auto-detect for
session grouping. This PR adds `X-Opencode-Session-Id` alongside the existing header
so those tools can track sessions without any extra configuration.

### How did you verify your code works?

Ran `bun dev` locally, pointed OpenCode at a LiteLLM proxy, and confirmed requests
now appear grouped under the same session in the LiteLLM logs UI.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
