### PR TITLE
fix(tui): render plugin slots and routes with component semantics

### DIFF
--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -1,10 +1,12 @@
 import { PluginContextProvider, type Plugin } from "@opencode-ai/plugin/tui"
 import {
   batch,
+  createComponent,
   createContext,
   createEffect,
   createMemo,
   For,
+  mergeProps,
   on,
   onCleanup,
   onMount,
@@ -584,7 +586,7 @@ export function PluginRoute(props: { readonly fallback: (id: string, name: strin
     if (route.data.type !== "plugin") return
     const render = plugins.route(route.data.id, route.data.name)
     if (!render) return props.fallback(route.data.id, route.data.name)
-    return render({ data: route.data.data })
+    return createComponent(render, { data: route.data.data })
   })
   return <>{content()}</>
 }
@@ -600,5 +602,16 @@ export function PluginSlot<Name extends SlotName>(props: {
     if (props.mode === "replace") return items.slice(-1)
     return items
   })
-  return <For each={renderers()}>{(render) => render(props.input)}</For>
+  return (
+    <For each={renderers()}>
+      {(render) =>
+        // Component semantics: the render body runs once and untracked, so
+        // signals and intervals created inside are stable, while props stay
+        // reactive through the merged getter. A bare render(props.input) call
+        // would run inside the host's tracked scope and re-execute the whole
+        // body (resetting plugin state) on every tracked read.
+        createComponent(render, mergeProps(() => props.input) as SlotMap[Name])
+      }
+    </For>
+  )
 }


### PR DESCRIPTION
## What

Plugin slot and route render functions were invoked as bare function calls inside the host's tracked reactive scope. Any reactive read in the returned JSX subscribed the *host's* resolution memo, so an update re-executed the plugin's **entire render body** — not a fine-grained update.

## Before / After

**Before**: a plugin slot like

```tsx
context.ui.slot("prompt.footer.end", () => {
  const [tick, setTick] = createSignal(0)
  const timer = setInterval(() => setTick((v) => v + 1), 1000)
  onCleanup(() => clearInterval(timer))
  return <text>{tick()}</text>
})
```

renders `0` forever. Instrumented sequence: body runs → `tick()` read subscribes the host memo → interval fires → memo re-runs the whole body → **new** signal at 0, old interval cleaned up → repeat. File markers show `render / expr tick=0 / cleanup / render / ...` in a loop — plugin-local state resets every update, and each cycle churns a create/cleanup pair. Anything stateful a plugin does in a slot (signals, timers, subscriptions) is silently broken.

**After**: the body runs exactly once and untracked, signals and intervals created inside are stable, and updates flow through the JSX bindings. The invariant is standard Solid component semantics: render bodies execute once; reactivity lives in the returned expressions.

## How

`packages/tui/src/plugin/context.tsx`: invoke plugin renders through `createComponent` instead of calling them directly.

- `PluginSlot`: `createComponent(render, mergeProps(() => props.input))` — `mergeProps` keeps slot input reactive through a getter, so plugins still see prop changes without a remount.
- `PluginRoute`: `createComponent(render, { data: route.data.data })` — the surrounding memo still recreates the component on navigation, matching existing behavior.

Found while building the hot-reload demos for #39776, but the bug predates that branch — it has existed since plugin slots were introduced.

## Scope

A deeper issue remains and is deliberately not addressed here: child *expressions* of plugin-returned JSX still resolve inside a host-tracked scope in some paths, so store-driven updates can remount rather than update fine-grained. That needs an OpenTUI-level fix and is tracked separately with full instrumentation notes.

## Testing

- `bun typecheck` and full `bun run test` in `packages/tui` (584 pass).
- Behavior verified end-to-end on the hot-reload branch with instrumented ticker plugins (file-marker lifecycle logs) — the render/cleanup churn loop disappears and interval-driven store updates render live; see the demo videos in #39776.
