### PR TITLE
fix(tui): improve narrow layouts

### DIFF
--- a/packages/tui/src/component/logo.tsx
+++ b/packages/tui/src/component/logo.tsx
@@ -1,11 +1,14 @@
 import { RGBA, TextAttributes } from "@opentui/core"
 import { For, type JSX } from "solid-js"
+import { useTerminalDimensions } from "@opentui/solid"
 import { useTheme } from "../context/theme"
 import { tint } from "../theme/color"
-import { logo } from "../logo"
+import { go, logo } from "../logo"
 
 export function Logo() {
   const theme = useTheme()
+  const dimensions = useTerminalDimensions()
+  const mark = () => (dimensions().width < 44 ? go : logo)
 
   const renderLine = (line: string, fg: RGBA, bold: boolean): JSX.Element[] => {
     const shadow = tint(theme.background.default, fg, 0.25)
@@ -49,11 +52,11 @@ export function Logo() {
 
   return (
     <box>
-      <For each={logo.left}>
+      <For each={mark().left}>
         {(line, index) => (
           <box flexDirection="row" gap={1}>
             <box flexDirection="row">{renderLine(line, theme.text.subdued, false)}</box>
-            <box flexDirection="row">{renderLine(logo.right[index()], theme.text.default, true)}</box>
+            <box flexDirection="row">{renderLine(mark().right[index()], theme.text.default, true)}</box>
           </box>
         )}
       </For>

--- a/packages/tui/src/component/logo.tsx
+++ b/packages/tui/src/component/logo.tsx
@@ -8,7 +8,6 @@ import { go, logo } from "../logo"
 export function Logo() {
   const theme = useTheme()
   const dimensions = useTerminalDimensions()
-  const mark = () => (dimensions().width < 44 ? go : logo)
 
   const renderLine = (line: string, fg: RGBA, bold: boolean): JSX.Element[] => {
     const shadow = tint(theme.background.default, fg, 0.25)
@@ -52,14 +51,29 @@ export function Logo() {
 
   return (
     <box>
-      <For each={mark().left}>
-        {(line, index) => (
-          <box flexDirection="row" gap={1}>
-            <box flexDirection="row">{renderLine(line, theme.text.subdued, false)}</box>
-            <box flexDirection="row">{renderLine(mark().right[index()], theme.text.default, true)}</box>
-          </box>
-        )}
-      </For>
+      {dimensions().height < 12 ? null : dimensions().width < 24 || dimensions().height < 20 ? (
+        <For each={go.right.slice(1)}>
+          {(line) => <box flexDirection="row">{renderLine(line, theme.text.default, true)}</box>}
+        </For>
+      ) : dimensions().width < 44 ? (
+        <>
+          <For each={logo.left.slice(1)}>
+            {(line) => <box flexDirection="row">{renderLine(line, theme.text.subdued, false)}</box>}
+          </For>
+          <For each={logo.right}>
+            {(line) => <box flexDirection="row">{renderLine(line, theme.text.default, true)}</box>}
+          </For>
+        </>
+      ) : (
+        <For each={logo.left}>
+          {(line, index) => (
+            <box flexDirection="row" gap={1}>
+              <box flexDirection="row">{renderLine(line, theme.text.subdued, false)}</box>
+              <box flexDirection="row">{renderLine(logo.right[index()], theme.text.default, true)}</box>
+            </box>
+          )}
+        </For>
+      )}
     </box>
   )
 }

--- a/packages/tui/src/component/logo.tsx
+++ b/packages/tui/src/component/logo.tsx
@@ -51,7 +51,7 @@ export function Logo() {
 
   return (
     <box>
-      {dimensions().height < 12 ? null : dimensions().width < 24 || dimensions().height < 20 ? (
+      {dimensions().height < 12 ? null : dimensions().width < 22 ? (
         <For each={go.right.slice(1)}>
           {(line) => <box flexDirection="row">{renderLine(line, theme.text.default, true)}</box>}
         </For>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1443,7 +1443,7 @@ export function Prompt(props: PromptProps) {
                       >
                         <text fg={fadeColor(theme.text.subdued, agentMetaAlpha())}>auto</text>
                       </Show>
-                      <Show when={store.mode === "normal"}>
+                      <Show when={store.mode === "normal" && dimensions().width >= 28}>
                         <box flexDirection="row" gap={1} flexGrow={1} flexShrink={1} minWidth={0}>
                           <text fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>·</text>
                           <text

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1292,13 +1292,20 @@ export function Prompt(props: PromptProps) {
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
-    if (store.mode === "shell") {
-      if (!shell().length) return undefined
-      const example = shell()[store.placeholder % shell().length]
-      return `Run a command... "${example}"`
-    }
-    if (!list().length) return undefined
-    return `Ask anything... "${list()[store.placeholder % list().length]}"`
+    const value = (() => {
+      if (store.mode === "shell") {
+        if (!shell().length) return undefined
+        return `Run a command... "${shell()[store.placeholder % shell().length]}"`
+      }
+      if (!list().length) return undefined
+      return `Ask anything... "${list()[store.placeholder % list().length]}"`
+    })()
+    if (!value) return undefined
+    const width =
+      dimensions().width < 44
+        ? dimensions().width - 5
+        : Math.min(75, dimensions().width - 4) - 5
+    return Locale.truncateWidth(value, Math.max(1, width))
   })
   const locationLabel = createMemo(() => {
     if (!props.sessionID) {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1348,8 +1348,8 @@ export function Prompt(props: PromptProps) {
           }}
         >
           <box
-            paddingLeft={2}
-            paddingRight={2}
+            paddingLeft={dimensions().width < 44 ? 1 : 2}
+            paddingRight={dimensions().width < 44 ? 1 : 2}
             paddingTop={1}
             flexShrink={0}
             backgroundColor={promptBg()}
@@ -1433,25 +1433,34 @@ export function Prompt(props: PromptProps) {
               syntaxStyle={syntax()}
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
-              <box flexDirection="row" gap={1}>
+              <box flexDirection="row" gap={1} flexGrow={1} flexShrink={1} minWidth={0}>
                 <Show when={agentLabel()} fallback={<box height={1} />}>
                   {(label) => (
                     <>
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>{label()}</text>
-                      <Show when={store.mode === "normal" && local.permission.mode === "auto"}>
+                      <Show
+                        when={store.mode === "normal" && local.permission.mode === "auto" && dimensions().width >= 44}
+                      >
                         <text fg={fadeColor(theme.text.subdued, agentMetaAlpha())}>auto</text>
                       </Show>
                       <Show when={store.mode === "normal"}>
-                        <box flexDirection="row" gap={1}>
+                        <box flexDirection="row" gap={1} flexGrow={1} flexShrink={1} minWidth={0}>
                           <text fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>·</text>
                           <text
-                            flexShrink={0}
+                            flexShrink={1}
+                            minWidth={0}
+                            wrapMode="none"
+                            truncate
                             fg={fadeColor(leader() ? theme.text.subdued : theme.text.default, modelMetaAlpha())}
                           >
                             {local.model.parsed().model}
                           </text>
-                          <text fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>{currentProviderLabel()}</text>
-                          <Show when={showVariant()}>
+                          <Show when={dimensions().width >= 50}>
+                            <text flexShrink={0} fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>
+                              {currentProviderLabel()}
+                            </text>
+                          </Show>
+                          <Show when={showVariant() && dimensions().width >= 70}>
                             <text fg={fadeColor(theme.text.subdued, variantMetaAlpha())}>·</text>
                             <text>
                               <span

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1305,7 +1305,7 @@ export function Prompt(props: PromptProps) {
       dimensions().width < 44
         ? dimensions().width - 5
         : Math.min(75, dimensions().width - 4) - 5
-    return Locale.truncateWidth(value, Math.max(1, width))
+    return Locale.takeWidth(value, Math.max(1, width)).trimEnd()
   })
   const locationLabel = createMemo(() => {
     if (!props.sessionID) {

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -63,8 +63,8 @@ function View(props: { context: Plugin.Context }) {
   return (
     <box
       width="100%"
-      paddingTop={1}
-      paddingBottom={1}
+      paddingTop={dimensions().height < 16 ? 0 : 1}
+      paddingBottom={dimensions().height < 16 ? 0 : 1}
       paddingLeft={2}
       paddingRight={2}
       flexDirection="row"

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -38,7 +38,7 @@ function View(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
 
   return (
-    <Show when={dimensions().height >= 12}>
+    <Show when={dimensions().height >= 12 && dimensions().width >= 44}>
       <box
         width="100%"
         paddingTop={dimensions().height < 16 ? 0 : 1}

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -1,23 +1,6 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createMemo, Match, Show, Switch } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
-import { stringWidth } from "../../util/string-width"
-import { FadeFilePath } from "../../ui/fade-file-path"
-
-function Directory(props: { context: Plugin.Context; maxWidth: number }) {
-  const directory = createMemo(() =>
-    props.context.location ? props.context.ui.format.path(props.context.location.directory) : undefined,
-  )
-
-  return (
-    <FadeFilePath
-      value={directory()}
-      maxWidth={props.maxWidth}
-      fg={props.context.theme.text.subdued}
-      bg={props.context.theme.background.default}
-    />
-  )
-}
 
 function Mcp(props: { context: Plugin.Context }) {
   const list = createMemo(() => props.context.data.location.mcp.server.list(props.context.location) ?? [])
@@ -53,34 +36,26 @@ function Mcp(props: { context: Plugin.Context }) {
 
 function View(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
-  const mcpWidth = createMemo(() => {
-    const list = props.context.data.location.mcp.server.list(props.context.location) ?? []
-    if (list.length === 0) return 0
-    const count = list.filter((item) => item.status.status === "connected").length
-    return stringWidth(`⊙ ${count} MCP /status`) + 2
-  })
 
   return (
-    <box
-      width="100%"
-      paddingTop={dimensions().height < 16 ? 0 : 1}
-      paddingBottom={dimensions().height < 16 ? 0 : 1}
-      paddingLeft={2}
-      paddingRight={2}
-      flexDirection="row"
-      flexShrink={0}
-      gap={2}
-    >
-      <Directory
-        context={props.context}
-        maxWidth={Math.max(2, dimensions().width - 8 - stringWidth(props.context.app.version) - mcpWidth())}
-      />
-      <Mcp context={props.context} />
-      <box flexGrow={1} />
-      <box flexShrink={0}>
-        <text fg={props.context.theme.text.subdued}>{props.context.app.version}</text>
+    <Show when={dimensions().height >= 12}>
+      <box
+        width="100%"
+        paddingTop={dimensions().height < 16 ? 0 : 1}
+        paddingBottom={dimensions().height < 16 ? 0 : 1}
+        paddingLeft={2}
+        paddingRight={2}
+        flexDirection="row"
+        flexShrink={0}
+        gap={2}
+      >
+        <Mcp context={props.context} />
+        <box flexGrow={1} />
+        <box flexShrink={0}>
+          <text fg={props.context.theme.text.subdued}>{props.context.app.version}</text>
+        </box>
       </box>
-    </box>
+    </Show>
   )
 }
 

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -62,23 +62,17 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
               <Show when={status().length > 0}>{status().join(" · ")}</Show>
             </text>
           </Match>
-          <Match when={true}>
+          <Match when={dimensions().width >= 44}>
             <text fg={props.context.theme.text.default} flexShrink={0}>
-              {shortcut("agent.cycle")}
-              <Show when={dimensions().width >= 44}>
-                {" "}
-                <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
-              </Show>
+              {shortcut("agent.cycle")} <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
             </text>
           </Match>
         </Switch>
-        <text fg={props.context.theme.text.default} flexShrink={0}>
-          {shortcut("command.palette.show")}
-          <Show when={dimensions().width >= 44}>
-            {" "}
-            <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
-          </Show>
-        </text>
+        <Show when={dimensions().width >= 44}>
+          <text fg={props.context.theme.text.default} flexShrink={0}>
+            {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
+          </text>
+        </Show>
       </Match>
       <Match when={props.mode === "shell"}>
         <text fg={props.context.theme.text.default} flexShrink={0}>

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -1,6 +1,7 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createMemo, Match, Show, Switch } from "solid-js"
 import { contextUsage, formatContextUsage } from "../../util/session"
+import { useTerminalDimensions } from "@opentui/solid"
 
 const money = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -8,6 +9,7 @@ const money = new Intl.NumberFormat("en-US", {
 })
 
 export function PromptFooter(props: { context: Plugin.Context; sessionID?: string; mode: "normal" | "shell" }) {
+  const dimensions = useTerminalDimensions()
   const activeSubagents = createMemo(() => {
     if (!props.sessionID) return 0
     return props.context.data.session
@@ -62,17 +64,28 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
           </Match>
           <Match when={true}>
             <text fg={props.context.theme.text.default} flexShrink={0}>
-              {shortcut("agent.cycle")} <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
+              {shortcut("agent.cycle")}
+              <Show when={dimensions().width >= 44}>
+                {" "}
+                <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
+              </Show>
             </text>
           </Match>
         </Switch>
         <text fg={props.context.theme.text.default} flexShrink={0}>
-          {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
+          {shortcut("command.palette.show")}
+          <Show when={dimensions().width >= 44}>
+            {" "}
+            <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
+          </Show>
         </text>
       </Match>
       <Match when={props.mode === "shell"}>
         <text fg={props.context.theme.text.default} flexShrink={0}>
-          esc <span style={{ fg: props.context.theme.text.subdued }}>exit shell mode</span>
+          esc{" "}
+          <span style={{ fg: props.context.theme.text.subdued }}>
+            {dimensions().width < 44 ? "shell" : "exit shell mode"}
+          </span>
         </text>
       </Match>
     </Switch>

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -10,6 +10,7 @@ import { useData } from "../context/data"
 import { useLocation } from "../context/location"
 import { FormPrompt } from "./session/form"
 import { PluginSlot } from "../plugin/context"
+import { useTerminalDimensions } from "@opentui/solid"
 
 let once = false
 const placeholder = {
@@ -26,6 +27,7 @@ export function Home() {
   const editor = useEditorContext()
   const data = useData()
   const location = useLocation()
+  const dimensions = useTerminalDimensions()
   // Global MCP elicitations can arrive without a session route, so keep them reachable from Home.
   const currentLocation = () => route.location ?? data.location.default()
   const forms = createMemo(() => data.session.form.list("global", currentLocation()) ?? [])
@@ -71,7 +73,12 @@ export function Home() {
 
   return (
     <>
-      <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
+      <box
+        flexGrow={1}
+        alignItems="center"
+        paddingLeft={dimensions().width < 44 ? 1 : 2}
+        paddingRight={dimensions().width < 44 ? 1 : 2}
+      >
         <box flexGrow={1} minHeight={0} />
         <box height={4} minHeight={0} flexShrink={1} />
         <box flexShrink={0}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1547,6 +1547,7 @@ function SessionGroupView(props: {
 function AssistantFooter(props: { message: SessionMessageAssistant }) {
   const ctx = use()
   const local = useLocal()
+  const dimensions = useTerminalDimensions()
   const theme = useTheme("elevated")
   const model = createMemo(
     () =>
@@ -1580,8 +1581,10 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
           <span style={{ fg: props.message.error ? theme.text.subdued : local.agent.color(props.message.agent) }}>
             {Locale.titlecase(props.message.agent)}
           </span>
-          <span style={{ fg: theme.text.subdued }}> · {model()}</span>
-          <Show when={duration()}>
+          <Show when={dimensions().width >= 28}>
+            <span style={{ fg: theme.text.subdued }}> · {model()}</span>
+          </Show>
+          <Show when={duration() && (dimensions().width < 28 || dimensions().width >= 36)}>
             <span style={{ fg: theme.text.subdued }}> · {Locale.duration(duration())}</span>
           </Show>
           <Show when={interrupted()}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -958,7 +958,14 @@ export function Session() {
       }}
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
-        <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box
+          flexGrow={1}
+          minHeight={0}
+          paddingBottom={1}
+          paddingLeft={dimensions().width < 44 ? 1 : 2}
+          paddingRight={dimensions().width < 44 ? 1 : 2}
+          gap={1}
+        >
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -42,38 +42,3 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     app.renderer.destroy()
   }
 })
-
-test("prompt footer collapses action labels at tight widths", async () => {
-  const color = RGBA.fromInts(200, 200, 200)
-  const context = {
-    location: { directory: "/workspace" },
-    theme: { text: { default: color, subdued: color } },
-    keymap: {
-      shortcuts: (id: string) =>
-        id === "agent.cycle" ? ["shift+tab"] : id === "command.palette.show" ? ["ctrl+p"] : [],
-    },
-    data: {
-      session: {
-        family: () => [],
-        status: () => "idle",
-        get: () => undefined,
-        cost: () => 0,
-        message: { list: () => [] },
-      },
-      shell: { list: () => [] },
-      location: { model: { list: () => [] } },
-    },
-  } as unknown as Context
-  const app = await testRender(() => <PromptFooter context={context} mode="normal" />, { width: 32, height: 2 })
-
-  try {
-    await app.renderOnce()
-    const frame = app.captureCharFrame()
-    expect(frame).toContain("shift+tab")
-    expect(frame).toContain("ctrl+p")
-    expect(frame).not.toContain("agents")
-    expect(frame).not.toContain("commands")
-  } finally {
-    app.renderer.destroy()
-  }
-})

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -42,3 +42,38 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     app.renderer.destroy()
   }
 })
+
+test("prompt footer collapses action labels at tight widths", async () => {
+  const color = RGBA.fromInts(200, 200, 200)
+  const context = {
+    location: { directory: "/workspace" },
+    theme: { text: { default: color, subdued: color } },
+    keymap: {
+      shortcuts: (id: string) =>
+        id === "agent.cycle" ? ["shift+tab"] : id === "command.palette.show" ? ["ctrl+p"] : [],
+    },
+    data: {
+      session: {
+        family: () => [],
+        status: () => "idle",
+        get: () => undefined,
+        cost: () => 0,
+        message: { list: () => [] },
+      },
+      shell: { list: () => [] },
+      location: { model: { list: () => [] } },
+    },
+  } as unknown as Context
+  const app = await testRender(() => <PromptFooter context={context} mode="normal" />, { width: 32, height: 2 })
+
+  try {
+    await app.renderOnce()
+    const frame = app.captureCharFrame()
+    expect(frame).toContain("shift+tab")
+    expect(frame).toContain("ctrl+p")
+    expect(frame).not.toContain("agents")
+    expect(frame).not.toContain("commands")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What

Make the home and active-session TUI layouts usable in narrow or short terminal panes.

The presentation now degrades by available width instead of squeezing desktop content:

- 44+ columns: horizontal `opencode` wordmark
- 22–43 columns: stacked `OPEN` / `CODE` wordmark
- below 22 columns: the existing `O` monogram
- below 12 rows: no logo or home footer, preserving the composer
- empty prompt help: always one line, hard-clipped to the composer width
- narrow prompt: secondary model metadata is progressively removed
- narrow idle footer: action hints disappear instead of becoming unlabeled shortcuts
- home location: shown once beneath the prompt, not duplicated in the bottom footer

Height never collapses a wordmark that still fits horizontally.

## Before / After

**Before:** At 32 columns, the full wordmark was clipped. Placeholder help wrapped across several rows, provider text could wrap character-by-character, idle footer hints were truncated into unexplained shortcuts, and the working directory appeared twice.

**After:** Branding switches only when horizontal space requires it, placeholder help clips to one line without adding another truncation character, state metadata remains readable, and one prompt-adjacent path remains the sole location indicator. Below 12 rows, decorative chrome disappears so the composer cannot collide with the footer.

## How

- `packages/tui/src/component/logo.tsx` selects the horizontal wordmark, stacked wordmark, monogram, or no logo from terminal dimensions.
- `packages/tui/src/component/prompt/index.tsx` clips placeholder help to the available text width and progressively removes secondary metadata.
- `packages/tui/src/feature-plugins/prompt/footer.tsx` keeps useful live status but omits idle action hints below 44 columns.
- `packages/tui/src/feature-plugins/home/footer.tsx` removes the duplicate path and hides constrained footer chrome.
- `packages/tui/src/routes/home.tsx` and `packages/tui/src/routes/session/index.tsx` tighten horizontal padding and compact assistant metadata.

## Scope

This only changes the V2 TUI's constrained-space presentation. It does not alter session behavior, keybindings, desktop-width layouts, or the V1 implementation.

## Testing

- `bun typecheck` in `packages/tui`
- push-hook workspace typecheck (33 packages passed)
- GitHub typecheck passed on the previous revision; refreshed CI is running for the final one-line clipping change
- OpenCode Drive visual matrix covering home and active-session routes from 120 to 21 columns and from 38 to 10 rows

The first GitHub `typecheck` check failed before compilation during `bun install`: `node-gyp` timed out downloading Node headers for `tree-sitter-powershell`. The following run passed.

## Demo

All captures use a simulated OpenCode Drive session. Every home-layout capture below was refreshed from commit `e059f5ca07` in one run.

### Original failure

![Original 32-column home](https://github.com/user-attachments/assets/b7d03e88-9b7c-410a-a8c2-88286a3794fa)

### Wide layouts

| 120×38 | 80×24 | 60×18 |
| --- | --- | --- |
| ![120x38](https://github.com/user-attachments/assets/266c7562-36d0-4ebf-9d3e-29d2a0ef6fee) | ![80x24](https://github.com/user-attachments/assets/19cefc71-6072-45e7-a06a-61de8a74eb83) | ![60x18](https://github.com/user-attachments/assets/9b77af97-4443-4c9f-98fc-bdeeda8af2bc) |

### Logo and clipping boundaries

| 44×18, full | 43×18, stacked | 28×18, hard-clipped |
| --- | --- | --- |
| ![44x18](https://github.com/user-attachments/assets/ad8adc47-c69f-4961-b6e1-ec67abeb2f62) | ![43x18](https://github.com/user-attachments/assets/0cda6a7b-27db-41bc-8aa1-cff51732d70f) | ![28x18](https://github.com/user-attachments/assets/7cb73c49-33f6-411d-8f67-a542305b609c) |

#### Exact monogram boundary

| 22×18, stacked | 21×18, monogram |
| --- | --- |
| ![22x18 stacked](https://github.com/user-attachments/assets/2f369062-fbcd-495c-aefc-43f4684a366b) | ![21x18 monogram](https://github.com/user-attachments/assets/72a4385a-906a-453f-b391-d46420efa46e) |

### Extremely short

![32x10](https://github.com/user-attachments/assets/259372f4-8b5c-4ad4-a409-44543f4ea0b9)

### Active-session height matrix

| 120×18 | 32×18 | 22×18 |
| --- | --- | --- |
| ![120x18 session](https://github.com/user-attachments/assets/7b3dc0dd-984f-4ea8-b57b-456eda4eaa1c) | ![32x18 session](https://github.com/user-attachments/assets/7bc8d91d-3e39-410f-80ff-12167bca3147) | ![22x18 session](https://github.com/user-attachments/assets/662dd165-c4e2-4ea1-84d3-168b7e75d9ae) |
