### PR TITLE
feat(plugin): expose session rename and wait to plugins

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -341,6 +341,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
       create: (input) =>
         runtime.session.create({
           id: input?.id,
+          title: input?.title,
           agent: input?.agent,
           model: input?.model,
           location:
@@ -350,8 +351,10 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
       prompt: runtime.session.prompt,
       generate: (input) => runtime.session.generate(input).pipe(Effect.map((text) => ({ text }))),
       command: runtime.session.command,
+      rename: runtime.session.rename,
       synthetic: runtime.session.synthetic,
       interrupt: (input) => runtime.session.interrupt(input.sessionID),
+      wait: (input) => runtime.session.wait(input.sessionID),
     },
   } satisfies Plugin.Context
 })

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -11,7 +11,17 @@ import { Session } from "../session"
 export interface Interface {
   readonly session: Pick<
     Session.Interface,
-    "get" | "create" | "messages" | "prompt" | "generate" | "command" | "resume" | "interrupt" | "synthetic"
+    | "get"
+    | "create"
+    | "messages"
+    | "prompt"
+    | "generate"
+    | "command"
+    | "rename"
+    | "resume"
+    | "interrupt"
+    | "synthetic"
+    | "wait"
   >
   readonly job: Pick<Job.Interface, "start" | "wait" | "block" | "background" | "cancel">
   readonly location: {
@@ -52,9 +62,11 @@ export const layerWithCell = (cell: Cell) =>
         prompt: (input) => require(cell, (runtime) => runtime.session.prompt(input)),
         generate: (input) => require(cell, (runtime) => runtime.session.generate(input)),
         command: (input) => require(cell, (runtime) => runtime.session.command(input)),
+        rename: (input) => require(cell, (runtime) => runtime.session.rename(input)),
         resume: (sessionID) => require(cell, (runtime) => runtime.session.resume(sessionID)),
         interrupt: (sessionID) => require(cell, (runtime) => runtime.session.interrupt(sessionID)),
         synthetic: (input) => require(cell, (runtime) => runtime.session.synthetic(input)),
+        wait: (sessionID) => require(cell, (runtime) => runtime.session.wait(sessionID)),
       },
       job: {
         start: (input) => require(cell, (runtime) => runtime.job.start(input)),

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -106,8 +106,10 @@ export function host(overrides: Overrides = {}): Plugin.Context {
       prompt: overrides.session?.prompt ?? (() => Effect.die("unused session.prompt")),
       generate: overrides.session?.generate ?? (() => Effect.die("unused session.generate")),
       command: overrides.session?.command ?? (() => Effect.die("unused session.command")),
+      rename: overrides.session?.rename ?? (() => Effect.die("unused session.rename")),
       synthetic: overrides.session?.synthetic ?? (() => Effect.die("unused session.synthetic")),
       interrupt: overrides.session?.interrupt ?? (() => Effect.die("unused session.interrupt")),
+      wait: overrides.session?.wait ?? (() => Effect.die("unused session.wait")),
     },
   }
 }

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -29,7 +29,7 @@ export interface SessionHooks {
 
 export type SessionDomain = Pick<
   SessionApi<unknown>,
-  "create" | "get" | "prompt" | "generate" | "command" | "synthetic" | "interrupt"
+  "create" | "get" | "prompt" | "generate" | "command" | "synthetic" | "interrupt" | "rename" | "wait"
 > & {
   readonly hook: Hooks<SessionHooks>
 }

--- a/packages/www/content/docs/build/plugins.mdx
+++ b/packages/www/content/docs/build/plugins.mdx
@@ -177,7 +177,7 @@ and plugin options.
 | `ctx.integration`      | `list`, `get`, `connect`, `attempt`, `transform`, `reload`, and connection lookup/resolution |
 | `ctx.plugin`           | `list` currently active plugin IDs                                                           |
 | `ctx.reference`        | `list`, `transform`, `reload`                                                                |
-| `ctx.session`          | `create`, `get`, `prompt`, `command`, `synthetic`, `interrupt`, and `hook`                   |
+| `ctx.session`          | `create`, `get`, `prompt`, `command`, `rename`, `synthetic`, `interrupt`, `wait`, and `hook`  |
 | `ctx.skill`            | `list`, `transform`, `reload`                                                                |
 | `ctx.tool`             | `transform` and `hook`                                                                       |
 | `ctx.aisdk`            | `hook`                                                                                       |


### PR DESCRIPTION
## What

Plugins can now rename sessions and wait for a session's agent loop to go idle, and pass the new `title` on session create through the plugin host.

Motivated by a code-mode `tools.session.*` plugin (create / prompt / notify / interrupt across sessions): a plugin can start work in another session but can never name it or await it.

Follows #39935 (`title` on session create, merged). #39939 stacks on this and adds `list` and `messages` with cursor pagination.

## How

- **core**: extend the `PluginRuntime` session `Pick` with `rename` and `wait` (`packages/core/src/plugin/runtime.ts`); the host passes `title` on create and adapts `rename` and `wait` (`packages/core/src/plugin/host.ts`).
- **plugin**: `SessionDomain` picks `rename` and `wait` straight from the client API (`packages/plugin/src/effect/session.ts`). Documented in `packages/www/content/docs/build/plugins.mdx`.

## Scope

Deliberately not included:

- **`list` and `messages`** — stacked as #39939 together with the cursor pagination they need for client parity.
- **Session-level metadata / creator origin.** `Session.Info` has no metadata bag; orchestrating plugins want "created by session X via tool Y" for client-side correlation. Needs its own design pass on the created event.
- **A published idle signal.** `session.status` (`idle`/`busy`/`retry`) is defined in `@opencode-ai/schema` and included in the server event manifest but never published anywhere in V2. `wait` here delegates to `Session.wait`; actually publishing `session.status` is a separate change.

## Testing

- `bun typecheck` in `packages/core` and `packages/plugin` — clean.
- `bun run test` in `packages/plugin` (3 pass).
- `bun run test test/plugin/ test/config/` in `packages/core`: 293 pass, 1 pre-existing failure (`PluginSupervisor config > logs invalid packages and continues loading`) that fails identically on the base commit.
- End-to-end: the motivating session-control plugin runs against a live next-channel service; these capabilities were validated against the internal `Session` service surface the runtime delegates to.