### PR TITLE
fix(opencode): guard shell permission parse failures

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -623,6 +623,11 @@ export const ShellTool = Tool.define(
                     Effect.sync(() => tree.delete()),
                   )
                   const scan = yield* collect(tree.rootNode, cwd, ps, shell, instanceCtx)
+                  if (tree.rootNode.hasError) {
+                    scan.patterns.clear()
+                    scan.patterns.add(params.command)
+                    scan.always.clear()
+                  }
                   if (!containsPath(cwd, instanceCtx)) scan.dirs.add(cwd)
                   yield* ask(ctx, scan, params)
                 }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -289,6 +289,36 @@ describe("tool.shell permissions", () => {
   }
 
   for (const item of ps) {
+    it.live(`falls back to the raw command when PowerShell parsing fails [${item.label}]`, () =>
+      withShell(
+        item,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail(
+                  {
+                    command: "git diff --",
+                  },
+                  capture(requests, err),
+                ),
+              ).toMatchObject({ message: err.message })
+              const bashReq = requests.find((r) => r.permission === "bash")
+              expect(bashReq).toBeDefined()
+              expect(bashReq!.patterns).toEqual(["git diff --"])
+              expect(bashReq!.always).toEqual([])
+            }),
+          )
+        }),
+      ),
+    )
+  }
+
+  for (const item of ps) {
     it.live(`uses PowerShell cmdlet prefixes for always-allow prompts [${item.label}]`, () =>
       withShell(
         item,


### PR DESCRIPTION
### Issue for this PR

Closes #39931

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PowerShell parsing can return an error tree with no command patterns, causing the shell permission check to be skipped. When the syntax tree contains errors, this change checks the raw command instead and avoids deriving a reusable approval pattern from the invalid tree.

### How did you verify your code works?

- `bun test test/tool/shell.test.ts --timeout 30000 -t "falls back to the raw command"`
- `bun typecheck`
- `bunx prettier --check src/tool/shell.ts test/tool/shell.test.ts`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
