### PR TITLE
fix(tui): ignore hidden tab close hitbox

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -341,6 +341,9 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
                   fg={closeColor()}
                   selectable={false}
                   onMouseUp={(event) => {
+                    // The close mark only renders while hovered; without motion events a click can
+                    // land here first, and must select the tab instead of closing it invisibly.
+                    if (hovered() !== tab.sessionID) return
                     event.stopPropagation()
                     tabs.close(tab === NEW_SESSION_TAB ? undefined : tab.sessionID)
                   }}


### PR DESCRIPTION
## What

The session tab close mark (`×`) only renders while its tab is hovered, but its `onMouseUp` handler was always live. In terminals that report button events without motion tracking, no hover state ever exists, so clicking the rightmost content cell of a tab closed it invisibly instead of selecting it.

## Before / After

**Before:** in a terminal without mouse-motion reporting, click near the right edge of a tab → the tab closes, with no visible close affordance ever shown. The click was swallowed by an invisible one-cell hitbox with `stopPropagation`.

**After:** the handler returns early unless that tab is currently hovered (which is the only state in which the `×` is drawn). The unhandled click propagates to the tab's own `onMouseUp` and selects it, matching what the user sees.

## How

- `packages/tui/src/component/session-tabs.tsx`: guard the close `onMouseUp` on `hovered() === tab.sessionID` before `stopPropagation` + `close`.

## Scope

Only the close control's hit-testing. No change to close behavior when the mark is visible, keyboard close, or tab selection.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/context/session-tabs.test.tsx` in `packages/tui` (4 pass)
- No component-level mouse harness exists today; the fix is a one-line visibility guard on an existing handler.