### PR TITLE
fix(tui): persist tab reorder once per drag

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -6,6 +6,7 @@ import { useSessionTabs } from "../context/session-tabs"
 import { useTheme, useThemes } from "../context/theme"
 import {
   adaptiveSessionTabLayout,
+  moveSessionTab,
   NEW_SESSION_TAB_TITLE,
   sessionTabComplete,
   seedSessionTabMotion,
@@ -48,6 +49,10 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   const animations = () => props.animations ?? config.animations ?? true
   const [hovered, setHovered] = createSignal<string>()
   const [dragging, setDragging] = createSignal<string>()
+  // A drag reorders a local preview and persists one move on release instead of writing
+  // per slot crossing; the preview holds after release until the store reflects the move,
+  // so the strip never flashes the pre-drag order while the write is in flight.
+  const [preview, setPreview] = createSignal<{ sessionID: string; index: number }>()
   let strip: { screenX: number } | undefined
   const hueStep = () => (mode() === "light" ? 800 : 200)
   const accent = () => theme.hue.accent[hueStep()]
@@ -55,7 +60,18 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
   const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
   const newTab = () => tabs.newTab?.() ?? false
   const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB.sessionID : tabs.current()))
-  const items = createMemo(() => (newTab() ? [...tabs.tabs(), NEW_SESSION_TAB] : tabs.tabs()))
+  const ordered = createMemo(() => {
+    const pending = preview()
+    if (!pending) return tabs.tabs()
+    return moveSessionTab(tabs.tabs(), pending.sessionID, pending.index)
+  })
+  const items = createMemo(() => (newTab() ? [...ordered(), NEW_SESSION_TAB] : ordered()))
+  createEffect(() => {
+    const pending = preview()
+    if (!pending || dragging()) return
+    const index = tabs.tabs().findIndex((tab) => tab.sessionID === pending.sessionID)
+    if (index === -1 || index === Math.min(pending.index, tabs.tabs().length - 1)) setPreview(undefined)
+  })
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
     adaptiveSessionTabLayout(items(), activeID(), dimensions().width, previous?.start),
   )
@@ -279,6 +295,8 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
           // keeping sloppy clicks indistinguishable from clean ones.
           const release = () => {
             setDragging(undefined)
+            const pending = preview()
+            if (pending?.sessionID === tab.sessionID) tabs.move(pending.sessionID, pending.index)
             if (tab === NEW_SESSION_TAB) return
             tabs.select(tab.sessionID)
           }
@@ -295,7 +313,8 @@ export function SessionTabs(props: { controller?: SessionTabsController; animati
               onMouseDrag={(event) => {
                 if (tab === NEW_SESSION_TAB) return
                 const slot = slotAt(event.x)
-                if (slot !== undefined && slot !== tabNumber() - 1) tabs.move(tab.sessionID, slot)
+                if (slot !== undefined && slot !== tabNumber() - 1)
+                  setPreview({ sessionID: tab.sessionID, index: slot })
               }}
               onMouseDragEnd={release}
             >


### PR DESCRIPTION
## What

Dragging a session tab used to persist on every slot crossing: each crossing ran a flock → read → mutate → atomic-write → reconcile cycle against `tabs.json`, and the visual reorder only rendered after each write landed. Since a drag moves exactly one tab, the whole gesture reduces to a single move. Reorder now previews locally during the drag and persists once on release.

## Before / After

**Before:** dragging a tab across N slots issued N locked read-modify-write cycles to `tabs.json`, and each visual reorder step waited on its disk write.

**After:** slot crossings update a component-local preview (pure `moveSessionTab` over the store order, no I/O); releasing the drag commits one `tabs.move()`. The preview holds after release until the store reflects the committed order, so the strip never flashes the pre-drag order while the single write is in flight.

## How

`packages/tui/src/component/session-tabs.tsx`:

- new `preview` signal `{ sessionID, index }`; `ordered()` applies it over `tabs.tabs()` and feeds the existing `items()`/layout pipeline, so hit-testing, tab numbers, and the width/motion seeding all see the previewed order with no other changes
- `onMouseDrag` sets the preview instead of calling `tabs.move()`
- `release` (mouse up / drag end) commits the pending move for the dragged tab, then selects as before
- a small effect clears the preview once the store order matches (or the session disappears); index clamping mirrors `moveSessionTab`

```mermaid
sequenceDiagram
  participant Mouse
  participant Strip as SessionTabs (component)
  participant Ctx as SessionTabs context
  participant Disk as tabs.json (flock)
  Note over Strip: before: every crossing → Ctx.move → Disk
  Mouse->>Strip: drag crossing xN
  Strip->>Strip: setPreview (reorder rendered locally)
  Mouse->>Strip: release
  Strip->>Ctx: move(sessionID, finalIndex)
  Ctx->>Disk: one locked atomic write
  Disk-->>Strip: store reconciles → preview cleared
```

## Scope

Follows up on the drag-write finding recorded in #39941's scope section. No change to `useStorage()` semantics, keyboard-driven `move`, or the plugin `ui.tabs` surface (which reads committed order only; a transient preview is deliberately not visible to plugins).

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/context/session-tabs.test.tsx test/context/session-tabs-model.test.ts` in `packages/tui` (31 pass)
- No component-level mouse harness exists to script a synthetic drag; the preview path reuses the pure `moveSessionTab` already covered by model tests, and commit goes through the existing `tabs.move()` path.