### PR TITLE
fix(opencode): make long-lived provider streams robust to silent SSE terminations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -95,7 +95,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -143,7 +143,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -157,7 +157,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -193,7 +193,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -220,7 +220,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -242,7 +242,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -266,7 +266,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -286,7 +286,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -380,7 +380,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",
@@ -434,7 +434,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -448,7 +448,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -460,7 +460,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -492,7 +492,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -508,7 +508,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -539,7 +539,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -558,7 +558,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -689,7 +689,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -765,7 +765,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -780,7 +780,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -795,7 +795,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -839,7 +839,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -852,7 +852,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -886,7 +886,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -905,7 +905,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -946,7 +946,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -973,7 +973,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1024,7 +1024,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -20,11 +20,33 @@ export class ResponseStreamError extends Error {
   }
 }
 
+// Raised when a provider stream reaches EOF without ever sending a finish
+// frame. The AI SDK papers over that truncation with a synthesized
+// finish-step (reason "other", no raw finish reason, no usage); treating it
+// as a completed turn silently drops the rest of the response.
+export class StreamIncompleteError extends Error {
+  public override readonly name = "ProviderStreamIncompleteError"
+
+  constructor() {
+    super("Provider stream ended before sending a finish frame; the response is incomplete")
+  }
+}
+
 function isOpenAiErrorRetryable(e: APICallError) {
   const status = e.statusCode
   if (!status) return e.isRetryable
   // openai sometimes returns 404 for models that are actually available
   return status === 404 || e.isRetryable
+}
+
+// Keeps surfaced provider errors diagnosable without dumping arbitrarily
+// large payloads into session errors and logs.
+const RESPONSE_BODY_PREVIEW_LIMIT = 2_000
+
+function boundedResponseBody(responseBody: string) {
+  const trimmed = responseBody.trim()
+  if (trimmed.length <= RESPONSE_BODY_PREVIEW_LIMIT) return trimmed
+  return `${trimmed.slice(0, RESPONSE_BODY_PREVIEW_LIMIT)}… (response body truncated)`
 }
 
 // Providers not reliably handled in this function:
@@ -41,8 +63,18 @@ function message(providerID: ProviderV2.ID, e: APICallError) {
       return "Unknown error"
     }
 
-    if (!e.responseBody || (e.statusCode && msg !== STATUS_CODES[e.statusCode])) {
+    if (!e.responseBody) {
       return msg
+    }
+
+    if (e.statusCode && msg !== STATUS_CODES[e.statusCode]) {
+      // Provider SDKs often reduce a rejection to one generic sentence (for
+      // example a bare "Invalid request.") while the response body carries the
+      // actual reason. Keep the bounded body so 4xx failures stay diagnosable.
+      if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) return msg
+      const body = boundedResponseBody(e.responseBody)
+      if (body === "" || msg.includes(body)) return msg
+      return `${msg}: ${body}`
     }
 
     try {
@@ -66,7 +98,7 @@ function message(providerID: ProviderV2.ID, e: APICallError) {
       return msg
     }
 
-    return `${msg}: ${e.responseBody}`
+    return `${msg}: ${boundedResponseBody(e.responseBody)}`
   }).trim()
 }
 

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -26,6 +26,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import * as Option from "effect/Option"
 import * as OtelTracer from "@effect/opentelemetry/Tracer"
+import { iife } from "@/util/iife"
 import { LLMAISDK } from "./llm/ai-sdk"
 import { LLMNativeRuntime } from "./llm/native-runtime"
 import { LLMRequestPrep } from "./llm/request"
@@ -273,10 +274,20 @@ const live: Layer.Layer<
         "llm.provider": input.model.providerID,
         "llm.model": input.model.id,
       })
+      // The provider-level fetch wrapper only sees raw bytes, so SSE keepalive
+      // comments reset its timer while the model stream delivers nothing. The
+      // chunk deadline wrapped around fullStream consumption below counts
+      // parsed model chunks instead, which is the gap the chunkTimeout
+      // provider option promises to bound.
+      const chunkTimeoutMs = iife(() => {
+        const configured = item.options["chunkTimeout"]
+        return typeof configured === "number" && configured > 0 ? configured : undefined
+      })
       // Default runtime path: AI SDK owns provider execution and tool dispatch;
       // LLMAISDK.toLLMEvents below normalizes fullStream parts for the processor.
       return {
         type: "ai-sdk" as const,
+        chunkTimeoutMs,
         result: streamText({
           onError(error) {
             bridge.fork(
@@ -370,10 +381,19 @@ const live: Layer.Layer<
             // Adapter seam: both runtimes expose the same LLMEvent stream. Native
             // already returns one; AI SDK streams are converted here.
             const state = LLMAISDK.adapterState()
-            return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            ).pipe(
-              Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
+            const events =
+              result.chunkTimeoutMs === undefined
+                ? result.result.fullStream
+                : LLMAISDK.boundChunkGaps(result.result.fullStream, {
+                    chunkTimeoutMs: result.chunkTimeoutMs,
+                    requestAbort: ctrl,
+                  })
+            return Stream.fromAsyncIterable(events, (e) => (e instanceof Error ? e : new Error(String(e)))).pipe(
+              Stream.mapEffect((event) => {
+                const failure = LLMAISDK.streamFailure(event)
+                if (failure) return Effect.fail(failure)
+                return LLMAISDK.toLLMEvents(state, event)
+              }),
               Stream.flatMap((events) => Stream.fromIterable(events)),
             )
           }),

--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -2,9 +2,80 @@ import { FinishReason, LLMEvent, ProviderMetadata, ToolResultValue } from "@open
 import { Effect, Schema } from "effect"
 import { type streamText } from "ai"
 import { errorMessage } from "@/util/error"
+import { ProviderError } from "@/provider/error"
 
 type Result = Awaited<ReturnType<typeof streamText>>
 type AISDKEvent = Result["fullStream"] extends AsyncIterable<infer T> ? T : never
+
+// A synthesized finish-step (reason "other", no raw finish reason, no usage)
+// means the provider stream hit EOF without a finish frame: the AI SDK falls
+// back to its initial step state instead of failing. A real finish frame
+// always carries the provider's raw finish reason, and legitimate unusual
+// reasons keep flowing through toLLMEvents as "unknown" untouched.
+export function streamFailure(event: AISDKEvent) {
+  if (event.type !== "finish-step") return undefined
+  if (event.finishReason !== "other" || event.rawFinishReason != null) return undefined
+  if (usage(event.usage) !== undefined) return undefined
+  return new ProviderError.StreamIncompleteError()
+}
+
+// Bounds the gap between AI SDK stream events with the provider's
+// chunkTimeout option. The deadline is disarmed while locally executed tool
+// calls are outstanding: their results flow through the same stream, and a
+// long-running tool (a bash call, a human-gated approval) is not a stalled
+// provider. On expiry the request's AbortController is aborted so the
+// underlying HTTP request is torn down, and the stream fails with a terminal
+// provider error.
+export async function* boundChunkGaps(
+  fullStream: AsyncIterable<AISDKEvent>,
+  input: { chunkTimeoutMs: number; requestAbort: AbortController },
+): AsyncGenerator<AISDKEvent> {
+  const iterator = fullStream[Symbol.asyncIterator]()
+  const pendingToolCallIDs = new Set<string>()
+
+  const nextWithDeadline = () =>
+    new Promise<IteratorResult<AISDKEvent>>((resolve, reject) => {
+      const deadline = setTimeout(() => {
+        const failure = new ProviderError.ResponseStreamError(
+          `Provider stream stalled: no chunk received within ${input.chunkTimeoutMs}ms`,
+        )
+        input.requestAbort.abort(failure)
+        reject(failure)
+      }, input.chunkTimeoutMs)
+      iterator.next().then(
+        (result) => {
+          clearTimeout(deadline)
+          resolve(result)
+        },
+        (error) => {
+          clearTimeout(deadline)
+          reject(error)
+        },
+      )
+    })
+
+  try {
+    while (true) {
+      const result = pendingToolCallIDs.size > 0 ? await iterator.next() : await nextWithDeadline()
+      if (result.done) return
+      const event = result.value
+      switch (event.type) {
+        case "tool-call":
+          if (!event.providerExecuted) pendingToolCallIDs.add(event.toolCallId)
+          break
+        case "tool-result":
+          if (!event.preliminary) pendingToolCallIDs.delete(event.toolCallId)
+          break
+        case "tool-error":
+          pendingToolCallIDs.delete(event.toolCallId)
+          break
+      }
+      yield event
+    }
+  } finally {
+    await iterator.return?.()
+  }
+}
 
 export function adapterState() {
   return {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -673,6 +673,17 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case e instanceof ProviderError.StreamIncompleteError:
+      return new APIError(
+        {
+          message: e.message,
+          isRetryable: true,
+          metadata: {
+            code: e.name,
+          },
+        },
+        { cause: e },
+      ).toObject()
     case APICallError.isInstance(e):
       const parsed = ProviderError.parseAPICallError({
         providerID: ctx.providerID,

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,6 +28,15 @@ export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
+// A stream that ends without a finish frame is transient (retrying usually
+// gets a complete response), but a provider that truncates every response
+// must fail the turn instead of retrying forever.
+export const STREAM_INCOMPLETE_RETRY_LIMIT = 3
+
+export function isIncompleteStream(error: Err) {
+  return SessionV1.APIError.isInstance(error) && error.data.metadata?.code === "ProviderStreamIncompleteError"
+}
+
 function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
@@ -183,6 +192,7 @@ export function policy(opts: {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
+      if (isIncompleteStream(error) && meta.attempt > STREAM_INCOMPLETE_RETRY_LIMIT) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -8,6 +8,11 @@ import { Effect } from "effect"
 import { reply } from "../../lib/llm-server"
 import { cliIt } from "../../lib/cli-process"
 
+const promptCalls = (inputs: Effect.Effect<Record<string, unknown>[]>): Effect.Effect<number> =>
+  inputs.pipe(
+    Effect.map((bodies) => bodies.filter((body) => !JSON.stringify(body).includes("Generate a title")).length),
+  )
+
 describe("opencode run (non-interactive subprocess)", () => {
   // Happy path: prompt completes, output reaches stdout, process exits 0.
   // If this fails, all the others likely will too — debug here first.
@@ -81,11 +86,12 @@ describe("opencode run (non-interactive subprocess)", () => {
     30_000,
   )
 
-  // The test provider's SSE error item is interpreted by the SDK as an unknown
-  // finish, not a fatal provider/session error. Lock that distinction in so it
-  // is not accidentally used as the failure compatibility oracle.
+  // A stream that dies without a finish frame is a truncated provider
+  // response, not a completed turn. The request is retried within the turn;
+  // when the retry succeeds (the empty queue auto-replies "ok"), the turn
+  // completes with both the preserved partial output and the retried reply.
   cliIt.concurrent(
-    "unknown stream finish preserves partial output and exits 0",
+    "retries a stream that ends without a finish frame and exits 0 once the retry succeeds",
     ({ llm, opencode }) =>
       Effect.gen(function* () {
         yield* llm.push(
@@ -97,8 +103,31 @@ describe("opencode run (non-interactive subprocess)", () => {
         yield* llm.fail("upstream provider exploded mid-stream")
         const result = yield* opencode.run("trigger midstream error", { timeoutMs: 30_000 })
         expect(result.exitCode).toBe(0)
-        expect(result.stdout).toBe("partial response\n")
+        expect(result.stdout).toBe("partial response\nok\n")
         expect(result.stderr).not.toContain("upstream provider exploded mid-stream")
+        // Two requests in the truncated attempt plus one retry; the automatic
+        // session-title request is not a prompt attempt.
+        expect(yield* promptCalls(llm.inputs)).toBe(3)
+      }),
+    60_000,
+  )
+
+  // When every retry of a truncated stream is truncated again, the turn must
+  // fail with a provider error and a nonzero exit instead of exiting 0 with
+  // half a turn.
+  cliIt.concurrent(
+    "exits nonzero when streams without a finish frame exhaust the retry budget",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        // Initial attempt + STREAM_INCOMPLETE_RETRY_LIMIT (3) retries.
+        yield* llm.fail("truncated")
+        yield* llm.fail("truncated")
+        yield* llm.fail("truncated")
+        yield* llm.fail("truncated")
+        const result = yield* opencode.run("exhaust truncated retries", { timeoutMs: 45_000 })
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stderr).toContain("finish frame")
+        expect(yield* promptCalls(llm.inputs)).toBe(4)
       }),
     60_000,
   )
@@ -213,7 +242,7 @@ describe("opencode run (non-interactive subprocess)", () => {
   )
 
   cliIt.concurrent(
-    "--format json records partial output for an unknown stream finish",
+    "--format json records the retried completion after a stream ends without a finish frame",
     ({ llm, opencode }) =>
       Effect.gen(function* () {
         yield* llm.push(
@@ -233,10 +262,15 @@ describe("opencode run (non-interactive subprocess)", () => {
           "tool_use",
           "step_finish",
           "step_start",
+          "step_start",
+          "text",
           "step_finish",
         ])
         expect(events[1]?.part).toEqual(expect.objectContaining({ type: "text", text: "partial json" }))
-        expect(events.at(-1)?.part).toEqual(expect.objectContaining({ type: "step-finish", reason: "unknown" }))
+        // The truncated attempt never records a fallback "unknown" step-finish;
+        // the retried attempt concludes the turn with a real finish reason.
+        expect(events.at(-2)?.part).toEqual(expect.objectContaining({ type: "text", text: "ok" }))
+        expect(events.at(-1)?.part).toEqual(expect.objectContaining({ type: "step-finish", reason: "stop" }))
       }),
     60_000,
   )

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -17,6 +17,7 @@ import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { testEffect } from "../lib/effect"
 import type { Agent } from "../../src/agent/agent"
 import { MessageV2 } from "../../src/session/message-v2"
+import { ProviderError } from "@/provider/error"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Permission } from "@/permission"
@@ -501,6 +502,71 @@ describe("session.llm.ai-sdk adapter", () => {
     })
     expect(result.tokens.cache.write).toBe(300)
     expect(result.tokens.cache.read).toBe(200)
+  })
+
+  test("streamFailure flags the synthesized finish-step left by EOF without a finish frame", () => {
+    const failure = LLMAISDK.streamFailure({
+      type: "finish-step",
+      response: { id: "response-1", timestamp: new Date(0), modelId: "gpt-test" },
+      finishReason: "other",
+      rawFinishReason: undefined,
+      usage: {
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+        inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+        outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+      },
+      providerMetadata: undefined,
+    })
+
+    expect(failure).toBeInstanceOf(ProviderError.StreamIncompleteError)
+  })
+
+  test("streamFailure keeps finish frames that carry a raw finish reason or usage", () => {
+    const emptyUsage = {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+      outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+    }
+    const response = { id: "response-1", timestamp: new Date(0), modelId: "gpt-test" }
+
+    // A provider that maps an unusual raw reason to "other" still sent a finish frame.
+    expect(
+      LLMAISDK.streamFailure({
+        type: "finish-step",
+        response,
+        finishReason: "other",
+        rawFinishReason: "some_provider_reason",
+        usage: emptyUsage,
+        providerMetadata: undefined,
+      }),
+    ).toBeUndefined()
+
+    // Usage is proof of a finish frame even when the raw reason is missing.
+    expect(
+      LLMAISDK.streamFailure({
+        type: "finish-step",
+        response,
+        finishReason: "other",
+        rawFinishReason: undefined,
+        usage: { ...emptyUsage, inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+        providerMetadata: undefined,
+      }),
+    ).toBeUndefined()
+
+    expect(
+      LLMAISDK.streamFailure({
+        type: "finish-step",
+        response,
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        usage: emptyUsage,
+        providerMetadata: undefined,
+      }),
+    ).toBeUndefined()
   })
 
   test("captures Copilot billed usage from raw Anthropic message deltas per step", async () => {
@@ -1996,6 +2062,252 @@ describe("session.llm.stream", () => {
         provider: {
           [geminiFixture.providerID]: {
             options: { apiKey: "test-google-key", baseURL: `${state.server!.url.origin}/v1beta` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "fails the stream when the provider hits EOF without a finish frame",
+    () =>
+      Effect.gen(function* () {
+        const fixture = loadFixture(vivgridFixture.providerID, vivgridFixture.modelID)
+        // Partial content, then a bare EOF: no finish chunk, no [DONE] marker.
+        void waitRequest(
+          "/chat/completions",
+          new Response(
+            createEventStream([
+              { id: "chatcmpl-eof", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] },
+              { id: "chatcmpl-eof", object: "chat.completion.chunk", choices: [{ delta: { content: "partial" } }] },
+            ]),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+        )
+
+        const resolved = yield* Provider.use.getModel(
+          ProviderV2.ID.make(vivgridFixture.providerID),
+          ModelV2.ID.make(fixture.model.id),
+        )
+        const sessionID = SessionID.make("session-test-eof-no-finish")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const exit = yield* drain({
+          user: {
+            id: MessageID.make("msg_user-eof-no-finish"),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: agent.name,
+            model: { providerID: ProviderV2.ID.make(vivgridFixture.providerID), modelID: resolved.id },
+          } satisfies SessionV1.User,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        }).pipe(Effect.exit)
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (!Exit.isFailure(exit)) return
+        expect(Cause.squash(exit.cause)).toBeInstanceOf(ProviderError.StreamIncompleteError)
+      }),
+    {
+      config: () => ({
+        enabled_providers: [vivgridFixture.providerID],
+        provider: {
+          [vivgridFixture.providerID]: {
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "chunkTimeout aborts a stream that stalls behind SSE keepalives",
+    () =>
+      Effect.gen(function* () {
+        const fixture = loadFixture(vivgridFixture.providerID, vivgridFixture.modelID)
+        const encoder = new TextEncoder()
+        // Keepalive comments keep raw bytes flowing, so only a deadline on
+        // parsed model chunks can notice that the stream stalled.
+        void waitRequest(
+          "/chat/completions",
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({
+                      id: "chatcmpl-stall",
+                      object: "chat.completion.chunk",
+                      choices: [{ delta: { role: "assistant", content: "beginning" } }],
+                    })}\n\n`,
+                  ),
+                )
+                const keepalive = setInterval(() => {
+                  try {
+                    controller.enqueue(encoder.encode(": keepalive\n\n"))
+                  } catch {
+                    clearInterval(keepalive)
+                  }
+                }, 50)
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+        )
+
+        const resolved = yield* Provider.use.getModel(
+          ProviderV2.ID.make(vivgridFixture.providerID),
+          ModelV2.ID.make(fixture.model.id),
+        )
+        const sessionID = SessionID.make("session-test-keepalive-stall")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const started = Date.now()
+        const exit = yield* drain({
+          user: {
+            id: MessageID.make("msg_user-keepalive-stall"),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: agent.name,
+            model: { providerID: ProviderV2.ID.make(vivgridFixture.providerID), modelID: resolved.id },
+          } satisfies SessionV1.User,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        }).pipe(Effect.exit)
+        const elapsed = Date.now() - started
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (!Exit.isFailure(exit)) return
+        const failure = Cause.squash(exit.cause)
+        expect(failure).toBeInstanceOf(ProviderError.ResponseStreamError)
+        expect(String(failure)).toContain("no chunk received within 400ms")
+        expect(elapsed).toBeGreaterThanOrEqual(400)
+        expect(elapsed).toBeLessThan(5_000)
+      }),
+    {
+      config: () => ({
+        enabled_providers: [vivgridFixture.providerID],
+        provider: {
+          [vivgridFixture.providerID]: {
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1`, chunkTimeout: 400 },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "chunkTimeout does not fire while a slow local tool call executes",
+    () =>
+      Effect.gen(function* () {
+        const fixture = loadFixture(alibabaQwenFixture.providerID, alibabaQwenFixture.modelID)
+        void waitRequest(
+          "/chat/completions",
+          new Response(
+            createEventStream(
+              [
+                { id: "chatcmpl-tool", object: "chat.completion.chunk", choices: [{ delta: { role: "assistant" } }] },
+                {
+                  id: "chatcmpl-tool",
+                  object: "chat.completion.chunk",
+                  choices: [
+                    {
+                      delta: {
+                        tool_calls: [
+                          {
+                            index: 0,
+                            id: "call-slow",
+                            type: "function",
+                            function: { name: "lookup", arguments: '{"query":"weather"}' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                { id: "chatcmpl-tool", object: "chat.completion.chunk", choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+              ],
+              true,
+            ),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          ),
+        )
+        void waitRequest(
+          "/chat/completions",
+          new Response(createChatStream("done"), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+        )
+
+        const resolved = yield* Provider.use.getModel(
+          ProviderV2.ID.make(alibabaQwenFixture.providerID),
+          ModelV2.ID.make(fixture.model.id),
+        )
+        const sessionID = SessionID.make("session-test-slow-tool")
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const exit = yield* drain({
+          user: {
+            id: MessageID.make("msg_user-slow-tool"),
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: agent.name,
+            model: { providerID: ProviderV2.ID.make(alibabaQwenFixture.providerID), modelID: resolved.id },
+          } satisfies SessionV1.User,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Use lookup" }],
+          tools: {
+            lookup: tool({
+              description: "Lookup data",
+              inputSchema: z.object({ query: z.string() }),
+              execute: async () => {
+                // Longer than the configured chunkTimeout: the deadline must be
+                // disarmed while the tool call is outstanding.
+                await new Promise((resolve) => setTimeout(resolve, 800))
+                return { output: "looked up" }
+              },
+            }),
+          },
+        }).pipe(Effect.exit)
+
+        expect(Exit.isSuccess(exit)).toBe(true)
+      }),
+    {
+      config: () => ({
+        enabled_providers: [alibabaQwenFixture.providerID],
+        provider: {
+          [alibabaQwenFixture.providerID]: {
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1`, chunkTimeout: 300 },
           },
         },
       }),

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1488,6 +1488,58 @@ describe("session.message-v2.fromError", () => {
     expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(true)
   })
 
+  test("keeps the provider response body in surfaced 400-class errors", () => {
+    const responseBody = JSON.stringify({
+      error: {
+        message: "Invalid request.",
+        type: "invalid_request_error",
+        param: "input[3].content",
+        code: "invalid_value",
+      },
+    })
+    const result = MessageV2.fromError(
+      new APICallError({
+        message: "Invalid request.",
+        url: "https://example.com/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody,
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toContain("Invalid request.")
+    expect(result.data.message).toContain("invalid_value")
+    expect(result.data.message).toContain("input[3].content")
+    expect(result.data.responseBody).toBe(responseBody)
+  })
+
+  test("bounds oversized response bodies in surfaced error messages", () => {
+    const responseBody = JSON.stringify({
+      error: { message: "Invalid request.", detail: "x".repeat(10_000) },
+    })
+    const result = MessageV2.fromError(
+      new APICallError({
+        message: "Invalid request.",
+        url: "https://example.com/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody,
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message.length).toBeLessThan(2_200)
+    expect(result.data.message).toContain("(response body truncated)")
+  })
+
   test("does not classify 429 no body as context overflow", () => {
     const result = MessageV2.fromError(
       new APICallError({

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -604,6 +604,71 @@ it.live("session.processor effect tests retry recognized structured json errors"
   ),
 )
 
+it.live("session.processor effect tests retry a stream that ends without a finish frame within the turn", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        // First attempt: partial content, then EOF with no finish frame. The
+        // fallback finish-step the AI SDK synthesizes for it must not conclude
+        // the turn; the request is retried and the second attempt completes.
+        yield* llm.push(
+          raw({
+            head: [
+              {
+                id: "chatcmpl-truncated",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" } }],
+              },
+              {
+                id: "chatcmpl-truncated",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { content: "partial" } }],
+              },
+            ],
+          }),
+        )
+        yield* llm.text("after")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "truncate")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "truncate" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests publish retry status updates", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -4,7 +4,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import type { NamedError } from "@opencode-ai/core/util/error"
 import { APICallError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
-import { Effect, Schedule, Schema } from "effect"
+import { Effect, Exit, Schedule, Schema } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -115,6 +115,72 @@ describe("session.retry.delay", () => {
       })
     }),
   )
+
+  it.instance("policy stops retrying incomplete streams once the bounded budget is spent", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("session-incomplete-stream-budget")
+      // Same marker fromError sets for StreamIncompleteError; the zero
+      // retry-after header only keeps the test from sleeping between steps.
+      const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+        new SessionV1.APIError({
+          message: "Provider stream ended before sending a finish frame; the response is incomplete",
+          isRetryable: true,
+          metadata: { code: "ProviderStreamIncompleteError" },
+          responseHeaders: { "retry-after-ms": "0" },
+        }).toObject(),
+      )
+      expect(SessionRetry.isIncompleteStream(error)).toBe(true)
+      const status = yield* SessionStatus.Service
+
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          parse: (input) => input as ReturnType<NamedError["toObject"]>,
+          set: (info) =>
+            status.set(sessionID, {
+              type: "retry",
+              attempt: info.attempt,
+              message: info.message,
+              next: info.next,
+            }),
+        }),
+      )
+
+      for (let attempt = 1; attempt <= SessionRetry.STREAM_INCOMPLETE_RETRY_LIMIT; attempt++) {
+        const allowed = yield* step(error).pipe(Effect.exit)
+        expect(Exit.isSuccess(allowed)).toBe(true)
+      }
+      const exhausted = yield* step(error).pipe(Effect.exit)
+      expect(Exit.isSuccess(exhausted)).toBe(false)
+    }),
+  )
+
+  it.instance("policy keeps retrying other retryable errors past the incomplete-stream budget", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("session-retryable-unbounded")
+      const error = apiError({ "retry-after-ms": "0" })
+      const status = yield* SessionStatus.Service
+
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: (info) =>
+            status.set(sessionID, {
+              type: "retry",
+              attempt: info.attempt,
+              message: info.message,
+              next: info.next,
+            }),
+        }),
+      )
+
+      for (let attempt = 1; attempt <= SessionRetry.STREAM_INCOMPLETE_RETRY_LIMIT + 2; attempt++) {
+        const allowed = yield* step(error).pipe(Effect.exit)
+        expect(Exit.isSuccess(allowed)).toBe(true)
+      }
+    }),
+  )
 })
 
 describe("session.retry.retryable", () => {
@@ -179,6 +245,17 @@ describe("session.retry.retryable", () => {
     expect(SessionV1.APIError.isInstance(request)).toBe(true)
     expect(SessionRetry.retryable(request, retryProvider)).toEqual({
       message: "WebSocket closed before response.completed (code 1006: Connection ended)",
+    })
+  })
+
+  test("retries streams that ended without a finish frame", () => {
+    const request = MessageV2.fromError(new ProviderError.StreamIncompleteError(), { providerID })
+    expect(SessionV1.APIError.isInstance(request)).toBe(true)
+    if (!SessionV1.APIError.isInstance(request)) throw new Error("expected APIError")
+    expect(request.data.metadata?.code).toBe("ProviderStreamIncompleteError")
+    expect(SessionRetry.isIncompleteStream(request)).toBe(true)
+    expect(SessionRetry.retryable(request, retryProvider)).toEqual({
+      message: "Provider stream ended before sending a finish frame; the response is incomplete",
     })
   })
 

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #39968

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the three defects described in #39968, observed when a gateway terminates or stalls long-lived SSE completion responses (23 bare-EOF terminations across 13,312 requests in one ~12h run, plus one 9.5h half-open stall):

1. **EOF without a finish frame is no longer a completed turn.** When a provider stream ends without a finish frame, the AI SDK synthesizes a fallback finish-step whose signature is unambiguous: unified reason `"other"`, `rawFinishReason: undefined`, and null usage (a real finish frame always carries the provider's raw reason, and unusual-but-real reasons carry usage). `LLMAISDK.streamFailure` converts exactly that signature into a new retryable `ProviderError.StreamIncompleteError` before adaptation, so the session-level retry policy retries the request within the turn. The budget is bounded (`STREAM_INCOMPLETE_RETRY_LIMIT = 3`, existing backoff) because a provider that truncates every response must fail the turn (nonzero exit) rather than retry forever or exit 0 with half a turn. Legitimate `unknown` finish reasons (unrecognized raw reasons from real finish frames) flow through unchanged.

2. **`chunkTimeout` now bounds the parsed-chunk gap.** The existing fetch-level `wrapSSE` timer watches raw bytes, so keepalive comments reset it while the model stream delivers nothing, and stalls above the byte layer never trip it. `LLMAISDK.boundChunkGaps` wraps fullStream consumption in `session/llm.ts` with a per-event deadline from the same `chunkTimeout` provider option (no new config). The deadline is disarmed while locally executed tool calls are outstanding — their results arrive on the same stream and a long-running local tool is not a stalled provider. On expiry it aborts the request's AbortController and fails the stream with `ProviderError.ResponseStreamError`, surfaced like any provider failure. I considered the AI SDK's native `timeout: { chunkMs }` instead, but its timer spans tool execution inside each step (`resetChunkTimeout` only ticks on stream chunks and is cleared at step flush), which would abort any local tool that runs longer than the chunk deadline.

3. **Provider error bodies survive normalization.** `ProviderError.message()` previously returned the SDK message alone whenever it differed from the bare status text, discarding `responseBody` — which is how a 400 surfaced as just `Invalid request.`. It now appends the response body, bounded to 2000 chars, skipping HTML bodies and bodies already contained in the message; the existing behavior for empty messages, status-text messages, and the HTML 401/403 hints is unchanged.

Two existing tests (`unknown stream finish preserves partial output and exits 0` and its `--format json` twin) pinned the old exit-0-on-truncation behavior and are updated to the new contract: retry within the turn (exit 0 once the retry succeeds, with the partial output preserved), and a new test asserts nonzero exit when every retry is truncated too.

### How did you verify your code works?

New regression tests:

- `test/session/llm.test.ts`: mock SSE server streaming partial content then bare EOF → stream fails with `StreamIncompleteError`; stream that stalls behind 50ms SSE keepalives with `chunkTimeout: 400` → aborted at ~400ms with the deadline error (raw-byte timers provably can't catch this one); a local tool call running longer than `chunkTimeout` → no false abort; `streamFailure` unit cases (raw-reason/usage-carrying finish frames are kept).
- `test/session/processor-effect.test.ts`: truncated stream is retried within the turn and the retry's output completes the turn without error.
- `test/session/retry.test.ts`: incomplete-stream errors map to retryable `APIError` with the marker code; the retry schedule stops after `STREAM_INCOMPLETE_RETRY_LIMIT`; other retryable errors stay unbounded.
- `test/cli/run/run-process.test.ts`: subprocess-level — truncated stream retries and exits 0 when the retry succeeds; four consecutive truncations exit nonzero with the finish-frame error on stderr.
- `test/session/message-v2.test.ts`: 400 with a JSON body keeps `Invalid request.` plus the body's `code`/`param` in the surfaced message; a 10KB body is truncated with a marker.

Full `packages/opencode` suite: 3181 pass / 1 fail — the one failure is `tool.write > sets file permissions when writing sensitive data`, which fails identically on the untouched v1.18.2 checkout in this environment (umask-dependent), unrelated to this change. `bun run test:httpapi` gates: 208 pass / 0 fail. `bun turbo typecheck`: 30/30 packages pass. `oxlint`: 0 errors.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Made with [Cursor](https://cursor.com)