### PR TITLE
feat: add OPENCODE_AIRGAP to disable automatic internet access

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -20,6 +20,10 @@ export const Flag = {
   OPENCODE_GIT_BASH_PATH: process.env["OPENCODE_GIT_BASH_PATH"],
   OPENCODE_CONFIG: process.env["OPENCODE_CONFIG"],
   OPENCODE_CONFIG_CONTENT: process.env["OPENCODE_CONFIG_CONTENT"],
+  // Disables all automatic internet-bound behavior (update checks, models.dev
+  // fetch, share sync, remote config/skills/plugins, LSP downloads) while
+  // keeping user-configured endpoints (providers, MCP, webfetch) working.
+  OPENCODE_AIRGAP: truthy("OPENCODE_AIRGAP"),
   OPENCODE_DISABLE_AUTOUPDATE: truthy("OPENCODE_DISABLE_AUTOUPDATE"),
   OPENCODE_ALWAYS_NOTIFY_UPDATE: truthy("OPENCODE_ALWAYS_NOTIFY_UPDATE"),
   OPENCODE_DISABLE_PRUNE: truthy("OPENCODE_DISABLE_PRUNE"),

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -219,7 +219,7 @@ const layer = Layer.effect(
       if (fromDisk) return fromDisk
       const snapshot = yield* loadSnapshot
       if (snapshot) return snapshot
-      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
+      if (Flag.OPENCODE_DISABLE_MODELS_FETCH || Flag.OPENCODE_AIRGAP) return {}
       // Flock is cross-process: concurrent opencode CLIs can race on this cache file.
       const text = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -252,7 +252,7 @@ const layer = Layer.effect(
       )
     })
 
-    if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
+    if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !Flag.OPENCODE_AIRGAP && !process.argv.includes("--get-yargs-completions")) {
       // Schedule.spaced runs the effect once, then waits between completions.
       yield* Effect.forkScoped(refresh().pipe(Effect.repeat(Schedule.spaced("60 minutes")), Effect.ignore))
     }

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -5,6 +5,7 @@ import npa from "npm-package-arg"
 import { Effect, Schema, Context, Layer, Option, FileSystem } from "effect"
 import { NodeFileSystem } from "@effect/platform-node"
 import { FSUtil } from "./fs-util"
+import { Flag } from "./flag/flag"
 import { Global } from "./global"
 import { EffectFlock } from "./util/effect-flock"
 import { makeGlobalNode } from "./effect/app-node"
@@ -124,6 +125,14 @@ const layer = Layer.effect(
 
       if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
         return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+      }
+
+      if (Flag.OPENCODE_AIRGAP) {
+        return yield* new InstallFailedError({
+          add: [pkg],
+          dir,
+          cause: new Error(`Package ${pkg} is not cached and OPENCODE_AIRGAP disables npm registry access`),
+        })
       }
 
       const tree = yield* reify({ dir, add: [pkg] })

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -300,10 +300,13 @@ const main = Effect.gen(function* () {
     recordFatalRendererError: (error) => writeLog("renderer", "fatal renderer error", { ...error }, "error"),
   })
   registerWslIpcHandlers(wslServers)
-  void updater.start()
-  const updateTimer = setInterval(() => void updater.check(), 10 * 60 * 1000)
-  updateTimer.unref()
-  app.once("will-quit", () => clearInterval(updateTimer))
+  const airgap = ["1", "true"].includes((process.env.OPENCODE_AIRGAP ?? "").toLowerCase())
+  if (!airgap) {
+    void updater.start()
+    const updateTimer = setInterval(() => void updater.check(), 10 * 60 * 1000)
+    updateTimer.unref()
+    app.once("will-quit", () => clearInterval(updateTimer))
+  }
   yield* Effect.promise(() => startNetLog()).pipe(
     Effect.catch((error) =>
       Effect.sync(() => {

--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -7,7 +7,7 @@ import { GlobalBus } from "@/bus/global"
 
 export async function upgrade() {
   const config = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.getGlobal()))
-  if (config.autoupdate === false || Flag.OPENCODE_DISABLE_AUTOUPDATE) return
+  if (config.autoupdate === false || Flag.OPENCODE_DISABLE_AUTOUPDATE || Flag.OPENCODE_AIRGAP) return
   const method = await Installation.method()
   const latest = await Installation.latest(method).catch(() => {})
   if (!latest) return

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -354,7 +354,7 @@ const layer = Layer.effect(
         }
 
         for (const [key, value] of Object.entries(auth)) {
-          if (value.type === "wellknown") {
+          if (value.type === "wellknown" && !Flag.OPENCODE_AIRGAP) {
             const url = key.replace(/\/+$/, "")
             authEnv[value.key] = value.token
             const wellknownURL = `${url}/.well-known/opencode`

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -19,7 +19,10 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   disableDefaultPlugins: bool("OPENCODE_DISABLE_DEFAULT_PLUGINS"),
   disableEmbeddedWebUi: bool("OPENCODE_DISABLE_EMBEDDED_WEB_UI"),
   disableExternalSkills: bool("OPENCODE_DISABLE_EXTERNAL_SKILLS"),
-  disableLspDownload: bool("OPENCODE_DISABLE_LSP_DOWNLOAD"),
+  disableLspDownload: Config.all({
+    direct: bool("OPENCODE_DISABLE_LSP_DOWNLOAD"),
+    airgap: bool("OPENCODE_AIRGAP"),
+  }).pipe(Config.map((flags) => flags.direct || flags.airgap)),
   disableClaudeCodePrompt: Config.all({
     broad: bool("OPENCODE_DISABLE_CLAUDE_CODE"),
     direct: bool("OPENCODE_DISABLE_CLAUDE_CODE_PROMPT"),

--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -1,4 +1,5 @@
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Effect, Stream } from "effect"
 import { HttpBody, HttpClient, HttpClientRequest, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { createHash } from "node:crypto"
@@ -84,6 +85,8 @@ export function serveUIEffect(
     const path = new URL(request.url, "http://localhost").pathname
 
     if (embeddedWebUI) return yield* serveEmbeddedUIEffect(path, services.fs, embeddedWebUI)
+
+    if (Flag.OPENCODE_AIRGAP) return notFound()
 
     const response = yield* services.client.execute(
       HttpClientRequest.make(request.method)(upstreamURL(path), {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -13,6 +13,7 @@ import { Session } from "@/session/session"
 import { MessageV2 } from "@/session/message-v2"
 import type { SessionID } from "@/session/schema"
 import { Database } from "@opencode-ai/core/database/database"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { eq } from "drizzle-orm"
 import { Config } from "@/config/config"
 import { SessionShareTable } from "@opencode-ai/core/share/sql"
@@ -20,7 +21,8 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { EventV2 } from "@opencode-ai/core/event"
 
-const disabled = process.env["OPENCODE_DISABLE_SHARE"] === "true" || process.env["OPENCODE_DISABLE_SHARE"] === "1"
+const disabled =
+  process.env["OPENCODE_DISABLE_SHARE"] === "true" || process.env["OPENCODE_DISABLE_SHARE"] === "1" || Flag.OPENCODE_AIRGAP
 
 export type Api = {
   create: string

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -6,6 +6,7 @@ import type { Agent } from "@/agent/agent"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { Global } from "@opencode-ai/core/global"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
 import { Permission } from "@/permission"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -219,7 +220,7 @@ const discoverSkills = Effect.fnUntraced(function* (
     yield* scan(state, dir, SKILL_PATTERN)
   }
 
-  for (const url of cfg.skills?.urls ?? []) {
+  for (const url of Flag.OPENCODE_AIRGAP ? [] : (cfg.skills?.urls ?? [])) {
     const pulledDirs = yield* discovery.pull(url)
     for (const dir of pulledDirs) {
       yield* scan(state, dir, SKILL_PATTERN)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -11,6 +11,7 @@ import { GrepTool } from "./grep"
 import { ReadTool } from "./read"
 import { TaskTool } from "./task"
 import { Database } from "@opencode-ai/core/database/database"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { TodoWriteTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
@@ -286,6 +287,7 @@ const layer = Layer.effect(
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
       const filtered = (yield* all()).filter((tool) => {
         if (tool.id === WebSearchTool.id) {
+          if (Flag.OPENCODE_AIRGAP) return false
           return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
         }
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -697,6 +697,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
 | `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
 | `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
+| `OPENCODE_AIRGAP`                     | boolean | Disable all automatic internet access (intranet/air-gapped environments) |
 | `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
 | `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |


### PR DESCRIPTION
### Issue for this PR

Ref #18233, #37888

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a single kill switch, `OPENCODE_AIRGAP=1`, for intranet and air-gapped deployments. When set, all **automatic** internet-bound behavior is disabled, while user-configured endpoints (custom providers, MCP servers, webfetch, intranet tools) keep working — the target environment has no internet but does have a working intranet.

Each change is a small additive guard that ORs into the existing per-feature disable flags — no default behavior changes.

What AIRGAP disables:

| Behavior | Location |
|---|---|
| Startup update check / auto-upgrade | `cli/upgrade.ts` |
| models.dev catalog fetch + 60min refresh | `core/models-dev.ts` |
| npm registry installs for plugins/providers (cache hits still work, with a clear error otherwise) | `core/npm.ts` |
| LSP server downloads (all 25 branches via `disableLspDownload`) | `effect/runtime-flags.ts` |
| Session share + background share sync | `share/share-next.ts` |
| Remote skill catalog pulls (`skills.urls`) | `skill/index.ts` |
| well-known remote config fetching | `config/config.ts` |
| `websearch` tool (Exa/Parallel are internet-only) | `tool/registry.ts` |
| Web UI proxy fallback to `app.opencode.ai` (returns 404) | `server/shared/ui.ts` |
| Desktop auto-updater (start + 10min poll) | `desktop/main/index.ts` |

Explicitly user-initiated actions (`opencode auth login`, `opencode github run`) are intentionally out of scope — they only run on demand. Desktop Sentry stays compile-time gated via `VITE_SENTRY_DSN`.

### How did you verify your code works?

- `tsgo --noEmit` passes in `packages/core`, `packages/opencode`, `packages/desktop`
- `packages/core` models tests: 11 pass (the `OPENCODE_DISABLE_MODELS_FETCH` check stays lazily evaluated at call time because these tests mutate flags at runtime)
- `packages/opencode` config tests: 183 pass; share tests: 7 pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
