### PR TITLE
docs: add opencode-solo-memory plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-solo-memory](https://github.com/baaai123/solo-memory)                                    | Transparent long-term memory – auto weave/ingest on every turn, local-first, with a learning loop  |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -49,6 +49,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 捆绑式多代理编排套件——16 个组件，一次安装                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 的零摩擦 git worktree 管理                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | 使用 Sentry AI Monitoring 追踪和调试您的 AI 代理                       |
+| [opencode-solo-memory](https://github.com/baaai123/solo-memory)                                    | 透明长期记忆——每轮对话自动注入/存储，本地优先，支持主动学习闭环         |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add [opencode-solo-memory](https://github.com/baaai123/solo-memory) to the OpenCode ecosystem plugins list (English + zh-cn pages, one table row each).

Solo-memory is a transparent long-term memory plugin for OpenCode: it auto-injects memory context before every turn via the `chat.message` hook and auto-stores user+assistant pairs after replies via the `event` hook — the agent never needs to remember to call memory tools. It is local-first (SQLite + ChromaDB, zero cloud), supports Chinese and English content (Chinese via BM25/jieba, English via semantic bge-large-en-v1.5), and includes a gap-detection → crawl → synthesize → verify learning loop.

### How did you verify your code works?

Tested locally with a real OpenCode session: memory context is injected on `chat.message` and user+assistant turns are persisted on `event`. The plugin's bridge (`bridge.py`) runs the real MemorySkill API in-process and is path-independent (project root auto-detected). JS syntax validated; the plugin exports both `plugin` and `server` names per OpenCode convention.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR