### PR TITLE
feat(provider): inject session_id for OpenRouter

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1186,6 +1186,10 @@ export function options(input: {
     }
   }
 
+  if (input.model.api.npm === "@openrouter/ai-sdk-provider") {
+    result["extraBody"] = { session_id: input.sessionID }
+  }
+
   if (
     input.model.providerID === "baseten" ||
     (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -300,6 +300,19 @@ describe("ProviderTransform.options - setCacheKey", () => {
     })
     expect(result.prompt_cache_key).toBeUndefined()
   })
+
+  test("should inject session_id via extraBody for OpenRouter", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "openrouter",
+        api: { ...mockModel.api, npm: "@openrouter/ai-sdk-provider" },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.extraBody).toEqual({ session_id: sessionID })
+  })
 })
 
 describe("ProviderTransform.options - zai/zhipuai thinking", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #40017

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenRouter supports session-level grouping via a `session_id` field passed in the request body. This lets upstream providers attribute and group requests by conversation session — useful for analytics, billing, and debugging across multi-turn conversations.

Currently opencode does not pass `session_id` to OpenRouter, so requests from the same conversation are ungrouped at the provider level.

This PR injects `session_id` into the request `extraBody` when the model's API provider is `@openrouter/ai-sdk-provider`. The AI SDK's `extraBody` mechanism merges the field into the outgoing HTTP request body without requiring provider-specific request restructuring. The `session_id` is already available as `input.sessionID` in the `options` transform, so no new plumbing is needed.

### How did you verify your code works?

Added a unit test in `packages/opencode/test/provider/transform.test.ts` that calls `ProviderTransform.options` with an OpenRouter model and asserts `result.extraBody` equals `{ session_id: sessionID }`. Ran `bun test` from `packages/opencode` — all tests pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
