### PR TITLE
fix(server): exempt session shell route from response compression

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
@@ -9,7 +9,7 @@ const COMPRESSIBLE_CONTENT_TYPE_REGEX =
 const NO_TRANSFORM_REGEX = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 
 const STREAMING_PATHS = new Set(["/event", "/global/event"])
-const STREAMING_POST_REGEX = /^\/session\/[^/]+\/(?:message|prompt_async)$/
+const STREAMING_POST_REGEX = /^\/session\/[^/]+\/(?:message|prompt_async|shell)$/
 
 const THRESHOLD_BYTES = 1024
 


### PR DESCRIPTION
Fixes #40007

`/session/:sessionID/shell` returns a buffered JSON body like `message` and `prompt_async`, but it is not in `STREAMING_POST_REGEX`, so its responses get compressed unlike its sibling routes. This adds `shell` to the alternation so all three buffered session POST routes are exempt from response compression.

Verified: the regex now matches `/session/abc/shell` and still rejects `/session/abc/shell/extra` and non-session paths; reviewers can confirm by POSTing to the shell route with `Accept-Encoding: gzip` and checking the response has no `content-encoding` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
