### PR TITLE
fix(provider): recover stalled model streams

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -244,7 +244,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -268,7 +268,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -288,7 +288,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -382,7 +382,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -436,7 +436,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -450,7 +450,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -462,7 +462,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -494,7 +494,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -510,7 +510,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -541,7 +541,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -560,7 +560,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -691,7 +691,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -767,7 +767,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -782,7 +782,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -797,7 +797,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -837,7 +837,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -850,7 +850,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -877,7 +877,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -896,7 +896,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -938,7 +938,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -965,7 +965,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1016,7 +1016,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.24",
+      "version": "1.18.25",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -114,9 +114,9 @@ export const Info = Schema.Struct({
           description:
             "Timeout in milliseconds to wait for response headers. Provider integrations may set defaults. Set to false to disable timeout.",
         }),
-        chunkTimeout: Schema.optional(PositiveInt).annotate({
+        chunkTimeout: Schema.optional(Schema.Union([Schema.Finite, Schema.Literal(false)])).annotate({
           description:
-            "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+            "Timeout in milliseconds between streamed SSE chunks for this provider. Set to false, zero, or a negative number to disable the timeout.",
         }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -13,10 +13,20 @@ export class HeaderTimeoutError extends Error {
 }
 
 export class ResponseStreamError extends Error {
-  public override readonly name = "ProviderResponseStreamError"
+  public override readonly name: string = "ProviderResponseStreamError"
 
   constructor(message: string, options?: ErrorOptions) {
     super(message, options)
+  }
+}
+
+export class ResponseStreamTimeoutError extends ResponseStreamError {
+  public override readonly name = "ProviderResponseStreamTimeoutError"
+
+  constructor(public readonly ms: number) {
+    super(
+      `Provider response stream timed out after ${ms}ms of inactivity. Check provider connectivity or increase provider.options.chunkTimeout before retrying.`,
+    )
   }
 }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,56 +31,9 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { StreamLiveness } from "./stream-liveness"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
-
-function wrapSSE(res: Response, ms: number, ctl: AbortController) {
-  if (typeof ms !== "number" || ms <= 0) return res
-  if (!res.body) return res
-  if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
-
-  const reader = res.body.getReader()
-  const body = new ReadableStream<Uint8Array>({
-    async pull(ctrl) {
-      const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-        const id = setTimeout(() => {
-          const err = new ProviderError.ResponseStreamError("SSE read timed out")
-          ctl.abort(err)
-          void reader.cancel(err)
-          reject(err)
-        }, ms)
-
-        reader.read().then(
-          (part) => {
-            clearTimeout(id)
-            resolve(part)
-          },
-          (err) => {
-            clearTimeout(id)
-            reject(err)
-          },
-        )
-      })
-
-      if (part.done) {
-        ctrl.close()
-        return
-      }
-
-      ctrl.enqueue(part.value)
-    },
-    async cancel(reason) {
-      ctl.abort(reason)
-      await reader.cancel(reason)
-    },
-  })
-
-  return new Response(body, {
-    headers: new Headers(res.headers),
-    status: res.status,
-    statusText: res.statusText,
-  })
-}
 
 function timeoutController(ms: number) {
   const ctl = new AbortController()
@@ -1208,6 +1161,7 @@ interface State {
   sdk: Map<string, BundledSDK>
   modelLoaders: Record<string, CustomModelLoader>
   varsLoaders: Record<string, CustomVarsLoader>
+  streamLiveness: StreamLiveness.Detector
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Provider") {}
@@ -1410,6 +1364,7 @@ const layer = Layer.effect(
           [providerID: string]: CustomVarsLoader
         } = {}
         const sdk = new Map<string, BundledSDK>()
+        const streamLiveness = StreamLiveness.create()
         const discoveryLoaders: {
           [providerID: string]: CustomDiscoverModels
         } = {}
@@ -1721,6 +1676,7 @@ const layer = Layer.effect(
           sdk,
           modelLoaders,
           varsLoaders,
+          streamLiveness,
         }
       }),
     )
@@ -1792,7 +1748,13 @@ const layer = Layer.effect(
         if (existing) return existing
 
         const customFetch = options["fetch"]
-        const chunkTimeout = options["chunkTimeout"]
+        const configuredChunkTimeout = options["chunkTimeout"]
+        const fixedChunkTimeout =
+          typeof configuredChunkTimeout === "number" && Number.isFinite(configuredChunkTimeout)
+            ? configuredChunkTimeout
+            : undefined
+        const streamTimeoutDisabled =
+          configuredChunkTimeout === false || (fixedChunkTimeout !== undefined && fixedChunkTimeout <= 0)
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
@@ -1800,13 +1762,13 @@ const layer = Layer.effect(
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
           const opts = init ?? {}
-          const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
+          const streamAbortController = streamTimeoutDisabled ? undefined : new AbortController()
           const headerTimeoutMs = headerTimeout === false ? undefined : headerTimeout
           const headerTimeoutCtl = typeof headerTimeoutMs === "number" ? timeoutController(headerTimeoutMs) : undefined
           const signals: AbortSignal[] = []
 
           if (opts.signal) signals.push(opts.signal)
-          if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
+          if (streamAbortController) signals.push(streamAbortController.signal)
           if (headerTimeoutCtl) signals.push(headerTimeoutCtl.signal)
           if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
             signals.push(AbortSignal.timeout(options["timeout"]))
@@ -1820,8 +1782,13 @@ const layer = Layer.effect(
             timeout: false,
           }).finally(() => headerTimeoutCtl?.clear())
 
-          if (!chunkAbortCtl) return res
-          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+          if (!streamAbortController) return res
+          return s.streamLiveness.wrap({
+            response: res,
+            bucket: `${model.providerID}:${model.api.npm}`,
+            controller: streamAbortController,
+            timeout: fixedChunkTimeout,
+          })
         }
 
         const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -18,7 +18,7 @@ import { iife } from "@/util/iife"
 import { Global } from "@opencode-ai/core/global"
 import path from "path"
 import { pathToFileURL } from "url"
-import { Effect, Layer, Context, Schema, Types } from "effect"
+import { Effect, Layer, Context, Option, Schema, Types } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectPromise } from "@/effect/promise"
@@ -42,6 +42,14 @@ function timeoutController(ms: number) {
     signal: ctl.signal,
     clear: () => clearTimeout(id),
   }
+}
+
+const decodeJson = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
+
+function streamsResponse(body: BodyInit | null | undefined) {
+  if (typeof body !== "string") return false
+  const value = Option.getOrUndefined(decodeJson(body))
+  return isRecord(value) && value.stream === true
 }
 
 function googleVertexAnthropicBaseURL(project: string | undefined, location: string | undefined) {
@@ -1788,6 +1796,7 @@ const layer = Layer.effect(
             bucket: `${model.providerID}:${model.api.npm}`,
             controller: streamAbortController,
             timeout: fixedChunkTimeout,
+            stream: streamsResponse(opts.body),
           })
         }
 

--- a/packages/opencode/src/provider/stream-liveness.ts
+++ b/packages/opencode/src/provider/stream-liveness.ts
@@ -1,0 +1,110 @@
+import { ProviderError } from "./error"
+
+export type Policy = {
+  initial: number
+  minimum: number
+  maximum: number
+  multiplier: number
+  historySize: number
+}
+
+export const defaultPolicy = {
+  initial: 900_000,
+  minimum: 900_000,
+  maximum: 1_800_000,
+  multiplier: 2,
+  historySize: 32,
+} satisfies Policy
+
+export type Detector = ReturnType<typeof create>
+
+export function create(policy: Policy = defaultPolicy, now = () => performance.now()) {
+  const histories = new Map<string, number[]>()
+
+  function deadline(bucket: string) {
+    const values = histories.get(bucket)
+    if (!values?.length) return policy.initial
+    return Math.min(policy.maximum, Math.max(policy.minimum, Math.max(...values) * policy.multiplier))
+  }
+
+  function observe(bucket: string, elapsed: number) {
+    if (!Number.isFinite(elapsed) || elapsed < 0) return
+    const values = histories.get(bucket) ?? []
+    values.push(elapsed)
+    if (values.length > policy.historySize) values.shift()
+    histories.set(bucket, values)
+  }
+
+  function wrap(input: {
+    response: Response
+    bucket: string
+    controller: AbortController
+    timeout?: number | false
+  }) {
+    const fixed =
+      typeof input.timeout === "number" && Number.isFinite(input.timeout) ? input.timeout : undefined
+    if (input.timeout === false || (fixed !== undefined && fixed <= 0)) return input.response
+    if (!input.response.body) return input.response
+    if (!input.response.headers.get("content-type")?.includes("text/event-stream")) return input.response
+
+    const ms = fixed ?? deadline(input.bucket)
+    const reader = input.response.body.getReader()
+    let maximum = 0
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const started = now()
+        const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
+          const id = setTimeout(() => {
+            const error = new ProviderError.ResponseStreamTimeoutError(ms)
+            input.controller.abort(error)
+            void reader.cancel(error).catch(() => {})
+            reject(error)
+          }, ms)
+
+          const read = () =>
+            reader.read().then(
+              (part) => {
+                if (!part.done && part.value.byteLength === 0) {
+                  void read()
+                  return
+                }
+                clearTimeout(id)
+                resolve(part)
+              },
+              (error) => {
+                clearTimeout(id)
+                reject(error)
+              },
+            )
+          void read()
+        })
+
+        maximum = Math.max(maximum, now() - started)
+        if (part.done) {
+          observe(input.bucket, maximum)
+          controller.close()
+          return
+        }
+        controller.enqueue(part.value)
+      },
+      async cancel(reason) {
+        input.controller.abort(reason)
+        await reader.cancel(reason)
+      },
+    })
+
+    return new Response(body, {
+      headers: new Headers(input.response.headers),
+      status: input.response.status,
+      statusText: input.response.statusText,
+    })
+  }
+
+  return {
+    deadline,
+    observe,
+    wrap,
+  }
+}
+
+export * as StreamLiveness from "./stream-liveness"

--- a/packages/opencode/src/provider/stream-liveness.ts
+++ b/packages/opencode/src/provider/stream-liveness.ts
@@ -40,12 +40,13 @@ export function create(policy: Policy = defaultPolicy, now = () => performance.n
     bucket: string
     controller: AbortController
     timeout?: number | false
+    stream?: boolean
   }) {
     const fixed =
       typeof input.timeout === "number" && Number.isFinite(input.timeout) ? input.timeout : undefined
     if (input.timeout === false || (fixed !== undefined && fixed <= 0)) return input.response
     if (!input.response.body) return input.response
-    if (!input.response.headers.get("content-type")?.includes("text/event-stream")) return input.response
+    if (!input.stream && !input.response.headers.get("content-type")?.includes("text/event-stream")) return input.response
 
     const ms = fixed ?? deadline(input.bucket)
     const reader = input.response.body.getReader()

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -665,6 +665,18 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case e instanceof ProviderError.ResponseStreamTimeoutError:
+      return new APIError(
+        {
+          message: e.message,
+          isRetryable: true,
+          metadata: {
+            code: e.name,
+            timeoutMs: String(e.ms),
+          },
+        },
+        { cause: e },
+      ).toObject()
     case e instanceof ProviderError.ResponseStreamError:
       return new APIError(
         {

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -83,6 +83,42 @@ it.live("chunkTimeout raises a typed timeout when SSE body never yields or close
   }),
 )
 
+it.live("chunkTimeout uses request stream intent when the response omits its content type", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => hangingBodyServer(false)),
+      (server) => Effect.sync(() => server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const result = streamText({
+            model: yield* provider.getLanguage(model),
+            abortSignal: AbortSignal.timeout(200),
+            onError() {},
+            messages: [{ role: "user", content: "hello" }],
+          })
+
+          const error = yield* Effect.promise(async () => {
+            try {
+              for await (const part of result.fullStream) {
+                if (part.type === "error") return part.error
+              }
+            } catch (error) {
+              return error
+            }
+            return undefined
+          })
+          expect(error).toBeInstanceOf(ProviderError.ResponseStreamTimeoutError)
+        }),
+      { config: providerConfig(server.url, { chunkTimeout: 50 }) },
+    )
+  }),
+)
+
 for (const chunkTimeout of [false, 0] as const) {
   it.live(`chunkTimeout ${chunkTimeout} disables the SSE body watchdog`, () =>
     Effect.gen(function* () {
@@ -241,12 +277,12 @@ async function delayedBodyServer(delay: number): Promise<{ server: Server; url: 
   return { server, url: `http://127.0.0.1:${address.port}` }
 }
 
-async function hangingBodyServer(): Promise<{ close(): void; url: string }> {
+async function hangingBodyServer(contentType = true): Promise<{ close(): void; url: string }> {
   const responses = new Set<ServerResponse>()
   const server = createServer((_, res) => {
     responses.add(res)
     res.on("close", () => responses.delete(res))
-    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.writeHead(200, contentType ? { "content-type": "text/event-stream" } : {})
     res.flushHeaders()
   })
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect } from "bun:test"
-import { createServer, type Server } from "node:http"
+import { createServer, type Server, type ServerResponse } from "node:http"
 import { streamText } from "ai"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -46,11 +46,11 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
   }),
 )
 
-it.live("chunkTimeout raises a response stream error when SSE body stalls", () =>
+it.live("chunkTimeout raises a typed timeout when SSE body never yields or closes", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
-      Effect.promise(() => delayedBodyServer(250)),
-      (server) => Effect.sync(() => server.server.close()),
+      Effect.promise(() => hangingBodyServer()),
+      (server) => Effect.sync(() => server.close()),
     )
 
     yield* provideTmpdirInstance(
@@ -72,13 +72,42 @@ it.live("chunkTimeout raises a response stream error when SSE body stalls", () =
             } catch (error) {
               return error
             }
+            return undefined
           })
-          expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)
+          expect(error).toBeInstanceOf(ProviderError.ResponseStreamTimeoutError)
+          if (!(error instanceof ProviderError.ResponseStreamTimeoutError)) throw new Error("expected stream timeout")
+          expect(error.ms).toBe(50)
         }),
       { config: providerConfig(server.url, { chunkTimeout: 50 }) },
     )
   }),
 )
+
+for (const chunkTimeout of [false, 0] as const) {
+  it.live(`chunkTimeout ${chunkTimeout} disables the SSE body watchdog`, () =>
+    Effect.gen(function* () {
+      const server = yield* Effect.acquireRelease(
+        Effect.promise(() => delayedBodyServer(100)),
+        (server) => Effect.sync(() => server.server.close()),
+      )
+
+      yield* provideTmpdirInstance(
+        () =>
+          Effect.gen(function* () {
+            const provider = yield* Provider.Service
+            const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+            const result = streamText({
+              model: yield* provider.getLanguage(model),
+              messages: [{ role: "user", content: "hello" }],
+            })
+
+            expect(yield* Effect.promise(() => result.text)).toBe("late")
+          }),
+        { config: providerConfig(server.url, { chunkTimeout }) },
+      )
+    }),
+  )
+}
 
 it.live("headerTimeout aborts when response headers do not arrive", () =>
   Effect.gen(function* () {
@@ -154,7 +183,7 @@ it.live("OpenAI Codex headerTimeout default can be disabled by config", () =>
   }),
 )
 
-it.live("OpenAI API auth gets default headerTimeout", () =>
+it.live("OpenAI keeps its header default without a provider-only stream default", () =>
   Effect.gen(function* () {
     yield* withAuthContent(
       Effect.gen(function* () {
@@ -163,6 +192,7 @@ it.live("OpenAI API auth gets default headerTimeout", () =>
             const provider = yield* Provider.Service
             const openai = yield* provider.getProvider(ProviderV2.ID.openai)
             expect(openai.options.headerTimeout).toBe(300_000)
+            expect(openai.options.chunkTimeout).toBeUndefined()
           }),
         )
       }),
@@ -209,6 +239,26 @@ async function delayedBodyServer(delay: number): Promise<{ server: Server; url: 
   const address = server.address()
   if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port")
   return { server, url: `http://127.0.0.1:${address.port}` }
+}
+
+async function hangingBodyServer(): Promise<{ close(): void; url: string }> {
+  const responses = new Set<ServerResponse>()
+  const server = createServer((_, res) => {
+    responses.add(res)
+    res.on("close", () => responses.delete(res))
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.flushHeaders()
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port")
+  return {
+    close() {
+      responses.forEach((response) => response.destroy())
+      server.close()
+    },
+    url: `http://127.0.0.1:${address.port}`,
+  }
 }
 
 function withAuthContent<A, E, R>(self: Effect.Effect<A, E, R>, value: Record<string, unknown> = defaultAuthContent()) {

--- a/packages/opencode/test/provider/stream-liveness.test.ts
+++ b/packages/opencode/test/provider/stream-liveness.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test"
+import { StreamLiveness } from "@/provider/stream-liveness"
+
+const policy = {
+  initial: 30,
+  minimum: 10,
+  maximum: 100,
+  multiplier: 2,
+  historySize: 2,
+} satisfies StreamLiveness.Policy
+
+describe("stream liveness deadline", () => {
+  test("uses the cold-start deadline without observations", () => {
+    expect(StreamLiveness.create(policy).deadline("anthropic:@ai-sdk/anthropic")).toBe(30)
+  })
+
+  test("doubles the rolling maximum and applies both bounds", () => {
+    const detector = StreamLiveness.create(policy)
+    detector.observe("provider:transport", 2)
+    expect(detector.deadline("provider:transport")).toBe(10)
+    detector.observe("provider:transport", 60)
+    expect(detector.deadline("provider:transport")).toBe(100)
+  })
+
+  test("evicts observations outside the bounded history", () => {
+    const detector = StreamLiveness.create(policy)
+    detector.observe("provider:transport", 40)
+    detector.observe("provider:transport", 20)
+    detector.observe("provider:transport", 5)
+    expect(detector.deadline("provider:transport")).toBe(40)
+  })
+
+  test("isolates provider and transport buckets", () => {
+    const detector = StreamLiveness.create(policy)
+    detector.observe("openai:@ai-sdk/openai", 40)
+    expect(detector.deadline("anthropic:@ai-sdk/anthropic")).toBe(30)
+  })
+})
+
+describe("stream liveness response body", () => {
+  test("fails a post-header SSE body that never yields or closes", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 20 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(new ReadableStream({ pull: () => new Promise(() => {}) }), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    })
+
+    await expect(response.text()).rejects.toHaveProperty("name", "ProviderResponseStreamTimeoutError")
+  })
+
+  test("raw heartbeat bytes reset the pending-read deadline", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 30 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            setTimeout(() => controller.enqueue(new TextEncoder().encode(": heartbeat\n\n")), 10)
+            setTimeout(() => controller.close(), 20)
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    })
+
+    expect(await response.text()).toBe(": heartbeat\n\n")
+  })
+
+  test("empty chunks do not count as body progress", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 20 })
+    let id: ReturnType<typeof setInterval> | undefined
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            id = setInterval(() => controller.enqueue(new Uint8Array()), 5)
+          },
+          cancel() {
+            clearInterval(id)
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    })
+
+    await expect(response.text()).rejects.toHaveProperty("name", "ProviderResponseStreamTimeoutError")
+  })
+
+  test("commits one maximum-gap observation only on normal EOF", async () => {
+    const readings = [0, 7, 7, 20]
+    const detector = StreamLiveness.create(policy, () => readings.shift() ?? 20)
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1]))
+            controller.close()
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    })
+
+    await response.arrayBuffer()
+    expect(detector.deadline("test:transport")).toBe(26)
+  })
+
+  test("does not train history after timeout", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 20 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(new ReadableStream({ pull: () => new Promise(() => {}) }), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    })
+
+    await expect(response.text()).rejects.toBeDefined()
+    expect(detector.deadline("test:transport")).toBe(20)
+  })
+
+  test("does not train history after consumer cancellation", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 20 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(new ReadableStream(), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    })
+
+    await response.body?.cancel()
+    expect(detector.deadline("test:transport")).toBe(20)
+  })
+
+  test("leaves non-SSE and explicitly disabled responses unchanged", () => {
+    const detector = StreamLiveness.create(policy)
+    const json = new Response("{}")
+    expect(
+      detector.wrap({ response: json, bucket: "test:transport", controller: new AbortController() }),
+    ).toBe(json)
+
+    const sse = new Response("", { headers: { "content-type": "text/event-stream" } })
+    expect(
+      detector.wrap({
+        response: sse,
+        bucket: "test:transport",
+        controller: new AbortController(),
+        timeout: false,
+      }),
+    ).toBe(sse)
+  })
+
+  test("uses a positive fixed override instead of the adaptive deadline", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 100 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(new ReadableStream({ pull: () => new Promise(() => {}) }), {
+        headers: { "content-type": "text/event-stream" },
+      }),
+      timeout: 8,
+    })
+
+    await expect(response.text()).rejects.toMatchObject({
+      name: "ProviderResponseStreamTimeoutError",
+      ms: 8,
+    })
+  })
+})

--- a/packages/opencode/test/provider/stream-liveness.test.ts
+++ b/packages/opencode/test/provider/stream-liveness.test.ts
@@ -51,6 +51,26 @@ describe("stream liveness response body", () => {
     await expect(response.text()).rejects.toHaveProperty("name", "ProviderResponseStreamTimeoutError")
   })
 
+  test("uses request stream intent when the response omits its content type", async () => {
+    const detector = StreamLiveness.create({ ...policy, initial: 10 })
+    const response = detector.wrap({
+      bucket: "test:transport",
+      controller: new AbortController(),
+      response: new Response(
+        new ReadableStream({
+          async pull(controller) {
+            await Bun.sleep(30)
+            controller.enqueue(new TextEncoder().encode("late"))
+            controller.close()
+          },
+        }),
+      ),
+      stream: true,
+    })
+
+    await expect(response.text()).rejects.toHaveProperty("name", "ProviderResponseStreamTimeoutError")
+  })
+
   test("raw heartbeat bytes reset the pending-read deadline", async () => {
     const detector = StreamLiveness.create({ ...policy, initial: 30 })
     const response = detector.wrap({

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -70,7 +70,7 @@ const cfg = {
   },
 }
 
-function providerCfg(url: string) {
+function providerCfg(url: string, options: Record<string, unknown> = {}) {
   return {
     ...cfg,
     provider: {
@@ -80,6 +80,7 @@ function providerCfg(url: string) {
         options: {
           ...cfg.provider.test.options,
           baseURL: url,
+          ...options,
         },
       },
     },
@@ -705,6 +706,64 @@ it.live("session.processor effect tests retry network_error finish reasons", () 
         expect(handle.message.error).toBeUndefined()
       }),
     { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests retry response stream inactivity timeouts", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const events = yield* EventV2Bridge.Service
+
+        yield* llm.hang
+        yield* llm.text("after timeout")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "retry stalled stream")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const states: number[] = []
+        const off = yield* events.listen((evt) => {
+          if (evt.type !== SessionStatus.Event.Status.type) return Effect.void
+          const data = evt.data as typeof SessionStatus.Event.Status.data.Type
+          if (data.sessionID === chat.id && data.status.type === "retry") states.push(data.status.attempt)
+          return Effect.void
+        })
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "retry stalled stream" }],
+          tools: {},
+        })
+
+        yield* off
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(states).toStrictEqual([1])
+        expect(parts.some((part) => part.type === "text" && part.text === "after timeout")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+      }),
+    { config: (url) => providerCfg(url, { chunkTimeout: 50 }) },
   ),
 )
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -252,6 +252,20 @@ describe("session.retry.retryable", () => {
     })
   })
 
+  test("retries response stream inactivity timeouts", () => {
+    const request = MessageV2.fromError(new ProviderError.ResponseStreamTimeoutError(900_000), { providerID })
+    expect(SessionV1.APIError.isInstance(request)).toBe(true)
+    if (!SessionV1.APIError.isInstance(request)) throw new Error("expected APIError")
+    expect(request.data.metadata).toEqual({
+      code: "ProviderResponseStreamTimeoutError",
+      timeoutMs: "900000",
+    })
+    expect(SessionRetry.retryable(request, retryProvider)).toEqual({
+      message:
+        "Provider response stream timed out after 900000ms of inactivity. Check provider connectivity or increase provider.options.chunkTimeout before retrying.",
+    })
+  })
+
   test("retries websocket stream transport errors", () => {
     const request = MessageV2.fromError(
       new ProviderError.ResponseStreamError("WebSocket closed before response.completed (code 1006: Connection ended)"),

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.24",
+  "version": "1.18.25",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #37580

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A model endpoint can return headers and then stop sending body data. OpenCode waits forever in that state, so a stalled child can pin a parent session.

This adds a provider-neutral idle watchdog for streaming responses. The default starts at 15 minutes, learns from successful streams per provider and transport, and stays between 15 and 30 minutes. An explicit `chunkTimeout` is still a fixed override. `false`, `0`, or a negative value turns the watchdog off.

The watchdog arms when the response is SSE or the request set `stream: true`. That second path matters because the ChatGPT Codex endpoint has been seen to stream without `Content-Type`. Non-streaming requests stay unchanged.

A timeout becomes a typed retryable provider error and goes through the existing retry and status flow. It does not change Task orchestration, durable session records, retry policy, or UI.

Related work:

- #39516 expands opt-in `chunkTimeout` to every response body. This change is a zero-config adaptive default, and it only wraps requests identified as streams.
- #39970 detects incomplete EOF and gaps between parsed model events, including stalls hidden by SSE keepalives. Complementary. This change is transport-level body silence.

### How did you verify your code works?

Rebased onto current `dev` (no merge commit).

- `bun test --timeout 30000 test/provider/header-timeout.test.ts test/provider/stream-liveness.test.ts test/session/processor-effect.test.ts test/session/retry.test.ts` in `packages/opencode` (94 passed)
- `bun typecheck` in `packages/opencode` and `packages/core`
- Repo pre-push typecheck: 30/30 tasks passed

Not re-run after this rebase: the earlier isolated foreground Task stall E2E.

### Screenshots / recordings

Not applicable. No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
