### PR TITLE
fix(plugin): skip mismatched detected plugins

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -281,6 +281,8 @@ export function readV1Plugin(
     throw new TypeError(`Plugin ${spec} must default export an object with ${kind}()`)
   }
   if (mode === "detect" && !("id" in value) && !("server" in value) && !("tui" in value)) return
+  if (mode === "detect" && kind === "server" && !("server" in value)) return
+  if (mode === "detect" && kind === "tui" && !("tui" in value)) return
 
   const server = "server" in value ? value.server : undefined
   const tui = "tui" in value ? value.tui : undefined

--- a/packages/opencode/test/plugin/shared.test.ts
+++ b/packages/opencode/test/plugin/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { parsePluginSpecifier } from "../../src/plugin/shared"
+import { parsePluginSpecifier, readV1Plugin } from "../../src/plugin/shared"
 
 describe("parsePluginSpecifier", () => {
   test("parses standard npm package without version", () => {
@@ -84,5 +84,25 @@ describe("parsePluginSpecifier", () => {
       pkg: "@opencode/acme",
       version: "latest",
     })
+  })
+})
+
+describe("readV1Plugin", () => {
+  test("detect mode skips plugins missing the requested entrypoint", () => {
+    expect(readV1Plugin({ default: { id: "only-tui", tui: () => undefined } }, "only-tui", "server", "detect")).toBe(
+      undefined,
+    )
+    expect(
+      readV1Plugin({ default: { id: "only-server", server: () => undefined } }, "only-server", "tui", "detect"),
+    ).toBe(undefined)
+  })
+
+  test("strict mode still rejects plugins missing the requested entrypoint", () => {
+    expect(() => readV1Plugin({ default: { id: "only-tui", tui: () => undefined } }, "only-tui", "server")).toThrow(
+      "server()",
+    )
+    expect(() => readV1Plugin({ default: { id: "only-server", server: () => undefined } }, "only-server", "tui")).toThrow(
+      "tui()",
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Skip V1 plugins in detect mode when the requested entrypoint is absent
- Keep strict mode behavior unchanged for missing server/tui entrypoints
- Add regression coverage for mismatched server-only and TUI-only plugins

Fixes #31610

## Test Plan
- bun test test/plugin/shared.test.ts --timeout 30000
- bun run typecheck
- bun run lint packages/opencode/src/plugin/shared.ts packages/opencode/test/plugin/shared.test.ts