### PR TITLE
docs: add opencode-olostep to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-olostep](https://github.com/olostep/opencode-olostep)                                    | Web scraping, crawling, search, and AI-grounded answers via the Olostep CLI                        |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs addition, no related issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-olostep to the Plugins list in the ecosystem docs. It's an OpenCode plugin that gives agents web scraping, crawling, search, site mapping, batch extraction, and AI-grounded answers via the Olostep CLI. It registers the Olostep skill so the agent knows how to use each command and forwards OLOSTEP_API_KEY to execution — the same pattern as the existing Firecrawl and Tavily entries.

- Plugin repo: https://github.com/olostep/opencode-olostep
- npm package: https://www.npmjs.com/package/opencode-olostep

### How did you verify your code works?

Tested locally in OpenCode 1.18.9 — the plugin loads, the skill is picked up, and the agent runs "olostep scrape" against a live URL and returns real content.

### Screenshots / recordings

N/A — docs only, one-line table addition.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR