### PR TITLE
fix(app): prevent stale session file tab reads

### DIFF
--- a/packages/app/src/components/session/session-sortable-tab-v2.tsx
+++ b/packages/app/src/components/session/session-sortable-tab-v2.tsx
@@ -66,7 +66,9 @@ export function SortableTabV2(props: {
           onMiddleClick={() => props.onTabClose(props.tab)}
           onDblClick={() => props.onTabDoubleClick?.(props.tab)}
         >
-          <Show when={content()}>{(value) => value()}</Show>
+          <Show when={content()} keyed>
+            {(value) => value}
+          </Show>
         </Tabs.Trigger>
       </div>
     </div>

--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -70,7 +70,9 @@ export function SortableTab(props: {
           onMiddleClick={() => props.onTabClose(props.tab)}
           onDblClick={() => props.onTabDoubleClick?.(props.tab)}
         >
-          <Show when={content()}>{(value) => value()}</Show>
+          <Show when={content()} keyed>
+            {(value) => value}
+          </Show>
         </Tabs.Trigger>
       </div>
     </div>


### PR DESCRIPTION
### Issue for this PR

Closes #39991

Related: #39704, #39766, #39840 (same crash, other call sites), and the fixes in #39767 / #39842.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`#39767` fixed the `Stale read from <Show>` crash in `session-header.tsx`, `titlebar-tab-nav.tsx` and `new-session-view.tsx`, and `#39842` fixed the prompt controls. Two sibling components in the same area were missed:

- `packages/app/src/components/session/session-sortable-tab.tsx:73`
- `packages/app/src/components/session/session-sortable-tab-v2.tsx:69`

Both had the same shape:

```tsx
<Show when={content()}>{(value) => value()}</Show>
```

These render the file tabs in the session side panel (`session-side-panel.tsx:400` and `:613`). `content()` is a memo derived from `file.pathFromTab(props.tab)`:

```tsx
const content = createMemo(() => {
  const value = path()
  if (!value) return
  return <FileVisual path={value} temporary={props.temporary} />
})
```

Without `keyed`, `<Show>` passes the child an *accessor*. When a file tab is closed, `pathFromTab` returns undefined, so `content()` becomes undefined and `when` flips falsy — but the child is still holding the accessor and calls `value()`. Solid then throws `Stale read from <Show>`, which propagates to the top-level `ErrorBoundary` in `app.tsx` and replaces the whole app with the error page rather than failing locally. That matches the reported trigger of closing/switching sessions and tabs.

The fix is the same one used in #39767: add `keyed` so the child receives the resolved value instead of an accessor, and drop the call.

```tsx
<Show when={content()} keyed>
  {(value) => value}
</Show>
```

Since `content()` is already a memo returning a JSX element, there is no behavioural change to rendering — only the stale re-read is removed.

Note this is not desktop-specific: I hit it in a plain browser against a headless `opencode serve`, so it is not tied to Electron.

### How did you verify your code works?

- `tsgo -b` in `packages/app`: passes, 0 errors.
- `prettier --check` on both files: passes.
- `oxlint` on both files: 0 errors (the 2 `consistent-return` warnings are pre-existing and unrelated).
- Manually in the browser via `bun run --cwd packages/app dev` against a running server, with the devtools console open the whole time:
  - opened multiple file tabs in the session side panel (`bunfig.toml`, `AGENTS.md`, `CONTEXT.md`, `package.json`, `README.md`)
  - closed tabs with the X button and with middle-click, including the active tab
  - closed several tabs rapidly in succession, and closed the last remaining tab
  - promoted a temporary tab via double-click, then closed it
  - switched between tabs quickly while closing, and switched between projects and servers

  No `Stale read from <Show>` in the console, no other console errors, and the error page never appeared. Tab labels and file-type icons continue to render correctly through temporary/active/pinned transitions.

One caveat, stated plainly: my original crash stack was minified with no sourcemap, so I could not map it to a specific line. I identified these two sites by matching the anti-pattern that #39767 and #39842 fixed, and confirmed the reasoning against the code. I could not reproduce the crash on demand beforehand, so this is "the remaining instances of a known bug pattern, in the component the reports point at" rather than a before/after reproduction.

### Screenshots / recordings

This is a one-line correctness fix with no visual change — the file tabs render identically before and after. Verified visually that labels and file-type icons still render through open/close/switch transitions.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
