### PR TITLE
fix(opencode): retry SQLITE_BUSY in todowrite instead of crashing

### DIFF
--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,12 +1,38 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionID } from "./schema"
-import { Effect, Layer, Context } from "effect"
+import { Cause, Duration, Effect, Layer, Context } from "effect"
+import { isSqlError } from "effect/unstable/sql/SqlError"
 import { Database } from "@opencode-ai/core/database/database"
 import { eq } from "drizzle-orm"
 import { asc } from "drizzle-orm"
 import { TodoTable } from "@opencode-ai/core/session/sql"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionTodo } from "@opencode-ai/schema/session-todo"
+
+/**
+ * True when the failure is a transient SQLite write-lock conflict (SQLITE_BUSY).
+ * Drizzle wraps the underlying SqlError in an EffectDrizzleQueryError whose
+ * `cause` is a `Cause<SqlError>`, so walk the error/cause chain until we find
+ * a SqlError.
+ */
+export function isRetryableSqlError(cause: Cause.Cause<unknown>): boolean {
+  let current: unknown = Cause.squash(cause)
+  for (let i = 0; i < 5 && current !== undefined; i++) {
+    if (isSqlError(current)) return current.isRetryable
+    if (Cause.isCause(current)) {
+      current = Cause.squash(current)
+      continue
+    }
+    if (current instanceof Error) {
+      const nested = (current as { cause?: unknown }).cause
+      if (nested === undefined || nested === current) break
+      current = nested
+    } else {
+      break
+    }
+  }
+  return false
+}
 
 export const Info = SessionTodo.Info
 export type Info = SessionTodo.Info
@@ -27,8 +53,11 @@ const layer = Layer.effect(
     const { db } = yield* Database.Service
 
     const update = Effect.fn("Todo.update")(function* (input: { sessionID: SessionID; todos: ReadonlyArray<Info> }) {
-      yield* db
-        .transaction((tx) =>
+      // Retry transient write-lock conflicts (SQLITE_BUSY) instead of crashing:
+      // parallel subagents can call todowrite concurrently, and a busy error is
+      // retryable — orDie turned it into a fatal defect (issue #40020).
+      const writeTransaction = () =>
+        db.transaction((tx) =>
           Effect.gen(function* () {
             yield* tx.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
             if (input.todos.length === 0) return
@@ -46,7 +75,16 @@ const layer = Layer.effect(
               .run()
           }),
         )
-        .pipe(Effect.orDie)
+      const runWrite = (attempt: number): Effect.Effect<void, never, never> =>
+        writeTransaction().pipe(
+          Effect.catchCause((cause) => {
+            if (!isRetryableSqlError(cause) || attempt >= 4) return Effect.failCause(cause).pipe(Effect.orDie)
+            return Effect.sleep(Duration.millis(10 * 2 ** attempt)).pipe(
+              Effect.andThen(runWrite(attempt + 1)),
+            )
+          }),
+        )
+      yield* runWrite(0)
       yield* events.publish(Event.Updated, input)
     })
 

--- a/packages/opencode/test/session/todo-retry.test.ts
+++ b/packages/opencode/test/session/todo-retry.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { Cause } from "effect"
+import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
+import { isRetryableSqlError } from "../../src/session/todo"
+
+function sqliteError(code: string): Error {
+  const err = new Error(`SQLite error: ${code}`) as Error & { code: string }
+  err.code = code
+  return err
+}
+
+function sqlErrorFor(code: string): SqlError {
+  return new SqlError({
+    reason: classifySqliteError(sqliteError(code), { message: "Failed to execute statement", operation: "execute" }),
+  })
+}
+
+test("isRetryableSqlError detects SQLITE_BUSY through the drizzle error wrapper", () => {
+  const sqlError = sqlErrorFor("SQLITE_BUSY")
+  // Simulate drizzle's EffectDrizzleQueryError whose cause is Cause<SqlError>.
+  const wrapped = new Error("Failed query") as Error & { cause: unknown }
+  wrapped.cause = Cause.fail(sqlError)
+
+  expect(isRetryableSqlError(Cause.fail(wrapped))).toBe(true)
+})
+
+test("isRetryableSqlError detects SQLITE_BUSY directly on a SqlError cause", () => {
+  expect(isRetryableSqlError(Cause.fail(sqlErrorFor("SQLITE_BUSY")))).toBe(true)
+})
+
+test("isRetryableSqlError returns false for non-retryable SQL errors", () => {
+  expect(isRetryableSqlError(Cause.fail(sqlErrorFor("SQLITE_CONSTRAINT_UNIQUE")))).toBe(false)
+})
+
+test("isRetryableSqlError returns false for unrelated errors", () => {
+  expect(isRetryableSqlError(Cause.fail(new Error("boom")))).toBe(false)
+})

--- a/packages/opencode/test/session/todo.test.ts
+++ b/packages/opencode/test/session/todo.test.ts
@@ -1,0 +1,110 @@
+import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { expect } from "bun:test"
+import { Effect, Exit } from "effect"
+import { Todo } from "../../src/session/todo"
+import { SessionID } from "../../src/session/schema"
+import { testEffect } from "../lib/effect"
+
+const root = LayerNode.group([Todo.node, EventV2Bridge.node, Database.node])
+const it = testEffect(LayerNode.compile(root, []))
+
+function todoInfo(content: string, status: "pending" | "completed" = "pending"): Todo.Info {
+  return { content, status, priority: "medium" }
+}
+
+// Create a project + session row so the todo insert satisfies its foreign keys.
+const withSession = (sessionID: SessionID) =>
+  Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const worktree = AbsolutePath.make(`/tmp/opencode-todo-${sessionID}`)
+    const projectID = ProjectV2.ID.make(`proj-${sessionID}`)
+    yield* db
+      .insert(ProjectTable)
+      .values({
+        id: projectID,
+        worktree,
+        sandboxes: [],
+        time_created: Date.now(),
+        time_updated: Date.now(),
+      })
+      .run()
+      .pipe(Effect.orDie)
+    yield* db
+      .insert(SessionTable)
+      .values({
+        id: sessionID,
+        project_id: projectID,
+        slug: sessionID,
+        directory: worktree,
+        title: "todo test",
+        version: "0.0.0-test",
+        time_created: Date.now(),
+        time_updated: Date.now(),
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
+
+it.live("concurrent todowrite updates do not crash on SQLITE_BUSY (#40020)", () =>
+  Effect.gen(function* () {
+    const sessionID = SessionID.create()
+    yield* withSession(sessionID)
+
+    // Two subagents call todowrite in parallel, each replacing the todo list.
+    // The delete-then-insert transaction conflicts on the SQLite write lock;
+    // the retry must absorb SQLITE_BUSY instead of orDie-ing into a defect.
+    const results = yield* Effect.all(
+      [
+        Todo.Service.use((svc) =>
+          svc.update({ sessionID, todos: [todoInfo("task-a"), todoInfo("task-b")] }),
+        ),
+        Todo.Service.use((svc) =>
+          svc.update({ sessionID, todos: [todoInfo("task-c"), todoInfo("task-d"), todoInfo("task-e")] }),
+        ),
+      ],
+      { concurrency: 2 },
+    ).pipe(Effect.exit)
+
+    expect(Exit.isSuccess(results)).toBe(true)
+
+    // The surviving write is one of the two (last-writer-wins is acceptable).
+    const todos = yield* Todo.Service.use((svc) => svc.get(sessionID))
+    const contents = todos.map((t) => t.content)
+    expect(
+      contents.every((c) => ["task-a", "task-b", "task-c", "task-d", "task-e"].includes(c)),
+    ).toBe(true)
+    expect(contents.length).toBeGreaterThan(0)
+  }),
+)
+
+it.live("todowrite persists a full replace of the todo list", () =>
+  Effect.gen(function* () {
+    const sessionID = SessionID.create()
+    yield* withSession(sessionID)
+
+    yield* Todo.Service.use((svc) => svc.update({ sessionID, todos: [todoInfo("a"), todoInfo("b")] }))
+    yield* Todo.Service.use((svc) => svc.update({ sessionID, todos: [todoInfo("c")] }))
+
+    const todos = yield* Todo.Service.use((svc) => svc.get(sessionID))
+    expect(todos.map((t) => t.content)).toEqual(["c"])
+  }),
+)
+
+it.live("todowrite with an empty list clears the todo table", () =>
+  Effect.gen(function* () {
+    const sessionID = SessionID.create()
+    yield* withSession(sessionID)
+
+    yield* Todo.Service.use((svc) => svc.update({ sessionID, todos: [todoInfo("a")] }))
+    yield* Todo.Service.use((svc) => svc.update({ sessionID, todos: [] }))
+
+    const todos = yield* Todo.Service.use((svc) => svc.get(sessionID))
+    expect(todos).toEqual([])
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #40020

### Type of change

- [x] Bug fix

### What does this PR do?

Parallel todowrite calls both start with a delete-then-insert transaction and conflict on the SQLite write lock, surfacing SQLITE_BUSY. Effect.orDie turned that transient lock contention into a fatal defect, so the tool crashed instead of retrying. Todo.update now retries retryable SqlErrors (SQLITE_BUSY / SQLITE_LOCKED) with exponential backoff up to 4 attempts before giving up; non-retryable errors still propagate immediately.

### How did you verify your code works?

- bun test test/session/todo.test.ts test/session/todo-retry.test.ts — 7 tests pass
- bun run typecheck — pass

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR