### PR TITLE
fix(opencode): fail runs when the model stream ends without a finish frame

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -19,7 +19,12 @@ export function adapterState() {
 }
 
 function finishReason(value: string | undefined): FinishReason {
-  return Schema.is(FinishReason)(value) ? value : "unknown"
+  if (Schema.is(FinishReason)(value)) return value
+  // The AI SDK reports "other" (or undefined) when a stream ends without a
+  // provider finish frame — e.g. an upstream SSE connection was cut mid-turn
+  // (issue #39968). That is an interrupted generation, not a normal
+  // completion, so surface it as "error" instead of the benign "unknown".
+  return "error"
 }
 
 function providerMetadata(value: unknown): ProviderMetadata | undefined {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -433,6 +433,25 @@ const layer = Layer.effect(
             return
 
           case "step-finish": {
+            // A stream that ended without a provider finish frame (e.g. an
+            // upstream SSE connection was cut mid-turn) surfaces an "error"
+            // finish. That is an interrupted generation — fail the turn so the
+            // caller (opencode run, the loop, integrations) does not treat the
+            // truncated output as a successful completion (issue #39968).
+            if (value.reason === "error") {
+              ctx.assistantMessage.finish = "error"
+              ctx.assistantMessage.error = new SessionV1.APIError({
+                message: "The model stream ended without a finish frame",
+                isRetryable: true,
+                responseBody: "Stream terminated before a finish reason was received",
+              }).toObject()
+              yield* events.publish(Session.Event.Error, {
+                sessionID: ctx.assistantMessage.sessionID,
+                error: ctx.assistantMessage.error,
+              })
+              yield* status.set(ctx.sessionID, { type: "idle" })
+              return
+            }
             const completedSnapshot = yield* snapshot.track()
             yield* Effect.forEach(Object.keys(ctx.reasoningMap), finishReasoning)
             const usage = Session.getUsage({

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -83,9 +83,11 @@ describe("opencode run (non-interactive subprocess)", () => {
 
   // The test provider's SSE error item is interpreted by the SDK as an unknown
   // finish, not a fatal provider/session error. Lock that distinction in so it
-  // is not accidentally used as the failure compatibility oracle.
+  // A stream that ends without a finish frame (upstream SSE cut mid-turn) is an
+  // interrupted generation, not a successful completion: partial output is
+  // still surfaced, but the process must fail (issue #39968).
   cliIt.concurrent(
-    "unknown stream finish preserves partial output and exits 0",
+    "unknown stream finish preserves partial output but exits non-zero",
     ({ llm, opencode }) =>
       Effect.gen(function* () {
         yield* llm.push(
@@ -96,9 +98,8 @@ describe("opencode run (non-interactive subprocess)", () => {
         )
         yield* llm.fail("upstream provider exploded mid-stream")
         const result = yield* opencode.run("trigger midstream error", { timeoutMs: 30_000 })
-        expect(result.exitCode).toBe(0)
+        expect(result.exitCode).not.toBe(0)
         expect(result.stdout).toBe("partial response\n")
-        expect(result.stderr).not.toContain("upstream provider exploded mid-stream")
       }),
     60_000,
   )
@@ -213,7 +214,7 @@ describe("opencode run (non-interactive subprocess)", () => {
   )
 
   cliIt.concurrent(
-    "--format json records partial output for an unknown stream finish",
+    "--format json records partial output and an error for an interrupted stream finish",
     ({ llm, opencode }) =>
       Effect.gen(function* () {
         yield* llm.push(
@@ -226,17 +227,10 @@ describe("opencode run (non-interactive subprocess)", () => {
         const result = yield* opencode.run("fail after output", { format: "json" })
 
         const events = opencode.parseJsonEvents(result.stdout)
-        expect(result.exitCode).toBe(0)
-        expect(events.map((event) => event.type)).toEqual([
-          "step_start",
-          "text",
-          "tool_use",
-          "step_finish",
-          "step_start",
-          "step_finish",
-        ])
+        // A stream cut without a finish frame must fail the run, not exit 0.
+        expect(result.exitCode).not.toBe(0)
+        expect(events.map((event) => event.type)).toContain("error")
         expect(events[1]?.part).toEqual(expect.objectContaining({ type: "text", text: "partial json" }))
-        expect(events.at(-1)?.part).toEqual(expect.objectContaining({ type: "step-finish", reason: "unknown" }))
       }),
     60_000,
   )

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -279,7 +279,7 @@ describe("session.llm.ai-sdk adapter", () => {
       {
         type: "step-finish",
         index: 0,
-        reason: "unknown",
+        reason: "error",
         usage: {
           inputTokens: 10,
           outputTokens: 5,
@@ -292,7 +292,7 @@ describe("session.llm.ai-sdk adapter", () => {
       },
       {
         type: "finish",
-        reason: "unknown",
+        reason: "error",
         usage: {
           inputTokens: 11,
           outputTokens: 6,


### PR DESCRIPTION
## Summary

An upstream SSE connection cut mid-turn (EOF with no finish frame, no error event) made the AI SDK emit a synthesized finish-step with finishReason "other"/undefined. opencode mapped that to the benign "unknown" finish, persisted the truncated output as a completed turn, and `opencode run` exited 0 — silently accepting partial generations as success (issue #39968).

## Changes

- packages/opencode/src/session/llm/ai-sdk.ts: "other"/undefined finish reasons now map to "error" instead of "unknown", matching the native runtime's semantics.
- packages/opencode/src/session/processor.ts: a step-finish with reason "error" fails the turn, publishing a session error so `opencode run` exits non-zero.
- packages/opencode/test/cli/run/run-process.test.ts: updated the two tests that pinned the exit-0 behavior — an interrupted stream now preserves partial output but exits non-zero.
- packages/opencode/test/session/llm.test.ts: updated the adapter expectations.

## Test plan

- [x] bun test test/cli/run/run-process.test.ts — 13 pass
- [x] bun test test/session/llm.test.ts — 28 pass
- [x] bun run typecheck in packages/opencode — pass
- [x] biome check — clean

## Human note

I am a 19-year-old independent full-stack developer. I reviewed the full diff and confirmed the change: a model stream that ends without a finish frame now fails the run instead of exiting 0 with truncated output.

Fixes #39968