### PR TITLE
fix(snapshot): preserve unicode paths on revert

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -428,7 +428,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                   cwd: state.worktree,
                 })
                 if (result.code === 0) return
-                const tree = yield* git([...core, ...args(["ls-tree", op.hash, "--", op.rel])], {
+                const tree = yield* git([...quote, ...args(["ls-tree", op.hash, "--", op.rel])], {
                   cwd: state.worktree,
                 })
                 if (tree.code === 0 && tree.text.trim()) {
@@ -464,7 +464,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                 }
 
                 const tree = yield* git(
-                  [...core, ...args(["ls-tree", "--name-only", first.hash, "--", ...run.map((item) => item.rel)])],
+                  [...quote, ...args(["ls-tree", "--name-only", first.hash, "--", ...run.map((item) => item.rel)])],
                   {
                     cwd: state.worktree,
                   },

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -311,7 +311,7 @@ it.instance(
   { git: true },
 )
 
-it.instance.skip(
+it.instance(
   "unicode filenames modification and restore",
   Effect.gen(function* () {
     const tmp = yield* bootstrap()


### PR DESCRIPTION
## Summary
- Use the snapshot git command set with `core.quotepath=false` for revert-time `ls-tree` checks
- Prevent non-ASCII paths from being octal-escaped before comparison with raw relative paths
- Re-enable the unicode filename restore regression test

Fixes #39616

## Test Plan
- bun test test/snapshot/snapshot.test.ts --timeout 120000 --test-name-pattern "unicode filenames modification and restore"
- bun run typecheck
- bun run lint packages/opencode/src/snapshot/index.ts packages/opencode/test/snapshot/snapshot.test.ts