### PR TITLE
fix(skill): ignore root skill files

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -165,6 +165,8 @@ const scan = Effect.fnUntraced(function* (
   )
 
   for (const match of matches) {
+    const parent = path.basename(path.dirname(match))
+    if (parent === "skill" || parent === "skills") continue
     state.matches.add(match)
     state.dirs.add(path.dirname(match))
   }

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -122,6 +122,43 @@ Instructions here.
     ),
   )
 
+  it.live("ignores SKILL.md directly under .opencode/skills", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skills", "SKILL.md"),
+                `---
+name: root-skill
+description: Root skill should be ignored.
+---
+
+# Root Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".opencode", "skills", "nested-skill", "SKILL.md"),
+                `---
+name: nested-skill
+description: Nested skill should be loaded.
+---
+
+# Nested Skill
+`,
+              ),
+            ]),
+          )
+
+          const skill = yield* Skill.Service
+          const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
+          expect(list.map((item) => item.name)).toEqual(["nested-skill"])
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("returns skill directories from Skill.dirs", () =>
     provideTmpdirInstance(
       (dir) =>


### PR DESCRIPTION
## Summary
- Ignore `SKILL.md` files placed directly under `skill` or `skills` roots
- Keep loading skills from named directories like `.opencode/skills/<name>/SKILL.md`
- Add regression coverage for the root-file case

Refs #31616

## Test Plan
- bun test test/skill/skill.test.ts --timeout 60000 --test-name-pattern "ignores SKILL.md directly under .opencode/skills"
- bun test test/skill/skill.test.ts --timeout 60000 --test-name-pattern "discovers skills from .opencode/skill/ directory|ignores SKILL.md directly under .opencode/skills|discovers multiple skills from .opencode/skill/ directory|returns skill directories"
- bun run typecheck
- bun run lint packages/opencode/src/skill/index.ts packages/opencode/test/skill/skill.test.ts