### PR TITLE
fix(patch): match canonical unicode lines

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -480,7 +480,10 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: canonical Unicode equivalence
+  return tryMatch(lines, pattern, startIndex, (a, b) => a.normalize("NFC").trim() === b.normalize("NFC").trim(), eof)
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -204,6 +204,28 @@ PATCH`
       }),
     )
 
+    it.live("should match canonically equivalent Unicode lines", () =>
+      Effect.gen(function* () {
+        const filePath = path.join(tempDir, "unicode.md")
+        yield* Effect.promise(() =>
+          fs.writeFile(filePath, "# Сводка\nРайон: Астана\n".normalize("NFD"), "utf-8"),
+        )
+
+        const patchText = `*** Begin Patch
+*** Update File: ${filePath}
+@@
+-Район: Астана
++Район: Алматы
+*** End Patch`
+
+        const result = yield* Patch.applyPatch(patchText)
+        expect(result.modified).toEqual([filePath])
+
+        const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
+        expect(content).toContain("Район: Алматы")
+      }),
+    )
+
     it.live("should move and update a file", () =>
       Effect.gen(function* () {
         const oldPath = path.join(tempDir, "old-name.txt")


### PR DESCRIPTION
## Summary
- Add a canonical Unicode-equivalence fallback in patch hunk matching
- Let NFC patch context match NFD file contents without weakening earlier exact/trim/punctuation passes
- Add regression coverage for Cyrillic text stored in NFD and patched with NFC context

Fixes #31651

## Test Plan
- bun test test/patch/patch.test.ts --timeout 60000 --test-name-pattern "should match canonically equivalent Unicode lines"
- bun test test/patch/patch.test.ts --timeout 60000 --test-name-pattern "should update an existing file|should match canonically equivalent Unicode lines|does not invent a first-line diff for BOM files"
- bun run typecheck
- bun run lint packages/opencode/src/patch/index.ts packages/opencode/test/patch/patch.test.ts