### PR TITLE
fix(todo): retry SQLITE_BUSY/LOCKED on parallel todowrite calls

### DIFF
--- a/packages/core/src/session/todo.ts
+++ b/packages/core/src/session/todo.ts
@@ -1,13 +1,32 @@
 export * as SessionTodo from "./todo"
 
 import { asc, eq } from "drizzle-orm"
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Schedule } from "effect"
 import { SessionTodo } from "@opencode-ai/schema/session-todo"
 import { Database } from "../database/database"
 import { makeLocationNode } from "../effect/app-node"
 import { EventV2 } from "../event"
 import { SessionSchema } from "./schema"
 import { TodoTable } from "./sql"
+
+/**
+ * Retry SQLite lock conflicts (SQLITE_BUSY/SQLITE_LOCKED) with short
+ * exponential backoff. Parallel subagents calling todowrite simultaneously
+ * can hit these even with busy_timeout=5000 when both transactions hold
+ * write locks. #40020.
+ */
+function withSqliteLockRetry<A, E>(effect: Effect.Effect<A, E>): Effect.Effect<A, E> {
+  return effect.pipe(
+    Effect.retry({
+      times: 5,
+      schedule: Schedule.exponential(10, 2),
+      while: (error) => {
+        const e = error as { code?: string }
+        return e?.code === "SQLITE_BUSY" || e?.code === "SQLITE_LOCKED"
+      },
+    }),
+  )
+}
 
 export const Info = SessionTodo.Info
 export type Info = typeof Info.Type
@@ -33,8 +52,8 @@ const layer = Layer.effect(
       readonly sessionID: SessionSchema.ID
       readonly todos: ReadonlyArray<Info>
     }) {
-      yield* db
-        .transaction((tx) =>
+      yield* withSqliteLockRetry(
+        db.transaction((tx) =>
           Effect.gen(function* () {
             yield* tx.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
             if (input.todos.length === 0) return
@@ -51,8 +70,8 @@ const layer = Layer.effect(
               )
               .run()
           }),
-        )
-        .pipe(Effect.orDie)
+        ),
+      ).pipe(Effect.orDie)
       yield* events.publish(Event.Updated, input)
     })
 


### PR DESCRIPTION
## Description

When two subagents call `todowrite` in parallel (e.g. via `task` with `background: true`), both transactions attempt to delete+insert the same session's todo rows. Even with `busy_timeout=5000` and WAL mode, one can hit `SQLITE_BUSY` or `SQLITE_LOCKED` when both hold write transactions. The previous `Effect.orDie` killed the subagent with a `SQLITE_BUSY` crash.

## Changes

- Add `withSqliteLockRetry()` helper that retries on `SQLITE_BUSY`/`SQLITE_LOCKED` with short exponential backoff (up to 5 attempts, starting at 10ms)
- Wrap the todo update transaction in the retry helper
- No changes to `get()` (read-only, doesn't conflict)

## Testing

- Existing `todowrite` and `session-todo` tests continue to pass
- The retry only fires on SQLITE_BUSY/SQLITE_LOCKED; all other errors propagate as before

Fixes #40020