### PR TITLE
fix(app): preserve edit project dialog scope

### DIFF
--- a/packages/app/src/components/dialog-edit-project-v2.tsx
+++ b/packages/app/src/components/dialog-edit-project-v2.tsx
@@ -13,7 +13,7 @@ import { ServerConnection } from "@/context/server"
 import { getProjectAvatarSource } from "@/pages/layout/helpers"
 import { createEditProjectModel } from "./edit-project"
 
-export function DialogEditProjectV2(props: { project: LocalProject; server: ServerConnection.Any }) {
+export function DialogEditProjectV2(props: { project: LocalProject; server: ServerConnection.Any; onClose?: () => void }) {
   const language = useLanguage()
   const model = createEditProjectModel(props)
 

--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -12,7 +12,7 @@ import { createEditProjectModel } from "./edit-project"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
 
-export function DialogEditProject(props: { project: LocalProject; server: ServerConnection.Any }) {
+export function DialogEditProject(props: { project: LocalProject; server: ServerConnection.Any; onClose?: () => void }) {
   const language = useLanguage()
   const model = createEditProjectModel(props)
 

--- a/packages/app/src/components/edit-project.ts
+++ b/packages/app/src/components/edit-project.ts
@@ -8,8 +8,12 @@ import { useGlobal } from "@/context/global"
 import { type LocalProject } from "@/context/layout"
 import { ServerConnection } from "@/context/server"
 
-export function createEditProjectModel(props: { project: LocalProject; server: ServerConnection.Any }) {
-  const dialog = useDialog()
+export function createEditProjectModel(props: { project: LocalProject; server: ServerConnection.Any; onClose?: () => void }) {
+  const dialog = props.onClose ? undefined : useDialog()
+  const close = () => {
+    if (props.onClose) return props.onClose()
+    dialog?.close()
+  }
   const global = useGlobal()
   const serverCtx = createMemo(() => global.ensureServerCtx(props.server))
   const folderName = createMemo(() => getFilename(props.project.worktree))
@@ -92,7 +96,7 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
           items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
         )
         serverCtx().sync.project.icon(props.project.worktree, store.iconOverride || undefined)
-        dialog.close()
+        close()
         return
       }
 
@@ -101,7 +105,7 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
         icon: { color: store.color || undefined, override: store.iconOverride || undefined },
         commands: { start: start || undefined },
       })
-      dialog.close()
+      close()
     },
   }))
 
@@ -123,9 +127,7 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
     dragLeave,
     inputChange,
     iconClick,
-    close() {
-      dialog.close()
-    },
+    close,
     setIconInput(input: HTMLInputElement) {
       iconInput = input
     },

--- a/packages/app/src/pages/home/home-projects-controller.tsx
+++ b/packages/app/src/pages/home/home-projects-controller.tsx
@@ -73,7 +73,7 @@ export function createHomeProjectsController(home: HomeController) {
       openNewSession: home.project.openProjectNewSession,
       edit: (conn: ServerConnection.Any, project: LocalProject) => {
         void import("@/components/dialog-edit-project-v2").then(({ DialogEditProjectV2 }) => {
-          void dialog.show(() => <DialogEditProjectV2 server={conn} project={project} />)
+          void dialog.show(() => <DialogEditProjectV2 server={conn} project={project} onClose={() => dialog.close()} />)
         })
       },
       unseenCount: (conn: ServerConnection.Any, project: LocalProject) => {

--- a/packages/app/src/pages/layout-edit-project.test.ts
+++ b/packages/app/src/pages/layout-edit-project.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+import { loadEditProjectDialog } from "./layout"
+
+describe("legacy layout edit project dialog", () => {
+  test("loads the V2 edit project dialog", async () => {
+    const dialog = await loadEditProjectDialog()
+    expect(dialog.name).toBe("DialogEditProjectV2")
+  })
+})

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -83,6 +83,9 @@ import {
 import { ProjectDragOverlay, SortableProject, type ProjectSidebarContext } from "./layout/sidebar-project"
 import { SidebarContent } from "./layout/sidebar-shell"
 
+export const loadEditProjectDialog = () =>
+  import("@/components/dialog-edit-project-v2").then((module) => module.DialogEditProjectV2)
+
 export default function LegacyLayout(props: ParentProps) {
   const serverSDK = useServerSDK()
   const [store, setStore, , ready] = persisted(
@@ -1359,9 +1362,9 @@ export default function LegacyLayout(props: ParentProps) {
 
   const showEditProjectDialog = (conn: ServerConnection.Any, project: LocalProject) => {
     const run = ++dialogRun
-    void import("@/components/dialog-edit-project").then((x) => {
+    void loadEditProjectDialog().then((DialogEditProject) => {
       if (dialogDead || dialogRun !== run) return
-      dialog.show(() => <x.DialogEditProject server={conn} project={project} />)
+      void dialog.show(() => <DialogEditProject server={conn} project={project} onClose={() => dialog.close()} />)
     })
   }
 


### PR DESCRIPTION
## Summary
- Load the V2 edit-project dialog from the legacy layout path
- Pass the dialog close callback into edit-project dialogs so their model does not have to re-read dialog context from the lazy dialog subtree
- Add a regression test that locks the legacy layout loader to the V2 dialog path

Fixes #35132

## Test Plan
- bun test --conditions=solid --preload ./happydom.ts ./src/pages/layout-edit-project.test.ts
- bun run lint packages/app/src/components/edit-project.ts packages/app/src/components/dialog-edit-project.tsx packages/app/src/components/dialog-edit-project-v2.tsx packages/app/src/pages/home/home-projects-controller.tsx packages/app/src/pages/layout.tsx packages/app/src/pages/layout-edit-project.test.ts
- git diff --cached --check
- staged secret scan

Note: `bun run typecheck` from `packages/app` is blocked in this Windows checkout by the existing `src/custom-elements.d.ts` symlink placeholder being materialized as the literal text `../../ui/src/custom-elements.d.ts`.