### PR TITLE
feat(tui): prioritize favorite model search results

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -63,15 +63,15 @@ export function DialogModel(props: { providerID?: string }) {
         .filter((model) => (props.providerID ? model.providerID === props.providerID : true))
         .map((model) => {
           const provider = providers().get(model.providerID)
+          const favorite = favorites.some((item) => item.providerID === model.providerID && item.modelID === model.id)
           return {
             value: { providerID: model.providerID, modelID: model.id },
             providerID: model.providerID,
             providerName: provider?.name ?? model.providerID,
             title: model.name,
             releaseDate: model.time.released,
-            description: favorites.some((item) => item.providerID === model.providerID && item.modelID === model.id)
-              ? "(Favorite)"
-              : undefined,
+            favorite,
+            description: favorite ? "(Favorite)" : undefined,
             category: connected() ? (provider?.name ?? model.providerID) : undefined,
             footer: free(model) ? "Free" : undefined,
             onSelect() {
@@ -96,7 +96,9 @@ export function DialogModel(props: { providerID?: string }) {
     )
 
     if (needle) {
-      return fuzzysort.go(needle, modelOptions, { keys: ["title", "category"] }).map((item) => item.obj)
+      return prioritizeFavorites(
+        fuzzysort.go(needle, modelOptions, { keys: ["title", "category"] }).map((item) => item.obj),
+      )
     }
 
     return [...favoriteOptions, ...recentOptions, ...modelOptions]
@@ -158,6 +160,10 @@ export function DialogModel(props: { providerID?: string }) {
       focusCurrent={false}
     />
   )
+}
+
+export function prioritizeFavorites<T extends { favorite: boolean }>(options: T[]) {
+  return options.toSorted((a, b) => Number(b.favorite) - Number(a.favorite))
 }
 
 export function sortModelOptions<

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, test } from "bun:test"
-import { sortModelOptions } from "../../../../src/component/dialog-model"
+import { prioritizeFavorites, sortModelOptions } from "../../../../src/component/dialog-model"
+
+describe("prioritizeFavorites", () => {
+  test("moves favorites first while preserving fuzzy result order", () => {
+    const prioritized = prioritizeFavorites([
+      { title: "Best match", favorite: false },
+      { title: "Favorite match", favorite: true },
+      { title: "Second best match", favorite: false },
+      { title: "Second favorite match", favorite: true },
+    ])
+
+    expect(prioritized.map((model) => model.title)).toEqual([
+      "Favorite match",
+      "Second favorite match",
+      "Best match",
+      "Second best match",
+    ])
+  })
+})
 
 describe("sortModelOptions", () => {
   test("orders opencode models before other providers", () => {


### PR DESCRIPTION
## What

Prioritize favorite models when searching in the TUI model picker. Only models matching the existing fuzzy search are considered; matching favorites appear before matching non-favorites.

## How

- Record favorite status on catalog model options.
- Stable-sort fuzzy search results by favorite status, preserving fuzzy relevance within the favorite and non-favorite groups.
- Add a focused test covering both the priority and stable ordering.

## Scope

This intentionally uses favorites-first ranking rather than a weighted relevance bonus. The ranking can be tuned later based on usage. Empty-query Favorites and Recent sections are unchanged.

## Testing

- `bun run test test/cli/cmd/tui/model-options.test.ts`
- `bun run test` (588 tests, 0 failures)
- `bun typecheck` in `packages/tui`
- repository-wide typecheck via push hook (33/33 tasks)
- `bunx prettier --check src/component/dialog-model.tsx test/cli/cmd/tui/model-options.test.ts`
- `bunx oxlint packages/tui/src/component/dialog-model.tsx packages/tui/test/cli/cmd/tui/model-options.test.ts`