### PR TITLE
fix(process): ensure child processes inherit environment variables

### DIFF
--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -204,10 +204,11 @@ const layer = Layer.effect(
           cause: new Error("stdin option only supports StandardCommand; received PipedCommand"),
         })
       }
-      const next = ChildProcess.make(command.command, command.args, {
-        ...command.options,
-        stdin: normalizeStdin(options.stdin),
-      })
+       const next = ChildProcess.make(command.command, command.args, {
+         ...command.options,
+         stdin: normalizeStdin(options.stdin),
+         extendEnv: true,
+       })
       return yield* runCommand(next, options)
     })
 

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -155,13 +155,14 @@ const layer = Layer.effectDiscard(
               const shell =
                 Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
                   .shell ?? defaultShell()
-              const command = ChildProcess.make(input.command, [], {
-                cwd: target.canonical,
-                shell,
-                stdin: "ignore",
-                detached: process.platform !== "win32",
-                forceKillAfter: Duration.seconds(3),
-              })
+               const command = ChildProcess.make(input.command, [], {
+                 cwd: target.canonical,
+                 shell,
+                 stdin: "ignore",
+                 detached: process.platform !== "win32",
+                 forceKillAfter: Duration.seconds(3),
+                 extendEnv: true,
+               })
               const timeout = input.timeout ?? DEFAULT_TIMEOUT_MS
               const result = yield* appProcess
                 .run(command, {

--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -364,5 +364,18 @@ describe("AppProcess", () => {
         }),
       ),
     )
-  })
-})
+   })
+
+   it.effect(
+     "inherits environment variables including PATH",
+     Effect.gen(function* () {
+       const svc = yield* AppProcess.Service
+       // Test that PATH is inherited by checking we can find a basic command
+       const result = yield* svc.run(cmd("-e", "process.stdout.write(process.env.PATH || '')"))
+       expect(result.exitCode).toBe(0)
+       const pathValue = result.stdout.toString("utf8").trim()
+       expect(pathValue.length).toBeGreaterThan(0)
+       expect(pathValue.includes("/")).toBe(true) // PATH should contain path separators
+     }),
+   )
+ })


### PR DESCRIPTION
Fixes subprocess environment propagation bugs in OpenCode CLI, ensuring custom binary PATHs and environment variables inherit correctly.

- Added `extendEnv: true` to ChildProcess.make in process.ts and bash.ts
- Added test to verify PATH inheritance
- Fixes #38897