### PR TITLE
fix(core): sanitize optional tool metadata on permission requests

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -161,6 +161,29 @@ const layer = Layer.effect(
       return { effect, rules: all }
     })
 
+    function sanitizeValue(value: unknown): unknown {
+      if (value === undefined) return undefined
+      if (Array.isArray(value)) {
+        return value.map(sanitizeValue).filter((item) => item !== undefined)
+      }
+      if (typeof value === "object" && value !== null) {
+        const cleaned: Record<string, unknown> = {}
+        for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+          if (val !== undefined) {
+            cleaned[key] = sanitizeValue(val)
+          }
+        }
+        return cleaned
+      }
+      return value
+    }
+
+    function sanitizeMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+      if (!metadata) return undefined
+      const cleaned = sanitizeValue(metadata) as Record<string, unknown>
+      return Object.keys(cleaned).length > 0 ? cleaned : undefined
+    }
+
     function request(input: AssertInput): Request {
       return {
         id: input.id ?? ID.create(),
@@ -168,7 +191,7 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        metadata: sanitizeMetadata(input.metadata),
         source: input.source,
       }
     }

--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -65,8 +65,8 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: input.path ?? ".",
-                  path: input.path,
-                  limit: input.limit,
+                  ...(input.path !== undefined ? { path: input.path } : {}),
+                  ...(input.limit !== undefined ? { limit: input.limit } : {}),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -84,9 +84,9 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: ".",
-                  path: input.path,
-                  include: input.include,
-                  limit: input.limit,
+                  ...(input.path !== undefined ? { path: input.path } : {}),
+                  ...(input.include !== undefined ? { include: input.include } : {}),
+                  ...(input.limit !== undefined ? { limit: input.limit } : {}),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -312,4 +312,40 @@ describe("PermissionV2", () => {
       expect(yield* saved.list()).toEqual([])
     }),
   )
+
+  it.effect("sanitizes undefined metadata properties on permission requests", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      const asked = yield* Deferred.make<PermissionV2.Request>()
+      const events = yield* EventV2.Service
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === PermissionV2.Event.Asked.type
+          ? Deferred.succeed(asked, event.data as PermissionV2.Request).pipe(Effect.asVoid)
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const fiber = yield* service
+        .assert(
+          assertion({
+            metadata: {
+              root: ".",
+              path: undefined,
+              limit: undefined,
+              nested: { valid: "ok", empty: undefined },
+            },
+          }),
+        )
+        .pipe(Effect.forkScoped)
+      const request = yield* Deferred.await(asked)
+      expect(request.metadata).toEqual({
+        root: ".",
+        nested: { valid: "ok" },
+      })
+      expect(Object.prototype.hasOwnProperty.call(request.metadata, "path")).toBe(false)
+      expect(Object.prototype.hasOwnProperty.call(request.metadata, "limit")).toBe(false)
+      yield* service.reply({ requestID: request.id, reply: "once" })
+      yield* Fiber.join(fiber)
+    }),
+  )
 })


### PR DESCRIPTION
Omit undefined keys in glob/grep tool metadata construction and recursively sanitize metadata in permission request creation to prevent JSON schema encoding failures.

- Added recursive sanitizeValue/sanitizeMetadata helpers in permission.ts
- Updated glob.ts and grep.ts to conditionally spread optional fields
- Added test verifying undefined metadata properties are stripped
- Fixes #37650