### PR TITLE
fix(tui): prevent sidebar scrollbar flash

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -7,7 +7,7 @@ const money = new Intl.NumberFormat("en-US", {
   currency: "USD",
 })
 
-function View(props: { context: Plugin.Context; sessionID: string }) {
+export function SidebarContext(props: { context: Plugin.Context; sessionID: string }) {
   const theme = props.context.theme
   const msg = createMemo(() => props.context.data.session.message.list(props.sessionID))
   const session = createMemo(() => props.context.data.session.get(props.sessionID))
@@ -18,28 +18,32 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
   )
 
   return (
-    <box>
-      <text fg={theme.text.default}>
-        <b>Context</b>
-      </text>
-      <Show when={state()} fallback={<text fg={theme.text.subdued}>Not measured</text>}>
-        {(value) => (
-          <>
-            <text fg={theme.text.subdued}>{value().tokens.toLocaleString()} tokens</text>
-            <Show when={value().percent !== undefined}>
-              <text fg={theme.text.subdued}>{value().percent}% used</text>
-            </Show>
-          </>
-        )}
-      </Show>
-      <text fg={theme.text.subdued}>{money.format(cost())} spent</text>
-    </box>
+    <Show when={state() || cost() > 0}>
+      <box>
+        <text fg={theme.text.default}>
+          <b>Context</b>
+        </text>
+        <Show when={state()}>
+          {(value) => (
+            <>
+              <text fg={theme.text.subdued}>{value().tokens.toLocaleString()} tokens</text>
+              <Show when={value().percent !== undefined}>
+                <text fg={theme.text.subdued}>{value().percent}% used</text>
+              </Show>
+            </>
+          )}
+        </Show>
+        <Show when={cost() > 0}>
+          <text fg={theme.text.subdued}>{money.format(cost())} spent</text>
+        </Show>
+      </box>
+    </Show>
   )
 }
 
 export default Plugin.define({
   id: "internal:sidebar-context",
   setup(context) {
-    context.ui.slot("sidebar.content", (props) => <View context={context} sessionID={props.sessionID} />)
+    context.ui.slot("sidebar.content", (props) => <SidebarContext context={context} sessionID={props.sessionID} />)
   },
 })

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -27,9 +27,11 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         position={props.overlay ? "absolute" : "relative"}
       >
         <scrollbox
+          ref={(scroll) => queueMicrotask(() => scroll.verticalScrollBar.resetVisibilityControl())}
           flexGrow={1}
           scrollAcceleration={scrollAcceleration()}
           verticalScrollbarOptions={{
+            visible: false,
             trackOptions: {
               backgroundColor: theme.background.default,
               foregroundColor: theme.scrollbar.default,

--- a/packages/tui/test/feature-plugins/sidebar-context.test.tsx
+++ b/packages/tui/test/feature-plugins/sidebar-context.test.tsx
@@ -1,0 +1,70 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import type { Context } from "@opencode-ai/plugin/tui/context"
+import { SidebarContext } from "../../src/feature-plugins/sidebar/context"
+
+function context(options?: { cost?: number; tokens?: number }) {
+  const color = RGBA.fromInts(200, 200, 200)
+  return {
+    theme: { text: { default: color, subdued: color } },
+    data: {
+      session: {
+        get: () => ({ location: { directory: "/workspace" } }),
+        cost: () => options?.cost ?? 0,
+        message: {
+          list: () =>
+            options?.tokens
+              ? [
+                  {
+                    id: "message",
+                    type: "assistant",
+                    model: { providerID: "provider", id: "model" },
+                    tokens: {
+                      input: options.tokens,
+                      output: 0,
+                      reasoning: 0,
+                      cache: { read: 0, write: 0 },
+                    },
+                  },
+                ]
+              : [],
+        },
+      },
+      location: {
+        model: { list: () => [] },
+      },
+    },
+  } as unknown as Context
+}
+
+test("sidebar omits context before usage is available", async () => {
+  const app = await testRender(() => <SidebarContext context={context()} sessionID="session" />, {
+    width: 42,
+    height: 8,
+  })
+
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).not.toContain("Context")
+    expect(app.captureCharFrame()).not.toContain("Not measured")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("sidebar shows available context usage", async () => {
+  const app = await testRender(() => <SidebarContext context={context({ tokens: 1234 })} sessionID="session" />, {
+    width: 42,
+    height: 8,
+  })
+
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("Context")
+    expect(app.captureCharFrame()).toContain("1,234 tokens")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What

Prevent the V2 TUI sidebar scrollbar from flashing for one frame when switching session tabs. Empty sessions also stop showing the internal `Not measured` context placeholder and `$0.00 spent`.

## Before / After

**Before**

Switching tabs remounted the keyed session view. OpenTUI created the sidebar scrollbar as visible, rendered that state, then hid it after calculating the viewport and content sizes.

```text
Tab switch -> sidebar mounts -> scrollbar flashes -> layout measures -> scrollbar hides
```

A new session also showed a context section with `Not measured` and `$0.00 spent` despite having no usage.

**After**

The sidebar scrollbar starts hidden and returns visibility control to OpenTUI after mount. It appears only when measured content actually overflows.

```text
Tab switch -> sidebar mounts hidden -> layout measures -> scrollbar appears only if needed
```

The context section remains absent until usage or cost data is meaningful.

## How

- `packages/tui/src/routes/session/sidebar.tsx` initializes the vertical scrollbar as hidden, then resets manual visibility control after creation so OpenTUI resumes normal overflow-driven behavior.
- `packages/tui/src/feature-plugins/sidebar/context.tsx` renders context usage and cost only when either value is available.
- `packages/tui/test/feature-plugins/sidebar-context.test.tsx` covers empty and populated context rendering.

## Scope

This only changes the V2 TUI session sidebar. It does not change the main transcript scrollbar or web/desktop sidebars.

## Testing

- `bun run test test/feature-plugins test/util/session.test.ts` (26 passed)
- `bun typecheck` from `packages/tui`
- Full repository typecheck from the pre-push hook (33 packages passed)
- `git diff --check`

## Demo

The scrollbar defect exists only in the pre-measurement frame, so a settled terminal screenshot cannot capture it honestly. The before/after lifecycle above describes the visible transition; rendered-output tests cover the context-state change.
