### PR TITLE
fix(app): encode UNC file URLs

### DIFF
--- a/packages/app/src/components/prompt-input/build-request-parts.test.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.test.ts
@@ -309,6 +309,25 @@ describe("buildRequestParts", () => {
     })
   })
 
+  test("uses a valid UNC file URL when workspace is on a network share", () => {
+    const result = buildRequestParts({
+      prompt: [{ type: "file", path: "src\\foo.ts", content: "@src\\foo.ts", start: 0, end: 11 }],
+      context: [],
+      images: [],
+      text: "@src\\foo.ts",
+      messageID: "msg_unc_1",
+      sessionID: "ses_unc_1",
+      sessionDirectory: "\\\\server\\share\\project",
+    })
+
+    const filePart = result.requestParts.find((part) => part.type === "file")
+    expect(filePart).toBeDefined()
+    if (filePart?.type === "file") {
+      expect(filePart.url).toBe("file://server/share/project/src/foo.ts")
+      expect(() => new URL(filePart.url)).not.toThrow()
+    }
+  })
+
   test("handles absolute Windows paths (user manually specifies full path)", () => {
     const prompt: Prompt = [
       { type: "file", path: "D:\\other\\project\\file.ts", content: "@D:\\other\\project\\file.ts", start: 0, end: 25 },

--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -142,6 +142,19 @@ describe("encodeFilePath", () => {
       expect(result).toBe("/D:/dev/projects/opencode/README.bs.md")
     })
 
+    test("should encode UNC paths as file URL hosts", () => {
+      const uncPath = "\\\\server\\share\\project\\src\\app.ts"
+      const result = encodeFilePath(uncPath)
+      const fileUrl = `file://${result}`
+
+      expect(result).toBe("server/share/project/src/app.ts")
+      expect(() => new URL(fileUrl)).not.toThrow()
+
+      const url = new URL(fileUrl)
+      expect(url.host).toBe("server")
+      expect(url.pathname).toBe("/share/project/src/app.ts")
+    })
+
     test("should handle mixed separator path (Windows + Unix)", () => {
       // This is what happens in build-request-parts.ts when concatenating paths
       const mixedPath = "D:\\dev\\projects\\opencode/README.bs.md"

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -81,8 +81,13 @@ export function decodeFilePath(input: string) {
 }
 
 export function encodeFilePath(filepath: string): string {
+  const unc = filepath.startsWith("\\\\")
   // Normalize Windows paths: convert backslashes to forward slashes
   let normalized = filepath.replace(/\\/g, "/")
+
+  if (unc) {
+    normalized = normalized.replace(/^\/+/, "")
+  }
 
   // Handle Windows absolute paths (D:/path -> /D:/path for proper file:// URLs)
   if (/^[A-Za-z]:/.test(normalized)) {


### PR DESCRIPTION
## Summary
- Encode UNC workspace paths as file URL hosts instead of `file:////...`
- Keep existing drive-letter and POSIX file URL behavior unchanged
- Add regression coverage for UNC request parts built from prompt file references

Fixes #31627

## Test Plan
- bun test --conditions=solid --preload ./happydom.ts ./src/context/file/path.test.ts ./src/components/prompt-input/build-request-parts.test.ts
- bun run lint packages/app/src/context/file/path.ts packages/app/src/context/file/path.test.ts packages/app/src/components/prompt-input/build-request-parts.test.ts
- git diff --cached --check
- staged secret scan

Note: `bun run typecheck` from `packages/app` is blocked in this Windows checkout by the existing `src/custom-elements.d.ts` symlink placeholder being materialized as the literal text `../../ui/src/custom-elements.d.ts`.