### PR TITLE
fix(desktop): open Windows terminals at the project directory

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process"
+import { execFile, spawn } from "node:child_process"
 import { stat } from "node:fs/promises"
 import { basename } from "node:path"
 import { app, BrowserWindow, clipboard, dialog, ipcMain, shell } from "electron"
@@ -193,6 +193,19 @@ export function registerIpcHandlers(deps: Deps) {
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
     if (!app) return shell.openPath(path)
+    // PowerShell treats a positional path argument as a command to run, so open
+    // it in its own console with the path as the working directory instead.
+    if (process.platform === "win32" && /^(powershell|pwsh)(\.exe)?$/i.test(basename(app))) {
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(app, [], { cwd: path, detached: true, stdio: "ignore" })
+        child.once("error", reject)
+        child.once("spawn", () => {
+          child.unref()
+          resolve()
+        })
+      })
+      return
+    }
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)


### PR DESCRIPTION
### Issue for this PR

Closes #39851

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, the `open-path` IPC handler runs `execFile(<app>, [path])` for every app. That works for editors (`code`, `cursor`, etc. accept a directory argument), but PowerShell interprets its first positional argument as a command to execute, so "Open in PowerShell" fails with `CommandNotFoundException` on the project path.

The fix: when the resolved app is `powershell`/`pwsh` on win32, spawn it with no arguments, `cwd` set to the project directory, and `detached: true` + `stdio: "ignore"` so it gets its own console window starting in the project folder. A `spawn`/`error` listener keeps the promise contract of the handler (rejects on ENOENT etc.). All other apps and platforms keep the existing `execFile` path.

`detached: true` on Windows gives the child its own console, and PowerShell starts in the inherited `cwd`, which is exactly the expected behavior from the issue ("a PowerShell window opens with the working directory set to the project folder").

### How did you verify your code works?

- `bun typecheck` in `packages/desktop` passes; full-repo typecheck (30 turbo tasks) passes via the pre-push hook.
- I don't have Windows hardware to click through the desktop app, so the runtime behavior is verified against Node's documented `spawn` semantics (`detached` on Windows = own console, `cwd` inherited). Happy to adjust if a maintainer with a Windows box spots an issue; the reporter of #39851 offered a clear repro to test against.

### Screenshots / recordings

_Not a UI change (main-process IPC only)._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
