### PR TITLE
fix(opencode): warn PowerShell shells against backslash escapes

### DIFF
--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -48,7 +48,9 @@ function powershellNotes(name: string) {
 - Prefer full cmdlet names like \`Get-ChildItem\`, \`Set-Content\`, \`Remove-Item\`, and \`New-Item\` over aliases.
 - Use \`$(...)\` for subexpressions. Use \`@(...)\` for array expressions.
 - To call a native executable whose path contains spaces, use the call operator: \`& "path/to/exe" args\`.
-- Escape special characters with the PowerShell backtick character.`
+- Escape special characters with the PowerShell backtick character.
+- Backslash is NOT an escape character in this shell. Sequences like \`\\n\`, \`\\t\`, or \`\\\`\` are not interpreted and land literally in arguments and output; never use POSIX/bash-style backslash escaping.
+- Pass multi-line or verbatim content (markdown, code, commit messages, PR bodies) with a single-quoted here-string (\`@'...'@\`) or write it to a file and use file-based flags such as \`git commit -F\` or \`gh pr create --body-file\`; do not inline it with escape sequences.`
   }
   if (name === "powershell") {
     return `# Windows PowerShell (5.1) shell notes
@@ -57,7 +59,9 @@ function powershellNotes(name: string) {
 - Prefer full cmdlet names like \`Get-ChildItem\`, \`Set-Content\`, \`Remove-Item\`, and \`New-Item\` over aliases.
 - Use \`$(...)\` for subexpressions. Use \`@(...)\` for array expressions.
 - To call a native executable whose path contains spaces, use the call operator: \`& "path/to/exe" args\`.
-- Escape special characters with the PowerShell backtick character.`
+- Escape special characters with the PowerShell backtick character.
+- Backslash is NOT an escape character in this shell. Sequences like \`\\n\`, \`\\t\`, or \`\\\`\` are not interpreted and land literally in arguments and output; never use POSIX/bash-style backslash escaping.
+- Pass multi-line or verbatim content (markdown, code, commit messages, PR bodies) with a single-quoted here-string (\`@'...'@\`) or write it to a file and use file-based flags such as \`git commit -F\` or \`gh pr create --body-file\`; do not inline it with escape sequences.`
   }
   return ""
 }


### PR DESCRIPTION
### Issue for this PR

Closes #39884

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the shell tool runs on PowerShell (5.1 or 7+), models trained mostly on POSIX shells keep writing backslash escapes (`` \` ``, `\n`, `\t`) inside command arguments. PowerShell's escape character is the backtick, so those sequences land literally in the output — the issue shows a real PR body corrupted this way (`` `SENTRY_AUTH_TOKEN` `` became `\SENTRY_AUTH_TOKEN\`).

The existing PowerShell notes in the tool prompt say "escape special characters with the backtick" but never say backslash is *not* an escape character — which is the actual mistake models make. This adds two lines to both PowerShell profiles (`powershell` and `pwsh`) in `packages/opencode/src/tool/shell/prompt.ts`:

1. an explicit warning that backslash is not an escape character and backslash sequences land literally;
2. guidance to pass multi-line/verbatim content (markdown, commit messages, PR bodies) via single-quoted here-strings or file-based flags (`git commit -F`, `gh pr create --body-file`) instead of inlining it with escapes.

This complements the existing here-string example in `createPrExample` — that one only covers `gh pr create`, while the corruption in the issue also hits commit messages and any other verbatim argument.

### How did you verify your code works?

- Rendered the tool description locally for both `powershell`/win32 and `pwsh` via `ShellPrompt.render()` and reviewed the output text (bullets appear correctly, backticks render as intended).
- `bun typecheck` in `packages/opencode` passes; full-repo typecheck passes via the pre-push hook.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
