### PR TITLE
fix(opencode): apply default header timeout to all providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -32,7 +32,9 @@ import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
 
-const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
+// A connection that is established but silently blackholed (e.g. a broken IPv6
+// path, see #36029/#39859) would otherwise wait for response headers forever.
+const HEADER_TIMEOUT_DEFAULT = 300_000
 
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
@@ -205,7 +207,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
           return sdk.responses(modelID)
         },
-        options: { headerTimeout: OPENAI_HEADER_TIMEOUT_DEFAULT },
+        options: { headerTimeout: HEADER_TIMEOUT_DEFAULT },
       }),
     meta: () =>
       Effect.succeed({
@@ -1736,7 +1738,7 @@ const layer = Layer.effect(
 
         const customFetch = options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
-        const headerTimeout = options["headerTimeout"]
+        const headerTimeout = options["headerTimeout"] ?? HEADER_TIMEOUT_DEFAULT
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
 

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -112,7 +112,7 @@ it.live("headerTimeout aborts when response headers do not arrive", () =>
   }),
 )
 
-it.live("headerTimeout is opt-in for non-OpenAI providers", () =>
+it.live("default headerTimeout does not abort briefly delayed headers", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
       Effect.promise(() => delayedHeaderServer(100)),


### PR DESCRIPTION
### Issue for this PR

Closes #39859

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Only the `openai` provider gets a default `headerTimeout` (300s). Every other provider — including the zen/`opencode` provider from the issue — waits for response headers forever. When a connection is established but silently blackholed, the CLI hangs indefinitely with no error: exactly the symptom in #39859 (log stops after `llm runtime selected`, nothing ever happens). #36029 root-caused one common trigger on Windows: the CLI connects over an IPv6 path that stays Established but never delivers data, while browsers/Electron retry over IPv4 and work — which is why the Web UI works on the same machine.

This applies the same 300s header-timeout default to all providers at the fetch layer (`packages/opencode/src/provider/provider.ts`), so a blackholed connection now fails with the existing actionable `ProviderHeaderTimeoutError` instead of hanging forever. Behavior details:

- config `headerTimeout: <ms>` still overrides, and `headerTimeout: false` still disables entirely (`??` preserves `false`);
- the OpenAI loader keeps its explicit default, unchanged;
- the timeout only covers time-to-headers — slow/long streams are unaffected once headers arrive (covered by an existing test).

One existing test was renamed (`headerTimeout is opt-in for non-OpenAI providers` → `default headerTimeout does not abort briefly delayed headers`) since it now documents the new default; its assertions are unchanged and still pass. If keeping header timeout opt-in for non-OpenAI providers was a deliberate decision, happy to hear the reasoning — but a silent infinite hang seems strictly worse than a 5-minute failure with a clear error, and anyone with a legitimately slower provider can raise or disable it in config.

### How did you verify your code works?

- `bun test test/provider/header-timeout.test.ts` — 6/6 pass (including headers-never-arrive abort and delayed-SSE-body no-abort).
- `bun test test/provider/provider.test.ts` — 99/99 pass.
- `bun typecheck` in `packages/opencode` passes; full-repo typecheck passes via the pre-push hook.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
