### PR TITLE
fix(core): await initial plugin readiness before serving catalog reads

### DIFF
--- a/packages/core/src/config/plugin/external.ts
+++ b/packages/core/src/config/plugin/external.ts
@@ -70,6 +70,8 @@ export const Plugin = define({
         }
       }
 
+      // External plugins contribute to the initial catalog, so they must finish
+      // loading before the loader seals initial readiness.
       for (const ref of configured) {
         yield* Effect.gen(function* () {
           const entrypoint = path.isAbsolute(ref.package)
@@ -86,6 +88,6 @@ export const Plugin = define({
           })
         }).pipe(Effect.ignoreCause)
       }
-    }).pipe(Effect.forkScoped({ startImmediately: true }))
+    })
   }),
 })

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -24,6 +24,14 @@ export interface Interface {
   readonly add: (id: ID, effect: PluginRuntime["effect"]) => Effect.Effect<void>
   readonly remove: (id: ID) => Effect.Effect<void>
   readonly wait: (id: ID) => Effect.Effect<void>
+  /**
+   * One-shot initial-readiness barrier. Completes once the loader's initial
+   * plugin batch has finished loading. Catalog read handlers await this so a
+   * cold start never serves a partially populated catalog as authoritative.
+   */
+  readonly flush: () => Effect.Effect<void>
+  /** Marks the end of the initial plugin batch. Called by the loader after boot. */
+  readonly sealInitial: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Plugin") {}
@@ -38,6 +46,9 @@ const layer = Layer.effect(
     const loading = new Set<ID>()
     const waiters = new Map<ID, Set<Deferred.Deferred<void>>>()
     const failures = new Map<ID, Exit.Exit<void, never>>()
+    const initialDone = yield* Deferred.make<void>()
+    let initialSealed = false
+    let initialSettled = false
     let host: Parameters<PluginRuntime["effect"]>[0]
 
     const add = Effect.fn("Plugin.add")(function* (id: ID, effect: PluginRuntime["effect"]) {
@@ -125,6 +136,22 @@ const layer = Layer.effect(
       )
     })
 
+    const sealInitial = (): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        if (initialSealed) return Effect.void
+        initialSealed = true
+        return Deferred.succeed(initialDone, undefined)
+      })
+
+    const flush = (): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        if (initialSettled) return Effect.void
+        return Deferred.await(initialDone).pipe(
+          Effect.asVoid,
+          Effect.tap(() => Effect.sync(() => (initialSettled = true))),
+        )
+      })
+
     yield* Effect.addFinalizer((exit) =>
       Effect.gen(function* () {
         active.clear()
@@ -136,6 +163,8 @@ const layer = Layer.effect(
       add,
       remove,
       wait,
+      flush,
+      sealInitial,
     })
     host = yield* PluginHost.make(service)
     return service

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -119,7 +119,7 @@ const layer = Layer.effectDiscard(
         yield* add(ConfigExternalPlugin.Plugin)
         yield* add(ConfigProviderPlugin.Plugin)
         yield* add(VariantPlugin.Plugin)
-      }),
+      }).pipe(Effect.andThen(plugin.sealInitial)),
     ).pipe(Effect.withSpan("PluginInternal.boot"), Effect.forkScoped({ startImmediately: true }))
   }),
 )

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Effect, Exit, Fiber } from "effect"
+import { Duration, Effect, Exit, Fiber } from "effect"
 import { define } from "@opencode-ai/plugin/v2/effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { PluginV2 } from "@opencode-ai/core/plugin"
@@ -66,6 +66,30 @@ describe("PluginV2", () => {
 
       yield* plugins.remove(PluginV2.ID.make("managed"))
       expect(yield* agents.get(AgentV2.ID.make("configured"))).toBeUndefined()
+    }),
+  )
+
+  it.live("flush hangs until the initial batch is sealed, then resolves", () =>
+    Effect.gen(function* () {
+      const plugins = yield* PluginV2.Service
+      yield* plugins.add(PluginV2.ID.make("fast"), () => Effect.void)
+
+      const early = yield* plugins.flush().pipe(Effect.timeout(Duration.millis(50)), Effect.exit)
+      expect(Exit.isFailure(early)).toBe(true)
+
+      yield* plugins.sealInitial()
+      yield* plugins.flush()
+    }),
+  )
+
+  it.live("flush is idempotent once the initial batch is sealed", () =>
+    Effect.gen(function* () {
+      const plugins = yield* PluginV2.Service
+      yield* plugins.sealInitial()
+      yield* plugins.flush()
+      yield* plugins.flush()
+      yield* plugins.add(PluginV2.ID.make("later"), () => Effect.void)
+      yield* plugins.flush()
     }),
   )
 })

--- a/packages/opencode/test/server/httpapi-catalog-readiness.test.ts
+++ b/packages/opencode/test/server/httpapi-catalog-readiness.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Effect, Layer } from "effect"
+import { resetDatabase } from "../fixture/db"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { httpApiLayer, request } from "./httpapi-layer"
+
+const testStateLayer = Layer.effectDiscard(
+  Effect.acquireRelease(
+    Effect.promise(() => resetDatabase()),
+    () => Effect.promise(() => resetDatabase()),
+  ),
+)
+
+const it = testEffect(Layer.mergeAll(testStateLayer, LayerNode.compile(FSUtil.node), httpApiLayer))
+const projectOptions = { config: { formatter: false, lsp: false } }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+describe("catalog cold-start readiness", () => {
+  it.instance(
+    "serves provider and model lists only after initial plugins settle",
+    Effect.gen(function* () {
+      const directory = (yield* TestInstance).directory
+      const headers = { "x-opencode-directory": directory }
+
+      // Concurrent cold-start reads must not race ahead of the initial
+      // catalog-producing plugins; both responses come from the settled catalog.
+      const [providerResponse, modelResponse] = yield* Effect.all(
+        [request("/api/provider", { headers }), request("/api/model", { headers })],
+        { concurrency: 2 },
+      )
+
+      expect(providerResponse.status).toBe(200)
+      expect(modelResponse.status).toBe(200)
+
+      const providerBody = (yield* providerResponse.json) as { data: unknown[] }
+      const modelBody = (yield* modelResponse.json) as { data: unknown[] }
+
+      // preload.ts pins OPENCODE_MODELS_PATH to test/tool/fixtures/models-api.json,
+      // which contributes requesty and xai/grok-4 through the models-dev plugin.
+      const providerIDs = new Set(
+        providerBody.data
+          .filter(isRecord)
+          .map((item) => item.id)
+          .filter((id): id is string => typeof id === "string"),
+      )
+      const modelIDs = new Set(
+        modelBody.data
+          .filter(isRecord)
+          .map((item) => item.id)
+          .filter((id): id is string => typeof id === "string"),
+      )
+      expect(providerIDs.has("requesty")).toBe(true)
+      expect(modelIDs.has("xai/grok-4")).toBe(true)
+    }),
+    projectOptions,
+    30000,
+  )
+})

--- a/packages/server/src/handlers/model.ts
+++ b/packages/server/src/handlers/model.ts
@@ -1,8 +1,20 @@
 import { Catalog } from "@opencode-ai/core/catalog"
-import { Effect } from "effect"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { Duration, Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
+import { ServiceUnavailableError } from "@opencode-ai/protocol/errors"
 import { response } from "../location"
+
+/** Cold starts must not serve a partially populated catalog as authoritative state. */
+const awaitCatalogReadiness: Effect.Effect<void, ServiceUnavailableError, PluginV2.Service> = Effect.gen(function* () {
+  yield* (yield* PluginV2.Service).flush().pipe(
+    Effect.timeout(Duration.seconds(10)),
+    Effect.catchTag("TimeoutError", () =>
+      new ServiceUnavailableError({ message: "Catalog is still initializing", service: "catalog" }),
+    ),
+  )
+})
 
 export const ModelHandler = HttpApiBuilder.group(Api, "server.model", (handlers) =>
   Effect.gen(function* () {
@@ -10,6 +22,7 @@ export const ModelHandler = HttpApiBuilder.group(Api, "server.model", (handlers)
       "model.list",
       Effect.fn(function* () {
         const catalog = yield* Catalog.Service
+        yield* awaitCatalogReadiness
         return yield* response(catalog.model.available())
       }),
     )

--- a/packages/server/src/handlers/provider.ts
+++ b/packages/server/src/handlers/provider.ts
@@ -1,9 +1,20 @@
 import { Catalog } from "@opencode-ai/core/catalog"
-import { Effect } from "effect"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { Duration, Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
-import { ProviderNotFoundError } from "@opencode-ai/protocol/errors"
+import { ProviderNotFoundError, ServiceUnavailableError } from "@opencode-ai/protocol/errors"
 import { response } from "../location"
+
+/** Cold starts must not serve a partially populated catalog as authoritative state. */
+const awaitCatalogReadiness: Effect.Effect<void, ServiceUnavailableError, PluginV2.Service> = Effect.gen(function* () {
+  yield* (yield* PluginV2.Service).flush().pipe(
+    Effect.timeout(Duration.seconds(10)),
+    Effect.catchTag("TimeoutError", () =>
+      new ServiceUnavailableError({ message: "Catalog is still initializing", service: "catalog" }),
+    ),
+  )
+})
 
 export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (handlers) =>
   Effect.gen(function* () {
@@ -12,6 +23,7 @@ export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (han
         "provider.list",
         Effect.fn(function* () {
           const catalog = yield* Catalog.Service
+          yield* awaitCatalogReadiness
           return yield* response(catalog.provider.available())
         }),
       )
@@ -19,6 +31,7 @@ export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (han
         "provider.get",
         Effect.fn(function* (ctx) {
           const catalog = yield* Catalog.Service
+          yield* awaitCatalogReadiness
           const provider = yield* catalog.provider.get(ctx.params.providerID)
           if (!provider)
             return yield* new ProviderNotFoundError({


### PR DESCRIPTION
### Issue for this PR

Closes #36117

### Type of change

- [x] Bug fix

### What does this PR do?

Cold-start catalog reads returned a successful but partial snapshot while initial catalog-producing plugins were still activating, so a client bootstrapping during that window saw incomplete providers/models as authoritative state.

PluginV2 now exposes a one-shot initial-readiness barrier (`flush`/`sealInitial`): the internal loader seals it once boot has finished, including externally configured plugins which now finish loading before boot completes. The provider.list, provider.get, and model.list handlers await the barrier before reading the catalog, returning 503 ServiceUnavailableError when readiness cannot complete within a bounded period (10s).

### How did you verify your code works?

- bun test test/plugin.test.ts (core) — 5 pass, incl. 2 new flush tests
- bun test test/server/httpapi-catalog-readiness.test.ts (opencode) — new cold-start regression, pass
- bun run typecheck (core, server) — pass
- biome check — clean

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR