### PR TITLE
fix(core): expand AWS_REGION in Bedrock Mantle base URL

### DIFF
--- a/packages/core/src/plugin/provider/amazon-bedrock.ts
+++ b/packages/core/src/plugin/provider/amazon-bedrock.ts
@@ -94,6 +94,10 @@ export const AmazonBedrockPlugin = define({
 
         options.region = region
         if (typeof options.endpoint === "string") options.baseURL = options.endpoint
+        // The catalog advertises the Mantle endpoint as a template, ie.
+        // https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1, and nothing else
+        // substitutes it on the v2 path.
+        if (typeof options.baseURL === "string") options.baseURL = options.baseURL.replaceAll("${AWS_REGION}", region)
         if (!bearerToken && options.credentialProvider === undefined) {
           // Do not gate SDK creation on explicit AWS env vars. The default chain
           // also handles ~/.aws/credentials, SSO, process creds, and instance roles.

--- a/packages/core/test/plugin/provider-amazon-bedrock.test.ts
+++ b/packages/core/test/plugin/provider-amazon-bedrock.test.ts
@@ -336,6 +336,66 @@ describe("AmazonBedrockPlugin", () => {
     ),
   )
 
+  it.effect("expands the AWS_REGION template in the catalog Mantle base URL", () =>
+    withEnv({ AWS_BEARER_TOKEN_BEDROCK: "token", AWS_PROFILE: undefined, AWS_REGION: undefined }, () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(ProviderV2.ID.amazonBedrock, ModelV2.ID.make("openai.gpt-5.6-sol")),
+            api: {
+              id: ModelV2.ID.make("openai.gpt-5.6-sol"),
+              type: "aisdk",
+              package: "@ai-sdk/amazon-bedrock/mantle",
+            },
+          }),
+          package: "@ai-sdk/amazon-bedrock/mantle",
+          options: {
+            name: "amazon-bedrock",
+            // models.dev advertises the Mantle endpoint as a template
+            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+            region: "us-east-2",
+          },
+        })
+        const language = result.sdk.responses("openai.gpt-5.6-sol")
+        expect(openAIUrl(language, "/responses", "openai.gpt-5.6-sol")).toBe(
+          "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses",
+        )
+      }),
+    ),
+  )
+
+  it.effect("expands the AWS_REGION template from the environment region", () =>
+    withEnv({ AWS_BEARER_TOKEN_BEDROCK: "token", AWS_PROFILE: undefined, AWS_REGION: "us-east-1" }, () =>
+      Effect.gen(function* () {
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(ProviderV2.ID.amazonBedrock, ModelV2.ID.make("openai.gpt-oss-safeguard-120b")),
+            api: {
+              id: ModelV2.ID.make("openai.gpt-oss-safeguard-120b"),
+              type: "aisdk",
+              package: "@ai-sdk/amazon-bedrock/mantle",
+            },
+          }),
+          package: "@ai-sdk/amazon-bedrock/mantle",
+          options: {
+            name: "amazon-bedrock",
+            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          },
+        })
+        const language = result.sdk.chat("openai.gpt-oss-safeguard-120b")
+        expect(openAIUrl(language, "/chat/completions", "openai.gpt-oss-safeguard-120b")).toBe(
+          "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+        )
+      }),
+    ),
+  )
+
   it.effect("selects Mantle APIs without Bedrock cross-region prefixes", () =>
     Effect.gen(function* () {
       const plugin = yield* PluginV2.Service

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -283,6 +283,40 @@ To use Amazon Bedrock with OpenCode:
 
    ***
 
+   #### OpenAI models on Bedrock
+
+   The `openai.*` models on Bedrock — GPT-5.6 Sol, Terra, and Luna, plus the
+   `gpt-oss` models — are served by Bedrock's OpenAI-compatible endpoint
+   (`https://bedrock-mantle.{region}.api.aws`) rather than the Converse API.
+   opencode routes them there automatically using the same authentication as the
+   rest of Bedrock, so no extra configuration is needed.
+
+   These models are available in fewer regions than the rest of the catalog:
+
+   | Model                  | Regions                               |
+   | ---------------------- | ------------------------------------- |
+   | `openai.gpt-5.6-sol`   | `us-east-1`, `us-east-2`              |
+   | `openai.gpt-5.6-terra` | `us-east-1`, `us-east-2`, `us-west-2` |
+   | `openai.gpt-5.6-luna`  | `us-east-1`, `us-east-2`, `us-west-2` |
+
+   Set `region` explicitly if your default region isn't one of them, otherwise
+   the model won't be reachable:
+
+   ```json title="opencode.json"
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "amazon-bedrock": {
+         "options": {
+           "region": "us-east-1"
+         }
+       }
+     }
+   }
+   ```
+
+   ***
+
    #### Authentication Methods
    - **`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`**: Create an IAM user and generate access keys in the AWS Console
    - **`AWS_PROFILE`**: Use named profiles from `~/.aws/credentials`. First configure with `aws configure --profile my-profile` or `aws sso login`


### PR DESCRIPTION
### Issue for this PR

Closes #40075

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The catalog gives the Mantle endpoint as a template, `https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1`. v1 substitutes it through the bedrock loader's `vars()` hook (added in #31001, expanded at `packages/opencode/src/provider/provider.ts:1712`). The v2 plugin never did: it resolves a region for the SDK but leaves `options.baseURL` alone, and `packages/core/src/aisdk.ts:80` assigns `model.api.url` verbatim. So every `openai.*` Bedrock model on v2 requested that literal hostname and could not connect.

This ports the same substitution to `packages/core/src/plugin/provider/amazon-bedrock.ts`, reusing the region the plugin already resolves (config `region` -> `AWS_REGION` -> `us-east-1`). It runs after the `endpoint` override so a VPC endpoint still wins. That matches how the other v2 plugins expand their own templates (`google-vertex.ts:78`, `cloudflare-workers-ai.ts:64`) — bedrock was simply missing it.

Also documents the Bedrock OpenAI models in `providers.mdx`: they are served by the OpenAI-compatible endpoint rather than Converse, and are in fewer regions than the rest of the catalog. A wrong region produces a failure indistinguishable from this bug, so it seemed worth writing down next to the fix.

### How did you verify your code works?

Added two tests to `packages/core/test/plugin/provider-amazon-bedrock.test.ts` — one for a config-supplied region, one for `AWS_REGION` from the env — covering both `/openai/v1` (responses) and `/v1` (chat, used by `gpt-oss-safeguard-*`). Both were red before the change:

```
Expected: "https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"
Received: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1/chat/completions"
```

From `packages/core`:

```
bun test test/plugin/command.test.ts test/plugin/provider-amazon-bedrock.test.ts
```

19 pass, 1 fail. Two caveats a reviewer will hit locally, neither caused by this change (both reproduce with it stashed):

- The provider plugin tests cannot run standalone on `dev`. `bun test test/plugin/provider-amazon-bedrock.test.ts` alone dies with `ReferenceError: Cannot access 'AmazonBedrockPlugin' before initialization` from a TDZ cycle at `packages/core/src/plugin/provider.ts:38`. Loading any non-provider test file first avoids it, hence the two paths above.
- The 1 failure is `uses SigV4 credential env when bearer token is absent`, which hits the real AWS credential chain and fails on my machine with an expired SSO token.

Also ran `bun typecheck` from `packages/core`: clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Re the duplicate bot's suggestion of #35787: that one prompts for a region during `/connect` on the v1 provider and touches `packages/opencode`. This is the v2 plugin failing to expand a catalog URL template. They do both edit the Bedrock section of `providers.mdx`, but different hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)