### PR TITLE
test(core): stabilize shell integration timing

### DIFF
--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -301,6 +301,7 @@ describe("ShellTool", () => {
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
     ),
+    { timeout: 15_000 },
   )
 
   it.live("rejects a workdir that stops being a directory during approval", () =>
@@ -472,6 +473,7 @@ describe("ShellTool", () => {
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
     ),
+    { timeout: 15_000 },
   )
 
   it.live(
@@ -538,7 +540,7 @@ describe("ShellTool", () => {
       (tmp) => {
           reset()
           return withSession(tmp.path, (registry) =>
-            executeTool(registry, call({ command: timeoutOutputCommand, timeout: isWindows ? 500 : 50 })),
+            executeTool(registry, call({ command: timeoutOutputCommand, timeout: isWindows ? 3_000 : 50 })),
           ).pipe(
             Effect.andThen((settled) =>
               Effect.sync(() => {
@@ -557,6 +559,7 @@ describe("ShellTool", () => {
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
     ),
+    { timeout: 15_000 },
   )
 
   it.live("returns the shell id for a background command", () =>


### PR DESCRIPTION
## What

Stabilize three `ShellTool` integration scenarios that have failed intermittently on Windows CI under runner contention.

## Before / After

**Before:** the stderr/mixed-output and overflow tests inherited Bun's 5-second deadline and occasionally finished just after it. The timeout-output test could terminate PowerShell after 500 ms, before PowerShell executed its first write, producing `(no output)` instead of the expected partial output.

**After:** real-process scenarios have a 15-second test deadline. The Windows timeout-output fixture gets 3 seconds to start and write before timing out its 60-second sleep, preserving the behavior under test.

## How

Only `packages/core/test/tool-shell.test.ts` changes. Production shell timeout behavior is unchanged.

## Scope

This addresses the repeated recent `ShellTool` Windows failures. Separate service-registration and config-debounce flakes observed in CI need independent diagnosis.

## Testing

- `bun run test test/tool-shell.test.ts --rerun-each 10` from `packages/core`: 170 passed
- `bun run test` from `packages/core`: 1,528 passed, 6 skipped
- `bun typecheck` from `packages/core`
- Push hook workspace typecheck: 33 packages passed
