### PR TITLE
refactor(opencode): propagate typed Skill.NotFoundError instead of defect

### DIFF
--- a/packages/opencode/specs/effect/todo.md
+++ b/packages/opencode/specs/effect/todo.md
@@ -138,12 +138,13 @@ shapes and sometimes collapse rich errors into opaque strings.
 - [x] Session HTTP error contracts tightened (#27308); busy-session
       mapping centralized (#27375, #27473).
 - [x] Provider init (#27484) and LSP init (#27494) errors typed.
+- [x] `ERR-4` part 1: [`tool/skill.ts`](../../src/tool/skill.ts) propagate typed Skill.NotFoundError instead of defect
 
 ### First PR Candidates
 
 - [ ] `HTTP-2` Audit one route group for explicit error contracts and
       decide which mappings stay inline vs. shared helper.
-- [ ] `ERR-4` Sweep remaining `NamedError.create(...)` and
+- [ ] `ERR-5` Sweep remaining `NamedError.create(...)` and
       `Effect.die(...)` callsites for expected failures — re-run `git
 grep` to build a current inventory.
 - [ ] `RENDER-2` Audit CLI and TUI surfaces for any remaining opaque

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -20,9 +20,7 @@ export const SkillTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const info = yield* skill
-            .require(params.name)
-            .pipe(Effect.catchTag("Skill.NotFoundError", (error) => Effect.die(new Error(error.message))))
+          const info = yield* skill.require(params.name)
 
           yield* ctx.ask({
             permission: "skill",


### PR DESCRIPTION
### Issue for this PR

Closes #40091

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Per `ERR-4` in `packages/opencode/specs/effect/todo.md`, clean up the
`Effect.die(...)` call in `packages/opencode/src/tool/skill.ts`. It
violates the rule in `packages/opencode/specs/effect/guide.md` that says:
Do not use `Effect.die(...)` for missing-resource failures.

### How did you verify your code works?
cd packages/opencode && bun test test/tool/skill.test.ts      
### Screenshots / recordings
<img width="467" height="134" alt="Screenshots" src="https://github.com/user-attachments/assets/cd6b1452-a4e4-427c-9d00-7858a03ab751" />

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
