### PR TITLE
fix(opencode): finish prompt loop by parent link

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1112,7 +1112,7 @@ const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -368,10 +368,10 @@ const succeedVoid = (deferred: Deferred.Deferred<void>) => {
   Effect.runSync(Deferred.succeed(deferred, void 0).pipe(Effect.ignore))
 }
 
-const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
+const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string, id = MessageID.ascending()) {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
-    id: MessageID.ascending(),
+    id,
     role: "user",
     sessionID,
     agent: "build",
@@ -388,11 +388,14 @@ const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: strin
   return msg
 })
 
-const seed = Effect.fn("test.seed")(function* (sessionID: SessionID, opts?: { finish?: string }) {
+const seed = Effect.fn("test.seed")(function* (
+  sessionID: SessionID,
+  opts?: { finish?: string; userID?: MessageID; assistantID?: MessageID },
+) {
   const session = yield* Session.Service
-  const msg = yield* user(sessionID, "hello")
+  const msg = yield* user(sessionID, "hello", opts?.userID)
   const assistant: SessionV1.Assistant = {
-    id: MessageID.ascending(),
+    id: opts?.assistantID ?? MessageID.ascending(),
     role: "assistant",
     parentID: msg.id,
     sessionID,
@@ -456,6 +459,26 @@ noLLMServer.instance(
       const result = yield* prompt.loop({ sessionID: chat.id })
       expect(result.info.role).toBe("assistant")
       if (result.info.role === "assistant") expect(result.info.finish).toBe("stop")
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
+  "loop exits when a client-generated user id sorts after its server assistant id",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      const seeded = yield* seed(chat.id, {
+        finish: "stop",
+        userID: MessageID.make("msg_ffff_client_clock"),
+        assistantID: MessageID.make("msg_0000_server_clock"),
+      })
+
+      expect(seeded.assistant.id < seeded.user.id).toBe(true)
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.id).toBe(seeded.assistant.id)
     }),
   { config: cfg },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #40098

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A finished assistant turn is linked to its user message by `parentID`. Comparing their IDs assumes the client and server clocks agree; when a client clock is ahead, the prompt loop can run the completed turn again. This uses the parent link instead and adds a regression test with deliberately reversed ID order.

### How did you verify your code works?

- Regression test times out before the fix and passes after it.
- `bun test test/session/prompt.test.ts` — 57 pass, 1 skip.
- `bun typecheck` from `packages/opencode`.
- Prettier check on both changed files.

### Screenshots / recordings

Not applicable; this is a prompt-loop fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
