### PR TITLE
fix(opencode): clear stale permission prompts

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -43,6 +43,15 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service
+    const cleanup = Effect.fn("Permission.cleanup")(function* (pending: State["pending"], item: PendingEntry) {
+      if (!pending.delete(item.info.id)) return
+      yield* events.publish(Event.Replied, {
+        sessionID: item.info.sessionID,
+        requestID: item.info.id,
+        reply: "reject",
+      })
+      yield* Deferred.fail(item.deferred, new PermissionV1.RejectedError())
+    })
     const state = yield* InstanceState.make<State>(
       Effect.fn("Permission.state")(function* (ctx) {
         void ctx
@@ -54,9 +63,8 @@ const layer = Layer.effect(
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
             for (const item of state.pending.values()) {
-              yield* Deferred.fail(item.deferred, new PermissionV1.RejectedError())
+              yield* cleanup(state.pending, item)
             }
-            state.pending.clear()
           }),
         )
 
@@ -96,14 +104,10 @@ const layer = Layer.effect(
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, PermissionV1.RejectedError | PermissionV1.CorrectedError>()
-      pending.set(id, { info, deferred })
+      const item = { info, deferred }
+      pending.set(id, item)
       yield* events.publish(Event.Asked, info)
-      return yield* Effect.ensuring(
-        Deferred.await(deferred),
-        Effect.sync(() => {
-          pending.delete(id)
-        }),
-      )
+      return yield* Effect.ensuring(Deferred.await(deferred), cleanup(pending, item))
     })
 
     const reply = Effect.fn("Permission.reply")(function* (input: PermissionV1.ReplyInput) {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -49,6 +49,34 @@ const waitForPending = (count: number) =>
     )
   })
 
+type ReplyEvent = {
+  sessionID: SessionID
+  requestID: PermissionV1.ID
+  reply: PermissionV1.Reply
+}
+
+const captureReplyEvent = (requestID: PermissionV1.ID) =>
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const seen = yield* Deferred.make<ReplyEvent>()
+    const unsub = yield* events.listen((event) => {
+      if (event.type !== Permission.Event.Replied.type) return Effect.void
+      const data = event.data as ReplyEvent
+      if (data.requestID === requestID) Deferred.doneUnsafe(seen, Effect.succeed(data))
+      return Effect.void
+    })
+    yield* Effect.addFinalizer(() => unsub)
+    return seen
+  })
+
+const waitForReplyEvent = (seen: Deferred.Deferred<ReplyEvent>) =>
+  Deferred.await(seen).pipe(
+    Effect.timeoutOrElse({
+      duration: "1 second",
+      orElse: () => Effect.fail(new Error("timed out waiting for permission reply event")),
+    }),
+  )
+
 const fail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
   Effect.gen(function* () {
     const exit = yield* self.pipe(Effect.exit)
@@ -694,6 +722,35 @@ it.instance(
   { git: true },
 )
 
+it.instance(
+  "ask - publishes rejected reply event when interrupted",
+  () =>
+    Effect.gen(function* () {
+      const seen = yield* captureReplyEvent(PermissionV1.ID.make("per_interrupt"))
+
+      const fiber = yield* ask({
+        id: PermissionV1.ID.make("per_interrupt"),
+        sessionID: SessionID.make("session_interrupt"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      yield* waitForPending(1)
+      yield* Fiber.interrupt(fiber)
+
+      expect(yield* waitForReplyEvent(seen)).toEqual({
+        sessionID: SessionID.make("session_interrupt"),
+        requestID: PermissionV1.ID.make("per_interrupt"),
+        reply: "reject",
+      })
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
 // reply tests
 
 it.instance(
@@ -1016,11 +1073,12 @@ it.live("permission requests stay isolated by directory", () =>
 )
 
 it.instance(
-  "pending permission rejects on instance dispose",
+  "pending permission rejects and publishes reply event on instance dispose",
   () =>
     Effect.gen(function* () {
       const test = yield* TestInstance
       const store = yield* InstanceStore.Service
+      const seen = yield* captureReplyEvent(PermissionV1.ID.make("per_dispose"))
       const fiber = yield* ask({
         id: PermissionV1.ID.make("per_dispose"),
         sessionID: SessionID.make("session_dispose"),
@@ -1038,6 +1096,11 @@ it.instance(
       const exit = yield* Fiber.await(fiber)
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(PermissionV1.RejectedError)
+      expect(yield* waitForReplyEvent(seen)).toEqual({
+        sessionID: SessionID.make("session_dispose"),
+        requestID: PermissionV1.ID.make("per_dispose"),
+        reply: "reject",
+      })
     }),
   { git: true },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #29422

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Interrupted or disposed permission requests were removed from the server without publishing `permission.replied`, so Web/Desktop could keep a prompt that could no longer be answered. This routes both cleanup paths through one guarded helper that removes the request, publishes a `reject` reply, and rejects the pending deferred. The delete guard prevents duplicate events after a normal reply.

### How did you verify your code works?

- Both new regression tests time out before the fix and pass after it.
- `bun test test/permission/next.test.ts` — 80 pass.
- `bun typecheck` from `packages/opencode`.
- Prettier check on both changed files.

### Screenshots / recordings

Not applicable; the stale prompt is cleared through the existing reply event reducer.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
