### PR TITLE
fix(console): order Go usage chart by request count

### DIFF
--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -65,8 +65,8 @@ function LimitsGraph(props: { href: string }) {
 
   const baseline = 100
   const graph = [
-    { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "50ms" },
     { id: "kimi-k3", name: "Kimi K3", req: 110, d: "75ms" },
+    { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "50ms" },
     { id: "glm-5.2", name: "GLM-5.2", req: 880, d: "100ms" },
     { id: "minimax-m3", name: "MiniMax M3", req: 3200, d: "210ms" },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", req: 3450, d: "270ms" },

--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -65,8 +65,8 @@ function LimitsGraph(props: { href: string }) {
 
   const baseline = 100
   const graph = [
-    { id: "kimi-k3", name: "Kimi K3", req: 110, d: "75ms" },
-    { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "50ms" },
+    { id: "kimi-k3", name: "Kimi K3", req: 110, d: "50ms" },
+    { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "75ms" },
     { id: "glm-5.2", name: "GLM-5.2", req: 880, d: "100ms" },
     { id: "minimax-m3", name: "MiniMax M3", req: 3200, d: "210ms" },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", req: 3450, d: "270ms" },


### PR DESCRIPTION
### Issue for this PR

Closes #40102

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves Kimi K3 above Grok 4.5 in the Go usage chart so its rows remain ordered by requests per five hours. Request counts and model data are unchanged.

### How did you verify your code works?

Ran `bun typecheck` from `packages/console/app` and the repository pre-push typecheck. Rendered `/go` locally from this branch and confirmed the chart starts with Kimi K3 (110), Grok 4.5 (120), then GLM-5.2 (880).

### Screenshots / recordings

#### Before

Production capture from the linked issue: Grok 4.5 (120) appears above Kimi K3 (110).

<img width="1180" height="489" alt="Before: OpenCode Go chart with Grok 4.5 above Kimi K3" src="https://github.com/user-attachments/assets/fb68fc03-b04d-4e6a-be62-3a88f9d497ad" />

#### After

Local render from this branch: Kimi K3 (110) appears above Grok 4.5 (120). All other chart rows are unchanged.

<img width="1180" height="600" alt="After: OpenCode Go chart with Kimi K3 above Grok 4.5" src="https://github.com/user-attachments/assets/cc04907c-3a8d-4fba-bff7-c6400438101e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
