### PR TITLE
docs: Add oc-supermemory-redux plugin to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
+| [oc-supermemory-redux](https://github.com/drewlius/oc-supermemory-redux)                           | Streamlined Supermemory plugin following documented best practices.                                |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control          |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                    |


### PR DESCRIPTION
### Issue for this PR

Not-Applicable. Documentation update to add new plugin to ecosystem.

### Closes #

Not-Applicable. Documentation update to add new plugin to ecosystem. 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds oc-supermemory-redux to the OpenCode ecosystem documentation as an alternative implementation of opencode-supermemory. The plugin uses one configurable containerTag, injects the Supermemory profile when a session starts, searches for relevant memories on later turns, and sends structured conversation updates through /v4/conversations. It leaves compaction to OpenCode and does not search legacy cross-application configuration or container tags. It is primarily intended for single-user installations, although separate deployments can use distinct container tags for tenant isolation.

### How did you verify your code works?

Verified the documentation entry and repository link locally. The plugin was also tested end-to-end for profile injection, per-turn search, structured conversation ingestion, direct and document memory creation, listing, forgetting, and keyword-triggered saves. Requests and container routing were cross-checked against the Supermemory web console.

### Screenshots / recordings

<img width="630" height="1116" alt="image" src="https://github.com/user-attachments/assets/0cdc9f61-67fe-4a40-ba2a-f87967286af9" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
