### PR TITLE
fix(app): prevent Enter from sending/interrupting on empty input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1378,16 +1378,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault()
       if (event.repeat) return
-      if (
-        working() &&
-        prompt
-          .current()
-          .map((part) => ("content" in part ? part.content : ""))
-          .join("")
-          .trim().length === 0 &&
-        imageAttachments().length === 0 &&
-        commentCount() === 0
-      ) {
+      if (blank()) {
         return
       }
       void handleSubmit(event)

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -172,7 +172,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
               if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
                 event.preventDefault()
                 if (event.repeat) return
-                props.controller.submit()
+                if (props.controller.canSubmit()) props.controller.submit()
               }
             }}
             onKeyUp={updateCursor}


### PR DESCRIPTION
Fixes #40106

In the desktop/web app, pressing Enter on an empty prompt input could either waste work running through the submission pipeline (V1) or silently interrupt/abort an ongoing task (V2). Both cases are wrong — Enter on empty input should be a no-op.

**V2 fix** (`packages/session-ui`): Added `canSubmit()` check before calling `controller.submit()` in the `onKeyDown` handler. The `canSubmit()` function already exists and checks for non-empty content. This matches the existing guard on the submit button.

**V1 fix** (`packages/app`): Widened the existing empty-input guard from "only when working" to "always", using the existing `blank()` memo. Previously, idle+empty Enter fell through to the `submit.ts` downstream guard, which was wasted work. Now it returns early at the keydown boundary.