### PR TITLE
feat(desktop-ui): expand scroll view thumb on hover

### DIFF
--- a/packages/app/e2e/smoke/scroll-view-hover.spec.ts
+++ b/packages/app/e2e/smoke/scroll-view-hover.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, type Locator, type Page } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { fixture, pageMessages } from "./session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { APP_READY_TIMEOUT, expectSessionTitle } from "../utils/waits"
+
+test.describe("smoke: scroll view thumb hover expansion", () => {
+  test("expands on hover, holds while dragging off the strip, and collapses after the pointer leaves", async ({
+    page,
+  }) => {
+    await mockOpenCodeServer(page, {
+      sessions: fixture.sessions,
+      provider: fixture.provider,
+      directory: fixture.directory,
+      project: fixture.project,
+      pageMessages,
+    })
+    await seedProject(page, fixture.directory)
+    await page.goto(`/${base64Encode(fixture.directory)}/session/${fixture.targetID}`)
+    await expectSessionTitle(page, fixture.expected.targetTitle)
+
+    const scroller = page.locator(".scroll-view__viewport", { has: page.locator("[data-timeline-row]") })
+    await expect(scroller).toBeVisible({ timeout: APP_READY_TIMEOUT })
+    const thumb = page
+      .locator(".scroll-view")
+      .filter({ has: page.locator("[data-timeline-row]") })
+      .locator(".scroll-view__thumb")
+    await expect(thumb).toBeAttached()
+
+    const geometry = () => thumbGeometry(thumb)
+    await expect.poll(geometry).toEqual({ strip: 12, bar: 4 })
+    const viewportWidth = await scroller.evaluate((element) => element.clientWidth)
+
+    // Hovering the thumb strip expands it as an overlay.
+    await hoverThumb(page, thumb)
+    await expect.poll(geometry).toEqual({ strip: 16, bar: 8 })
+    expect(await scroller.evaluate((element) => element.clientWidth)).toBe(viewportWidth)
+
+    // Leaving the strip collapses it again.
+    await pointAway(page, scroller)
+    await expect.poll(geometry).toEqual({ strip: 12, bar: 4 })
+
+    // The expanded state stays stable for the entire drag, even when the
+    // pointer moves off the strip, and collapses once released outside it.
+    await hoverThumb(page, thumb)
+    await expect.poll(geometry).toEqual({ strip: 16, bar: 8 })
+    const box = await thumb.boundingBox()
+    if (!box) throw new Error("Scroll thumb is not visible")
+    await page.mouse.down()
+    await expect(thumb).toHaveAttribute("data-dragging", "true")
+    await page.mouse.move(box.x - 300, box.y + box.height / 2, { steps: 5 })
+    await expect.poll(geometry).toEqual({ strip: 16, bar: 8 })
+    await page.mouse.up()
+    await expect.poll(geometry).toEqual({ strip: 12, bar: 4 })
+  })
+})
+
+async function seedProject(page: Page, directory: string) {
+  await page.addInitScript((directory) => {
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({
+        projects: {
+          local: [{ worktree: directory, expanded: true }],
+        },
+        lastProject: {
+          local: directory,
+        },
+      }),
+    )
+  }, directory)
+}
+
+async function thumbGeometry(thumb: Locator) {
+  return thumb.evaluate((element) => ({
+    strip: parseFloat(getComputedStyle(element).width),
+    bar: parseFloat(getComputedStyle(element, "::after").width),
+  }))
+}
+
+async function hoverThumb(page: Page, thumb: Locator) {
+  const box = await thumb.boundingBox()
+  if (!box) throw new Error("Scroll thumb is not visible")
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+}
+
+async function pointAway(page: Page, scroller: Locator) {
+  const box = await scroller.boundingBox()
+  if (!box) throw new Error("Timeline scroller is not visible")
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+}

--- a/packages/session-ui/src/v2/components/session-review-v2.css
+++ b/packages/session-ui/src/v2/components/session-review-v2.css
@@ -193,6 +193,7 @@
 [data-component="session-review-v2-sidebar-root"]
   [data-slot="session-review-v2-sidebar-tree"]
   .scroll-view__thumb[data-dragging="true"]::after {
+  width: 10px;
   background-color: var(--v2-border-border-strong, var(--border-strong-base));
 }
 

--- a/packages/ui/src/components/scroll-view.css
+++ b/packages/ui/src/components/scroll-view.css
@@ -24,7 +24,9 @@
   right: 0;
   top: 0;
   width: 12px;
-  transition: opacity 200ms ease;
+  transition:
+    opacity 200ms ease,
+    width 150ms ease;
   cursor: default;
   user-select: none;
   pointer-events: auto;
@@ -42,11 +44,24 @@
   border-radius: 9999px;
   background-color: var(--border-weak-base);
   backdrop-filter: blur(4px);
-  transition: background-color 150ms ease;
+  transition:
+    width 150ms ease,
+    background-color 150ms ease;
+}
+
+/* Hover-expanding overlay: widen the hit strip and visual bar so the thumb is
+   easier to acquire and drag. The thumb stays absolutely positioned, so the
+   expansion overlays content without shifting layout. data-dragging keeps the
+   expanded state stable for the whole drag even when the pointer leaves the
+   strip; collapsing is handled by :hover ending after the drag finishes. */
+.scroll-view__thumb:hover,
+.scroll-view__thumb[data-dragging="true"] {
+  width: 16px;
 }
 
 .scroll-view__thumb:hover::after,
 .scroll-view__thumb[data-dragging="true"]::after {
+  width: 8px;
   background-color: var(--border-strong-base);
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #37350

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop app's custom overlay scrollbar (the shared `ScrollView` behind the session timeline, home views, command palette, model picker, review panel, etc.) keeps a 4px thumb even while hovered, which makes the drag target hard to acquire on long sessions and high-DPI displays.

This adds the WinUI-style hover-expanding behavior from the issue:

- Hovering the thumb strip widens the visual bar 4px → 8px and the hit strip 12px → 16px with a 150ms transition.
- `data-dragging` holds the expanded state for the entire drag, even when the pointer leaves the strip mid-drag; it collapses once released outside / when hover ends.
- The thumb is absolutely positioned, so expansion is overlay-only and surrounding content does not shift (asserted in the test via unchanged viewport width).
- The session review sidebar thumb (a wider 6px variant) grows to 10px on hover for consistency.

All panes using the shared `ScrollView` get the behavior automatically. Panes that deliberately hide scrollbars (`no-scrollbar`) and embedded terminal scrollbars are unchanged.

### How did you verify your code works?

- Added `packages/app/e2e/smoke/scroll-view-hover.spec.ts`, which drives the real session timeline in Chromium against the existing mock server and asserts computed widths: idle (12/4) → hover (16/8) → leave (12/4) → drag with the pointer moved 300px off the strip (stays 16/8, `data-dragging="true"`) → release outside (12/4).
- Full `smoke/` e2e suite passes (6/6), including the existing session timeline tests.
- `bun test` for `packages/ui` scroll-view tests passes; `typecheck:e2e` is clean.

### Screenshots / recordings

Verified locally with screenshots of the three states (idle 4px bar, hover 8px bar, mid-drag with pointer off the strip still 8px). The e2e spec above asserts the same geometry.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR