### PR TITLE
feat(session): support Gemini image generation

### DIFF
--- a/packages/ai/anthropic-messages.md
+++ b/packages/ai/anthropic-messages.md
@@ -1,0 +1,184 @@
+# Anthropic Messages Protocol Support
+
+This checklist tracks correctness and parity for the native Anthropic Messages
+protocol in `src/protocols/anthropic-messages.ts`, including direct Anthropic,
+Anthropic-compatible deployments, and Claude on Google Vertex.
+
+The scope is protocol behavior: request lowering, streamed lifecycle events,
+reasoning state, tool calls and results, terminal outcomes, persistence, replay,
+and usage. Optional provider capabilities are tracked separately from baseline
+flow correctness.
+
+## Status Legend
+
+- `[x]` Implemented and covered by focused tests.
+- `[ ]` Missing, incomplete, or awaiting an unmerged fix.
+
+## Reference Baseline
+
+- [Anthropic TypeScript SDK Messages types](https://github.com/anthropics/anthropic-sdk-typescript/blob/bfa9197f0182084941052be9752c948638421601/src/resources/messages/messages.ts)
+- [Anthropic TypeScript SDK stream accumulator](https://github.com/anthropics/anthropic-sdk-typescript/blob/bfa9197f0182084941052be9752c948638421601/src/lib/MessageStream.ts)
+- [Anthropic TypeScript Vertex client](https://github.com/anthropics/anthropic-sdk-typescript/blob/bfa9197f0182084941052be9752c948638421601/packages/vertex-sdk/src/client.ts)
+- [Anthropic streaming protocol](https://platform.claude.com/docs/en/build-with-claude/streaming)
+- [Anthropic stop reasons](https://platform.claude.com/docs/en/build-with-claude/handling-stop-reasons)
+- [Anthropic mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages)
+- [Claude on Google Cloud](https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai)
+- OpenCode tracker: [#41932](https://github.com/anomalyco/opencode/issues/41932)
+
+## Change Log
+
+| Status | Change | Tracking |
+| --- | --- | --- |
+| Merged | Accept nullable Anthropic input usage without losing the `message_start` count | [#43759](https://github.com/anomalyco/opencode/issues/43759), [#43761](https://github.com/anomalyco/opencode/pull/43761) |
+| In progress | Ignore unknown named SSE events before JSON decoding | [#43765](https://github.com/anomalyco/opencode/issues/43765), [#43767](https://github.com/anomalyco/opencode/pull/43767) |
+
+Anthropic's `AnthropicVertex` client reuses the Messages API implementation. It
+rewrites Google authentication, the endpoint URL, `model`, and
+`anthropic_version`; it does not perform agent-history normalization. OpenCode's
+basic Vertex projection in `src/providers/google-vertex-messages.ts` follows the
+same model.
+
+## Request Lowering
+
+- [x] Lower initial system prompts through the top-level `system` field.
+- [x] Lower supported chronological system updates as native `system` messages.
+- [x] Reject system updates that split a local `tool_use` from its `tool_result`.
+- [x] Fall back to escaped user text when native chronological system updates are unsupported.
+- [x] Batch parallel local tool results into one immediately following user turn.
+- [x] Lower signed thinking blocks without changing their text or signature.
+- [x] Round-trip opaque `redacted_thinking` blocks.
+- [x] Lower text, supported base64 images, and PDF documents.
+- [x] Enforce Anthropic's four explicit cache-breakpoint limit.
+- [ ] Reject or safely lower visible reasoning that has no Anthropic signature. Current lowering emits an invalid unsigned `thinking` block.
+- [ ] Enforce manual thinking budget constraints: `budget_tokens >= 1024` and, outside interleaved-thinking exceptions, `budget_tokens < max_tokens`.
+- [ ] Reconcile canonical answer-token limits with Anthropic's `max_tokens`, which includes thinking output.
+- [ ] Select manual, adaptive, disabled, and always-on thinking according to model capability.
+- [ ] Suppress unsupported `temperature`, `top_p`, and `top_k` values for newer models.
+- [ ] Reject unsupported thinking and effort combinations before network I/O.
+- [ ] Normalize or reject final assistant prefills according to model capability and whitespace rules.
+- [ ] Normalize Anthropic tool-call IDs to the provider's accepted character and length constraints.
+- [ ] Filter empty request text blocks at the AI-package boundary rather than relying on Core history conversion.
+- [ ] Restrict base64 image MIME types to JPEG, PNG, GIF, and WebP.
+- [ ] Support URL image/document sources, plain-text/content documents, search-result blocks, and tool references where available.
+- [ ] Model typed request metadata and current request controls instead of requiring raw HTTP body overlays.
+
+## Stream Lifecycle
+
+- [x] Parse text, thinking, signature, and tool-input deltas.
+- [x] Emit canonical text and reasoning start, delta, and end events.
+- [x] Assemble streamed tool JSON and emit one terminal local tool call.
+- [x] Settle pending streamed tool calls at `message_stop`.
+- [x] Require a canonical terminal event before transport EOF.
+- [x] Reject canonical events emitted after a terminal event.
+- [ ] Require exactly one `message_start` before message or content events.
+- [ ] Reject duplicate `message_start` events.
+- [ ] Track open content-block indexes and reject deltas or stops without matching starts.
+- [ ] Reject duplicate block starts and stops.
+- [ ] Distinguish a normal `content_block_stop` from cleanup at `message_stop` or transport interruption.
+- [ ] Require a valid terminal message delta and stop reason before accepting `message_stop`.
+- [ ] Reject a standalone `message_stop` instead of manufacturing an unknown successful finish.
+- [ ] Preserve abnormal closure state for interrupted text, reasoning, and tool input.
+- [x] Ignore unknown named SSE events before decoding their data payload while keeping recognized non-empty event payloads strict. Tracked by [#43765](https://github.com/anomalyco/opencode/issues/43765) and [#43767](https://github.com/anomalyco/opencode/pull/43767).
+- [ ] Preserve citation deltas and attach them to their text blocks.
+- [ ] Fail safely on unknown replay-critical content blocks instead of silently dropping them.
+
+## Terminal Outcomes
+
+- [x] Preserve raw stop reasons alongside normalized finish reasons.
+- [x] Map `end_turn` and `stop_sequence` to normal stop.
+- [x] Map `max_tokens` and `model_context_window_exceeded` to length.
+- [x] Map `tool_use` to tool continuation.
+- [x] Map `refusal` to content-filter outcome.
+- [ ] Treat `pause_turn` as a continuation requirement by replaying the assistant content immediately. It is currently normalized as an ordinary stop.
+- [ ] Preserve structured refusal `stop_details`, including category and explanation.
+- [ ] Discard or quarantine partial visible output when a streamed refusal requires it.
+- [ ] Retain response ID, actual served model, container state, initial message metadata, and complete stop diagnostics.
+- [ ] Apply a runner-level policy for valid empty `end_turn` responses when the product requires usable output. Empty `end_turn` is valid Anthropic protocol and must not be rejected by the adapter itself.
+
+## Compaction And Context Management
+
+- [ ] Model native context-management request options.
+- [ ] Parse `compaction` content blocks and `compaction_delta` events.
+- [ ] Preserve compaction `content` and opaque `encrypted_content` exactly.
+- [ ] Persist and replay compaction blocks across stateless requests.
+- [ ] Map the compaction stop reason to a continuation outcome.
+- [ ] Include compaction, advisor, fallback, and message iterations in usage accounting.
+- [ ] Fail safely when raw HTTP overlays enable unsupported context management. Current behavior can silently drop compaction output and report an empty unknown completion.
+
+## Hosted Tools
+
+- [x] Parse and replay `server_tool_use` blocks.
+- [x] Parse and replay web-search, web-fetch, and code-execution result payloads.
+- [x] Mark hosted calls and results as provider-executed so local dispatch is skipped.
+- [ ] Lower `ToolDefinition.native` into Anthropic hosted-tool definitions.
+- [ ] Support current web search, web fetch, code execution, bash, editor, memory, and tool-search request definitions where deployed.
+- [ ] Preserve bash, editor, tool-search, and container-upload response blocks.
+- [ ] Preserve `caller` provenance and container continuation state.
+- [ ] Support strict schemas, deferred loading, tool references, and eager input streaming.
+- [ ] Gate hosted-tool definitions and result families by deployment capability, especially on Vertex.
+
+## Usage And Accounting
+
+- [x] Merge usage split between `message_start` and `message_delta`.
+- [x] Preserve unknown Anthropic usage fields in provider metadata.
+- [x] Normalize cache-read, cache-write, non-cached input, output, and thinking-token counts.
+- [x] Accept nullable `message_delta.usage.input_tokens` while retaining the earlier start count for normalized usage. Implemented by [PR #43761](https://github.com/anomalyco/opencode/pull/43761).
+- [ ] Normalize the five-minute and one-hour cache-write split for accurate costing.
+- [ ] Aggregate iteration usage once at terminal completion without double counting.
+
+## Google Vertex
+
+- [x] Remove `model` from the body and place it in the Vertex endpoint URL.
+- [x] Add `anthropic_version: "vertex-2023-10-16"` to the request body.
+- [x] Use `streamRawPredict` for streaming requests.
+- [x] Support global, `us`, `eu`, and regional endpoint hosts.
+- [x] Support explicit access tokens and lazy Application Default Credentials.
+- [ ] Resolve project identity from the Google auth client or quota-project header when not configured explicitly.
+- [ ] Preserve all Google auth headers, including quota-project headers, rather than reducing authentication to a bearer token.
+- [ ] Classify transient ADC acquisition failures as retryable transport failures instead of missing credentials.
+- [ ] Handle the Vertex terminal-system-after-tool-result divergence without treating the workaround as the canonical Messages representation. Tracked by [#43478](https://github.com/anomalyco/opencode/issues/43478) and [PR #43498](https://github.com/anomalyco/opencode/pull/43498).
+
+Anthropic documents a terminal system message immediately after a `tool_result`
+as valid and supported on Google Cloud. Vertex nevertheless returns 404 for the
+reported continuation shape. Folding the update into the user tool-result turn
+avoids the deployment error, but lowers system authority and adds text after a
+tool result, which can cause an empty `end_turn`. Treat this as deployment
+capability policy rather than a change to the canonical Messages protocol.
+
+## Comparison With Pi
+
+| Area | OpenCode | pi |
+| --- | --- | --- |
+| Unknown named SSE events | Filters before JSON parsing | Filters before JSON parsing |
+| Response ID and refusal details | Missing | Preserved |
+| Unsigned thinking replay | Emits invalid thinking | Safely lowers to text by default |
+| Empty request content | Core filters some paths | Adapter filters directly |
+| Tool-call ID normalization | Missing | Implemented |
+| Temperature compatibility | Missing | Model compatibility driven |
+| One-hour cache-write accounting | Raw metadata only | Normalized for costing |
+| Vertex Anthropic | First-class route | Available through custom `AnthropicVertex` client injection |
+| Required terminal EOF | Enforced | Less strict |
+| Parallel tool-result batching | Implemented | Implemented |
+| Pending tool settlement | Implemented | Implemented |
+| Redacted-thinking replay | Implemented | Implemented |
+| PDF and media tool results | Implemented | Narrower support |
+| Native compaction | Missing | Missing |
+| `pause_turn` continuation | Missing | Missing |
+
+## Confirmed Non-Gaps
+
+- [x] Treat `signature_delta.signature` as the complete signature value. Anthropic documents one signature delta before block stop, and the official `MessageStream` also replaces rather than appends it. Appending is optional proxy tolerance.
+- [x] Accept empty `end_turn` as a valid provider response. Product-level recovery may request continuation, but the protocol must preserve the valid outcome.
+- [x] Require `message_stop` before clean completion. OpenCode is stricter than Anthropic's raw SDK stream here.
+
+## Suggested Work Order
+
+- [x] Merge nullable input usage support in [PR #43761](https://github.com/anomalyco/opencode/pull/43761).
+- [ ] Handle unsigned reasoning replay.
+- [ ] Restrict image MIME types.
+- [ ] Validate manual thinking budgets.
+- [ ] Preserve response identity and refusal details.
+- [x] Filter unknown named SSE events while preserving strict recognized-event decoding.
+- [ ] Enforce the complete stream lifecycle grammar.
+- [ ] Add native compaction representation, persistence, and replay.
+- [ ] Complete hosted-tool request and response support.

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -341,10 +341,25 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
       // Parallel Gemini 3 calls may carry one signature on the first call; unsigned sibling calls are valid.
       let hasSignedToolCall = false
       for (const part of message.content) {
-        if (!ProviderShared.supportsContent(part, ["text", "reasoning", "tool-call"]))
-          return yield* ProviderShared.unsupportedContent("Gemini", "assistant", ["text", "reasoning", "tool-call"])
+        if (!ProviderShared.supportsContent(part, ["text", "media", "reasoning", "tool-call"]))
+          return yield* ProviderShared.unsupportedContent("Gemini", "assistant", [
+            "text",
+            "media",
+            "reasoning",
+            "tool-call",
+          ])
         if (part.type === "text") {
           parts.push({ text: part.text, thoughtSignature: thoughtSignature(part.providerMetadata) })
+          continue
+        }
+        if (part.type === "media") {
+          const media = ProviderShared.normalizeMedia(part)
+          parts.push({
+            inlineData: { mimeType: media.mime, data: media.base64 },
+            thoughtSignature:
+              thoughtSignature(part.providerMetadata) ??
+              (media.mime.startsWith("image/") ? SKIP_THOUGHT_SIGNATURE_VALIDATOR : undefined),
+          })
           continue
         }
         if (part.type === "reasoning") {

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -98,6 +98,8 @@ const GeminiInlineDataPart = Schema.Struct({
     mimeType: Schema.String,
     data: Schema.String,
   }),
+  thought: Schema.optional(Schema.Boolean),
+  thoughtSignature: Schema.optional(Schema.String),
 })
 type GeminiInlineDataPart = Schema.Schema.Type<typeof GeminiInlineDataPart>
 
@@ -650,6 +652,27 @@ const step = (state: ParserState, event: GeminiEvent) => {
         textSignature ? googleMetadata({ thoughtSignature: textSignature }) : undefined,
       )
       textSignature = undefined
+      continue
+    }
+
+    if ("inlineData" in part) {
+      if (part.thought) continue
+      lifecycle = Lifecycle.reasoningEnd(
+        lifecycle,
+        events,
+        "reasoning-0",
+        reasoningSignature ? googleMetadata({ thoughtSignature: reasoningSignature }) : undefined,
+      )
+      lifecycle = Lifecycle.stepStart(lifecycle, events)
+      events.push(
+        LLMEvent.file({
+          mediaType: part.inlineData.mimeType,
+          data: part.inlineData.data,
+          providerMetadata: part.thoughtSignature
+            ? googleMetadata({ thoughtSignature: part.thoughtSignature })
+            : undefined,
+        }),
+      )
       continue
     }
 

--- a/packages/ai/src/schema/events.ts
+++ b/packages/ai/src/schema/events.ts
@@ -138,6 +138,14 @@ export const ReasoningEnd = Schema.Struct({
 }).annotate({ identifier: "LLM.Event.ReasoningEnd" })
 export type ReasoningEnd = Schema.Schema.Type<typeof ReasoningEnd>
 
+export const File = Schema.Struct({
+  type: Schema.tag("file"),
+  mediaType: Schema.String,
+  data: Schema.Union([Schema.String, Schema.Uint8Array]),
+  providerMetadata: Schema.optional(ProviderMetadata),
+}).annotate({ identifier: "LLM.Event.File" })
+export type File = Schema.Schema.Type<typeof File>
+
 export const ToolInputStart = Schema.Struct({
   type: Schema.tag("tool-input-start"),
   id: ToolCallID,
@@ -244,6 +252,7 @@ const llmEventTagged = Schema.Union([
   ReasoningStart,
   ReasoningDelta,
   ReasoningEnd,
+  File,
   ToolInputStart,
   ToolInputDelta,
   ToolInputEnd,
@@ -280,6 +289,7 @@ export const LLMEvent = Object.assign(llmEventTagged, {
     ReasoningDelta.make({ ...input, id: contentBlockID(input.id) }),
   reasoningEnd: (input: WithID<ReasoningEnd, ContentBlockID>) =>
     ReasoningEnd.make({ ...input, id: contentBlockID(input.id) }),
+  file: File.make,
   toolInputStart: (input: WithID<ToolInputStart, ToolCallID>) =>
     ToolInputStart.make({ ...input, id: toolCallID(input.id) }),
   toolInputDelta: (input: WithID<ToolInputDelta, ToolCallID>) =>
@@ -314,6 +324,7 @@ export const LLMEvent = Object.assign(llmEventTagged, {
     reasoningStart: llmEventTagged.guards["reasoning-start"],
     reasoningDelta: llmEventTagged.guards["reasoning-delta"],
     reasoningEnd: llmEventTagged.guards["reasoning-end"],
+    file: llmEventTagged.guards.file,
     toolInputStart: llmEventTagged.guards["tool-input-start"],
     toolInputDelta: llmEventTagged.guards["tool-input-delta"],
     toolInputEnd: llmEventTagged.guards["tool-input-end"],

--- a/packages/ai/src/schema/events.ts
+++ b/packages/ai/src/schema/events.ts
@@ -553,6 +553,13 @@ const reduceToolCall = (state: ResponseState, event: ToolCall): ResponseState =>
 const reduceResponseState = (state: ResponseState, event: LLMEvent): ResponseState => {
   const next = appendEvent(state, event)
   switch (event.type) {
+    case "file":
+      return appendContent(next, {
+        type: "media",
+        mediaType: event.mediaType,
+        data: event.data,
+        providerMetadata: event.providerMetadata,
+      })
     case "text-start":
       return ensureText(next, event.id, event.providerMetadata)
     case "text-delta":

--- a/packages/ai/src/schema/messages.ts
+++ b/packages/ai/src/schema/messages.ts
@@ -53,6 +53,7 @@ export const MediaPart = Schema.Struct({
   filename: Schema.optional(Schema.String),
   cache: Schema.optional(CacheHint),
   metadata: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  providerMetadata: Schema.optional(ProviderMetadata),
 }).annotate({ identifier: "LLM.Content.Media" })
 export type MediaPart = Schema.Schema.Type<typeof MediaPart>
 

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -1217,6 +1217,36 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("preserves thoughtSignature from a final empty text chunk", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { candidates: [{ content: { role: "model", parts: [{ text: "hello" }] } }] },
+              {
+                candidates: [
+                  {
+                    content: { role: "model", parts: [{ text: "", thoughtSignature: "text_sig" }] },
+                    finishReason: "STOP",
+                  },
+                ],
+              },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.message.content).toEqual([
+        {
+          type: "text",
+          text: "hello",
+          providerMetadata: { google: { thoughtSignature: "text_sig" } },
+        },
+      ])
+    }),
+  )
+
   it.effect("emits streamed tool calls and maps finish reason", () =>
     Effect.gen(function* () {
       const body = sseEvents({
@@ -1340,7 +1370,7 @@ describe("Gemini route", () => {
             content: {
               role: "model",
               parts: [
-                { text: "[IMAGE]" },
+                { text: "[IMAGE]", thoughtSignature: "final_text" },
                 {
                   inlineData: { mimeType: "image/png", data: "ignored" },
                   thought: true,
@@ -1366,8 +1396,17 @@ describe("Gemini route", () => {
       })
       expect(response.events.filter((event) => event.type === "file")).toHaveLength(1)
       expect(response.message.content).toEqual([
-        { type: "text", text: "[IMAGE]" },
-        { type: "media", mediaType: "image/png", data: "AAECAw==" },
+        {
+          type: "text",
+          text: "[IMAGE]",
+          providerMetadata: { google: { thoughtSignature: "final_text" } },
+        },
+        {
+          type: "media",
+          mediaType: "image/png",
+          data: "AAECAw==",
+          providerMetadata: { google: { thoughtSignature: "final_image" } },
+        },
       ])
     }),
   )
@@ -1660,19 +1699,68 @@ describe("Gemini route", () => {
     }),
   )
 
-  it.effect("rejects unsupported assistant media content", () =>
+  it.effect("replays generated assistant images for conversational editing", () =>
     Effect.gen(function* () {
-      const error = yield* compileRequest(
+      const prepared = yield* compileRequest(
         LLM.request({
           id: "req_media",
           model,
+          messages: [
+            Message.assistant([
+              {
+                type: "text",
+                text: "Here is the dinosaur.",
+                providerMetadata: { google: { thoughtSignature: "text-signature" } },
+              },
+              {
+                type: "media",
+                mediaType: "image/png",
+                data: "data:image/png;base64,AAECAw==",
+                providerMetadata: { google: { thoughtSignature: "image-signature" } },
+              },
+            ]),
+            Message.user("Make it a T-Rex."),
+          ],
+        }),
+      )
+
+      expect(prepared.body.contents).toEqual([
+        {
+          role: "model",
+          parts: [
+            { text: "Here is the dinosaur.", thoughtSignature: "text-signature" },
+            {
+              inlineData: { mimeType: "image/png", data: "AAECAw==" },
+              thoughtSignature: "image-signature",
+            },
+          ],
+        },
+        { role: "user", parts: [{ text: "Make it a T-Rex." }] },
+      ])
+    }),
+  )
+
+  it.effect("replays legacy generated images with Gemini's signature validator bypass", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          id: "req_legacy_media",
+          model,
           messages: [Message.assistant({ type: "media", mediaType: "image/png", data: "AAECAw==" })],
         }),
-      ).pipe(Effect.flip)
-
-      expect(error.message).toContain(
-        "Gemini assistant messages only support text, reasoning, and tool-call content for now",
       )
+
+      expect(prepared.body.contents).toEqual([
+        {
+          role: "model",
+          parts: [
+            {
+              inlineData: { mimeType: "image/png", data: "AAECAw==" },
+              thoughtSignature: "skip_thought_signature_validator",
+            },
+          ],
+        },
+      ])
     }),
   )
 })

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -1332,6 +1332,46 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("emits generated inline images as file events", () =>
+    Effect.gen(function* () {
+      const body = sseEvents({
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                { text: "[IMAGE]" },
+                {
+                  inlineData: { mimeType: "image/png", data: "ignored" },
+                  thought: true,
+                  thoughtSignature: "thought_image",
+                },
+                {
+                  inlineData: { mimeType: "image/png", data: "AAECAw==" },
+                  thoughtSignature: "final_image",
+                },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      })
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.events.find((event) => event.type === "file")).toEqual({
+        type: "file",
+        mediaType: "image/png",
+        data: "AAECAw==",
+        providerMetadata: { google: { thoughtSignature: "final_image" } },
+      })
+      expect(response.events.filter((event) => event.type === "file")).toHaveLength(1)
+      expect(response.message.content).toEqual([
+        { type: "text", text: "[IMAGE]" },
+        { type: "media", mediaType: "image/png", data: "AAECAw==" },
+      ])
+    }),
+  )
+
   it.effect("assigns unique ids to multiple streamed tool calls", () =>
     Effect.gen(function* () {
       const body = sseEvents({

--- a/packages/ai/test/schema.test.ts
+++ b/packages/ai/test/schema.test.ts
@@ -65,6 +65,14 @@ describe("llm schema", () => {
     expect(LLMEvent.finish({ reason: { normalized: "stop" }, usage: { outputTokens: 2 } }).usage).toBeInstanceOf(Usage)
   })
 
+  test("decodes generated file events", () => {
+    expect(decodeLLMEvent({ type: "file", mediaType: "image/png", data: "iVBORw0KGgo=" })).toMatchObject({
+      type: "file",
+      mediaType: "image/png",
+      data: "iVBORw0KGgo=",
+    })
+  })
+
   test("content part tagged union exposes guards", () => {
     expect(ContentPart.guards.text({ type: "text", text: "hi" })).toBe(true)
     expect(ContentPart.guards.media({ type: "text", text: "hi" })).toBe(false)

--- a/packages/cli/src/acp/event.ts
+++ b/packages/cli/src/acp/event.ts
@@ -478,6 +478,15 @@ async function replayMessage(
       })
       continue
     }
+    if (part.type === "file") {
+      for (const chunk of partsToContentChunks([part])) {
+        await connection.sessionUpdate({
+          sessionId: sessionID,
+          update: { sessionUpdate: "agent_message_chunk", messageId: message.id, ...chunk },
+        })
+      }
+      continue
+    }
     await connection.sessionUpdate({
       sessionId: sessionID,
       update: {

--- a/packages/cli/src/run/noninteractive.ts
+++ b/packages/cli/src/run/noninteractive.ts
@@ -571,6 +571,7 @@ export async function runNonInteractivePrompt(input: Input) {
           writeReasoning(part, timestamp)
           continue
         }
+        if (item.type === "file") continue
 
         const key = toolKey(message.id, item.id)
         if (renderedTools.has(key) || item.state.status === "streaming" || item.state.status === "running") continue

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -775,6 +775,19 @@ export type SessionLogOutput =
           readonly id: Event.ID
           readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
+          readonly type: "session.file.generated"
+          readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
+          readonly location?: Location.Ref | undefined
+          readonly data: {
+            readonly sessionID: Session.ID
+            readonly assistantMessageID: SessionMessage.ID
+            readonly file: SessionMessage.AssistantFile
+          }
+        }
+      | {
+          readonly id: Event.ID
+          readonly created: DateTime.Utc
+          readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.input.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
           readonly location?: Location.Ref | undefined

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -904,6 +904,14 @@ export function createData(config: CreateDataInput) {
           }
         })
         return
+      case "session.file.generated":
+        message.update(event.data.sessionID, (draft, index) => {
+          const assistant = message.assistant(draft, index, event.data.assistantMessageID)
+          if (!assistant || assistant.content.some((content) => content.type === "file" && content.id === event.data.file.id))
+            return
+          assistant.content.push(event.data.file)
+        })
+        return
       case "session.retry.scheduled":
         message.update(event.data.sessionID, (draft, index) => {
           const currentAssistant = message.assistant(draft, index, event.data.assistantMessageID)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -147,6 +147,7 @@ const serialize = (message: SessionMessage.Info) => {
       .flatMap((part) => {
         if (part.type === "text") return [`[Assistant]: ${part.text}`]
         if (part.type === "reasoning") return part.text ? [`[Assistant reasoning]: ${part.text}`] : []
+        if (part.type === "file") return [`[Assistant file]: ${part.filename ?? part.mime}`]
         const input = typeof part.state.input === "string" ? part.state.input : JSON.stringify(part.state.input)
         if (part.state.status === "completed")
           return [

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -373,6 +373,11 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           }
         })
       },
+      "session.file.generated": (event) => {
+        return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
+          draft.content.push(castDraft(event.data.file))
+        })
+      },
       "session.retry.scheduled": (event) => {
         return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
           draft.retry = {

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -661,6 +661,7 @@ const layer = Layer.effectDiscard(
     yield* bus.project(SessionEvent.Tool.Failed, (event) => run(db, event))
     yield* bus.project(SessionEvent.Reasoning.Started, (event) => run(db, event))
     yield* bus.project(SessionEvent.Reasoning.Ended, (event) => run(db, event))
+    yield* bus.project(SessionEvent.File.Generated, (event) => run(db, event))
     yield* bus.project(SessionEvent.RetryScheduled, (event) => run(db, event))
     yield* bus.project(SessionEvent.Compaction.Started, (event) => run(db, event))
     yield* bus.project(SessionEvent.Compaction.Ended, (event) =>

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -103,6 +103,8 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
   let stepFailed = false
   let providerFailed = false
   let outputStarted = false
+  let retryEvidence = false
+  let nextFile = 0
   let stepFailure: SessionError.Error | undefined
   let stepSettlement: StepRecord["finish"]
 
@@ -415,6 +417,25 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
       case "reasoning-end":
         yield* reasoning.end(event.id, providerState(event.providerMetadata))
         return
+      case "file": {
+        retryEvidence = true
+        const messageID = yield* startAssistant()
+        const index = nextFile++
+        const id = `generated-${messageID}-${index}`
+        yield* bus.publish(SessionEvent.File.Generated, {
+          sessionID: input.sessionID,
+          assistantMessageID: messageID,
+          file: {
+            type: "file",
+            id,
+            mime: event.mediaType,
+            filename: `${id}.${fileExtension(event.mediaType)}`,
+            url: fileDataUrl(event),
+            state: providerState(event.providerMetadata),
+          },
+        })
+        return
+      }
       case "tool-input-start":
         outputStarted = true
         yield* startToolInput(event)
@@ -600,4 +621,19 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     startAssistant,
     assistantMessageID: assistantMessageIDForTool,
   }
+}
+
+function fileDataUrl(event: Extract<LLMEvent, { type: "file" }>) {
+  if (typeof event.data === "string") {
+    if (event.data.startsWith("data:")) return event.data
+    return `data:${event.mediaType};base64,${event.data}`
+  }
+  return `data:${event.mediaType};base64,${Buffer.from(event.data).toString("base64")}`
+}
+
+function fileExtension(mediaType: string) {
+  const subtype = mediaType.split(";")[0]?.split("/")[1]?.toLowerCase()
+  if (subtype === "jpeg") return "jpg"
+  if (subtype === "svg+xml") return "svg"
+  return subtype?.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "bin"
 }

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -169,6 +169,16 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
         : item.text.length > 0
           ? [{ type: "text", text: item.text }]
           : []
+    if (item.type === "file")
+      return [
+        {
+          type: "media",
+          mediaType: item.mime,
+          data: item.url,
+          filename: item.filename,
+          providerMetadata: reuseProviderMetadata ? providerMetadata(providerMetadataKey, item.state) : undefined,
+        },
+      ]
     // Call-side metadata is model-scoped proof of generation (Gemini thought
     // signatures, OpenAI encrypted reasoning): only the producing model may
     // replay it.
@@ -197,8 +207,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
     return result ? [call, result] : [call]
   })
   const meaningful = content.filter((part) => {
-    if (part.type === "text") return part.text !== ""
-    if (part.type !== "reasoning") return true
+    if (part.type !== "text" && part.type !== "reasoning") return true
     return part.text !== "" || (part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
   })
   const results = message.content

--- a/packages/core/src/session/transfer.ts
+++ b/packages/core/src/session/transfer.ts
@@ -263,6 +263,14 @@ function sanitizeMessage(message: SessionMessage.Info): SessionMessage.Info {
             text: redact("reasoning", message.id, content.text),
             state: content.state ? { redacted: `reasoning-state:${message.id}` } : undefined,
           }
+        if (content.type === "file")
+          return {
+            ...content,
+            filename:
+              content.filename === undefined ? undefined : redact("assistant-file-name", content.id, content.filename),
+            url: redact("assistant-file-url", content.id, content.url),
+            state: content.state ? { redacted: `file-state:${message.id}` } : undefined,
+          }
         return {
           ...content,
           providerState: content.providerState ? { redacted: `tool-provider-state:${message.id}` } : undefined,

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -1160,6 +1160,7 @@ describe("SessionTransfer", () => {
       const template = yield* session.create({ location, title: "Exported" })
       const sessionID = Session.ID.create()
       const sourceMessageID = SessionMessage.ID.create()
+      const assistantMessageID = SessionMessage.ID.create()
       const errorMessageID = SessionMessage.ID.create()
 
       const imported = yield* transfer.import({
@@ -1181,12 +1182,29 @@ describe("SessionTransfer", () => {
               time: { created: DateTime.makeUnsafe(100) },
             },
             {
+              id: assistantMessageID,
+              type: "assistant",
+              agent: Agent.defaultID,
+              model: { id: Model.ID.make("model"), providerID: Provider.ID.make("provider") },
+              content: [
+                {
+                  type: "file",
+                  id: "file_1",
+                  mime: "image/png",
+                  filename: "secret.png",
+                  url: "data:image/png;base64,aW1hZ2U=",
+                  state: { thoughtSignature: "secret" },
+                },
+              ],
+              time: { created: DateTime.makeUnsafe(101) },
+            },
+            {
               id: errorMessageID,
               type: "compaction",
               status: "failed",
               reason: "manual",
               error: { type: "test_error", message: "Original error" },
-              time: { created: DateTime.makeUnsafe(101) },
+              time: { created: DateTime.makeUnsafe(102) },
             },
           ],
         },
@@ -1198,9 +1216,10 @@ describe("SessionTransfer", () => {
       expect(imported.time).toMatchObject({ idle: DateTime.makeUnsafe(200), viewed: DateTime.makeUnsafe(150) })
       expect(messages).toMatchObject([
         { id: sourceMessageID, type: "user", text: "Imported message" },
+        { id: assistantMessageID, type: "assistant" },
         { id: errorMessageID, type: "compaction", error: { type: "test_error", message: "Original error" } },
       ])
-      expect(yield* Bus.latestSequence(db, sessionID)).toBe(2)
+      expect(yield* Bus.latestSequence(db, sessionID)).toBe(3)
       const exported = yield* transfer.export({ sessionID })
       expect(exported.info.time).toMatchObject({ idle: DateTime.makeUnsafe(200), viewed: DateTime.makeUnsafe(150) })
       expect(exported.messages).toEqual(messages)
@@ -1208,6 +1227,17 @@ describe("SessionTransfer", () => {
       expect(sanitized.info.time).toMatchObject({ idle: DateTime.makeUnsafe(200), viewed: DateTime.makeUnsafe(150) })
       expect(sanitized.messages).toMatchObject([
         { id: sourceMessageID, text: `[redacted:text:${sourceMessageID}]` },
+        {
+          id: assistantMessageID,
+          content: [
+            {
+              type: "file",
+              filename: "[redacted:assistant-file-name:file_1]",
+              url: "[redacted:assistant-file-url:file_1]",
+              state: { redacted: `file-state:${assistantMessageID}` },
+            },
+          ],
+        },
         { id: errorMessageID, error: { type: "test_error", message: "Original error" } },
       ])
 
@@ -1216,10 +1246,11 @@ describe("SessionTransfer", () => {
 
       expect((yield* session.messages({ sessionID, order: "asc" })).map((message) => message.type)).toEqual([
         "user",
+        "assistant",
         "compaction",
         "user",
       ])
-      expect(yield* Bus.latestSequence(db, sessionID)).toBe(4)
+      expect(yield* Bus.latestSequence(db, sessionID)).toBe(5)
     }),
   )
 

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -34,6 +34,9 @@ describe("toLLMMessages", () => {
       [
         assistant("empty", []),
         assistant("empty-text", [SessionMessage.AssistantText.make({ type: "text", text: "" })]),
+        assistant("empty-text-state", [
+          SessionMessage.AssistantText.make({ type: "text", text: "", state: { thoughtSignature: "sig_0" } }),
+        ]),
         assistant("empty-reasoning", [SessionMessage.AssistantReasoning.make({ type: "reasoning", text: "" })]),
         assistant("text", [SessionMessage.AssistantText.make({ type: "text", text: "Partial" })]),
         assistant("reasoning", [
@@ -47,7 +50,45 @@ describe("toLLMMessages", () => {
       model,
     )
 
-    expect(messages.map((message) => message.id)).toEqual([id("text"), id("reasoning")])
+    expect(messages.map((message) => message.id)).toEqual([id("empty-text-state"), id("text"), id("reasoning")])
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "", providerMetadata: { provider: { thoughtSignature: "sig_0" } } },
+    ])
+  })
+
+  test("restores generated file provider metadata", () => {
+    const messages = toLLMMessages(
+      [
+        SessionMessage.Assistant.make({
+          id: id("generated-file"),
+          type: "assistant",
+          agent: build,
+          model,
+          content: [
+            SessionMessage.AssistantFile.make({
+              type: "file",
+              id: "generated-image",
+              mime: "image/png",
+              filename: "generated-image.png",
+              url: "data:image/png;base64,aGVsbG8=",
+              state: { thoughtSignature: "image-signature" },
+            }),
+          ],
+          time: { created, completed: created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages[0]?.content).toEqual([
+      {
+        type: "media",
+        mediaType: "image/png",
+        data: "data:image/png;base64,aGVsbG8=",
+        filename: "generated-image.png",
+        providerMetadata: { provider: { thoughtSignature: "image-signature" } },
+      },
+    ])
   })
 
   test("maps every top-level Session message type", () => {

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -176,6 +176,30 @@ test("provider metadata is flattened using the route key", async () => {
   })
 })
 
+test("model-generated files are persisted as assistant content", async () => {
+  const { published, publisher } = capture("google")
+  await Effect.runPromise(
+    publisher.publish(
+      LLMEvent.file({
+        mediaType: "image/png",
+        data: new TextEncoder().encode("image"),
+        providerMetadata: { google: { thoughtSignature: "image-signature" } },
+      }),
+    ),
+  )
+
+  expect(published.map((event) => event.type)).toEqual(["session.step.started.1", "session.file.generated.1"])
+  expect(published.at(-1)?.data).toMatchObject({
+    sessionID,
+    file: {
+      type: "file",
+      mime: "image/png",
+      url: "data:image/png;base64,aW1hZ2U=",
+      state: { thoughtSignature: "image-signature" },
+    },
+  })
+})
+
 test("reasoning state from start, empty delta, and end is merged", async () => {
   const { published, publisher } = capture()
   await Effect.runPromise(

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -417,6 +417,19 @@ export namespace Reasoning {
   export type Ended = typeof Ended.Type
 }
 
+export namespace File {
+  export const Generated = Event.durable({
+    type: "session.file.generated",
+    ...options,
+    schema: {
+      ...Base,
+      assistantMessageID: SessionMessage.ID,
+      file: SessionMessage.AssistantFile,
+    },
+  })
+  export type Generated = typeof Generated.Type
+}
+
 export namespace Tool {
   const ToolBase = {
     ...Base,
@@ -624,6 +637,7 @@ export const Definitions = Event.inventory(
   Reasoning.Started,
   Reasoning.Delta,
   Reasoning.Ended,
+  File.Generated,
   Tool.Input.Started,
   Tool.Input.Delta,
   Tool.Input.Ended,

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -190,10 +190,20 @@ export const AssistantReasoning = Schema.Struct({
   }).pipe(optional),
 }).annotate({ identifier: "Session.Message.Assistant.Reasoning" })
 
-export const AssistantContent = Schema.Union([AssistantText, AssistantReasoning, AssistantTool]).pipe(
+export interface AssistantFile extends Schema.Schema.Type<typeof AssistantFile> {}
+export const AssistantFile = Schema.Struct({
+  type: Schema.tag("file"),
+  id: Schema.String,
+  mime: Schema.String,
+  filename: Schema.String.pipe(optional),
+  url: Schema.String,
+  state: ProviderState.pipe(optional),
+}).annotate({ identifier: "Session.Message.Assistant.File" })
+
+export const AssistantContent = Schema.Union([AssistantText, AssistantReasoning, AssistantFile, AssistantTool]).pipe(
   Schema.toTaggedUnion("type"),
 )
-export type AssistantContent = AssistantText | AssistantReasoning | AssistantTool
+export type AssistantContent = AssistantText | AssistantReasoning | AssistantFile | AssistantTool
 
 export interface AssistantRetry extends Schema.Schema.Type<typeof AssistantRetry> {}
 export const AssistantRetry = Schema.Struct({

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -263,6 +263,77 @@
   }
 }
 
+[data-component="file-part"] {
+  width: 100%;
+  margin-top: 16px;
+  display: flex;
+  align-items: flex-start;
+
+  [data-slot="file-part-attachment"] {
+    min-width: 0;
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--surface-weak);
+    border: 1px solid var(--border-weak-base);
+    transition: border-color 0.15s ease;
+
+    &:hover {
+      border-color: var(--border-strong-base);
+    }
+  }
+
+  button[data-slot="file-part-attachment"] {
+    appearance: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+  }
+
+  [data-slot="file-part-attachment"][data-clickable] {
+    cursor: pointer;
+  }
+
+  [data-slot="file-part-attachment"][data-type="image"] {
+    max-width: min(100%, 640px);
+    max-height: min(60vh, 640px);
+  }
+
+  [data-slot="file-part-image"] {
+    display: block;
+    max-width: 100%;
+    max-height: min(60vh, 640px);
+    width: auto;
+    height: auto;
+    object-fit: contain;
+  }
+
+  [data-slot="file-part-attachment"][data-type="file"] {
+    width: min(320px, 100%);
+    min-height: 48px;
+    padding: 0 10px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  [data-slot="file-part-attachment"][data-type="file"] [data-component="file-icon"] {
+    width: 20px;
+    height: 20px;
+    flex: none;
+  }
+
+  [data-slot="file-part-name"] {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-base);
+    font-size: var(--font-size-small);
+    line-height: var(--line-height-large);
+  }
+}
+
 [data-component="reasoning-part"] {
   width: 100%;
   color: var(--v2-text-text-muted);

--- a/packages/session-ui/src/message/current-message.tsx
+++ b/packages/session-ui/src/message/current-message.tsx
@@ -5,7 +5,12 @@ import type {
 } from "@opencode-ai/client/promise"
 import { Match, Switch } from "solid-js"
 import type { SessionUserActions, SessionUserComment } from "../actions"
-import { AssistantReasoningContent, AssistantTextContent, CurrentUserMessageDisplay } from "./message-content"
+import { 
+  AssistantFileContent,
+  AssistantReasoningContent,
+  AssistantTextContent,
+  CurrentUserMessageDisplay,
+} from "./message-content"
 import { CurrentContextToolGroup, CurrentFileToolGroup, ToolDisplay } from "../tools/tool-renderer"
 import { currentToolError, currentToolInput, currentToolMetadata, currentToolOutput } from "./current-tool-state"
 
@@ -67,6 +72,9 @@ export function SessionAssistantContent(props: {
             streaming={typeof props.message.time.completed !== "number"}
           />
         )}
+      </Match>
+      <Match when={props.content.type === "file" ? props.content : undefined}>
+        {(file) => <AssistantFileContent file={file()} />}
       </Match>
       <Match when={props.content.type === "tool" ? props.content : undefined}>
         {(tool) => (

--- a/packages/session-ui/src/message/message-content.tsx
+++ b/packages/session-ui/src/message/message-content.tsx
@@ -12,6 +12,7 @@ import { TimelineSeparator } from "../components/timeline-separator"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Icon } from "@opencode-ai/ui/icon"
+import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Button } from "@opencode-ai/ui/button"
 import { Card } from "@opencode-ai/ui/card"
 import type {
@@ -19,6 +20,7 @@ import type {
   PromptFileAttachment,
   SessionMessageAssistant,
   SessionMessageCompaction,
+  SessionMessageAssistantFile,
   SessionMessageUser,
 } from "@opencode-ai/client/promise"
 import type { SessionUserActions, SessionUserComment } from "../actions"
@@ -337,6 +339,37 @@ export function CurrentUserMessageDisplay(props: {
             />
           </Show>
         </div>
+      </Show>
+    </div>
+  )
+}
+
+export function AssistantFileContent(props: { file: SessionMessageAssistantFile }) {
+  const dialog = useDialog()
+  const i18n = useI18n()
+  const image = createMemo(() => props.file.mime.startsWith("image/"))
+  const name = createMemo(() => props.file.filename ?? i18n.t("ui.message.attachment.alt"))
+
+  return (
+    <div data-component="file-part" data-kind={image() ? "image" : "file"} data-timeline-part-id={props.file.id}>
+      <Show
+        when={image()}
+        fallback={
+          <div data-slot="file-part-attachment" data-type="file" title={name()}>
+            <FileIcon node={{ path: name(), type: "file" }} />
+            <span data-slot="file-part-name">{name()}</span>
+          </div>
+        }
+      >
+        <button
+          type="button"
+          data-slot="file-part-attachment"
+          data-type="image"
+          data-clickable="true"
+          onClick={() => dialog.show(() => <ImagePreview src={props.file.url} alt={name()} />)}
+        >
+          <img data-slot="file-part-image" src={props.file.url} alt={name()} />
+        </button>
       </Show>
     </div>
   )

--- a/packages/session-ui/src/timeline/rows-current.test.ts
+++ b/packages/session-ui/src/timeline/rows-current.test.ts
@@ -83,6 +83,35 @@ describe("current session timeline rows", () => {
     ])
   })
 
+  test("keeps generated assistant files as timeline parts", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "draw", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "file",
+            id: "file_1",
+            mime: "image/png",
+            filename: "chart.png",
+            url: "data:image/png;base64,AAAA",
+          },
+        ],
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+
+    const result = Timeline.constructSessionMessageRows(source, true, { type: "idle" })
+
+    expect(result.rows.map(TimelineRow.key)).toEqual([
+      "user-message:msg_user",
+      "assistant-part:msg_user:part:msg_assistant:file_1",
+    ])
+  })
+
   test("keeps CLI notice messages between the assistant steps they surround", () => {
     const source = [
       { id: "msg_user", type: "user", text: "run", time: { created: 1 } },

--- a/packages/tui/src/mini/stream-v2.subagent.ts
+++ b/packages/tui/src/mini/stream-v2.subagent.ts
@@ -377,6 +377,7 @@ export function createSubagentTracker(input: SubagentTrackerInput): SubagentTrac
             })
           continue
         }
+        if (item.type === "file") continue
         childTool(child, item, message.id)
       }
       if (message.error) {

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -771,6 +771,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
           ])
         continue
       }
+      if (item.type === "file") continue
       renderTool(message.id, item, render)
     }
     if (message.error && !state.errors.has(message.id)) {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -32,6 +32,7 @@ import type {
   ModelInfo,
   SessionMessageInfo,
   SessionMessageAssistant,
+  SessionMessageAssistantFile,
   SessionMessageAssistantReasoning,
   SessionMessageAssistantText,
   SessionMessageAssistantTool,
@@ -1670,6 +1671,9 @@ function SessionPartView(props: { partRef: PartRef; message: (messageID: string)
               last={false}
             />
           </Match>
+          <Match when={item().type === "file"}>
+            <GeneratedFile part={item() as SessionMessageAssistantFile} />
+          </Match>
           <Match when={item().type === "tool"}>
             <ToolPart part={item() as SessionMessageAssistantTool} />
           </Match>
@@ -2496,6 +2500,15 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
         />
       </box>
     </Show>
+  )
+}
+
+function GeneratedFile(props: { part: SessionMessageAssistantFile }) {
+  const theme = useTheme()
+  return (
+    <box paddingLeft={3} flexShrink={0}>
+      <text fg={theme.text.subdued}>Generated file: {props.part.filename ?? props.part.mime}</text>
+    </box>
   )
 }
 
@@ -3686,6 +3699,7 @@ function formatSessionTranscript(session: SessionInfo, messages: SessionMessageI
     const content = message.content.flatMap((item) => {
       if (item.type === "text") return [item.text]
       if (item.type === "reasoning") return thinking ? [`_Thinking:_\n\n${item.text}`] : []
+      if (item.type === "file") return [`[${item.filename ?? item.mime}](${item.url})`]
       const input = typeof item.state.input === "string" ? item.state.input : JSON.stringify(item.state.input, null, 2)
       const output =
         item.state.status === "error"

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3699,7 +3699,12 @@ function formatSessionTranscript(session: SessionInfo, messages: SessionMessageI
     const content = message.content.flatMap((item) => {
       if (item.type === "text") return [item.text]
       if (item.type === "reasoning") return thinking ? [`_Thinking:_\n\n${item.text}`] : []
-      if (item.type === "file") return [`[${item.filename ?? item.mime}](${item.url})`]
+      if (item.type === "file") {
+        const name = item.filename ?? item.mime
+        if (!item.url.startsWith("http://") && !item.url.startsWith("https://") && !item.url.startsWith("file://"))
+          return [`Generated file: ${name}`]
+        return [`[${name}](${item.url})`]
+      }
       const input = typeof item.state.input === "string" ? item.state.input : JSON.stringify(item.state.input, null, 2)
       const output =
         item.state.status === "error"

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -253,6 +253,10 @@ export function createSessionRows(sessionID: Accessor<string>, onSynced?: (sessi
           { type: "reasoning" },
         )
     }),
+    data.on("session.file.generated", (event) => {
+      if (event.data.sessionID === sessionID())
+        appendPart({ messageID: event.data.assistantMessageID, partID: event.data.file.id }, { type: "file" })
+    }),
     data.on("session.tool.input.started", (event) => {
       if (event.data.sessionID === sessionID())
         appendPart(
@@ -304,7 +308,7 @@ export function reduceSessionRows(messages: SessionMessageInfo[], inputs = new S
     usage?.steps.push(message)
     const ordinals = { text: 0, reasoning: 0 }
     message.content.forEach((part) => {
-      const partID = part.type === "tool" ? part.id : `${part.type}:${ordinals[part.type]++}`
+      const partID = part.type === "tool" || part.type === "file" ? part.id : `${part.type}:${ordinals[part.type]++}`
       if ((part.type === "text" || part.type === "reasoning") && !part.text.trim()) return
       append(rows, { messageID: message.id, partID }, part)
     })
@@ -396,15 +400,17 @@ function rowBoundaryMessageID(row: SessionRow, messages: Map<string, SessionMess
 }
 
 export function resolvePart(message: SessionMessageAssistant, partID: string) {
-  const tool = message.content.find((part) => part.type === "tool" && part.id === partID)
-  if (tool) return tool
+  const identified = message.content.find(
+    (part) => (part.type === "tool" || part.type === "file") && part.id === partID,
+  )
+  if (identified) return identified
   const match = /^(text|reasoning):(\d+)$/.exec(partID)
   if (!match) return
   const ordinal = Number(match[2])
   return message.content.filter((part) => part.type === match[1])[ordinal]
 }
 
-type AppendPart = { type: "text" } | { type: "reasoning" } | { type: "tool"; name: string }
+type AppendPart = { type: "text" } | { type: "reasoning" } | { type: "file" } | { type: "tool"; name: string }
 
 function append(rows: SessionRow[], ref: PartRef, part: AppendPart, index = rows.length) {
   if (part.type === "reasoning") {


### PR DESCRIPTION
### Issue for this PR

Closes #40124

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gemini can return generated images as inline data, but V2 did not carry that output through the session pipeline. This PR emits durable assistant file events, projects and renders generated images, preserves Gemini thought signatures for replay and follow-up edits, and handles filesystem change invalidation for generated files.

### How did you verify your code works?

- `bun turbo typecheck --concurrency=3` (34 packages)
- AI Gemini/schema tests (34 passing)
- Core session runner tests (30 passing)
- App reducer and file watcher tests (9 passing)
- Regenerated the client from the public schema

### Screenshots / recordings

<img width="1413" height="1115" alt="WeChatWorkScreenshot_d4bd283c-8e89-449c-b6b6-69a0a1bbb997" src="https://github.com/user-attachments/assets/b4aec695-48ab-44ba-bc82-d43d12a4b78c" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
