### PR TITLE
fix(tui): skip pending undo boundaries

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -56,6 +56,7 @@ import { DialogSessionRename } from "../../component/dialog-session-rename"
 import { DialogMessage } from "./dialog-message"
 import { DialogFork } from "./dialog-fork"
 import { DialogTimeline } from "./dialog-timeline"
+import { findUndoBoundary } from "./undo"
 import { Sidebar } from "./sidebar"
 import { Composer } from "./composer"
 import { filetype } from "../../util/filetype"
@@ -591,10 +592,10 @@ export function Session() {
       group: "Session",
       slash: { name: "undo" },
       run: () => {
-        const boundary = session()?.revert?.messageID
-        const message = messages().findLast(
-          (message): message is SessionMessageUser =>
-            message.type === "user" && !!message.text.trim() && (!boundary || message.id < boundary),
+        const message = findUndoBoundary(
+          messages(),
+          data.session.input.list(route.sessionID),
+          session()?.revert?.messageID,
         )
         if (!message) {
           toast.show({ message: "Nothing to undo", variant: "error", duration: 3000 })

--- a/packages/tui/src/routes/session/undo.ts
+++ b/packages/tui/src/routes/session/undo.ts
@@ -1,0 +1,11 @@
+import type { SessionMessageInfo, SessionMessageUser } from "@opencode-ai/client"
+
+export function findUndoBoundary(messages: SessionMessageInfo[], pendingInputIDs: string[], boundary?: string) {
+  return messages.findLast(
+    (message): message is SessionMessageUser =>
+      message.type === "user" &&
+      !!message.text.trim() &&
+      !pendingInputIDs.includes(message.id) &&
+      (!boundary || message.id < boundary),
+  )
+}

--- a/packages/tui/test/cli/tui/undo.test.ts
+++ b/packages/tui/test/cli/tui/undo.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import type { SessionMessageInfo, SessionMessageUser } from "@opencode-ai/client"
+import { findUndoBoundary } from "../../../src/routes/session/undo"
+
+test("selects the latest promoted user message without pending inputs", () => {
+  expect(findUndoBoundary([user("msg_001", "First"), user("msg_002", "Second")], [])?.id).toBe("msg_002")
+})
+
+test("skips the latest user message while it is pending", () => {
+  expect(findUndoBoundary([user("msg_001", "First"), user("msg_002", "Second")], ["msg_002"])?.id).toBe("msg_001")
+})
+
+test("returns no boundary when all user messages are pending", () => {
+  expect(
+    findUndoBoundary([user("msg_001", "First"), user("msg_002", "Second")], ["msg_001", "msg_002"]),
+  ).toBeUndefined()
+})
+
+test("selects only messages before an existing revert boundary", () => {
+  expect(
+    findUndoBoundary([user("msg_001", "First"), user("msg_002", "Second"), user("msg_003", "Third")], [], "msg_003")
+      ?.id,
+  ).toBe("msg_002")
+})
+
+test("skips blank user messages", () => {
+  expect(findUndoBoundary([user("msg_001", "First"), user("msg_002", "  \n  ")], [])?.id).toBe("msg_001")
+})
+
+test("selects a newer promoted message when an earlier message is pending", () => {
+  expect(
+    findUndoBoundary([user("msg_001", "First"), user("msg_002", "Pending"), user("msg_003", "Third")], ["msg_002"])?.id,
+  ).toBe("msg_003")
+})
+
+function user(id: string, text: string): SessionMessageUser {
+  return { type: "user", id, text, time: { created: 0 } } satisfies SessionMessageInfo
+}


### PR DESCRIPTION
### Issue for this PR

Closes #39736

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The V2 TUI displays user inputs as soon as they are admitted, before they are promoted into materialized session history.

During that window, `/undo` could select the visible pending input as its revert boundary and pass its ID to `session.revert.stage`. The server could not resolve that ID yet and returned `Message not found`.

This change excludes admitted-but-unpromoted input IDs when selecting the undo boundary. If the latest visible input is still pending, `/undo` falls back to the most recent promoted user message. If no promoted user message is available, the existing `Nothing to undo` behavior is preserved.

The fix is limited to the TUI and does not add any server events or API surface.

### How did you verify your code works?

From `packages/tui`:

- `bun test test/cli/tui/undo.test.ts` — 6 passed, 0 failed
- `bun typecheck` — passed
- `bun test test/cli/tui/session-rows.test.ts` — 15 passed, 0 failed
- `git diff --check` — passed

The regression tests cover:

- selecting the latest promoted user message
- skipping the latest pending input
- returning no boundary when all user inputs are pending
- respecting an existing revert boundary
- skipping blank user messages
- selecting a newer promoted message when an earlier message is pending

### Screenshots / recordings

Not applicable. This changes undo boundary selection and does not introduce a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
