### PR TITLE
fix(tui): render Windows file:// plugin names correctly in /status

### DIFF
--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -19,9 +19,9 @@ export function DialogStatus() {
     const result = list.map((item) => {
       const value = typeof item === "string" ? item : item[0]
       if (value.startsWith("file://")) {
-        const path = fileURLToPath(value)
-        const parts = path.split("/")
-        const filename = parts.pop() || path
+        const filePath = fileURLToPath(value)
+        const parts = filePath.split(/[\\/]/)
+        const filename = parts.pop() || filePath
         if (!filename.includes(".")) return { name: filename }
         const basename = filename.split(".")[0]
         if (basename === "index") {
@@ -166,3 +166,4 @@ export function DialogStatus() {
     </box>
   )
 }
+


### PR DESCRIPTION
### Issue for this PR

Closes #40131

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, /status derived the plugin name by splitting the fileURLToPath() result on "/", which does not split backslash paths. The whole path became the "filename" and was truncated at the first dot (e.g. "C:\Users\me" for a plugin under the home directory). This PR splits on both "/" and "\" so the last path segment (the plugin file name) is used on every platform. The index.ts fallback (parent directory name) is unchanged.

### How did you verify your code works?

Verified the derived names with Node for both path styles:

- file:///C:/Users/me/.config/opencode/plugins/superpowers.js -> superpowers (was "C:\Users\me")
- file:///home/me/.config/opencode/plugins/superpowers.js -> superpowers (unchanged)
- file:///home/me/.config/opencode/plugins/my-plugin/index.ts -> my-plugin (unchanged)
- oh-my-openagent@latest -> oh-my-openagent @latest (unchanged)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR