### PR TITLE
fix(tui): format effect causes

### DIFF
--- a/packages/tui/src/util/error.ts
+++ b/packages/tui/src/util/error.ts
@@ -1,3 +1,4 @@
+import { Cause } from "effect"
 import { isRecord } from "./record"
 
 type ConfigIssue = { message: string; path: string[] }
@@ -95,6 +96,10 @@ function field(input: Record<string, unknown>, key: string) {
 }
 
 export function errorFormat(error: unknown): string {
+  if (Cause.isCause(error)) {
+    return Cause.pretty(error)
+  }
+
   if (error instanceof Error) {
     return error.stack ?? `${error.name}: ${error.message}`
   }

--- a/packages/tui/test/util/error.test.ts
+++ b/packages/tui/test/util/error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Cause } from "effect"
 import { errorData, errorFormat, errorMessage } from "../../src/util/error"
 
 describe("util.error", () => {
@@ -45,5 +46,14 @@ describe("util.error", () => {
     const data = errorData(err)
     expect(data.message).toBe("ResolveMessage: Cannot resolve module")
     expect(String(data.formatted)).toContain("ResolveMessage")
+  })
+
+  test("formats Effect causes without exposing raw internals", () => {
+    const cause = Cause.fail(new Error("MCP transport closed"))
+    const formatted = errorFormat(cause)
+
+    expect(formatted).toContain("MCP transport closed")
+    expect(formatted).not.toContain('"_id"')
+    expect(formatted).not.toContain('"Cause"')
   })
 })


### PR DESCRIPTION
## Summary
- Format Effect `Cause` values with `Cause.pretty` before falling back to JSON
- Avoid printing raw Cause internals such as `_id: "Cause"` in TUI/CLI error output
- Add regression coverage for Effect cause formatting

Fixes #34925

## Test Plan
- bun test test/util/error.test.ts
- bun run typecheck
- bun run lint packages/tui/src/util/error.ts packages/tui/test/util/error.test.ts
- git diff --cached --check
- staged secret scan