### PR TITLE
fix(server): log upstream 5xx bodies from proxied workspace requests

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/proxy.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/proxy.ts
@@ -97,6 +97,29 @@ export function http(
     headers.delete("content-encoding")
     headers.delete("content-length")
 
+    // An upstream 5xx from a remote workspace sandbox arrives here as an opaque
+    // status — its real cause (and log line) live only inside the sandbox. Buffer
+    // the small error body, log it locally so it shows up in the host's log, and
+    // forward it unchanged (preserving content-type so the client can still parse
+    // the structured error, e.g. its `ref`).
+    if (response.status >= 500) {
+      const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed("")))
+      const contentType = response.headers["content-type"] ?? "application/json"
+      headers.delete("content-type")
+      yield* Effect.logError("workspace proxy upstream error", {
+        url: url.toString(),
+        method: request.method,
+        status: response.status,
+        body: body.slice(0, 2000),
+      })
+      return HttpServerResponse.text(body, {
+        status: response.status,
+        statusText: statusText(response),
+        headers,
+        contentType,
+      })
+    }
+
     return HttpServerResponse.stream(response.stream.pipe(Stream.catchCause(() => Stream.empty)), {
       status: response.status,
       statusText: statusText(response),


### PR DESCRIPTION
### Issue for this PR

Related to #39471, #36826

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The workspace proxy streams the upstream response straight through. When a remote sandbox returns a 5xx, the detailed cause is only logged inside the sandbox, so a maintainer tailing the host's log sees nothing — just an error surfacing on the client with no local trace to correlate it against.

For 5xx responses only, this buffers the (small) error body, logs it on the host via `Effect.logError` with the url/method/status, and then forwards the body unchanged with its original content-type. Buffering is fine here because these are short error payloads, not streamed content, and preserving the content-type means the client can still parse the structured error (e.g. its `ref`). Success/2xx responses keep streaming exactly as before.

### How did you verify your code works?

- Pointed the proxy at a workspace endpoint that returns a 500 with a JSON error body; confirmed the body now appears in the host log and the client still receives the same status + body + content-type it did before.
- Confirmed non-5xx responses are untouched (still streamed, no buffering).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
