### PR TITLE
fix(server): don't forward host directory to remote workspace

### DIFF
--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -34,5 +34,12 @@ export function workspaceProxyURL(target: string | URL, requestURL: URL) {
   proxyURL.search = requestURL.search
   proxyURL.hash = requestURL.hash
   proxyURL.searchParams.delete("workspace")
+  // The `directory` param is the *host's* working directory (e.g. a Windows
+  // path like `F:\proj`). It is meaningless — and dangerous — on the remote:
+  // the sandbox would `path.resolve` it against its own cwd, producing a bogus
+  // path like `/home/daytona/workspace/repo/F:\proj` that does not exist and
+  // crashes prompt handling. Drop it so the remote falls back to its own
+  // project root. This mirrors ProxyUtil.headers stripping `x-opencode-directory`.
+  proxyURL.searchParams.delete("directory")
   return proxyURL
 }

--- a/packages/opencode/test/server/workspace-routing.test.ts
+++ b/packages/opencode/test/server/workspace-routing.test.ts
@@ -80,6 +80,13 @@ describe("workspaceProxyURL", () => {
     expect(result.searchParams.get("keep")).toBe("yes")
   })
 
+  test("strips the host directory param so the remote resolves its own root", () => {
+    const url = new URL("http://localhost/session/abc?directory=F%3A%5Cproj&keep=yes")
+    const result = workspaceProxyURL("http://remote:8080/base", url)
+    expect(result.searchParams.get("directory")).toBeNull()
+    expect(result.searchParams.get("keep")).toBe("yes")
+  })
+
   test("preserves hash from request", () => {
     const url = new URL("http://localhost/page#section")
     const result = workspaceProxyURL("http://remote:8080", url)


### PR DESCRIPTION
### Issue for this PR

Related to #36902

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a request is proxied to a remote workspace, `workspaceProxyURL` copied the whole query string and only deleted `workspace`. That left the `directory` param in place — but `directory` is the *host's* cwd. From a Windows host it's a path like `F:\proj`, which is meaningless on the remote Linux sandbox.

On the remote, that value flows into `defaultDirectory()` and gets `path.resolve`d against the sandbox cwd, producing something like `/home/daytona/workspace/repo/F:\proj`. The session is created against that
non-existent dir, and the first prompt blows up in `SystemPrompt.environment` (`realPath` -> ENOENT). The prompt handler turns that into a defect -> opaque 500, which the TUI shows as a bare "Failed to send prompt" toast.

The fix is one line: strip `directory` before forwarding, so the remote falls back to its own project root. This mirrors what `ProxyUtil.headers` already does for the `x-opencode-directory` header — the query param was just the one path that slipped through.

### How did you verify your code works?

- Added a unit test in `workspace-routing.test.ts` asserting `directory` is dropped (and an unrelated param like `keep` is preserved) by `workspaceProxyURL`.
- Reproduced the original crash by driving a remote workspace from a Windows host: before the change the first prompt 500s; after it, the session boots on the remote's own project root and the prompt succeeds.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
