### PR TITLE
fix(desktop): hide helper process windows

### DIFF
--- a/packages/desktop/src/main/apps.test.ts
+++ b/packages/desktop/src/main/apps.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { lookupAppOptions } from "./apps"
+
+test("hides Windows app lookup helper windows", () => {
+  expect(lookupAppOptions("win32")).toEqual({ windowsHide: true })
+  expect(lookupAppOptions("darwin")).toEqual({ windowsHide: false })
+})

--- a/packages/desktop/src/main/apps.ts
+++ b/packages/desktop/src/main/apps.ts
@@ -2,8 +2,13 @@ import { execFile } from "node:child_process"
 import { access, readFile, readdir } from "node:fs/promises"
 import { dirname, extname, join } from "node:path"
 import util from "node:util"
+import { hiddenWindowOptions } from "./process-options"
 
 const execFilePromise = util.promisify(execFile)
+
+export function lookupAppOptions(os: NodeJS.Platform = process.platform) {
+  return hiddenWindowOptions(os)
+}
 
 const exists = (path: string) =>
   access(path)
@@ -31,7 +36,7 @@ async function checkMacosApp(appName: string) {
     if (await exists(location)) return true
   }
 
-  return execFilePromise("which", [appName])
+  return execFilePromise("which", [appName], lookupAppOptions())
     .then(() => true)
     .catch(() => false)
 }
@@ -39,7 +44,7 @@ async function checkMacosApp(appName: string) {
 async function resolveWindowsAppPath(appName: string): Promise<string | null> {
   let output: string
   try {
-    output = await execFilePromise("where", [appName]).then((r) => r.stdout.toString())
+    output = await execFilePromise("where", [appName], lookupAppOptions()).then((r) => r.stdout)
   } catch {
     return null
   }

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import type { DesktopMenuAction } from "@opencode-ai/app/desktop-menu"
 import type { FatalRendererError, ServerReadyData, TitlebarTheme } from "../preload/types"
 import { runDesktopMenuAction } from "./desktop-menu-actions"
 import { setForceFocus } from "./debug"
+import { hiddenWindowOptions } from "./process-options"
 import { assertAttachmentBudget, createPickedFileAuthorizations } from "./attachment-picker"
 import { getStore, removeStoreFileIfEmpty } from "./store"
 import {
@@ -196,8 +197,9 @@ export function registerIpcHandlers(deps: Deps) {
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
-      execFile(cmd, args, (err) => (err ? reject(err) : resolve()))
+      execFile(cmd, args, hiddenWindowOptions(), (err) => (err ? reject(err) : resolve()))
     })
+    return undefined
   })
 
   ipcMain.handle("reveal-path", async (_event: IpcMainInvokeEvent, path: string) => {

--- a/packages/desktop/src/main/process-options.test.ts
+++ b/packages/desktop/src/main/process-options.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { hiddenWindowOptions } from "./process-options"
+
+test("hides subprocess windows only on Windows", () => {
+  expect(hiddenWindowOptions("win32")).toEqual({ windowsHide: true })
+  expect(hiddenWindowOptions("linux")).toEqual({ windowsHide: false })
+})

--- a/packages/desktop/src/main/process-options.ts
+++ b/packages/desktop/src/main/process-options.ts
@@ -1,0 +1,3 @@
+export function hiddenWindowOptions(os: NodeJS.Platform = process.platform) {
+  return { windowsHide: os === "win32" }
+}

--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -6,9 +6,17 @@ import { promisify } from "node:util"
 
 const exec = promisify(execFile)
 
+export function clipboardCommandOptions(input: string | undefined, os: NodeJS.Platform = process.platform) {
+  const stdin = input === undefined ? "ignore" : "pipe"
+  return {
+    stdio: [stdin, "pipe", "ignore"] as ["ignore" | "pipe", "pipe", "ignore"],
+    windowsHide: os === "win32",
+  }
+}
+
 function command(command: string, args: string[] = [], input?: string) {
   return new Promise<Buffer>((resolve, reject) => {
-    const child = spawn(command, args, { stdio: [input === undefined ? "ignore" : "pipe", "pipe", "ignore"] })
+    const child = spawn(command, args, clipboardCommandOptions(input))
     const output: Buffer[] = []
     child.on("error", reject)
     child.stdout?.on("data", (chunk: Buffer) => output.push(chunk))
@@ -71,6 +79,7 @@ export async function read() {
   const { default: clipboardy } = await import("clipboardy")
   const text = await clipboardy.read().catch(() => undefined)
   if (text) return { data: text, mime: "text/plain" }
+  return undefined
 }
 
 export function copyCommand(
@@ -91,6 +100,7 @@ export function copyCommand(
       "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())",
     ]
   }
+  return undefined
 }
 
 let copyMethod: Promise<(text: string) => Promise<void>> | undefined

--- a/packages/tui/src/editor.ts
+++ b/packages/tui/src/editor.ts
@@ -7,7 +7,19 @@ import { spawn } from "node:child_process"
 import type { Stream } from "node:stream"
 import { resolveZedDbPath, resolveZedSelection } from "./editor-zed"
 
-type EditorStdio = "inherit" | "pipe" | "ignore" | number | Stream
+export type EditorStdio = "inherit" | "pipe" | "ignore" | number | Stream
+
+export function editorSpawnOptions(
+  input: { cwd?: string; stdin?: EditorStdio },
+  os: NodeJS.Platform = process.platform,
+) {
+  return {
+    cwd: input.cwd && existsSync(input.cwd) ? input.cwd : process.cwd(),
+    stdio: [input.stdin ?? "inherit", "inherit", "inherit"] as [EditorStdio, "inherit", "inherit"],
+    shell: os === "win32",
+    windowsHide: os === "win32",
+  }
+}
 
 export function normalizePromptContent(content: string) {
   if (content.endsWith("\r\n")) {
@@ -25,7 +37,7 @@ export function normalizePromptContent(content: string) {
 
 export async function openEditor(input: { value: string; renderer: CliRenderer; cwd?: string; stdin?: EditorStdio }) {
   const editor = process.env.VISUAL || process.env.EDITOR
-  if (!editor) return
+  if (!editor) return undefined
   const file = path.join(os.tmpdir(), `${Date.now()}.md`)
   await writeFile(file, input.value)
   input.renderer.suspend()
@@ -33,11 +45,7 @@ export async function openEditor(input: { value: string; renderer: CliRenderer; 
   try {
     await new Promise<void>((resolve, reject) => {
       const parts = editor.split(" ")
-      const child = spawn(parts[0]!, [...parts.slice(1), file], {
-        cwd: input.cwd && existsSync(input.cwd) ? input.cwd : process.cwd(),
-        stdio: [input.stdin ?? "inherit", "inherit", "inherit"],
-        shell: process.platform === "win32",
-      })
+      const child = spawn(parts[0], [...parts.slice(1), file], editorSpawnOptions(input))
       child.on("error", reject)
       child.on("exit", (code, signal) => {
         if (code === 0) return resolve()

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { copyCommand } from "../src/clipboard"
+import { clipboardCommandOptions, copyCommand } from "../src/clipboard"
 
 test("prefers Wayland clipboard when available", () => {
   expect(copyCommand("linux", true, (name) => name === "wl-copy")).toEqual(["wl-copy"])
@@ -16,4 +16,15 @@ test("falls back through X11 clipboard commands", () => {
 
 test("returns undefined when native clipboard is unavailable", () => {
   expect(copyCommand("linux", false, () => false)).toBeUndefined()
+})
+
+test("hides native clipboard helper windows on Windows", () => {
+  expect(clipboardCommandOptions(undefined, "win32")).toEqual({
+    stdio: ["ignore", "pipe", "ignore"],
+    windowsHide: true,
+  })
+  expect(clipboardCommandOptions("copied", "win32")).toEqual({
+    stdio: ["pipe", "pipe", "ignore"],
+    windowsHide: true,
+  })
 })

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
-import { normalizePromptContent, openEditor } from "../src/editor"
+import { editorSpawnOptions, normalizePromptContent, openEditor } from "../src/editor"
 
 const editor = process.env.EDITOR
 const visual = process.env.VISUAL
@@ -29,4 +29,12 @@ test("normalizes a single trailing editor newline for one-line prompts", () => {
 
 test("preserves multiline prompts that end with a newline", () => {
   expect(normalizePromptContent("hello\nworld\n")).toBe("hello\nworld\n")
+})
+
+test("hides external editor windows on Windows", () => {
+  const options = editorSpawnOptions({ stdin: "pipe" }, "win32")
+
+  expect(options.shell).toBe(true)
+  expect(options.windowsHide).toBe(true)
+  expect(options.stdio).toEqual(["pipe", "inherit", "inherit"])
 })


### PR DESCRIPTION
## Summary
- Set `windowsHide` for remaining TUI native helper subprocesses (clipboard/editor)
- Add a shared desktop main-process helper for hidden subprocess windows
- Use it for app lookup and custom open-path launches

Fixes #31629

## Test Plan
- bun test test/clipboard.test.ts test/editor.test.ts
- bun test src/main/apps.test.ts src/main/process-options.test.ts
- bun run typecheck (packages/tui)
- bun run lint packages/tui/src/clipboard.ts packages/tui/test/clipboard.test.ts packages/tui/src/editor.ts packages/tui/test/editor.test.ts packages/desktop/src/main/apps.ts packages/desktop/src/main/apps.test.ts packages/desktop/src/main/process-options.ts packages/desktop/src/main/process-options.test.ts packages/desktop/src/main/ipc.ts
- git diff --cached --check
- staged secret scan

Note: `bun run typecheck` from `packages/desktop` is blocked in this Windows checkout by the existing `packages/app/src/custom-elements.d.ts` symlink placeholder being materialized as the literal text `../../ui/src/custom-elements.d.ts`.