### PR TITLE
fix(app): preserve selected project workspace

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -64,6 +64,7 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
+  explicitProjectDirectory,
   latestRootSession,
   sortedRootSessions,
 } from "./layout/helpers"
@@ -1212,6 +1213,32 @@ export default function LegacyLayout(props: ParentProps) {
       setStore("lastProjectSession", root, { directory: resolved.directory, id: resolved.id, at: Date.now() })
       navigateWithSidebarReset(`/${base64Encode(resolved.directory)}/session/${resolved.id}`)
       return true
+    }
+
+    const explicit = explicitProjectDirectory(root, directory, dirs)
+    if (explicit) {
+      await refreshDirs(explicit)
+      const local = serverSync().child(explicit, { bootstrap: false })[0]
+      const localLatest = latestRootSession([local], Date.now())
+      if (localLatest && (await openSession(localLatest))) return
+
+      const fetched = latestRootSession(
+        [
+          {
+            path: { directory: explicit },
+            session: await listAllSessions(serverSDK().api.session, {
+              directory: explicit,
+              parentID: null,
+              order: "desc",
+            }).catch(() => []),
+          },
+        ],
+        Date.now(),
+      )
+      if (fetched && (await openSession(fetched))) return
+
+      navigateWithSidebarReset(`/${base64Encode(explicit)}/session`)
+      return
     }
 
     const projectSession = store.lastProjectSession[root]

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   displayName,
   effectiveWorkspaceOrder,
   errorMessage,
+  explicitProjectDirectory,
   hasProjectPermissions,
   homeProjectNavigation,
   homeProjectDirectories,
@@ -127,6 +128,12 @@ describe("layout workspace helpers", () => {
   test("keeps local first while preserving known order", () => {
     const result = effectiveWorkspaceOrder("/root", ["/root", "/b", "/c"], ["/root", "/c", "/a", "/b"])
     expect(result).toEqual(["/root", "/c", "/b"])
+  })
+
+  test("keeps an explicitly selected sandbox directory distinct from the project root", () => {
+    expect(explicitProjectDirectory("/repo", "/repo-copy", ["/repo", "/repo-copy"])).toBe("/repo-copy")
+    expect(explicitProjectDirectory("/repo", "/repo", ["/repo", "/repo-copy"])).toBeUndefined()
+    expect(explicitProjectDirectory("/repo", "/missing", ["/repo", "/repo-copy"])).toBeUndefined()
   })
 
   test("finds the latest root session across workspaces", () => {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -148,3 +148,10 @@ export const effectiveWorkspaceOrder = (local: string, dirs: string[], persisted
 
   return [...result, ...live.values()]
 }
+
+export function explicitProjectDirectory(root: string, requested: string, dirs: string[]): string | undefined {
+  const rootKey = pathKey(root)
+  const requestedKey = pathKey(requested)
+  if (requestedKey === rootKey) return undefined
+  return dirs.find((dir) => pathKey(dir) === requestedKey)
+}


### PR DESCRIPTION
## Summary
- Keep an explicitly selected sandbox/workspace directory distinct from its project root during navigation
- Prefer sessions from the selected directory before falling back to project-level last-session state
- Add regression coverage for selecting a copied checkout that shares the same project root identity

Fixes #31632

## Test Plan
- `bun test --conditions=solid --preload ./happydom.ts ./src/pages/layout/helpers.test.ts`
- `bun run lint packages/app/src/pages/layout.tsx packages/app/src/pages/layout/helpers.ts packages/app/src/pages/layout/helpers.test.ts`
- `git diff --check`
- Staged diff secret scan

Note: `bun run typecheck` in `packages/app` is still blocked on this Windows checkout by the existing `src/custom-elements.d.ts` symlink placeholder, which matches `upstream/dev`.