### PR TITLE
fix(server): isolate sessions per-worktree — require an explicit directory

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -31,6 +31,7 @@ type RemoteTarget = Extract<Target, { type: "remote" }>
 type RequestPlan = Data.TaggedEnum<{
   InvalidWorkspace: {}
   MissingWorkspace: { readonly workspaceID: WorkspaceV2.ID }
+  MissingDirectory: {}
   Local: { readonly directory: string; readonly workspaceID?: WorkspaceV2.ID }
   Remote: {
     readonly request: HttpServerRequest.HttpServerRequest
@@ -83,8 +84,8 @@ function selectedV2WorkspaceID(
   return workspaceID.value
 }
 
-function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string | undefined {
+  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || undefined
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
@@ -178,8 +179,10 @@ function planRequest(
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 
+    const directory = session?.directory || defaultDirectory(request, url)
+    if (directory === undefined) return RequestPlan.MissingDirectory()
     return RequestPlan.Local({
-      directory: session?.directory || defaultDirectory(request, url),
+      directory,
       workspaceID: envWorkspaceID ?? workspaceID,
     })
   })
@@ -203,6 +206,17 @@ function routeWorkspace<E>(
         ),
       ),
     MissingWorkspace: ({ workspaceID }) => Effect.succeed(missingWorkspaceResponse(workspaceID)),
+    MissingDirectory: () =>
+      Effect.succeed(
+        HttpServerResponse.jsonUnsafe(
+          new InvalidRequestError({
+            message: "Missing directory: set ?directory= or x-opencode-directory",
+            kind: "Query",
+            field: "directory",
+          }),
+          { status: 400 },
+        ),
+      ),
     Remote: ({ request, workspace, target, url }) => proxyRemote(client, request, workspace, target, url),
     Local: ({ directory, workspaceID }) =>
       effect.pipe(Effect.provideService(WorkspaceRouteContext, WorkspaceRouteContext.of({ directory, workspaceID }))),

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -793,6 +793,25 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "rejects directory-less session creation with a v2 public request error",
+    () =>
+      Effect.gen(function* () {
+        const created = yield* request(SessionPaths.create, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+        })
+
+        expect(created.status).toBe(400)
+        expect(yield* responseJson(created)).toMatchObject({
+          _tag: "InvalidRequestError",
+          kind: "Query",
+          field: "directory",
+        })
+      }),
+    { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
+  )
+
+  it.instance(
     "persists selected workspace id when creating a session",
     () =>
       Effect.gen(function* () {

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -6,12 +6,12 @@ import { SessionsCursor } from "@opencode-ai/protocol/groups/session"
 import {
   ConflictError,
   InvalidCursorError,
+  InvalidRequestError,
   MessageNotFoundError,
   ServiceUnavailableError,
   SessionNotFoundError,
   UnknownError,
 } from "@opencode-ai/protocol/errors"
-import { AbsolutePath } from "@opencode-ai/core/schema"
 
 const DefaultSessionsLimit = 50
 const DefaultSessionHistoryLimit = 50
@@ -67,12 +67,21 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
       .handle(
         "session.create",
         Effect.fn(function* (ctx) {
+          if (ctx.payload.location === undefined) {
+            return yield* Effect.fail(
+              new InvalidRequestError({
+                message: "Missing location: create a session at an explicit location",
+                kind: "Payload",
+                field: "location",
+              }),
+            )
+          }
           return {
             data: yield* session.create({
               id: ctx.payload.id,
               agent: ctx.payload.agent,
               model: ctx.payload.model,
-              location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
+              location: ctx.payload.location,
             }),
           }
         }),

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -2,8 +2,9 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
+import { InvalidRequestError } from "@opencode-ai/protocol/errors"
 import { Effect, Layer } from "effect"
-import { HttpServerRequest } from "effect/unstable/http"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 
 export type LocationServices = Layer.Success<ReturnType<(typeof LocationServiceMap.Service)["get"]>>
@@ -26,12 +27,12 @@ export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
   })
 }
 
-function ref(request: HttpServerRequest.HttpServerRequest): Location.Ref {
+function ref(request: HttpServerRequest.HttpServerRequest): Location.Ref | undefined {
   const query = new URL(request.url, "http://localhost").searchParams
   const workspaceID = query.get("location[workspace]") || request.headers["x-opencode-workspace"]
-  const directory =
-    query.get("location[directory]") ||
-    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : process.cwd())
+  const headerDirectory = request.headers["x-opencode-directory"]
+  const directory = query.get("location[directory]") || (headerDirectory ? decode(headerDirectory) : undefined)
+  if (directory === undefined) return undefined
   return Location.Ref.make({
     directory: AbsolutePath.make(directory),
     workspaceID: workspaceID ? WorkspaceV2.ID.make(workspaceID) : undefined,
@@ -53,7 +54,18 @@ export const layer = Layer.effect(
     return LocationMiddleware.of((effect) =>
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest
-        return yield* effect.pipe(Effect.provide(locations.get(ref(request))))
+        const location = ref(request)
+        if (location === undefined) {
+          return HttpServerResponse.jsonUnsafe(
+            new InvalidRequestError({
+              message: "Missing directory: set x-opencode-directory or location[directory]",
+              kind: "Query",
+              field: "location[directory]",
+            }),
+            { status: 400 },
+          )
+        }
+        return yield* effect.pipe(Effect.provide(locations.get(location)))
       }),
     )
   }),


### PR DESCRIPTION
## What this PR does (plain English)

Makes sure that a session (a chat with the coding agent) always knows **which project folder** it belongs to — and never silently assumes the folder of whatever process happened to be running the server.

Right now, when a request reaches the server without saying which folder it is for, the server "falls back" to its own current working directory (`process.cwd()`). That is a problem when the same server is shared across many projects (worktrees): two sessions can end up bound to the wrong folder, or a folder that doesn't belong to anyone, because they inherited the *server's* folder instead of the *session's* folder.

This PR changes that rule: **a request that does not declare its folder is rejected** with a clear 400 error, instead of being silently attached to a guess. The folder must now be provided explicitly, either in the request URL or via the `x-opencode-directory` header.

## Why this matters

- **Correctness** — sessions belong to the folder they were started in, not to the server process.
- **Isolation** — this is the foundation for safely running one server across many worktrees (per-worktree isolation). Work on this continues in later phases.
- **Predictability** — a missing folder now fails loudly and immediately, so the caller knows they forgot something, rather than getting subtly wrong behaviour later.

## How (conceptual, no code needed)

The server had **three** places that used the "fallback to the current folder" rule. All three now follow the new rule: no folder declared → 400 error.

| Where | What it did before | What it does now |
|---|---|---|
| Global request middleware | Used the server's folder when none was provided | Returns **400 "missing directory"** |
| Route-planning middleware | Used the server's folder as a last resort | Returns **400 "missing directory"** |
| "New session" handler | Created sessions in the server's folder by default | Rejects the request with **400** unless a folder is given |

Sessions that **already have a folder** (for example, replying to an existing conversation, forking, or renaming) are unaffected — they keep working because the folder is recovered from the session itself.

A regression test was added that proves a folder-less "new session" request is rejected with the new 400 error.

## What changed (this phase)

- 3 server source files (middleware + session handler)
- 1 test file (new regression test)
- No user-facing UI changes yet

## How it was tested

- `bun run typecheck` — all packages pass
- Server test suite (`workspace-proxy`, `httpapi-provider`, `httpapi-mcp`, `httpapi-session`) — 37 passing, 1 pre-existing skip, 0 failures

## Phases / roadmap

This is **Phase 1** of a larger effort to give each worktree a fully isolated server. Later phases (each kept reviewable on its own) will:

1. ✅ **Phase 1 — Server hardening** (this PR): reject directory-less requests instead of guessing.
2. **Phase 2 — Per-agent enforcement**: ensure every agent/session carries its directory end-to-end.
3. **Phase 3 — UI/UX**: user-facing behaviour and copy updates (flagged for design review).
4. **Phase 4 — Read-only cross-worktree access**: allow viewing sessions across worktrees without mutating them.
5. **Phase 5 — PR / git subagents**: directory-aware git and PR tooling.
6. **Phase 6 — Verification & PR polish**: full end-to-end checks, docs, and release notes.

> **Note on process:** GitHub's stacked-PR feature requires all branches in the *same* repository. Because this PR is contributed from a fork (`JoshGatto/opencode` → `anomalyco/opencode`), the phases are tracked as clearly separated commits on this branch and described above, so the review history stays readable even without native cross-fork stacking.