### PR TITLE
fix(tui): reject unavailable project destinations

### DIFF
--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -15,6 +15,31 @@ function moveReminderText(directory: string) {
   return `<system-reminder>The user has changed the current working directory to "${directory}". This is still the same project but at a possibly new location; take this into account when working with any files from now on.</system-reminder>`
 }
 
+export function createMoveSessionSelectionHandler(input: {
+  validate: (directory: string) => Promise<unknown>
+  onSelect: (selection: MoveSessionSelection) => void | Promise<unknown>
+  onError: (error: unknown) => void
+}) {
+  let pending = false
+  return async (selection: MoveSessionSelection) => {
+    if (pending) return
+    pending = true
+    try {
+      if (selection.type !== "new") {
+        try {
+          await input.validate(selection.directory)
+        } catch (error) {
+          input.onError(error)
+          return
+        }
+      }
+      await input.onSelect(selection)
+    } finally {
+      pending = false
+    }
+  }
+}
+
 export function usePromptMove(input: { projectID: () => string | undefined; sessionID: () => string | undefined }) {
   const dialog = useDialog()
   const sdk = useSDK()
@@ -26,6 +51,21 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
   const [creating, setCreating] = createSignal(false)
   const [creatingDots, setCreatingDots] = createSignal(3)
   const [progress, setProgress] = createSignal<string>()
+  const select = createMoveSessionSelectionHandler({
+    validate: (directory) => sdk.client.file.list({ directory, path: "." }, { throwOnError: true }),
+    onSelect: (selection) => {
+      const sessionID = input.sessionID()
+      if (!sessionID) {
+        homeDestination?.setDestination(selection)
+        dialog.clear()
+        return
+      }
+      return moveExistingSession(sessionID, selection)
+    },
+    onError: (error) => {
+      toast.show({ title: "Project directory unavailable", message: errorMessage(error), variant: "error" })
+    },
+  })
 
   async function create(context?: string) {
     const projectID = input.projectID()
@@ -88,15 +128,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
               })
         }
         onCurrentChange={(selection) => homeDestination?.setDestination(selection)}
-        onSelect={(selection) => {
-          const sessionID = input.sessionID()
-          if (!sessionID) {
-            homeDestination?.setDestination(selection)
-            dialog.clear()
-            return
-          }
-          void moveExistingSession(sessionID, selection)
-        }}
+        onSelect={(selection) => void select(selection)}
       />
     ))
   }

--- a/packages/tui/test/component/prompt-move.test.ts
+++ b/packages/tui/test/component/prompt-move.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test"
+import { createMoveSessionSelectionHandler } from "../../src/component/prompt/move"
+
+const selection = { type: "directory", directory: "/project", subdirectory: false } as const
+
+describe("prompt move selection", () => {
+  test("updates the destination after the directory is validated", async () => {
+    const validated: string[] = []
+    let destination = "/current"
+    const select = createMoveSessionSelectionHandler({
+      validate: async (directory) => {
+        validated.push(directory)
+      },
+      onSelect: (value) => {
+        if (value.type === "directory") destination = value.directory
+      },
+      onError() {},
+    })
+
+    await select(selection)
+
+    expect(validated).toEqual(["/project"])
+    expect(destination).toBe("/project")
+  })
+
+  test("keeps the destination unchanged when validation fails", async () => {
+    const failure = new Error("Directory not found")
+    const errors: unknown[] = []
+    let destination = "/current"
+    const select = createMoveSessionSelectionHandler({
+      validate: async () => {
+        throw failure
+      },
+      onSelect: (value) => {
+        if (value.type === "directory") destination = value.directory
+      },
+      onError: (error) => errors.push(error),
+    })
+
+    await select(selection)
+
+    expect(destination).toBe("/current")
+    expect(errors).toEqual([failure])
+  })
+
+  test("reports synchronous validation failures and allows retrying", async () => {
+    const failure = new Error("Directory not found")
+    const errors: unknown[] = []
+    let validations = 0
+    let selections = 0
+    const select = createMoveSessionSelectionHandler({
+      validate: () => {
+        validations += 1
+        if (validations === 1) throw failure
+        return Promise.resolve()
+      },
+      onSelect: () => {
+        selections += 1
+      },
+      onError: (error) => errors.push(error),
+    })
+
+    await select(selection)
+    await select(selection)
+
+    expect(validations).toBe(2)
+    expect(selections).toBe(1)
+    expect(errors).toEqual([failure])
+  })
+
+  test("selects a new destination without directory validation", async () => {
+    let validations = 0
+    let selected: string | undefined
+    const select = createMoveSessionSelectionHandler({
+      validate: async () => {
+        validations += 1
+      },
+      onSelect: (value) => {
+        selected = value.type
+      },
+      onError() {},
+    })
+
+    await select({ type: "new" })
+
+    expect(validations).toBe(0)
+    expect(selected).toBe("new")
+  })
+
+  test("ignores duplicate selections while validation is pending", async () => {
+    let resolve!: () => void
+    let validations = 0
+    let selections = 0
+    const select = createMoveSessionSelectionHandler({
+      validate: () => {
+        validations += 1
+        return new Promise<void>((done) => (resolve = done))
+      },
+      onSelect: () => {
+        selections += 1
+      },
+      onError() {},
+    })
+
+    const first = select(selection)
+    const second = select(selection)
+
+    expect(validations).toBe(1)
+    expect(selections).toBe(0)
+    resolve()
+    await Promise.all([first, second])
+    expect(selections).toBe(1)
+  })
+
+  test("ignores duplicate selections while onSelect is pending", async () => {
+    let resolve!: () => void
+    let validations = 0
+    let selections = 0
+    const select = createMoveSessionSelectionHandler({
+      validate: async () => {
+        validations += 1
+      },
+      onSelect: () => {
+        selections += 1
+        return new Promise<void>((done) => (resolve = done))
+      },
+      onError() {},
+    })
+
+    const first = select(selection)
+    await Promise.resolve()
+    const second = select(selection)
+
+    expect(validations).toBe(1)
+    expect(selections).toBe(1)
+    resolve()
+    await Promise.all([first, second])
+    expect(selections).toBe(1)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39903

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Deleted project directories could remain selectable in the TUI project picker.

This change checks that an existing destination directory is accessible before updating the home destination or moving a session. If validation fails, the current destination remains unchanged and an error toast is shown.

It does not change `Project.list()` or remove persisted project records.

### How did you verify your code works?

Ran the following locally from `packages/tui`:

- `bun test test/component/prompt-move.test.ts` — 6 passed
- `bun run typecheck` — passed
- `bun x prettier --check src/component/prompt/move.tsx test/component/prompt-move.test.ts` — passed
- `git diff --check` — passed

The tests cover successful and failed validation, synchronous errors, retries, new destinations, and duplicate selections while an operation is pending.

### Screenshots / recordings

Not applicable. This changes validation behavior without changing the visual layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
