### PR TITLE
fix(opencode): match absolute permission patterns outside the worktree

### DIFF
--- a/packages/opencode/src/project/instance-context.ts
+++ b/packages/opencode/src/project/instance-context.ts
@@ -1,4 +1,5 @@
 import { LocalContext } from "@/util/local-context"
+import path from "path"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import type * as Project from "./project"
 
@@ -21,4 +22,10 @@ export function containsPath(filepath: string, ctx: InstanceContext): boolean {
   // Skip worktree check in this case to preserve external_directory permissions.
   if (ctx.worktree === "/") return false
   return FSUtil.contains(ctx.worktree, filepath)
+}
+
+export function permissionPath(filepath: string, ctx: InstanceContext): string {
+  // A root worktree is the non-git sentinel, not a project boundary.
+  if (ctx.worktree === "/" || !containsPath(filepath, ctx)) return filepath
+  return path.relative(ctx.worktree, filepath)
 }

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -4,6 +4,7 @@ import * as Tool from "./tool"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { InstanceState } from "@/effect/instance-state"
+import { permissionPath } from "@/project/instance-context"
 import { Patch } from "../patch"
 import { createTwoFilesPatch, diffLines } from "diff"
 import { assertExternalDirectoryEffect } from "./external-directory"
@@ -202,7 +203,7 @@ export const ApplyPatchTool = Tool.define(
       }))
 
       // Check permissions if needed
-      const relativePaths = fileChanges.map((c) => path.relative(instance.worktree, c.filePath).replaceAll("\\", "/"))
+      const relativePaths = fileChanges.map((c) => permissionPath(c.filePath, instance).replaceAll("\\", "/"))
       yield* ctx.ask({
         permission: "edit",
         patterns: relativePaths,

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -14,6 +14,7 @@ import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Format } from "../format"
 import { InstanceState } from "@/effect/instance-state"
+import { permissionPath } from "@/project/instance-context"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -101,7 +102,7 @@ export const EditTool = Tool.define(
                 diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
                 yield* ctx.ask({
                   permission: "edit",
-                  patterns: [path.relative(instance.worktree, filePath)],
+                  patterns: [permissionPath(filePath, instance)],
                   always: ["*"],
                   metadata: {
                     filepath: filePath,
@@ -144,7 +145,7 @@ export const EditTool = Tool.define(
               )
               yield* ctx.ask({
                 permission: "edit",
-                patterns: [path.relative(instance.worktree, filePath)],
+                patterns: [permissionPath(filePath, instance)],
                 always: ["*"],
                 metadata: {
                   filepath: filePath,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -6,6 +6,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { LSP } from "@/lsp/lsp"
 import DESCRIPTION from "./read.txt"
 import { InstanceState } from "@/effect/instance-state"
+import { permissionPath } from "@/project/instance-context"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isPdfAttachment, sniffAttachmentMime } from "@/util/media"
@@ -254,7 +255,7 @@ export const ReadTool = Tool.define<
 
       yield* ctx.ask({
         permission: "read",
-        patterns: [path.relative(instance.worktree, filepath)],
+        patterns: [permissionPath(filepath, instance)],
         always: ["*"],
         metadata: {},
       })

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,6 +11,7 @@ import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { Format } from "../format"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceState } from "@/effect/instance-state"
+import { permissionPath } from "@/project/instance-context"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import * as Bom from "@/util/bom"
@@ -53,7 +54,7 @@ export const WriteTool = Tool.define(
           const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
           yield* ctx.ask({
             permission: "edit",
-            patterns: [path.relative(instance.worktree, filepath)],
+            patterns: [permissionPath(filepath, instance)],
             always: ["*"],
             metadata: {
               filepath,

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -13,6 +13,8 @@ import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Truncate } from "@/tool/truncate"
 import { TestInstance } from "../fixture/fixture"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Permission } from "../../src/permission"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(
@@ -73,6 +75,24 @@ const makeCtx = () => {
   return { ctx, calls }
 }
 
+const makeRulesCtx = (ruleset: PermissionV1.Ruleset) => {
+  const calls: AskInput[] = []
+  const ctx: ToolCtx = {
+    ...baseCtx,
+    ask: (input) =>
+      Effect.sync(() => {
+        calls.push(input)
+        if (input.permission === "external_directory") return
+        for (const pattern of input.patterns) {
+          const rule = Permission.evaluate(input.permission, pattern, ruleset)
+          if (rule.action !== "allow") throw new Error(`permission ${rule.action}: ${pattern}`)
+        }
+      }),
+  }
+
+  return { ctx, calls }
+}
+
 const readText = (filepath: string) => Effect.promise(() => fs.readFile(filepath, "utf-8"))
 const writeText = (filepath: string, content: string) => Effect.promise(() => fs.writeFile(filepath, content, "utf-8"))
 const makeDir = (dir: string) => Effect.promise(() => fs.mkdir(dir, { recursive: true }))
@@ -85,6 +105,33 @@ const expectFailure = <A, E, R>(effect: Effect.Effect<A, E, R>, message?: string
   })
 
 const expectReadFailure = (filepath: string) => expectFailure(readText(filepath))
+
+describe("tool.apply_patch permission paths", () => {
+  it.instance(
+    "checks absolute rules for every outside path in a multi-file patch",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const outer = yield* Effect.promise(() => fs.mkdtemp(path.join(path.dirname(test.directory), "opencode-outside-")))
+        const first = path.join(outer, "first.txt")
+        const second = path.join(outer, "second.txt")
+        const firstRelative = path.relative(test.directory, first).replaceAll("\\", "/")
+        const secondRelative = path.relative(test.directory, second).replaceAll("\\", "/")
+        const patchText = `*** Begin Patch\n*** Add File: ${firstRelative}\n+first\n*** Add File: ${secondRelative}\n+second\n*** End Patch`
+        const { ctx, calls } = makeRulesCtx(
+          Permission.fromConfig({ edit: { "*": "allow", [`${outer}/**`]: "deny" } }),
+        )
+
+        const exit = yield* execute({ patchText }, ctx).pipe(Effect.exit)
+        expect(exit._tag).toBe("Failure")
+        expect(calls.at(-1)?.patterns).toEqual([first, second].map((file) => file.replaceAll("\\", "/")))
+        expect(yield* Effect.promise(() => fs.stat(first).catch(() => undefined))).toBeUndefined()
+        expect(yield* Effect.promise(() => fs.stat(second).catch(() => undefined))).toBeUndefined()
+        yield* Effect.promise(() => fs.rm(outer, { recursive: true, force: true }))
+      }),
+    { git: true },
+  )
+})
 
 describe("tool.apply_patch freeform", () => {
   it.live("requires patchText", () =>

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Cause, Effect, Exit, Layer, Stream } from "effect"
 import path from "path"
+import os from "os"
+import * as fs from "fs/promises"
 import { Agent } from "../../src/agent/agent"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -147,6 +149,54 @@ const asks = () => {
     },
   }
 }
+
+const askWithRules = (ruleset: PermissionV1.Ruleset) => ({
+  ...ctx,
+  ask: (input: Omit<PermissionV1.Request, "id" | "sessionID" | "tool">) =>
+    Effect.sync(() => {
+      if (input.permission === "external_directory") return
+      for (const pattern of input.patterns) {
+        const rule = Permission.evaluate(input.permission, pattern, ruleset)
+        if (rule.action !== "allow") throw new Error(`permission ${rule.action}: ${pattern}`)
+      }
+    }),
+})
+
+describe("tool.read permission paths", () => {
+  it.live("allows an outside-worktree absolute rule", () =>
+    Effect.gen(function* () {
+      const outer = yield* tmpdirScoped()
+      const dir = yield* tmpdirScoped({ git: true })
+      const filepath = path.join(outer, "allowed.txt")
+      yield* put(filepath, "allowed")
+
+      const result = yield* exec(
+        dir,
+        { filePath: filepath },
+        askWithRules(Permission.fromConfig({ read: { [`${outer}/**`]: "allow" } })),
+      )
+      expect(result.output).toContain("allowed")
+    }),
+  )
+
+  it.live("expands a tilde rule for an outside-worktree home path", () =>
+    Effect.gen(function* () {
+      const outer = yield* Effect.promise(() => fs.mkdtemp(path.join(os.homedir(), "opencode-permission-")))
+      const dir = yield* tmpdirScoped({ git: true })
+      const filepath = path.join(outer, "home-file.txt")
+      yield* put(filepath, "home content")
+
+      const rule = `~/${path.relative(os.homedir(), outer).replaceAll("\\", "/")}/**`
+      const result = yield* exec(
+        dir,
+        { filePath: filepath },
+        askWithRules(Permission.fromConfig({ read: { [rule]: "allow" } })),
+      )
+      expect(result.output).toContain("home content")
+      yield* Effect.promise(() => fs.rm(outer, { recursive: true, force: true }))
+    }),
+  )
+})
 
 describe("tool.read external_directory permission", () => {
   it.live("allows reading absolute path inside project directory", () =>

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -12,6 +12,8 @@ import { Truncate } from "@/tool/truncate"
 import { Tool } from "@/tool/tool"
 import { Agent } from "../../src/agent/agent"
 import { SessionID, MessageID } from "../../src/session/schema"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Permission } from "../../src/permission"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -56,6 +58,76 @@ const run = Effect.fn("WriteToolTest.run")(function* (
 ) {
   const tool = yield* init()
   return yield* tool.execute(args, next)
+})
+
+const askWithRules = (ruleset: PermissionV1.Ruleset) => ({
+  ...ctx,
+  ask: (input: Parameters<Tool.Context["ask"]>[0]) =>
+    Effect.sync(() => {
+      if (input.permission === "external_directory") return
+      for (const pattern of input.patterns) {
+        const rule = Permission.evaluate(input.permission, pattern, ruleset)
+        if (rule.action !== "allow") throw new Error(`permission ${rule.action}: ${pattern}`)
+      }
+    }),
+})
+
+describe("tool.write permission paths", () => {
+  it.instance("matches an inside-worktree relative rule", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const filepath = path.join(test.directory, "src", "inside.txt")
+      yield* run(
+        { filePath: filepath, content: "inside" },
+        askWithRules(Permission.fromConfig({ edit: { "src/**": "allow" } })),
+      )
+      expect(yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))).toBe("inside")
+    }),
+    { git: true },
+  )
+
+  it.instance("allows an outside-worktree absolute rule", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const outer = yield* Effect.promise(() => fs.mkdtemp(path.join(path.dirname(test.directory), "opencode-outside-")))
+      const filepath = path.join(outer, "allowed.txt")
+      yield* run(
+        { filePath: filepath, content: "allowed" },
+        askWithRules(Permission.fromConfig({ edit: { [`${outer}/**`]: "allow" } })),
+      )
+      expect(yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))).toBe("allowed")
+      yield* Effect.promise(() => fs.rm(outer, { recursive: true, force: true }))
+    }),
+    { git: true },
+  )
+
+  it.instance("enforces an outside-worktree absolute deny over a wildcard allow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const outer = yield* Effect.promise(() => fs.mkdtemp(path.join(path.dirname(test.directory), "opencode-outside-")))
+      const filepath = path.join(outer, "denied.txt")
+      const rules = Permission.fromConfig({ edit: { "*": "allow", [`${outer}/**`]: "deny" } })
+      const exit = yield* run({ filePath: filepath, content: "denied" }, askWithRules(rules)).pipe(Effect.exit)
+      expect(exit._tag).toBe("Failure")
+      expect(yield* Effect.promise(() => fs.stat(filepath).catch(() => undefined))).toBeUndefined()
+      yield* Effect.promise(() => fs.rm(outer, { recursive: true, force: true }))
+    }),
+    { git: true },
+  )
+
+  it.instance("does not match an outside-worktree relative rule", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const outer = yield* Effect.promise(() => fs.mkdtemp(path.join(path.dirname(test.directory), "opencode-outside-")))
+      const filepath = path.join(outer, "not-src.txt")
+      const rules = Permission.fromConfig({ edit: { "src/**": "allow" } })
+      const exit = yield* run({ filePath: filepath, content: "not allowed" }, askWithRules(rules)).pipe(Effect.exit)
+      expect(exit._tag).toBe("Failure")
+      expect(yield* Effect.promise(() => fs.stat(filepath).catch(() => undefined))).toBeUndefined()
+      yield* Effect.promise(() => fs.rm(outer, { recursive: true, force: true }))
+    }),
+    { git: true },
+  )
 })
 
 describe("tool.write", () => {


### PR DESCRIPTION
### Issue for this PR

Fixes #30551.

Same root cause as #20045, #22465 and #25097 (all closed unfixed) and the proposal in #22336. Those reported it as an ergonomics problem — a rule that should allow doesn't, so the tool prompts. This PR reports the other direction, which nobody filed: a rule that should **deny** doesn't either.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Five tool call sites send the permission matcher a worktree-relativized path:

```
tool/write.ts:56          patterns: [path.relative(instance.worktree, filepath)]
tool/edit.ts:104, :147    same
tool/read.ts:257          same
tool/apply_patch.ts:208   relativePaths, built the same way at :205
```

A target outside the worktree becomes `../../../../etc/passwd`. `permission/index.ts:32` matches that against `rule.pattern`, so a rule written `/etc/**` or `~/...` is not a candidate — no leading slash — and `findLast` falls through to whatever broad rule exists, or to the `ask` default.

**The deny direction, against real `Permission.evaluate` on current `dev`:**

```
config { edit: { "*": "allow", "/etc/**": "deny" } }
ruleset after fromConfig+expand:
  [{"permission":"edit","pattern":"*","action":"allow"},
   {"permission":"edit","pattern":"/etc/**","action":"deny"}]

target                                 : /etc/passwd
pattern the tool sends (path.relative) : ../../../../etc/passwd
VERDICT                                : allow      ← matched rule "*"

same target sent as "/etc/passwd":
VERDICT                                : deny
```

The deny is loaded, expanded, and present in the ruleset. It loses to `*` because it never competes. Changing only the pattern representation flips the verdict.

**The documented example has the same problem.** This is `docs/permissions.mdx` verbatim, presented as the way to allow reads but block edits in an external directory:

```
config: external_directory allow + edit deny on ~/projects/personal/**

target                             : /home/icetea/projects/personal/notes.md
edit pattern sent by the tool      : ../personal/notes.md
edit VERDICT (documented: deny)    : ask
external_directory VERDICT         : allow
```

The `external_directory` half works. The `edit` half returns `ask`. Same operator, same block, same pattern text.

Note the two relativized forms: `../../../../etc/passwd` and `../personal/notes.md`. The `../` count is a function of where the session was started, so **no relative form works portably** — an operator cannot write a rule that matches an outside path from more than one project root.

**The codebase already contains the correct model, in three places:**

- `permission/index.ts:178-184` — `expand()` deliberately turns `~/...` into an absolute pattern, called on every rule by `fromConfig`. The config layer manufactures absolute patterns the matcher then cannot match.
- `tool/external-directory.ts:30-37` — passes an **absolute** glob to the same `ctx.ask`, which is why `external_directory` rules work while `edit` rules don't.
- `project/instance-context.ts:18` — `containsPath` already solves inside-vs-outside, including the non-git `worktree === "/"` case, with a comment explaining it.

**The change** adds one helper beside `containsPath` and uses it at all five sites:

```ts
export function permissionPath(filepath: string, ctx: InstanceContext): string {
  // A root worktree is the non-git sentinel, not a project boundary.
  if (ctx.worktree === "/" || !containsPath(filepath, ctx)) return filepath
  return path.relative(ctx.worktree, filepath)
}
```

Inside the worktree → relative, exactly as today, so existing `src/**` rules are untouched. Outside → absolute, so `/tmp/**` and expanded `~/...` rules match as the config layer intends. `*` still matches both.

`evaluate()` and last-match-wins are unchanged. `external-directory.ts` is unchanged. This is deliberately the smallest change that fixes the matching, not a rework of the rule semantics — #22336's broader proposal is a separate discussion.

**Guidance this makes statable:** relative patterns for in-worktree targets, absolute for outside. Today the second half has no working form at all.

### Behaviour change worth a release note

Under a **non-git project** (`worktree === "/"`), the helper returns absolute for every target, so a relative rule like `src/**` now falls through to `ask` where it previously matched. That is the same sentinel `containsPath` already special-cases, and the alternative — stripping the leading slash — leaves the bug unfixed for exactly those users. Affected rules can be written `**/src/**` or given an absolute form.

Worth knowing alongside it: an `ask` verdict parks on `Deferred.await` at `permission/index.ts:101` with no timeout and no default, resolvable only by a human reply. In an automated or headless lane that is an indefinite park rather than a prompt.

### How did you verify your code works?

Seven tool-level arms in `write.test.ts`, `read.test.ts` and `apply_patch.test.ts`, written before the production change: inside-relative still matches · outside absolute allow fires · **outside absolute deny fires** · outside relative rule still does not match · `read` absolute · `~` expansion · `apply_patch` multi-path deny.

Red-first: 83 pass / 5 fail, with the inside-relative and outside-relative arms green in both states. After the fix: 88 / 0.

Mutation-checked both ways. Reverting the production change re-exposes the bug on exactly the five new arms. An over-broad mutation — returning the absolute path unconditionally — turns the inside-relative arm red, so the suite pins the boundary rather than just the fix.

`bun test` in `packages/opencode`: **3235 pass / 0 fail** (baseline on `dev` is 3228, measured on a clean checkout). `bun typecheck` clean in `packages/opencode` and `packages/core`.

An independent OpenCode deployment replayed the change against its own permission logs before this was filed: 125,800 evaluated `edit`/`read` lines reduced to 19,411 distinct (pattern, rule, verdict) triples, re-evaluated with the platform's own `Wildcard.match`. **Zero regressions, zero unexpected verdict changes.** 181 verdicts flipped deny→allow, every one a `/tmp` scratch path an operator had already written an allow rule for. Both real-world rule forms — expanded `~/...` and hand-written absolute — behaved as intended.

A cross-family security review probed the boundary and found no blocking issues. Prefix collision is safe: `FSUtil.contains` uses `path.relative`, so worktree `/home/user/proj` correctly rejects `/home/user/proj-evil/x.ts`. Two pre-existing gaps it surfaced are **not** introduced or changed by this PR and are left alone deliberately: a symlink inside the worktree pointing outside is classified inside (shared with `external-directory.ts` via the same `containsPath`), and literal `..` segments in a target are not normalised before matching. Both deserve their own issues.

One honest weakness: the `does not match an outside-worktree relative rule` arm passes under both mutations, so it documents intent rather than pinning the boundary. The other three write arms pin it.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
