### PR TITLE
fix(permission): scope "always" approval to the command that was shown

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -387,6 +387,7 @@ export const ShellTool = Tool.define(
         patterns: new Set<string>(),
         always: new Set<string>(),
       }
+      const found: { pattern: string; always: string }[] = []
       const shellKind = ShellID.toKind(Shell.name(shell))
 
       for (const node of commands(root)) {
@@ -405,10 +406,23 @@ export const ShellTool = Tool.define(
         }
 
         if (tokens.length && (!cmd || !CWD.has(cmd))) {
-          scan.patterns.add(source(node))
-          scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
+          found.push({
+            pattern: source(node),
+            always: BashArity.prefix(tokens).join(" ") + " *",
+          })
         }
       }
+
+      for (const item of found) scan.patterns.add(item.pattern)
+
+      // A single "always" reply approves every pattern in `scan.always`, so the widened
+      // arity prefix is only safe when the request covers exactly one command. For a
+      // compound command the user is shown one prompt and makes one decision, but each
+      // command would contribute its own widened rule -- approving `git status && rm -rf ~`
+      // would install `git status *` AND `rm *`, the latter matching `rm -rf /`. Fall back
+      // to the literal commands so "always" grants exactly what was displayed.
+      if (found.length === 1) scan.always.add(found[0].always)
+      else for (const item of found) scan.always.add(item.pattern)
 
       return scan
     })

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -263,6 +263,58 @@ describe("tool.shell permissions", () => {
     }),
   )
 
+  each("widens the always pattern for a single command", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          expect(
+            yield* fail(
+              {
+                command: "git status",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.always).toContain("git status *")
+        }),
+      )
+    }),
+  )
+
+  each("does not widen always patterns for compound commands", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          expect(
+            yield* fail(
+              {
+                command: "git status && rm -rf tmp",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          // Approving the prompt once must not install a rule that matches `rm -rf /`.
+          expect(bashReq!.always).not.toContain("rm *")
+          expect(bashReq!.always).not.toContain("git status *")
+          expect(bashReq!.always).toContain("git status")
+          expect(bashReq!.always).toContain("rm -rf tmp")
+        }),
+      )
+    }),
+  )
+
   for (const item of ps) {
     it.live(`parses PowerShell conditionals for permission prompts [${item.label}]`, () =>
       withShell(


### PR DESCRIPTION
`collect()` accumulated one arity-widened `always` pattern per command node into a single set, and `Permission.reply` installs an allow rule for every entry of that set when the user answers "always".

  For a compound command this turns one user decision into several grants: approving `git status && rm -rf ~` installs both `git status *` and `rm *`, and `rm *` matches `rm -rf /` on the next turn.

  Keep the widened prefix only when the request covers exactly one command. Otherwise fall back to the literal command strings, so "always" grants exactly the commands that were displayed in the prompt.

  ### Issue for this PR

  Closes #40158

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  `scan.always` in `tool/shell.ts` is a `Set` that gets one entry per command node found in the parsed command. `ask()` sends the whole set as the request's `always` list, and `permission/index.ts` loops that list on an "always" reply, pushing an allow rule for each entry.

  So the widening is per command but the approval is per request. With one command that is fine: you approve `git status`, you get `git status *`. With two it is wrong, because you see one prompt, click once, and get a rule for each command in it. The `rm` case is the bad one, since `BashArity` gives `rm` an arity of 1, so `rm -rf ~` widens to `rm *`, which then matches any future `rm`.

  The fix keeps the existing widening when `found.length === 1` and otherwise uses the literal command text. Re-running the same compound command still matches and stays allowed. `rm -rf /` does not match `rm -rf tmp` and still prompts.

  ### How did you verify your code works?

  Two tests in `packages/opencode/test/tool/shell.test.ts`. One asserts `git status` still widens to `git status *`. The other asserts `git status && rm -rf tmp` yields neither `rm *` nor `git status *`, but does yield both literals. Both use the existing `capture(requests, err)` helper so the command never actually executes.

  `cd packages/opencode && bun test test/tool/shell.test.ts`

  ### Screenshots / recordings

  N/A, no UI change.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR