### PR TITLE
fix(shell): close external_directory gaps in the command path scan

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -36,6 +36,29 @@ const FILES = new Set([
   "chmod",
   "chown",
   "cat",
+  // Writers that take their destination as a plain positional argument. Without these
+  // `tee ~/.ssh/authorized_keys` reaches the shell with no external_directory prompt,
+  // even though the documented behaviour is that the permission fires whenever a tool
+  // touches paths outside the project directory.
+  "dd",
+  "install",
+  "ln",
+  "rsync",
+  "shred",
+  "split",
+  "tee",
+  "truncate",
+  "unlink",
+  // Readers. These match how the read tool already prompts for out-of-project files.
+  "cmp",
+  "diff",
+  "head",
+  "less",
+  "more",
+  "sed",
+  "sort",
+  "tail",
+  "wc",
   // Leave PowerShell aliases out for now. Common ones like cat/cp/mv/rm/mkdir
   // already hit the entries above, and alias normalization should happen in one
   // place later so we do not risk double-prompting.
@@ -156,6 +179,17 @@ function expand(text: string, cwd: string, shell: string) {
     .replace(/\$\{env:([^}]+)\}/gi, (_, key: string) => envValue(key) || "")
     .replace(/\$env:([A-Za-z_][A-Za-z0-9_]*)/gi, (_, key: string) => envValue(key) || "")
     .replace(/\$(HOME|PWD|PSHOME)(?=$|[\\/])/gi, (_, key: string) => auto(key, cwd, shell) || "")
+  return home(out)
+}
+
+// POSIX counterpart to `expand`. Without it `$HOME`/`$PWD` survive into `dynamic()`,
+// which drops the argument, so `rm $HOME/.ssh/id_rsa` skipped the external_directory
+// scan even though `rm` is scanned. Only the two variables we can resolve without
+// running the shell are substituted; anything else still falls through to `dynamic()`.
+function posixExpand(text: string, cwd: string) {
+  const out = unquote(text).replace(/\$\{?(HOME|PWD)\}?(?=$|[\\/])/g, (_, key: string) =>
+    key === "HOME" ? os.homedir() : cwd,
+  )
   return home(out)
 }
 
@@ -367,7 +401,7 @@ export const ShellTool = Tool.define(
     })
 
     const argPath = Effect.fn("ShellTool.argPath")(function* (arg: string, cwd: string, ps: boolean, shell: string) {
-      const text = ps ? expand(arg, cwd, shell) : home(unquote(arg))
+      const text = ps ? expand(arg, cwd, shell) : posixExpand(arg, cwd)
       const file = text && prefix(text)
       if (!file || dynamic(file, ps)) return
       const next = ps ? provider(file) : file

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -263,6 +263,56 @@ describe("tool.shell permissions", () => {
     }),
   )
 
+  if (process.platform !== "win32") {
+    it.live("asks for external_directory permission for tee targets", () =>
+      Effect.gen(function* () {
+        const tmp = yield* tmpdirScoped()
+        yield* runIn(
+          tmp,
+          Effect.gen(function* () {
+            const err = new Error("stop after permission")
+            const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+            expect(
+              yield* fail(
+                {
+                  command: "echo hi | tee /etc/opencode-external-test",
+                },
+                capture(requests, err),
+              ),
+            ).toMatchObject({ message: err.message })
+            const extDirReq = requests.find((r) => r.permission === "external_directory")
+            expect(extDirReq).toBeDefined()
+            expect(extDirReq!.patterns).toContain("/etc/*")
+          }),
+        )
+      }),
+    )
+
+    it.live("asks for external_directory permission for $HOME paths", () =>
+      Effect.gen(function* () {
+        const tmp = yield* tmpdirScoped()
+        yield* runIn(
+          tmp,
+          Effect.gen(function* () {
+            const err = new Error("stop after permission")
+            const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+            expect(
+              yield* fail(
+                {
+                  command: "rm $HOME/.ssh/opencode-external-test",
+                },
+                capture(requests, err),
+              ),
+            ).toMatchObject({ message: err.message })
+            const extDirReq = requests.find((r) => r.permission === "external_directory")
+            expect(extDirReq).toBeDefined()
+            expect(extDirReq!.patterns).toContain(path.join(os.homedir(), ".ssh", "*"))
+          }),
+        )
+      }),
+    )
+  }
+
   for (const item of ps) {
     it.live(`parses PowerShell conditionals for permission prompts [${item.label}]`, () =>
       withShell(


### PR DESCRIPTION
The docs say `external_directory` fires whenever a tool touches paths outside the project directory. The file tools do that for every call. The shell tool only did it for a short allowlist of command names, and threw away any argument containing a `$`.

  So `tee ~/.ssh/authorized_keys` never prompted, because `tee` was not scanned. And `rm $HOME/.ssh/id_rcause although `rm` is scanned, `dynamic()` discarded the argument before it could be resolved.

  Add the common readers and writers that take their target as a plain positional argument, and expand `hells the way `expand()` already does for PowerShell.

  ### Issue for this PR

  Closes #40159

  ### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  Two changes in `tool/shell.ts`.

  `FILES` gains the file commands that were missing: `tee`, `dd`, `ln`, `rsync`, `shred`, `split`, `truncate`, `install`, `unlink` on the write side, and `head`, `tail`, `sed`, `sort`, `wc`, `diff`, `cmp`, `less`, `more` on the read
  side. Only commands whose target is a plain positional argument, since that is what `pathArgs()` can aready inside the project resolves and is skipped as before, so this only prompts for paths thatgenuinely leave the project.

  `argPath()` now runs POSIX arguments through a new `posixExpand()` that substitutes `$HOME` and `$PWD` (both `$VAR` and `${VAR}` forms) before `dynamic()` sees them. Only those two, because they are the only ones resolvable without running the shell. `$OTHER`, `$(cmd)`, and backticks still fall through `dynamic()` and get skipped exactly as they do today. `$HOMEBREW` deliberately does not match, because the pattern requires a `/` or end of string after the name.

  Redirection targets such as `echo x > /etc/foo` are still not scanned, because `parts()` skips redirection nodes and handling them means walking `redirected_statement` children. That is a bigger change and worth a follow-up.

  ### How did you verify your code works?

  Two tests in `packages/opencode/test/tool/shell.test.ts`, POSIX only. `echo hi | tee /etc/...` expects an `external_directory` request for `/etc/*`, and `rm $HOME/.ssh/...` expects one for `<home>/.ssh/*`. Both stop at the permissioncall so nothing runs.

  I also ran `posixExpand` against `$HOME/x`, `${HOME}/x`, `"$HOME/x"`, `$PWD/../x`, `$HOMEBREW/x`, `$OTHER/x`, `$(whoami)/x`, `~/x`, and a plain relative path, to confirm the first four expand and the rest stay dynamic.

  `cd packages/opencode && bun test test/tool/shell.test.ts`

  ### Screenshots / recordings

  N/A, no UI change.

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR