### PR TITLE
fix(tool): resolve symlinks before the project containment check

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { realpathSync } from "fs"
 import { Effect } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import type * as Tool from "./tool"
@@ -6,6 +7,34 @@ import { containsPath } from "../project/instance-context"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 
 type Kind = "file" | "directory"
+
+// `containsPath` is pure path math (`path.relative`), but every caller then hands the
+// same string to an fs call, and fs follows symlinks. A link inside the project that
+// points outside it therefore passed the check while the read/write landed outside --
+// and the permission prompt rendered the in-project path, so it named the wrong file.
+//
+// Windows already resolved here via `normalizePath` (which calls `realpathSync.native`).
+// Do the same on POSIX so both platforms check, and display, the path the filesystem
+// will actually touch.
+function resolveTarget(target: string) {
+  return follow(process.platform === "win32" ? FSUtil.normalizePath(target) : path.resolve(target))
+}
+
+// A plain realpath is not enough: `write` and `apply_patch` legitimately target files
+// that do not exist yet, and realpath fails with ENOENT on those. Walk up to the nearest
+// existing ancestor and re-attach the tail, so a symlinked parent directory is still
+// followed. Any other error (ELOOP, EACCES) keeps the lexical path, which is the
+// behaviour that shipped before -- resolution is a guard here, not a hard requirement.
+function follow(input: string): string {
+  try {
+    return realpathSync(input)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") return input
+    const parent = path.dirname(input)
+    if (parent === input) return input
+    return path.join(follow(parent), path.basename(input))
+  }
+}
 
 type Options = {
   bypass?: boolean
@@ -22,7 +51,7 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   if (options?.bypass) return false
 
   const ins = yield* InstanceState.context
-  const full = process.platform === "win32" ? FSUtil.normalizePath(target) : target
+  const full = resolveTarget(target)
   if (containsPath(full, ins)) return false
 
   const kind = options?.kind ?? "file"

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -2,6 +2,8 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { describe, expect } from "bun:test"
 import path from "path"
+import { realpathSync } from "fs"
+import { symlink } from "fs/promises"
 import { Effect } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import type { Tool } from "@/tool/tool"
@@ -104,6 +106,64 @@ describe("tool.assertExternalDirectory", () => {
       expect(requests.length).toBe(0)
     }),
   )
+
+  if (process.platform !== "win32") {
+    it.instance("follows symlinks that escape the project before checking containment", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { requests, ctx } = makeCtx()
+
+        const outside = yield* tmpdirScoped()
+        const link = path.join(test.directory, "vendor")
+        yield* Effect.promise(() => symlink(outside, link))
+
+        // Lexically inside the project, but resolves outside it.
+        const target = path.join(link, "existing.txt")
+        yield* Effect.promise(() => Bun.write(target, "x"))
+        const expected = glob(path.join(realpathSync(outside), "*"))
+
+        yield* assertExternalDirectoryEffect(ctx, target)
+
+        const req = requests.find((r) => r.permission === "external_directory")
+        expect(req).toBeDefined()
+        expect(req!.patterns).toEqual([expected])
+        expect(req!.metadata.filepath).toBe(path.join(realpathSync(outside), "existing.txt"))
+      }),
+    )
+
+    it.instance("follows symlinks for targets that do not exist yet", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { requests, ctx } = makeCtx()
+
+        const outside = yield* tmpdirScoped()
+        const link = path.join(test.directory, "vendor")
+        yield* Effect.promise(() => symlink(outside, link))
+
+        // `write` and `apply_patch` target files that do not exist yet; realpath
+        // fails on those, so the nearest existing ancestor has to be resolved.
+        const target = path.join(link, "brand-new.txt")
+        const expected = glob(path.join(realpathSync(outside), "*"))
+
+        yield* assertExternalDirectoryEffect(ctx, target)
+
+        const req = requests.find((r) => r.permission === "external_directory")
+        expect(req).toBeDefined()
+        expect(req!.patterns).toEqual([expected])
+      }),
+    )
+
+    it.instance("does not prompt for ordinary paths inside the project", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { requests, ctx } = makeCtx()
+
+        yield* assertExternalDirectoryEffect(ctx, path.join(test.directory, "src", "new-file.ts"))
+
+        expect(requests.length).toBe(0)
+      }),
+    )
+  }
 
   if (process.platform === "win32") {
     it.instance(


### PR DESCRIPTION
`containsPath` is `path.relative` string math, but every caller hands the same unresolved string to an fs call, and fs follows symlinks. A link inside the project pointing outside it passes the check while the read or write lands outside, so `external_directory` never fires.

The fallback prompt is wrong too, not just missing. `read` and `edit` display `path.relative(worktree, filepath)`, so you see the in-project link path while a different file is being touched.

Windows already resolved here via `normalizePath` and `realpathSync.native`. POSIX passed the target straight through. This resolves on both.

### Issue for this PR

Closes #40160

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`assertExternalDirectoryEffect` now resolves the target before `containsPath`, so the check, the glob it builds, and the `filepath` it puts in the prompt metadata all refer to the file the OS will actually open.

A plain `realpath` is not enough on its own. `write` and `apply_patch` legitimately target files that do not exist yet, and `realpath` fails with ENOENT on those, which would silently fall back to the lexical path and leave the hole open for exactly the case that writes a new file. So `follow()` walks up to the nearest existing ancestor and re-attaches the tail, which resolves a symlinked parent directory even when the leaf is new.

Errors other than ENOENT, such as ELOOP or EACCES, keep the lexical path. Resolution is a guard here, not a hard requirement, and failing a tool call because a path could not be resolved would be worse than the current behaviour.

Note this does not change anything for ordinary in-project paths, since they resolve to themselves, so it should not add prompts to normal use.

### How did you verify your code works?

Three tests in `packages/opencode/test/tool/external-directory.test.ts`: a symlink to an outside dir with an existing file behind it (asserting both the glob and that `metadata.filepath` names the real target), the same with a file that does not exist yet, and a regression test that an ordinary in-project path still produces no request.

I also built the symlink layout on disk and checked `follow()` directly for `vendor/existing.txt`, `vendor/brand-new.txt`, `vendor/deep/a/b.txt`, and a normal in-project file. The first three flip from contained to not contained, the last stays contained.

`cd packages/opencode && bun test test/tool/external-directory.test.ts`

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR