### PR TITLE
fix(tui): let the prompt Down arrow reach the end of the text

### DIFF
--- a/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
@@ -21,6 +21,9 @@ import {
   mentionTriggerIndex,
   isNewCommand,
   movePromptHistory,
+  promptOffsetWidth,
+  promptOnFirstRow,
+  promptOnLastRow,
   pushPromptHistory,
 } from "./prompt.shared"
 import { OPENCODE_BASE_MODE, useBindings } from "@opencode-ai/tui/keymap"
@@ -591,7 +594,7 @@ export function createPromptState(input: PromptInput): PromptState {
     })
   }
 
-  const restore = (value: RunPrompt, cursor = Bun.stringWidth(value.text)) => {
+  const restore = (value: RunPrompt, cursor = promptOffsetWidth(value.text)) => {
     draft = clonePrompt(value)
     setShell(value.mode === "shell")
     if (!area || area.isDestroyed) {
@@ -601,7 +604,7 @@ export function createPromptState(input: PromptInput): PromptState {
     hide()
     area.setText(value.text)
     restoreParts(value.parts)
-    area.cursorOffset = Math.min(cursor, Bun.stringWidth(area.plainText))
+    area.cursorOffset = Math.min(cursor, promptOffsetWidth(area.plainText))
     scheduleRows()
     area.focus()
   }
@@ -632,7 +635,7 @@ export function createPromptState(input: PromptInput): PromptState {
     area.setText(text)
     clearParts()
     draft = shell() ? { text: area.plainText, parts: [], mode: "shell" } : { text: area.plainText, parts: [] }
-    area.cursorOffset = Math.min(Bun.stringWidth(text), Bun.stringWidth(area.plainText))
+    area.cursorOffset = Math.min(promptOffsetWidth(text), promptOffsetWidth(area.plainText))
     scheduleRows()
     area.focus()
   }
@@ -766,19 +769,15 @@ export function createPromptState(input: PromptInput): PromptState {
     if (move(dir, event)) return
     if (!area || area.isDestroyed) return false
 
-    const endOffset = Bun.stringWidth(area.plainText)
-    if (dir === -1 && area.visualCursor.visualRow === 0) {
-      area.cursorOffset = 0
+    if (dir === -1 && promptOnFirstRow(area)) {
+      area.gotoBufferHome()
     }
 
-    const end =
-      typeof area.height === "number" && Number.isFinite(area.height) && area.height > 0
-        ? area.height - 1
-        : Math.max(0, (area.virtualLineCount ?? 1) - 1)
-    if (dir === 1 && area.visualCursor.visualRow === end) {
-      area.cursorOffset = endOffset
+    if (dir === 1 && promptOnLastRow(area)) {
+      area.gotoBufferEnd()
     }
 
+    // Reject so the textarea layer still moves the cursor one row.
     return false
   }
 
@@ -871,13 +870,13 @@ export function createPromptState(input: PromptInput): PromptState {
         shell() || !head
           ? cursor
           : local
-            ? Bun.stringWidth(area.plainText)
-            : Bun.stringWidth(area.plainText.slice(0, head.end))
+            ? promptOffsetWidth(area.plainText)
+            : promptOffsetWidth(area.plainText.slice(0, head.end))
       const end = area.logicalCursor
 
       area.deleteRange(start.row, start.col, end.row, end.col)
       area.insertText(text)
-      area.cursorOffset = Bun.stringWidth(text)
+      area.cursorOffset = promptOffsetWidth(text)
       hide()
       syncDraft()
       if (!shell()) {
@@ -902,7 +901,7 @@ export function createPromptState(input: PromptInput): PromptState {
 
     const text = "@" + next.value
     const startOffset = at()
-    const endOffset = startOffset + Bun.stringWidth(text)
+    const endOffset = startOffset + promptOffsetWidth(text)
     const part = structuredClone(next.part)
     if (part.type === "agent") {
       part.source = {

--- a/packages/opencode/src/cli/cmd/run/prompt.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/prompt.shared.ts
@@ -7,7 +7,15 @@
 // the current browse position. When the user arrows up at cursor offset 0,
 // the current draft is saved and history begins. Arrowing past the end
 // restores the draft.
-export { displayCharAt, displaySlice, mentionTriggerIndex } from "../prompt-display"
+export {
+  displayCharAt,
+  displaySlice,
+  mentionTriggerIndex,
+  promptOffsetWidth,
+  promptOnFirstRow,
+  promptOnLastRow,
+} from "../prompt-display"
+import { promptOffsetWidth } from "../prompt-display"
 import type { RunPrompt } from "./types"
 
 const HISTORY_LIMIT = 200
@@ -102,7 +110,7 @@ export function movePromptHistory(state: PromptHistoryState, dir: -1 | 1, text: 
     return { state, apply: false }
   }
 
-  if (dir === 1 && cursor !== Bun.stringWidth(text)) {
+  if (dir === 1 && cursor !== promptOffsetWidth(text)) {
     return { state, apply: false }
   }
 
@@ -136,7 +144,7 @@ export function movePromptHistory(state: PromptHistoryState, dir: -1 | 1, text: 
         index: null,
       },
       text: state.draft,
-      cursor: Bun.stringWidth(state.draft),
+      cursor: promptOffsetWidth(state.draft),
       apply: true,
     }
   }
@@ -147,7 +155,7 @@ export function movePromptHistory(state: PromptHistoryState, dir: -1 | 1, text: 
       index: idx,
     },
     text: state.items[idx].text,
-    cursor: dir === -1 ? 0 : Bun.stringWidth(state.items[idx].text),
+    cursor: dir === -1 ? 0 : promptOffsetWidth(state.items[idx].text),
     apply: true,
   }
 }

--- a/packages/opencode/test/cli/run/footer.prompt.cursor.test.tsx
+++ b/packages/opencode/test/cli/run/footer.prompt.cursor.test.tsx
@@ -1,0 +1,208 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender, useRenderer } from "@opentui/solid"
+import { createSignal } from "solid-js"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "@opencode-ai/tui/keymap"
+import { RunFooterView } from "@/cli/cmd/run/footer.view"
+import { RUN_THEME_FALLBACK } from "@/cli/cmd/run/theme"
+import { promptOffsetWidth } from "@opencode-ai/tui/prompt/display"
+import type { FooterState, FooterSubagentState, FooterView, RunPrompt } from "@/cli/cmd/run/types"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+
+const tuiConfig = createTuiResolvedConfig()
+
+async function renderComposer(input: { history?: RunPrompt[] } = {}) {
+  const [view] = createSignal<FooterView>({ type: "prompt" })
+  const [subagents] = createSignal<FooterSubagentState>({ tabs: [], details: {}, permissions: [], questions: [] })
+  const [state] = createSignal<FooterState>({
+    phase: "idle",
+    status: "",
+    queue: 0,
+    model: "gpt-5",
+    duration: "",
+    usage: "",
+    first: true,
+    interrupt: 0,
+    exit: 0,
+  })
+  let offKeymap: (() => void) | undefined
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    offKeymap = registerOpencodeKeymap(keymap, renderer, tuiConfig)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <RunFooterView
+          directory="/tmp"
+          findFiles={async () => []}
+          agents={() => []}
+          resources={() => []}
+          commands={() => []}
+          providers={() => undefined}
+          currentModel={() => undefined}
+          variants={() => []}
+          currentVariant={() => undefined}
+          state={state}
+          view={view}
+          subagent={subagents}
+          theme={() => RUN_THEME_FALLBACK}
+          tuiConfig={tuiConfig}
+          backgroundSubagents={true}
+          agent="opencode"
+          history={input.history}
+          onSubmit={() => true}
+          onPermissionReply={() => {}}
+          onQuestionReply={() => {}}
+          onQuestionReject={() => {}}
+          onCycle={() => {}}
+          onInterrupt={() => false}
+          onEditorOpen={async () => undefined}
+          onInputClear={() => {}}
+          onExit={() => {}}
+          onModelSelect={() => {}}
+          onVariantSelect={() => {}}
+          onRows={() => {}}
+          onLayout={() => {}}
+          onStatus={() => {}}
+          onQueuedRemove={async () => true}
+        />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(
+    () => (
+      <box width={40} height={16}>
+        <Harness />
+      </box>
+    ),
+    { width: 40, height: 16, kittyKeyboard: true },
+  )
+  await app.renderOnce()
+
+  return {
+    ...app,
+    area() {
+      return app.renderer.currentFocusedEditor!
+    },
+    async press(dir: "up" | "down", times: number) {
+      for (let i = 0; i < times; i++) {
+        app.mockInput.pressArrow(dir)
+        await app.renderOnce()
+      }
+    },
+    cleanup() {
+      app.renderer.currentFocusedRenderable?.blur()
+      app.renderer.currentFocusedEditor?.blur()
+      offKeymap?.()
+      offKeymap = undefined
+      app.renderer.destroy()
+    },
+  }
+}
+
+test("direct composer down arrow walks a multi-line prompt to its end", async () => {
+  const app = await renderComposer()
+
+  try {
+    const area = app.area()
+    area.setText("one\ntwo\nthree")
+    await app.renderOnce()
+    const end = promptOffsetWidth(area.plainText)
+
+    // Middle of the second line. Each newline costs one offset position, so the
+    // end offset is 13 here while Bun.stringWidth would report 11.
+    area.cursorOffset = 5
+    await app.renderOnce()
+    await app.press("down", 1)
+    expect(area.cursorOffset).toBe(9)
+
+    await app.press("down", 3)
+    expect(area.cursorOffset).toBe(end)
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct composer down arrow reaches the end of wide-character text", async () => {
+  const app = await renderComposer()
+
+  try {
+    const area = app.area()
+    area.setText("你好世界\n第二行文字\n第三行")
+    await app.renderOnce()
+
+    area.gotoBufferHome()
+    await app.renderOnce()
+    await app.press("down", 6)
+    expect(area.cursorOffset).toBe(promptOffsetWidth(area.plainText))
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct composer arrows never move backwards in a scrolled prompt", async () => {
+  const app = await renderComposer()
+
+  try {
+    const area = app.area()
+    // Eight lines against TEXTAREA_MAX_ROWS (6) forces the viewport to scroll.
+    area.setText("l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8")
+    await app.renderOnce()
+    area.gotoBufferHome()
+    await app.renderOnce()
+
+    const seen = [area.cursorOffset]
+    for (let i = 0; i < 9; i++) {
+      app.mockInput.pressArrow("down")
+      await app.renderOnce()
+      expect(area.cursorOffset).toBeGreaterThanOrEqual(seen[seen.length - 1])
+      seen.push(area.cursorOffset)
+    }
+    expect(area.cursorOffset).toBe(promptOffsetWidth(area.plainText))
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct composer up arrow walks a multi-line prompt to its start", async () => {
+  const app = await renderComposer()
+
+  try {
+    const area = app.area()
+    area.setText("你好世界\n第二行文字\n第三行")
+    await app.renderOnce()
+    area.gotoBufferEnd()
+    await app.renderOnce()
+
+    await app.press("up", 6)
+    expect(area.cursorOffset).toBe(0)
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct composer recalls history from the end of a multi-line draft", async () => {
+  const app = await renderComposer({ history: [{ text: "older prompt", parts: [] }] })
+
+  try {
+    const area = app.area()
+    area.setText("draft one\ndraft two")
+    await app.renderOnce()
+    area.gotoBufferEnd()
+    await app.renderOnce()
+
+    // Up walks to the top of the draft, then swaps in the history entry.
+    await app.press("up", 3)
+    expect(area.plainText).toBe("older prompt")
+
+    // Down at the end of the entry restores the draft rather than stalling.
+    await app.press("down", 2)
+    expect(area.plainText).toBe("draft one\ndraft two")
+  } finally {
+    app.cleanup()
+  }
+})

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { promptOffsetWidth } from "../../prompt/display"
+import { promptOffsetWidth, promptOnFirstRow, promptOnLastRow } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -508,7 +508,7 @@ export function Prompt(props: PromptProps) {
             parts: updatedNonTextParts,
           })
           restoreExtmarksFromParts(updatedNonTextParts)
-          input.cursorOffset = Bun.stringWidth(normalized)
+          input.gotoBufferEnd()
         },
       },
       {
@@ -872,7 +872,7 @@ export function Prompt(props: PromptProps) {
           category: "Prompt",
           run() {
             if (input.cursorOffset !== 0) {
-              if (input.scrollY + input.visualCursor.visualRow === 0) input.cursorOffset = 0
+              if (promptOnFirstRow(input)) input.gotoBufferHome()
               return false
             }
 
@@ -903,12 +903,8 @@ export function Prompt(props: PromptProps) {
           title: "Next prompt history",
           category: "Prompt",
           run() {
-            if (input.cursorOffset !== input.plainText.length) {
-              if (
-                input.scrollY + input.visualCursor.visualRow ===
-                Math.max(0, input.editorView.getTotalVirtualLineCount() - 1)
-              )
-                input.cursorOffset = input.plainText.length
+            if (input.cursorOffset !== promptOffsetWidth(input.plainText)) {
+              if (promptOnLastRow(input)) input.gotoBufferEnd()
               return false
             }
 
@@ -918,7 +914,7 @@ export function Prompt(props: PromptProps) {
             setStore("prompt", item)
             setStore("mode", item.mode ?? "normal")
             restoreExtmarksFromParts(item.parts)
-            input.cursorOffset = input.plainText.length
+            input.gotoBufferEnd()
           },
         },
       ],

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -7,7 +7,20 @@ export function promptOffsetWidth(value: string) {
   for (const part of graphemes.segment(value)) {
     // Textarea offsets count newlines as one position and tabs as two, while
     // Bun.stringWidth counts both as zero.
-    width += part.segment === "\n" ? 1 : part.segment === "\t" ? 2 : Bun.stringWidth(part.segment)
+    if (part.segment === "\n") {
+      width += 1
+      continue
+    }
+    if (part.segment === "\t") {
+      width += 2
+      continue
+    }
+
+    // The widget measures a cluster by the width of the character it renders,
+    // so decomposed input (IME-committed hangul jamo, か + combining dakuten)
+    // has to be composed first or each piece gets counted on its own. Only
+    // multi-codepoint clusters can decompose, so single ones skip the work.
+    width += Bun.stringWidth(part.segment.length > 1 ? part.segment.normalize("NFC") : part.segment)
   }
   return width
 }

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -1,12 +1,26 @@
+import type { EditBufferRenderable } from "@opentui/core"
+
 const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" })
 
 export function promptOffsetWidth(value: string) {
   let width = 0
   for (const part of graphemes.segment(value)) {
-    // Textarea offsets count newlines as one position; Bun.stringWidth counts them as zero.
-    width += part.segment === "\n" ? 1 : Bun.stringWidth(part.segment)
+    // Textarea offsets count newlines as one position and tabs as two, while
+    // Bun.stringWidth counts both as zero.
+    width += part.segment === "\n" ? 1 : part.segment === "\t" ? 2 : Bun.stringWidth(part.segment)
   }
   return width
+}
+
+// visualCursor.visualRow is viewport-relative, so scrollY is what makes it a
+// document row. Comparing visualRow alone treats the top of a scrolled viewport
+// as the first line of the buffer.
+export function promptOnFirstRow(input: EditBufferRenderable) {
+  return input.scrollY + input.visualCursor.visualRow === 0
+}
+
+export function promptOnLastRow(input: EditBufferRenderable) {
+  return input.scrollY + input.visualCursor.visualRow === Math.max(0, input.editorView.getTotalVirtualLineCount() - 1)
 }
 
 function displayOffsetIndex(value: string, offset: number) {

--- a/packages/tui/test/prompt/display-offset.test.tsx
+++ b/packages/tui/test/prompt/display-offset.test.tsx
@@ -1,0 +1,119 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { TextareaRenderable } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { promptOffsetWidth, promptOnFirstRow, promptOnLastRow } from "../../src/prompt/display"
+
+// The textarea's cursorOffset lives in a display-column space where a newline
+// takes one position and a tab takes two, so neither Bun.stringWidth (newline
+// and tab count as zero) nor String.length (wide characters count as one) can
+// stand in for it. These tests pin promptOffsetWidth and the row predicates
+// against what the real widget reports.
+async function mount(width = 40) {
+  let area!: TextareaRenderable
+  const app = await testRender(
+    () => (
+      <box width={width} height={10}>
+        <textarea
+          width="100%"
+          minHeight={1}
+          maxHeight={6}
+          wrapMode="word"
+          ref={(next: TextareaRenderable) => (area = next)}
+        />
+      </box>
+    ),
+    { width, height: 10 },
+  )
+  await app.renderOnce()
+  return { app, area }
+}
+
+async function endOffset(app: Awaited<ReturnType<typeof mount>>["app"], area: TextareaRenderable, text: string) {
+  area.setText(text)
+  await app.renderOnce()
+  area.gotoBufferEnd()
+  await app.renderOnce()
+  return area.cursorOffset
+}
+
+test("promptOffsetWidth matches the textarea end-of-buffer offset", async () => {
+  const { app, area } = await mount()
+
+  try {
+    for (const text of [
+      "",
+      "abc",
+      "one\ntwo\nthree",
+      "trailing\n",
+      "\nleading",
+      "a\n\nb",
+      "中文",
+      "中文\n中文",
+      "你好世界\n第二行文字\n第三行",
+      "中a文b\nc中d",
+      "tab\there",
+      "x\n\ty",
+      "wrap ".repeat(20).trim(),
+      "wrap ".repeat(20).trim() + "\nsecond line that is also quite long indeed",
+    ]) {
+      expect(promptOffsetWidth(text)).toBe(await endOffset(app, area, text))
+    }
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("row predicates track document rows, not viewport rows", async () => {
+  const { app, area } = await mount()
+
+  try {
+    // Eight logical lines against maxHeight 6, so the viewport has to scroll and
+    // visualRow stops matching the document row.
+    await endOffset(app, area, "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8")
+    expect(area.editorView.getTotalVirtualLineCount()).toBe(8)
+    expect(area.scrollY).toBeGreaterThan(0)
+    expect(promptOnLastRow(area)).toBe(true)
+    expect(promptOnFirstRow(area)).toBe(false)
+
+    area.gotoBufferHome()
+    await app.renderOnce()
+    expect(area.scrollY).toBe(0)
+    expect(promptOnFirstRow(area)).toBe(true)
+    expect(promptOnLastRow(area)).toBe(false)
+
+    // Walk down one row at a time. The predicate must stay false for every row
+    // above the last one, including the rows the viewport scrolls through where
+    // visualRow no longer equals the document row.
+    const scrolled: number[] = []
+    for (let row = 0; row < 7; row++) {
+      expect(promptOnLastRow(area)).toBe(false)
+      if (area.scrollY > 0) scrolled.push(area.visualCursor.visualRow)
+      area.moveCursorDown()
+      await app.renderOnce()
+    }
+    expect(promptOnLastRow(area)).toBe(true)
+    expect(scrolled.every((visualRow) => visualRow !== 7)).toBe(true)
+    expect(scrolled.length).toBeGreaterThan(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("row predicates hold for a word-wrapped single logical line", async () => {
+  const { app, area } = await mount()
+
+  try {
+    await endOffset(app, area, "这是一段很长的中文文本用来测试自动折行之后光标能不能一直走到最末尾")
+    expect(area.lineCount).toBe(1)
+    expect(area.editorView.getTotalVirtualLineCount()).toBeGreaterThan(1)
+    expect(promptOnLastRow(area)).toBe(true)
+
+    area.gotoBufferHome()
+    await app.renderOnce()
+    expect(promptOnFirstRow(area)).toBe(true)
+    expect(promptOnLastRow(area)).toBe(false)
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/tui/test/prompt/display-offset.test.tsx
+++ b/packages/tui/test/prompt/display-offset.test.tsx
@@ -64,6 +64,39 @@ test("promptOffsetWidth matches the textarea end-of-buffer offset", async () => 
   }
 })
 
+test("promptOffsetWidth measures decomposed clusters as the widget renders them", async () => {
+  const { app, area } = await mount()
+
+  try {
+    // An IME can commit hangul as separate jamo and Japanese kana as a base
+    // plus a combining mark. The widget draws one character and charges its
+    // width once, so the cluster has to be composed before measuring.
+    for (const text of [
+      "한국어",
+      "한국어".normalize("NFD"),
+      "가".normalize("NFD"),
+      "안녕하세요 테스트입니다",
+      "안녕하세요 테스트입니다".normalize("NFD"),
+      "안녕하세요\n테스트입니다\n마지막",
+      "안녕하세요\n테스트입니다\n마지막".normalize("NFD"),
+      "が",
+      "が".normalize("NFD"),
+      "こんにちは".normalize("NFD"),
+      "café".normalize("NFD"),
+      "👨‍👩‍👧‍👦",
+      "🇰🇷",
+      // Jamo typed on their own stay separate characters and keep their own widths.
+      "ᄀ",
+      "ᅡ",
+      "ㄱㅏ",
+    ]) {
+      expect(promptOffsetWidth(text)).toBe(await endOffset(app, area, text))
+    }
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("row predicates track document rows, not viewport rows", async () => {
   const { app, area } = await mount()
 


### PR DESCRIPTION
### Issue for this PR

Closes #40161

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The textarea's `cursorOffset` is measured in display columns, and in that space a newline takes one position and a tab takes two. Both prompt implementations compared it against something else:

- `packages/tui` used `input.plainText.length`. Any wide character makes that smaller than the real end offset (`你好世界\n第二行文字\n第三行` ends at 26, `plainText.length` is 14). So when the cursor was already at the end, `prompt.history.next` decided it was not, reset the offset to 14 — the middle of the text — and the built-in `input.move.down` moved it back to 25. Pressing Down just bounced between two positions and never reached the end.
- The run-mode composer used `Bun.stringWidth`, which counts a newline as zero, so its end offset was short by one per newline and failed on plain ASCII too. It also compared `visualCursor.visualRow` against `area.height`, but `visualRow` is viewport-relative, so in a scrolled prompt Down could move the cursor *backwards*.

Fix: use `promptOffsetWidth` (already in `packages/tui/src/prompt/display.ts`, it counts newlines as 1) for the arithmetic, and call `gotoBufferEnd()` / `gotoBufferHome()` where only cursor placement is needed so the widget measures for itself. Added `promptOnFirstRow` / `promptOnLastRow`, which add `scrollY` to `visualRow` and compare against `getTotalVirtualLineCount()` — the document row rather than the viewport row.

Both handlers still `return false` after the jump, which is what lets the textarea layer's `move-down` run; that fallthrough is intentional and unchanged.

`promptOffsetWidth` also needed a tab case: the widget gives a tab two columns, `Bun.stringWidth` gives it zero.

### How did you verify your code works?

Reproduced first, against the real opentui renderer, then wrote the tests to fail before the fix:

- `packages/tui/test/prompt/display-offset.test.tsx` — checks `promptOffsetWidth` against what `gotoBufferEnd()` reports for 14 strings (newlines, CJK, tabs, wrapped text), and walks a scrolled 8-line buffer row by row to confirm the row predicates never fire early. Reverting just the tab case makes it fail with `Expected: 9, Received: 7`.
- `packages/opencode/test/cli/run/footer.prompt.cursor.test.tsx` — drives the run composer through real arrow keys: Down to the end of multi-line and CJK text, no backwards movement in a scrolled prompt, Up to the start, and history recall from the end of a multi-line draft. 3 of 5 fail without the fix (`Expected: 26, Received: 24` and `Expected: >= 21, Received: 19`).

To confirm by hand: run `opencode`, type Chinese text across three lines with shift+enter, put the cursor in the middle, hold Down. Before, it sticks one position short of the end; after, it walks to the end.

Also ran `bun test` in `packages/tui` (194 pass), `bun test test/cli/run/` in `packages/opencode` (200 pass), and `bun typecheck` (30/30).

### Screenshots / recordings

_Not a visual change — cursor position only. The measured offsets are in the section above._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
