### PR TITLE
fix(schema): encode output format values read back from storage

### DIFF
--- a/packages/opencode/test/session/structured-output.test.ts
+++ b/packages/opencode/test/session/structured-output.test.ts
@@ -8,6 +8,8 @@ import { SessionID, MessageID } from "../../src/session/schema"
 const decodeFormat = Schema.decodeUnknownExit(SessionV1.Format)
 const decodeUser = Schema.decodeUnknownExit(SessionV1.User)
 const decodeAssistant = Schema.decodeUnknownExit(SessionV1.Assistant)
+const encodeFormat = Schema.encodeUnknownSync(SessionV1.Format)
+const encodeUser = Schema.encodeUnknownSync(SessionV1.User)
 
 describe("structured-output.OutputFormat", () => {
   test("parses text format", () => {
@@ -61,6 +63,30 @@ describe("structured-output.OutputFormat", () => {
       retryCount: -1,
     })
     expect(Exit.isFailure(result)).toBe(true)
+  })
+
+  // Messages come back out of storage as plain JSON, and that value is what the
+  // message routes and MessageUpdated events encode.
+  test("encodes a text format read back from storage", () => {
+    expect(encodeFormat({ type: "text" })).toEqual({ type: "text" })
+  })
+
+  test("encodes a json_schema format read back from storage", () => {
+    const stored = { type: "json_schema" as const, schema: { type: "object" }, retryCount: 2 }
+    expect(encodeFormat(stored)).toEqual(stored)
+  })
+
+  test("encodes a stored user message that carries a format", () => {
+    const encoded = encodeUser({
+      id: MessageID.ascending(),
+      sessionID: SessionID.descending(),
+      role: "user",
+      time: { created: Date.now() },
+      agent: "default",
+      model: { providerID: "anthropic", modelID: "claude-3" },
+      format: { type: "json_schema", schema: { type: "object" }, retryCount: 2 },
+    }) as Record<string, unknown>
+    expect(encoded.format).toEqual({ type: "json_schema", schema: { type: "object" }, retryCount: 2 })
   })
 })
 

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -62,15 +62,17 @@ export const ContentFilterError = namedError("ContentFilterError", {
   message: Schema.String,
 })
 
-export class OutputFormatText extends Schema.Class<OutputFormatText>("OutputFormatText")({
+// Messages are read back out of storage as plain JSON, so these must stay structs: a
+// Schema.Class only encodes an actual class instance and rejects the stored object.
+export const OutputFormatText = Schema.Struct({
   type: Schema.Literal("text"),
-}) {}
+}).annotate({ identifier: "OutputFormatText" })
 
-export class OutputFormatJsonSchema extends Schema.Class<OutputFormatJsonSchema>("OutputFormatJsonSchema")({
+export const OutputFormatJsonSchema = Schema.Struct({
   type: Schema.Literal("json_schema"),
   schema: Schema.Record(Schema.String, Schema.Any).annotate({ identifier: "JSONSchema" }),
   retryCount: NonNegativeInt.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(2))),
-}) {}
+}).annotate({ identifier: "OutputFormatJsonSchema" })
 
 export const Format = Schema.Union([OutputFormatText, OutputFormatJsonSchema]).annotate({
   discriminator: "type",

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2787,16 +2787,6 @@ export type ProviderNotFoundError = {
   message: string
 }
 
-export type OutputFormat1 =
-  | {
-      type: "text"
-    }
-  | {
-      type: "json_schema"
-      schema: JsonSchema
-      retryCount?: number
-    }
-
 export type SessionStatus2 = {
   id: string
   metadata?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -23806,39 +23806,6 @@
         "required": ["_tag", "providerID", "message"],
         "additionalProperties": false
       },
-      "OutputFormat1": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["text"]
-              }
-            },
-            "required": ["type"],
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["json_schema"]
-              },
-              "schema": {
-                "$ref": "#/components/schemas/JSONSchema"
-              },
-              "retryCount": {
-                "type": "integer",
-                "minimum": 0
-              }
-            },
-            "required": ["type", "schema"],
-            "additionalProperties": false
-          }
-        ]
-      },
       "session.status": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Fixes #40169.

`OutputFormatText` / `OutputFormatJsonSchema` were `Schema.Class`, which only encodes an actual class instance. Messages come back out of storage as plain JSON, so every path that re-emits a stored message carrying `format` failed:

- `GET /session/:id/message` returns 400 `Expected OutputFormatJsonSchema, got {...} at [0]["info"]["format"]` for any session where a prompt used an output format. The route encodes stored rows against `Schema.Array(SessionV1.WithParts)`.
- `session/fork` copies no messages: it re-publishes each copied message through `updateMessage` -> `events.publish(MessageUpdated)`, which hits the same encode. The forked session is created but stays empty, and because the request never completes, a client that retries on timeout/5xx keeps creating empty sessions.

Making both plain structs (keeping their `identifier` annotations) lets the stored value encode, while leaving the wire format, the OpenAPI component names and the decode behaviour - including the `retryCount` default - unchanged. Nothing constructs these classes (no `new`, no `instanceof`); they are only re-exported as values from `packages/core/src/v1/session.ts`.

## Tests

Three cases added to `packages/opencode/test/session/structured-output.test.ts`: encoding a stored `text` format, a stored `json_schema` format, and a stored user message carrying one. On `dev` they fail with the production error; with the fix they pass.

## Verification

- `bun test test/session` in `packages/opencode`: 372 pass, 0 fail
- `bun turbo typecheck`: 30/30 successful
- prettier and oxlint clean on the changed files (oxlint warning count unchanged from `dev`)
- `bun dev generate` + `packages/sdk/js/script/build.ts`: the only regeneration diff is the removal of the orphan `OutputFormat1` component and its generated type, which the class-based union duplicated and which nothing referenced. That is the one API-visible consequence, in case you would rather keep the symbol around.

The two `public event manifest` failures in `packages/schema` reproduce identically on a clean `dev` checkout and are unrelated to this change.