### PR TITLE
fix(tui): keep closed tabs closed

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { isDeepEqual } from "remeda"
 import { createSimpleContext } from "./helper"
 import { useClient } from "./client"
@@ -126,22 +126,40 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       })
     }
 
+    createEffect(
+      on(
+        [
+          () => (enabled() && route.data.type === "session" ? route.data.sessionID : undefined),
+          () => config.tabs?.scope,
+          () => paths.cwd,
+        ],
+        ([routed]) => {
+          if (!routed || routed === "dummy") return
+          const sessionID = root(routed)
+          history = recordSessionTabHistory(history, sessionID)
+          const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
+          update((draft) => {
+            draft.tabs = openSessionTab(draft.tabs, {
+              sessionID,
+              title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
+            })
+            delete draft.unread[sessionID]
+          })
+        },
+      ),
+    )
+
     createEffect(() => {
-      if (!enabled()) return
-      if (route.data.type !== "session" || route.data.sessionID === "dummy") return
+      if (!enabled() || route.data.type !== "session" || route.data.sessionID === "dummy") return
       const sessionID = root(route.data.sessionID)
-      history = recordSessionTabHistory(history, sessionID)
-      const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
-      const tabs = openSessionTab(state().tabs, {
-        sessionID,
-        title: title(sessionID, state().tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
-      })
-      if (tabs === state().tabs && !state().unread[sessionID]) return
+      const tab = state().tabs.find((tab) => tab.sessionID === sessionID)
+      if (!tab) return
+      const nextTitle = title(sessionID, tab.title)
+      if ((!nextTitle || nextTitle === tab.title) && !state().unread[sessionID]) return
       update((draft) => {
-        draft.tabs = openSessionTab(draft.tabs, {
-          sessionID,
-          title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
-        })
+        const tab = draft.tabs.find((tab) => tab.sessionID === sessionID)
+        if (!tab) return
+        draft.tabs = openSessionTab(draft.tabs, { sessionID, title: title(sessionID, tab.title) })
         delete draft.unread[sessionID]
       })
     })

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -170,6 +170,31 @@ test("concurrent TUIs do not alternate shared tab titles from divergent session 
   }
 })
 
+test("closing a tab is not undone by another TUI viewing the same session", async () => {
+  const state = stateDir("opencode-session-tabs-shared-close-")
+  const first = await renderSessionTabs("shared", { state })
+  const second = await renderSessionTabs("shared", { state })
+
+  try {
+    await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    await wait(() => second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    first.tabs.close()
+    await wait(() => first.route.data.type === "home")
+    await wait(() => !second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    await Bun.sleep(50)
+
+    expect(first.tabs.tabs().some((tab) => tab.sessionID === "shared")).toBe(false)
+
+    second.route.navigate({ type: "home" })
+    await wait(() => second.route.data.type === "home")
+    second.route.navigate({ type: "session", sessionID: "shared" })
+    await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+  } finally {
+    first.destroy()
+    second.destroy()
+  }
+})
+
 test("user prompt admissions pulse an already-busy background tab", async () => {
   const setup = await renderSessionTabs("background")
   const admitted = (sessionID: string, inputID: string): OpenCodeEvent => ({


### PR DESCRIPTION
## What

Keep a session tab closed when another TUI process is still viewing the same session.

## Before / After

**Before:** session tabs use shared persisted state. Closing the active tab in one TUI removed it and navigated that TUI away, but another TUI whose route still pointed at the same session observed the removal. Its route-sync effect treated the missing tab as new and appended it again, so the closed tab reappeared at the end of the strip.

**After:** a missing tab is opened only when that TUI actually enters the session route, enables tabs, or changes tab scope. Reactive title, unread, root-hydration, and shared-storage updates can update an existing tab but cannot resurrect a removed one. Explicitly navigating away and back still opens the session again.

## How

- `packages/tui/src/context/session-tabs.tsx` separates route admission from metadata reconciliation with Solid's `on` helper.
- Route admission tracks the raw route plus tab scope, so later root hydration does not masquerade as navigation while scope changes still populate the selected store.
- Metadata reconciliation checks tab presence both before scheduling persistence and again inside the locked mutation, closing the stale-write race.
- `packages/tui/test/context/session-tabs.test.tsx` runs two TUI providers against the same persisted state and verifies close, non-resurrection, and explicit reopen behavior.

## Scope

- This preserves shared global/cwd tab persistence across TUI processes.
- This does not change tab keybindings, close animations, or session deletion.

## Testing

- `bun run test test/context/session-tabs.test.tsx test/context/session-tabs-model.test.ts` from `packages/tui` (34 passed)
- `bun typecheck` from `packages/tui`
- `bun run test` from `packages/tui` (592 passed, 5 skipped)
- Push-hook workspace typecheck (33 tasks passed)
- `git diff --check`

The full suite emits the existing asynchronous session-tab lock teardown warning and completes with zero failures.

## Flow

```mermaid
sequenceDiagram
  participant A as TUI A
  participant S as Shared tab state
  participant B as TUI B
  A->>S: Close session tab
  S-->>B: Persisted tab removed
  Note over B: Route is unchanged
  B->>B: Metadata sync sees no existing tab
  Note over S: Tab remains closed
  B->>B: Navigate away and back
  B->>S: Open session tab
```
