### PR TITLE
feat(teach): Add Teach mode for pedagogical workflows

### DIFF
--- a/packages/opencode/test/agent/teach-mode-behavior.test.ts
+++ b/packages/opencode/test/agent/teach-mode-behavior.test.ts
@@ -1,0 +1,77 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { expect, describe, test } from "bun:test"
+import { Effect } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Session } from "../../src/session/session"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(Agent.node))
+
+describe("Teach Mode - Agent Behavior", () => {
+  it.instance("teach agent has primary mode for tab cycling", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.mode).toBe("primary")
+    }),
+  )
+
+  it.instance("teach agent is not hidden", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.hidden).toBeFalsy()
+    }),
+  )
+
+  it.instance("teach agent is native (built-in)", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.native).toBe(true)
+    }),
+  )
+
+  it.instance("teach agent has options object", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.options).toBeDefined()
+      expect(typeof agent.options).toBe("object")
+    }),
+  )
+
+  it.instance("teach agent has permission ruleset", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.permission).toBeDefined()
+      expect(Array.isArray(agent.permission)).toBe(true)
+      expect(agent.permission.length).toBeGreaterThan(0)
+    }),
+  )
+
+  it.instance("teach agent can be switched to via API", () =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.use.list()
+      
+      // Verify teach agent exists in the list
+      const teach = agents.find((a) => a.name === "teach")
+      expect(teach).toBeDefined()
+      
+      // The switchAgent API should accept "teach" as a valid agent name
+      // We can't actually switch without a session, but we can verify the agent exists
+      expect(teach?.name).toBe("teach")
+    }),
+  )
+
+  it.instance("teach agent has pedagogical description", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const description = agent.description?.toLowerCase() ?? ""
+      
+      expect(description).toContain("teach")
+      expect(description).toContain("pedagogical")
+    }),
+  )
+})

--- a/packages/opencode/test/agent/teach-mode-registration.test.ts
+++ b/packages/opencode/test/agent/teach-mode-registration.test.ts
@@ -1,0 +1,55 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { expect, describe, test } from "bun:test"
+import { Effect } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(Agent.node))
+
+describe("Teach Mode - Agent Registration", () => {
+  it.instance("teach agent is registered and visible", () =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.use.list()
+      const teach = agents.find((a) => a.name === "teach")
+      
+      expect(teach).toBeDefined()
+      expect(teach?.name).toBe("teach")
+      expect(teach?.mode).toBe("primary")
+      expect(teach?.native).toBe(true)
+      expect(teach?.hidden).toBeFalsy()
+    }),
+  )
+
+  it.instance("teach agent has correct description", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent.description).toBeDefined()
+      expect(agent.description).toContain("Teach")
+      expect(agent.description?.toLowerCase()).toContain("pedagogical")
+    }),
+  )
+
+  it.instance("teach agent can be retrieved by name", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      
+      expect(agent).toBeDefined()
+      expect(agent.name).toBe("teach")
+    }),
+  )
+
+  it.instance("teach agent appears in default agent list", () =>
+    Effect.gen(function* () {
+      const defaultAgent = yield* Agent.use.defaultAgent()
+      const agents = yield* Agent.use.list()
+      
+      // teach should be in the list of all agents
+      const teach = agents.find((a) => a.name === "teach")
+      expect(teach).toBeDefined()
+      
+      // Default agent might be build or something else, but teach should exist
+      expect(agents.map((a) => a.name)).toContain("teach")
+    }),
+  )
+})

--- a/packages/opencode/test/agent/teach-mode-restrictions.test.ts
+++ b/packages/opencode/test/agent/teach-mode-restrictions.test.ts
@@ -1,0 +1,142 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Global } from "@opencode-ai/core/global"
+import path from "path"
+import { expect, describe, test } from "bun:test"
+import { Effect } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { Permission } from "../../src/permission"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(Agent.node))
+
+describe("Teach Mode - Tool Restrictions", () => {
+  it.instance("denies write tool globally", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("write", "*", agent.permission)
+      
+      expect(rule.action).toBe("deny")
+    }),
+  )
+
+  it.instance("denies edit tool globally", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("edit", "*", agent.permission)
+      
+      expect(rule.action).toBe("deny")
+    }),
+  )
+
+  it.instance("denies bash tool globally", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("bash", "*", agent.permission)
+      
+      expect(rule.action).toBe("deny")
+    }),
+  )
+
+  it.instance("denies task.general", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("task", "general", agent.permission)
+      
+      expect(rule.action).toBe("deny")
+    }),
+  )
+
+  it.instance("denies todowrite tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("todowrite", "*", agent.permission)
+      
+      expect(rule.action).toBe("deny")
+    }),
+  )
+
+  // Read-only tools should be allowed
+  it.instance("allows read tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("read", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows glob tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("glob", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows grep tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("grep", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows list tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("list", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows question tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("question", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows webfetch tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("webfetch", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows websearch tool", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const rule = Permission.evaluate("websearch", "*", agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  // Teach-specific directory permissions
+  it.instance("allows edit in teach data directory", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const teachPath = path.join(Global.Path.data, "teach", "*")
+      const rule = Permission.evaluate("edit", teachPath, agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+
+  it.instance("allows edit in .opencode/teach directory", () =>
+    Effect.gen(function* () {
+      const agent = yield* Agent.use.get("teach")
+      const teachPath = path.join(".opencode", "teach", "*.md")
+      const rule = Permission.evaluate("edit", teachPath, agent.permission)
+      
+      expect(rule.action).toBe("allow")
+    }),
+  )
+})


### PR DESCRIPTION
## Issue for this PR
Related to #36521

## Type of change
- New feature

## What does this PR do?
This PR wants to add the Teach mode in opencode as suggested in issue #36521 requesting this specific feature.

As of now, I open it as WIP/Draft with only some tests files to discuss the implementation plan together. And here's what and how I plan to do it right now, sorry I'm not an expert on this repo, just trying my best.

---

## Implementation Plan

### Phase 1: Core Agent Definition
- Add teach agent to packages/opencode/src/agent/agent.ts after plan agent
- Deny all mutating tools (write, edit, bash, task, todowrite)
- Allow read-only tools (read, glob, grep, list, webfetch, websearch, question)
- Allow teach-specific directory editing (.opencode/teach/*.md)
- Mode: primary, native: true, hidden: false

### Phase 2: Pedagogical Prompt
- Create packages/opencode/src/agent/prompt/teach.txt
- Socratic method: ask questions, never provide direct answers
- Progressive disclosure: reveal info only when user demonstrates readiness
- No solution leakage: never write complete code or give direct answers
- Include example interactions

### Phase 3: Session Logging (Optional)
- Create tool to log teach sessions to ~/.opencode/teach/*.md

### Phase 4: Mode Switching
- No changes needed - Tab key already cycles through primary agents

### Phase 5: Testing
- Verify all 25 tests pass (GREEN phase) after implementation

---

## How did you verify your code works?
- All 25 tests run and fail as expected (RED phase of TDD)
- Tests cover: agent registration, tool restrictions, and agent behavior
- TypeScript typecheck passes
- Tests follow existing patterns from plan-mode-subagent-bypass.test.ts

## Checklist
- I have tested my changes locally
- I have not included unrelated changes in this PR