### PR TITLE
fix(opencode): match canonically equivalent Unicode in patches

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -480,7 +480,17 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: NFC normalization (canonical Unicode equivalence)
+  const canonical = tryMatch(
+    lines,
+    pattern,
+    startIndex,
+    (a, b) => a.normalize("NFC").trim() === b.normalize("NFC").trim(),
+    eof,
+  )
+  return canonical
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -139,6 +139,55 @@ PATCH`
     })
   })
 
+  describe("canonical Unicode matching", () => {
+    test("matches Cyrillic text when the file is NFD and the patch is NFC", () => {
+      const original = "Район: Астана\n".normalize("NFD")
+      const result = Patch.deriveNewContentsFromChunks(
+        "summary.md",
+        [
+          {
+            old_lines: ["Район: Астана".normalize("NFC")],
+            new_lines: ["Район: Алматы"],
+          },
+        ],
+        original,
+      )
+
+      expect(result.content).toBe("Район: Алматы\n")
+    })
+
+    test("matches Latin text when the file is NFC and the patch is NFD", () => {
+      const replacement = "touché".normalize("NFD")
+      const result = Patch.deriveNewContentsFromChunks(
+        "notes.md",
+        [
+          {
+            old_lines: ["café".normalize("NFD")],
+            new_lines: [replacement],
+          },
+        ],
+        "café\n".normalize("NFC"),
+      )
+
+      expect(result.content).toBe(replacement + "\n")
+    })
+
+    test("does not match genuinely different Unicode text", () => {
+      expect(() =>
+        Patch.deriveNewContentsFromChunks(
+          "notes.md",
+          [
+            {
+              old_lines: ["cafe"],
+              new_lines: ["updated"],
+            },
+          ],
+          "café\n",
+        ),
+      ).toThrow("Failed to find expected lines")
+    })
+  })
+
   describe("applyPatch", () => {
     it.live("should add a new file", () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #31651

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a final canonical Unicode-equivalence matching pass to
`seekSequence()`.

Patch verification previously failed when the file and patch contained
visually identical text represented using different Unicode normalization
forms, such as NFC and NFD.

The existing matching passes and their order are preserved. If they all
fail, the new pass compares both lines after NFC normalization and trimming:

```ts
a.normalize("NFC").trim() === b.normalize("NFC").trim()
```

This deliberately uses NFC rather than NFKC, so it only handles canonical
equivalence and does not introduce compatibility or fuzzy matching.

The file contents and replacement text are not globally normalized, so the
replacement retains its original normalization form.

### How did you verify your code works?

Added regression coverage for:

- Cyrillic text with NFD file content and an NFC patch
- Latin `é` with NFC file content and an NFD patch
- Non-equivalent Unicode text continuing to fail
- Replacement text retaining its supplied normalization form

Commands run:

```text
bun test test/patch/patch.test.ts
23 passed, 0 failed

bun run typecheck
passed

Prettier check
passed

git diff --check
passed
```

Before the implementation change, the focused regression tests reproduced
`Failed to find expected lines`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
