### PR TITLE
fix(app): search every known project in the open project dialog

### DIFF
--- a/packages/app/e2e/regression/project-picker-recent-search.spec.ts
+++ b/packages/app/e2e/regression/project-picker-recent-search.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+const NAMES = ["alpha-service", "bravo-web", "charlie-api", "delta-tools", "echo-infra", "foxtrot-docs"]
+const worktrees = NAMES.map((name) => `/opencode-demo/${name}`)
+
+// The sixth project sits outside the five-item recent cap, so it is only reachable if the
+// dialog hands every recent project to the list filter instead of a pre-truncated slice.
+const OUTSIDE_CAP = "foxtrot-docs"
+
+// Dialog rows carry data-directory-path; the sidebar project list does not, so this
+// scopes assertions to the picker instead of matching the sidebar entry of the same name.
+const rows = (page: Page) => page.locator("[data-directory-path]")
+const row = (page: Page, name: string) => page.locator(`[data-directory-path*="${name}"]`)
+
+async function openProjectDialog(page: Page) {
+  await mockOpenCodeServer(page, {
+    sessions: fixture.sessions,
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages,
+    fileList: () => [],
+    findFiles: () => [],
+  })
+  await page.addInitScript((dirs) => {
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({
+        projects: { local: dirs.map((worktree: string) => ({ worktree, expanded: false })) },
+        lastProject: {},
+      }),
+    )
+  }, worktrees)
+  await page.goto("/")
+  const add = page.getByRole("button", { name: "Add project" }).first()
+  await expectAppVisible(add)
+  await add.click()
+  await expect(rows(page)).toHaveCount(5)
+  return page.getByRole("textbox").last()
+}
+
+test("searches every recent project, not just the five most recent", async ({ page }) => {
+  const search = await openProjectDialog(page)
+  await expect(row(page, OUTSIDE_CAP)).toHaveCount(0)
+
+  await search.fill("foxtrot")
+
+  await expect(row(page, OUTSIDE_CAP)).toHaveCount(1)
+})
+
+test("still caps the idle recent list at five projects", async ({ page }) => {
+  await openProjectDialog(page)
+
+  await expect(row(page, NAMES[4])).toHaveCount(1)
+  await expect(row(page, OUTSIDE_CAP)).toHaveCount(0)
+})

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -18,6 +18,8 @@ interface DialogSelectDirectoryProps {
   server: ServerConnection.Any
 }
 
+const RECENT_PROJECT_LIMIT = 5
+
 type Row = {
   absolute: string
   search: string
@@ -102,7 +104,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     return projects
       .map((project, index) => ({ project, at: byProject.get(project.worktree) ?? 0, index }))
       .sort((a, b) => b.at - a.at || a.index - b.index)
-      .slice(0, 5)
       .map(({ project }) => {
         const row = toRow(project.worktree, home(), "recent")
         const name = project.name || getFilename(project.worktree)
@@ -116,7 +117,10 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const items = async (value: string) => {
     const results = await directories(value)
     const directoryRows = results.map((absolute) => toRow(absolute, home(), "folders"))
-    return uniqueRows([...recentProjects(), ...directoryRows])
+    // Cap the idle list only. Once a query narrows the results, every project stays searchable.
+    const recent = recentProjects()
+    const visible = value ? recent : recent.slice(0, RECENT_PROJECT_LIMIT)
+    return uniqueRows([...visible, ...directoryRows])
   }
 
   function resolve(absolute: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #39142

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Searching the Open Project dialog now includes projects beyond the five most recent, while the empty dialog still shows only five.

Before this change, `recentProjects()` applied `.slice(0, 5)` before its rows reached `List`. Because `useFilteredList` only filters the array returned by `items()`, projects outside that slice were excluded from fuzzy search. Entering an absolute path still worked because directory search handles that separately.

This follows the reporter's proposed fix by moving the cap to `items()`, where the query is available. With no query, it returns five recent projects. When you type, it passes every known project to the existing filter. Sorting, grouping, directory results, and deduplication are unchanged.

### How did you verify your code works?

`e2e/regression/project-picker-recent-search.spec.ts` registers six projects and verifies that the sixth can be found by name while the idle list still shows five. With the old slice temporarily restored, the search test fails and the idle-cap test continues to pass.

- `bun typecheck` and `bun typecheck:e2e` in `packages/app`, both exit 0
- `bun test src/components/directory-picker-domain.test.ts`, 20 pass, 0 fail
- `bun test src/components/directory-picker.test.ts`, 1 pass, 0 fail
- `bunx playwright test e2e/regression/project-picker-recent-search.spec.ts --project=chromium`, 2 pass, 0 fail
- `prettier --check` on both changed files and `git diff --check`, clean

### Screenshots / recordings

Six projects registered, with `foxtrot-docs` sixth and outside the five-item cap.

Before, searching `foxtrot` finds nothing:

![before](https://raw.githubusercontent.com/NumerousJLs/su26-ai301-contribution/main/pr-screenshots/before-2-search-foxtrot.png)

After, searching `foxtrot` finds it:

![after](https://raw.githubusercontent.com/NumerousJLs/su26-ai301-contribution/main/pr-screenshots/after-2-search-foxtrot.png)

With no query, the dialog still shows five recents:

![idle](https://raw.githubusercontent.com/NumerousJLs/su26-ai301-contribution/main/pr-screenshots/after-1-idle.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
