### PR TITLE
fix(console): emit complete Responses-API SSE lifecycle for converted streams

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -1,4 +1,4 @@
-import { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
+import type { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
 
 type Usage = {
   prompt_tokens?: number

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -195,15 +195,21 @@ export function toOaCompatibleRequest(body: CommonRequest) {
     }
   }
 
+  // Chat-completions upstreams only accept function tools. Responses-API
+  // requests carry extra tool types (e.g. web_search) that have no chat
+  // equivalent; mapping them into a function tool yields an undefined name
+  // and a 400 from the upstream, so drop them instead.
   const tools = Array.isArray(body.tools)
-    ? body.tools.map((tool: any) => ({
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-        },
-      }))
+    ? body.tools
+        .filter((tool: any) => tool && typeof tool === "object" && tool.type === "function")
+        .map((tool: any) => ({
+          type: "function",
+          function: {
+            name: tool.function?.name,
+            description: tool.function?.description,
+            parameters: tool.function?.parameters,
+          },
+        }))
     : undefined
 
   return {

--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -1,4 +1,4 @@
-import { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
+import type { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
 
 type Usage = {
   input_tokens?: number
@@ -556,75 +556,160 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
   return out
 }
 
-export function toOpenaiChunk(chunk: CommonChunk): string {
-  if (!chunk.choices || !Array.isArray(chunk.choices) || chunk.choices.length === 0) {
-    return ""
-  }
+export function createToOpenaiChunk() {
+  let responseId = ""
+  let itemId = ""
+  let started = false
+  let text = ""
+  let itemAdded = false
+  let partAdded = false
+  let itemDone = false
+  let toolCallId = ""
+  let toolName = ""
+  let toolArguments = ""
 
-  const choice = chunk.choices[0]
-  const d = choice.delta
-  if (!d) return ""
+  const messageItem = (status: string) => ({
+    id: itemId,
+    type: "message",
+    status,
+    role: "assistant",
+    content: partAdded ? [{ type: "output_text", text, annotations: [] }] : [],
+  })
 
-  const id = chunk.id
-  const model = chunk.model
+  const toolCallItem = () => ({
+    id: toolCallId,
+    type: "function_call",
+    call_id: toolCallId,
+    name: toolName,
+    arguments: toolArguments,
+  })
 
-  if (d.content) {
-    const data = {
-      id,
-      type: "response.output_text.delta",
-      delta: d.content,
-      response: { id, model },
+  return (chunk: CommonChunk): string => {
+    if (!chunk.choices || !Array.isArray(chunk.choices) || chunk.choices.length === 0) {
+      return ""
     }
-    return `event: response.output_text.delta\ndata: ${JSON.stringify(data)}`
-  }
 
-  if (d.tool_calls) {
-    for (const tc of d.tool_calls) {
-      if (tc.function?.name) {
-        const data = {
+    const choice = chunk.choices[0]
+    const d = choice.delta
+    if (!d) return ""
+
+    const events: string[] = []
+    const emit = (event: string, data: Record<string, unknown>) => {
+      events.push(`event: ${event}\ndata: ${JSON.stringify(data)}`)
+    }
+
+    if (!started) {
+      started = true
+      responseId = chunk.id || `resp_${Math.random().toString(36).slice(2)}`
+      itemId = `msg_${Math.random().toString(36).slice(2)}`
+      const response = { id: responseId, object: "response", status: "in_progress", model: chunk.model, output: [] }
+      emit("response.created", { type: "response.created", response })
+      emit("response.in_progress", { type: "response.in_progress", response })
+    }
+
+    if (d.content) {
+      if (!itemAdded) {
+        itemAdded = true
+        emit("response.output_item.added", {
           type: "response.output_item.added",
           output_index: 0,
-          item: {
-            id: tc.id,
-            type: "function_call",
-            name: tc.function.name,
-            call_id: tc.id,
-            arguments: "",
-          },
-        }
-        return `event: response.output_item.added\ndata: ${JSON.stringify(data)}`
+          item: messageItem("in_progress"),
+        })
       }
-      if (tc.function?.arguments) {
-        const data = {
-          type: "response.function_call_arguments.delta",
+      if (!partAdded) {
+        partAdded = true
+        emit("response.content_part.added", {
+          type: "response.content_part.added",
           output_index: 0,
-          delta: tc.function.arguments,
+          item_id: itemId,
+          part: { type: "output_text", text: "", annotations: [] },
+        })
+      }
+      text += d.content
+      emit("response.output_text.delta", {
+        id: responseId,
+        type: "response.output_text.delta",
+        delta: d.content,
+        response: { id: responseId, model: chunk.model },
+      })
+    }
+
+    if (d.tool_calls) {
+      for (const tc of d.tool_calls) {
+        if (!tc || tc.type !== "function") continue
+        if (tc.function?.name) {
+          toolCallId = tc.id || `call_${Math.random().toString(36).slice(2)}`
+          toolName = tc.function.name
+          itemAdded = true
+          emit("response.output_item.added", {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: toolCallItem(),
+          })
         }
-        return `event: response.function_call_arguments.delta\ndata: ${JSON.stringify(data)}`
+        if (tc.function?.arguments) {
+          toolArguments += tc.function.arguments
+          emit("response.function_call_arguments.delta", {
+            type: "response.function_call_arguments.delta",
+            output_index: 0,
+            item_id: toolCallId,
+            delta: tc.function.arguments,
+          })
+        }
       }
     }
-  }
 
-  if (choice.finish_reason) {
-    const u = chunk.usage
-    const usage = u
-      ? {
-          input_tokens: u.prompt_tokens,
-          output_tokens: u.completion_tokens,
-          total_tokens: u.total_tokens,
-          ...(u.prompt_tokens_details?.cached_tokens
-            ? { input_tokens_details: { cached_tokens: u.prompt_tokens_details.cached_tokens } }
-            : {}),
+    if (choice.finish_reason) {
+      if (itemAdded && !itemDone) {
+        itemDone = true
+        if (toolCallId) {
+          emit("response.function_call_arguments.done", {
+            type: "response.function_call_arguments.done",
+            output_index: 0,
+            item_id: toolCallId,
+            arguments: toolArguments,
+          })
+          emit("response.output_item.done", {
+            type: "response.output_item.done",
+            output_index: 0,
+            item: toolCallItem(),
+          })
+        } else {
+          emit("response.output_item.done", {
+            type: "response.output_item.done",
+            output_index: 0,
+            item: messageItem("completed"),
+          })
         }
-      : undefined
+      }
 
-    const data: any = {
-      id,
-      type: "response.completed",
-      response: { id, model, ...(usage ? { usage } : {}) },
+      const u = chunk.usage
+      const usage = u
+        ? {
+            input_tokens: u.prompt_tokens,
+            output_tokens: u.completion_tokens,
+            total_tokens: u.total_tokens,
+            ...(u.prompt_tokens_details?.cached_tokens
+              ? { input_tokens_details: { cached_tokens: u.prompt_tokens_details.cached_tokens } }
+              : {}),
+          }
+        : undefined
+
+      const stop_reason = (() => {
+        const r = choice.finish_reason
+        if (r === "stop") return "stop"
+        if (r === "tool_calls") return "tool_call"
+        if (r === "length") return "max_output_tokens"
+        if (r === "content_filter") return "content_filter"
+        return null
+      })()
+
+      const output = toolCallId ? [toolCallItem()] : itemAdded ? [messageItem("completed")] : []
+      const response: any = { id: responseId, model: chunk.model, output, stop_reason }
+      if (usage) response.usage = usage
+      emit("response.completed", { id: responseId, type: "response.completed", response })
     }
-    return `event: response.completed\ndata: ${JSON.stringify(data)}`
-  }
 
-  return ""
+    return events.join("\n\n")
+  }
 }

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -8,10 +8,10 @@ import {
   toAnthropicResponse,
 } from "./anthropic"
 import {
+  createToOpenaiChunk,
   fromOpenaiChunk,
   fromOpenaiRequest,
   fromOpenaiResponse,
-  toOpenaiChunk,
   toOpenaiRequest,
   toOpenaiResponse,
 } from "./openai"
@@ -195,6 +195,7 @@ export function createBodyConverter(from: ZenData.Format, to: ZenData.Format) {
 }
 
 export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Format) {
+  const toOpenaiChunk = to === "openai" ? createToOpenaiChunk() : undefined
   return (part: any): any => {
     if (from === to) return part
 
@@ -207,7 +208,7 @@ export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Form
     if (typeof raw === "string") return raw
 
     if (to === "anthropic") return toAnthropicChunk(raw)
-    if (to === "openai") return toOpenaiChunk(raw)
+    if (to === "openai") return toOpenaiChunk!(raw)
     if (to === "oa-compat") return toOaCompatibleChunk(raw)
   }
 }

--- a/packages/console/app/test/openaiCompatibleRequest.test.ts
+++ b/packages/console/app/test/openaiCompatibleRequest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { fromOpenaiRequest } from "../src/routes/zen/util/provider/openai"
+import {
+  fromOaCompatibleRequest,
+  toOaCompatibleRequest,
+} from "../src/routes/zen/util/provider/openai-compatible"
+
+describe("toOaCompatibleRequest tool conversion", () => {
+  test("drops non-function tools like web_search and keeps function tools", () => {
+    const common = fromOpenaiRequest({
+      model: "deepseek-v4-flash-free",
+      input: [{ role: "user", content: "hi" }],
+      tools: [
+        { type: "function", function: { name: "get_weather", description: "x", parameters: { type: "object" } } },
+        { type: "web_search", external_web_access: false },
+      ],
+    })
+
+    expect(toOaCompatibleRequest(common).tools).toEqual([
+      {
+        type: "function",
+        function: { name: "get_weather", description: "x", parameters: { type: "object" } },
+      },
+    ])
+  })
+
+  test("passes through chat-completions function tools unchanged", () => {
+    const common = fromOaCompatibleRequest({
+      model: "m",
+      messages: [{ role: "user", content: "hi" }],
+      tools: [{ type: "function", function: { name: "get_weather", parameters: { type: "object" } } }],
+    })
+
+    expect(toOaCompatibleRequest(common).tools).toEqual([
+      { type: "function", function: { name: "get_weather", parameters: { type: "object" } } },
+    ])
+  })
+
+  test("omits tools when the request has none", () => {
+    const common = fromOpenaiRequest({ model: "m", input: [{ role: "user", content: "hi" }] })
+    expect(toOaCompatibleRequest(common).tools).toBeUndefined()
+  })
+})

--- a/packages/console/app/test/openaiResponsesStream.test.ts
+++ b/packages/console/app/test/openaiResponsesStream.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test"
+import { createToOpenaiChunk } from "../src/routes/zen/util/provider/openai"
+import { fromOaCompatibleChunk } from "../src/routes/zen/util/provider/openai-compatible"
+
+function convert(chunks: string[]) {
+  const toOpenai = createToOpenaiChunk()
+  return chunks
+    .map((part) => {
+      const raw = fromOaCompatibleChunk(part)
+      return typeof raw === "string" ? raw : toOpenai(raw)
+    })
+    .filter((part) => part.length > 0)
+    .join("\n\n")
+}
+
+const chunk = (delta: string, finishReason?: string, usage?: Record<string, unknown>) =>
+  JSON.stringify({
+    id: "chatcmpl-1",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "deepseek-v4-flash",
+    choices: [{ index: 0, delta: JSON.parse(delta), finish_reason: finishReason ?? null }],
+    ...(usage ? { usage } : {}),
+  })
+
+const eventOrder = (stream: string) => [...stream.matchAll(/event: ([a-z_.]+)/g)].map((m) => m[1])
+
+const eventData = (stream: string, event: string) => {
+  const match = stream.match(new RegExp(`event: ${event}\\ndata: (\\{.*?\\})(?:\\n\\n|$)`))
+  if (!match) throw new Error(`missing ${event}`)
+  return JSON.parse(match[1])
+}
+
+describe("createToOpenaiChunk", () => {
+  test("text stream emits the full Responses-API lifecycle in order", () => {
+    const stream = convert([
+      `data: ${chunk('{"role":"assistant","content":""}')}`,
+      `data: ${chunk('{"content":"ok"}')}`,
+      `data: ${chunk('{"content":"!"}')}`,
+      `data: ${chunk("{}", "stop", { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 })}`,
+      "data: [DONE]",
+    ])
+
+    expect(eventOrder(stream)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.delta",
+      "response.output_item.done",
+      "response.completed",
+    ])
+    expect((stream.match(/event: response\.created/g) ?? []).length).toBe(1)
+    expect(stream).toContain("data: [DONE]")
+
+    const item = eventData(stream, "response.output_item.done").item
+    expect(item).toMatchObject({ type: "message", status: "completed", role: "assistant" })
+    expect(item.content[0].text).toBe("ok!")
+
+    const completed = eventData(stream, "response.completed").response
+    expect(completed.output[0].content[0].text).toBe("ok!")
+    expect(completed.usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 3,
+      total_tokens: 13,
+    })
+  })
+
+  test("[DONE] passes through unchanged", () => {
+    expect(convert(["data: [DONE]"])).toBe("data: [DONE]")
+  })
+
+  test("tool call stream emits the function-call lifecycle", () => {
+    const stream = convert([
+      `data: ${chunk('{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]}')}`,
+      `data: ${chunk('{"tool_calls":[{"index":0,"function":{"arguments":"{\\"city\\":"}}]}')}`,
+      `data: ${chunk('{"tool_calls":[{"index":0,"function":{"arguments":"\\"Sydney\\""}}]}')}`,
+      `data: ${chunk('{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}')}`,
+      `data: ${chunk("{}", "tool_calls")}`,
+    ])
+
+    expect(eventOrder(stream)).toEqual([
+      "response.created",
+      "response.in_progress",
+      "response.output_item.added",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.delta",
+      "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.completed",
+    ])
+
+    const item = eventData(stream, "response.output_item.done").item
+    expect(item).toMatchObject({ type: "function_call", name: "get_weather" })
+    expect(item.arguments).toBe('{"city":"Sydney"}')
+  })
+
+  test("stream with no visible text still opens and closes the response", () => {
+    const stream = convert([`data: ${chunk("{}", "stop")}`])
+    expect(eventOrder(stream)).toEqual(["response.created", "response.in_progress", "response.completed"])
+    expect(eventData(stream, "response.completed").response.output).toEqual([])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #40171

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two gateway fixes for the Zen/Go `/v1/responses` endpoint when the upstream speaks chat completions (`oa-compat`):

1. **Complete Responses-API SSE lifecycle.** The stream converter only emitted `response.output_text.delta` and `response.completed`, so Responses-API clients (e.g. the Codex CLI) never saw `response.created`, `response.in_progress`, `response.output_item.added`, `response.content_part.added` or `response.output_item.done` and could not complete a turn. The converter is now stateful (`createToOpenaiChunk`) and emits the full sequence in order: `created` -> `in_progress` -> `output_item.added` (message) -> `content_part.added` -> `output_text.delta` -> `output_item.done` (with accumulated text) -> `completed` (with `output`, `stop_reason`, `usage`). Tool-call streams additionally get `function_call_arguments.done` and `output_item.done`.

2. **Drop unsupported tool types when converting to chat completions.** Codex always sends a `web_search` tool; `toOaCompatibleRequest` mapped every tool into `{"type":"function","function":{...}}`, producing an undefined `name` that upstream serde rejects with `tools[N].function: missing field "name"`, 400ing the whole request. Non-function tools are now filtered out (chat-completions upstreams have no equivalent), and function tools keep their nested `function.name`.

Verified live before the fix: `deepseek-v4-flash` on `zen/go/v1` streamed only `output_text.delta` -> `completed` -> `[DONE]` -> `ping`; `deepseek-v4-flash-free` on `zen/v1` rejects a `web_search` tool with the serde error above. Note that the paid tier has since been switched server-side to DeepSeek's native `/v1/responses` (full lifecycle observed live on 2026-08-05), but the free tier and any remaining oa-compat-backed models still hit both issues.

### How did you verify your code works?

- Added `packages/console/app/test/openaiResponsesStream.test.ts`: text-stream lifecycle ordering with a single `response.created`, accumulated text in `output_item.done`/`completed`, tool-call lifecycle (`function_call_arguments.done`, `output_item.done`), stream with no visible text, `[DONE]` passthrough.
- Added `packages/console/app/test/openaiCompatibleRequest.test.ts`: `web_search` dropped while function tools are kept with their nested name, chat-completions tools pass through, no-tools stays `undefined`.
- Ran the same assertions through a Node type-stripping harness locally (bun is not installed in this environment); all passed.

### Screenshots / recordings

N/A (server-side gateway change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
