### PR TITLE
docs: add Shopify App Builder plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [shopify-app-builder](https://github.com/khadinakbarlabs/shopify-app-builder)                       | Register 32 focused Shopify app engineering, UX, launch, and growth skills from npm                 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs-only ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the published `shopify-app-builder` npm plugin to the OpenCode ecosystem table. The plugin registers 32 Shopify-focused Agent Skills through `config.skills.paths`.

### How did you verify your code works?

- Imported the published plugin entrypoint and ran its `config` hook against an empty config object.
- Confirmed it adds the packaged absolute `skills/` directory to `skills.paths`.
- Ran `git diff --check`.

### Screenshots / recordings

Not applicable; documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR