### PR TITLE
feat(opencode): let tools opt into strict mode

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -99,6 +99,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     tools[item.id] = tool({
       description: item.description,
       inputSchema: jsonSchema(schema),
+      ...(item.strict !== undefined && { strict: item.strict }),
       execute(args, options) {
         return run.promise(
           Effect.gen(function* () {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -134,6 +134,7 @@ const layer = Layer.effect(
             id,
             parameters,
             jsonSchema,
+            strict: def.strict,
             description: def.description,
             execute: (args, toolCtx) =>
               Effect.gen(function* () {
@@ -309,6 +310,7 @@ const layer = Layer.effect(
             description: tool.description,
             parameters: tool.parameters,
             jsonSchema: tool.jsonSchema,
+            strict: tool.strict,
           }
           yield* plugin.trigger("tool.definition", { toolID: tool.id }, output)
           const jsonSchema =
@@ -326,6 +328,7 @@ const layer = Layer.effect(
               .join("\n"),
             parameters: output.parameters,
             jsonSchema,
+            strict: output.strict,
             execute: tool.execute,
             formatValidationError: tool.formatValidationError,
           }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -60,6 +60,7 @@ export interface Def<
   description: string
   parameters: Parameters
   jsonSchema?: JSONSchema7
+  strict?: boolean
   execute(args: Schema.Schema.Type<Parameters>, ctx: Context): Effect.Effect<ExecuteResult<M>>
   formatValidationError?(error: unknown): string
 }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -586,6 +586,60 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.tools.lookup.strict).toBe(false)
   })
 
+  test("a tool's strict flag survives on bedrock and is still overridden on mantle", async () => {
+    const prepare = (npm: string) =>
+      Effect.runPromise(
+        LLMRequestPrep.prepare({
+          user: {
+            id: "msg_user-test",
+            sessionID,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "test",
+            model: { providerID: "amazon-bedrock", modelID: "anthropic.claude-sonnet-4-6" },
+          } as any,
+          sessionID,
+          model: {
+            ...createGpt5Model("anthropic.claude-sonnet-4-6"),
+            id: "amazon-bedrock/anthropic.claude-sonnet-4-6",
+            providerID: "amazon-bedrock",
+            api: {
+              id: "anthropic.claude-sonnet-4-6",
+              url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+              npm,
+            },
+          },
+          agent: {
+            name: "test",
+            mode: "primary",
+            options: {},
+            permission: [],
+          } as any,
+          system: [],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            lookup: {
+              description: "Look up a value",
+              inputSchema: jsonSchema({ type: "object", properties: {} }),
+              strict: true,
+            },
+          },
+          provider: { id: "amazon-bedrock", options: {} } as any,
+          auth: undefined,
+          plugin: {
+            trigger: (_name: string, _input: unknown, output: unknown) => Effect.succeed(output),
+            list: () => Effect.succeed([]),
+            init: () => Effect.void,
+          } as any,
+          flags: { outputTokenMax: 32_000, client: "test" } as any,
+          isWorkflow: false,
+        }),
+      )
+
+    expect((await prepare("@ai-sdk/amazon-bedrock")).tools.lookup.strict).toBe(true)
+    expect((await prepare("@ai-sdk/amazon-bedrock/mantle")).tools.lookup.strict).toBe(false)
+  })
+
   test("gpt-5.1 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.1")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -587,7 +587,7 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   })
 
   test("a tool's strict flag survives on bedrock and is still overridden on mantle", async () => {
-    const prepare = (npm: string) =>
+    const prepare = (npm: string, apiId: string, url: string) =>
       Effect.runPromise(
         LLMRequestPrep.prepare({
           user: {
@@ -596,18 +596,14 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
             role: "user",
             time: { created: Date.now() },
             agent: "test",
-            model: { providerID: "amazon-bedrock", modelID: "anthropic.claude-sonnet-4-6" },
+            model: { providerID: "amazon-bedrock", modelID: apiId },
           } as any,
           sessionID,
           model: {
-            ...createGpt5Model("anthropic.claude-sonnet-4-6"),
-            id: "amazon-bedrock/anthropic.claude-sonnet-4-6",
+            ...createGpt5Model(apiId),
+            id: `amazon-bedrock/${apiId}`,
             providerID: "amazon-bedrock",
-            api: {
-              id: "anthropic.claude-sonnet-4-6",
-              url: "https://bedrock-runtime.us-east-1.amazonaws.com",
-              npm,
-            },
+            api: { id: apiId, url, npm },
           },
           agent: {
             name: "test",
@@ -636,8 +632,19 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
         }),
       )
 
-    expect((await prepare("@ai-sdk/amazon-bedrock")).tools.lookup.strict).toBe(true)
-    expect((await prepare("@ai-sdk/amazon-bedrock/mantle")).tools.lookup.strict).toBe(false)
+    const converse = await prepare(
+      "@ai-sdk/amazon-bedrock",
+      "anthropic.claude-sonnet-4-6",
+      "https://bedrock-runtime.us-east-1.amazonaws.com",
+    )
+    const mantle = await prepare(
+      "@ai-sdk/amazon-bedrock/mantle",
+      "openai.gpt-5.5",
+      "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+    )
+
+    expect(converse.tools.lookup.strict).toBe(true)
+    expect(mantle.tools.lookup.strict).toBe(false)
   })
 
   test("gpt-5.1 should have textVerbosity set to low", () => {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -194,6 +194,39 @@ describe("tool.registry", () => {
     }),
   )
 
+  it.instance("carries strict from a custom tool definition", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const tool = path.join(test.directory, ".opencode", "tool")
+      yield* Effect.promise(() => fs.mkdir(tool, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tool, "strict_tool.ts"),
+          [
+            "export default {",
+            "  description: 'strict tool',",
+            "  args: {},",
+            "  strict: true,",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const agents = yield* Agent.Service
+      const tools = yield* registry.tools({
+        providerID: ProviderV2.ID.opencode,
+        modelID: ModelV2.ID.make("test"),
+        agent: yield* agents.defaultInfo(),
+      })
+
+      expect(tools.find((item) => item.id === "strict_tool")?.strict).toBe(true)
+      expect(tools.filter((item) => item.id !== "strict_tool").every((item) => item.strict === undefined)).toBe(true)
+    }),
+  )
+
   it.instance("ignores non-tool exports in .opencode/tool files", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -331,5 +331,8 @@ export interface Hooks {
   /**
    * Modify tool definitions (description and parameters) sent to LLM
    */
-  "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  "tool.definition"?: (
+    input: { toolID: string },
+    output: { description: string; parameters: any; strict?: boolean },
+  ) => Promise<void>
 }

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -45,6 +45,7 @@ export type ToolResult =
 export function tool<Args extends z.ZodRawShape>(input: {
   description: string
   args: Args
+  strict?: boolean
   execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<ToolResult>
 }) {
   return input


### PR DESCRIPTION
### Issue for this PR

Closes #40214

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Lets a tool ask for strict mode, instead of it being decided only by which provider you're on.

`strict?: boolean` is added to the tool definition and to the `tool.definition` plugin hook, and passed to the AI SDK `Tool` only when explicitly set. The `strict: false` injection from #33392 for `@ai-sdk/openai`, `@ai-sdk/azure` and `@ai-sdk/amazon-bedrock/mantle` is untouched and still wins, so nothing changes unless a tool opts in.

It reaches the model because `strict?: boolean` is a documented field on the AI SDK `Tool` type, `@ai-sdk/amazon-bedrock@4.0.112` forwards it into `toolSpec`, and Bedrock's Converse API enforces it.

Five lines of production code, the rest is tests. AI SDK path only — the TODO at `packages/llm/src/protocols/openai-responses.ts:264` is a separate change.

### How did you verify your code works?

- Root `bun run typecheck`: 30/30 tasks pass.
- `bun test test/tool/ test/provider/`: 872 pass. `bun test test/session/ test/plugin/`: 536 pass.
- New tests: a custom `.opencode/tool` declaring `strict: true` reaches the registry with it set and doesn't leak onto other tools, and it survives `LLMRequestPrep.prepare` on `@ai-sdk/amazon-bedrock` while still being forced to `false` on mantle.
- Checked against Bedrock directly (`us.anthropic.claude-sonnet-4-6`) that the flag does something: optional properties are fine, `additionalProperties` must be explicitly `false`, and `minimum`/`maximum`/`maxItems` are rejected.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
