### PR TITLE
fix(app): correct Chinese continue label

### DIFF
--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -84,6 +84,16 @@ describe.skipIf(!!process.env.CI)("i18n parity", () => {
     }
   })
 
+  test("Chinese locales distinguish continue from submit", async () => {
+    const expected = { zh: "继续", zht: "繼續" }
+    for (const locale of ["zh", "zht"] as const) {
+      const target = await dictionary(`./${locale}.ts`)
+      expect(target["common.continue"]).toBe(expected[locale])
+      expect(target["common.submit"]).toBeDefined()
+      expect(target["common.continue"]).not.toBe(target["common.submit"])
+    }
+  })
+
   test("changed-file summary keys preserve rendered English copy and localize complete phrases", async () => {
     const source = await dictionary("../../../ui/src/i18n/en.ts")
     expect(source["ui.sessionTurn.diffs.changed.one"].replace("{{count}}", "1")).toBe("1 Changed file")

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -253,7 +253,7 @@ export const dict = {
   "common.clear": "清除",
   "common.connect": "连接",
   "common.disconnect": "断开连接",
-  "common.continue": "提交",
+  "common.continue": "继续",
   "common.submit": "提交",
   "common.save": "保存",
   "common.saving": "保存中...",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -231,7 +231,7 @@ export const dict = {
   "common.clear": "清除",
   "common.connect": "連線",
   "common.disconnect": "中斷連線",
-  "common.continue": "提交",
+  "common.continue": "繼續",
   "common.submit": "提交",
   "common.save": "儲存",
   "common.saving": "儲存中...",


### PR DESCRIPTION
## Summary
- Correct Simplified Chinese `common.continue` from `提交` to `继续`
- Correct Traditional Chinese `common.continue` from `提交` to `繼續`
- Add a targeted regression test so Chinese continue/submit labels stay distinct

Refs #31660

## Test Plan
- `bun test --conditions=solid --preload ./happydom.ts ./src/i18n/parity.test.ts --test-name-pattern "Chinese locales distinguish continue from submit"`
- `bun run lint packages/app/src/i18n/zh.ts packages/app/src/i18n/zht.ts packages/app/src/i18n/parity.test.ts`
- `git diff --check`
- Staged diff secret scan

Notes:
- Full `parity.test.ts` still reports pre-existing missing keys in other locales; this PR only fixes the explicitly reported Chinese `common.continue` mistranslation slice.
- `bun run typecheck` in `packages/app` is still blocked on this Windows checkout by the existing `src/custom-elements.d.ts` symlink placeholder, which matches `upstream/dev`.