### PR TITLE
docs(go): add Qwen3.8 Max

### DIFF
--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -32,6 +32,7 @@ const models = [
   { name: "Kimi K2.6", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "MiMo-V2.5-Pro", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "MiMo-V2.5", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
+  { name: "Qwen3.8 Max", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "Qwen3.7 Max", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "Qwen3.7 Plus", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "Qwen3.6 Plus", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
@@ -67,6 +68,7 @@ function LimitsGraph(props: { href: string }) {
   const graph = [
     { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "50ms" },
     { id: "kimi-k3", name: "Kimi K3", req: 110, d: "75ms" },
+    { id: "qwen3.8-max", name: "Qwen3.8 Max", req: 160, d: "90ms" },
     { id: "glm-5.2", name: "GLM-5.2", req: 880, d: "100ms" },
     { id: "minimax-m3", name: "MiniMax M3", req: 3200, d: "210ms" },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", req: 3450, d: "270ms" },

--- a/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
@@ -313,6 +313,7 @@ export function LiteSection(props: { lite: LiteSubscription | undefined }) {
             <li>Kimi K2.6</li>
             <li>MiniMax M3</li>
             <li>MiniMax M2.7</li>
+            <li>Qwen3.8 Max</li>
             <li>Qwen3.7 Max</li>
             <li>Qwen3.7 Plus</li>
             <li>Qwen3.6 Plus</li>

--- a/packages/web/src/content/docs/ar/go.mdx
+++ b/packages/web/src/content/docs/ar/go.mdx
@@ -60,6 +60,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | MiMo-V2.5-Pro     | 3,250               | 8,150              | 16,300           |
 | MiniMax M3        | 3,200               | 8,000              | 16,000           |
 | MiniMax M2.7      | 3,400               | 8,500              | 17,000           |
-| Qwen3.7 Max       | 950                 | 2,390              | 4,770            |
+| Qwen3.8 Max       | 160                 | 400                | 810              |
+| Qwen3.7 Max       | 340                 | 840                | 1,690            |
 | Qwen3.7 Plus      | 4,300               | 10,800             | 21,600           |
 | Qwen3.6 Plus      | 3,300               | 8,200              | 16,300           |
 | DeepSeek V4 Pro   | 3,450               | 8,550              | 17,150           |
@@ -114,6 +116,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - DeepSeek V4 Flash — ‏790 input، و68,000 cached، و280 output tokens لكل طلب
 - MiniMax M3 — ‏510 input، و56,000 cached، و190 output tokens لكل طلب
 - MiniMax M2.7 — ‏300 input، و55,000 cached، و125 output tokens لكل طلب
+- Qwen3.8 Max — ‏420 input، و66,000 cached، و200 output tokens لكل طلب
 - Qwen3.7 Max — ‏420 input، و66,000 cached، و200 output tokens لكل طلب
 - Qwen3.7 Plus — ‏500 input، و57,000 cached، و190 output tokens لكل طلب
 - Qwen3.6 Plus — ‏500 input، و57,000 cached، و190 output tokens لكل طلب
@@ -138,6 +141,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | MiniMax M3                   | $0.30   | $1.20   | $0.06           | -               | $60       |
 | MiniMax M2.7                 | $0.30   | $1.20   | $0.06           | $0.375          | $60       |
 | MiniMax M2.5                 | $0.30   | $1.20   | $0.06           | $0.375          | $60       |
+| Qwen3.8 Max                  | $2.00   | $6.00   | $0.25           | $2.50           | $15       |
 | Qwen3.7 Max                  | $2.50   | $7.50   | $0.50           | $3.125          | $60       |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40   | $1.60   | $0.04           | $0.50           | $60       |
 | Qwen3.7 Plus (> 256K tokens) | $1.20   | $4.80   | $0.12           | $1.50           | $60       |
@@ -195,6 +199,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | غير مستخدَمة  | 0 أيام             |
 | MiMo-V2.5-Pro     | غير مستخدَمة  | 0 أيام             |
 | MiMo-V2.5         | غير مستخدَمة  | 0 أيام             |
+| Qwen3.8 Max       | غير مستخدَمة  | 0 أيام             |
 | Qwen3.7 Max       | غير مستخدَمة  | 0 أيام             |
 | Qwen3.7 Plus      | غير مستخدَمة  | 0 أيام             |
 | Qwen3.6 Plus      | غير مستخدَمة  | 0 أيام             |

--- a/packages/web/src/content/docs/bs/go.mdx
+++ b/packages/web/src/content/docs/bs/go.mdx
@@ -70,6 +70,7 @@ Trenutna lista modela uključuje:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ Tabela ispod pruža procijenjeni broj zahtjeva na osnovu tipičnih obrazaca kori
 | MiMo-V2.5-Pro     | 3,250              | 8,150             | 16,300            |
 | MiniMax M3        | 3,200              | 8,000             | 16,000            |
 | MiniMax M2.7      | 3,400              | 8,500             | 17,000            |
-| Qwen3.7 Max       | 950                | 2,390             | 4,770             |
+| Qwen3.8 Max       | 160                | 400               | 810               |
+| Qwen3.7 Max       | 340                | 840               | 1,690             |
 | Qwen3.7 Plus      | 4,300              | 10,800            | 21,600            |
 | Qwen3.6 Plus      | 3,300              | 8,200             | 16,300            |
 | DeepSeek V4 Pro   | 3,450              | 8,550             | 17,150            |
@@ -124,6 +126,7 @@ Procjene se zasnivaju na zapaženim obrascima zahtjeva:
 - DeepSeek V4 Flash — 790 ulaznih, 68,000 keširanih, 280 izlaznih tokena po zahtjevu
 - MiniMax M3 — 510 ulaznih, 56,000 keširanih, 190 izlaznih tokena po zahtjevu
 - MiniMax M2.7 — 300 ulaznih, 55,000 keširanih, 125 izlaznih tokena po zahtjevu
+- Qwen3.8 Max — 420 ulaznih, 66,000 keširanih, 200 izlaznih tokena po zahtjevu
 - Qwen3.7 Max — 420 ulaznih, 66,000 keširanih, 200 izlaznih tokena po zahtjevu
 - Qwen3.7 Plus — 500 ulaznih, 57,000 keširanih, 190 izlaznih tokena po zahtjevu
 - Qwen3.6 Plus — 500 ulaznih, 57,000 keširanih, 190 izlaznih tokena po zahtjevu
@@ -148,6 +151,7 @@ Procjene se također zasnivaju na sljedećim cijenama po 1M tokena i mjesečnoj 
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60       |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60       |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60       |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15       |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60       |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60       |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60       |
@@ -207,6 +211,7 @@ Također možete pristupiti Go modelima putem sljedećih API endpointa.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Ne koristi se     | 0 dana               |
 | MiMo-V2.5-Pro     | Ne koristi se     | 0 dana               |
 | MiMo-V2.5         | Ne koristi se     | 0 dana               |
+| Qwen3.8 Max       | Ne koristi se     | 0 dana               |
 | Qwen3.7 Max       | Ne koristi se     | 0 dana               |
 | Qwen3.7 Plus      | Ne koristi se     | 0 dana               |
 | Qwen3.6 Plus      | Ne koristi se     | 0 dana               |

--- a/packages/web/src/content/docs/da/go.mdx
+++ b/packages/web/src/content/docs/da/go.mdx
@@ -70,6 +70,7 @@ Den nuværende liste over modeller inkluderer:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ Tabellen nedenfor giver et estimeret antal anmodninger baseret på typiske Go-fo
 | MiMo-V2.5-Pro     | 3,250                   | 8,150               | 16,300                |
 | MiniMax M3        | 3,200                   | 8,000               | 16,000                |
 | MiniMax M2.7      | 3,400                   | 8,500               | 17,000                |
-| Qwen3.7 Max       | 950                     | 2,390               | 4,770                 |
+| Qwen3.8 Max       | 160                     | 400                 | 810                   |
+| Qwen3.7 Max       | 340                     | 840                 | 1,690                 |
 | Qwen3.7 Plus      | 4,300                   | 10,800              | 21,600                |
 | Qwen3.6 Plus      | 3,300                   | 8,200               | 16,300                |
 | DeepSeek V4 Pro   | 3,450                   | 8,550               | 17,150                |
@@ -124,6 +126,7 @@ Estimaterne er baseret på observerede anmodningsmønstre:
 - DeepSeek V4 Flash — 790 input, 68.000 cachelagrede, 280 output-tokens pr. anmodning
 - MiniMax M3 — 510 input, 56.000 cachelagrede, 190 output-tokens pr. anmodning
 - MiniMax M2.7 — 300 input, 55.000 cachelagrede, 125 output-tokens pr. anmodning
+- Qwen3.8 Max — 420 input, 66.000 cachelagrede, 200 output-tokens pr. anmodning
 - Qwen3.7 Max — 420 input, 66.000 cachelagrede, 200 output-tokens pr. anmodning
 - Qwen3.7 Plus — 500 input, 57.000 cachelagrede, 190 output-tokens pr. anmodning
 - Qwen3.6 Plus — 500 input, 57.000 cachelagrede, 190 output-tokens pr. anmodning
@@ -148,6 +151,7 @@ Estimaterne er også baseret på følgende priser pr. 1M tokens og det månedlig
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60     |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15     |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60     |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60     |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60     |
@@ -207,6 +211,7 @@ Du kan også få adgang til Go-modeller gennem følgende API-endpoints.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Ikke brugt   | 0 dage         |
 | MiMo-V2.5-Pro     | Ikke brugt   | 0 dage         |
 | MiMo-V2.5         | Ikke brugt   | 0 dage         |
+| Qwen3.8 Max       | Ikke brugt   | 0 dage         |
 | Qwen3.7 Max       | Ikke brugt   | 0 dage         |
 | Qwen3.7 Plus      | Ikke brugt   | 0 dage         |
 | Qwen3.6 Plus      | Ikke brugt   | 0 dage         |

--- a/packages/web/src/content/docs/de/go.mdx
+++ b/packages/web/src/content/docs/de/go.mdx
@@ -62,6 +62,7 @@ Die aktuelle Liste der Modelle umfasst:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -98,7 +99,8 @@ Die folgende Tabelle zeigt eine geschätzte Anzahl von Anfragen basierend auf ty
 | MiMo-V2.5-Pro     | 3,250                  | 8,150              | 16,300             |
 | MiniMax M3        | 3,200                  | 8,000              | 16,000             |
 | MiniMax M2.7      | 3,400                  | 8,500              | 17,000             |
-| Qwen3.7 Max       | 950                    | 2,390              | 4,770              |
+| Qwen3.8 Max       | 160                    | 400                | 810                |
+| Qwen3.7 Max       | 340                    | 840                | 1,690              |
 | Qwen3.7 Plus      | 4,300                  | 10,800             | 21,600             |
 | Qwen3.6 Plus      | 3,300                  | 8,200              | 16,300             |
 | DeepSeek V4 Pro   | 3,450                  | 8,550              | 17,150             |
@@ -116,6 +118,7 @@ Die Schätzungen basieren auf beobachteten Anfragemustern:
 - DeepSeek V4 Flash — 790 Input-, 68.000 Cached-, 280 Output-Tokens pro Anfrage
 - MiniMax M3 — 510 Input-, 56.000 Cached-, 190 Output-Tokens pro Anfrage
 - MiniMax M2.7 — 300 Input-, 55.000 Cached-, 125 Output-Tokens pro Anfrage
+- Qwen3.8 Max — 420 Input-, 66.000 Cached-, 200 Output-Tokens pro Anfrage
 - Qwen3.7 Max — 420 Input-, 66.000 Cached-, 200 Output-Tokens pro Anfrage
 - Qwen3.7 Plus — 500 Input-, 57.000 Cached-, 190 Output-Tokens pro Anfrage
 - Qwen3.6 Plus — 500 Input-, 57.000 Cached-, 190 Output-Tokens pro Anfrage
@@ -140,6 +143,7 @@ Die Schätzungen basieren außerdem auf den folgenden Preisen pro 1M Tokens und 
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60     |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15     |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60     |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60     |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60     |
@@ -197,6 +201,7 @@ Du kannst auf die Go-Modelle auch über die folgenden API-Endpunkte zugreifen.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -229,6 +234,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Nicht verwendet | 0 Tage            |
 | MiMo-V2.5-Pro     | Nicht verwendet | 0 Tage            |
 | MiMo-V2.5         | Nicht verwendet | 0 Tage            |
+| Qwen3.8 Max       | Nicht verwendet | 0 Tage            |
 | Qwen3.7 Max       | Nicht verwendet | 0 Tage            |
 | Qwen3.7 Plus      | Nicht verwendet | 0 Tage            |
 | Qwen3.6 Plus      | Nicht verwendet | 0 Tage            |

--- a/packages/web/src/content/docs/es/go.mdx
+++ b/packages/web/src/content/docs/es/go.mdx
@@ -70,6 +70,7 @@ La lista actual de modelos incluye:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ La siguiente tabla proporciona una cantidad estimada de peticiones basada en los
 | MiMo-V2.5-Pro     | 3,250                  | 8,150                 | 16,300             |
 | MiniMax M3        | 3,200                  | 8,000                 | 16,000             |
 | MiniMax M2.7      | 3,400                  | 8,500                 | 17,000             |
-| Qwen3.7 Max       | 950                    | 2,390                 | 4,770              |
+| Qwen3.8 Max       | 160                    | 400                   | 810                |
+| Qwen3.7 Max       | 340                    | 840                   | 1,690              |
 | Qwen3.7 Plus      | 4,300                  | 10,800                | 21,600             |
 | Qwen3.6 Plus      | 3,300                  | 8,200                 | 16,300             |
 | DeepSeek V4 Pro   | 3,450                  | 8,550                 | 17,150             |
@@ -124,6 +126,7 @@ Las estimaciones se basan en los patrones de peticiones observados:
 - DeepSeek V4 Flash — 790 tokens de entrada, 68,000 en caché, 280 tokens de salida por petición
 - MiniMax M3 — 510 tokens de entrada, 56,000 en caché, 190 tokens de salida por petición
 - MiniMax M2.7 — 300 tokens de entrada, 55,000 en caché, 125 tokens de salida por petición
+- Qwen3.8 Max — 420 tokens de entrada, 66,000 en caché, 200 tokens de salida por petición
 - Qwen3.7 Max — 420 tokens de entrada, 66,000 en caché, 200 tokens de salida por petición
 - Qwen3.7 Plus — 500 tokens de entrada, 57,000 en caché, 190 tokens de salida por petición
 - Qwen3.6 Plus — 500 tokens de entrada, 57,000 en caché, 190 tokens de salida por petición
@@ -148,6 +151,7 @@ Las estimaciones también se basan en los siguientes precios por 1M tokens y en 
 | MiniMax M3                   | $0.30   | $1.20  | $0.06            | -                  | $60 |
 | MiniMax M2.7                 | $0.30   | $1.20  | $0.06            | $0.375             | $60 |
 | MiniMax M2.5                 | $0.30   | $1.20  | $0.06            | $0.375             | $60 |
+| Qwen3.8 Max                  | $2.00   | $6.00  | $0.25            | $2.50              | $15 |
 | Qwen3.7 Max                  | $2.50   | $7.50  | $0.50            | $3.125             | $60 |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40   | $1.60  | $0.04            | $0.50              | $60 |
 | Qwen3.7 Plus (> 256K tokens) | $1.20   | $4.80  | $0.12            | $1.50              | $60 |
@@ -207,6 +211,7 @@ También puedes acceder a los modelos de Go a través de los siguientes endpoint
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | No utilizado             | 0 días             |
 | MiMo-V2.5-Pro     | No utilizado             | 0 días             |
 | MiMo-V2.5         | No utilizado             | 0 días             |
+| Qwen3.8 Max       | No utilizado             | 0 días             |
 | Qwen3.7 Max       | No utilizado             | 0 días             |
 | Qwen3.7 Plus      | No utilizado             | 0 días             |
 | Qwen3.6 Plus      | No utilizado             | 0 días             |

--- a/packages/web/src/content/docs/fr/go.mdx
+++ b/packages/web/src/content/docs/fr/go.mdx
@@ -60,6 +60,7 @@ La liste actuelle des modèles comprend :
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ Le tableau ci-dessous fournit une estimation du nombre de requêtes basée sur d
 | MiMo-V2.5-Pro     | 3,250                 | 8,150                | 16,300            |
 | MiniMax M3        | 3,200                 | 8,000                | 16,000            |
 | MiniMax M2.7      | 3,400                 | 8,500                | 17,000            |
-| Qwen3.7 Max       | 950                   | 2,390                | 4,770             |
+| Qwen3.8 Max       | 160                   | 400                  | 810               |
+| Qwen3.7 Max       | 340                   | 840                  | 1,690             |
 | Qwen3.7 Plus      | 4,300                 | 10,800               | 21,600            |
 | Qwen3.6 Plus      | 3,300                 | 8,200                | 16,300            |
 | DeepSeek V4 Pro   | 3,450                 | 8,550                | 17,150            |
@@ -114,6 +116,7 @@ Les estimations sont basées sur les schémas de requêtes observés :
 - DeepSeek V4 Flash — 790 tokens en entrée, 68,000 en cache, 280 tokens en sortie par requête
 - MiniMax M3 — 510 tokens en entrée, 56,000 en cache, 190 tokens en sortie par requête
 - MiniMax M2.7 — 300 tokens en entrée, 55,000 en cache, 125 tokens en sortie par requête
+- Qwen3.8 Max — 420 tokens en entrée, 66,000 en cache, 200 tokens en sortie par requête
 - Qwen3.7 Max — 420 tokens en entrée, 66,000 en cache, 200 tokens en sortie par requête
 - Qwen3.7 Plus — 500 tokens en entrée, 57,000 en cache, 190 tokens en sortie par requête
 - Qwen3.6 Plus — 500 tokens en entrée, 57,000 en cache, 190 tokens en sortie par requête
@@ -138,6 +141,7 @@ Les estimations sont également basées sur les prix suivants par 1M tokens et s
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60         |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60         |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60         |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15         |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60         |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60         |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60         |
@@ -195,6 +199,7 @@ Vous pouvez également accéder aux modèles Go via les points de terminaison d'
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Non utilisé              | 0 jour                   |
 | MiMo-V2.5-Pro     | Non utilisé              | 0 jour                   |
 | MiMo-V2.5         | Non utilisé              | 0 jour                   |
+| Qwen3.8 Max       | Non utilisé              | 0 jour                   |
 | Qwen3.7 Max       | Non utilisé              | 0 jour                   |
 | Qwen3.7 Plus      | Non utilisé              | 0 jour                   |
 | Qwen3.6 Plus      | Non utilisé              | 0 jour                   |

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -70,6 +70,7 @@ The current list of models includes:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ The table below provides an estimated request count based on typical Go usage pa
 | MiMo-V2.5-Pro     | 3,250               | 8,150             | 16,300             |
 | MiniMax M3        | 3,200               | 8,000             | 16,000             |
 | MiniMax M2.7      | 3,400               | 8,500             | 17,000             |
-| Qwen3.7 Max       | 950                 | 2,390             | 4,770              |
+| Qwen3.8 Max       | 160                 | 400               | 810                |
+| Qwen3.7 Max       | 340                 | 840               | 1,690              |
 | Qwen3.7 Plus      | 4,300               | 10,800            | 21,600             |
 | Qwen3.6 Plus      | 3,300               | 8,200             | 16,300             |
 | DeepSeek V4 Pro   | 3,450               | 8,550             | 17,150             |
@@ -126,6 +128,7 @@ The estimates are based on observed request patterns:
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens per request
 - MiMo-V2.5 — 830 input, 71,500 cached, 295 output tokens per request
 - MiMo-V2.5-Pro — 790 input, 86,000 cached, 305 output tokens per request
+- Qwen3.8 Max — 420 input, 66,000 cached, 200 output tokens per request
 - Qwen3.7 Max — 420 input, 66,000 cached, 200 output tokens per request
 - Qwen3.7 Plus — 500 input, 57,000 cached, 190 output tokens per request
 - Qwen3.6 Plus — 500 input, 57,000 cached, 190 output tokens per request
@@ -148,6 +151,7 @@ The estimates are also based on the following prices per 1M tokens and the month
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60   |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60   |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60   |
@@ -207,6 +211,7 @@ You can also access Go models through the following API endpoints.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Not used       | 0 days         |
 | MiMo-V2.5-Pro     | Not used       | 0 days         |
 | MiMo-V2.5         | Not used       | 0 days         |
+| Qwen3.8 Max       | Not used       | 0 days         |
 | Qwen3.7 Max       | Not used       | 0 days         |
 | Qwen3.7 Plus      | Not used       | 0 days         |
 | Qwen3.6 Plus      | Not used       | 0 days         |

--- a/packages/web/src/content/docs/it/go.mdx
+++ b/packages/web/src/content/docs/it/go.mdx
@@ -68,6 +68,7 @@ L'elenco attuale dei modelli include:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -104,7 +105,8 @@ La tabella seguente fornisce una stima del conteggio delle richieste in base a p
 | MiMo-V2.5-Pro     | 3,250                | 8,150                 | 16,300            |
 | MiniMax M3        | 3,200                | 8,000                 | 16,000            |
 | MiniMax M2.7      | 3,400                | 8,500                 | 17,000            |
-| Qwen3.7 Max       | 950                  | 2,390                 | 4,770             |
+| Qwen3.8 Max       | 160                  | 400                   | 810               |
+| Qwen3.7 Max       | 340                  | 840                   | 1,690             |
 | Qwen3.7 Plus      | 4,300                | 10,800                | 21,600            |
 | Qwen3.6 Plus      | 3,300                | 8,200                 | 16,300            |
 | DeepSeek V4 Pro   | 3,450                | 8,550                 | 17,150            |
@@ -122,6 +124,7 @@ Le stime si basano sui pattern di richieste osservati:
 - DeepSeek V4 Flash — 790 di input, 68.000 in cache, 280 token di output per richiesta
 - MiniMax M3 — 510 di input, 56.000 in cache, 190 token di output per richiesta
 - MiniMax M2.7 — 300 di input, 55.000 in cache, 125 token di output per richiesta
+- Qwen3.8 Max — 420 di input, 66.000 in cache, 200 token di output per richiesta
 - Qwen3.7 Max — 420 di input, 66.000 in cache, 200 token di output per richiesta
 - Qwen3.7 Plus — 500 di input, 57.000 in cache, 190 token di output per richiesta
 - Qwen3.6 Plus — 500 di input, 57.000 in cache, 190 token di output per richiesta
@@ -146,6 +149,7 @@ Le stime si basano anche sui seguenti prezzi per 1M token e sull'utilizzo mensil
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60      |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15      |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60      |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60      |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60      |
@@ -205,6 +209,7 @@ Puoi anche accedere ai modelli Go tramite i seguenti endpoint API.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -239,6 +244,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Non utilizzato            | 0 giorni               |
 | MiMo-V2.5-Pro     | Non utilizzato            | 0 giorni               |
 | MiMo-V2.5         | Non utilizzato            | 0 giorni               |
+| Qwen3.8 Max       | Non utilizzato            | 0 giorni               |
 | Qwen3.7 Max       | Non utilizzato            | 0 giorni               |
 | Qwen3.7 Plus      | Non utilizzato            | 0 giorni               |
 | Qwen3.6 Plus      | Non utilizzato            | 0 giorni               |

--- a/packages/web/src/content/docs/ja/go.mdx
+++ b/packages/web/src/content/docs/ja/go.mdx
@@ -60,6 +60,7 @@ OpenCode Goをサブスクライブできるのは、1つのワークスペー�
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Goには以下の制限が含まれています：
 | MiMo-V2.5-Pro     | 3,250                     | 8,150            | 16,300           |
 | MiniMax M3        | 3,200                     | 8,000            | 16,000           |
 | MiniMax M2.7      | 3,400                     | 8,500            | 17,000           |
-| Qwen3.7 Max       | 950                       | 2,390            | 4,770            |
+| Qwen3.8 Max       | 160                       | 400              | 810              |
+| Qwen3.7 Max       | 340                       | 840              | 1,690            |
 | Qwen3.7 Plus      | 4,300                     | 10,800           | 21,600           |
 | Qwen3.6 Plus      | 3,300                     | 8,200            | 16,300           |
 | DeepSeek V4 Pro   | 3,450                     | 8,550            | 17,150           |
@@ -114,6 +116,7 @@ OpenCode Goには以下の制限が含まれています：
 - DeepSeek V4 Flash — リクエストあたり 入力 790トークン、キャッシュ 68,000トークン、出力 280トークン
 - MiniMax M3 — リクエストあたり 入力 510トークン、キャッシュ 56,000トークン、出力 190トークン
 - MiniMax M2.7 — リクエストあたり 入力 300トークン、キャッシュ 55,000トークン、出力 125トークン
+- Qwen3.8 Max — リクエストあたり 入力 420トークン、キャッシュ 66,000トークン、出力 200トークン
 - Qwen3.7 Max — リクエストあたり 入力 420トークン、キャッシュ 66,000トークン、出力 200トークン
 - Qwen3.7 Plus — リクエストあたり 入力 500トークン、キャッシュ 57,000トークン、出力 190トークン
 - Qwen3.6 Plus — リクエストあたり 入力 500トークン、キャッシュ 57,000トークン、出力 190トークン
@@ -138,6 +141,7 @@ OpenCode Goには以下の制限が含まれています：
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60   |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60   |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60   |
@@ -195,6 +199,7 @@ Goでは月額$10を支払い、その6倍の利用枠を提供することを�
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | 使用なし             | 0日        |
 | MiMo-V2.5-Pro     | 使用なし             | 0日        |
 | MiMo-V2.5         | 使用なし             | 0日        |
+| Qwen3.8 Max       | 使用なし             | 0日        |
 | Qwen3.7 Max       | 使用なし             | 0日        |
 | Qwen3.7 Plus      | 使用なし             | 0日        |
 | Qwen3.6 Plus      | 使用なし             | 0日        |

--- a/packages/web/src/content/docs/ko/go.mdx
+++ b/packages/web/src/content/docs/ko/go.mdx
@@ -60,6 +60,7 @@ workspace당 한 명의 멤버만 OpenCode Go를 구독할 수 있습니다.
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | MiMo-V2.5-Pro     | 3,250             | 8,150          | 16,300         |
 | MiniMax M3        | 3,200             | 8,000          | 16,000         |
 | MiniMax M2.7      | 3,400             | 8,500          | 17,000         |
-| Qwen3.7 Max       | 950               | 2,390          | 4,770          |
+| Qwen3.8 Max       | 160               | 400            | 810            |
+| Qwen3.7 Max       | 340               | 840            | 1,690          |
 | Qwen3.7 Plus      | 4,300             | 10,800         | 21,600         |
 | Qwen3.6 Plus      | 3,300             | 8,200          | 16,300         |
 | DeepSeek V4 Pro   | 3,450             | 8,550          | 17,150         |
@@ -114,6 +116,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 - DeepSeek V4 Flash — 요청당 입력 790, 캐시 68,000, 출력 토큰 280
 - MiniMax M3 — 요청당 입력 510, 캐시 56,000, 출력 토큰 190
 - MiniMax M2.7 — 요청당 입력 300, 캐시 55,000, 출력 토큰 125
+- Qwen3.8 Max — 요청당 입력 420, 캐시 66,000, 출력 토큰 200
 - Qwen3.7 Max — 요청당 입력 420, 캐시 66,000, 출력 토큰 200
 - Qwen3.7 Plus — 요청당 입력 500, 캐시 57,000, 출력 토큰 190
 - Qwen3.6 Plus — 요청당 입력 500, 캐시 57,000, 출력 토큰 190
@@ -138,6 +141,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60   |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60   |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60   |
@@ -195,6 +199,7 @@ Go에서는 월 $10를 지불하며, 저희는 그 6배의 사용량을 제공�
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | 사용되지 않음 | 0일         |
 | MiMo-V2.5-Pro     | 사용되지 않음 | 0일         |
 | MiMo-V2.5         | 사용되지 않음 | 0일         |
+| Qwen3.8 Max       | 사용되지 않음 | 0일         |
 | Qwen3.7 Max       | 사용되지 않음 | 0일         |
 | Qwen3.7 Plus      | 사용되지 않음 | 0일         |
 | Qwen3.6 Plus      | 사용되지 않음 | 0일         |

--- a/packages/web/src/content/docs/nb/go.mdx
+++ b/packages/web/src/content/docs/nb/go.mdx
@@ -70,6 +70,7 @@ Den nåværende listen over modeller inkluderer:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ Tabellen nedenfor gir et estimert antall forespørsler basert på typiske bruksm
 | MiMo-V2.5-Pro     | 3,250                    | 8,150                | 16,300                 |
 | MiniMax M3        | 3,200                    | 8,000                | 16,000                 |
 | MiniMax M2.7      | 3,400                    | 8,500                | 17,000                 |
-| Qwen3.7 Max       | 950                      | 2,390                | 4,770                  |
+| Qwen3.8 Max       | 160                      | 400                  | 810                    |
+| Qwen3.7 Max       | 340                      | 840                  | 1,690                  |
 | Qwen3.7 Plus      | 4,300                    | 10,800               | 21,600                 |
 | Qwen3.6 Plus      | 3,300                    | 8,200                | 16,300                 |
 | DeepSeek V4 Pro   | 3,450                    | 8,550                | 17,150                 |
@@ -124,6 +126,7 @@ Estimatene er basert på observerte forespørselsmønstre:
 - DeepSeek V4 Flash — 790 input, 68 000 bufret, 280 output-tokens per forespørsel
 - MiniMax M3 — 510 input, 56 000 bufret, 190 output-tokens per forespørsel
 - MiniMax M2.7 — 300 input, 55 000 bufret, 125 output-tokens per forespørsel
+- Qwen3.8 Max — 420 input, 66 000 bufret, 200 output-tokens per forespørsel
 - Qwen3.7 Max — 420 input, 66 000 bufret, 200 output-tokens per forespørsel
 - Qwen3.7 Plus — 500 input, 57 000 bufret, 190 output-tokens per forespørsel
 - Qwen3.6 Plus — 500 input, 57 000 bufret, 190 output-tokens per forespørsel
@@ -148,6 +151,7 @@ Estimatene er også basert på følgende priser per 1M tokens og den månedlige 
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60  |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60  |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60  |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15  |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60  |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60  |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60  |
@@ -207,6 +211,7 @@ Du kan også få tilgang til Go-modeller gjennom følgende API-endepunkter.
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Brukes ikke   | 0 dager         |
 | MiMo-V2.5-Pro     | Brukes ikke   | 0 dager         |
 | MiMo-V2.5         | Brukes ikke   | 0 dager         |
+| Qwen3.8 Max       | Brukes ikke   | 0 dager         |
 | Qwen3.7 Max       | Brukes ikke   | 0 dager         |
 | Qwen3.7 Plus      | Brukes ikke   | 0 dager         |
 | Qwen3.6 Plus      | Brukes ikke   | 0 dager         |

--- a/packages/web/src/content/docs/pl/go.mdx
+++ b/packages/web/src/content/docs/pl/go.mdx
@@ -64,6 +64,7 @@ Obecna lista modeli obejmuje:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -100,7 +101,8 @@ Poniższa tabela przedstawia szacunkową liczbę żądań na podstawie typowych 
 | MiMo-V2.5-Pro     | 3,250               | 8,150              | 16,300             |
 | MiniMax M3        | 3,200               | 8,000              | 16,000             |
 | MiniMax M2.7      | 3,400               | 8,500              | 17,000             |
-| Qwen3.7 Max       | 950                 | 2,390              | 4,770              |
+| Qwen3.8 Max       | 160                 | 400                | 810                |
+| Qwen3.7 Max       | 340                 | 840                | 1,690              |
 | Qwen3.7 Plus      | 4,300               | 10,800             | 21,600             |
 | Qwen3.6 Plus      | 3,300               | 8,200              | 16,300             |
 | DeepSeek V4 Pro   | 3,450               | 8,550              | 17,150             |
@@ -118,6 +120,7 @@ Szacunki te opierają się na zaobserwowanych wzorcach żądań:
 - DeepSeek V4 Flash — 790 tokenów wejściowych, 68 000 w pamięci podręcznej, 280 tokenów wyjściowych na żądanie
 - MiniMax M3 — 510 tokenów wejściowych, 56 000 w pamięci podręcznej, 190 tokenów wyjściowych na żądanie
 - MiniMax M2.7 — 300 tokenów wejściowych, 55 000 w pamięci podręcznej, 125 tokenów wyjściowych na żądanie
+- Qwen3.8 Max — 420 tokenów wejściowych, 66 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
 - Qwen3.7 Max — 420 tokenów wejściowych, 66 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
 - Qwen3.7 Plus — 500 tokenów wejściowych, 57 000 w pamięci podręcznej, 190 tokenów wyjściowych na żądanie
 - Qwen3.6 Plus — 500 tokenów wejściowych, 57 000 w pamięci podręcznej, 190 tokenów wyjściowych na żądanie
@@ -142,6 +145,7 @@ Szacunki opierają się również na następujących cenach za 1M tokenów oraz 
 | MiniMax M3                   | $0.30   | $1.20   | $0.06          | -              | $60    |
 | MiniMax M2.7                 | $0.30   | $1.20   | $0.06          | $0.375         | $60    |
 | MiniMax M2.5                 | $0.30   | $1.20   | $0.06          | $0.375         | $60    |
+| Qwen3.8 Max                  | $2.00   | $6.00   | $0.25          | $2.50          | $15    |
 | Qwen3.7 Max                  | $2.50   | $7.50   | $0.50          | $3.125         | $60    |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40   | $1.60   | $0.04          | $0.50          | $60    |
 | Qwen3.7 Plus (> 256K tokens) | $1.20   | $4.80   | $0.12          | $1.50          | $60    |
@@ -199,6 +203,7 @@ Możesz również uzyskać dostęp do modeli Go za pośrednictwem następującyc
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -233,6 +238,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Niewykorzystywane | 0 dni           |
 | MiMo-V2.5-Pro     | Niewykorzystywane | 0 dni           |
 | MiMo-V2.5         | Niewykorzystywane | 0 dni           |
+| Qwen3.8 Max       | Niewykorzystywane | 0 dni           |
 | Qwen3.7 Max       | Niewykorzystywane | 0 dni           |
 | Qwen3.7 Plus      | Niewykorzystywane | 0 dni           |
 | Qwen3.6 Plus      | Niewykorzystywane | 0 dni           |

--- a/packages/web/src/content/docs/pt-br/go.mdx
+++ b/packages/web/src/content/docs/pt-br/go.mdx
@@ -70,6 +70,7 @@ A lista atual de modelos inclui:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ A tabela abaixo fornece uma contagem estimada de requisições com base nos padr
 | MiMo-V2.5-Pro     | 3,250                   | 8,150                  | 16,300              |
 | MiniMax M3        | 3,200                   | 8,000                  | 16,000              |
 | MiniMax M2.7      | 3,400                   | 8,500                  | 17,000              |
-| Qwen3.7 Max       | 950                     | 2,390                  | 4,770               |
+| Qwen3.8 Max       | 160                     | 400                    | 810                 |
+| Qwen3.7 Max       | 340                     | 840                    | 1,690               |
 | Qwen3.7 Plus      | 4,300                   | 10,800                 | 21,600              |
 | Qwen3.6 Plus      | 3,300                   | 8,200                  | 16,300              |
 | DeepSeek V4 Pro   | 3,450                   | 8,550                  | 17,150              |
@@ -124,6 +126,7 @@ As estimativas se baseiam nos padrões de requisições observados:
 - DeepSeek V4 Flash — 790 tokens de entrada, 68.000 em cache, 280 tokens de saída por requisição
 - MiniMax M3 — 510 tokens de entrada, 56.000 em cache, 190 tokens de saída por requisição
 - MiniMax M2.7 — 300 tokens de entrada, 55.000 em cache, 125 tokens de saída por requisição
+- Qwen3.8 Max — 420 tokens de entrada, 66.000 em cache, 200 tokens de saída por requisição
 - Qwen3.7 Max — 420 tokens de entrada, 66.000 em cache, 200 tokens de saída por requisição
 - Qwen3.7 Plus — 500 tokens de entrada, 57.000 em cache, 190 tokens de saída por requisição
 - Qwen3.6 Plus — 500 tokens de entrada, 57.000 em cache, 190 tokens de saída por requisição
@@ -148,6 +151,7 @@ As estimativas também se baseiam nos seguintes preços por 1M tokens e no uso m
 | MiniMax M3                   | $0.30   | $1.20  | $0.06            | -                | $60 |
 | MiniMax M2.7                 | $0.30   | $1.20  | $0.06            | $0.375           | $60 |
 | MiniMax M2.5                 | $0.30   | $1.20  | $0.06            | $0.375           | $60 |
+| Qwen3.8 Max                  | $2.00   | $6.00  | $0.25            | $2.50            | $15 |
 | Qwen3.7 Max                  | $2.50   | $7.50  | $0.50            | $3.125           | $60 |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40   | $1.60  | $0.04            | $0.50            | $60 |
 | Qwen3.7 Plus (> 256K tokens) | $1.20   | $4.80  | $0.12            | $1.50            | $60 |
@@ -207,6 +211,7 @@ Você também pode acessar os modelos do Go através dos seguintes endpoints de 
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Não usado              | 0 dias            |
 | MiMo-V2.5-Pro     | Não usado              | 0 dias            |
 | MiMo-V2.5         | Não usado              | 0 dias            |
+| Qwen3.8 Max       | Não usado              | 0 dias            |
 | Qwen3.7 Max       | Não usado              | 0 dias            |
 | Qwen3.7 Plus      | Não usado              | 0 dias            |
 | Qwen3.6 Plus      | Não usado              | 0 dias            |

--- a/packages/web/src/content/docs/ru/go.mdx
+++ b/packages/web/src/content/docs/ru/go.mdx
@@ -70,6 +70,7 @@ OpenCode Go работает так же, как и любой другой пр
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -106,7 +107,8 @@ OpenCode Go включает следующие лимиты:
 | MiMo-V2.5-Pro     | 3,250               | 8,150             | 16,300           |
 | MiniMax M3        | 3,200               | 8,000             | 16,000           |
 | MiniMax M2.7      | 3,400               | 8,500             | 17,000           |
-| Qwen3.7 Max       | 950                 | 2,390             | 4,770            |
+| Qwen3.8 Max       | 160                 | 400               | 810              |
+| Qwen3.7 Max       | 340                 | 840               | 1,690            |
 | Qwen3.7 Plus      | 4,300               | 10,800            | 21,600           |
 | Qwen3.6 Plus      | 3,300               | 8,200             | 16,300           |
 | DeepSeek V4 Pro   | 3,450               | 8,550             | 17,150           |
@@ -124,6 +126,7 @@ OpenCode Go включает следующие лимиты:
 - DeepSeek V4 Flash — 790 входных, 68,000 кешированных, 280 выходных токенов на запрос
 - MiniMax M3 — 510 входных, 56,000 кешированных, 190 выходных токенов на запрос
 - MiniMax M2.7 — 300 входных, 55,000 кешированных, 125 выходных токенов на запрос
+- Qwen3.8 Max — 420 входных, 66,000 кешированных, 200 выходных токенов на запрос
 - Qwen3.7 Max — 420 входных, 66,000 кешированных, 200 выходных токенов на запрос
 - Qwen3.7 Plus — 500 входных, 57,000 кешированных, 190 выходных токенов на запрос
 - Qwen3.6 Plus — 500 входных, 57,000 кешированных, 190 выходных токенов на запрос
@@ -148,6 +151,7 @@ OpenCode Go включает следующие лимиты:
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60           |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60           |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60           |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15           |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60           |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60           |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60           |
@@ -207,6 +211,7 @@ OpenCode Go включает следующие лимиты:
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Не используется  | 0 дней          |
 | MiMo-V2.5-Pro     | Не используется  | 0 дней          |
 | MiMo-V2.5         | Не используется  | 0 дней          |
+| Qwen3.8 Max       | Не используется  | 0 дней          |
 | Qwen3.7 Max       | Не используется  | 0 дней          |
 | Qwen3.7 Plus      | Не используется  | 0 дней          |
 | Qwen3.6 Plus      | Не используется  | 0 дней          |

--- a/packages/web/src/content/docs/th/go.mdx
+++ b/packages/web/src/content/docs/th/go.mdx
@@ -60,6 +60,7 @@ OpenCode Go ทำงานเหมือนกับผู้ให้บร�
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiMo-V2.5-Pro     | 3,250                  | 8,150               | 16,300            |
 | MiniMax M3        | 3,200                  | 8,000               | 16,000            |
 | MiniMax M2.7      | 3,400                  | 8,500               | 17,000            |
-| Qwen3.7 Max       | 950                    | 2,390               | 4,770             |
+| Qwen3.8 Max       | 160                    | 400                 | 810               |
+| Qwen3.7 Max       | 340                    | 840                 | 1,690             |
 | Qwen3.7 Plus      | 4,300                  | 10,800              | 21,600            |
 | Qwen3.6 Plus      | 3,300                  | 8,200               | 16,300            |
 | DeepSeek V4 Pro   | 3,450                  | 8,550               | 17,150            |
@@ -114,6 +116,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 - DeepSeek V4 Flash — 790 input, 68,000 cached, 280 output tokens ต่อ request
 - MiniMax M3 — 510 input, 56,000 cached, 190 output tokens ต่อ request
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens ต่อ request
+- Qwen3.8 Max — 420 input, 66,000 cached, 200 output tokens ต่อ request
 - Qwen3.7 Max — 420 input, 66,000 cached, 200 output tokens ต่อ request
 - Qwen3.7 Plus — 500 input, 57,000 cached, 190 output tokens ต่อ request
 - Qwen3.6 Plus — 500 input, 57,000 cached, 190 output tokens ต่อ request
@@ -138,6 +141,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60   |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60   |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60   |
@@ -195,6 +199,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | ไม่นำไปใช้  | 0 วัน              |
 | MiMo-V2.5-Pro     | ไม่นำไปใช้  | 0 วัน              |
 | MiMo-V2.5         | ไม่นำไปใช้  | 0 วัน              |
+| Qwen3.8 Max       | ไม่นำไปใช้  | 0 วัน              |
 | Qwen3.7 Max       | ไม่นำไปใช้  | 0 วัน              |
 | Qwen3.7 Plus      | ไม่นำไปใช้  | 0 วัน              |
 | Qwen3.6 Plus      | ไม่นำไปใช้  | 0 วัน              |

--- a/packages/web/src/content/docs/tr/go.mdx
+++ b/packages/web/src/content/docs/tr/go.mdx
@@ -60,6 +60,7 @@ Mevcut model listesi şunları içerir:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ Aşağıdaki tablo, tipik Go kullanım modellerine dayalı tahmini bir istek say
 | MiMo-V2.5-Pro     | 3,250              | 8,150          | 16,300      |
 | MiniMax M3        | 3,200              | 8,000          | 16,000      |
 | MiniMax M2.7      | 3,400              | 8,500          | 17,000      |
-| Qwen3.7 Max       | 950                | 2,390          | 4,770       |
+| Qwen3.8 Max       | 160                | 400            | 810         |
+| Qwen3.7 Max       | 340                | 840            | 1,690       |
 | Qwen3.7 Plus      | 4,300              | 10,800         | 21,600      |
 | Qwen3.6 Plus      | 3,300              | 8,200          | 16,300      |
 | DeepSeek V4 Pro   | 3,450              | 8,550          | 17,150      |
@@ -114,6 +116,7 @@ Tahminler, gözlemlenen istek modellerine dayanır:
 - DeepSeek V4 Flash — İstek başına 790 girdi, 68.000 önbelleğe alınmış, 280 çıktı token'ı
 - MiniMax M3 — İstek başına 510 girdi, 56.000 önbelleğe alınmış, 190 çıktı token'ı
 - MiniMax M2.7 — İstek başına 300 girdi, 55.000 önbelleğe alınmış, 125 çıktı token'ı
+- Qwen3.8 Max — İstek başına 420 girdi, 66.000 önbelleğe alınmış, 200 çıktı token'ı
 - Qwen3.7 Max — İstek başına 420 girdi, 66.000 önbelleğe alınmış, 200 çıktı token'ı
 - Qwen3.7 Plus — İstek başına 500 girdi, 57.000 önbelleğe alınmış, 190 çıktı token'ı
 - Qwen3.6 Plus — İstek başına 500 girdi, 57.000 önbelleğe alınmış, 190 çıktı token'ı
@@ -138,6 +141,7 @@ Tahminler ayrıca 1M token başına aşağıdaki fiyatlara ve her modelle birlik
 | MiniMax M3                   | $0.30  | $1.20  | $0.06       | -            | $60      |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25       | $2.50        | $15      |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50       | $3.125       | $60      |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04       | $0.50        | $60      |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12       | $1.50        | $60      |
@@ -195,6 +199,7 @@ Go modellerine aşağıdaki API uç noktaları aracılığıyla da erişebilirsi
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | Kullanılmaz   | 0 gün        |
 | MiMo-V2.5-Pro     | Kullanılmaz   | 0 gün        |
 | MiMo-V2.5         | Kullanılmaz   | 0 gün        |
+| Qwen3.8 Max       | Kullanılmaz   | 0 gün        |
 | Qwen3.7 Max       | Kullanılmaz   | 0 gün        |
 | Qwen3.7 Plus      | Kullanılmaz   | 0 gün        |
 | Qwen3.6 Plus      | Kullanılmaz   | 0 gün        |

--- a/packages/web/src/content/docs/zh-cn/go.mdx
+++ b/packages/web/src/content/docs/zh-cn/go.mdx
@@ -60,6 +60,7 @@ OpenCode Go 的工作方式与 OpenCode 中的其他提供商一样。
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Go 包含以下限制：
 | MiMo-V2.5-Pro     | 3,250           | 8,150      | 16,300     |
 | MiniMax M3        | 3,200           | 8,000      | 16,000     |
 | MiniMax M2.7      | 3,400           | 8,500      | 17,000     |
-| Qwen3.7 Max       | 950             | 2,390      | 4,770      |
+| Qwen3.8 Max       | 160             | 400        | 810        |
+| Qwen3.7 Max       | 340             | 840        | 1,690      |
 | Qwen3.7 Plus      | 4,300           | 10,800     | 21,600     |
 | Qwen3.6 Plus      | 3,300           | 8,200      | 16,300     |
 | DeepSeek V4 Pro   | 3,450           | 8,550      | 17,150     |
@@ -116,6 +118,7 @@ OpenCode Go 包含以下限制：
 - MiMo-V2.5-Pro — 每次请求 790 个输入 token，86,000 个缓存 token，305 个输出 token
 - MiniMax M3 — 每次请求 510 个输入 token，56,000 个缓存 token，190 个输出 token
 - MiniMax M2.7 — 每次请求 300 个输入 token，55,000 个缓存 token，125 个输出 token
+- Qwen3.8 Max — 每次请求 420 个输入 token，66,000 个缓存 token，200 个输出 token
 - Qwen3.7 Max — 每次请求 420 个输入 token，66,000 个缓存 token，200 个输出 token
 - Qwen3.7 Plus — 每次请求 500 个输入 token，57,000 个缓存 token，190 个输出 token
 - Qwen3.6 Plus — 每次请求 500 个输入 token，57,000 个缓存 token，190 个输出 token
@@ -138,6 +141,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                   | $0.30  | $1.20  | $0.06     | -        | $60      |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06     | $0.375   | $60      |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06     | $0.375   | $60      |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25     | $2.50    | $15      |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50     | $3.125   | $60      |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04     | $0.50    | $60      |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12     | $1.50    | $60      |
@@ -195,6 +199,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | 不使用   | 0 天     |
 | MiMo-V2.5-Pro     | 不使用   | 0 天     |
 | MiMo-V2.5         | 不使用   | 0 天     |
+| Qwen3.8 Max       | 不使用   | 0 天     |
 | Qwen3.7 Max       | 不使用   | 0 天     |
 | Qwen3.7 Plus      | 不使用   | 0 天     |
 | Qwen3.6 Plus      | 不使用   | 0 天     |

--- a/packages/web/src/content/docs/zh-tw/go.mdx
+++ b/packages/web/src/content/docs/zh-tw/go.mdx
@@ -60,6 +60,7 @@ OpenCode Go 的運作方式與 OpenCode 中的任何其他供應商相同。
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Qwen3.8 Max**
 - **Qwen3.7 Max**
 - **Qwen3.7 Plus**
 - **Qwen3.6 Plus**
@@ -96,7 +97,8 @@ OpenCode Go 包含以下限制：
 | MiMo-V2.5-Pro     | 3,250           | 8,150      | 16,300     |
 | MiniMax M3        | 3,200           | 8,000      | 16,000     |
 | MiniMax M2.7      | 3,400           | 8,500      | 17,000     |
-| Qwen3.7 Max       | 950             | 2,390      | 4,770      |
+| Qwen3.8 Max       | 160             | 400        | 810        |
+| Qwen3.7 Max       | 340             | 840        | 1,690      |
 | Qwen3.7 Plus      | 4,300           | 10,800     | 21,600     |
 | Qwen3.6 Plus      | 3,300           | 8,200      | 16,300     |
 | DeepSeek V4 Pro   | 3,450           | 8,550      | 17,150     |
@@ -114,6 +116,7 @@ OpenCode Go 包含以下限制：
 - DeepSeek V4 Flash — 每次請求 790 個輸入 token、68,000 個快取 token、280 個輸出 token
 - MiniMax M3 — 每次請求 510 個輸入 token、56,000 個快取 token、190 個輸出 token
 - MiniMax M2.7 — 每次請求 300 個輸入 token、55,000 個快取 token、125 個輸出 token
+- Qwen3.8 Max — 每次請求 420 個輸入 token、66,000 個快取 token、200 個輸出 token
 - Qwen3.7 Max — 每次請求 420 個輸入 token、66,000 個快取 token、200 個輸出 token
 - Qwen3.7 Plus — 每次請求 500 個輸入 token、57,000 個快取 token、190 個輸出 token
 - Qwen3.6 Plus — 每次請求 500 個輸入 token、57,000 個快取 token、190 個輸出 token
@@ -138,6 +141,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                   | $0.30  | $1.20  | $0.06     | -        | $60    |
 | MiniMax M2.7                 | $0.30  | $1.20  | $0.06     | $0.375   | $60    |
 | MiniMax M2.5                 | $0.30  | $1.20  | $0.06     | $0.375   | $60    |
+| Qwen3.8 Max                  | $2.00  | $6.00  | $0.25     | $2.50    | $15    |
 | Qwen3.7 Max                  | $2.50  | $7.50  | $0.50     | $3.125   | $60    |
 | Qwen3.7 Plus (≤ 256K tokens) | $0.40  | $1.60  | $0.04     | $0.50    | $60    |
 | Qwen3.7 Plus (> 256K tokens) | $1.20  | $4.80  | $0.12     | $1.50    | $60    |
@@ -195,6 +199,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3        | minimax-m3        | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7      | minimax-m2.7      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5      | minimax-m2.5      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Qwen3.8 Max       | qwen3.8-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Max       | qwen3.7-max       | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus      | qwen3.7-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus      | qwen3.6-plus      | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | Kimi K2.6         | 不使用   | 0 天     |
 | MiMo-V2.5-Pro     | 不使用   | 0 天     |
 | MiMo-V2.5         | 不使用   | 0 天     |
+| Qwen3.8 Max       | 不使用   | 0 天     |
 | Qwen3.7 Max       | 不使用   | 0 天     |
 | Qwen3.7 Plus      | 不使用   | 0 天     |
 | Qwen3.6 Plus      | 不使用   | 0 天     |


### PR DESCRIPTION
## Summary
- add Qwen3.8 Max to the Go landing and workspace model lists
- add Qwen3.8 Max to the limits graph with $15 usage estimates
- document pricing, request estimates, endpoints, and privacy across all locales
- correct stale Qwen3.7 Max request estimates

## Verification
- `bun typecheck` in `packages/console/app`
- `bun run build` in `packages/web`
- production Go model discovery and generation through Anthropic and OpenAI-compatible endpoints