### PR TITLE
fix(core): dedupe duplicate tool_call_id before lowering to provider

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -71,7 +71,35 @@ const assistant = (message: SessionMessage.Assistant, model: Model) => {
   const sameModel =
     String(message.model.providerID) === String(model.provider) && String(message.model.id) === String(model.id)
   const reuseProviderMetadata = sameModel && message.error === undefined
-  const content = message.content.flatMap((item): ContentPart[] => {
+  // An interrupted tool run can leave a second tool part that reuses an
+  // existing callID (e.g. a `completed` part plus an `error`/`Tool execution
+  // aborted` part with `metadata.interrupted`). Serializing both to the
+  // provider yields a duplicate `tool_call_id`, which every provider rejects
+  // with a 400 - and because compaction re-sends the full history, the
+  // session can never compact again. Drop the duplicate before lowering,
+  // keeping the most informative state (completed > error > running > pending).
+  // See #40235.
+  const toolStateRank: Record<SessionMessage.ToolState["status"], number> = {
+    completed: 0,
+    error: 1,
+    running: 2,
+    pending: 3,
+  }
+  // For each callID, pick the part with the most informative status. The
+  // first occurrence's position is preserved so tool/text/reasoning order
+  // stays stable.
+  const bestToolByCallID = new Map<string, SessionMessage.AssistantTool>()
+  for (const item of message.content) {
+    if (item.type !== "tool") continue
+    const prev = bestToolByCallID.get(item.id)
+    if (!prev || toolStateRank[item.state.status] < toolStateRank[prev.state.status]) {
+      bestToolByCallID.set(item.id, item)
+    }
+  }
+  const dedupedContent = message.content.filter(
+    (item) => item.type !== "tool" || item === bestToolByCallID.get(item.id),
+  )
+  const content = dedupedContent.flatMap((item): ContentPart[] => {
     if (item.type === "text") return [{ type: "text", text: item.text }]
     if (item.type === "reasoning")
       return sameModel
@@ -98,7 +126,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model) => {
     if (part.type !== "reasoning") return true
     return part.text !== "" || (part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
   })
-  const results = message.content
+  const results = dedupedContent
     .filter((item): item is SessionMessage.AssistantTool => item.type === "tool" && item.provider?.executed !== true)
     .map((item) =>
       toolResult(item, reuseProviderMetadata ? (item.provider?.resultMetadata ?? item.provider?.metadata) : undefined),

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -498,4 +498,67 @@ Recent work
       },
     ])
   })
+
+  test("drops duplicate tool_call_id left by an interrupted run (#40235)", () => {
+    // An interrupted tool run can leave a second part that reuses an
+    // existing callID: a `completed` part plus an `error`/`Tool execution
+    // aborted` part with `metadata.interrupted`. Serializing both to the
+    // provider yields a duplicate `tool_call_id`, which providers reject with
+    // a 400 - and because compaction re-sends the full history, the session
+    // can never compact again. The fix keeps the most informative part
+    // (completed) and drops the duplicate.
+    const assistant = (content: SessionMessage.Assistant["content"]) =>
+      SessionMessage.Assistant.make({
+        id: id("dup"),
+        type: "assistant",
+        agent: "build",
+        model: { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") },
+        content,
+        time: { created, completed: created },
+      })
+    const messages = toLLMMessages(
+      [
+        assistant([
+          SessionMessage.AssistantTool.make({
+            type: "tool",
+            id: "functions.todowrite:1",
+            name: "todowrite",
+            state: SessionMessage.ToolStateCompleted.make({
+              status: "completed",
+              input: { todos: [] },
+              content: [{ type: "text", text: "ok" }],
+              structured: {},
+            }),
+            time: { created, completed: created },
+          }),
+          SessionMessage.AssistantTool.make({
+            type: "tool",
+            id: "functions.todowrite:1",
+            name: "unknown",
+            state: SessionMessage.ToolStateError.make({
+              status: "error",
+              input: {},
+              raw: "",
+              error: { type: "unknown", message: "Tool execution aborted" },
+              metadata: { interrupted: true },
+              content: [],
+              structured: {},
+            }),
+            time: { created, completed: created },
+          }),
+        ]),
+      ],
+      model,
+    )
+
+    // Exactly one assistant message with one tool-call + one tool-result,
+    // both carrying the single callID - no duplicate.
+    expect(messages).toHaveLength(2)
+    const toolCalls = messages[0]!.content.filter((part) => part.type === "tool-call")
+    const toolResults = messages[1]!.content.filter((part) => part.type === "tool-result")
+    expect(toolCalls).toHaveLength(1)
+    expect(toolResults).toHaveLength(1)
+    expect(toolCalls[0]).toMatchObject({ id: "functions.todowrite:1", name: "todowrite" })
+    expect(toolResults[0]).toMatchObject({ id: "functions.todowrite:1" })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #40235

### Type of change

- [x] Bug fix

### What does this PR do?

An interrupted tool run can leave a **second tool part that reuses an existing callID** in the assistant message — a `completed` part plus an `error`/"Tool execution aborted" part with `metadata.interrupted`. When `toLLMMessages` serializes both to the provider, it emits two `ToolCallPart`s with the same `id`, and every provider rejects that with `400 Duplicate value for 'tool_call_id'`.

Because **compaction re-sends the full history head** to summarize, the duplicate is always present, so compaction can never complete — the summary is never written, the token counter never resets, and every subsequent auto-compaction fails the same way. The session is effectively poisoned until `/new`.

**Fix:** in `packages/core/src/session/runner/to-llm-message.ts`, the `assistant()` lowering now deduplicates tool parts by `callID` before building provider messages, keeping the most informative state (`completed > error > running > pending`) and preserving first-occurrence position so tool/text/reasoning order stays stable. Both the `content` (tool calls) and the trailing `results` (tool results) paths consume the deduped list, so a duplicate can no longer reach the provider.

I verified the root cause against the reporter's sqlite evidence: two parts sharing `callID` `functions.todowrite:1`, one `completed` (`tool=todowrite`) and one `error` (`tool=unknown`, `error="Tool execution aborted"`, `metadata.interrupted=true`) — exactly the shape the dedup now collapses.

### How did you verify your code works?

Added a regression test in `packages/core/test/session-runner-message.test.ts` that builds an assistant message with two tool parts sharing `functions.todowrite:1` (a `completed` todowrite + an `error`/"Tool execution aborted" interrupted part, matching the issue's sqlite evidence) and asserts `toLLMMessages` emits exactly one `tool-call` and one `tool-result`, both carrying the single callID with no duplicate.

```
$ bun test ./test/session-runner-message.test.ts
 7 pass, 0 fail
```

The pre-existing 6 tests in that file (empty turns, message-type mapping, durable media replay, OpenAI encrypted reasoning, provider continuation metadata on failed turns and after model switch) all still pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
