### PR TITLE
fix(core): update session activity timestamps

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -187,7 +187,23 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       appendMessage,
     }
     yield* SessionMessageUpdater.update(adapter, event)
+    if (bumpsSessionActivity(event)) {
+      yield* db
+        .update(SessionTable)
+        .set({ time_updated: DateTime.toEpochMillis(event.data.timestamp) })
+        .where(eq(SessionTable.id, event.data.sessionID))
+        .run()
+        .pipe(Effect.orDie)
+    }
   })
+}
+
+function bumpsSessionActivity(event: SessionEvent.Event) {
+  return (
+    event.type === "session.next.step.started" ||
+    event.type === "session.next.step.ended" ||
+    event.type === "session.next.step.failed"
+  )
 }
 
 function insertMessage(db: DatabaseService, event: SessionEvent.Event, message: SessionMessage.Message) {

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -377,6 +377,54 @@ describe("SessionProjector", () => {
     }),
   )
 
+  it.effect("bumps session updated time when projecting step lifecycle events", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+          time_created: 1,
+          time_updated: 1,
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      const events = yield* EventV2.Service
+      const assistantMessageID = SessionMessage.ID.make("msg_step_lifecycle")
+      yield* events.publish(SessionEvent.Step.Started, {
+        sessionID,
+        assistantMessageID,
+        timestamp: DateTime.makeUnsafe(5),
+        agent: "build",
+        model,
+      })
+      yield* events.publish(SessionEvent.Step.Ended, {
+        sessionID,
+        assistantMessageID,
+        timestamp: DateTime.makeUnsafe(9),
+        finish: "stop",
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      })
+
+      expect(
+        (yield* db.select().from(SessionTable).where(eq(SessionTable.id, sessionID)).get().pipe(Effect.orDie))
+          ?.time_updated,
+      ).toBe(9)
+    }),
+  )
+
   it.effect("does not revive a stale incomplete in-memory assistant projection", () =>
     Effect.gen(function* () {
       const stale = SessionMessage.Assistant.make({


### PR DESCRIPTION
## Summary
- Update the projected session `time_updated` when step lifecycle events are projected
- Keep session recency tied to active turns without updating on every streaming delta
- Add a projector regression test covering step start/end activity timestamps

Refs #36893

## Test Plan
- `bun test test/session-projector.test.ts --test-name-pattern "bumps session updated time when projecting step lifecycle events"`
- `bun test test/session-projector.test.ts`
- `cd packages/core && bun run typecheck`
- `bun run lint packages/core/src/session/projector.ts packages/core/test/session-projector.test.ts`
- `git diff --check`