### PR TITLE
fix(cli): report mismatched service status

### DIFF
--- a/packages/cli/src/services/daemon.test.ts
+++ b/packages/cli/src/services/daemon.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import * as NodeServices from "@effect/platform-node/NodeServices"
+import { Global } from "@opencode-ai/core/global"
+import { Effect } from "effect"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { Daemon } from "./daemon"
+
+const originalState = Global.Path.state
+
+afterEach(() => {
+  ;(Global.Path as { state: string }).state = originalState
+})
+
+describe("Daemon.status", () => {
+  test("reports a healthy daemon even when its version differs from the client", async () => {
+    const state = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-daemon-status-"))
+    ;(Global.Path as { state: string }).state = state
+
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return Response.json({ healthy: true, version: "older-version", pid: process.pid })
+      },
+    })
+    const url = server.url.origin
+    await fs.writeFile(
+      path.join(state, "server.json"),
+      JSON.stringify({ id: "test", version: "older-version", url, pid: process.pid }),
+    )
+
+    const status = await Effect.runPromise(
+      Daemon.Service.use((daemon) => daemon.status()).pipe(
+        Effect.provide(Daemon.layer),
+        Effect.provide(NodeServices.layer),
+        Effect.scoped,
+      ),
+    )
+
+    expect(status).toBe(url)
+  })
+})

--- a/packages/cli/src/services/daemon.ts
+++ b/packages/cli/src/services/daemon.ts
@@ -146,8 +146,7 @@ export const layer = Layer.effect(
     const status = Effect.fn("cli.daemon.status")(function* () {
       const existing = yield* healthy().pipe(Effect.option)
       const found = Option.getOrUndefined(existing)
-      if (found?.version === InstallationVersion) return found.url
-      if (found) return undefined
+      if (found) return found.url
       yield* fs.remove(file).pipe(Effect.ignore)
       return undefined
     })


### PR DESCRIPTION
## Summary
- Report a healthy registered daemon from `service status` even when its version differs from the current CLI
- Keep stale/unhealthy registrations reported as stopped and removed as before
- Add a daemon service regression test with a real health endpoint for the mismatch case

Fixes #36274

## Test Plan
- `bun test src/services/daemon.test.ts --test-name-pattern "reports a healthy daemon even when its version differs from the client"`
- `bun test src/commands/handlers/api.test.ts src/services/daemon.test.ts`
- `cd packages/cli && bun run typecheck`
- `bun run lint packages/cli/src/services/daemon.ts packages/cli/src/services/daemon.test.ts`
- `git diff --check`