### PR TITLE
docs: remove obsolete vouch system section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,33 +252,6 @@ These are not strictly enforced, they are just general guidelines:
 
 For net-new functionality, start with a design conversation. Open an issue describing the problem, your proposed approach (optional), and why it belongs in OpenCode. The core team will help decide whether it should move forward; please wait for that approval instead of opening a feature PR directly.
 
-## Trust & Vouch System
-
-This project uses [vouch](https://github.com/mitchellh/vouch) to manage contributor trust. The vouch list is maintained in [`.github/VOUCHED.td`](.github/VOUCHED.td).
-
-### How it works
-
-- **Vouched users** are explicitly trusted contributors.
-- **Denounced users** are explicitly blocked. Issues and pull requests from denounced users are automatically closed. If you have been denounced, you can request to be unvouched by reaching out to a maintainer on [Discord](https://opencode.ai/discord)
-- **Everyone else** can participate normally — you don't need to be vouched to open issues or PRs.
-
-### For maintainers
-
-Collaborators with write access can manage the vouch list by commenting on any issue:
-
-- `vouch` — vouch for the issue author
-- `vouch @username` — vouch for a specific user
-- `denounce` — denounce the issue author
-- `denounce @username` — denounce a specific user
-- `denounce @username <reason>` — denounce with a reason
-- `unvouch` / `unvouch @username` — remove someone from the list
-
-Changes are committed automatically to `.github/VOUCHED.td`.
-
-### Denouncement policy
-
-Denouncement is reserved for users who repeatedly submit low-quality AI-generated contributions, spam, or otherwise act in bad faith. It is not used for disagreements or honest mistakes.
-
 ## Issue Requirements
 
 All issues **must** use one of our issue templates:


### PR DESCRIPTION
### Issue for this PR

Closes #40263

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Removes the "Trust & Vouch System" section from `CONTRIBUTING.md`. That system no longer exists: `b205e104f6` deleted `.github/VOUCHED.td` and the three vouch workflows back in May.

The section was actively misleading rather than just outdated. It linked to `.github/VOUCHED.td` (404), said issues and PRs from denounced users are automatically closed (no workflow does this), and documented `vouch` / `denounce` / `unvouch` comment commands for maintainers that nothing listens for.

Deletion with no replacement, since that commit removed the mechanism deliberately rather than swapping it for something else.

I left the "Issue Requirements" section directly below it alone. Its 2-hour edit window is still real, implemented by `compliance-close.yml` via the `needs:compliance` label.

### How did you verify your code works?

- `grep -in vouch CONTRIBUTING.md` — no matches left
- `grep -ril vouch --include='*.yml' --include='*.yaml' --include='*.ts' .` — confirmed this section was the last reference in the repo
- `bunx prettier --check CONTRIBUTING.md` — passes
- Read the section boundary to confirm "Feature Requests" now flows into "Issue Requirements" cleanly

### Screenshots / recordings

Not applicable, docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
