### PR TITLE
fix(session): cascade archive to child sessions

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -756,8 +756,19 @@ const layer: Layer.Layer<
       yield* patch(input.sessionID, { title: input.title }).pipe(Effect.orDie)
     })
 
-    const setArchived = Effect.fn("Session.setArchived")(function* (input: { sessionID: SessionID; time?: number }) {
+    const setArchived: Interface["setArchived"] = Effect.fn("Session.setArchived")(function* (input: {
+      sessionID: SessionID
+      time?: number
+    }) {
       yield* patch(input.sessionID, { time: { archived: input.time } }).pipe(Effect.orDie)
+
+      // Archiving a session also archives every descendant so that child sessions
+      // cannot remain active after their parent is hidden.
+      if (input.time === undefined) return
+      const kids = yield* children(input.sessionID)
+      for (const child of kids) {
+        yield* setArchived({ sessionID: child.id, time: input.time })
+      }
     })
 
     const setMetadata = Effect.fn("Session.setMetadata")(function* (input: typeof SetMetadataInput.Type) {

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -206,6 +206,23 @@ describe("step-finish token propagation via event", () => {
 })
 
 describe("Session", () => {
+  it.instance("archives descendants with the same timestamp", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const parent = yield* session.create({ title: "parent" })
+      const child = yield* session.create({ title: "child", parentID: parent.id })
+      const grandchild = yield* session.create({ title: "grandchild", parentID: child.id })
+
+      yield* session.setArchived({ sessionID: parent.id, time: 123 })
+
+      expect((yield* session.get(parent.id)).time.archived).toBe(123)
+      expect((yield* session.get(child.id)).time.archived).toBe(123)
+      expect((yield* session.get(grandchild.id)).time.archived).toBe(123)
+
+      yield* session.remove(parent.id)
+    }),
+  )
+
   it.live("remove works without an instance", () =>
     Effect.gen(function* () {
       const session = yield* SessionNs.Service


### PR DESCRIPTION
Fixes #40258

Archiving a session now recursively archives its descendants with the same timestamp, preventing active child sessions from remaining under an archived parent.

Tested:
- bun test --timeout 30000 test/session/session.test.ts
- bun test --timeout 30000 test/server/httpapi-session.test.ts
- bun run typecheck
- bunx prettier --check ...