### PR TITLE
fix(tui): eagerly index child sessions

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -144,6 +144,8 @@ export const {
     const fullSyncedSessions = new Set<string>()
     const syncingSessions = new Map<string, Promise<void>>()
     const hydratingSessions = new Map<string, { messages: Set<string>; parts: Set<string> }>()
+    const sessionEventRevisions = new Map<string, number>()
+    let sessionEventRevision = 0
     const touchMessage = (sessionID: string, messageID: string) => {
       hydratingSessions.get(sessionID)?.messages.add(messageID)
     }
@@ -162,9 +164,32 @@ export const {
     }
 
     function listSessions() {
+      const revisions = new Map(sessionEventRevisions)
       return sdk.client.session
         .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
-        .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
+        .then((x) => ({ revisions, sessions: (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)) }))
+    }
+
+    function applySessionList(result: { revisions: Map<string, number>; sessions: Session[] }) {
+      const current = new Map(store.session.map((session) => [session.id, session] as const))
+      const listed = new Set(result.sessions.map((session) => session.id))
+      const sessions = result.sessions.flatMap((session) => {
+        if (sessionEventRevisions.get(session.id) === result.revisions.get(session.id)) return [session]
+        const live = current.get(session.id)
+        return live ? [live] : []
+      })
+      sessions.push(
+        ...store.session.filter(
+          (session) =>
+            !listed.has(session.id) && sessionEventRevisions.get(session.id) !== result.revisions.get(session.id),
+        ),
+      )
+      setStore("session", reconcile(sessions.toSorted((a, b) => a.id.localeCompare(b.id))))
+    }
+
+    function markSessionEvent(sessionID: string) {
+      sessionEventRevision++
+      sessionEventRevisions.set(sessionID, sessionEventRevision)
     }
 
     event.subscribe((event, { directory, workspace }) => {
@@ -265,6 +290,7 @@ export const {
           break
 
         case "session.deleted": {
+          markSessionEvent(event.properties.info.id)
           const result = search(store.session, event.properties.info.id, (s) => s.id)
           if (result.found) {
             setStore(
@@ -276,7 +302,9 @@ export const {
           }
           break
         }
+        case "session.created":
         case "session.updated": {
+          markSessionEvent(event.properties.info.id)
           const result = search(store.session, event.properties.info.id, (s) => s.id)
           if (result.found) {
             setStore("session", result.index, reconcile(event.properties.info))
@@ -294,6 +322,7 @@ export const {
         case "session.next.moved": {
           const result = search(store.session, event.properties.sessionID, (s) => s.id)
           if (!result.found) break
+          markSessionEvent(event.properties.sessionID)
           setStore(
             "session",
             result.index,
@@ -504,7 +533,7 @@ export const {
               setStore("console_state", reconcile(consoleState))
               setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
-              if (sessions !== undefined) setStore("session", reconcile(sessions))
+              if (sessions !== undefined) applySessionList(sessions)
             })
           })
         })
@@ -512,7 +541,7 @@ export const {
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
+            ...(args.continue ? [] : [sessionListPromise.then((sessions) => applySessionList(sessions))]),
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
@@ -573,7 +602,7 @@ export const {
         },
         async refresh() {
           const list = await listSessions()
-          setStore("session", reconcile(list))
+          applySessionList(list)
         },
         status(sessionID: string) {
           const session = result.session.get(sessionID)

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -22,7 +22,7 @@ export async function wait(fn: () => boolean, timeout = 2000) {
 
 type Ctx = { kv: ReturnType<typeof useKV>; project: ReturnType<typeof useProject>; sync: ReturnType<typeof useSync> }
 
-export async function mount(override?: FetchHandler, state?: string) {
+export async function mount(override?: FetchHandler, state?: string, options?: { waitForReady?: boolean }) {
   const calls = createFetch(override)
   const events = createEventSource()
   let sync!: ReturnType<typeof useSync>
@@ -65,6 +65,6 @@ export async function mount(override?: FetchHandler, state?: string) {
   ))
 
   await ready
-  await wait(() => sync.status === "complete")
+  if (options?.waitForReady !== false) await wait(() => sync.status === "complete")
   return { app, emit: events.emit, kv, project, sync, session: calls.session }
 }

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -260,3 +260,94 @@ test("a message removed during hydration does not regain stale parts", async () 
     app.renderer.destroy()
   }
 })
+
+test("a child session created event updates metadata without hydrating the session", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const childSessionID = "ses_hydration_child"
+  const childSession = {
+    ...session,
+    id: childSessionID,
+    parentID: sessionID,
+    title: "child",
+    slug: "child",
+    projectID: "proj_test",
+  }
+  let childSessionRequests = 0
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${childSessionID}`) {
+      childSessionRequests++
+      return json(childSession)
+    }
+    return undefined
+  }, tmp.path)
+
+  try {
+    emit(global({ id: "evt_session", type: "session.created", properties: { sessionID: childSessionID, info: childSession } }))
+
+    expect(sync.session.get(childSessionID)).toEqual(childSession)
+    expect(childSessionRequests).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("a live child session survives a stale initial session list", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const childSessionID = "ses_hydration_child_stale_list"
+  const childSession = {
+    ...session,
+    id: childSessionID,
+    parentID: sessionID,
+    title: "child",
+    slug: "child-stale-list",
+    projectID: "proj_test",
+  }
+  const rootSession = {
+    ...session,
+    id: "ses_hydration_root",
+    title: "root",
+    slug: "root",
+    projectID: "proj_test",
+  }
+  let resolveSessions!: (response: Response) => void
+  const sessions = new Promise<Response>((resolve) => {
+    resolveSessions = resolve
+  })
+  let sessionListRequested = false
+  let childSessionRequests = 0
+  const { app, emit, sync } = await mount(
+    (url) => {
+      if (url.pathname === "/session") {
+        sessionListRequested = true
+        return sessions
+      }
+      if (url.pathname === `/session/${childSessionID}`) {
+        childSessionRequests++
+        return json(childSession)
+      }
+      return undefined
+    },
+    tmp.path,
+    { waitForReady: false },
+  )
+
+  try {
+    await wait(() => sessionListRequested)
+    emit(global({ id: "evt_session", type: "session.created", properties: { sessionID: childSessionID, info: childSession } }))
+    expect(sync.session.get(childSessionID)).toEqual(childSession)
+
+    resolveSessions(json([rootSession]))
+    await wait(() => sync.status === "complete")
+
+    expect(sync.session.get(childSessionID)).toEqual(childSession)
+    expect(sync.session.get(rootSession.id)).toEqual(rootSession)
+    expect(sync.data.session.map((item) => item.id)).toEqual([childSessionID, rootSession.id])
+    expect(childSessionRequests).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## Summary
- add `session.created` to the TUI session metadata upsert path
- preserve live child metadata across delayed session-list responses
- keep child transcript hydration lazy

## Test plan
- `bun test test/cli/cmd/tui/sync-live-hydration.test.tsx`
- `bun typecheck`