### PR TITLE
test(ai): simplify TestLLM setup

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -214,22 +214,20 @@ the requests sent by code under test:
 import { Effect } from "effect"
 import { TestLLM } from "@opencode-ai/ai/testing"
 
-const testLLM = TestLLM.layer({
-  fallback: TestLLM.text("Hello from the test model", "text-1"),
+const testLLM = TestLLM.layerWithClient({
+  fallback: TestLLM.text("Hello from the test model"),
 })
 
-// TestLLM.clientLayer provides LLMClient.Service and consumes TestLLM.Service.
 const programWithTestClient = Effect.gen(function* () {
   const result = yield* program
-  const test = yield* TestLLM.Service
-  console.log(test.requests)
+  console.log(yield* TestLLM.requests)
   return result
-}).pipe(Effect.provide(TestLLM.clientLayer), Effect.provide(testLLM))
+}).pipe(Effect.provide(testLLM))
 ```
 
 `TestLLM.push(...)` scripts one-shot responses, `TestLLM.always(...)` changes the fallback, and
 `TestLLM.wait(...)` lets concurrent tests wait until a request has arrived. Every received canonical request is
-available on the yielded `TestLLM.Service`.
+available from `TestLLM.requests`.
 
 ## Caching
 

--- a/packages/ai/src/testing.ts
+++ b/packages/ai/src/testing.ts
@@ -53,7 +53,7 @@ const textEvents = (value: string, id: string) => [
   LLMEvent.textEnd({ id }),
 ]
 
-export const text = (value: string, id: string) => stop(...textEvents(value, id))
+export const text = (value: string, id = "text-0") => stop(...textEvents(value, id))
 
 export const textWithUsage = (value: string, id: string, inputTokens: number) =>
   complete(
@@ -146,6 +146,10 @@ export const clientLayer = Layer.effect(
   LLMClient.Service,
   Effect.map(Service, (service) => service.client),
 )
+
+export const layerWithClient = (options: LayerOptions = {}) => clientLayer.pipe(Layer.provideMerge(layer(options)))
+
+export const requests = Service.use((service) => Effect.succeed(service.requests))
 
 export const push = (...responses: readonly Response[]) => Service.use((service) => service.push(...responses))
 

--- a/packages/ai/test/exports.test.ts
+++ b/packages/ai/test/exports.test.ts
@@ -32,6 +32,8 @@ describe("public exports", () => {
     expect(Provider.make).toBeFunction()
     expect(ProviderSubpath.make).toBe(Provider.make)
     expect(TestLLM.layer).toBeFunction()
+    expect(TestLLM.layerWithClient).toBeFunction()
+    expect(TestLLM.requests).toBeDefined()
   })
 
   test("route barrel exposes route-authoring APIs", () => {

--- a/packages/ai/test/testing.test.ts
+++ b/packages/ai/test/testing.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { LLM, LLMClient, LLMEvent } from "../src"
+import { OpenAIChat } from "../src/protocols"
+import { TestLLM } from "../src/testing"
+import { testEffect } from "./lib/effect"
+
+const model = OpenAIChat.route.model({ id: "test" })
+const it = testEffect(TestLLM.layerWithClient({ fallback: TestLLM.text("Hello") }))
+
+it.effect("provides a client and exposes received requests", () =>
+  Effect.gen(function* () {
+    const response = yield* LLMClient.generate(LLM.request({ model, prompt: "Say hello" }))
+
+    expect(response.text).toBe("Hello")
+    expect(response.events.filter(LLMEvent.is.textDelta)).toEqual([{ type: "text-delta", id: "text-0", text: "Hello" }])
+    expect(yield* TestLLM.requests).toHaveLength(1)
+  }),
+)

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -65,7 +65,7 @@ const aisdk = Layer.mock(AISDK.Service, {
   },
   model: () => Effect.succeed(runtime),
 })
-const client = TestLLM.clientLayer.pipe(Layer.provide(TestLLM.layer({ fallback: TestLLM.text("OK", "generate") })))
+const client = TestLLM.layerWithClient({ fallback: TestLLM.text("OK") })
 
 const resolver = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk)))
 const it = testEffect(Generate.layer.pipe(Layer.provide(Layer.merge(resolver, client))))


### PR DESCRIPTION
## summary
- add a composed `TestLLM.layerWithClient` that retains both test and client services
- expose received requests through `TestLLM.requests` and default text event IDs
- document the shorter setup and migrate an existing core test

## testing
- `bun typecheck` in `packages/ai`
- `bun typecheck` in `packages/core`
- `bun test test/testing.test.ts test/exports.test.ts` in `packages/ai`
- `bun test test/generate.test.ts` in `packages/core`
- monorepo pre-push typecheck: 33 packages pass