### PR TITLE
docs: add opencode-focus to ecosystem plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -48,6 +48,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                              |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                  |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                    |
+| [opencode-focus](https://github.com/kivervinicius/opencode-focus)                                  | Status-aware terminal titles, desktop notifications and click-to-focus (GNOME) for the TUI          |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                           |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                           |


### PR DESCRIPTION
Add [opencode-focus](https://github.com/kivervinicius/opencode-focus) to the ecosystem plugins table.

**What it does**: status-aware terminal titles (spinner/state in the window title), minimal desktop notifications (error, waiting decision, completion, retry) and click-to-focus window via a GNOME shell extension (D-Bus `org.opencode.Focus`), with focus-based notification suppression.

- npm: `opencode-focus` (server + TUI plugins, v1 contract)
- Install: `opencode plugin opencode-focus --global`
- GNOME extension (optional): `npx opencode-focus setup`
- Docs: README + docs/DEVELOPERS.md in the repo