### PR TITLE
fix(app): refresh agent picker visibility

### DIFF
--- a/packages/app/src/components/prompt-input-v2.test.ts
+++ b/packages/app/src/components/prompt-input-v2.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { agentControlVisible } from "./prompt-input-v2"
+
+test("shows the agent control when visibility becomes enabled", () => {
+  createRoot((dispose) => {
+    const [visible, setVisible] = createSignal(false)
+
+    expect(agentControlVisible(visible, ["build", "plan"])).toBe(false)
+    setVisible(true)
+    expect(agentControlVisible(visible, ["build", "plan"])).toBe(true)
+
+    dispose()
+  })
+})

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -44,6 +44,10 @@ export type PromptInputV2ComposerController = PromptInputV2Interaction & {
   readonly model: PromptInputProps["controls"]["model"]
 }
 
+export function agentControlVisible(visible: () => boolean, options: string[]) {
+  return visible() && options.length > 0
+}
+
 export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
   const dialog = useDialog()
   const command = useCommand()
@@ -382,7 +386,7 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
     view: {
       placeholder: designPlaceholder,
       get agent() {
-        return props.controls.agents.visible && props.controls.agents.options.length > 0
+        return agentControlVisible(props.controls.agents.visible, props.controls.agents.options)
           ? {
               options: () => props.controls.agents.options.map((name) => ({ id: name, label: name })),
               current: () => props.controls.agents.current,

--- a/packages/app/src/components/prompt-input.stories.tsx
+++ b/packages/app/src/components/prompt-input.stories.tsx
@@ -54,7 +54,7 @@ function PromptInputExample() {
         return controls.agent
       },
       loading: false,
-      visible: true,
+      visible: () => true,
       select: (agent?: string) => setControls("agent", agent ?? "build"),
     },
     model: {
@@ -132,7 +132,7 @@ function PromptInputWithOpenDock() {
         return controls.agent
       },
       loading: false,
-      visible: true,
+      visible: () => true,
       select: (agent?: string) => setControls("agent", agent ?? "build"),
     },
     model: {

--- a/packages/app/src/components/prompt-input/contracts.ts
+++ b/packages/app/src/components/prompt-input/contracts.ts
@@ -2,6 +2,7 @@ import type { useLocal } from "@/context/local"
 import type { Prompt, usePrompt } from "@/context/prompt"
 import type { PromptInputHistory } from "./history-store"
 import type { FollowupDraft } from "./submit"
+import type { Accessor } from "solid-js"
 
 export type PromptInputState = ReturnType<typeof usePrompt>
 
@@ -16,7 +17,7 @@ export type PromptInputControls = {
     options: string[]
     current: string
     loading: boolean
-    visible: boolean
+    visible: Accessor<boolean>
     select: (name: string | undefined) => void
   }
   model: {

--- a/packages/app/src/pages/session/composer/session-composer-controls.ts
+++ b/packages/app/src/pages/session/composer/session-composer-controls.ts
@@ -40,7 +40,7 @@ export function createPromptInputController(input: {
         options: local.agent.list().map((agent) => agent.name),
         current: local.agent.current()?.name ?? "",
         loading: agentsQuery.isLoading,
-        visible: local.agent.visible(),
+        visible: local.agent.visible,
         select: local.agent.set,
       },
       model: {

--- a/packages/app/src/pages/session/composer/todo-panel-motion.stories.tsx
+++ b/packages/app/src/pages/session/composer/todo-panel-motion.stories.tsx
@@ -57,7 +57,7 @@ const btn = (accent?: boolean) =>
   }) as const
 
 const controls = {
-  agents: { available: [], options: ["build"], current: "build", loading: false, visible: true, select: () => {} },
+  agents: { available: [], options: ["build"], current: "build", loading: false, visible: () => true, select: () => {} },
   model: {
     selection: {
       current: () => ({ id: "claude-3-7-sonnet", name: "Claude 3.7 Sonnet", provider: { id: "anthropic" } }),


### PR DESCRIPTION
## Summary
- keep composer agent visibility reactive after Desktop startup initialization
- update prompt input control fixtures for the accessor contract
- add regression coverage for a visibility transition without recreating the composer

Fixes #40288

## Testing
- `bun test --conditions=solid --preload ./happydom.ts ./src/components/prompt-input-v2.test.ts`
- `bun typecheck`