### PR TITLE
feat(tui): add Chinese locale support

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -162,7 +162,11 @@ export type ParsedAPICallError =
       metadata?: Record<string, string>
     }
 
-export function parseAPICallError(input: { providerID: ProviderV2.ID; error: APICallError }): ParsedAPICallError {
+export function parseAPICallError(input: {
+  providerID: ProviderV2.ID
+  retry400RateLimit?: boolean
+  error: APICallError
+}): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
   if (isContextOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
@@ -174,11 +178,18 @@ export function parseAPICallError(input: { providerID: ProviderV2.ID; error: API
   }
 
   const metadata = input.error.url ? { url: input.error.url } : undefined
+  const rateLimitExceeded =
+    input.retry400RateLimit === true &&
+    input.error.statusCode === 400 &&
+    typeof body?.detail === "string" &&
+    body.detail.toLowerCase().includes("rate limit exceeded")
   return {
     type: "api_error",
     message: m,
     statusCode: input.error.statusCode,
-    isRetryable: input.providerID.startsWith("openai") ? isOpenAiErrorRetryable(input.error) : input.error.isRetryable,
+    isRetryable:
+      rateLimitExceeded ||
+      (input.providerID.startsWith("openai") ? isOpenAiErrorRetryable(input.error) : input.error.isRetryable),
     responseHeaders: input.error.responseHeaders,
     responseBody: input.error.responseBody,
     metadata,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -602,7 +602,7 @@ export function latest(msgs: WithParts[]) {
 
 export function fromError(
   e: unknown,
-  ctx: { providerID: ProviderV2.ID; aborted?: boolean },
+  ctx: { providerID: ProviderV2.ID; aborted?: boolean; retry400RateLimit?: boolean },
 ): NonNullable<Assistant["error"]> {
   switch (true) {
     case e instanceof DOMException && e.name === "AbortError":
@@ -676,6 +676,7 @@ export function fromError(
     case APICallError.isInstance(e):
       const parsed = ProviderError.parseAPICallError({
         providerID: ctx.providerID,
+        retry400RateLimit: ctx.retry400RateLimit,
         error: e,
       })
       if (parsed.type === "context_overflow") {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -113,11 +113,14 @@ const layer = Layer.effect(
         reasoningMap: {},
       }
       let aborted = false
+      const cfg = yield* config.get()
+      const retry400RateLimit = cfg.provider?.[input.model.providerID]?.options?.retry400RateLimit === true
 
       const parse = (e: unknown) =>
         MessageV2.fromError(e, {
           providerID: input.model.providerID,
           aborted,
+          retry400RateLimit,
         })
 
       const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -141,6 +141,18 @@ it.instance("loads tui config with the same precedence order as server config pa
   ),
 )
 
+it.instance("loads the TUI locale from tui.json", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      yield* fs.writeJson(path.join(test.directory, "tui.json"), { locale: "zh-CN" })
+
+      expect((yield* getTuiConfig(test.directory)).locale).toBe("zh-CN")
+    }),
+  ),
+)
+
 it.instance("resolves attention config defaults and overrides", () =>
   withCleanState(
     Effect.gen(function* () {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -70,7 +70,7 @@ const cfg = {
   },
 }
 
-function providerCfg(url: string) {
+function providerCfg(url: string, retry400RateLimit = false) {
   return {
     ...cfg,
     provider: {
@@ -80,6 +80,7 @@ function providerCfg(url: string) {
         options: {
           ...cfg.provider.test.options,
           baseURL: url,
+          retry400RateLimit,
         },
       },
     },
@@ -554,6 +555,52 @@ it.live("session.processor effect tests do not retry unknown json errors", () =>
         expect(handle.message.error?.name).toBe("APIError")
       }),
     { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests retry provider-local 400 rate limits when enabled", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.error(400, { detail: "Rate limit exceeded" })
+        yield* llm.text("after")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "retry configured 400")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "retry configured 400" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+      }),
+    { config: (url) => providerCfg(url, true) },
   ),
 )
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -437,4 +437,56 @@ describe("session.message-v2.fromError", () => {
       message: "An error occurred while processing your request.",
     })
   })
+
+  test("marks provider 400 rate limit response bodies as retryable when enabled", () => {
+    const error = new APICallError({
+      message: "Bad request",
+      url: "https://example.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({
+        detail:
+          "Rate limit exceeded for end_user: test@example.com. Limit type: tokens. Current limit: 500000, Remaining: 0. Limit resets at: 2026-06-07 22:57:15 UTC",
+      }),
+      isRetryable: false,
+    })
+    const result = MessageV2.fromError(error, { providerID, retry400RateLimit: true })
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.statusCode).toBe(400)
+    expect(result.data.isRetryable).toBe(true)
+    expect(SessionRetry.retryable(result, retryProvider)).toEqual({ message: result.data.message })
+  })
+
+  test("keeps provider 400 rate limit response bodies non-retryable when disabled", () => {
+    const error = new APICallError({
+      message: "Bad request",
+      url: "https://example.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({ detail: "Rate limit exceeded" }),
+      isRetryable: false,
+    })
+    const result = MessageV2.fromError(error, { providerID })
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(false)
+    expect(SessionRetry.retryable(result, retryProvider)).toBeUndefined()
+  })
+
+  test("keeps generic provider 400 API call errors non-retryable when enabled", () => {
+    const error = new APICallError({
+      message: "Bad request",
+      url: "https://example.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({ error: "invalid request" }),
+      isRetryable: false,
+    })
+    const result = MessageV2.fromError(error, { providerID, retry400RateLimit: true })
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(false)
+    expect(SessionRetry.retryable(result, retryProvider)).toBeUndefined()
+  })
 })

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -66,6 +66,7 @@ import { ArgsProvider, useArgs, type Args } from "./context/args"
 import open from "open"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { TuiConfigProvider, useTuiConfig, type TuiConfig } from "./config"
+import { TuiI18nProvider } from "./i18n"
 import { createTuiApiAdapters } from "./plugin/adapters"
 import { createTuiApi } from "./plugin/api"
 import { createPluginRuntime, PluginRuntimeProvider, usePluginRuntime, type TuiPluginHost } from "./plugin/runtime"
@@ -294,46 +295,48 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                     }
                                   >
                                     <TuiConfigProvider config={input.config}>
-                                      <PluginRuntimeProvider value={pluginRuntime}>
-                                        <SDKProvider
-                                          url={input.url}
-                                          directory={input.directory}
-                                          fetch={input.fetch}
-                                          headers={input.headers}
-                                          events={input.events}
-                                        >
-                                          <PermissionProvider>
-                                            <ProjectProvider>
-                                              <SyncProvider>
-                                                <DataProvider>
-                                                  <ThemeProvider mode={mode}>
-                                                    <LocalProvider>
-                                                      <PromptStashProvider>
-                                                        <DialogProvider>
-                                                          <FrecencyProvider>
-                                                            <PromptHistoryProvider>
-                                                              <PromptRefProvider>
-                                                                <EditorContextProvider>
-                                                                  <LocationProvider>
-                                                                    <App
-                                                                      onSnapshot={input.onSnapshot}
-                                                                      pluginHost={input.pluginHost}
-                                                                    />
-                                                                  </LocationProvider>
-                                                                </EditorContextProvider>
-                                                              </PromptRefProvider>
-                                                            </PromptHistoryProvider>
-                                                          </FrecencyProvider>
-                                                        </DialogProvider>
-                                                      </PromptStashProvider>
-                                                    </LocalProvider>
-                                                  </ThemeProvider>
-                                                </DataProvider>
-                                              </SyncProvider>
-                                            </ProjectProvider>
-                                          </PermissionProvider>
-                                        </SDKProvider>
-                                      </PluginRuntimeProvider>
+                                      <TuiI18nProvider locale={input.config.locale}>
+                                        <PluginRuntimeProvider value={pluginRuntime}>
+                                          <SDKProvider
+                                            url={input.url}
+                                            directory={input.directory}
+                                            fetch={input.fetch}
+                                            headers={input.headers}
+                                            events={input.events}
+                                          >
+                                            <PermissionProvider>
+                                              <ProjectProvider>
+                                                <SyncProvider>
+                                                  <DataProvider>
+                                                    <ThemeProvider mode={mode}>
+                                                      <LocalProvider>
+                                                        <PromptStashProvider>
+                                                          <DialogProvider>
+                                                            <FrecencyProvider>
+                                                              <PromptHistoryProvider>
+                                                                <PromptRefProvider>
+                                                                  <EditorContextProvider>
+                                                                    <LocationProvider>
+                                                                      <App
+                                                                        onSnapshot={input.onSnapshot}
+                                                                        pluginHost={input.pluginHost}
+                                                                      />
+                                                                    </LocationProvider>
+                                                                  </EditorContextProvider>
+                                                                </PromptRefProvider>
+                                                              </PromptHistoryProvider>
+                                                            </FrecencyProvider>
+                                                          </DialogProvider>
+                                                        </PromptStashProvider>
+                                                      </LocalProvider>
+                                                    </ThemeProvider>
+                                                  </DataProvider>
+                                                </SyncProvider>
+                                              </ProjectProvider>
+                                            </PermissionProvider>
+                                          </SDKProvider>
+                                        </PluginRuntimeProvider>
+                                      </TuiI18nProvider>
                                     </TuiConfigProvider>
                                   </RouteProvider>
                                 </ToastProvider>

--- a/packages/tui/src/component/command-palette.tsx
+++ b/packages/tui/src/component/command-palette.tsx
@@ -9,6 +9,7 @@ import {
   useOpencodeKeymap,
 } from "../keymap"
 import { useTuiConfig } from "../config"
+import { useTuiI18n } from "../i18n"
 
 type PaletteCommandEntry = ReturnType<OpenTuiKeymap["getCommandEntries"]>[number]
 
@@ -25,6 +26,7 @@ function isSuggestedPaletteCommand(entry: PaletteCommandEntry) {
 
 export function CommandPaletteDialog() {
   const config = useTuiConfig()
+  const i18n = useTuiI18n()
   const keymap = useOpencodeKeymap()
   const entries = useKeymapSelector((keymap: OpenTuiKeymap) => {
     const query = {
@@ -69,11 +71,11 @@ export function CommandPaletteDialog() {
         .map((option) => ({
           ...option,
           value: `suggested:${option.value}`,
-          category: "Suggested",
+          category: i18n.t("palette.suggested"),
         })),
       ...options(),
     ]
   }
 
-  return <DialogSelect ref={(value) => (ref = value)} title="Commands" options={list()} />
+  return <DialogSelect ref={(value) => (ref = value)} title={i18n.t("palette.commands")} options={list()} />
 }

--- a/packages/tui/src/component/startup-loading.tsx
+++ b/packages/tui/src/component/startup-loading.tsx
@@ -1,11 +1,13 @@
 import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
 import { useTheme } from "../context/theme"
 import { Spinner } from "./spinner"
+import { useTuiI18n } from "../i18n"
 
 export function StartupLoading(props: { ready: () => boolean }) {
   const theme = useTheme().theme
+  const i18n = useTuiI18n()
   const [show, setShow] = createSignal(false)
-  const text = createMemo(() => (props.ready() ? "Finishing startup..." : "Loading plugins..."))
+  const text = createMemo(() => (props.ready() ? i18n.t("startup.finishing") : i18n.t("startup.loadingPlugins")))
   let wait: NodeJS.Timeout | undefined
   let hold: NodeJS.Timeout | undefined
   let stamp = 0

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -4,6 +4,7 @@ import { createBindingLookup } from "@opentui/keymap/extras"
 import { Schema } from "effect"
 import { createContext, type JSX, useContext } from "solid-js"
 import { TuiKeybind } from "./keybind"
+import { resolveLocale } from "../i18n"
 
 export const AttentionSoundName = Schema.Literals([
   "default",
@@ -30,6 +31,8 @@ export const ScrollAcceleration = Schema.Struct({
 export const DiffStyle = Schema.Literals(["auto", "stacked"]).annotate({
   description: "Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column",
 })
+export const Locale = Schema.Literals(["en", "zh-CN"]).annotate({ description: "TUI display language" })
+export type Locale = Schema.Schema.Type<typeof Locale>
 
 export const AttentionSounds = Schema.Record(AttentionSoundName, Schema.optionalKey(Schema.String))
 export type AttentionSoundPaths = Schema.Schema.Type<typeof AttentionSounds>
@@ -62,11 +65,12 @@ export const Info = Schema.Struct({
   scroll_speed: Schema.optional(ScrollSpeed).annotate({ description: "TUI scroll speed" }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
+  locale: Schema.optional(Locale),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse"> & {
+export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "locale" | "mouse"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -77,6 +81,7 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
   }
   keybinds: TuiKeybind.BindingLookupView
   leader_timeout: number
+  locale: Locale
   mouse: boolean
 }
 
@@ -112,6 +117,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
       bindingDefaults: TuiKeybind.bindingDefaults(),
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
+    locale: resolveLocale(input.locale),
     mouse: input.mouse ?? true,
   }
 }

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -3,11 +3,13 @@ import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo, Show } from "solid-js"
 import { abbreviateHome } from "../../runtime"
 import { useTuiPaths } from "../../context/runtime"
+import { useTuiI18n } from "../../i18n"
 
 const id = "internal:sidebar-footer"
 
 function View(props: { api: TuiPluginApi; sessionID: string }) {
   const paths = useTuiPaths()
+  const i18n = useTuiI18n()
   const theme = () => props.api.theme.current
   const has = createMemo(() =>
     props.api.state.provider.some(
@@ -47,18 +49,18 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
           <box flexGrow={1} gap={1}>
             <box flexDirection="row" justifyContent="space-between">
               <text fg={theme().text}>
-                <b>Getting started</b>
+                <b>{i18n.t("sidebar.gettingStarted")}</b>
               </text>
               <text fg={theme().textMuted} onMouseDown={() => props.api.kv.set("dismissed_getting_started", true)}>
                 ✕
               </text>
             </box>
-            <text fg={theme().textMuted}>OpenCode includes free models so you can start immediately.</text>
+            <text fg={theme().textMuted}>{i18n.t("sidebar.freeModels")}</text>
             <text fg={theme().textMuted}>
-              Connect from 75+ providers to use other models, including Claude, GPT, Gemini etc
+              {i18n.t("sidebar.providers")}
             </text>
             <box flexDirection="row" gap={1} justifyContent="space-between">
-              <text fg={theme().text}>Connect provider</text>
+              <text fg={theme().text}>{i18n.t("sidebar.connectProvider")}</text>
               <text fg={theme().textMuted}>/connect</text>
             </box>
           </box>

--- a/packages/tui/src/i18n.tsx
+++ b/packages/tui/src/i18n.tsx
@@ -1,0 +1,67 @@
+import { createContext, type JSX, useContext } from "solid-js"
+
+const dictionaries = {
+  en: {
+    "home.placeholder.fixTodo": "Fix a TODO in the codebase",
+    "home.placeholder.techStack": "What is the tech stack of this project?",
+    "home.placeholder.fixTests": "Fix broken tests",
+    "sidebar.gettingStarted": "Getting started",
+    "sidebar.freeModels": "OpenCode includes free models so you can start immediately.",
+    "sidebar.providers": "Connect from 75+ providers to use other models, including Claude, GPT, Gemini etc",
+    "sidebar.connectProvider": "Connect provider",
+    "footer.getStarted": "Get started",
+    "footer.permission": "Permission",
+    "footer.permissions": "Permissions",
+    "startup.finishing": "Finishing startup...",
+    "startup.loadingPlugins": "Loading plugins...",
+    "dialog.cancel": "Cancel",
+    "dialog.confirm": "Confirm",
+    "palette.commands": "Commands",
+    "palette.suggested": "Suggested",
+  },
+  "zh-CN": {
+    "home.placeholder.fixTodo": "修复代码库中的待办事项",
+    "home.placeholder.techStack": "这个项目使用什么技术栈？",
+    "home.placeholder.fixTests": "修复失败的测试",
+    "sidebar.gettingStarted": "开始使用",
+    "sidebar.freeModels": "OpenCode 包含免费模型，您可以立即开始使用。",
+    "sidebar.providers": "连接超过 75 家提供商以使用其他模型，包括 Claude、GPT、Gemini 等。",
+    "sidebar.connectProvider": "连接提供商",
+    "footer.getStarted": "开始使用",
+    "footer.permission": "项权限",
+    "footer.permissions": "项权限",
+    "startup.finishing": "正在完成启动...",
+    "startup.loadingPlugins": "正在加载插件...",
+    "dialog.cancel": "取消",
+    "dialog.confirm": "确认",
+    "palette.commands": "命令",
+    "palette.suggested": "推荐",
+  },
+} as const
+
+export type Locale = keyof typeof dictionaries
+export type TranslationKey = keyof (typeof dictionaries)["en"]
+
+export function resolveLocale(value: unknown, env = process.env): Locale {
+  if (value === "en" || value === "zh-CN") return value
+  const system = env.LC_ALL || env.LC_MESSAGES || env.LANG || ""
+  return /^zh(?:[_-]CN|$)/i.test(system) ? "zh-CN" : "en"
+}
+
+export function translate(locale: Locale, key: TranslationKey) {
+  return dictionaries[locale][key] ?? dictionaries.en[key]
+}
+
+const Context = createContext<Locale>("en")
+
+export function TuiI18nProvider(props: { locale: Locale; children: JSX.Element }) {
+  return <Context.Provider value={props.locale}>{props.children}</Context.Provider>
+}
+
+export function useTuiI18n() {
+  const locale = useContext(Context)
+  return {
+    locale,
+    t: (key: TranslationKey) => translate(locale, key),
+  }
+}

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -12,13 +12,9 @@ import { useEditorContext } from "../context/editor"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useTuiConfig } from "../config"
 import { HomeSessionDestinationProvider } from "./home/session-destination"
+import { useTuiI18n } from "../i18n"
 
 let once = false
-const placeholder = {
-  normal: ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"],
-  shell: ["ls -la", "git status", "pwd"],
-}
-
 export function Home() {
   const pluginRuntime = usePluginRuntime()
   const sync = useSync()
@@ -30,6 +26,11 @@ export function Home() {
   const editor = useEditorContext()
   const dimensions = useTerminalDimensions()
   const tuiConfig = useTuiConfig()
+  const i18n = useTuiI18n()
+  const placeholder = {
+    normal: [i18n.t("home.placeholder.fixTodo"), i18n.t("home.placeholder.techStack"), i18n.t("home.placeholder.fixTests")],
+    shell: ["ls -la", "git status", "pwd"],
+  }
   const promptMaxWidth = createMemo(() => {
     const configured = tuiConfig.prompt?.max_width
     if (configured === "auto") return Math.max(75, Math.floor(dimensions().width * 0.7))

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -5,6 +5,7 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/use-connected"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useTuiI18n } from "../../i18n"
 
 export function Footer() {
   const { theme } = useTheme()
@@ -19,6 +20,7 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
+  const i18n = useTuiI18n()
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -56,14 +58,15 @@ export function Footer() {
         <Switch>
           <Match when={store.welcome}>
             <text fg={theme.text}>
-              Get started <span style={{ fg: theme.textMuted }}>/connect</span>
+              {i18n.t("footer.getStarted")} <span style={{ fg: theme.textMuted }}>/connect</span>
             </text>
           </Match>
           <Match when={connected()}>
             <Show when={permissions().length > 0}>
               <text fg={theme.warning}>
-                <span style={{ fg: theme.warning }}>△</span> {permissions().length} Permission
-                {permissions().length > 1 ? "s" : ""}
+                <span style={{ fg: theme.warning }}>△</span> {permissions().length} {i18n.t(
+                  permissions().length > 1 ? "footer.permissions" : "footer.permission",
+                )}
               </text>
             </Show>
             <text fg={theme.text}>

--- a/packages/tui/src/ui/dialog-confirm.tsx
+++ b/packages/tui/src/ui/dialog-confirm.tsx
@@ -5,6 +5,7 @@ import { createStore } from "solid-js/store"
 import { For } from "solid-js"
 import { Locale } from "../util/locale"
 import { useBindings } from "../keymap"
+import { useTuiI18n } from "../i18n"
 
 export type DialogConfirmProps = {
   title: string
@@ -19,6 +20,7 @@ export type DialogConfirmResult = boolean | undefined
 export function DialogConfirm(props: DialogConfirmProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const i18n = useTuiI18n()
   const [store, setStore] = createStore({
     active: "confirm" as "confirm" | "cancel",
   })
@@ -80,7 +82,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
               }}
             >
               <text fg={key === store.active ? theme.selectedListItemText : theme.textMuted}>
-                {Locale.titlecase(key === "cancel" ? (props.label ?? key) : key)}
+                {key === "cancel" && props.label ? Locale.titlecase(props.label) : i18n.t(`dialog.${key}`)}
               </text>
             </box>
           )}

--- a/packages/tui/test/i18n.test.ts
+++ b/packages/tui/test/i18n.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { resolveLocale, translate } from "../src/i18n"
+
+describe("TUI locale", () => {
+  test("uses an explicit supported locale", () => {
+    expect(resolveLocale("zh-CN", { LANG: "en_US.UTF-8" })).toBe("zh-CN")
+  })
+
+  test("detects Chinese system locales", () => {
+    expect(resolveLocale(undefined, { LANG: "zh_CN.UTF-8" })).toBe("zh-CN")
+    expect(resolveLocale(undefined, { LC_MESSAGES: "zh", LANG: "en_US.UTF-8" })).toBe("zh-CN")
+    expect(resolveLocale(undefined, { LC_ALL: "en_US.UTF-8", LC_MESSAGES: "zh_CN.UTF-8" })).toBe("en")
+  })
+
+  test("falls back to English for unsupported values", () => {
+    expect(resolveLocale("fr", { LANG: "en_US.UTF-8" })).toBe("en")
+    expect(translate("zh-CN", "palette.commands")).toBe("命令")
+  })
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -273,6 +273,7 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
     "enabled": true
   },
   "diff_style": "auto",
+  "locale": "zh-CN",
   "mouse": true,
   "attention": {
     "enabled": true,
@@ -284,6 +285,8 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
 ```
 
 Use `OPENCODE_TUI_CONFIG` to point to a custom TUI config file.
+
+Set `locale` to `"en"` or `"zh-CN"` to choose the TUI display language. When omitted, OpenCode uses Chinese for a Chinese system locale and English otherwise.
 
 Set `attention.enabled` to turn on TUI desktop notifications and sounds. See [TUI attention](/docs/tui#attention).
 


### PR DESCRIPTION
## Summary
- add `locale` support to `tui.json` for English and Simplified Chinese
- resolve unset locales from `LC_ALL`, `LC_MESSAGES`, and `LANG`
- provide Chinese translations for TUI startup, home, navigation, confirmation, and command-palette surfaces
- document the setting and add locale/config regression coverage

Fixes #40270

## Testing
- `bun test` (from `packages/tui`)
- `bun typecheck` (from `packages/tui`)
- `bun test test/config/tui.test.ts` (from `packages/opencode`)
- `bun typecheck` (from `packages/opencode`)