### PR TITLE
fix(console): route Go links to Console

### DIFF
--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -1,7 +1,6 @@
 import "./index.css"
-import { createAsync, query } from "@solidjs/router"
 import { Title, Meta } from "@solidjs/meta"
-import { For, createMemo, createSignal, onCleanup, onMount } from "solid-js"
+import { For, createSignal, onCleanup, onMount } from "solid-js"
 //import { HttpHeader } from "@solidjs/start"
 import goLogoLight from "../../asset/go-ornate-light.svg"
 import goLogoDark from "../../asset/go-ornate-dark.svg"
@@ -11,16 +10,10 @@ import { Legal } from "~/component/legal"
 import { Footer } from "~/component/footer"
 import { Header } from "~/component/header"
 import { config } from "~/config"
-import { getLastSeenWorkspaceID } from "../workspace/common"
 import { IconMiniMax, IconMiMo, IconZai, IconAlibaba, IconDeepSeek } from "~/component/icon"
 import { useI18n } from "~/context/i18n"
 import { useLanguage } from "~/context/language"
 import { LocaleLinks } from "~/component/locale-links"
-
-const checkLoggedIn = query(async () => {
-  "use server"
-  return await getLastSeenWorkspaceID().catch(() => undefined)
-}, "checkLoggedIn.get")
 
 const models = [
   "Grok 4.5",
@@ -188,8 +181,7 @@ function LimitsGraph(props: { href: string }) {
 }
 
 export default function Home() {
-  const workspaceID = createAsync(() => checkLoggedIn())
-  const subscribeUrl = createMemo(() => (workspaceID() ? `/workspace/${workspaceID()}/go` : "/auth"))
+  const subscribeUrl = "/console/go"
   const i18n = useI18n()
   const language = useLanguage()
   return (
@@ -207,8 +199,6 @@ export default function Home() {
       <Meta name="twitter:title" content={i18n.t("go.title")} />
       <Meta name="twitter:description" content={i18n.t("go.meta.description")} />
       <Meta name="twitter:image" content="/social-share-black.png" />
-      <Meta name="opencode:auth" content={workspaceID() ? "true" : "false"} />
-
       <div data-component="container">
         <Header go hideGetStarted />
 
@@ -309,7 +299,7 @@ export default function Home() {
                 </div>
                 */}
               </div>
-              <a href={subscribeUrl()}>
+              <a href={subscribeUrl}>
                 <span>
                   <For
                     each={i18n
@@ -429,7 +419,7 @@ export default function Home() {
                   {i18n.t("go.faq.a4.p1.beforePricing")}{" "}
                   <a href={language.route("/docs/go/#pricing")}>{i18n.t("go.faq.a4.p1.pricingLink")}</a>{" "}
                   {i18n.t("go.faq.a4.p1.afterPricing")} {i18n.t("go.faq.a4.p2.beforeAccount")}{" "}
-                  <a href={subscribeUrl()}>{i18n.t("go.faq.a4.p2.accountLink")}</a>. {i18n.t("go.faq.a4.p3")}
+                  <a href={subscribeUrl}>{i18n.t("go.faq.a4.p2.accountLink")}</a>. {i18n.t("go.faq.a4.p3")}
                 </Faq>
               </li>
               <li>


### PR DESCRIPTION
## Summary

- send the public Go subscribe CTA to `/console/go`
- send the Go FAQ account link to the same stable Console entry
- remove the obsolete legacy workspace/login lookup from the public page

## Dependency

Do not merge this PR until the new Console Go stack is merged, deployed with Go enabled, and smoke-verified through a real authorized account. During rollback, remove this CTA before disabling Console exposure.

Console dependencies: anomalyco/opencode-console#1336, #1338, #1339, #1371, and the launch-wiring follow-up.

## Verification

- `bun typecheck` in `packages/console/app`
- `bunx prettier --check src/routes/go/index.tsx`
- repository push hook workspace typecheck: 33 tasks passed
- `git diff --check`

No deployment, Console enablement, production payment, or merge is authorized.