### PR TITLE
fix(app): prevent scroll snap while reading history during streaming

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2091,9 +2091,11 @@ export default function Page() {
                   onUserScroll={markUserScroll}
                   onHistoryScroll={onHistoryScroll}
                   onAutoScrollInteraction={autoScroll.handleInteraction}
-                  shouldAnchorBottom={() =>
-                    !location.hash && !store.messageId && !ui.pendingMessage && !autoScroll.userScrolled()
-                  }
+                  shouldAnchorBottom={() => {
+                    if (location.hash || store.messageId || ui.pendingMessage) return false
+                    if (autoScroll.userScrolled()) return false
+                    return autoScroll.atBottom()
+                  }}
                   centered={centered()}
                   setContentRef={(el) => {
                     content = el

--- a/packages/ui/src/components/scroll-view.tsx
+++ b/packages/ui/src/components/scroll-view.tsx
@@ -306,27 +306,27 @@ export function ScrollView(props: ScrollViewProps) {
     switch (next) {
       case "page-down":
         e.preventDefault()
-        viewportRef.scrollBy({ top: scrollAmount, behavior: "smooth" })
+        viewportRef.scrollBy({ top: scrollAmount })
         break
       case "page-up":
         e.preventDefault()
-        viewportRef.scrollBy({ top: -scrollAmount, behavior: "smooth" })
+        viewportRef.scrollBy({ top: -scrollAmount })
         break
       case "home":
         e.preventDefault()
-        viewportRef.scrollTo({ top: 0, behavior: "smooth" })
+        viewportRef.scrollTo({ top: 0 })
         break
       case "end":
         e.preventDefault()
-        viewportRef.scrollTo({ top: viewportRef.scrollHeight, behavior: "smooth" })
+        viewportRef.scrollTo({ top: viewportRef.scrollHeight })
         break
       case "up":
         e.preventDefault()
-        viewportRef.scrollBy({ top: -lineAmount, behavior: "smooth" })
+        viewportRef.scrollBy({ top: -lineAmount })
         break
       case "down":
         e.preventDefault()
-        viewportRef.scrollBy({ top: lineAmount, behavior: "smooth" })
+        viewportRef.scrollBy({ top: lineAmount })
         break
     }
   }

--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -22,6 +22,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
     contentRef: undefined as HTMLElement | undefined,
     scrollRef: undefined as HTMLElement | undefined,
     userScrolled: false,
+    atBottom: true,
   })
 
   const active = () => options.working() || settling
@@ -102,11 +103,12 @@ export function createAutoScroll(options: AutoScrollOptions) {
     if (!el) return
     if (!canScroll(el)) {
       if (store.userScrolled) setStore("userScrolled", false)
+      if (!store.atBottom) setStore("atBottom", true)
       return
     }
     if (store.userScrolled) return
 
-    setStore("userScrolled", true)
+    setStore({ userScrolled: true, atBottom: false })
     options.onUserInteracted?.()
   }
 
@@ -128,11 +130,13 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     if (!canScroll(el)) {
       if (store.userScrolled) setStore("userScrolled", false)
+      if (!store.atBottom) setStore("atBottom", true)
       return
     }
 
     if (distanceFromBottom(el) < threshold()) {
       if (store.userScrolled) setStore("userScrolled", false)
+      if (!store.atBottom) setStore("atBottom", true)
       return
     }
 
@@ -175,10 +179,14 @@ export function createAutoScroll(options: AutoScrollOptions) {
       const el = store.scrollRef
       if (el && !canScroll(el)) {
         if (store.userScrolled) setStore("userScrolled", false)
+        if (!store.atBottom) setStore("atBottom", true)
         return
       }
       if (!active()) return
       if (store.userScrolled) return
+      // Only follow content that grows while the user is anchored at the
+      // bottom; never pull the viewport down over content the user is reading.
+      if (!store.atBottom) return
       // ResizeObserver fires after layout, before paint.
       // Keep the bottom locked in the same frame to avoid visible
       // "jump up then catch up" artifacts while streaming content.
@@ -228,10 +236,12 @@ export function createAutoScroll(options: AutoScrollOptions) {
     pause: stop,
     resume: () => {
       if (store.userScrolled) setStore("userScrolled", false)
+      if (!store.atBottom) setStore("atBottom", true)
       scrollToBottom(true)
     },
     scrollToBottom: () => scrollToBottom(false),
     forceScrollToBottom: () => scrollToBottom(true),
     userScrolled: () => store.userScrolled,
+    atBottom: () => store.atBottom,
   }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #40322

### Type of change

- [x] Bug fix

### What does this PR do?

The session view pins the scroll position to the bottom while a response is streaming. Two problems cause this:

1. The auto-follow pause state (`userScrolled` in `create-auto-scroll`) only updates from scroll events inside a 250ms gesture window. Events outside that window are ignored, so the flag never turns on for some scroll gestures (wheel over nested scrollables, keyboard scrolling). With the flag off, every streamed token calls `scrollToEnd()` and yanks the viewport back to the bottom.
2. Keyboard scrolling uses `behavior: "smooth"`. The smooth animation gets cancelled by the per-token `scrollToEnd` before the viewport moves more than ~10px, so the threshold check never observes the user leaving the bottom and the state machine stays stuck.

Changes:

- `create-auto-scroll`: track an `atBottom` flag from actual scroll positions (updated wherever `userScrolled` is updated) and require it before auto-following in the ResizeObserver path.
- `session.tsx`: `shouldAnchorBottom` additionally requires `autoScroll.atBottom()`, so the virtualizer's `scrollToEnd` only runs while the user is at the bottom.
- `scroll-view`: keyboard scrolling is now instant instead of smooth, so it cannot be cancelled mid-animation by content updates.

Result: scrolling up during streaming holds the viewport in place; scrolling back to the bottom resumes auto-follow.

### How did you verify your code works?

- typecheck passes for `packages/ui` and `packages/app`
- existing scroll-view tests pass
- rebuilt the desktop app locally and verified: scroll up during a streaming response holds position (mouse wheel and PageUp), scrolling back to the bottom resumes auto-follow
- cherry-pick applies cleanly onto v1.18.11

### Screenshots / recordings

Can be added on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
