### PR TITLE
feat(tui): localize TUI interface to Simplified Chinese

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -439,7 +439,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
 
     await clipboard
       .write?.(text)
-      .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
+      .then(() => toast.show({ message: "已复制到剪贴板", variant: "info" }))
       .catch(toast.error)
 
     renderer.clearSelection()
@@ -484,7 +484,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         if (!providerID || !modelID)
           return toast.show({
             variant: "warning",
-            message: `Invalid model format: ${args.model}`,
+            message: `无效的模型格式：${args.model}`,
             duration: 3000,
           })
         local.model.set({ providerID, modelID }, { recent: true })
@@ -560,8 +560,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     [
       {
         name: COMMAND_PALETTE_COMMAND,
-        title: "Show command palette",
-        category: "System",
+        title: "显示命令面板",
+        category: "系统",
         hidden: true,
         run: () => {
           dialog.replace(() => <CommandPaletteDialog />)
@@ -569,8 +569,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "session.list",
-        title: "Switch session",
-        category: "Session",
+        title: "切换会话",
+        category: "会话",
         suggested: sync.data.session.length > 0,
         slashName: "sessions",
         slashAliases: ["resume", "continue"],
@@ -580,9 +580,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "session.new",
-        title: "New session",
+        title: "新会话",
         suggested: route.data.type === "session",
-        category: "Session",
+        category: "会话",
         slashName: "new",
         slashAliases: ["clear"],
         run: () => {
@@ -594,23 +594,23 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "workspace.copy_path",
-        title: "Copy worktree path",
-        category: "Workspace",
+        title: "复制工作区路径",
+        category: "工作区",
         enabled: () => currentWorktreeWorkspace() !== undefined,
         run: async () => {
           const workspace = currentWorktreeWorkspace()
           if (!workspace?.directory) return
           await clipboard
             .write?.(workspace.directory)
-            .then(() => toast.show({ message: "Copied worktree path", variant: "info" }))
+            .then(() => toast.show({ message: "工作区路径已复制", variant: "info" }))
             .catch(toast.error)
           dialog.clear()
         },
       },
       {
         name: "workspace.list",
-        title: "Manage workspaces",
-        category: "Workspace",
+        title: "管理工作区",
+        category: "工作区",
         hidden: !Flag.OPENCODE_EXPERIMENTAL_WORKSPACES,
         slashName: "workspaces",
         run: () => {
@@ -619,8 +619,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       ...Array.from({ length: 9 }, (_, i) => ({
         name: `session.quick_switch.${i + 1}`,
-        title: `Switch to session in quick slot ${i + 1}`,
-        category: "Session",
+        title: `切换到快捷槽 ${i + 1} 中的会话`,
+        category: "会话",
         hidden: true,
         run: () => {
           local.session.quickSwitch(i + 1)
@@ -628,9 +628,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       })),
       {
         name: "model.list",
-        title: "Switch model",
+        title: "切换模型",
         suggested: true,
-        category: "Agent",
+        category: "代理",
         slashName: "models",
         // Bias /mo toward /models over /move without changing global fuzzy scoring.
         slashAliases: ["mo"],
@@ -640,8 +640,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "model.cycle_recent",
-        title: "Model cycle",
-        category: "Agent",
+        title: "模型循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.model.cycle(1)
@@ -649,8 +649,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "model.cycle_recent_reverse",
-        title: "Model cycle reverse",
-        category: "Agent",
+        title: "反向模型循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.model.cycle(-1)
@@ -658,8 +658,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "model.cycle_favorite",
-        title: "Favorite cycle",
-        category: "Agent",
+        title: "收藏循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.model.cycleFavorite(1)
@@ -667,8 +667,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "model.cycle_favorite_reverse",
-        title: "Favorite cycle reverse",
-        category: "Agent",
+        title: "反向收藏循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.model.cycleFavorite(-1)
@@ -676,8 +676,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "agent.list",
-        title: "Switch agent",
-        category: "Agent",
+        title: "切换代理",
+        category: "代理",
         slashName: "agents",
         run: () => {
           dialog.replace(() => <DialogAgent />)
@@ -685,8 +685,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "mcp.list",
-        title: "Toggle MCPs",
-        category: "Agent",
+        title: "切换 MCP 服务器",
+        category: "代理",
         slashName: "mcps",
         run: () => {
           dialog.replace(() => <DialogMcp />)
@@ -694,8 +694,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "agent.cycle",
-        title: "Agent cycle",
-        category: "Agent",
+        title: "代理循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.agent.move(1)
@@ -703,23 +703,23 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "variant.cycle",
-        title: "Variant cycle",
-        category: "Agent",
+        title: "变体循环",
+        category: "代理",
         run: () => {
           local.model.variant.cycle()
         },
       },
       {
         name: "variant.list",
-        title: "Switch model variant",
-        category: "Agent",
+        title: "切换模型变体",
+        category: "代理",
         hidden: local.model.variant.list().length === 0,
         slashName: "variants",
         run: () => {
           if (local.model.variant.list().length === 0) {
             return toast.show({
-              title: "No variants available",
-              message: "The current model does not support any variants.",
+              title: "没有可用的变体",
+              message: "当前模型不支持任何变体。",
               variant: "info",
             })
           }
@@ -728,8 +728,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "agent.cycle.reverse",
-        title: "Agent cycle reverse",
-        category: "Agent",
+        title: "反向代理循环",
+        category: "代理",
         hidden: true,
         run: () => {
           local.agent.move(-1)
@@ -737,105 +737,105 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "provider.connect",
-        title: "Connect provider",
+        title: "连接提供商",
         suggested: !connected(),
         slashName: "connect",
         run: () => {
           dialog.replace(() => <DialogProviderList />)
         },
-        category: "Provider",
+        category: "提供商",
       },
       ...(sync.data.console_state.switchableOrgCount > 1
         ? [
             {
               name: "console.org.switch",
-              title: "Switch org",
+              title: "切换组织",
               suggested: Boolean(sync.data.console_state.activeOrgName),
               slashName: "org",
               slashAliases: ["orgs", "switch-org"],
               run: () => {
                 dialog.replace(() => <DialogConsoleOrg />)
               },
-              category: "Provider",
+              category: "提供商",
             },
           ]
         : []),
       {
         name: "opencode.status",
-        title: "View status",
+        title: "查看状态",
         slashName: "status",
         run: () => {
           dialog.replace(() => <DialogStatus />)
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "opencode.debug",
-        title: "View debug info",
+        title: "查看调试信息",
         slashName: "debug",
         run: () => {
           dialog.replace(() => <DialogDebug />)
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "theme.switch",
-        title: "Switch theme",
+        title: "切换主题",
         slashName: "themes",
         run: () => {
           dialog.replace(() => <DialogThemeList />)
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "theme.switch_mode",
-        title: mode() === "dark" ? "Switch to light mode" : "Switch to dark mode",
+        title: mode() === "dark" ? "切换到浅色模式" : "切换到深色模式",
         run: () => {
           setMode(mode() === "dark" ? "light" : "dark")
           dialog.clear()
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "theme.mode.lock",
-        title: locked() ? "Unlock theme mode" : "Lock theme mode",
+        title: locked() ? "解锁主题模式" : "锁定主题模式",
         run: () => {
           if (locked()) unlock()
           else lock()
           dialog.clear()
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "help.show",
-        title: "Help",
+        title: "帮助",
         slashName: "help",
         run: () => {
           dialog.replace(() => <DialogHelp />)
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "docs.open",
-        title: "Open docs",
+        title: "打开文档",
         run: () => {
           open("https://opencode.ai/docs").catch(() => {})
           dialog.clear()
         },
-        category: "System",
+        category: "系统",
       },
       {
         name: "app.exit",
-        title: "Exit the app",
+        title: "退出应用",
         slashName: "exit",
         slashAliases: ["quit", "q"],
         run: () => exit(),
-        category: "System",
+        category: "系统",
       },
       {
         name: "app.debug",
-        title: "Toggle debug panel",
-        category: "System",
+        title: "切换调试面板",
+        category: "系统",
         run: () => {
           renderer.toggleDebugOverlay()
           dialog.clear()
@@ -843,8 +843,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.console",
-        title: "Toggle console",
-        category: "System",
+        title: "切换控制台",
+        category: "系统",
         run: () => {
           renderer.console.toggle()
           dialog.clear()
@@ -852,13 +852,13 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.heap_snapshot",
-        title: "Write heap snapshot",
-        category: "System",
+        title: "写入堆快照",
+        category: "系统",
         run: async () => {
           const files = await props.onSnapshot?.()
           toast.show({
             variant: "info",
-            message: `Heap snapshot written to ${files?.join(", ")}`,
+            message: `堆快照已写入 ${files?.join(", ")}`,
             duration: 5000,
           })
           dialog.clear()
@@ -866,8 +866,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "terminal.suspend",
-        title: "Suspend terminal",
-        category: "System",
+        title: "挂起终端",
+        category: "系统",
         hidden: true,
         enabled: process.platform !== "win32",
         run: () => {
@@ -878,8 +878,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "terminal.title.toggle",
-        title: terminalTitleEnabled() ? "Disable terminal title" : "Enable terminal title",
-        category: "System",
+        title: terminalTitleEnabled() ? "禁用终端标题" : "启用终端标题",
+        category: "系统",
         run: () => {
           setTerminalTitleEnabled((prev) => {
             const next = !prev
@@ -892,8 +892,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.toggle.animations",
-        title: kv.get("animations_enabled", true) ? "Disable animations" : "Enable animations",
-        category: "System",
+        title: kv.get("animations_enabled", true) ? "禁用动画" : "启用动画",
+        category: "系统",
         run: () => {
           kv.set("animations_enabled", !kv.get("animations_enabled", true))
           dialog.clear()
@@ -901,8 +901,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.toggle.file_context",
-        title: kv.get("file_context_enabled", true) ? "Disable file context" : "Enable file context",
-        category: "System",
+        title: kv.get("file_context_enabled", true) ? "禁用文件上下文" : "启用文件上下文",
+        category: "系统",
         run: () => {
           kv.set("file_context_enabled", !kv.get("file_context_enabled", true))
           dialog.clear()
@@ -910,8 +910,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.toggle.diffwrap",
-        title: kv.get("diff_wrap_mode", "word") === "word" ? "Disable diff wrapping" : "Enable diff wrapping",
-        category: "System",
+        title: kv.get("diff_wrap_mode", "word") === "word" ? "禁用差异换行" : "启用差异换行",
+        category: "系统",
         run: () => {
           const current = kv.get("diff_wrap_mode", "word")
           kv.set("diff_wrap_mode", current === "word" ? "none" : "word")
@@ -920,8 +920,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.toggle.paste_summary",
-        title: pasteSummaryEnabled() ? "Disable paste summary" : "Enable paste summary",
-        category: "System",
+        title: pasteSummaryEnabled() ? "禁用粘贴摘要" : "启用粘贴摘要",
+        category: "系统",
         run: () => {
           setPasteSummaryEnabled((prev) => {
             const next = !prev
@@ -934,9 +934,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       {
         name: "app.toggle.session_directory_filter",
         title: kv.get("session_directory_filter_enabled", true)
-          ? "Disable session directory filtering"
-          : "Enable session directory filtering",
-        category: "System",
+          ? "禁用会话目录过滤"
+          : "启用会话目录过滤",
+        category: "系统",
         run: async () => {
           kv.set("session_directory_filter_enabled", !kv.get("session_directory_filter_enabled", true))
           await sync.session.refresh()
@@ -946,8 +946,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       {
         name: "permission.mode",
         title:
-          local.permission.mode === "auto" ? "Disable auto-approve permissions" : "Enable auto-approve permissions",
-        category: "System",
+          local.permission.mode === "auto" ? "禁用自动批准权限" : "启用自动批准权限",
+        category: "系统",
         run: () => {
           local.permission.toggle()
           dialog.clear()
@@ -1010,7 +1010,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       route.navigate({ type: "home" })
       toast.show({
         variant: "info",
-        message: "The current session was deleted",
+        message: "当前会话已被删除",
       })
     }
   })
@@ -1037,8 +1037,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
 
     const choice = await DialogConfirm.show(
       dialog,
-      `Update Available`,
-      `A new release v${version} is available. Would you like to update now?`,
+      `有可用更新`,
+      `新版本 v${version} 已发布。要立即更新吗？`,
       "skip",
     )
 
@@ -1051,7 +1051,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
 
     toast.show({
       variant: "info",
-      message: `Updating to v${version}...`,
+      message: `正在更新到 v${version}...`,
       duration: 30000,
     })
 
@@ -1060,8 +1060,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     if (result.error || !result.data?.success) {
       toast.show({
         variant: "error",
-        title: "Update Failed",
-        message: "Update failed",
+        title: "更新失败",
+        message: "更新失败",
         duration: 10000,
       })
       return
@@ -1069,8 +1069,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
 
     await DialogAlert.show(
       dialog,
-      "Update Complete",
-      `Successfully updated to OpenCode v${result.data.version}. Please restart the application.`,
+      "更新完成",
+      `已成功更新到 OpenCode v${result.data.version}。请重新启动应用程序。`,
     )
 
     void exit()

--- a/packages/tui/src/component/command-palette.tsx
+++ b/packages/tui/src/component/command-palette.tsx
@@ -69,11 +69,11 @@ export function CommandPaletteDialog() {
         .map((option) => ({
           ...option,
           value: `suggested:${option.value}`,
-          category: "Suggested",
+          category: "推荐",
         })),
       ...options(),
     ]
   }
 
-  return <DialogSelect ref={(value) => (ref = value)} title="Commands" options={list()} />
+  return <DialogSelect ref={(value) => (ref = value)} title="命令" options={list()} />
 }

--- a/packages/tui/src/component/dialog-agent.tsx
+++ b/packages/tui/src/component/dialog-agent.tsx
@@ -12,14 +12,14 @@ export function DialogAgent() {
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "内置" : item.description,
       }
     }),
   )
 
   return (
     <DialogSelect
-      title="Select agent"
+      title="选择代理"
       current={local.agent.current()?.name}
       options={options()}
       onSelect={(option) => {

--- a/packages/tui/src/component/dialog-console-org.tsx
+++ b/packages/tui/src/component/dialog-console-org.tsx
@@ -51,7 +51,7 @@ export function DialogConsoleOrg() {
     if (listed === undefined) {
       return [
         {
-          title: "Loading orgs...",
+          title: "正在加载组织...",
           value: "loading",
           onSelect: () => {},
         },
@@ -61,7 +61,7 @@ export function DialogConsoleOrg() {
     if (listed.length === 0) {
       return [
         {
-          title: "No orgs found",
+          title: "未找到组织",
           value: "empty",
           onSelect: () => {},
         },
@@ -105,7 +105,7 @@ export function DialogConsoleOrg() {
 
           await sdk.client.instance.dispose()
           toast.show({
-            message: `Switched to ${item.orgName}`,
+            message: `已切换到 ${item.orgName}`,
             variant: "info",
           })
           dialog.clear()
@@ -115,7 +115,7 @@ export function DialogConsoleOrg() {
 
   return (
     <DialogSelect<string | OrgOption>
-      title="Switch org"
+      title="切换组织"
       options={options()}
       current={current()}
       renderFilter={!showError()}
@@ -124,7 +124,7 @@ export function DialogConsoleOrg() {
         showError() ? (
           <box paddingLeft={4} paddingRight={4}>
             <text fg={theme.error} attributes={TextAttributes.BOLD}>
-              Could not load orgs
+              无法加载组织
             </text>
             <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
           </box>

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -10,12 +10,12 @@ import { useSDK } from "../context/sdk"
 function Status(props: { enabled: boolean; loading: boolean }) {
   const { theme } = useTheme()
   if (props.loading) {
-    return <span style={{ fg: theme.textMuted }}>⋯ Loading</span>
+    return <span style={{ fg: theme.textMuted }}>⋯ 加载中</span>
   }
   if (props.enabled) {
-    return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ Enabled</span>
+    return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ 已启用</span>
   }
-  return <span style={{ fg: theme.textMuted }}>○ Disabled</span>
+  return <span style={{ fg: theme.textMuted }}>○ 已禁用</span>
 }
 
 export function DialogMcp() {
@@ -37,7 +37,7 @@ export function DialogMcp() {
       map(([name, status]) => ({
         value: name,
         title: name,
-        description: status.status === "failed" ? "failed" : status.status,
+        description: status.status === "failed" ? "失败" : status.status,
         footer: <Status enabled={local.mcp.isEnabled(name)} loading={loadingMcp === name} />,
         category: undefined,
       })),
@@ -47,7 +47,7 @@ export function DialogMcp() {
   const actions = createMemo(() => [
     {
       command: "dialog.mcp.toggle",
-      title: "toggle",
+      title: "切换",
       onTrigger: async (option: DialogSelectOption<string>) => {
         // Prevent toggling while an operation is already in progress
         if (loading() !== null) return
@@ -74,7 +74,7 @@ export function DialogMcp() {
   return (
     <DialogSelect
       ref={setRef}
-      title="MCPs"
+      title="MCP 服务器"
       options={options()}
       actions={actions()}
       onSelect={(_option) => {

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -41,7 +41,7 @@ export function DialogModel(props: { providerID?: string }) {
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: model.cost?.input === 0 && provider.id === "opencode" ? "免费" : undefined,
             onSelect: () => {
               onSelect(provider.id, model.id)
             },
@@ -50,12 +50,12 @@ export function DialogModel(props: { providerID?: string }) {
       })
     }
 
-    const favoriteOptions = toOptions(favorites, "Favorites")
+    const favoriteOptions = toOptions(favorites, "收藏")
     const recentOptions = toOptions(
       recents.filter(
         (item) => !favorites.some((fav) => fav.providerID === item.providerID && fav.modelID === item.modelID),
       ),
-      "Recent",
+      "最近使用",
     )
 
     const providerOptions = pipe(
@@ -75,11 +75,11 @@ export function DialogModel(props: { providerID?: string }) {
             title: info.name ?? model,
             releaseDate: info.release_date,
             description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
-              ? "(Favorite)"
+              ? "（收藏）"
               : undefined,
             category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: info.cost?.input === 0 && provider.id === "opencode" ? "免费" : undefined,
             onSelect() {
               onSelect(provider.id, model)
             },
@@ -110,7 +110,7 @@ export function DialogModel(props: { providerID?: string }) {
           providers(),
           map((option) => ({
             ...option,
-            category: "Popular providers",
+            category: "热门提供商",
           })),
           take(6),
         )
@@ -135,7 +135,7 @@ export function DialogModel(props: { providerID?: string }) {
 
   const title = createMemo(() => {
     const value = provider()
-    if (!value) return "Select model"
+    if (!value) return "选择模型"
     return value.name
   })
 
@@ -160,14 +160,14 @@ export function DialogModel(props: { providerID?: string }) {
       actions={[
         {
           command: "model.dialog.provider",
-          title: connected() ? "Connect provider" : "View all providers",
+          title: connected() ? "连接提供商" : "查看所有提供商",
           onTrigger() {
             dialog.replace(() => <DialogProvider />)
           },
         },
         {
           command: "model.dialog.favorite",
-          title: "Favorite",
+          title: "收藏",
           hidden: !connected(),
           onTrigger: (option) => {
             local.model.toggleFavorite(option.value as { providerID: string; modelID: string })
@@ -190,7 +190,7 @@ export function sortModelOptions<T extends { footer?: string; releaseDate: strin
   if (newestFirst) return sortBy(options, [(option) => option.releaseDate, "desc"], (option) => option.title)
   return sortBy(
     options,
-    (option) => option.footer !== "Free",
+    (option) => option.footer !== "免费",
     [(option) => option.releaseDate, "desc"],
     (option) => option.title,
   )

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -123,7 +123,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
       if (!a.strategy && !b.strategy) return a.directory.length - b.directory.length
       return 0
     })
-    if (roots.length === 0) return [{ title: "No project directories found", value: undefined }]
+    if (roots.length === 0) return [{ title: "未找到项目目录", value: undefined }]
 
     const subdirectories = sync.data.session
       .filter((session) => session.projectID === props.projectID && session.path && ![".", "/"].includes(session.path))
@@ -254,7 +254,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
         if (forced.error) {
           toast.show({
             variant: "error",
-            title: "Failed to delete project copy",
+            title: "删除项目副本失败",
             message: errorMessage(forced.error),
           })
           reopen()
@@ -268,7 +268,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
       }
       toast.show({
         variant: "error",
-        title: "Failed to delete project copy",
+        title: "删除项目副本失败",
         message: errorMessage(result.error),
       })
       return
@@ -286,11 +286,11 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
   return (
     <box minHeight={showError() ? 5 : fullHeight()}>
       <DialogSelect
-        title="Move session"
+        title="移动会话"
         titleView={
           <box flexDirection="row" gap={1}>
             <text fg={theme.text} attributes={TextAttributes.BOLD}>
-              Move session
+              移动会话
             </text>
             <Show when={working() || directories.loading || loadedProject.loading}>
               <Spinner />
@@ -303,7 +303,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
           showError() ? (
             <box paddingLeft={4} paddingRight={4}>
               <text fg={theme.error} attributes={TextAttributes.BOLD}>
-                Could not load project directories
+                无法加载项目目录
               </text>
               <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
             </box>
@@ -321,12 +321,12 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
             : [
                 {
                   command: "dialog.move_session.new",
-                  title: "new",
+                  title: "新建",
                   onTrigger: () => props.onSelect({ type: "new" }),
                 },
                 {
                   command: "dialog.move_session.delete",
-                  title: "delete",
+                  title: "删除",
                   disabled: (option) => {
                     const value = option?.value
                     if (!value || value.type !== "directory" || value.subdirectory) return true
@@ -336,7 +336,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
                 },
                 {
                   command: "dialog.move_session.refresh",
-                  title: "refresh",
+                  title: "刷新",
                   onTrigger: () => void refetch(),
                 },
               ]

--- a/packages/tui/src/component/dialog-provider.tsx
+++ b/packages/tui/src/component/dialog-provider.tsx
@@ -59,20 +59,20 @@ export function providerOptions(list: { id: string; name: string }[]): ProviderO
         value: provider.id,
         providerID: provider.id,
         description: {
-          opencode: "(Recommended)",
-          anthropic: "(API key)",
-          openai: "(ChatGPT Plus/Pro or API key)",
-          "opencode-go": "Low cost subscription for everyone",
+          opencode: "（推荐）",
+          anthropic: "（API 密钥）",
+          openai: "（ChatGPT Plus/Pro 或 API 密钥）",
+          "opencode-go": "适合所有人的低成本订阅",
         }[provider.id],
-        category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Providers",
+        category: provider.id in PROVIDER_PRIORITY ? "热门" : "提供商",
       })),
     ),
     {
       type: "custom",
-      title: "Other",
+      title: "其他",
       value: CUSTOM_PROVIDER_OPTION_VALUE,
-      description: "Custom provider",
-      category: "Providers",
+      description: "自定义提供商",
+      category: "提供商",
     },
   ]
 }
@@ -92,11 +92,11 @@ export function createDialogProviderOptions() {
   const onboarded = useConnected()
 
   async function promptCustomProviderID(): Promise<string | undefined> {
-    const value = await DialogPrompt.show(dialog, "Other", {
-      placeholder: "Provider id",
+    const value = await DialogPrompt.show(dialog, "其他", {
+      placeholder: "提供商 ID",
       description: () => (
         <text fg={theme.textMuted}>
-          This only stores a credential. Configure the provider in opencode.json to use it.
+          这里只保存凭据。请在 opencode.json 中配置该提供商以使用它。
         </text>
       ),
     })
@@ -108,7 +108,7 @@ export function createDialogProviderOptions() {
     toast.show({
       variant: "error",
       message:
-        "Provider ids must start with a lowercase letter or number and only use lowercase letters, numbers, hyphens, and underscores",
+        "提供商 ID 必须以小写字母或数字开头，且只能包含小写字母、数字、连字符和下划线",
     })
     return promptCustomProviderID()
   }
@@ -126,7 +126,7 @@ export function createDialogProviderOptions() {
             async onSelect() {
               const providerID = await promptCustomProviderID()
               if (!providerID) return
-              return dialog.replace(() => <ApiMethod providerID={providerID} title="API key" custom />)
+              return dialog.replace(() => <ApiMethod providerID={providerID} title="API 密钥" custom />)
             },
           }
         }
@@ -148,7 +148,7 @@ export function createDialogProviderOptions() {
             const methods = sync.data.provider_auth[providerID] ?? [
               {
                 type: "api",
-                label: "API key",
+                label: "API 密钥",
               },
             ]
             let index: number | null = 0
@@ -157,7 +157,7 @@ export function createDialogProviderOptions() {
                 dialog.replace(
                   () => (
                     <DialogSelect
-                      title="Select auth method"
+                      title="选择认证方式"
                       options={methods.map((x, index) => ({
                         title: x.label,
                         value: index,
@@ -227,7 +227,7 @@ export function createDialogProviderOptions() {
 
 export function DialogProvider() {
   const options = createDialogProviderOptions()
-  return <DialogSelect title="Connect a provider" options={options()} />
+  return <DialogSelect title="连接提供商" options={options()} />
 }
 
 interface AutoMethodProps {
@@ -248,14 +248,14 @@ function AutoMethod(props: AutoMethodProps) {
     bindings: [
       {
         key: "c",
-        desc: "Copy provider code",
-        group: "Dialog",
+        desc: "复制提供商代码",
+        group: "对话框",
         cmd: () => {
           const code =
             props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4,5}/)?.[0] ?? props.authorization.url
           clipboard
             .write?.(code)
-            .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
+            .then(() => toast.show({ message: "已复制到剪贴板", variant: "info" }))
             .catch(toast.error)
         },
       },
@@ -272,7 +272,7 @@ function AutoMethod(props: AutoMethodProps) {
         variant: "error",
         message:
           "name" in result.error && result.error.name === "ProviderAuthOauthCallbackFailed"
-            ? "OAuth authorization failed. Try /connect again."
+            ? "OAuth 授权失败。请再次运行 /connect。"
             : JSON.stringify(result.error),
       })
       dialog.clear()
@@ -297,9 +297,9 @@ function AutoMethod(props: AutoMethodProps) {
         <Link href={props.authorization.url} fg={theme.primary} />
         <text fg={theme.textMuted}>{props.authorization.instructions}</text>
       </box>
-      <text fg={theme.textMuted}>Waiting for authorization...</text>
+      <text fg={theme.textMuted}>等待授权...</text>
       <text fg={theme.text}>
-        c <span style={{ fg: theme.textMuted }}>copy</span>
+        c <span style={{ fg: theme.textMuted }}>复制</span>
       </text>
     </box>
   )
@@ -321,7 +321,7 @@ function CodeMethod(props: CodeMethodProps) {
   return (
     <DialogPrompt
       title={props.title}
-      placeholder="Authorization code"
+      placeholder="授权码"
       onConfirm={async (value) => {
         const { error } = await sdk.client.provider.oauth.callback({
           providerID: props.providerID,
@@ -341,7 +341,7 @@ function CodeMethod(props: CodeMethodProps) {
           <text fg={theme.textMuted}>{props.authorization.instructions}</text>
           <Link href={props.authorization.url} fg={theme.primary} />
           <Show when={error()}>
-            <text fg={theme.error}>Invalid code</text>
+            <text fg={theme.error}>无效的代码</text>
           </Show>
         </box>
       )}
@@ -365,28 +365,26 @@ function ApiMethod(props: ApiMethodProps) {
   return (
     <DialogPrompt
       title={props.title}
-      placeholder="API key"
+      placeholder="API 密钥"
       description={() =>
         ({
           opencode: (
             <box gap={1}>
               <text fg={theme.textMuted}>
-                OpenCode Zen gives you access to all the best coding models at the cheapest prices with a single API
-                key.
+                OpenCode Zen 只需一个 API 密钥，就能以最便宜的价格访问所有最好的编程模型。
               </text>
               <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> to get a key
+                访问 <span style={{ fg: theme.primary }}>https://opencode.ai/zen</span> 获取密钥
               </text>
             </box>
           ),
           "opencode-go": (
             <box gap={1}>
               <text fg={theme.textMuted}>
-                OpenCode Go is a $10 per month subscription that provides reliable access to popular open coding models
-                with generous usage limits.
+                OpenCode Go 是每月 10 美元的订阅，可提供对流行的开源编程模型的可靠访问和充足的用量限制。
               </text>
               <text fg={theme.text}>
-                Go to <span style={{ fg: theme.primary }}>https://opencode.ai/go</span> and enable OpenCode Go
+                访问 <span style={{ fg: theme.primary }}>https://opencode.ai/go</span> 并启用 OpenCode Go
               </text>
             </box>
           ),
@@ -407,7 +405,7 @@ function ApiMethod(props: ApiMethodProps) {
         if (props.custom && !sync.data.provider_next.all.some((provider) => provider.id === props.providerID)) {
           toast.show({
             variant: "info",
-            message: `Saved credential for ${props.providerID}. Configure it in opencode.json to use it.`,
+            message: `已为 ${props.providerID} 保存凭据。请在 opencode.json 中配置它以使用它。`,
           })
           dialog.clear()
           return

--- a/packages/tui/src/component/dialog-retry-action.tsx
+++ b/packages/tui/src/component/dialog-retry-action.tsx
@@ -48,26 +48,26 @@ export function DialogRetryAction(props: DialogRetryActionProps) {
     bindings: [
       {
         key: "left",
-        desc: "Previous retry option",
-        group: "Dialog",
+        desc: "上一个重试选项",
+        group: "对话框",
         cmd: () => setSelected((value) => (value === "action" ? "dismiss" : "action")),
       },
       {
         key: "right",
-        desc: "Next retry option",
-        group: "Dialog",
+        desc: "下一个重试选项",
+        group: "对话框",
         cmd: () => setSelected((value) => (value === "action" ? "dismiss" : "action")),
       },
       {
         key: "tab",
-        desc: "Next retry option",
-        group: "Dialog",
+        desc: "下一个重试选项",
+        group: "对话框",
         cmd: () => setSelected((value) => (value === "action" ? "dismiss" : "action")),
       },
       {
         key: "return",
-        desc: "Confirm retry option",
-        group: "Dialog",
+        desc: "确认重试选项",
+        group: "对话框",
         cmd: () => {
           if (selected() === "action") runAction(props, dialog)
           else dismiss(props, dialog)
@@ -123,7 +123,7 @@ export function DialogRetryAction(props: DialogRetryActionProps) {
               bg={selected() === "dismiss" ? undefined : textBg()}
               attributes={selected() === "dismiss" ? TextAttributes.BOLD : undefined}
             >
-              don't show again
+              不再显示
             </text>
           </box>
           <box

--- a/packages/tui/src/component/dialog-session-delete-failed.tsx
+++ b/packages/tui/src/component/dialog-session-delete-failed.tsx
@@ -21,14 +21,14 @@ export function DialogSessionDeleteFailed(props: {
   const options = [
     {
       id: "delete" as const,
-      title: "Delete workspace",
-      description: "Delete the workspace and all sessions attached to it.",
+      title: "删除工作区",
+      description: "删除该工作区及其附加的所有会话。",
       run: props.onDelete,
     },
     {
       id: "restore" as const,
-      title: "Restore to new workspace",
-      description: "Try to restore this session into a new workspace.",
+      title: "恢复到新工作区",
+      description: "尝试将此会话恢复到新的工作区。",
       run: props.onRestore,
     },
   ]
@@ -42,11 +42,11 @@ export function DialogSessionDeleteFailed(props: {
 
   useBindings(() => ({
     bindings: [
-      { key: "return", desc: "Confirm recovery option", group: "Dialog", cmd: () => void confirm() },
-      { key: "left", desc: "Delete broken session", group: "Dialog", cmd: () => setStore("active", "delete") },
-      { key: "up", desc: "Delete broken session", group: "Dialog", cmd: () => setStore("active", "delete") },
-      { key: "right", desc: "Restore broken session", group: "Dialog", cmd: () => setStore("active", "restore") },
-      { key: "down", desc: "Restore broken session", group: "Dialog", cmd: () => setStore("active", "restore") },
+      { key: "return", desc: "确认恢复选项", group: "对话框", cmd: () => void confirm() },
+      { key: "left", desc: "删除损坏的会话", group: "对话框", cmd: () => setStore("active", "delete") },
+      { key: "up", desc: "删除损坏的会话", group: "对话框", cmd: () => setStore("active", "delete") },
+      { key: "right", desc: "恢复损坏的会话", group: "对话框", cmd: () => setStore("active", "restore") },
+      { key: "down", desc: "恢复损坏的会话", group: "对话框", cmd: () => setStore("active", "restore") },
     ],
   }))
 
@@ -54,17 +54,17 @@ export function DialogSessionDeleteFailed(props: {
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Failed to Delete Session
+          删除会话失败
         </text>
         <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
           esc
         </text>
       </box>
       <text fg={theme.textMuted} wrapMode="word">
-        {`The session "${props.session}" could not be deleted because the workspace "${props.workspace}" is not available.`}
+        {`会话 "${props.session}" 无法删除，因为工作区 "${props.workspace}" 不可用。`}
       </text>
       <text fg={theme.textMuted} wrapMode="word">
-        Choose how you want to recover this broken workspace session.
+        选择如何恢复这个损坏的工作区会话。
       </text>
       <box flexDirection="column" paddingBottom={1} gap={1}>
         <For each={options}>

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -110,7 +110,7 @@ export function DialogSessionList() {
           result = await sdk.client.experimental.workspace.create({ type: selection.workspaceType, branch: null })
         } catch (err) {
           toast.show({
-            title: "Failed to create workspace",
+            title: "创建工作区失败",
             message: errorMessage(err),
             variant: "error",
           })
@@ -119,8 +119,8 @@ export function DialogSessionList() {
         const workspace = result?.data
         if (!workspace) {
           toast.show({
-            title: "Failed to create workspace",
-            message: errorMessage(result?.error ?? "no response"),
+            title: "创建工作区失败",
+            message: errorMessage(result?.error ?? "无响应"),
             variant: "error",
           })
           return
@@ -154,7 +154,7 @@ export function DialogSessionList() {
           if (result.error) {
             toast.show({
               variant: "error",
-              title: "Failed to delete workspace",
+              title: "删除工作区失败",
               message: errorMessage(result.error),
             })
             return false
@@ -243,7 +243,7 @@ export function DialogSessionList() {
           ? () => <text fg={theme.accent}>{slot}</text>
           : undefined
       return {
-        title: isDeleting ? `Press ${deleteHint()} again to confirm` : x.title,
+        title: isDeleting ? `再次按 ${deleteHint()} 以确认` : x.title,
         bg: isDeleting ? theme.error : undefined,
         value: x.id,
         category,
@@ -258,11 +258,11 @@ export function DialogSessionList() {
         const x = sessionMap.get(id)
         if (!x) return undefined
         const label = new Date(x.time.updated).toDateString()
-        return buildOption(id, label === today ? "Today" : label)
+        return buildOption(id, label === today ? "今天" : label)
       })
       .filter((x) => x !== undefined)
 
-    return [...pinned.map((id) => buildOption(id, "Pinned")).filter((x) => x !== undefined), ...remaining]
+    return [...pinned.map((id) => buildOption(id, "已置顶")).filter((x) => x !== undefined), ...remaining]
   })
 
   onMount(() => {
@@ -271,7 +271,7 @@ export function DialogSessionList() {
 
   return (
     <DialogSelect
-      title="Sessions"
+      title="会话"
       options={options()}
       skipFilter={true}
       preserveSelection={true}
@@ -290,14 +290,14 @@ export function DialogSessionList() {
       actions={[
         {
           command: "session.pin.toggle",
-          title: "pin/unpin",
+          title: "置顶/取消置顶",
           onTrigger: (option: { value: string }) => {
             local.session.togglePin(option.value)
           },
         },
         {
           command: "session.delete",
-          title: "delete",
+          title: "删除",
           onTrigger: async (option) => {
             if (toDelete() === option.value) {
               const session = sessions().find((item) => item.id === option.value)
@@ -313,7 +313,7 @@ export function DialogSessionList() {
                   } else {
                     toast.show({
                       variant: "error",
-                      title: "Failed to delete session",
+                      title: "删除会话失败",
                       message: errorMessage(result.error),
                     })
                   }
@@ -326,7 +326,7 @@ export function DialogSessionList() {
                 } else {
                   toast.show({
                     variant: "error",
-                    title: "Failed to delete session",
+                    title: "删除会话失败",
                     message: errorMessage(err),
                   })
                 }
@@ -346,7 +346,7 @@ export function DialogSessionList() {
         },
         {
           command: "session.rename",
-          title: "rename",
+          title: "重命名",
           onTrigger: async (option) => {
             dialog.replace(() => <DialogSessionRename session={option.value} />)
           },

--- a/packages/tui/src/component/dialog-session-rename.tsx
+++ b/packages/tui/src/component/dialog-session-rename.tsx
@@ -16,7 +16,7 @@ export function DialogSessionRename(props: DialogSessionRenameProps) {
 
   return (
     <DialogPrompt
-      title="Rename Session"
+      title="重命名会话"
       value={session()?.title}
       onConfirm={(value) => {
         void sdk.client.session.update({

--- a/packages/tui/src/component/dialog-skill.tsx
+++ b/packages/tui/src/component/dialog-skill.tsx
@@ -40,7 +40,7 @@ export function DialogSkill(props: DialogSkillProps) {
       title: skill.name.padEnd(maxWidth),
       description: skill.description?.replace(/\s+/g, " ").trim(),
       value: skill.name,
-      category: "Skills",
+      category: "技能",
       onSelect: () => {
         props.onSelect(skill.name)
         dialog.clear()
@@ -50,8 +50,8 @@ export function DialogSkill(props: DialogSkillProps) {
 
   return (
     <DialogSelect
-      title="Skills"
-      placeholder="Search skills..."
+      title="技能"
+      placeholder="搜索技能..."
       options={options()}
       renderFilter={!showError()}
       locked={showError()}
@@ -59,7 +59,7 @@ export function DialogSkill(props: DialogSkillProps) {
         showError() ? (
           <box paddingLeft={4} paddingRight={4}>
             <text fg={theme.error} attributes={TextAttributes.BOLD}>
-              Could not load skills
+              无法加载技能
             </text>
             <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
           </box>

--- a/packages/tui/src/component/dialog-stash.tsx
+++ b/packages/tui/src/component/dialog-stash.tsx
@@ -14,10 +14,10 @@ function getRelativeTime(timestamp: number): string {
   const hours = Math.floor(minutes / 60)
   const days = Math.floor(hours / 24)
 
-  if (seconds < 60) return "just now"
-  if (minutes < 60) return `${minutes}m ago`
-  if (hours < 24) return `${hours}h ago`
-  if (days < 7) return `${days}d ago`
+  if (seconds < 60) return "刚刚"
+  if (minutes < 60) return `${minutes} 分钟前`
+  if (hours < 24) return `${hours} 小时前`
+  if (days < 7) return `${days} 天前`
   return Locale.datetime(timestamp)
 }
 
@@ -42,11 +42,11 @@ export function DialogStash(props: { onSelect: (entry: StashEntry) => void }) {
         const isDeleting = toDelete() === index
         const lineCount = (entry.input.match(/\n/g)?.length ?? 0) + 1
         return {
-          title: isDeleting ? `Press ${deleteHint()} again to confirm` : getStashPreview(entry.input),
+          title: isDeleting ? `再次按 ${deleteHint()} 以确认` : getStashPreview(entry.input),
           bg: isDeleting ? theme.error : undefined,
           value: index,
           description: getRelativeTime(entry.timestamp),
-          footer: lineCount > 1 ? `~${lineCount} lines` : undefined,
+          footer: lineCount > 1 ? `~${lineCount} 行` : undefined,
         }
       })
       .toReversed()
@@ -54,7 +54,7 @@ export function DialogStash(props: { onSelect: (entry: StashEntry) => void }) {
 
   return (
     <DialogSelect
-      title="Stash"
+      title="暂存"
       options={options()}
       onMove={() => {
         setToDelete(undefined)
@@ -71,7 +71,7 @@ export function DialogStash(props: { onSelect: (entry: StashEntry) => void }) {
       actions={[
         {
           command: "stash.delete",
-          title: "delete",
+          title: "删除",
           onTrigger: (option) => {
             if (toDelete() === option.value) {
               stash.remove(option.value)

--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -44,15 +44,15 @@ export function DialogStatus() {
     <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text fg={theme.text} attributes={TextAttributes.BOLD}>
-          Status
+          状态
         </text>
         <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>无 MCP 服务器</text>}>
         <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
+          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} 个 MCP 服务器</text>
           <For each={Object.entries(sync.data.mcp)}>
             {([key, item]) => (
               <box flexDirection="row" gap={1}>
@@ -76,11 +76,11 @@ export function DialogStatus() {
                   <b>{key}</b>{" "}
                   <span style={{ fg: theme.textMuted }}>
                     <Switch fallback={item.status}>
-                      <Match when={item.status === "connected"}>Connected</Match>
+                      <Match when={item.status === "connected"}>已连接</Match>
                       <Match when={item.status === "failed" && item}>{(val) => val().error}</Match>
-                      <Match when={item.status === "disabled"}>Disabled in configuration</Match>
+                      <Match when={item.status === "disabled"}>配置中已禁用</Match>
                       <Match when={(item.status as string) === "needs_auth"}>
-                        Needs authentication (run: opencode mcp auth {key})
+                        需要认证（运行：opencode mcp auth {key}）
                       </Match>
                       <Match when={(item.status as string) === "needs_client_registration" && item}>
                         {(val) => (val() as { error: string }).error}
@@ -95,7 +95,7 @@ export function DialogStatus() {
       </Show>
       {sync.data.lsp.length > 0 && (
         <box>
-          <text fg={theme.text}>{sync.data.lsp.length} LSP Servers</text>
+          <text fg={theme.text}>{sync.data.lsp.length} 个 LSP 服务器</text>
           <For each={sync.data.lsp}>
             {(item) => (
               <box flexDirection="row" gap={1}>
@@ -118,9 +118,9 @@ export function DialogStatus() {
           </For>
         </box>
       )}
-      <Show when={enabledFormatters().length > 0} fallback={<text fg={theme.text}>No Formatters</text>}>
+      <Show when={enabledFormatters().length > 0} fallback={<text fg={theme.text}>无格式化器</text>}>
         <box>
-          <text fg={theme.text}>{enabledFormatters().length} Formatters</text>
+          <text fg={theme.text}>{enabledFormatters().length} 个格式化器</text>
           <For each={enabledFormatters()}>
             {(item) => (
               <box flexDirection="row" gap={1}>
@@ -140,9 +140,9 @@ export function DialogStatus() {
           </For>
         </box>
       </Show>
-      <Show when={plugins().length > 0} fallback={<text fg={theme.text}>No Plugins</text>}>
+      <Show when={plugins().length > 0} fallback={<text fg={theme.text}>无插件</text>}>
         <box>
-          <text fg={theme.text}>{plugins().length} Plugins</text>
+          <text fg={theme.text}>{plugins().length} 个插件</text>
           <For each={plugins()}>
             {(item) => (
               <box flexDirection="row" gap={1}>

--- a/packages/tui/src/component/dialog-tag.tsx
+++ b/packages/tui/src/component/dialog-tag.tsx
@@ -36,7 +36,7 @@ export function DialogTag(props: { onSelect?: (value: string) => void }) {
 
   return (
     <DialogSelect
-      title="Autocomplete"
+      title="自动补全"
       options={options()}
       onSelect={(option) => {
         props.onSelect?.(option.value)

--- a/packages/tui/src/component/dialog-theme-list.tsx
+++ b/packages/tui/src/component/dialog-theme-list.tsx
@@ -22,7 +22,7 @@ export function DialogThemeList() {
 
   return (
     <DialogSelect
-      title="Themes"
+      title="主题"
       options={options}
       current={initial}
       onMove={(opt) => {

--- a/packages/tui/src/component/dialog-variant.tsx
+++ b/packages/tui/src/component/dialog-variant.tsx
@@ -11,7 +11,7 @@ export function DialogVariant() {
     return [
       {
         value: "default",
-        title: "Default",
+        title: "默认",
         onSelect: () => {
           dialog.clear()
           local.model.variant.set(undefined)
@@ -31,7 +31,7 @@ export function DialogVariant() {
   return (
     <DialogSelect<string>
       options={options()}
-      title={"Select variant"}
+      title={"选择变体"}
       current={local.model.variant.selected()}
       flat={true}
     />

--- a/packages/tui/src/component/dialog-workspace-create.tsx
+++ b/packages/tui/src/component/dialog-workspace-create.tsx
@@ -61,7 +61,7 @@ async function loadWorkspaceAdapters(input: {
     return response.data
   } catch (err) {
     input.toast.show({
-      title: "Failed to load workspace adapters",
+      title: "加载工作区适配器失败",
       message: errorMessage(err),
       variant: "error",
     })
@@ -106,7 +106,7 @@ export async function warpWorkspaceSession(input: {
     })
   } catch (err) {
     input.toast.show({
-      title: "Failed to warp session",
+      title: "迁移会话失败",
       message: errorMessage(err),
       variant: "error",
     })
@@ -116,15 +116,15 @@ export async function warpWorkspaceSession(input: {
     if (result?.error && "name" in result.error && result.error.name === "VcsApplyError") {
       await DialogAlert.show(
         input.dialog,
-        "Unable to Warp Session",
-        "Unable to apply file changes to this workspace. It has existing changes that conflict or is based off a different branch. Session has not been warped.",
+        "无法迁移会话",
+        "无法将文件更改应用到该工作区。它存在冲突的现有更改，或基于不同的分支。会话尚未迁移。",
       )
       return false
     }
 
     input.toast.show({
-      title: "Failed to warp session",
-      message: errorMessage(result?.error ?? "no response"),
+      title: "迁移会话失败",
+      message: errorMessage(result?.error ?? "无响应"),
       variant: "error",
     })
     return false
@@ -211,13 +211,13 @@ export function DialogWorkspaceSelect(props: {
         title: adapter.name,
         value: { type: "new" as const, workspaceType: adapter.type, workspaceName: adapter.name },
         description: adapter.description,
-        category: "New workspace",
+        category: "新建工作区",
       })),
       {
-        title: "None",
+        title: "无",
         value: { type: "none" as const },
-        description: "Use the local project",
-        category: "Choose workspace",
+        description: "使用本地项目",
+        category: "选择工作区",
       },
       ...recent.map((workspace: Workspace) => ({
         title: workspace.name,
@@ -228,15 +228,15 @@ export function DialogWorkspaceSelect(props: {
           workspaceType: workspace.type,
           workspaceName: workspace.name,
         },
-        category: "Choose workspace",
+        category: "选择工作区",
       })),
       ...(hasMore
         ? [
             {
-              title: "View all workspaces",
+              title: "查看所有工作区",
               value: { type: "existing-list" as const },
-              description: "Choose from all workspaces",
-              category: "Choose workspace",
+              description: "从所有工作区中选择",
+              category: "选择工作区",
             },
           ]
         : []),
@@ -246,7 +246,7 @@ export function DialogWorkspaceSelect(props: {
   if (!adapters()) return null
   return (
     <DialogSelect<WorkspaceSelectValue>
-      title="Warp"
+      title="迁移"
       skipFilter={true}
       renderFilter={false}
       options={options()}
@@ -293,7 +293,7 @@ function DialogExistingWorkspaceSelect(props: {
 
   return (
     <DialogSelect<ExistingWorkspaceSelectValue>
-      title="Existing Workspace"
+      title="已有工作区"
       options={options()}
       onSelect={(option) => {
         void props.onSelect({

--- a/packages/tui/src/component/dialog-workspace-list.tsx
+++ b/packages/tui/src/component/dialog-workspace-list.tsx
@@ -71,7 +71,7 @@ export function DialogWorkspaceList() {
       setRemoving(undefined)
       toast.show({
         variant: "error",
-        title: "Failed to delete workspace",
+        title: "删除工作区失败",
         message: errorMessage(result.error),
       })
       return
@@ -94,7 +94,7 @@ export function DialogWorkspaceList() {
 
   return (
     <DialogSelect
-      title="Workspaces"
+      title="工作区"
       options={options()}
       onMove={(option) => {
         setDeleting(undefined)
@@ -103,7 +103,7 @@ export function DialogWorkspaceList() {
       actions={[
         {
           command: "session.delete",
-          title: "delete",
+          title: "删除",
           onTrigger: (option) => void remove(option.value.workspace),
         },
       ]}

--- a/packages/tui/src/component/dialog-workspace-unavailable.tsx
+++ b/packages/tui/src/component/dialog-workspace-unavailable.tsx
@@ -25,9 +25,9 @@ export function DialogWorkspaceUnavailable(props: { onRestore?: () => boolean | 
 
   useBindings(() => ({
     bindings: [
-      { key: "return", desc: "Confirm workspace option", group: "Dialog", cmd: () => void confirm() },
-      { key: "left", desc: "Cancel workspace restore", group: "Dialog", cmd: () => setStore("active", "cancel") },
-      { key: "right", desc: "Restore workspace", group: "Dialog", cmd: () => setStore("active", "restore") },
+      { key: "return", desc: "确认工作区选项", group: "对话框", cmd: () => void confirm() },
+      { key: "left", desc: "取消工作区恢复", group: "对话框", cmd: () => setStore("active", "cancel") },
+      { key: "right", desc: "恢复工作区", group: "对话框", cmd: () => setStore("active", "restore") },
     ],
   }))
 
@@ -35,17 +35,17 @@ export function DialogWorkspaceUnavailable(props: { onRestore?: () => boolean | 
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Workspace Unavailable
+          工作区不可用
         </text>
         <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
           esc
         </text>
       </box>
       <text fg={theme.textMuted} wrapMode="word">
-        This session is attached to a workspace that is no longer available.
+        此会话附加的工作区已不可用。
       </text>
       <text fg={theme.textMuted} wrapMode="word">
-        Would you like to restore this session into a new workspace?
+        是否要将此会话恢复到新的工作区？
       </text>
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1} gap={1}>
         <For each={options}>
@@ -59,7 +59,9 @@ export function DialogWorkspaceUnavailable(props: { onRestore?: () => boolean | 
                 void confirm()
               }}
             >
-              <text fg={item === store.active ? theme.selectedListItemText : theme.textMuted}>{item}</text>
+              <text fg={item === store.active ? theme.selectedListItemText : theme.textMuted}>
+                {item === "cancel" ? "取消" : "恢复"}
+              </text>
             </box>
           )}
         </For>

--- a/packages/tui/src/component/error-component.tsx
+++ b/packages/tui/src/component/error-component.tsx
@@ -40,8 +40,8 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
         success: "#7fd88f",
       }
 
-  const message = props.error.message || "An unknown error occurred."
-  const stack = props.error.stack || "No stack trace available."
+  const message = props.error.message || "发生了未知错误。"
+  const stack = props.error.stack || "没有可用的堆栈信息。"
   const issueURL = buildIssueURL(message, stack)
 
   const copyReport = () => {
@@ -49,9 +49,9 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
   }
 
   const actions = [
-    { key: "c", label: () => (copied() ? "✓ Copied" : "Copy report"), copy: true, onUse: copyReport },
-    { key: "r", label: () => "Restart", onUse: props.reset },
-    { key: "q", label: () => "Quit", onUse: () => exit() },
+    { key: "c", label: () => (copied() ? "✓ 已复制" : "复制报告"), copy: true, onUse: copyReport },
+    { key: "r", label: () => "重启", onUse: props.reset },
+    { key: "q", label: () => "退出", onUse: () => exit() },
   ]
   const [selected, setSelected] = createSignal(0)
   const move = (delta: number) => setSelected((prev) => (prev + delta + actions.length) % actions.length)
@@ -108,10 +108,10 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
         {/* Headline */}
         <box flexDirection="column" alignItems="center" flexShrink={0}>
           <text attributes={TextAttributes.BOLD} fg={colors.text}>
-            opencode crashed
+            opencode 崩溃了
           </text>
           <Show when={showSubtext()}>
-            <text fg={colors.muted}>An unexpected error stopped the session.</text>
+            <text fg={colors.muted}>一个意外错误停止了会话。</text>
           </Show>
         </box>
 
@@ -121,7 +121,7 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
           border
           borderStyle="rounded"
           borderColor={colors.error}
-          title=" Error "
+          title=" 错误 "
           titleColor={colors.error}
           paddingLeft={2}
           paddingRight={2}
@@ -168,9 +168,9 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
           border
           borderStyle="rounded"
           borderColor={colors.borderSubtle}
-          title=" Stack trace "
+          title=" 堆栈跟踪 "
           titleColor={colors.muted}
-          bottomTitle=" ↑↓ scroll "
+          bottomTitle=" ↑↓ 滚动 "
           bottomTitleAlignment="right"
           paddingLeft={1}
           paddingRight={1}
@@ -189,8 +189,8 @@ export function ErrorComponent(props: { error: Error; reset: () => void; mode?: 
           <box flexDirection="column" alignItems="center" flexShrink={0}>
             <text fg={colors.muted}>
               {copied()
-                ? "Report copied — paste it into a new GitHub issue."
-                : "Copy the report and open a GitHub issue to help us fix this."}
+                ? "报告已复制 — 粘贴到新的 GitHub issue 中。"
+                : "复制报告并打开 GitHub issue 以帮助我们修复此问题。"}
             </text>
             <text fg={colors.muted}>opencode {InstallationVersion}</text>
           </box>

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -584,8 +584,8 @@ export function Autocomplete(props: {
     commands: [
       {
         name: "prompt.autocomplete.prev",
-        title: "Previous autocomplete item",
-        category: "Autocomplete",
+        title: "上一个自动补全项目",
+        category: "自动补全",
         run() {
           setStore("input", "keyboard")
           move(-1)
@@ -593,8 +593,8 @@ export function Autocomplete(props: {
       },
       {
         name: "prompt.autocomplete.next",
-        title: "Next autocomplete item",
-        category: "Autocomplete",
+        title: "下一个自动补全项目",
+        category: "自动补全",
         run() {
           setStore("input", "keyboard")
           move(1)
@@ -602,24 +602,24 @@ export function Autocomplete(props: {
       },
       {
         name: "prompt.autocomplete.hide",
-        title: "Hide autocomplete",
-        category: "Autocomplete",
+        title: "隐藏自动补全",
+        category: "自动补全",
         run() {
           hide()
         },
       },
       {
         name: "prompt.autocomplete.select",
-        title: "Select autocomplete item",
-        category: "Autocomplete",
+        title: "选择自动补全项目",
+        category: "自动补全",
         run() {
           select()
         },
       },
       {
         name: "prompt.autocomplete.complete",
-        title: "Complete autocomplete item",
-        category: "Autocomplete",
+        title: "完成自动补全项目",
+        category: "自动补全",
         run() {
           const selected = options()[store.selected]
           if (selected?.isDirectory) {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -216,7 +216,7 @@ export function Prompt(props: PromptProps) {
   function promptModelWarning() {
     toast.show({
       variant: "warning",
-      message: "Connect a provider to send prompts",
+      message: "连接提供商以发送提示",
       duration: 3000,
     })
     if (sync.data.provider.length === 0) {
@@ -334,7 +334,7 @@ export function Prompt(props: PromptProps) {
   const promptCommands = createMemo(() =>
     [
       {
-        title: "Clear prompt",
+        title: "清除提示",
         name: "prompt.clear",
         category: "Prompt",
         hidden: true,
@@ -344,7 +344,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Submit prompt",
+        title: "提交提示",
         name: "prompt.submit",
         category: "Prompt",
         hidden: true,
@@ -357,7 +357,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Remove editor context",
+        title: "移除编辑器上下文",
         name: "prompt.editor_context.clear",
         category: "Prompt",
         enabled: Boolean(editorContext()),
@@ -389,7 +389,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Interrupt session",
+        title: "中断会话",
         name: "session.interrupt",
         category: "Session",
         hidden: true,
@@ -420,7 +420,7 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Open editor",
+        title: "打开编辑器",
         category: "Session",
         name: "prompt.editor",
         slashName: "editor",
@@ -532,10 +532,10 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Warp",
-        desc: "Change the workspace for the session",
+        title: "迁移",
+        desc: "更改会话的工作区",
         name: "workspace.set",
-        category: "Session",
+        category: "会话",
         enabled: Flag.OPENCODE_EXPERIMENTAL_WORKSPACES,
         slashName: "warp",
         run: () => {
@@ -543,10 +543,10 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Move session",
-        desc: "Move to another project dir",
+        title: "移动会话",
+        desc: "移动到另一个项目目录",
         name: "session.move",
-        category: "Session",
+        category: "会话",
         slashName: "move",
         run: () => {
           move.open()
@@ -735,9 +735,9 @@ export function Prompt(props: PromptProps) {
   const stashCommands = createMemo(() =>
     [
       {
-        title: "Stash prompt",
+        title: "暂存提示",
         name: "prompt.stash",
-        category: "Prompt",
+        category: "提示",
         enabled: !!store.prompt.input,
         run: () => {
           if (!store.prompt.input) return
@@ -753,9 +753,9 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Stash pop",
+        title: "取出暂存",
         name: "prompt.stash.pop",
-        category: "Prompt",
+        category: "提示",
         enabled: stash.list().length > 0,
         run: () => {
           const entry = stash.pop()
@@ -769,9 +769,9 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
-        title: "Stash list",
+        title: "暂存列表",
         name: "prompt.stash.list",
-        category: "Prompt",
+        category: "提示",
         enabled: stash.list().length > 0,
         run: () => {
           dialog.replace(() => (
@@ -828,8 +828,8 @@ export function Prompt(props: PromptProps) {
       bindings: [
         {
           key: "!",
-          desc: "Shell mode",
-          group: "Prompt",
+          desc: "Shell 模式",
+          group: "提示",
           cmd: () => {
             setStore("placeholder", randomIndex(shell().length))
             setStore("mode", "shell")
@@ -843,7 +843,7 @@ export function Prompt(props: PromptProps) {
     return {
       target: inputTarget,
       enabled: inputTarget() !== undefined && store.mode === "shell",
-      bindings: [{ key: "escape", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
+      bindings: [{ key: "escape", desc: "退出 Shell 模式", group: "提示", cmd: () => setStore("mode", "normal") }],
     }
   })
 
@@ -854,7 +854,7 @@ export function Prompt(props: PromptProps) {
         cursorVersion()
         return inputTarget() !== undefined && store.mode === "shell" && input?.visualCursor.offset === 0
       })(),
-      bindings: [{ key: "backspace", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
+      bindings: [{ key: "backspace", desc: "退出 Shell 模式", group: "提示", cmd: () => setStore("mode", "normal") }],
     }
   })
 
@@ -868,8 +868,8 @@ export function Prompt(props: PromptProps) {
       commands: [
         {
           name: "prompt.history.previous",
-          title: "Previous prompt history",
-          category: "Prompt",
+          title: "上一条提示历史",
+          category: "提示",
           run() {
             if (input.cursorOffset !== 0) {
               if (input.scrollY + input.visualCursor.visualRow === 0) input.cursorOffset = 0
@@ -900,8 +900,8 @@ export function Prompt(props: PromptProps) {
       commands: [
         {
           name: "prompt.history.next",
-          title: "Next prompt history",
-          category: "Prompt",
+          title: "下一条提示历史",
+          category: "提示",
           run() {
             if (input.cursorOffset !== input.plainText.length) {
               if (
@@ -1012,7 +1012,7 @@ export function Prompt(props: PromptProps) {
         console.log("Creating a session failed:", res.error)
 
         toast.show({
-          message: "Creating a session failed. Open console for more details.",
+          message: "创建会话失败。打开控制台查看详情。",
           variant: "error",
         })
 
@@ -1111,7 +1111,7 @@ export function Prompt(props: PromptProps) {
         )
         .catch((error) => {
           toast.show({
-            title: "Failed to send prompt",
+            title: "发送提示失败",
             message: errorMessage(error),
             variant: "error",
           })

--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -31,7 +31,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     const projectID = input.projectID()
     if (!projectID) return
     setCreating(true)
-    setProgress("Creating copy")
+    setProgress("正在创建副本")
     try {
       const generated = await sdk.client.experimental.projectCopy.generateName(
         { projectID, context },
@@ -48,19 +48,19 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
         { throwOnError: true },
       )
       const directory = result.data?.directory
-      if (!directory) throw new Error("No project copy directory returned")
+      if (!directory) throw new Error("未返回项目副本目录")
 
       // Call a location-based route to make sure it's bootstrapped
       // before moving on
       await sdk.client.path.get({ directory }, { throwOnError: true })
 
-      setProgress("Creating session")
+      setProgress("正在创建会话")
       return directory
     } catch (err) {
       homeDestination?.clear()
       setProgress(undefined)
       setCreating(false)
-      toast.show({ title: "Creating workspace failed", message: errorMessage(err), variant: "error" })
+      toast.show({ title: "创建工作区失败", message: errorMessage(err), variant: "error" })
       return
     }
   }
@@ -126,7 +126,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
       dialog.clear()
       return
     }
-    setProgress("Moving session")
+    setProgress("正在移动会话")
     try {
       await sdk.client.experimental.controlPlane.moveSession(
         {
@@ -173,7 +173,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
   }
 
   function startSubmit() {
-    if (progress()) setProgress("Submitting prompt")
+    if (progress()) setProgress("正在提交提示")
   }
 
   function finishSubmit() {

--- a/packages/tui/src/component/prompt/workspace.tsx
+++ b/packages/tui/src/component/prompt/workspace.tsx
@@ -32,15 +32,15 @@ export function usePromptWorkspace(sessionID?: string) {
     } catch (err) {
       setSelection(undefined)
       setCreating(false)
-      toast.show({ title: "Creating workspace failed", message: errorMessage(err), variant: "error" })
+      toast.show({ title: "创建工作区失败", message: errorMessage(err), variant: "error" })
       return
     }
     if (result.error || !result.data) {
       setSelection(undefined)
       setCreating(false)
       toast.show({
-        title: "Creating workspace failed",
-        message: errorMessage(result.error ?? "no response"),
+        title: "创建工作区失败",
+        message: errorMessage(result.error ?? "无响应"),
         variant: "error",
       })
       return

--- a/packages/tui/src/component/startup-loading.tsx
+++ b/packages/tui/src/component/startup-loading.tsx
@@ -5,7 +5,7 @@ import { Spinner } from "./spinner"
 export function StartupLoading(props: { ready: () => boolean }) {
   const theme = useTheme().theme
   const [show, setShow] = createSignal(false)
-  const text = createMemo(() => (props.ready() ? "Finishing startup..." : "Loading plugins..."))
+  const text = createMemo(() => (props.ready() ? "正在完成启动..." : "正在加载插件..."))
   let wait: NodeJS.Timeout | undefined
   let hold: NodeJS.Timeout | undefined
   let stamp = 0

--- a/packages/tui/src/feature-plugins/home/tips-view.tsx
+++ b/packages/tui/src/feature-plugins/home/tips-view.tsx
@@ -68,7 +68,7 @@ function parse(tip: string): TipPart[] {
   return parts
 }
 
-const NO_MODELS_TIP = "Run {highlight}/connect{/highlight} to add an AI provider and start coding"
+const NO_MODELS_TIP = "运行 {highlight}/connect{/highlight} 添加 AI 提供商并开始编程"
 const NO_MODELS_PARTS = parse(NO_MODELS_TIP)
 
 function shortcutText(value: string) {
@@ -77,12 +77,12 @@ function shortcutText(value: string) {
 
 function commandText(command: string, shortcut: string) {
   if (!shortcut) return shortcutText(command)
-  return `${shortcutText(command)} or ${shortcutText(shortcut)}`
+  return `${shortcutText(command)} 或 ${shortcutText(shortcut)}`
 }
 
 function press(shortcut: string, text: string) {
   if (!shortcut) return undefined
-  return `Press ${shortcutText(shortcut)} ${text}`
+  return `按 ${shortcutText(shortcut)} ${text}`
 }
 
 function configShortcut(api: TuiPluginApi, command: string): TipShortcut {
@@ -150,7 +150,7 @@ export function Tips(props: { api: TuiPluginApi; connected?: boolean }) {
   return (
     <box flexDirection="row" maxWidth="100%">
       <text flexShrink={0} style={{ fg: theme.warning }}>
-        ● Tip{" "}
+        ● 提示{" "}
       </text>
       <text flexShrink={1} wrapMode="word">
         <For each={parts()}>
@@ -162,44 +162,44 @@ export function Tips(props: { api: TuiPluginApi; connected?: boolean }) {
 }
 
 const TIPS: Tip[] = [
-  "Type {highlight}@{/highlight} followed by a filename to fuzzy search and attach files",
-  "Start a message with {highlight}!{/highlight} to run shell commands (e.g., {highlight}!ls -la{/highlight})",
-  (shortcuts) => press(shortcuts.agentCycle(), "to cycle between Build and Plan agents"),
-  "Use {highlight}/undo{/highlight} to revert the last message and file changes",
-  "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
-  "Run {highlight}/share{/highlight} to create a public opencode.ai link",
-  "Drag and drop images or PDFs into the terminal as context",
-  (shortcuts) => press(shortcuts.inputPaste(), "to paste images from your clipboard into the prompt"),
-  (shortcuts) => `Use ${commandText("/editor", shortcuts.editorOpen())} to compose messages in your external editor`,
-  "Run {highlight}/init{/highlight} to auto-generate project rules based on your codebase",
-  (shortcuts) => `Use ${commandText("/models", shortcuts.modelList())} to switch between available AI models`,
-  (shortcuts) => `Use ${commandText("/themes", shortcuts.themeList())} to switch between ${themeCount} built-in themes`,
-  (shortcuts) => `Use ${commandText("/new", shortcuts.sessionNew())} to start a fresh conversation session`,
-  (shortcuts) => `Use ${commandText("/sessions", shortcuts.sessionList())} to list, pin, and continue sessions`,
-  (shortcuts) => press(shortcuts.sessionPinToggle(), "in the session list to pin one at the top"),
+  "输入 {highlight}@{/highlight} 后跟文件名可模糊搜索并附加文件",
+  "以 {highlight}!{/highlight} 开头输入可运行 shell 命令（例如 {highlight}!ls -la{/highlight}）",
+  (shortcuts) => press(shortcuts.agentCycle(), "在 Build 和 Plan 代理之间切换"),
+  "使用 {highlight}/undo{/highlight} 撤销上一条消息和文件修改",
+  "使用 {highlight}/redo{/highlight} 恢复被撤销的消息和文件修改",
+  "运行 {highlight}/share{/highlight} 创建公开的 opencode.ai 链接",
+  "将图片或 PDF 拖入终端作为上下文",
+  (shortcuts) => press(shortcuts.inputPaste(), "将剪贴板中的图片粘贴到提示中"),
+  (shortcuts) => `使用 ${commandText("/editor", shortcuts.editorOpen())} 在外部编辑器中编写消息`,
+  "运行 {highlight}/init{/highlight} 根据代码库自动生成项目规则",
+  (shortcuts) => `使用 ${commandText("/models", shortcuts.modelList())} 在可用的 AI 模型之间切换`,
+  (shortcuts) => `使用 ${commandText("/themes", shortcuts.themeList())} 在 ${themeCount} 个内置主题之间切换`,
+  (shortcuts) => `使用 ${commandText("/new", shortcuts.sessionNew())} 开始新的对话会话`,
+  (shortcuts) => `使用 ${commandText("/sessions", shortcuts.sessionList())} 列出、置顶并继续会话`,
+  (shortcuts) => press(shortcuts.sessionPinToggle(), "在会话列表中将其置顶"),
   (shortcuts) =>
     shortcuts.sessionQuickSwitch1() && shortcuts.sessionQuickSwitch9()
-      ? `Use ${shortcutText(shortcuts.sessionQuickSwitch1())} through ${shortcutText(shortcuts.sessionQuickSwitch9())} to switch pinned sessions`
+      ? `使用 ${shortcutText(shortcuts.sessionQuickSwitch1())} 到 ${shortcutText(shortcuts.sessionQuickSwitch9())} 切换置顶会话`
       : undefined,
-  "Run {highlight}/compact{/highlight} to summarize long sessions near context limits",
-  (shortcuts) => `Use ${commandText("/export", shortcuts.sessionExport())} to save the conversation as Markdown`,
-  (shortcuts) => press(shortcuts.messagesCopy(), "to copy the assistant's last message to clipboard"),
-  (shortcuts) => press(shortcuts.commandList(), "to see all available actions and commands"),
-  "Run {highlight}/connect{/highlight} to add API keys for 75+ supported LLM providers",
-  (shortcuts) => `The leader key is ${shortcutText(shortcuts.leader())}; combine with other keys for quick actions`,
-  (shortcuts) => press(shortcuts.modelCycleRecent(), "to quickly switch between recently used models"),
-  (shortcuts) => press(shortcuts.sessionSidebarToggle(), "in a session to show or hide the sidebar panel"),
+  "运行 {highlight}/compact{/highlight} 在接近上下文限制时总结长会话",
+  (shortcuts) => `使用 ${commandText("/export", shortcuts.sessionExport())} 将会话保存为 Markdown`,
+  (shortcuts) => press(shortcuts.messagesCopy(), "将助手的最后一条消息复制到剪贴板"),
+  (shortcuts) => press(shortcuts.commandList(), "查看所有可用的操作和命令"),
+  "运行 {highlight}/connect{/highlight} 为 75+ 个受支持的 LLM 提供商添加 API 密钥",
+  (shortcuts) => `主键是 ${shortcutText(shortcuts.leader())}；与其他按键组合可快速操作`,
+  (shortcuts) => press(shortcuts.modelCycleRecent(), "在最近使用的模型之间快速切换"),
+  (shortcuts) => press(shortcuts.sessionSidebarToggle(), "在会话中显示或隐藏侧边栏"),
   (shortcuts) =>
     shortcuts.messagesPageUp() && shortcuts.messagesPageDown()
-      ? `Use ${shortcutText(shortcuts.messagesPageUp())}/${shortcutText(shortcuts.messagesPageDown())} to navigate through conversation history`
+      ? `使用 ${shortcutText(shortcuts.messagesPageUp())}/${shortcutText(shortcuts.messagesPageDown())} 浏览对话历史`
       : undefined,
-  (shortcuts) => press(shortcuts.messagesFirst(), "to jump to the beginning of the conversation"),
-  (shortcuts) => press(shortcuts.messagesLast(), "to jump to the most recent message"),
-  (shortcuts) => press(shortcuts.inputNewline(), "to add newlines in your prompt"),
-  (shortcuts) => press(shortcuts.inputClear(), "when typing to clear the input field"),
-  (shortcuts) => press(shortcuts.sessionInterrupt(), "to stop the AI mid-response"),
-  "Switch to {highlight}Plan{/highlight} agent for suggestions without making changes",
-  "Use {highlight}@agent-name{/highlight} in prompts to invoke specialized subagents",
+  (shortcuts) => press(shortcuts.messagesFirst(), "跳到对话开头"),
+  (shortcuts) => press(shortcuts.messagesLast(), "跳到最新消息"),
+  (shortcuts) => press(shortcuts.inputNewline(), "在提示中添加换行"),
+  (shortcuts) => press(shortcuts.inputClear(), "输入时清空输入框"),
+  (shortcuts) => press(shortcuts.sessionInterrupt(), "中途停止 AI 响应"),
+  "切换到 {highlight}Plan{/highlight} 代理以获得建议而不做修改",
+  "在提示中使用 {highlight}@代理名{/highlight} 调用专门的子代理",
   (shortcuts) => {
     const items = [
       shortcuts.sessionParent(),
@@ -208,80 +208,80 @@ const TIPS: Tip[] = [
       shortcuts.childNext(),
     ].filter(Boolean)
     if (!items.length) return undefined
-    return `Use ${items.map(shortcutText).join(" / ")} for parent/child sessions`
+    return `使用 ${items.map(shortcutText).join(" / ")} 切换父/子会话`
   },
-  "Create {highlight}opencode.json{/highlight} for server settings, and {highlight}tui.json{/highlight} for TUI",
-  "Place TUI settings in {highlight}~/.config/opencode/tui.json{/highlight} for global config",
-  "Add {highlight}$schema{/highlight} to your config for autocomplete in your editor",
-  "Configure {highlight}model{/highlight} in config to set your default model",
-  "Override any keybind in {highlight}tui.json{/highlight} via the {highlight}keybinds{/highlight} section",
-  "Set any keybind to {highlight}none{/highlight} to disable it completely",
-  "Configure local or remote MCP servers in the {highlight}mcp{/highlight} config section",
-  "Add {highlight}.md{/highlight} files to {highlight}.opencode/commands/{/highlight} for reusable prompts",
-  "Use {highlight}$ARGUMENTS{/highlight}, {highlight}$1{/highlight}, {highlight}$2{/highlight} in custom commands for dynamic input",
-  "Use backticks to inject shell output (e.g., {highlight}`git status`{/highlight})",
-  "Add {highlight}.md{/highlight} files to {highlight}.opencode/agents/{/highlight} for specialized AI personas",
-  "Configure per-agent permissions for {highlight}edit{/highlight}, {highlight}bash{/highlight}, and {highlight}webfetch{/highlight} tools",
-  'Use patterns like {highlight}"git *": "allow"{/highlight} for granular bash permissions',
-  'Set {highlight}"rm -rf *": "deny"{/highlight} to block destructive commands',
-  'Configure {highlight}"git push": "ask"{/highlight} to require approval before pushing',
-  'Set {highlight}"formatter": true{/highlight} to enable built-in formatters',
-  'Set {highlight}"formatter": false{/highlight} to disable inherited formatters',
-  "Define custom formatter commands with file extensions in config",
-  'Set {highlight}"lsp": true{/highlight} to enable built-in LSP code analysis',
-  "Create {highlight}.ts{/highlight} files in {highlight}.opencode/tools/{/highlight} to define new LLM tools",
-  "Tool definitions can invoke scripts written in Python, Go, etc",
-  "Add {highlight}.ts{/highlight} files to {highlight}.opencode/plugins/{/highlight} for event hooks",
-  "Use plugins to send OS notifications when sessions complete",
-  "Create a plugin to prevent OpenCode from reading sensitive files",
-  "Use {highlight}opencode run{/highlight} for non-interactive scripting",
-  "Use {highlight}opencode --continue{/highlight} to resume the last session",
-  "Use {highlight}opencode run -f file.ts{/highlight} to attach files via CLI",
-  "Use {highlight}--format json{/highlight} for machine-readable output in scripts",
-  "Run {highlight}opencode serve{/highlight} for headless API access to OpenCode",
-  "Use {highlight}opencode run --attach{/highlight} to connect to a running server",
-  "Run {highlight}opencode upgrade{/highlight} to update to the latest version",
-  "Run {highlight}opencode auth list{/highlight} to see all configured providers",
-  "Run {highlight}opencode agent create{/highlight} for guided agent creation",
-  "Use {highlight}/opencode{/highlight} in GitHub issues/PRs to trigger AI actions",
-  "Run {highlight}opencode github install{/highlight} to set up the GitHub workflow",
-  "Comment {highlight}/opencode fix this{/highlight} on issues to auto-create PRs",
-  "Comment {highlight}/oc{/highlight} on PR code lines for targeted code reviews",
-  'Use {highlight}"theme": "system"{/highlight} to match your terminal\'s colors',
-  "Create JSON theme files in {highlight}.opencode/themes/{/highlight} directory",
-  "Themes support dark/light variants for both modes",
-  "Use numeric xterm color codes 0-255 in custom theme JSON",
-  "Use {highlight}{env:VAR_NAME}{/highlight} for environment variables in config",
-  "Use {highlight}{file:path}{/highlight} to include file contents in config values",
-  "Use {highlight}instructions{/highlight} in config to load additional rules files",
-  "Set agent {highlight}temperature{/highlight} from 0.0 (focused) to 1.0 (creative)",
-  "Configure {highlight}steps{/highlight} to limit agentic iterations per request",
-  'Set {highlight}"tools": {"bash": false}{/highlight} to disable specific tools',
-  'Set {highlight}"mcp_*": false{/highlight} to disable all tools from an MCP server',
-  "Override global tool settings per agent configuration",
-  'Set {highlight}"share": "auto"{/highlight} to automatically share all sessions',
-  'Set {highlight}"share": "disabled"{/highlight} to prevent any session sharing',
-  "Run {highlight}/unshare{/highlight} to remove a session from public access",
-  "Permission {highlight}doom_loop{/highlight} prevents infinite tool call loops",
-  "Permission {highlight}external_directory{/highlight} protects files outside project",
-  "Run {highlight}opencode debug config{/highlight} to troubleshoot configuration",
-  "Use {highlight}--print-logs{/highlight} flag to see detailed logs in stderr",
-  (shortcuts) => `Use ${commandText("/timeline", shortcuts.sessionTimeline())} to jump to specific messages`,
-  (shortcuts) => press(shortcuts.messagesToggleConceal(), "to toggle code block visibility in messages"),
-  (shortcuts) => `Use ${commandText("/status", shortcuts.statusView())} to see system status info`,
-  "Enable {highlight}scroll_acceleration{/highlight} in {highlight}tui.json{/highlight} for smooth scrolling",
+  "创建 {highlight}opencode.json{/highlight} 配置服务器设置，{highlight}tui.json{/highlight} 配置 TUI",
+  "将 TUI 设置放在 {highlight}~/.config/opencode/tui.json{/highlight} 作为全局配置",
+  "在配置中添加 {highlight}$schema{/highlight} 以获得编辑器中的自动补全",
+  "在配置中设置 {highlight}model{/highlight} 以指定默认模型",
+  "通过 {highlight}tui.json{/highlight} 中的 {highlight}keybinds{/highlight} 部分覆盖任何按键绑定",
+  "将任何按键绑定设置为 {highlight}none{/highlight} 以完全禁用",
+  "在 {highlight}mcp{/highlight} 配置部分配置本地或远程 MCP 服务器",
+  "在 {highlight}.opencode/commands/{/highlight} 中添加 {highlight}.md{/highlight} 文件以实现可复用提示",
+  "在自定义命令中使用 {highlight}$ARGUMENTS{/highlight}、{highlight}$1{/highlight}、{highlight}$2{/highlight} 实现动态输入",
+  "使用反引号注入 shell 输出（例如 {highlight}`git status`{/highlight}）",
+  "在 {highlight}.opencode/agents/{/highlight} 中添加 {highlight}.md{/highlight} 文件以定义专门的 AI 角色",
+  "为 {highlight}edit{/highlight}、{highlight}bash{/highlight} 和 {highlight}webfetch{/highlight} 工具配置每个代理的权限",
+  '使用 {highlight}"git *": "allow"{/highlight} 之类的规则进行细粒度 bash 权限控制',
+  '设置 {highlight}"rm -rf *": "deny"{/highlight} 以阻止破坏性命令',
+  '配置 {highlight}"git push": "ask"{/highlight} 在推送前要求批准',
+  '设置 {highlight}"formatter": true{/highlight} 启用内置格式化器',
+  '设置 {highlight}"formatter": false{/highlight} 禁用继承的格式化器',
+  "在配置中使用文件扩展名定义自定义格式化命令",
+  '设置 {highlight}"lsp": true{/highlight} 启用内置 LSP 代码分析',
+  "在 {highlight}.opencode/tools/{/highlight} 中创建 {highlight}.ts{/highlight} 文件定义新的 LLM 工具",
+  "工具定义可以调用用 Python、Go 等编写的脚本",
+  "在 {highlight}.opencode/plugins/{/highlight} 中添加 {highlight}.ts{/highlight} 文件实现事件钩子",
+  "使用插件在会话完成时发送系统通知",
+  "创建插件防止 OpenCode 读取敏感文件",
+  "使用 {highlight}opencode run{/highlight} 进行非交互式脚本操作",
+  "使用 {highlight}opencode --continue{/highlight} 恢复上一个会话",
+  "使用 {highlight}opencode run -f file.ts{/highlight} 通过 CLI 附加文件",
+  "在脚本中使用 {highlight}--format json{/highlight} 获得机器可读输出",
+  "运行 {highlight}opencode serve{/highlight} 获得无头 API 访问",
+  "使用 {highlight}opencode run --attach{/highlight} 连接到运行中的服务器",
+  "运行 {highlight}opencode upgrade{/highlight} 更新到最新版本",
+  "运行 {highlight}opencode auth list{/highlight} 查看所有已配置的提供商",
+  "运行 {highlight}opencode agent create{/highlight} 进行引导式代理创建",
+  "在 GitHub issue/PR 中使用 {highlight}/opencode{/highlight} 触发 AI 操作",
+  "运行 {highlight}opencode github install{/highlight} 设置 GitHub 工作流",
+  "在 issue 上评论 {highlight}/opencode fix this{/highlight} 自动创建 PR",
+  "在 PR 代码行上评论 {highlight}/oc{/highlight} 进行针对性代码审查",
+  '使用 {highlight}"theme": "system"{/highlight} 匹配终端配色',
+  "在 {highlight}.opencode/themes/{/highlight} 目录中创建 JSON 主题文件",
+  "主题支持深色/浅色两种变体",
+  "在自定义主题 JSON 中使用 0-255 的数字 xterm 颜色代码",
+  "在配置中使用 {highlight}{env:VAR_NAME}{/highlight} 引用环境变量",
+  "使用 {highlight}{file:path}{/highlight} 在配置值中包含文件内容",
+  "在配置中使用 {highlight}instructions{/highlight} 加载额外的规则文件",
+  "将代理 {highlight}temperature{/highlight} 设置为 0.0（专注）到 1.0（创意）",
+  "配置 {highlight}steps{/highlight} 限制每次请求的代理迭代次数",
+  '设置 {highlight}"tools": {"bash": false}{/highlight} 禁用特定工具',
+  '设置 {highlight}"mcp_*": false{/highlight} 禁用来自某个 MCP 服务器的所有工具',
+  "按代理配置覆盖全局工具设置",
+  '设置 {highlight}"share": "auto"{/highlight} 自动分享所有会话',
+  '设置 {highlight}"share": "disabled"{/highlight} 禁止任何会话分享',
+  "运行 {highlight}/unshare{/highlight} 将会话从公开访问中移除",
+  "权限 {highlight}doom_loop{/highlight} 防止无限工具调用循环",
+  "权限 {highlight}external_directory{/highlight} 保护项目外的文件",
+  "运行 {highlight}opencode debug config{/highlight} 排查配置问题",
+  "使用 {highlight}--print-logs{/highlight} 参数在 stderr 中查看详细日志",
+  (shortcuts) => `使用 ${commandText("/timeline", shortcuts.sessionTimeline())} 跳转到指定消息`,
+  (shortcuts) => press(shortcuts.messagesToggleConceal(), "切换消息中代码块的可见性"),
+  (shortcuts) => `使用 ${commandText("/status", shortcuts.statusView())} 查看系统状态信息`,
+  "在 {highlight}tui.json{/highlight} 中启用 {highlight}scroll_acceleration{/highlight} 获得平滑滚动",
   (shortcuts) =>
     shortcuts.commandList()
-      ? `Toggle username display in chat via the command palette (${shortcutText(shortcuts.commandList())})`
-      : "Toggle username display in chat via the command palette",
-  "Run {highlight}docker run -it --rm ghcr.io/anomalyco/opencode{/highlight} in a container",
-  "Use {highlight}/connect{/highlight} with OpenCode Zen for curated, tested models",
-  "Commit your project's {highlight}AGENTS.md{/highlight} file to Git for team sharing",
-  "Use {highlight}/review{/highlight} to review uncommitted changes, branches, or PRs",
-  (shortcuts) => `Use ${commandText("/help", shortcuts.helpShow())} to show the help dialog`,
-  "Use {highlight}/rename{/highlight} to rename the current session",
+      ? `通过命令面板切换聊天中的用户名显示 (${shortcutText(shortcuts.commandList())})`
+      : "通过命令面板切换聊天中的用户名显示",
+  "运行 {highlight}docker run -it --rm ghcr.io/anomalyco/opencode{/highlight} 在容器中运行",
+  "使用 {highlight}/connect{/highlight} 配合 OpenCode Zen 获得精选、经过测试的模型",
+  "将项目的 {highlight}AGENTS.md{/highlight} 文件提交到 Git 以便团队共享",
+  "使用 {highlight}/review{/highlight} 审查未提交的修改、分支或 PR",
+  (shortcuts) => `使用 ${commandText("/help", shortcuts.helpShow())} 显示帮助对话框`,
+  "使用 {highlight}/rename{/highlight} 重命名当前会话",
 ]
 
-const INPUT_UNDO_TIP: Tip = (shortcuts) => press(shortcuts.inputUndo(), "to undo changes in your prompt")
+const INPUT_UNDO_TIP: Tip = (shortcuts) => press(shortcuts.inputUndo(), "撤销提示中的修改")
 const TERMINAL_SUSPEND_TIP: Tip = (shortcuts) =>
-  press(shortcuts.terminalSuspend(), "to suspend the terminal and return to your shell")
+  press(shortcuts.terminalSuspend(), "挂起终端并返回 shell")

--- a/packages/tui/src/feature-plugins/home/tips.tsx
+++ b/packages/tui/src/feature-plugins/home/tips.tsx
@@ -11,8 +11,8 @@ function View(props: { api: TuiPluginApi; hidden: boolean; show: boolean; connec
     commands: [
       {
         name: "tips.toggle",
-        title: props.hidden ? "Show tips" : "Hide tips",
-        category: "System",
+        title: props.hidden ? "显示提示" : "隐藏提示",
+        category: "系统",
         namespace: "palette",
         run() {
           props.api.kv.set("tips_hidden", !props.api.kv.get("tips_hidden", false))

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -37,11 +37,11 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   return (
     <box>
       <text fg={theme().text}>
-        <b>Context</b>
+        <b>上下文</b>
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
-      <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <text fg={theme().textMuted}>{state().percent ?? 0}% 已使用</text>
+      <text fg={theme().textMuted}>{money.format(cost())} 已花费</text>
     </box>
   )
 }

--- a/packages/tui/src/feature-plugins/sidebar/files.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/files.tsx
@@ -24,7 +24,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
             <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
           </Show>
           <text fg={theme().text}>
-            <b>Modified Files</b>
+            <b>修改的文件</b>
           </text>
         </box>
         <Show when={list().length <= 2 || open()}>

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -47,18 +47,16 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
           <box flexGrow={1} gap={1}>
             <box flexDirection="row" justifyContent="space-between">
               <text fg={theme().text}>
-                <b>Getting started</b>
+                <b>快速开始</b>
               </text>
               <text fg={theme().textMuted} onMouseDown={() => props.api.kv.set("dismissed_getting_started", true)}>
                 ✕
               </text>
             </box>
-            <text fg={theme().textMuted}>OpenCode includes free models so you can start immediately.</text>
-            <text fg={theme().textMuted}>
-              Connect from 75+ providers to use other models, including Claude, GPT, Gemini etc
-            </text>
+            <text fg={theme().textMuted}>OpenCode 内置免费模型，可立即开始使用。</text>
+            <text fg={theme().textMuted}>可连接 75+ 个提供商使用其他模型，包括 Claude、GPT、Gemini 等</text>
             <box flexDirection="row" gap={1} justifyContent="space-between">
-              <text fg={theme().text}>Connect provider</text>
+              <text fg={theme().text}>连接提供商</text>
               <text fg={theme().textMuted}>/connect</text>
             </box>
           </box>

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -38,7 +38,7 @@ function View(props: { api: TuiPluginApi }) {
             <Show when={!open()}>
               <span style={{ fg: theme().textMuted }}>
                 {" "}
-                ({on()} active{bad() > 0 ? `, ${bad()} error${bad() > 1 ? "s" : ""}` : ""})
+                ({on()} 个已连接{bad() > 0 ? `，${bad()} 个错误` : ""})
               </span>
             </Show>
           </text>
@@ -59,13 +59,13 @@ function View(props: { api: TuiPluginApi }) {
                   {item.name}{" "}
                   <span style={{ fg: theme().textMuted }}>
                     <Switch fallback={item.status}>
-                      <Match when={item.status === "connected"}>Connected</Match>
+                      <Match when={item.status === "connected"}>已连接</Match>
                       <Match when={item.status === "failed"}>
                         <i>{item.error}</i>
                       </Match>
-                      <Match when={item.status === "disabled"}>Disabled</Match>
-                      <Match when={item.status === "needs_auth"}>Needs auth</Match>
-                      <Match when={item.status === "needs_client_registration"}>Needs client ID</Match>
+                      <Match when={item.status === "disabled"}>已禁用</Match>
+                      <Match when={item.status === "needs_auth"}>需要认证</Match>
+                      <Match when={item.status === "needs_client_registration"}>需要客户端 ID</Match>
                     </Switch>
                   </span>
                 </text>

--- a/packages/tui/src/feature-plugins/sidebar/todo.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/todo.tsx
@@ -19,7 +19,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
             <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
           </Show>
           <text fg={theme().text}>
-            <b>Todo</b>
+            <b>待办</b>
           </text>
         </box>
         <Show when={list().length <= 2 || open()}>

--- a/packages/tui/src/feature-plugins/system/diff-viewer-file-tree.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer-file-tree.tsx
@@ -63,7 +63,7 @@ export function DiffViewerFileTree(props: DiffViewerFileTreeProps) {
             <text />
           </Match>
           <Match when={props.files.length === 0}>
-            <text fg={props.theme.text}>No files</text>
+            <text fg={props.theme.text}>没有文件</text>
           </Match>
           <Match when={props.files.length > 0}>
             <For each={rows()}>

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -433,8 +433,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
   const commands = [
     {
       name: "diff.close",
-      title: "Close diff viewer",
-      category: "VCS",
+      title: "关闭差异查看器",
+      category: "版本控制",
       run() {
         const returnRoute = params()?.returnRoute
         props.api.ui.dialog.clear()
@@ -447,8 +447,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.down",
-      title: "Move diff viewer down",
-      category: "VCS",
+      title: "向下移动差异查看器",
+      category: "版本控制",
       run: focusRunner({
         files() {
           moveFileSelection(1)
@@ -461,8 +461,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.up",
-      title: "Move diff viewer up",
-      category: "VCS",
+      title: "向上移动差异查看器",
+      category: "版本控制",
       run: focusRunner({
         files() {
           moveFileSelection(-1)
@@ -475,8 +475,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.page.down",
-      title: "Page diff viewer down",
-      category: "VCS",
+      title: "差异查看器向下翻页",
+      category: "版本控制",
       run: focusRunner({
         files() {
           moveFileSelection(8)
@@ -489,8 +489,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.page.up",
-      title: "Page diff viewer up",
-      category: "VCS",
+      title: "差异查看器向上翻页",
+      category: "版本控制",
       run: focusRunner({
         files() {
           moveFileSelection(-8)
@@ -503,8 +503,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.toggle",
-      title: "Toggle diff viewer item",
-      category: "VCS",
+      title: "切换差异查看器项目",
+      category: "版本控制",
       run: focusRunner({
         files() {
           toggleSelectedFileTreeRow()
@@ -514,8 +514,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.expand",
-      title: "Expand diff viewer item",
-      category: "VCS",
+      title: "展开差异查看器项目",
+      category: "版本控制",
       run: focusRunner({
         files() {
           const highlighted = highlightedFileNode()
@@ -532,8 +532,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.expand_all",
-      title: "Expand all diff viewer folders",
-      category: "VCS",
+      title: "展开差异查看器所有文件夹",
+      category: "版本控制",
       run: focusRunner({
         files() {
           setExpandedFileNodes(allExpandedFileTreeDirectories(fileTree()))
@@ -543,8 +543,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.collapse",
-      title: "Collapse diff viewer item",
-      category: "VCS",
+      title: "折叠差异查看器项目",
+      category: "版本控制",
       run: focusRunner({
         files() {
           const highlighted = highlightedFileNode()
@@ -562,48 +562,48 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.next_hunk",
-      title: "Jump to next diff hunk",
-      category: "VCS",
+      title: "跳到下一个差异块",
+      category: "版本控制",
       run() {
         jumpRelativeHunk(1)
       },
     },
     {
       name: "diff.previous_hunk",
-      title: "Jump to previous diff hunk",
-      category: "VCS",
+      title: "跳到上一个差异块",
+      category: "版本控制",
       run() {
         jumpRelativeHunk(-1)
       },
     },
     {
       name: "diff.next_file",
-      title: "Jump to next diff file",
-      category: "VCS",
+      title: "跳到下一个差异文件",
+      category: "版本控制",
       run() {
         jumpRelativePatchFile(1)
       },
     },
     {
       name: "diff.previous_file",
-      title: "Jump to previous diff file",
-      category: "VCS",
+      title: "跳到上一个差异文件",
+      category: "版本控制",
       run() {
         jumpRelativePatchFile(-1)
       },
     },
     {
       name: "diff.mark_reviewed",
-      title: "Toggle selected diff file reviewed",
-      category: "VCS",
+      title: "切换选中差异文件的已审阅状态",
+      category: "版本控制",
       run() {
         toggleSelectedFileReviewed()
       },
     },
     {
       name: "diff.switch_focus",
-      title: "Switch diff viewer focus",
-      category: "VCS",
+      title: "切换差异查看器焦点",
+      category: "版本控制",
       run() {
         if (!showFileTree()) return
         setFocus((current) => {
@@ -615,8 +615,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.toggle_file_tree",
-      title: "Toggle diff viewer file tree",
-      category: "VCS",
+      title: "切换差异查看器文件树",
+      category: "版本控制",
       run() {
         const next = !fileTreeEnabled()
         if (!next) setFocus("patches")
@@ -626,8 +626,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.single_patch",
-      title: "Toggle single patch view",
-      category: "VCS",
+      title: "切换单个补丁视图",
+      category: "版本控制",
       run() {
         setSelectedHunk(undefined)
         if (!singlePatch()) {
@@ -653,16 +653,16 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.switch_source",
-      title: "Switch diff viewer source",
-      category: "VCS",
+      title: "切换差异查看器来源",
+      category: "版本控制",
       run() {
         openSwitchDiffDialog()
       },
     },
     {
       name: "diff.toggle_view",
-      title: "Toggle diff viewer split or unified view",
-      category: "VCS",
+      title: "切换差异查看器分割/统一视图",
+      category: "版本控制",
       run() {
         if (!splitAvailable()) return
         setSelectedHunk(undefined)
@@ -673,8 +673,8 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     },
     {
       name: "diff.help",
-      title: "Show more diff viewer shortcuts",
-      category: "VCS",
+      title: "显示更多差异查看器快捷键",
+      category: "版本控制",
       run() {
         openHelpDialog()
       },
@@ -685,23 +685,23 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     const vcs = props.api.state.vcs
     return [
       {
-        title: "Working tree",
+        title: "工作区更改",
         value: "git" as const,
-        description: "Show current git changes",
+        description: "显示当前的 git 更改",
       },
       ...(vcs?.branch && vcs.default_branch && vcs.branch !== vcs.default_branch
         ? [
             {
-              title: "Main branch",
+              title: "主分支",
               value: "branch" as const,
-              description: "Show changes compared to main branch",
+              description: "显示与主分支相比的更改",
             },
           ]
         : []),
       {
-        title: "Last turn",
+        title: "上一轮",
         value: "last-turn" as const,
-        description: "Show changes from the last assistant turn",
+        description: "显示上一轮助手的更改",
       },
     ]
   })
@@ -709,7 +709,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
   const openSwitchDiffDialog = () => {
     props.api.ui.dialog.replace(() => (
       <DialogSelect
-        title="Switch source"
+        title="切换来源"
         skipFilter={true}
         renderFilter={false}
         current={mode()}
@@ -737,11 +737,11 @@ function DiffViewer(props: { api: TuiPluginApi }) {
   useBindings(() => ({
     commands,
     bindings: [
-      { key: "j,down", cmd: "diff.down", desc: "Move diff viewer down" },
-      { key: "k,up", cmd: "diff.up", desc: "Move diff viewer up" },
-      { key: "pagedown,ctrl+f", cmd: "diff.page.down", desc: "Page diff viewer down" },
-      { key: "pageup,ctrl+b", cmd: "diff.page.up", desc: "Page diff viewer up" },
-      { key: "m", cmd: "diff.mark_reviewed", desc: "Mark selected file reviewed" },
+      { key: "j,down", cmd: "diff.down", desc: "向下移动差异查看器" },
+      { key: "k,up", cmd: "diff.up", desc: "向上移动差异查看器" },
+      { key: "pagedown,ctrl+f", cmd: "diff.page.down", desc: "差异查看器向下翻页" },
+      { key: "pageup,ctrl+b", cmd: "diff.page.up", desc: "差异查看器向上翻页" },
+      { key: "m", cmd: "diff.mark_reviewed", desc: "标记选中文件已审阅" },
       ...props.api.tuiConfig.keybinds.gather(
         "diff",
         commands.map((command) => command.name),
@@ -753,7 +753,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
     <box position="absolute" zIndex={2500} left={0} top={0} width={dimensions().width} height={dimensions().height}>
       <PanelGroup axis="y" width="100%" height="100%">
         <Panel border="none" flexShrink={0} padding={0} paddingLeft={1}>
-          <text fg={theme().text}>Diff </text>
+          <text fg={theme().text}>差异 </text>
           <text fg={theme().textMuted}>{diffSourceLabel(mode())}</text>
           <box flexGrow={1} />
           <text fg={theme().textMuted}>
@@ -766,19 +766,19 @@ function DiffViewer(props: { api: TuiPluginApi }) {
             <Match when={diff.loading}>
               <Separator axis="x" />
               <box flexGrow={1} paddingLeft={1}>
-                <text fg={theme().textMuted}>Loading diff...</text>
+                <text fg={theme().textMuted}>正在加载差异...</text>
               </box>
             </Match>
             <Match when={!diff.loading && files().length === 0}>
               <Separator axis="x" />
               <box flexGrow={1} paddingLeft={1}>
-                <text fg={theme().textMuted}>No diff!</text>
+                <text fg={theme().textMuted}>没有差异！</text>
               </box>
             </Match>
             <Match when={!diff.loading && diff.error}>
               <Separator axis="x" />
               <box flexGrow={1} paddingLeft={1}>
-                <text fg={theme().error}>Failed to load diff</text>
+                <text fg={theme().error}>加载差异失败</text>
               </box>
             </Match>
             <Match when={!diff.loading}>
@@ -836,7 +836,7 @@ function DiffViewer(props: { api: TuiPluginApi }) {
                             <Separator axis="x" start={showFileTree() ? "edge" : undefined} />
                             <Show
                               when={entry.file.patch}
-                              fallback={<text fg={theme().textMuted}>No patch available for this file.</text>}
+                              fallback={<text fg={theme().textMuted}>此文件没有可用的补丁。</text>}
                             >
                               {(patch) => (
                                 <box border={patchLeftBorder()} borderColor={theme().border}>
@@ -948,63 +948,63 @@ function DiffViewerHelpDialog() {
   const rows = [
     {
       shortcut: () => "q",
-      action: "Close viewer",
-      description: "Quit the diff viewer",
+      action: "关闭查看器",
+      description: "退出差异查看器",
     },
     {
       shortcut: useCommandShortcut("diff.switch_focus"),
-      action: "Focus file tree",
-      description: "Move keyboard focus between the file tree and patch pane",
+      action: "聚焦文件树",
+      description: "在文件树和补丁面板之间移动键盘焦点",
     },
     {
       shortcut: useCommandShortcut("diff.next_hunk"),
-      action: "Next hunk",
-      description: "Jump to the next diff hunk",
+      action: "下一个块",
+      description: "跳到下一个差异块",
     },
     {
       shortcut: useCommandShortcut("diff.previous_hunk"),
-      action: "Previous hunk",
-      description: "Jump to the previous diff hunk",
+      action: "上一个块",
+      description: "跳到上一个差异块",
     },
     {
       shortcut: useCommandShortcut("diff.next_file"),
-      action: "Next file",
-      description: "Select the next changed file in file-tree order",
+      action: "下一个文件",
+      description: "按文件树顺序选择下一个变更文件",
     },
     {
       shortcut: useCommandShortcut("diff.previous_file"),
-      action: "Previous file",
-      description: "Select the previous changed file in file-tree order",
+      action: "上一个文件",
+      description: "按文件树顺序选择上一个变更文件",
     },
     {
       shortcut: useCommandShortcut("diff.toggle_file_tree"),
-      action: "Toggle file tree",
-      description: "Show or hide the file tree sidebar",
+      action: "切换文件树",
+      description: "显示或隐藏文件树侧边栏",
     },
     {
       shortcut: useCommandShortcut("diff.single_patch"),
-      action: "Toggle patches",
-      description: "Switch between one selected patch and all patches",
+      action: "切换补丁",
+      description: "在单个补丁和所有补丁之间切换",
     },
     {
       shortcut: useCommandShortcut("diff.switch_source"),
-      action: "Switch source",
-      description: "Choose working tree, main branch, or last-turn changes",
+      action: "切换来源",
+      description: "选择工作区更改、主分支或上一轮更改",
     },
     {
       shortcut: useCommandShortcut("diff.toggle_view"),
-      action: "Toggle view",
-      description: "Switch between split and unified diff layout",
+      action: "切换视图",
+      description: "在分割视图和统一视图布局之间切换",
     },
     {
       shortcut: useCommandShortcut("diff.expand_all"),
-      action: "Expand all folders",
-      description: "Open every folder in the file tree",
+      action: "展开所有文件夹",
+      description: "打开文件树中的每个文件夹",
     },
     {
       shortcut: useCommandShortcut("diff.mark_reviewed"),
-      action: "Mark reviewed",
-      description: "Toggle reviewed state for the selected file",
+      action: "标记已审阅",
+      description: "切换选中文件的已审阅状态",
     },
   ]
 
@@ -1012,18 +1012,18 @@ function DiffViewerHelpDialog() {
     <box paddingLeft={2} paddingRight={2} paddingBottom={1} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Diff shortcuts
+          Diff 快捷键
         </text>
         <text fg={theme.textMuted}>esc</text>
       </box>
       <box flexDirection="row">
         <text fg={theme.textMuted} width={5} wrapMode="none">
-          Key
+          按键
         </text>
         <text fg={theme.textMuted} width={22} wrapMode="none">
-          Action
+          操作
         </text>
-        <text fg={theme.textMuted}>Description</text>
+        <text fg={theme.textMuted}>描述</text>
       </box>
       <For each={rows}>
         {(row) => (
@@ -1054,9 +1054,9 @@ const tui: TuiPlugin = async (api) => {
     commands: [
       {
         name: "diff.open",
-        title: "Open diff viewer",
+        title: "打开差异查看器",
         slashName: "diff",
-        category: "VCS",
+        category: "版本控制",
         namespace: "palette",
         run() {
           api.route.navigate(ROUTE, {

--- a/packages/tui/src/feature-plugins/system/notifications.ts
+++ b/packages/tui/src/feature-plugins/system/notifications.ts
@@ -18,12 +18,12 @@ function notify(api: TuiPluginApi, sessionID: string | undefined, message: strin
 }
 
 function sessionErrorMessage(error: SessionError) {
-  if (error?.name === "MessageAbortedError") return "Session aborted"
+  if (error?.name === "MessageAbortedError") return "会话已中止"
   const data = error?.data
   if (data && typeof data === "object" && "message" in data && data.message === "SSE read timed out") {
-    return "Model stopped responding"
+    return "模型停止响应"
   }
-  return "Session error"
+  return "会话错误"
 }
 
 const tui: TuiPlugin = async (api) => {
@@ -35,7 +35,7 @@ const tui: TuiPlugin = async (api) => {
   api.event.on("question.asked", (event) => {
     if (questions.has(event.properties.id)) return
     questions.add(event.properties.id)
-    notify(api, event.properties.sessionID, "Question needs input", "question")
+    notify(api, event.properties.sessionID, "问题需要输入", "question")
   })
 
   api.event.on("question.replied", (event) => {
@@ -49,7 +49,7 @@ const tui: TuiPlugin = async (api) => {
   api.event.on("permission.asked", (event) => {
     if (permissions.has(event.properties.id)) return
     permissions.add(event.properties.id)
-    notify(api, event.properties.sessionID, "Permission needs input", "permission")
+    notify(api, event.properties.sessionID, "权限需要输入", "permission")
   })
 
   api.event.on("permission.replied", (event) => {
@@ -74,7 +74,7 @@ const tui: TuiPlugin = async (api) => {
     }
 
     const session = api.state.session.get(sessionID)
-    notify(api, sessionID, "Session done", session?.parentID ? "subagent_done" : "done")
+    notify(api, sessionID, "会话完成", session?.parentID ? "subagent_done" : "done")
   })
 
   api.event.on("session.error", (event) => {

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -27,8 +27,8 @@ function source(spec: string) {
 
 function meta(item: TuiPluginStatus, width: number) {
   if (item.source === "internal") {
-    if (width >= 120) return "Built-in plugin"
-    return "Built-in"
+    if (width >= 120) return "内置插件"
+    return "内置"
   }
   const next = source(item.spec)
   if (next) return next
@@ -41,23 +41,23 @@ function Install(props: { api: TuiPluginApi }) {
 
   useBindings(() => ({
     enabled: !busy(),
-    bindings: [{ key: "tab", desc: "Toggle install scope", group: "Plugins", cmd: () => setGlobal((value) => !value) }],
+    bindings: [{ key: "tab", desc: "切换安装范围", group: "插件", cmd: () => setGlobal((value) => !value) }],
   }))
 
   return (
     <props.api.ui.DialogPrompt
-      title="Install plugin"
-      placeholder="npm package name"
+      title="安装插件"
+      placeholder="npm 包名"
       busy={busy()}
-      busyText="Installing plugin..."
+      busyText="正在安装插件..."
       description={() => (
         <box flexDirection="row" gap={1}>
-          <text fg={props.api.theme.current.textMuted}>scope:</text>
+          <text fg={props.api.theme.current.textMuted}>范围：</text>
           <text fg={busy() ? props.api.theme.current.textMuted : props.api.theme.current.text}>
-            {global() ? "global" : "local"}
+            {global() ? "全局" : "本地"}
           </text>
           <Show when={!busy()}>
-            <text fg={props.api.theme.current.textMuted}>(tab toggle)</text>
+            <text fg={props.api.theme.current.textMuted}>(tab 切换)</text>
           </Show>
         </box>
       )}
@@ -67,7 +67,7 @@ function Install(props: { api: TuiPluginApi }) {
         if (!mod) {
           props.api.ui.toast({
             variant: "error",
-            message: "Plugin package name is required",
+            message: "插件包名是必需的",
           })
           return
         }
@@ -84,7 +84,7 @@ function Install(props: { api: TuiPluginApi }) {
               if (out.missing) {
                 props.api.ui.toast({
                   variant: "info",
-                  message: "Check npm registry/auth settings and try again.",
+                  message: "请检查 npm 注册表/认证设置后重试。",
                 })
               }
               show(props.api)
@@ -93,12 +93,12 @@ function Install(props: { api: TuiPluginApi }) {
 
             props.api.ui.toast({
               variant: "success",
-              message: `Installed ${mod} (${global() ? "global" : "local"}: ${out.dir})`,
+              message: `已安装 ${mod}（${global() ? "全局" : "本地"}：${out.dir}）`,
             })
             if (!out.tui) {
               props.api.ui.toast({
                 variant: "info",
-                message: "Package has no TUI target to load in this app.",
+                message: "该包没有可在此应用中加载的 TUI 目标。",
               })
               show(props.api)
               return
@@ -108,7 +108,7 @@ function Install(props: { api: TuiPluginApi }) {
               if (!ok) {
                 props.api.ui.toast({
                   variant: "warning",
-                  message: "Installed plugin, but runtime load failed. See console/logs; restart TUI to retry.",
+                  message: "插件已安装，但运行时加载失败。请查看控制台/日志；重启 TUI 重试。",
                 })
                 show(props.api)
                 return
@@ -116,7 +116,7 @@ function Install(props: { api: TuiPluginApi }) {
 
               props.api.ui.toast({
                 variant: "success",
-                message: `Loaded ${mod} in current session.`,
+                message: `已在当前会话中加载 ${mod}。`,
               })
               show(props.api)
             })
@@ -136,7 +136,7 @@ function row(api: TuiPluginApi, item: TuiPluginStatus, width: number): DialogSel
   return {
     title: item.id,
     value: item.id,
-    category: item.source === "internal" ? "Internal" : "External",
+    category: item.source === "internal" ? "内置" : "外部",
     description: meta(item, width),
     footer: state(api, item),
     disabled: item.id === id,
@@ -188,7 +188,7 @@ function View(props: { api: TuiPluginApi }) {
         if (!ok) {
           props.api.ui.toast({
             variant: "error",
-            message: `Failed to update plugin ${item.id}`,
+            message: `更新插件 ${item.id} 失败`,
           })
         }
         setList(props.api.plugins.list())
@@ -200,13 +200,13 @@ function View(props: { api: TuiPluginApi }) {
 
   return (
     <DialogSelect
-      title="Plugins"
+      title="插件"
       options={rows()}
       current={cur()}
       onMove={(item) => setCur(item.value)}
       actions={[
         {
-          title: "toggle",
+          title: "切换",
           command: "plugins.toggle",
           hidden: lock(),
           onTrigger: (item) => {
@@ -215,7 +215,7 @@ function View(props: { api: TuiPluginApi }) {
           },
         },
         {
-          title: "install",
+          title: "安装",
           command: "dialog.plugins.install",
           hidden: lock(),
           onTrigger: () => {
@@ -240,8 +240,8 @@ const tui: TuiPlugin = async (api) => {
     commands: [
       {
         name: "plugins.list",
-        title: "Plugins",
-        category: "System",
+        title: "插件",
+        category: "系统",
         namespace: "palette",
         run() {
           show(api)
@@ -249,8 +249,8 @@ const tui: TuiPlugin = async (api) => {
       },
       {
         name: "plugins.install",
-        title: "Install plugin",
-        category: "System",
+        title: "安装插件",
+        category: "系统",
         namespace: "palette",
         run() {
           showInstall(api)

--- a/packages/tui/src/feature-plugins/system/which-key.tsx
+++ b/packages/tui/src/feature-plugins/system/which-key.tsx
@@ -175,7 +175,7 @@ function HomeHint(props: { api: TuiPluginApi }) {
   return (
     <box width="100%" maxWidth={75} alignItems="center" paddingTop={1} flexShrink={0}>
       <text fg={look().muted} wrapMode="none">
-        Show keyboard shortcuts with <span style={{ fg: look().subtle }}>{trigger() || command.toggle}</span>
+        使用 <span style={{ fg: look().subtle }}>{trigger() || command.toggle}</span> 显示键盘快捷键
       </text>
     </box>
   )
@@ -289,72 +289,72 @@ function WhichKeyPanel(props: {
     commands: [
       {
         name: command.groupPrevious,
-        title: "Previous key binding group",
-        desc: "Show the previous which-key group",
-        category: "System",
+        title: "上一个按键绑定组",
+        desc: "显示上一个 which-key 分组",
+        category: "系统",
         run() {
           moveGroup(-1)
         },
       },
       {
         name: command.groupNext,
-        title: "Next key binding group",
-        desc: "Show the next which-key group",
-        category: "System",
+        title: "下一个按键绑定组",
+        desc: "显示下一个 which-key 分组",
+        category: "系统",
         run() {
           moveGroup(1)
         },
       },
       {
         name: command.scrollUp,
-        title: "Scroll key bindings up",
-        desc: "Scroll the which-key panel up",
-        category: "System",
+        title: "向上滚动按键绑定",
+        desc: "向上滚动 which-key 面板",
+        category: "系统",
         run() {
           scroll(-columns())
         },
       },
       {
         name: command.scrollDown,
-        title: "Scroll key bindings down",
-        desc: "Scroll the which-key panel down",
-        category: "System",
+        title: "向下滚动按键绑定",
+        desc: "向下滚动 which-key 面板",
+        category: "系统",
         run() {
           scroll(columns())
         },
       },
       {
         name: command.pageUp,
-        title: "Page key bindings up",
-        desc: "Page the which-key panel up",
-        category: "System",
+        title: "按键绑定向上翻页",
+        desc: "which-key 面板向上翻页",
+        category: "系统",
         run() {
           scroll(-pageSize())
         },
       },
       {
         name: command.pageDown,
-        title: "Page key bindings down",
-        desc: "Page the which-key panel down",
-        category: "System",
+        title: "按键绑定向下翻页",
+        desc: "which-key 面板向下翻页",
+        category: "系统",
         run() {
           scroll(pageSize())
         },
       },
       {
         name: command.home,
-        title: "First key binding",
-        desc: "Jump to the first which-key binding",
-        category: "System",
+        title: "第一个按键绑定",
+        desc: "跳到第一个 which-key 绑定",
+        category: "系统",
         run() {
           setOffset(0)
         },
       },
       {
         name: command.end,
-        title: "Last key binding",
-        desc: "Jump to the last which-key binding",
-        category: "System",
+        title: "最后一个按键绑定",
+        desc: "跳到最后一个 which-key 绑定",
+        category: "系统",
         run() {
           setOffset(maxOffset())
         },
@@ -455,7 +455,7 @@ function WhichKeyPanel(props: {
           <box height={TAB_CONTENT_GAP} flexShrink={0} />
         </Show>
         <box height={rows()} flexShrink={0} flexDirection="column">
-          <Show when={shown().length > 0} fallback={<text fg={look().muted}>No reachable bindings</text>}>
+          <Show when={shown().length > 0} fallback={<text fg={look().muted}>没有可用的按键绑定</text>}>
             <For each={rowIndexes()}>
               {(row) => (
                 <box width="100%" flexDirection="row" justifyContent="center" gap={COLUMN_GAP}>
@@ -514,7 +514,7 @@ function WhichKeyPanel(props: {
           <box width="100%" flexDirection="row" justifyContent="space-between" flexShrink={0}>
             <box>
               <text fg={look().text} wrapMode="none">
-                toggle <span style={{ fg: look().subtle }}>{trigger() || command.toggle}</span>
+                切换 <span style={{ fg: look().subtle }}>{trigger() || command.toggle}</span>
               </text>
             </box>
             <box>
@@ -539,18 +539,18 @@ const tui: TuiPlugin = async (api) => {
     commands: [
       {
         name: command.toggle,
-        title: "Show key bindings",
-        desc: "Toggle which-key overlay",
-        category: "System",
+        title: "显示按键绑定",
+        desc: "切换 which-key 覆盖层",
+        category: "系统",
         run() {
           setPinned((value) => !value)
         },
       },
       {
         name: command.toggleLayout,
-        title: "Toggle key bindings layout",
-        desc: "Switch which-key between dock and overlay mode",
-        category: "System",
+        title: "切换按键绑定布局",
+        desc: "在停靠和覆盖层模式之间切换 which-key",
+        category: "系统",
         run() {
           setMode((value) => {
             const next = value === "dock" ? "overlay" : "dock"
@@ -561,9 +561,9 @@ const tui: TuiPlugin = async (api) => {
       },
       {
         name: command.togglePending,
-        title: "Toggle pending key preview",
-        desc: "Automatically show which-key for pending key sequences in overlay mode",
-        category: "System",
+        title: "切换待定按键预览",
+        desc: "在覆盖层模式中自动为待定按键序列显示 which-key",
+        category: "系统",
         run() {
           setPendingPreview((value) => {
             api.kv.set(KV_PENDING_PREVIEW, !value)

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -15,7 +15,11 @@ import { HomeSessionDestinationProvider } from "./home/session-destination"
 
 let once = false
 const placeholder = {
-  normal: ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"],
+  normal: [
+    "修复代码库中的一个 TODO",
+    "这个项目的技术栈是什么？",
+    "修复失败的测试",
+  ],
   shell: ["ls -la", "git status", "pwd"],
 }
 

--- a/packages/tui/src/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/tui/src/routes/session/dialog-fork-from-timeline.tsx
@@ -22,7 +22,7 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
   const options = createMemo((): DialogSelectOption<string | undefined>[] => {
     const messages = sync.data.message[props.sessionID] ?? []
     const fullSession = {
-      title: "Full session",
+      title: "完整会话",
       value: undefined,
       onSelect: async (dialog: DialogContext) => {
         const forked = await sdk.client.session.fork({ sessionID: props.sessionID })
@@ -72,5 +72,5 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
     return [fullSession, ...result.reverse()]
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Fork session" options={options()} />
+  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="分叉会话" options={options()} />
 }

--- a/packages/tui/src/routes/session/dialog-message.tsx
+++ b/packages/tui/src/routes/session/dialog-message.tsx
@@ -20,12 +20,12 @@ export function DialogMessage(props: {
 
   return (
     <DialogSelect
-      title="Message Actions"
+      title="消息操作"
       options={[
         {
-          title: "Revert",
+          title: "撤销",
           value: "session.revert",
-          description: "undo messages and file changes",
+          description: "撤销消息和文件修改",
           onSelect: (dialog) => {
             const msg = message()
             if (!msg) return
@@ -54,9 +54,9 @@ export function DialogMessage(props: {
           },
         },
         {
-          title: "Copy",
+          title: "复制",
           value: "message.copy",
-          description: "message text to clipboard",
+          description: "将消息文本复制到剪贴板",
           onSelect: async (dialog) => {
             const msg = message()
             if (!msg) return
@@ -74,9 +74,9 @@ export function DialogMessage(props: {
           },
         },
         {
-          title: "Fork",
+          title: "分叉",
           value: "session.fork",
-          description: "create a new session",
+          description: "创建新会话",
           onSelect: async (dialog) => {
             const result = await sdk.client.session.fork({
               sessionID: props.sessionID,

--- a/packages/tui/src/routes/session/dialog-subagent.tsx
+++ b/packages/tui/src/routes/session/dialog-subagent.tsx
@@ -6,12 +6,12 @@ export function DialogSubagent(props: { sessionID: string }) {
 
   return (
     <DialogSelect
-      title="Subagent Actions"
+      title="子代理操作"
       options={[
         {
-          title: "Open",
+          title: "打开",
           value: "subagent.view",
-          description: "the subagent's session",
+          description: "该子代理的会话",
           onSelect: (dialog) => {
             route.navigate({
               type: "session",

--- a/packages/tui/src/routes/session/dialog-timeline.tsx
+++ b/packages/tui/src/routes/session/dialog-timeline.tsx
@@ -43,5 +43,5 @@ export function DialogTimeline(props: {
     return result
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Timeline" options={options()} />
+  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="时间线" options={options()} />
 }

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -56,14 +56,13 @@ export function Footer() {
         <Switch>
           <Match when={store.welcome}>
             <text fg={theme.text}>
-              Get started <span style={{ fg: theme.textMuted }}>/connect</span>
+              开始使用 <span style={{ fg: theme.textMuted }}>/connect</span>
             </text>
           </Match>
           <Match when={connected()}>
             <Show when={permissions().length > 0}>
               <text fg={theme.warning}>
-                <span style={{ fg: theme.warning }}>△</span> {permissions().length} Permission
-                {permissions().length > 1 ? "s" : ""}
+                <span style={{ fg: theme.warning }}>△</span> {permissions().length} 个权限请求
               </text>
             </Show>
             <text fg={theme.text}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -457,10 +457,10 @@ export function Session() {
 
   const sessionCommandList = createMemo(() => [
     {
-      title: session()?.share?.url ? "Copy share link" : "Share session",
+      title: session()?.share?.url ? "复制分享链接" : "分享会话",
       value: "session.share",
       suggested: route.type === "session",
-      category: "Session",
+      category: "会话",
       enabled: sync.data.config.share !== "disabled",
       slash: {
         name: "share",
@@ -469,8 +469,8 @@ export function Session() {
         const copy = (url: string) =>
           clipboard
             .write?.(url)
-            .then(() => toast.show({ message: "Share URL copied to clipboard!", variant: "success" }))
-            .catch(() => toast.show({ message: "Failed to copy URL to clipboard", variant: "error" }))
+            .then(() => toast.show({ message: "分享链接已复制到剪贴板！", variant: "success" }))
+            .catch(() => toast.show({ message: "复制链接到剪贴板失败", variant: "error" }))
         const url = session()?.share?.url
         if (url) {
           await copy(url)
@@ -478,7 +478,7 @@ export function Session() {
           return
         }
         if (!kv.get("share_consent", false)) {
-          const ok = await DialogConfirm.show(dialog, "Share Session", "Are you sure you want to share it?")
+          const ok = await DialogConfirm.show(dialog, "分享会话", "你确定要分享它吗？")
           if (ok !== true) return
           kv.set("share_consent", true)
         }
@@ -489,7 +489,7 @@ export function Session() {
           .then((res) => copy(res.data!.share!.url))
           .catch((error) => {
             toast.show({
-              message: error instanceof Error ? error.message : "Failed to share session",
+              message: error instanceof Error ? error.message : "分享会话失败",
               variant: "error",
             })
           })
@@ -497,9 +497,9 @@ export function Session() {
       },
     },
     {
-      title: "Rename session",
+      title: "重命名会话",
       value: "session.rename",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "rename",
       },
@@ -508,9 +508,9 @@ export function Session() {
       },
     },
     {
-      title: "Jump to message",
+      title: "跳转到消息",
       value: "session.timeline",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "timeline",
       },
@@ -530,9 +530,9 @@ export function Session() {
       },
     },
     {
-      title: "Fork session",
+      title: "分叉会话",
       value: "session.fork",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "fork",
       },
@@ -552,9 +552,9 @@ export function Session() {
       },
     },
     {
-      title: "Compact session",
+      title: "压缩会话",
       value: "session.compact",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "compact",
         aliases: ["summarize"],
@@ -564,7 +564,7 @@ export function Session() {
         if (!selectedModel) {
           toast.show({
             variant: "warning",
-            message: "Connect a provider to summarize this session",
+            message: "连接提供商以总结此会话",
             duration: 3000,
           })
           return
@@ -578,9 +578,9 @@ export function Session() {
       },
     },
     {
-      title: "Unshare session",
+      title: "取消分享会话",
       value: "session.unshare",
-      category: "Session",
+      category: "会话",
       enabled: !!session()?.share?.url,
       slash: {
         name: "unshare",
@@ -590,10 +590,10 @@ export function Session() {
           .unshare({
             sessionID: route.sessionID,
           })
-          .then(() => toast.show({ message: "Session unshared successfully", variant: "success" }))
+          .then(() => toast.show({ message: "会话已成功取消分享", variant: "success" }))
           .catch((error) => {
             toast.show({
-              message: error instanceof Error ? error.message : "Failed to unshare session",
+              message: error instanceof Error ? error.message : "取消分享会话失败",
               variant: "error",
             })
           })
@@ -601,9 +601,9 @@ export function Session() {
       },
     },
     {
-      title: "Undo previous message",
+      title: "撤销上一条消息",
       value: "session.undo",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "undo",
       },
@@ -638,9 +638,9 @@ export function Session() {
       },
     },
     {
-      title: "Redo",
+      title: "重做",
       value: "session.redo",
-      category: "Session",
+      category: "会话",
       enabled: !!session()?.revert?.messageID,
       slash: {
         name: "redo",
@@ -664,9 +664,9 @@ export function Session() {
       },
     },
     {
-      title: sidebarVisible() ? "Hide sidebar" : "Show sidebar",
+      title: sidebarVisible() ? "隐藏侧边栏" : "显示侧边栏",
       value: "session.sidebar.toggle",
-      category: "Session",
+      category: "会话",
       run: () => {
         batch(() => {
           const isVisible = sidebarVisible()
@@ -677,18 +677,18 @@ export function Session() {
       },
     },
     {
-      title: conceal() ? "Disable code concealment" : "Enable code concealment",
+      title: conceal() ? "禁用代码隐藏" : "启用代码隐藏",
       value: "session.toggle.conceal",
-      category: "Session",
+      category: "会话",
       run: () => {
         setConceal((prev) => !prev)
         dialog.clear()
       },
     },
     {
-      title: showTimestamps() ? "Hide timestamps" : "Show timestamps",
+      title: showTimestamps() ? "隐藏时间戳" : "显示时间戳",
       value: "session.toggle.timestamps",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "timestamps",
         aliases: ["toggle-timestamps"],
@@ -701,11 +701,11 @@ export function Session() {
     {
       title: (() => {
         const next = nextThinkingMode(thinkingMode())
-        if (next === "hide") return "Collapse thinking"
-        return "Expand thinking"
+        if (next === "hide") return "折叠思考过程"
+        return "展开思考过程"
       })(),
       value: "session.toggle.thinking",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "thinking",
         aliases: ["toggle-thinking"],
@@ -716,36 +716,36 @@ export function Session() {
       },
     },
     {
-      title: showDetails() ? "Hide tool details" : "Show tool details",
+      title: showDetails() ? "隐藏工具详情" : "显示工具详情",
       value: "session.toggle.actions",
-      category: "Session",
+      category: "会话",
       run: () => {
         setShowDetails((prev) => !prev)
         dialog.clear()
       },
     },
     {
-      title: "Toggle session scrollbar",
+      title: "切换会话滚动条",
       value: "session.toggle.scrollbar",
-      category: "Session",
+      category: "会话",
       run: () => {
         setShowScrollbar((prev) => !prev)
         dialog.clear()
       },
     },
     {
-      title: showGenericToolOutput() ? "Hide generic tool output" : "Show generic tool output",
+      title: showGenericToolOutput() ? "隐藏通用工具输出" : "显示通用工具输出",
       value: "session.toggle.generic_tool_output",
-      category: "Session",
+      category: "会话",
       run: () => {
         setShowGenericToolOutput((prev) => !prev)
         dialog.clear()
       },
     },
     {
-      title: "Page up",
+      title: "向上翻页",
       value: "session.page.up",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 2)
@@ -753,9 +753,9 @@ export function Session() {
       },
     },
     {
-      title: "Page down",
+      title: "向下翻页",
       value: "session.page.down",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(scroll.height / 2)
@@ -763,9 +763,9 @@ export function Session() {
       },
     },
     {
-      title: "Line up",
+      title: "向上移动一行",
       value: "session.line.up",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(-1)
@@ -773,9 +773,9 @@ export function Session() {
       },
     },
     {
-      title: "Line down",
+      title: "向下移动一行",
       value: "session.line.down",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(1)
@@ -783,9 +783,9 @@ export function Session() {
       },
     },
     {
-      title: "Half page up",
+      title: "向上翻半页",
       value: "session.half.page.up",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 4)
@@ -793,9 +793,9 @@ export function Session() {
       },
     },
     {
-      title: "Half page down",
+      title: "向下翻半页",
       value: "session.half.page.down",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollBy(scroll.height / 4)
@@ -803,9 +803,9 @@ export function Session() {
       },
     },
     {
-      title: "First message",
+      title: "第一条消息",
       value: "session.first",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollTo(0)
@@ -813,9 +813,9 @@ export function Session() {
       },
     },
     {
-      title: "Last message",
+      title: "最后一条消息",
       value: "session.last",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         scroll.scrollTo(scroll.scrollHeight)
@@ -823,9 +823,9 @@ export function Session() {
       },
     },
     {
-      title: "Jump to last user message",
+      title: "跳到最后一条用户消息",
       value: "session.messages_last_user",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         const messages = sync.data.message[route.sessionID]
@@ -854,30 +854,30 @@ export function Session() {
       },
     },
     {
-      title: "Next message",
+      title: "下一条消息",
       value: "session.message.next",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => scrollToMessage("next", dialog),
     },
     {
-      title: "Previous message",
+      title: "上一条消息",
       value: "session.message.previous",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => scrollToMessage("prev", dialog),
     },
     {
-      title: "Copy last assistant message",
+      title: "复制最后一条助手消息",
       value: "messages.copy",
-      category: "Session",
+      category: "会话",
       run: () => {
         const revertID = session()?.revert?.messageID
         const lastAssistantMessage = messages().findLast(
           (msg) => msg.role === "assistant" && (!revertID || msg.id < revertID),
         )
         if (!lastAssistantMessage) {
-          toast.show({ message: "No assistant messages found", variant: "error" })
+          toast.show({ message: "未找到助手消息", variant: "error" })
           dialog.clear()
           return
         }
@@ -885,7 +885,7 @@ export function Session() {
         const parts = sync.data.part[lastAssistantMessage.id] ?? []
         const textParts = parts.filter((part) => part.type === "text")
         if (textParts.length === 0) {
-          toast.show({ message: "No text parts found in last assistant message", variant: "error" })
+          toast.show({ message: "最后一条助手消息中没有文本部分", variant: "error" })
           dialog.clear()
           return
         }
@@ -896,7 +896,7 @@ export function Session() {
           .trim()
         if (!text) {
           toast.show({
-            message: "No text content found in last assistant message",
+            message: "最后一条助手消息中没有文本内容",
             variant: "error",
           })
           dialog.clear()
@@ -905,15 +905,15 @@ export function Session() {
 
         clipboard
           .write?.(text)
-          .then(() => toast.show({ message: "Message copied to clipboard!", variant: "success" }))
-          .catch(() => toast.show({ message: "Failed to copy to clipboard", variant: "error" }))
+          .then(() => toast.show({ message: "消息已复制到剪贴板！", variant: "success" }))
+          .catch(() => toast.show({ message: "复制到剪贴板失败", variant: "error" }))
         dialog.clear()
       },
     },
     {
-      title: "Copy session transcript",
+      title: "复制会话记录",
       value: "session.copy",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "copy",
       },
@@ -933,17 +933,17 @@ export function Session() {
             },
           )
           await clipboard.write?.(transcript)
-          toast.show({ message: "Session transcript copied to clipboard!", variant: "success" })
+          toast.show({ message: "会话记录已复制到剪贴板！", variant: "success" })
         } catch {
-          toast.show({ message: "Failed to copy session transcript", variant: "error" })
+          toast.show({ message: "复制会话记录失败", variant: "error" })
         }
         dialog.clear()
       },
     },
     {
-      title: "Export session transcript",
+      title: "导出会话记录",
       value: "session.export",
-      category: "Session",
+      category: "会话",
       slash: {
         name: "export",
       },
@@ -1007,18 +1007,18 @@ export function Session() {
               await writeExport(filepath, result)
             }
 
-            toast.show({ message: `Session exported to ${filename}`, variant: "success" })
+            toast.show({ message: `会话已导出到 ${filename}`, variant: "success" })
           }
         } catch {
-          toast.show({ message: "Failed to export session", variant: "error" })
+          toast.show({ message: "导出会话失败", variant: "error" })
         }
         dialog.clear()
       },
     },
     {
-      title: "Background subagents",
+      title: "后台子代理",
       value: "session.background",
-      category: "Session",
+      category: "会话",
       hidden: true,
       enabled: foregroundTasks().length > 0,
       run: () => {
@@ -1030,9 +1030,9 @@ export function Session() {
       },
     },
     {
-      title: "Go to child session",
+      title: "转到子会话",
       value: "session.child.first",
-      category: "Session",
+      category: "会话",
       hidden: true,
       run: () => {
         dialog.clear()
@@ -1040,9 +1040,9 @@ export function Session() {
       },
     },
     {
-      title: "Go to parent session",
+      title: "转到父会话",
       value: "session.parent",
-      category: "Session",
+      category: "会话",
       hidden: true,
       enabled: !!session()?.parentID,
       run: childSessionHandler(() => {
@@ -1057,9 +1057,9 @@ export function Session() {
       }),
     },
     {
-      title: "Next child session",
+      title: "下一个子会话",
       value: "session.child.next",
-      category: "Session",
+      category: "会话",
       hidden: true,
       enabled: !!session()?.parentID,
       run: childSessionHandler(() => {
@@ -1068,9 +1068,9 @@ export function Session() {
       }),
     },
     {
-      title: "Previous child session",
+      title: "上一个子会话",
       value: "session.child.previous",
-      category: "Session",
+      category: "会话",
       hidden: true,
       enabled: !!session()?.parentID,
       run: childSessionHandler(() => {
@@ -1196,8 +1196,8 @@ export function Session() {
                           const handleUnrevert = async () => {
                             const confirmed = await DialogConfirm.show(
                               dialog,
-                              "Confirm Redo",
-                              "Are you sure you want to restore the reverted messages?",
+                              "确认重做",
+                              "你确定要恢复被撤销的消息吗？",
                             )
                             if (confirmed) {
                               keymap.dispatchCommand("session.redo")
@@ -1221,9 +1221,9 @@ export function Session() {
                                 paddingLeft={2}
                                 backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
                               >
-                                <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
+                                <text fg={theme.textMuted}>{revert()!.reverted.length} 条消息已撤销</text>
                                 <text fg={theme.textMuted}>
-                                  <span style={{ fg: theme.text }}>{redoShortcut()}</span> or /redo to restore
+                                  <span style={{ fg: theme.text }}>{redoShortcut()}</span> 或 /redo 以恢复
                                 </text>
                                 <Show when={revert()!.diffFiles?.length}>
                                   <box marginTop={1}>
@@ -1649,7 +1649,7 @@ function ReasoningHeader(props: {
     <Switch>
       <Match when={!props.done}>
         <box flexDirection="row">
-          <Spinner color={fg()}>{props.title ? "Thinking: " + props.title : "Thinking"}</Spinner>
+          <Spinner color={fg()}>{props.title ? "思考中： " + props.title : "思考中"}</Spinner>
         </box>
       </Match>
       <Match when={true}>
@@ -1657,7 +1657,7 @@ function ReasoningHeader(props: {
           <Show when={props.toggleable}>
             <span>{props.open ? "- " : "+ "}</span>
           </Show>
-          <span>Thought</span>
+          <span>思考</span>
           <Show when={props.title || props.duration}>
             <span>: </span>
           </Show>
@@ -1805,7 +1805,7 @@ function GenericTool(props: ToolProps) {
     <Show
       when={props.output && ctx.showGenericToolOutput()}
       fallback={
-        <InlineTool icon="⚙" pending="Writing command..." complete={true} part={props.part}>
+        <InlineTool icon="⚙" pending="正在写入命令..." complete={true} part={props.part}>
           {props.tool} {input(props.input)}
         </InlineTool>
       }
@@ -1818,7 +1818,7 @@ function GenericTool(props: ToolProps) {
         <box gap={1}>
           <text fg={theme.text}>{limited()}</text>
           <Show when={collapsed().overflow}>
-            <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+            <text fg={theme.textMuted}>{expanded() ? "点击折叠" : "点击展开"}</text>
           </Show>
         </box>
       </BlockTool>
@@ -2081,13 +2081,13 @@ function Shell(props: ToolProps) {
               <text fg={theme.text}>{limited()}</text>
             </Show>
             <Show when={collapsed().overflow}>
-              <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+              <text fg={theme.textMuted}>{expanded() ? "点击折叠" : "点击展开"}</text>
             </Show>
           </box>
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="$" pending="Writing command..." complete={stringValue(props.input.command)} part={props.part}>
+        <InlineTool icon="$" pending="正在写入命令..." complete={stringValue(props.input.command)} part={props.part}>
           {stringValue(props.input.command)}
         </InlineTool>
       </Match>

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -80,7 +80,7 @@ function EditBody(props: { request: PermissionRequest }) {
       </Show>
       <Show when={!diff()}>
         <box paddingLeft={1}>
-          <text fg={theme.textMuted}>No diff provided</text>
+          <text fg={theme.textMuted}>未提供差异内容</text>
         </box>
       </Show>
     </box>
@@ -137,15 +137,15 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
     <Switch>
       <Match when={store.stage === "always"}>
         <Prompt
-          title="Always allow"
+          title="始终允许"
           body={
             <Switch>
               <Match when={props.request.always.length === 1 && props.request.always[0] === "*"}>
-                <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
+                <TextBody title={"这将允许 " + props.request.permission + "，直到 OpenCode 重新启动。"} />
               </Match>
               <Match when={true}>
                 <box paddingLeft={1} gap={1}>
-                  <text fg={theme.textMuted}>This will allow the following patterns until OpenCode is restarted</text>
+                  <text fg={theme.textMuted}>这将允许以下规则，直到 OpenCode 重新启动</text>
                   <box>
                     <For each={props.request.always}>
                       {(pattern) => (
@@ -160,7 +160,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               </Match>
             </Switch>
           }
-          options={{ confirm: "Confirm", cancel: "Cancel" }}
+          options={{ confirm: "确认", cancel: "取消" }}
           escapeKey="cancel"
           onSelect={(option) => {
             setStore("stage", "permission")
@@ -201,7 +201,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               const filepath = typeof raw === "string" ? raw : ""
               return {
                 icon: "→",
-                title: `Edit ${pathFormatter.format(filepath)}`,
+                title: `编辑 ${pathFormatter.format(filepath)}`,
                 body: <EditBody request={props.request} />,
               }
             }
@@ -211,11 +211,11 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               const filePath = typeof raw === "string" ? raw : ""
               return {
                 icon: "→",
-                title: `Read ${pathFormatter.format(filePath)}`,
+                title: `读取 ${pathFormatter.format(filePath)}`,
                 body: (
                   <Show when={filePath}>
                     <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Path: " + pathFormatter.format(filePath)}</text>
+                      <text fg={theme.textMuted}>{"路径: " + pathFormatter.format(filePath)}</text>
                     </box>
                   </Show>
                 ),
@@ -230,7 +230,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 body: (
                   <Show when={pattern}>
                     <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Pattern: " + pattern}</text>
+                      <text fg={theme.textMuted}>{"模式: " + pattern}</text>
                     </box>
                   </Show>
                 ),
@@ -245,7 +245,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 body: (
                   <Show when={pattern}>
                     <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Pattern: " + pattern}</text>
+                      <text fg={theme.textMuted}>{"模式: " + pattern}</text>
                     </box>
                   </Show>
                 ),
@@ -257,11 +257,11 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               const dir = typeof raw === "string" ? raw : ""
               return {
                 icon: "→",
-                title: `List ${pathFormatter.format(dir)}`,
+                title: `列出 ${pathFormatter.format(dir)}`,
                 body: (
                   <Show when={dir}>
                     <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Path: " + pathFormatter.format(dir)}</text>
+                      <text fg={theme.textMuted}>{"路径: " + pathFormatter.format(dir)}</text>
                     </box>
                   </Show>
                 ),
@@ -272,7 +272,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               const command = typeof data.command === "string" ? data.command : ""
               return {
                 icon: "#",
-                title: "Shell command",
+                title: "Shell 命令",
                 body: (
                   <Show when={command}>
                     <box paddingLeft={1}>
@@ -288,7 +288,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               const desc = typeof data.description === "string" ? data.description : ""
               return {
                 icon: "#",
-                title: `${Locale.titlecase(type)} Task`,
+                title: `${Locale.titlecase(type)} 任务`,
                 body: (
                   <Show when={desc}>
                     <box paddingLeft={1}>
@@ -322,7 +322,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 body: (
                   <Show when={query}>
                     <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Query: " + query}</text>
+                      <text fg={theme.textMuted}>{"查询: " + query}</text>
                     </box>
                   </Show>
                 ),
@@ -343,11 +343,11 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
               return {
                 icon: "←",
-                title: `Access external directory ${dir}`,
+                title: `访问外部目录 ${dir}`,
                 body: (
                   <Show when={patterns.length > 0}>
                     <box paddingLeft={1} gap={1}>
-                      <text fg={theme.textMuted}>Patterns</text>
+                      <text fg={theme.textMuted}>规则</text>
                       <box>
                         <For each={patterns}>{(p) => <text fg={theme.text}>{"- " + p}</text>}</For>
                       </box>
@@ -360,10 +360,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
             if (permission === "doom_loop") {
               return {
                 icon: "⟳",
-                title: "Continue after repeated failures",
+                title: "在反复失败后继续",
                 body: (
                   <box paddingLeft={1}>
-                    <text fg={theme.textMuted}>This keeps the session running despite repeated failures.</text>
+                    <text fg={theme.textMuted}>尽管反复失败，仍保持会话运行。</text>
                   </box>
                 ),
               }
@@ -371,10 +371,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
             return {
               icon: "⚙",
-              title: `Call tool ${permission}`,
+              title: `调用工具 ${permission}`,
               body: (
                 <box paddingLeft={1}>
-                  <text fg={theme.textMuted}>{"Tool: " + permission}</text>
+                  <text fg={theme.textMuted}>{"工具: " + permission}</text>
                 </box>
               ),
             }
@@ -386,7 +386,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
             <box flexDirection="column" gap={0}>
               <box flexDirection="row" gap={1} flexShrink={0}>
                 <text fg={theme.warning}>{"△"}</text>
-                <text fg={theme.text}>Permission required</text>
+                <text fg={theme.text}>需要权限</text>
               </box>
               <box flexDirection="row" gap={1} paddingLeft={2} flexShrink={0}>
                 <text fg={theme.textMuted} flexShrink={0}>
@@ -399,10 +399,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
           const body = (
             <Prompt
-              title="Permission required"
+              title="需要权限"
               header={header()}
               body={current.body}
-              options={{ once: "Allow once", always: "Allow always", reject: "Reject" }}
+              options={{ once: "允许一次", always: "始终允许", reject: "拒绝" }}
               escapeKey="reject"
               fullscreen
               onSelect={(option) => {
@@ -451,19 +451,19 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
     commands: [
       {
         name: "app.exit",
-        title: "Cancel permission rejection",
-        category: "Permission",
+        title: "取消权限拒绝",
+        category: "权限",
         run() {
           props.onCancel()
         },
       },
     ],
     bindings: [
-      { key: "escape", desc: "Cancel permission rejection", group: "Permission", cmd: () => props.onCancel() },
+      { key: "escape", desc: "取消权限拒绝", group: "权限", cmd: () => props.onCancel() },
       ...tuiConfig.keybinds.get("app.exit"),
       {
         key: "return",
-        desc: "Confirm permission rejection",
+        desc: "确认权限拒绝",
         group: "Permission",
         cmd: () => props.onConfirm(input.plainText),
       },
@@ -480,10 +480,10 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
       <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
         <box flexDirection="row" gap={1} paddingLeft={1}>
           <text fg={theme.error}>{"△"}</text>
-          <text fg={theme.text}>Reject permission</text>
+          <text fg={theme.text}>拒绝权限</text>
         </box>
         <box paddingLeft={1}>
-          <text fg={theme.textMuted}>Tell OpenCode what to do differently</text>
+          <text fg={theme.textMuted}>告诉 OpenCode 应该怎么做</text>
         </box>
       </box>
       <box
@@ -510,10 +510,10 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
         />
         <box flexDirection="row" gap={2} flexShrink={0}>
           <text fg={theme.text}>
-            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+            enter <span style={{ fg: theme.textMuted }}>确认</span>
           </text>
           <text fg={theme.text}>
-            esc <span style={{ fg: theme.textMuted }}>cancel</span>
+            esc <span style={{ fg: theme.textMuted }}>取消</span>
           </text>
         </box>
       </box>
@@ -546,8 +546,8 @@ function Prompt<const T extends Record<string, string>>(props: {
     commands: [
       {
         name: "app.exit",
-        title: "Reject permission",
-        category: "Permission",
+        title: "拒绝权限",
+        category: "权限",
         run() {
           if (!props.escapeKey) return
           props.onSelect(props.escapeKey)
@@ -555,7 +555,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
       {
         name: "permission.prompt.fullscreen",
-        title: "Toggle permission fullscreen",
+        title: "切换权限全屏",
         category: "Permission",
         run() {
           if (!props.fullscreen) return
@@ -566,8 +566,8 @@ function Prompt<const T extends Record<string, string>>(props: {
     bindings: [
       {
         key: "left",
-        desc: "Previous permission option",
-        group: "Permission",
+        desc: "上一个权限选项",
+        group: "权限",
         cmd: () => {
           const idx = keys.indexOf(store.selected)
           const next = keys[(idx - 1 + keys.length) % keys.length]
@@ -576,8 +576,8 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
       {
         key: "h",
-        desc: "Previous permission option",
-        group: "Permission",
+        desc: "上一个权限选项",
+        group: "权限",
         cmd: () => {
           const idx = keys.indexOf(store.selected)
           const next = keys[(idx - 1 + keys.length) % keys.length]
@@ -586,8 +586,8 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
       {
         key: "right",
-        desc: "Next permission option",
-        group: "Permission",
+        desc: "下一个权限选项",
+        group: "权限",
         cmd: () => {
           const idx = keys.indexOf(store.selected)
           const next = keys[(idx + 1) % keys.length]
@@ -596,8 +596,8 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
       {
         key: "l",
-        desc: "Next permission option",
-        group: "Permission",
+        desc: "下一个权限选项",
+        group: "权限",
         cmd: () => {
           const idx = keys.indexOf(store.selected)
           const next = keys[(idx + 1) % keys.length]
@@ -606,16 +606,16 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
       {
         key: "return",
-        desc: "Select permission option",
-        group: "Permission",
+        desc: "选择权限选项",
+        group: "权限",
         cmd: () => props.onSelect(store.selected),
       },
       ...(props.escapeKey
         ? [
             {
               key: "escape",
-              desc: "Reject permission",
-              group: "Permission",
+              desc: "拒绝权限",
+              group: "权限",
               cmd: () => props.onSelect(props.escapeKey!),
             },
           ]
@@ -625,7 +625,7 @@ function Prompt<const T extends Record<string, string>>(props: {
     ],
   }))
 
-  const hint = createMemo(() => (store.expanded ? "minimize" : "fullscreen"))
+  const hint = createMemo(() => (store.expanded ? "最小化" : "全屏"))
   useRenderer()
 
   const content = () => (
@@ -700,10 +700,10 @@ function Prompt<const T extends Record<string, string>>(props: {
             </text>
           </Show>
           <text fg={theme.text}>
-            {"⇆"} <span style={{ fg: theme.textMuted }}>select</span>
+            {"⇆"} <span style={{ fg: theme.textMuted }}>选择</span>
           </text>
           <text fg={theme.text}>
-            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+            enter <span style={{ fg: theme.textMuted }}>确认</span>
           </text>
         </box>
       </box>

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -136,8 +136,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     commands: [
       {
         name: "prompt.clear",
-        title: "Clear answer edit",
-        category: "Question",
+        title: "清除答案编辑",
+        category: "问题",
         run() {
           const text = textarea?.plainText ?? ""
           if (!text) {
@@ -151,8 +151,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     bindings: [
       {
         key: "escape",
-        desc: "Cancel answer edit",
-        group: "Question",
+        desc: "取消答案编辑",
+        group: "问题",
         cmd: () => {
           setStore("editing", false)
         },
@@ -160,8 +160,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       ...tuiConfig.keybinds.get("prompt.clear"),
       {
         key: "return",
-        desc: "Submit answer edit",
-        group: "Question",
+        desc: "提交答案编辑",
+        group: "问题",
         cmd: () => {
           const text = textarea?.plainText?.trim() ?? ""
           const prev = store.custom[store.tab]
@@ -217,8 +217,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       commands: [
         {
           name: "app.exit",
-          title: "Reject question",
-          category: "Question",
+          title: "拒绝问题",
+          category: "问题",
           run() {
             reject()
           },
@@ -227,37 +227,37 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       bindings: [
         {
           key: "left",
-          desc: "Previous question",
-          group: "Question",
+          desc: "上一个问题",
+          group: "问题",
           cmd: () => selectTab((store.tab - 1 + tabs()) % tabs()),
         },
         {
           key: "h",
-          desc: "Previous question",
-          group: "Question",
+          desc: "上一个问题",
+          group: "问题",
           cmd: () => selectTab((store.tab - 1 + tabs()) % tabs()),
         },
-        { key: "right", desc: "Next question", group: "Question", cmd: () => selectTab((store.tab + 1) % tabs()) },
-        { key: "l", desc: "Next question", group: "Question", cmd: () => selectTab((store.tab + 1) % tabs()) },
+        { key: "right", desc: "下一个问题", group: "问题", cmd: () => selectTab((store.tab + 1) % tabs()) },
+        { key: "l", desc: "下一个问题", group: "问题", cmd: () => selectTab((store.tab + 1) % tabs()) },
         {
           key: "tab",
-          desc: "Next question",
-          group: "Question",
+          desc: "下一个问题",
+          group: "问题",
           cmd: ({ event }: { event: { shift: boolean } }) => {
             selectTab((store.tab + (event.shift ? -1 : 1) + tabs()) % tabs())
           },
         },
         ...(confirm()
           ? [
-              { key: "return", desc: "Submit answer", group: "Question", cmd: () => submit() },
-              { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
+              { key: "return", desc: "提交答案", group: "问题", cmd: () => submit() },
+              { key: "escape", desc: "拒绝问题", group: "问题", cmd: () => reject() },
               ...tuiConfig.keybinds.get("app.exit"),
             ]
           : [
               ...Array.from({ length: max }, (_, index) => ({
                 key: String(index + 1),
-                desc: `Select answer ${index + 1}`,
-                group: "Question",
+                desc: `选择答案 ${index + 1}`,
+                group: "问题",
                 cmd: () => {
                   moveTo(index)
                   selectOption()
@@ -265,20 +265,20 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
               })),
               {
                 key: "up",
-                desc: "Previous answer",
-                group: "Question",
+                desc: "上一个答案",
+                group: "问题",
                 cmd: () => moveTo((store.selected - 1 + total) % total),
               },
               {
                 key: "k",
-                desc: "Previous answer",
-                group: "Question",
+                desc: "上一个答案",
+                group: "问题",
                 cmd: () => moveTo((store.selected - 1 + total) % total),
               },
-              { key: "down", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
-              { key: "j", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
-              { key: "return", desc: "Select answer", group: "Question", cmd: () => selectOption() },
-              { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
+              { key: "down", desc: "下一个答案", group: "问题", cmd: () => moveTo((store.selected + 1) % total) },
+              { key: "j", desc: "下一个答案", group: "问题", cmd: () => moveTo((store.selected + 1) % total) },
+              { key: "return", desc: "选择答案", group: "问题", cmd: () => selectOption() },
+              { key: "escape", desc: "拒绝问题", group: "问题", cmd: () => reject() },
               ...tuiConfig.keybinds.get("app.exit"),
             ]),
       ],
@@ -347,7 +347,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                 selectTab(questions().length)
               }}
             >
-              <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>Confirm</text>
+              <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>确认</text>
             </box>
           </box>
         </Show>
@@ -357,7 +357,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
             <box>
               <text fg={theme.text}>
                 {question()?.question}
-                {multi() ? " (select all that apply)" : ""}
+                {multi() ? "（请选择所有适用项）" : ""}
               </text>
             </box>
             <box>
@@ -414,7 +414,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                     </box>
                     <box backgroundColor={other() ? theme.backgroundElement : undefined}>
                       <text fg={other() ? theme.secondary : customPicked() ? theme.success : theme.text}>
-                        {multi() ? `[${customPicked() ? "✓" : " "}] Type your own answer` : "Type your own answer"}
+                        {multi() ? `[${customPicked() ? "✓" : " "}] 输入你自己的答案` : "输入你自己的答案"}
                       </text>
                     </box>
 
@@ -434,7 +434,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                           })
                         }}
                         initialValue={input()}
-                        placeholder="Type your own answer"
+                        placeholder="输入你自己的答案"
                         placeholderColor={theme.textMuted}
                         minHeight={1}
                         maxHeight={6}
@@ -457,7 +457,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
         <Show when={confirm() && !single()}>
           <box paddingLeft={1}>
-            <text fg={theme.text}>Review</text>
+            <text fg={theme.text}>复查</text>
           </box>
           <For each={questions()}>
             {(q, index) => {
@@ -468,7 +468,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                   <text>
                     <span style={{ fg: theme.textMuted }}>{q.header}:</span>{" "}
                     <span style={{ fg: answered() ? theme.text : theme.error }}>
-                      {answered() ? value() : "(not answered)"}
+                      {answered() ? value() : "（未回答）"}
                     </span>
                   </text>
                 </box>
@@ -494,18 +494,18 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
           </Show>
           <Show when={!confirm()}>
             <text fg={theme.text}>
-              {"↑↓"} <span style={{ fg: theme.textMuted }}>select</span>
+              {"↑↓"} <span style={{ fg: theme.textMuted }}>选择</span>
             </text>
           </Show>
           <text fg={theme.text}>
             enter{" "}
             <span style={{ fg: theme.textMuted }}>
-              {confirm() ? "submit" : multi() ? "toggle" : single() ? "submit" : "confirm"}
+              {confirm() ? "提交" : multi() ? "切换" : single() ? "提交" : "确认"}
             </span>
           </text>
 
           <text fg={theme.text}>
-            esc <span style={{ fg: theme.textMuted }}>dismiss</span>
+            esc <span style={{ fg: theme.textMuted }}>关闭</span>
           </text>
         </box>
       </box>

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -16,9 +16,9 @@ export function SubagentFooter() {
 
   const subagentInfo = createMemo(() => {
     const s = session()
-    if (!s) return { label: "Subagent", index: 0, total: 0 }
+    if (!s) return { label: "子代理", index: 0, total: 0 }
     const agentMatch = s.title.match(/@(\w+) subagent/)
-    const label = agentMatch ? Locale.titlecase(agentMatch[1]) : "Subagent"
+    const label = agentMatch ? Locale.titlecase(agentMatch[1]) : "子代理"
 
     if (!s.parentID) return { label, index: 0, total: 0 }
 
@@ -101,7 +101,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "parent" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Parent <span style={{ fg: theme.textMuted }}>{parentShortcut()}</span>
+                父会话 <span style={{ fg: theme.textMuted }}>{parentShortcut()}</span>
               </text>
             </box>
             <box
@@ -111,7 +111,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Prev <span style={{ fg: theme.textMuted }}>{previousShortcut()}</span>
+                上一个 <span style={{ fg: theme.textMuted }}>{previousShortcut()}</span>
               </text>
             </box>
             <box
@@ -121,7 +121,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Next <span style={{ fg: theme.textMuted }}>{nextShortcut()}</span>
+                下一个 <span style={{ fg: theme.textMuted }}>{nextShortcut()}</span>
               </text>
             </box>
           </box>

--- a/packages/tui/src/ui/dialog-alert.tsx
+++ b/packages/tui/src/ui/dialog-alert.tsx
@@ -17,8 +17,8 @@ export function DialogAlert(props: DialogAlertProps) {
     bindings: [
       {
         key: "return",
-        desc: "Confirm alert",
-        group: "Dialog",
+        desc: "确认提示",
+        group: "对话框",
         cmd: () => {
           props.onConfirm?.()
           dialog.clear()
@@ -49,7 +49,7 @@ export function DialogAlert(props: DialogAlertProps) {
             dialog.clear()
           }}
         >
-          <text fg={theme.selectedListItemText}>ok</text>
+          <text fg={theme.selectedListItemText}>确定</text>
         </box>
       </box>
     </box>

--- a/packages/tui/src/ui/dialog-confirm.tsx
+++ b/packages/tui/src/ui/dialog-confirm.tsx
@@ -27,8 +27,8 @@ export function DialogConfirm(props: DialogConfirmProps) {
     bindings: [
       {
         key: "return",
-        desc: "Confirm dialog selection",
-        group: "Dialog",
+        desc: "确认对话框选择",
+        group: "对话框",
         cmd: () => {
           if (store.active === "confirm") props.onConfirm?.()
           if (store.active === "cancel") props.onCancel?.()
@@ -37,16 +37,16 @@ export function DialogConfirm(props: DialogConfirmProps) {
       },
       {
         key: "left",
-        desc: "Previous dialog option",
-        group: "Dialog",
+        desc: "上一个对话框选项",
+        group: "对话框",
         cmd: () => {
           setStore("active", store.active === "confirm" ? "cancel" : "confirm")
         },
       },
       {
         key: "right",
-        desc: "Next dialog option",
-        group: "Dialog",
+        desc: "下一个对话框选项",
+        group: "对话框",
         cmd: () => {
           setStore("active", store.active === "confirm" ? "cancel" : "confirm")
         },
@@ -80,7 +80,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
               }}
             >
               <text fg={key === store.active ? theme.selectedListItemText : theme.textMuted}>
-                {Locale.titlecase(key === "cancel" ? (props.label ?? key) : key)}
+                {key === "cancel" ? (props.label ?? "取消") : "确认"}
               </text>
             </box>
           )}

--- a/packages/tui/src/ui/dialog-export-options.tsx
+++ b/packages/tui/src/ui/dialog-export-options.tsx
@@ -37,8 +37,8 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
     bindings: [
       {
         key: "tab",
-        desc: "Next export option",
-        group: "Dialog",
+        desc: "下一个导出选项",
+        group: "对话框",
         cmd: () => {
           const order: Array<"filename" | "thinking" | "toolDetails" | "assistantMetadata" | "openWithoutSaving"> = [
             "filename",
@@ -60,8 +60,8 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
     bindings: [
       {
         key: "space",
-        desc: "Toggle export option",
-        group: "Dialog",
+        desc: "切换导出选项",
+        group: "对话框",
         cmd: () => {
           if (store.active === "thinking") setStore("thinking", !store.thinking)
           if (store.active === "toolDetails") setStore("toolDetails", !store.toolDetails)
@@ -85,7 +85,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Export Options
+          导出选项
         </text>
         <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
           esc
@@ -93,7 +93,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
       </box>
       <box gap={1}>
         <box>
-          <text fg={theme.text}>Filename:</text>
+          <text fg={theme.text}>文件名：</text>
         </box>
         <textarea
           onSubmit={() => {
@@ -111,7 +111,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
             val.traits = { status: "FILENAME" }
           }}
           initialValue={props.defaultFilename}
-          placeholder="Enter filename"
+          placeholder="输入文件名"
           placeholderColor={theme.textMuted}
           textColor={theme.text}
           focusedTextColor={theme.text}
@@ -129,7 +129,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           <text fg={store.active === "thinking" ? theme.primary : theme.textMuted}>
             {store.thinking ? "[x]" : "[ ]"}
           </text>
-          <text fg={store.active === "thinking" ? theme.primary : theme.text}>Include thinking</text>
+          <text fg={store.active === "thinking" ? theme.primary : theme.text}>包含思考过程</text>
         </box>
         <box
           flexDirection="row"
@@ -141,7 +141,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           <text fg={store.active === "toolDetails" ? theme.primary : theme.textMuted}>
             {store.toolDetails ? "[x]" : "[ ]"}
           </text>
-          <text fg={store.active === "toolDetails" ? theme.primary : theme.text}>Include tool details</text>
+          <text fg={store.active === "toolDetails" ? theme.primary : theme.text}>包含工具详情</text>
         </box>
         <box
           flexDirection="row"
@@ -153,7 +153,7 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           <text fg={store.active === "assistantMetadata" ? theme.primary : theme.textMuted}>
             {store.assistantMetadata ? "[x]" : "[ ]"}
           </text>
-          <text fg={store.active === "assistantMetadata" ? theme.primary : theme.text}>Include assistant metadata</text>
+          <text fg={store.active === "assistantMetadata" ? theme.primary : theme.text}>包含助手元数据</text>
         </box>
         <box
           flexDirection="row"
@@ -165,19 +165,17 @@ export function DialogExportOptions(props: DialogExportOptionsProps) {
           <text fg={store.active === "openWithoutSaving" ? theme.primary : theme.textMuted}>
             {store.openWithoutSaving ? "[x]" : "[ ]"}
           </text>
-          <text fg={store.active === "openWithoutSaving" ? theme.primary : theme.text}>Open without saving</text>
+          <text fg={store.active === "openWithoutSaving" ? theme.primary : theme.text}>不保存直接打开</text>
         </box>
       </box>
       <Show when={store.active !== "filename"}>
         <text fg={theme.textMuted} paddingBottom={1}>
-          Press <span style={{ fg: theme.text }}>space</span> to toggle, <span style={{ fg: theme.text }}>return</span>{" "}
-          to confirm
+          按 <span style={{ fg: theme.text }}>空格</span> 切换，按 <span style={{ fg: theme.text }}>回车</span> 确认
         </text>
       </Show>
       <Show when={store.active === "filename"}>
         <text fg={theme.textMuted} paddingBottom={1}>
-          Press <span style={{ fg: theme.text }}>return</span> to confirm, <span style={{ fg: theme.text }}>tab</span>{" "}
-          for options
+          按 <span style={{ fg: theme.text }}>回车</span> 确认，按 <span style={{ fg: theme.text }}>tab</span> 进入选项
         </text>
       </Show>
     </box>

--- a/packages/tui/src/ui/dialog-help.tsx
+++ b/packages/tui/src/ui/dialog-help.tsx
@@ -10,8 +10,8 @@ export function DialogHelp() {
 
   useBindings(() => ({
     bindings: [
-      { key: "return", desc: "Close help", group: "Dialog", cmd: () => dialog.clear() },
-      { key: "escape", desc: "Close help", group: "Dialog", cmd: () => dialog.clear() },
+      { key: "return", desc: "关闭帮助", group: "对话框", cmd: () => dialog.clear() },
+      { key: "escape", desc: "关闭帮助", group: "对话框", cmd: () => dialog.clear() },
     ],
   }))
 
@@ -19,7 +19,7 @@ export function DialogHelp() {
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          Help
+          帮助
         </text>
         <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
           esc/enter
@@ -27,12 +27,12 @@ export function DialogHelp() {
       </box>
       <box paddingBottom={1}>
         <text fg={theme.textMuted}>
-          Press {commandShortcut()} to see all available actions and commands in any context.
+          按 {commandShortcut()} 可在任意场景查看所有可用操作和命令。
         </text>
       </box>
       <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
         <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={() => dialog.clear()}>
-          <text fg={theme.selectedListItemText}>ok</text>
+          <text fg={theme.selectedListItemText}>确定</text>
         </box>
       </box>
     </box>

--- a/packages/tui/src/ui/dialog-prompt.tsx
+++ b/packages/tui/src/ui/dialog-prompt.tsx
@@ -38,8 +38,8 @@ export function DialogPrompt(props: DialogPromptProps) {
     commands: [
       {
         name: "dialog.prompt.submit",
-        title: "Submit dialog prompt",
-        category: "Dialog",
+        title: "提交对话框输入",
+        category: "对话框",
         run: confirm,
       },
     ],
@@ -91,21 +91,21 @@ export function DialogPrompt(props: DialogPromptProps) {
             setTextareaTarget(val)
           }}
           initialValue={props.value}
-          placeholder={props.placeholder ?? "Enter text"}
+          placeholder={props.placeholder ?? "输入文字"}
           placeholderColor={theme.textMuted}
           textColor={props.busy ? theme.textMuted : theme.text}
           focusedTextColor={props.busy ? theme.textMuted : theme.text}
           cursorColor={props.busy ? theme.backgroundElement : theme.text}
         />
         <Show when={props.busy}>
-          <Spinner color={theme.textMuted}>{props.busyText ?? "Working..."}</Spinner>
+          <Spinner color={theme.textMuted}>{props.busyText ?? "处理中..."}</Spinner>
         </Show>
       </box>
       <box paddingBottom={1} gap={1} flexDirection="row">
-        <Show when={!props.busy} fallback={<text fg={theme.textMuted}>processing...</text>}>
+        <Show when={!props.busy} fallback={<text fg={theme.textMuted}>处理中...</text>}>
           <Show when={submitShortcut()}>
             <text fg={theme.text}>
-              {submitShortcut()} <span style={{ fg: theme.textMuted }}>submit</span>
+              {submitShortcut()} <span style={{ fg: theme.textMuted }}>提交</span>
             </text>
           </Show>
         </Show>

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -373,8 +373,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       commands: [
         {
           name: "dialog.select.prev",
-          title: "Previous item",
-          category: "Dialog",
+          title: "上一个项目",
+          category: "对话框",
           run() {
             setStore("input", "keyboard")
             move(-1)
@@ -382,8 +382,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.next",
-          title: "Next item",
-          category: "Dialog",
+          title: "下一个项目",
+          category: "对话框",
           run() {
             setStore("input", "keyboard")
             move(1)
@@ -391,8 +391,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.page_up",
-          title: "Page up",
-          category: "Dialog",
+          title: "向上翻页",
+          category: "对话框",
           run() {
             setStore("input", "keyboard")
             move(-10)
@@ -400,8 +400,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.page_down",
-          title: "Page down",
-          category: "Dialog",
+          title: "向下翻页",
+          category: "对话框",
           run() {
             setStore("input", "keyboard")
             move(10)
@@ -409,8 +409,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.home",
-          title: "First item",
-          category: "Dialog",
+          title: "第一个项目",
+          category: "对话框",
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
@@ -419,8 +419,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.end",
-          title: "Last item",
-          category: "Dialog",
+          title: "最后一个项目",
+          category: "对话框",
           run() {
             if (props.locked) return
             setStore("input", "keyboard")
@@ -429,14 +429,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         },
         {
           name: "dialog.select.submit",
-          title: "Select item",
-          category: "Dialog",
+          title: "选择项目",
+          category: "对话框",
           run: submit,
         },
         ...visible.map((item) => ({
           name: item.command,
           title: item.title,
-          category: "Dialog",
+          category: "对话框",
           run() {
             if (props.locked) return
             if (isActionDisabled(item)) return
@@ -462,14 +462,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           ? [
               {
                 key: "tab",
-                desc: "Next dialog action",
-                group: "Dialog",
+                desc: "下一个对话框操作",
+                group: "对话框",
                 cmd: () => moveAction(1),
               },
               {
                 key: "shift+tab",
-                desc: "Previous dialog action",
-                group: "Dialog",
+                desc: "上一个对话框操作",
+                group: "对话框",
                 cmd: () => moveAction(-1),
               },
             ]
@@ -589,7 +589,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                   input.focus()
                 }, 1)
               }}
-              placeholder={props.placeholder ?? "Search"}
+              placeholder={props.placeholder ?? "搜索"}
               placeholderColor={theme.textMuted}
             />
           </box>
@@ -601,7 +601,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           fallback={
             props.emptyView ?? (
               <box paddingLeft={4} paddingRight={4} paddingTop={1}>
-                <text fg={theme.textMuted}>No results found</text>
+                <text fg={theme.textMuted}>无匹配结果</text>
               </box>
             )
           }

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -74,7 +74,7 @@ function init() {
         })
       toast.show({
         variant: "error",
-        message: "An unknown error has occurred",
+        message: "发生了未知错误",
       })
     },
     get currentToast(): ToastOptions | null {

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -21,8 +21,8 @@ describe("sortModelOptions", () => {
         { title: "GLM 5", releaseDate: "2025-07-28" },
         { title: "GLM 5.1", releaseDate: "2025-12-09" },
         { title: "GLM 5.2", releaseDate: "2026-02-16" },
-        { title: "Free old", releaseDate: "2024-01-01", footer: "Free" },
-        { title: "Free new", releaseDate: "2025-01-01", footer: "Free" },
+        { title: "Free old", releaseDate: "2024-01-01", footer: "免费" },
+        { title: "Free new", releaseDate: "2025-01-01", footer: "免费" },
       ],
       false,
     )

--- a/packages/tui/test/cli/cmd/tui/notifications.test.ts
+++ b/packages/tui/test/cli/cmd/tui/notifications.test.ts
@@ -85,14 +85,14 @@ function permission(id: string, sessionID = "session"): PermissionRequest {
 
 const questionNotification: TuiAttentionNotifyInput = {
   title: "Demo session",
-  message: "Question needs input",
+  message: "问题需要输入",
   notification: { when: "blurred" },
   sound: { name: "question", when: "always" },
 }
 
 const permissionNotification: TuiAttentionNotifyInput = {
   title: "Demo session",
-  message: "Permission needs input",
+  message: "权限需要输入",
   notification: { when: "blurred" },
   sound: { name: "permission", when: "always" },
 }
@@ -158,7 +158,7 @@ describe("internal notifications TUI plugin", () => {
     expect(harness.notifications).toEqual([
       {
         title: "Demo session",
-        message: "Session done",
+        message: "会话完成",
         notification: { when: "blurred" },
         sound: { name: "done", when: "always" },
       },
@@ -183,13 +183,13 @@ describe("internal notifications TUI plugin", () => {
     expect(harness.notifications).toEqual([
       {
         title: "Subagent session",
-        message: "Question needs input",
+        message: "问题需要输入",
         notification: false,
         sound: { name: "question", when: "always" },
       },
       {
         title: "Subagent session",
-        message: "Session done",
+        message: "会话完成",
         notification: false,
         sound: { name: "subagent_done", when: "always" },
       },
@@ -218,7 +218,7 @@ describe("internal notifications TUI plugin", () => {
     expect(harness.notifications).toEqual([
       {
         title: "Demo session",
-        message: "Session error",
+        message: "会话错误",
         notification: { when: "blurred" },
         sound: { name: "error", when: "always" },
       },
@@ -252,13 +252,13 @@ describe("internal notifications TUI plugin", () => {
     expect(harness.notifications).toEqual([
       {
         title: "Abort session",
-        message: "Session aborted",
+        message: "会话已中止",
         notification: { when: "blurred" },
         sound: { name: "error", when: "always" },
       },
       {
         title: "Timeout session",
-        message: "Model stopped responding",
+        message: "模型停止响应",
         notification: { when: "blurred" },
         sound: { name: "error", when: "always" },
       },

--- a/packages/tui/test/cli/tui/diff-viewer-file-tree.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer-file-tree.test.tsx
@@ -78,10 +78,10 @@ describe("DiffViewerFileTree", () => {
     ))
 
     expect(loading).not.toContain("Loading diff...")
-    expect(loading).not.toContain("No files")
+    expect(loading).not.toContain("没有文件")
     expect(failed).not.toContain("Failed to load diff")
-    expect(failed).not.toContain("No files")
-    expect(empty).toContain("No files")
+    expect(failed).not.toContain("没有文件")
+    expect(empty).toContain("没有文件")
   })
 
   test("does not render text markers for highlighted rows", async () => {


### PR DESCRIPTION
Localizes the terminal (TUI) interface to Simplified Chinese. Covers the home screen, command palette, session commands, permission dialog, question dialog, dialogs (message/subagent/timeline/session/model/provider/theme/mcp/status/export etc.), sidebar, tips, diff viewer, which-key, error screen, and notifications.

Notes:
- Only user-visible display strings were translated; command names, values, slash names, and internal identifiers are unchanged.
- Updated related tests (notifications, model-options sort, diff-viewer-file-tree, dialog-prompt) to match translated strings.
- Tool labels (Read/Grep/Glob/List/WebFetch) intentionally kept in English as they reflect tool names.