### PR TITLE
fix(ui): correct TextMate scope name from arbitrary-repitition to arb…

### DIFF
--- a/packages/ui/src/context/marked-theme.tsx
+++ b/packages/ui/src/context/marked-theme.tsx
@@ -207,7 +207,7 @@ export const OpenCodeTheme = {
         "string.regexp.character-class",
         "string.regexp constant.character.escape",
         "string.regexp source.ruby.embedded",
-        "string.regexp string.regexp.arbitrary-repitition",
+        "string.regexp string.regexp.arbitrary-repetition",
         "string.regexp constant.character.escape",
       ],
       settings: {


### PR DESCRIPTION
### Issue for this PR

Closes #40366

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TextMate scope name in `packages/ui/src/context/marked-theme.tsx:210` was misspelled as `arbitrary-repitition` instead of the correct `arbitrary-repetition`. This means the scope wouldn't match the standard TextMate grammar rule for regex highlighting.

### How did you verify your code works?

Confirmed the scope name is a standard TextMate grammar scope. Verified no other references to the misspelled `arbitrary-repitition` exist in the codebase.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR