### PR TITLE
fix(app): supply fallback session titles

### DIFF
--- a/packages/app/src/utils/session-title.ts
+++ b/packages/app/src/utils/session-title.ts
@@ -1,5 +1,17 @@
 const pattern = /^(New session|Child session) - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 
+interface Info {
+  readonly title?: string
+  readonly parentID?: string
+  readonly time: {
+    readonly created: number
+  }
+}
+
+export function withTimestampedFallback(info: Info) {
+  return info.title ?? `${info.parentID ? "Child" : "New"} session - ${new Date(info.time.created).toISOString()}`
+}
+
 export function sessionTitle(title?: string) {
   if (!title) return title
   const match = title.match(pattern)

--- a/packages/app/src/utils/session.test.ts
+++ b/packages/app/src/utils/session.test.ts
@@ -36,6 +36,14 @@ describe("normalizeSessionInfo", () => {
       revert: { messageID: "message-1", partID: "part-1", snapshot: "snapshot" },
     })
   })
+
+  test("supplies timestamped titles for untitled current sessions", () => {
+    const root = currentSession("session-1")
+    const child = currentSession("session-2", "session-1")
+
+    expect(normalizeSessionInfo(root).title).toBe("New session - 1970-01-01T00:00:00.000Z")
+    expect(normalizeSessionInfo(child).title).toBe("Child session - 1970-01-01T00:00:00.000Z")
+  })
 })
 
 describe("listAllSessions", () => {
@@ -89,6 +97,18 @@ function sessionInfo(id: string, archived = false) {
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
     time: { created: 1, updated: 1, archived: archived ? 2 : undefined },
     title: id,
+    location: { directory: "/repo" },
+  } as SessionInfo
+}
+
+function currentSession(id: string, parentID?: string) {
+  return {
+    id,
+    parentID,
+    projectID: "project-1",
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
     location: { directory: "/repo" },
   } as SessionInfo
 }

--- a/packages/app/src/utils/session.ts
+++ b/packages/app/src/utils/session.ts
@@ -1,5 +1,6 @@
 import type { SessionApi, SessionInfo, SessionListInput } from "@opencode-ai/client/promise"
 import type { Session } from "@opencode-ai/sdk/v2/client"
+import { withTimestampedFallback } from "./session-title"
 
 export function normalizeSessionInfo(input: SessionInfo | Session): Session {
   if (!("location" in input)) return input
@@ -13,7 +14,7 @@ export function normalizeSessionInfo(input: SessionInfo | Session): Session {
     parentID: input.parentID,
     cost: input.cost,
     tokens: input.tokens,
-    title: input.title,
+    title: withTimestampedFallback(input),
     agent: input.agent,
     model: input.model,
     version: "",


### PR DESCRIPTION
## Summary
- port the timestamped session-title fallback into the app compatibility utility
- apply fallback titles while normalizing current root and child sessions
- cover untitled session normalization with focused tests

## Validation
- `bun test --conditions=solid --only-failures --preload ./happydom.ts ./src/utils/session.test.ts`
- `bun typecheck`
- `git diff --check`