### PR TITLE
fix(core): sanitize permission metadata

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -106,6 +106,33 @@ interface Pending {
   readonly deferred: Deferred.Deferred<void, DeclinedError | CorrectedError>
 }
 
+function sanitizeMetadataValue(value: unknown): unknown {
+  if (value === undefined) return undefined
+  if (Array.isArray(value)) return value.flatMap((item) => {
+    const sanitized = sanitizeMetadataValue(item)
+    return sanitized === undefined ? [] : [sanitized]
+  })
+  if (typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype) {
+    return Object.fromEntries(
+      Object.entries(value).flatMap(([key, item]) => {
+        const sanitized = sanitizeMetadataValue(item)
+        return sanitized === undefined ? [] : [[key, sanitized]]
+      }),
+    )
+  }
+  return value
+}
+
+function sanitizeMetadata(metadata: Record<string, unknown> | undefined) {
+  if (metadata === undefined) return undefined
+  return Object.fromEntries(
+    Object.entries(metadata).flatMap(([key, value]) => {
+      const sanitized = sanitizeMetadataValue(value)
+      return sanitized === undefined ? [] : [[key, sanitized]]
+    }),
+  )
+}
+
 const layer = Layer.effect(
   Service,
   EffectRuntime.gen(function* () {
@@ -168,7 +195,7 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        metadata: sanitizeMetadata(input.metadata),
         source: input.source,
       }
     }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -118,6 +118,26 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("omits undefined metadata values from pending requests", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      yield* service.ask(
+        assertion({
+          metadata: {
+            root: ".",
+            path: undefined,
+            nested: { include: undefined, limit: 10 },
+          },
+        }),
+      )
+
+      const request = yield* service.get(PermissionV2.ID.create("per_test"))
+      expect(request?.metadata).toEqual({ root: ".", nested: { limit: 10 } })
+      expect(Object.hasOwn(request?.metadata ?? {}, "path")).toBe(false)
+    }),
+  )
+
   it.effect("evaluates against an explicit provider-turn agent", () =>
     Effect.gen(function* () {
       yield* setup([{ action: "read", resource: "*", effect: "allow" }])


### PR DESCRIPTION
## Summary
- Strip `undefined` values from V2 permission request metadata at the request boundary
- Recursively clean nested plain-object metadata so pending permissions remain JSON-encodable
- Add a PermissionV2 regression test for optional tool metadata values

Fixes #37650

## Test Plan
- `bun test test/permission.test.ts --test-name-pattern "omits undefined metadata values from pending requests"`
- `bun test test/permission.test.ts`
- `cd packages/core && bun run typecheck`
- `bun run lint packages/core/src/permission.ts packages/core/test/permission.test.ts`
- `git diff --check`