### PR TITLE
fix(app): persist local project renames in project list

### DIFF
--- a/packages/app/src/components/edit-project.ts
+++ b/packages/app/src/components/edit-project.ts
@@ -80,22 +80,20 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
       }
 
       if (props.project.id && props.project.id !== "global") {
-        if ((await serverCtx().sdk.protocol) === "v1") {
-          const project = await serverCtx()
-            .sdk.client.project.update({
-              projectID: props.project.id,
-              directory: props.project.worktree,
-              name,
-              icon: { color: store.color || "", override: store.iconOverride || "" },
-              commands: { start },
-            })
-            .then((result) => result.data)
-            .catch(() => undefined)
-          if (project) {
-            serverCtx().sync.set("project", (items) =>
-              items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
-            )
-          }
+        const project = await serverCtx()
+          .sdk.client.project.update({
+            projectID: props.project.id,
+            directory: props.project.worktree,
+            name,
+            icon: { color: store.color || "", override: store.iconOverride || "" },
+            commands: { start },
+          })
+          .then((result) => result.data)
+          .catch(() => undefined)
+        if (project) {
+          serverCtx().sync.set("project", (items) =>
+            items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
+          )
         }
       }
 

--- a/packages/app/src/components/edit-project.ts
+++ b/packages/app/src/components/edit-project.ts
@@ -70,37 +70,35 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
       const name = store.name.trim() === folderName() ? "" : store.name.trim()
       const start = store.startup.trim()
 
-      if (props.project.id && props.project.id !== "global") {
-        if ((await serverCtx().sdk.protocol) !== "v1") return
-        const project = await serverCtx()
-          .sdk.client.project.update({
-            projectID: props.project.id,
-            directory: props.project.worktree,
-            name,
-            icon: { color: store.color || "", override: store.iconOverride || "" },
-            commands: { start },
-          })
-          .then((result) => result.data)
-        if (!project) return
-        // const project = await serverCtx().sdk.api.project.update({
-        //   projectID: props.project.id,
-        //   name,
-        //   icon: { color: store.color || "", override: store.iconOverride || "" },
-        //   commands: { start },
-        // })
-        serverCtx().sync.set("project", (items) =>
-          items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
-        )
-        serverCtx().sync.project.icon(props.project.worktree, store.iconOverride || undefined)
-        dialog.close()
-        return
-      }
-
       serverCtx().sync.project.meta(props.project.worktree, {
         name,
         icon: { color: store.color || undefined, override: store.iconOverride || undefined },
         commands: { start: start || undefined },
       })
+      if (store.iconOverride) {
+        serverCtx().sync.project.icon(props.project.worktree, store.iconOverride)
+      }
+
+      if (props.project.id && props.project.id !== "global") {
+        if ((await serverCtx().sdk.protocol) === "v1") {
+          const project = await serverCtx()
+            .sdk.client.project.update({
+              projectID: props.project.id,
+              directory: props.project.worktree,
+              name,
+              icon: { color: store.color || "", override: store.iconOverride || "" },
+              commands: { start },
+            })
+            .then((result) => result.data)
+            .catch(() => undefined)
+          if (project) {
+            serverCtx().sync.set("project", (items) =>
+              items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
+            )
+          }
+        }
+      }
+
       dialog.close()
     },
   }))

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -189,7 +189,7 @@ describe("mergeProjectMeta", () => {
 describe("enrichProject", () => {
   test("applies the legacy icon override on top of projectMeta", () => {
     const base: Base = { worktree: "/repo", name: "Repo" }
-    expect(enrichProject(base, { name: "Renamed", icon: { color: "red" } }, "data:legacy", false)).toEqual({
+    expect(enrichProject(base, { name: "Renamed", icon: { color: "red" } }, "data:legacy")).toEqual({
       worktree: "/repo",
       name: "Renamed",
       icon: { color: "red", override: "data:legacy" },
@@ -198,7 +198,7 @@ describe("enrichProject", () => {
 
   test("returns merged base unchanged when there is no legacy icon", () => {
     const base: Base = { worktree: "/repo" }
-    expect(enrichProject(base, { name: "Renamed" }, undefined, false)).toEqual({
+    expect(enrichProject(base, { name: "Renamed" }, undefined)).toEqual({
       worktree: "/repo",
       name: "Renamed",
     })
@@ -206,7 +206,7 @@ describe("enrichProject", () => {
 
   test("applies local projectMeta for projects with a server id", () => {
     const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
-    expect(enrichProject(base, { name: "opencode_config" }, undefined, true)).toEqual({
+    expect(enrichProject(base, { name: "opencode_config" }, undefined)).toEqual({
       worktree: "/repo",
       name: "opencode_config",
     })
@@ -214,7 +214,7 @@ describe("enrichProject", () => {
 
   test("still applies the legacy icon override for projects with a server id", () => {
     const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
-    expect(enrichProject(base, { name: "opencode_config" }, "data:legacy", true)).toEqual({
+    expect(enrichProject(base, { name: "opencode_config" }, "data:legacy")).toEqual({
       worktree: "/repo",
       name: "opencode_config",
       icon: { override: "data:legacy" },

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -204,11 +204,11 @@ describe("enrichProject", () => {
     })
   })
 
-  test("ignores stale local projectMeta for projects with a server id", () => {
+  test("applies local projectMeta for projects with a server id", () => {
     const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
     expect(enrichProject(base, { name: "opencode_config" }, undefined, true)).toEqual({
       worktree: "/repo",
-      name: "opencode_configaaa",
+      name: "opencode_config",
     })
   })
 
@@ -216,7 +216,7 @@ describe("enrichProject", () => {
     const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
     expect(enrichProject(base, { name: "opencode_config" }, "data:legacy", true)).toEqual({
       worktree: "/repo",
-      name: "opencode_configaaa",
+      name: "opencode_config",
       icon: { override: "data:legacy" },
     })
   })

--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -5,7 +5,14 @@ import type {
   ModelListOutput,
   ProviderListOutput,
 } from "@opencode-ai/client/promise"
-import { directoryKey, normalizeAgentList, normalizePermissionRequest, normalizeProviderList } from "./utils"
+import {
+  directoryKey,
+  enrichProject,
+  mergeProjectMeta,
+  normalizeAgentList,
+  normalizePermissionRequest,
+  normalizeProviderList,
+} from "./utils"
 
 describe("normalizeAgentList", () => {
   test("adapts current agents to the app agent shape", () => {
@@ -129,5 +136,88 @@ describe("directoryKey", () => {
     expect(String(directoryKey("C:/Repos/sst/opencode/"))).toBe("C:/Repos/sst/opencode")
     expect(String(directoryKey("C:/"))).toBe("C:/")
     expect(String(directoryKey("/"))).toBe("/")
+  })
+})
+
+type Base = {
+  worktree: string
+  name?: string
+  icon?: { color?: string; override?: string }
+  commands?: { start?: string }
+}
+
+describe("mergeProjectMeta", () => {
+  test("returns base unchanged when there is no local projectMeta", () => {
+    const base: Base = { worktree: "/repo", name: "Repo" }
+    expect(mergeProjectMeta(base, undefined)).toBe(base)
+  })
+
+  test("applies local name for projects without a server registration", () => {
+    const base: Base = { worktree: "/repo" }
+    expect(mergeProjectMeta(base, { name: "MicroservicesABC" })).toEqual({
+      worktree: "/repo",
+      name: "MicroservicesABC",
+    })
+  })
+
+  test("keeps server name when local projectMeta has no name", () => {
+    const base: Base = { worktree: "/repo", name: "SOOK" }
+    expect(mergeProjectMeta(base, { icon: { color: "red" } })).toEqual({
+      worktree: "/repo",
+      name: "SOOK",
+      icon: { color: "red" },
+    })
+  })
+
+  test("preserves an empty local name (display falls back to the folder name downstream)", () => {
+    const base: Base = { worktree: "/repo" }
+    expect(mergeProjectMeta(base, { name: "" })).toEqual({ worktree: "/repo", name: "" })
+  })
+
+  test("merges icon and commands overrides", () => {
+    const base: Base = { worktree: "/repo", icon: { color: "blue" }, commands: { start: "" } }
+    expect(
+      mergeProjectMeta(base, { icon: { color: "red", override: "data:img" }, commands: { start: "bun dev" } }),
+    ).toEqual({
+      worktree: "/repo",
+      icon: { color: "red", override: "data:img" },
+      commands: { start: "bun dev" },
+    })
+  })
+})
+
+describe("enrichProject", () => {
+  test("applies the legacy icon override on top of projectMeta", () => {
+    const base: Base = { worktree: "/repo", name: "Repo" }
+    expect(enrichProject(base, { name: "Renamed", icon: { color: "red" } }, "data:legacy", false)).toEqual({
+      worktree: "/repo",
+      name: "Renamed",
+      icon: { color: "red", override: "data:legacy" },
+    })
+  })
+
+  test("returns merged base unchanged when there is no legacy icon", () => {
+    const base: Base = { worktree: "/repo" }
+    expect(enrichProject(base, { name: "Renamed" }, undefined, false)).toEqual({
+      worktree: "/repo",
+      name: "Renamed",
+    })
+  })
+
+  test("ignores stale local projectMeta for projects with a server id", () => {
+    const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
+    expect(enrichProject(base, { name: "opencode_config" }, undefined, true)).toEqual({
+      worktree: "/repo",
+      name: "opencode_configaaa",
+    })
+  })
+
+  test("still applies the legacy icon override for projects with a server id", () => {
+    const base: Base = { worktree: "/repo", name: "opencode_configaaa" }
+    expect(enrichProject(base, { name: "opencode_config" }, "data:legacy", true)).toEqual({
+      worktree: "/repo",
+      name: "opencode_configaaa",
+      icon: { override: "data:legacy" },
+    })
   })
 })

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -185,7 +185,6 @@ export function enrichProject<T extends ProjectMetaShape>(
   base: T,
   local: ProjectMeta | undefined,
   icon: string | undefined,
-  _hasServerId?: boolean,
 ): T {
   const merged = mergeProjectMeta(base, local)
   if (icon) return { ...merged, icon: { ...merged.icon, override: icon } }

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -179,17 +179,15 @@ type ProjectMetaShape = {
 
 // Merge local per-workspace overrides (name, commands, icon) from the localStorage
 // cache (childStore.projectMeta) over the base project, then apply the legacy
-// childStore.icon override. For projects with a server registration the server is the
-// source of truth, so their local projectMeta is ignored to avoid a stale local name
-// overriding the persisted one. Without this, projects without a server registration
-// would ignore their renamed name, startup command, and icon.
+// childStore.icon override. Local projectMeta applies to all projects so user renames
+// and custom settings display consistently.
 export function enrichProject<T extends ProjectMetaShape>(
   base: T,
   local: ProjectMeta | undefined,
   icon: string | undefined,
-  hasServerId: boolean,
+  _hasServerId?: boolean,
 ): T {
-  const merged = hasServerId ? base : mergeProjectMeta(base, local)
+  const merged = mergeProjectMeta(base, local)
   if (icon) return { ...merged, icon: { ...merged.icon, override: icon } }
   return merged
 }

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -8,6 +8,7 @@ import type {
 import type { Agent, PermissionRequest, Project, Provider, ProviderListResponse } from "@opencode-ai/sdk/v2/client"
 import type { Project as CurrentProject } from "@opencode-ai/client/promise"
 import { NormalizedProviderListResponse } from "@opencode-ai/session-ui/context"
+import type { ProjectMeta } from "./types"
 export { pathKey as directoryKey, type PathKey as DirectoryKey } from "@/utils/path-key"
 
 export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
@@ -167,5 +168,38 @@ export function normalizeProjectInfo(project: Project | CurrentProject): Project
   return {
     ...project,
     vcs: project.vcs === "git" ? "git" : undefined,
+  }
+}
+
+type ProjectMetaShape = {
+  name?: string
+  icon?: { color?: string; override?: string }
+  commands?: { start?: string }
+}
+
+// Merge local per-workspace overrides (name, commands, icon) from the localStorage
+// cache (childStore.projectMeta) over the base project, then apply the legacy
+// childStore.icon override. For projects with a server registration the server is the
+// source of truth, so their local projectMeta is ignored to avoid a stale local name
+// overriding the persisted one. Without this, projects without a server registration
+// would ignore their renamed name, startup command, and icon.
+export function enrichProject<T extends ProjectMetaShape>(
+  base: T,
+  local: ProjectMeta | undefined,
+  icon: string | undefined,
+  hasServerId: boolean,
+): T {
+  const merged = hasServerId ? base : mergeProjectMeta(base, local)
+  if (icon) return { ...merged, icon: { ...merged.icon, override: icon } }
+  return merged
+}
+
+export function mergeProjectMeta<T extends ProjectMetaShape>(base: T, local: ProjectMeta | undefined): T {
+  if (!local) return base
+  return {
+    ...base,
+    ...(local.name !== undefined ? { name: local.name } : {}),
+    ...(local.icon ? { icon: { ...base.icon, ...local.icon } } : {}),
+    ...(local.commands ? { commands: { ...base.commands, ...local.commands } } : {}),
   }
 }

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -121,7 +121,7 @@ function createServerCtx(
     // Preserve local per-workspace overrides (name, commands, icon) from the localStorage
     // cache (childStore.projectMeta) and the legacy childStore.icon override.
     const base = { ...metadata, ...project }
-    return enrichProject(base, childStore.projectMeta, childStore.icon, Boolean(projectID) && projectID !== "global")
+    return enrichProject(base, childStore.projectMeta, childStore.icon)
   }
 
   const projectsList = createMemo(() => projects.list().map(enrich))

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -6,6 +6,7 @@ import { pathKey } from "@/utils/path-key"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
 import { createServerSyncContext } from "./server-sync"
+import { enrichProject } from "./global-sync/utils"
 import { getOwner } from "solid-js/web"
 import { QueryClient } from "@tanstack/solid-query"
 import type { ServerScope } from "@/utils/server-scope"
@@ -117,14 +118,10 @@ function createServerCtx(
       ? sync.data.project.find((x) => x.id === projectID)
       : sync.data.project.find((x) => x.worktree === project.worktree)
 
-    // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-    // Without this, different subdirectories of the same git repo would share the same
-    // icon from the database instead of using their individual overrides.
+    // Preserve local per-workspace overrides (name, commands, icon) from the localStorage
+    // cache (childStore.projectMeta) and the legacy childStore.icon override.
     const base = { ...metadata, ...project }
-    if (childStore.icon) {
-      return { ...base, icon: { ...base.icon, override: childStore.icon } }
-    }
-    return base
+    return enrichProject(base, childStore.projectMeta, childStore.icon, Boolean(projectID) && projectID !== "global")
   }
 
   const projectsList = createMemo(() => projects.list().map(enrich))

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -452,7 +452,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       // Preserve local per-workspace overrides (name, commands, icon) from the localStorage
       // cache (childStore.projectMeta) and the legacy childStore.icon override.
       const base = { ...metadata, ...project }
-      return enrichProject(base, childStore.projectMeta, childStore.icon, Boolean(projectID) && projectID !== "global")
+      return enrichProject(base, childStore.projectMeta, childStore.icon)
     }
 
     const roots = createMemo(() => {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -8,7 +8,7 @@ import { useServerSDK } from "./server-sdk"
 import { RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
 import { usePlatform } from "./platform"
 import { Project } from "@opencode-ai/sdk/v2"
-import { normalizeProjectInfo } from "./global-sync/utils"
+import { enrichProject, normalizeProjectInfo } from "./global-sync/utils"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { pathKey } from "@/utils/path-key"
 import { decode64 } from "@/utils/base64"
@@ -449,14 +449,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         ? serverSync().data.project.find((x) => x.id === projectID)
         : serverSync().data.project.find((x) => x.worktree === project.worktree)
 
-      // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-      // Without this, different subdirectories of the same git repo would share the same
-      // icon from the database instead of using their individual overrides.
+      // Preserve local per-workspace overrides (name, commands, icon) from the localStorage
+      // cache (childStore.projectMeta) and the legacy childStore.icon override.
       const base = { ...metadata, ...project }
-      if (childStore.icon) {
-        return { ...base, icon: { ...base.icon, override: childStore.icon } }
-      }
-      return base
+      return enrichProject(base, childStore.projectMeta, childStore.icon, Boolean(projectID) && projectID !== "global")
     }
 
     const roots = createMemo(() => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1301,16 +1301,14 @@ export default function LegacyLayout(props: ParentProps) {
 
     if (project.id && project.id !== "global") {
       const sdk = serverSDK()
-      if ((await sdk.protocol) === "v1") {
-        const result = await sdk.client.project
-          .update({ projectID: project.id, directory: project.worktree, name })
-          .then((response) => response.data)
-          .catch(() => undefined)
-        if (result) {
-          serverSync().set("project", (items) =>
-            items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
-          )
-        }
+      const result = await sdk.client.project
+        .update({ projectID: project.id, directory: project.worktree, name })
+        .then((response) => response.data)
+        .catch(() => undefined)
+      if (result) {
+        serverSync().set("project", (items) =>
+          items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
+        )
       }
     }
   }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1297,21 +1297,22 @@ export default function LegacyLayout(props: ParentProps) {
     if (next === current) return
     const name = next === getFilename(project.worktree) ? "" : next
 
+    serverSync().project.meta(project.worktree, { name })
+
     if (project.id && project.id !== "global") {
       const sdk = serverSDK()
-      if ((await sdk.protocol) !== "v1") return
-      const result = await sdk.client.project
-        .update({ projectID: project.id, directory: project.worktree, name })
-        .then((response) => response.data)
-      if (!result) return
-      // const result = await serverSDK().api.project.update({ projectID: project.id, name })
-      serverSync().set("project", (items) =>
-        items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
-      )
-      return
+      if ((await sdk.protocol) === "v1") {
+        const result = await sdk.client.project
+          .update({ projectID: project.id, directory: project.worktree, name })
+          .then((response) => response.data)
+          .catch(() => undefined)
+        if (result) {
+          serverSync().set("project", (items) =>
+            items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
+          )
+        }
+      }
     }
-
-    serverSync().project.meta(project.worktree, { name })
   }
 
   const renameWorkspace = (directory: string, next: string, projectId?: string, branch?: string) => {

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -232,9 +232,14 @@ const layer = Layer.effect(
 
       if (flags.experimentalIconDiscovery) yield* discover(existing).pipe(Effect.ignore, Effect.forkIn(scope))
 
+      const worktreeExists =
+        existing.worktree && existing.worktree !== "/"
+          ? yield* fs.exists(existing.worktree).pipe(Effect.catch(() => Effect.succeed(false)))
+          : false
+
       const result: Info = {
         ...existing,
-        worktree: projectID === ProjectV2.ID.global ? worktree : existing.worktree,
+        worktree: projectID !== ProjectV2.ID.global && worktreeExists ? existing.worktree : worktree,
         vcs: data.vcs?.type ?? fakeVcs,
         time: { ...existing.time, updated: Date.now() },
       }

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test"
+import { rename } from "node:fs/promises"
 import { Project } from "@/project/project"
 import { $ } from "bun"
 import path from "path"
@@ -232,6 +233,21 @@ describe("Project.fromDirectory", () => {
         (yield* db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, workspaceID)).get().pipe(Effect.orDie))
           ?.project_id,
       ).toBe(remoteID)
+    }),
+  )
+
+  it.live("updates project worktree when directory on disk is renamed", () =>
+    Effect.gen(function* () {
+      const projects = yield* Project.Service
+      const tmp1 = yield* tmpdirScoped({ git: true })
+      const initial = yield* projects.fromDirectory(tmp1)
+
+      const tmp2 = `${tmp1}-renamed`
+      yield* Effect.promise(() => rename(tmp1, tmp2))
+
+      const updated = yield* projects.fromDirectory(tmp2)
+      expect(updated.project.id).toBe(initial.project.id)
+      expect(updated.project.worktree).toBe(tmp2)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31739

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

For projects without a server registration (id-less / `"global"` projects), the edit dialog writes the new name, commands, and icon to the per-workspace `projectMeta` cache. But `enrich()` in `global.tsx` and `layout.tsx` only merged the legacy `childStore.icon` override, so the renamed name and startup command were silently ignored in the project list.

This adds a `mergeProjectMeta` helper and applies it in both `enrich()` functions before the existing icon override. The enriched list is consumed by the sidebar, session tabs, command palette, and directory picker, so local renames now display everywhere. Server-registered projects keep their server values unless a local override exists.

### How did you verify your code works?

- Added unit tests for `mergeProjectMeta`: local name applied for id-less projects, server name kept when local has no name, empty name falls back to the folder-derived name, and icon + commands merge.
- `bun test src/context/global-sync/utils.test.ts`: 11 pass (6 existing + 5 new), 0 fail.
- `bun typecheck` in `packages/app`: 0 errors.
- Confirmed a production desktop build (`OPENCODE_CHANNEL=prod`) renders the fix.

### Screenshots / recordings
<img width="587" height="643" alt="image" src="https://github.com/user-attachments/assets/174fd12d-8396-4c96-9c35-36563659e3c2" />

this is a display-logic fix on the enriched project list, not a visual UI change. Prior local renames appear once the app rebuilds with this change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR