### PR TITLE
fix(core): settle prompt requests before publish

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -222,27 +222,31 @@ const layer = Layer.effect(
         EffectRuntime.gen(function* () {
           const existing = pending.get(input.requestID)
           if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
-          yield* events.publish(Event.Replied, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-            reply: input.reply,
-          })
+          pending.delete(input.requestID)
+          yield* events
+            .publish(Event.Replied, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+              reply: input.reply,
+            })
+            .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(input.requestID, existing))))
 
           if (input.reply === "reject") {
             yield* Deferred.fail(
               existing.deferred,
               input.message ? new CorrectedError({ feedback: input.message }) : new DeclinedError(),
             )
-            pending.delete(input.requestID)
             for (const [id, item] of pending) {
               if (item.request.sessionID !== existing.request.sessionID) continue
-              yield* events.publish(Event.Replied, {
-                sessionID: item.request.sessionID,
-                requestID: item.request.id,
-                reply: "reject",
-              })
-              yield* Deferred.fail(item.deferred, new DeclinedError())
               pending.delete(id)
+              yield* events
+                .publish(Event.Replied, {
+                  sessionID: item.request.sessionID,
+                  requestID: item.request.id,
+                  reply: "reject",
+                })
+                .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(id, item))))
+              yield* Deferred.fail(item.deferred, new DeclinedError())
             }
             return
           }
@@ -255,7 +259,6 @@ const layer = Layer.effect(
             })
           }
           yield* Deferred.succeed(existing.deferred, undefined)
-          pending.delete(input.requestID)
           if (input.reply !== "always" || !existing.request.save?.length) return
 
           const rememberedRules = yield* savedRules()
@@ -273,13 +276,15 @@ const layer = Layer.effect(
               )
             )
               continue
-            yield* events.publish(Event.Replied, {
-              sessionID: item.request.sessionID,
-              requestID: item.request.id,
-              reply: "always",
-            })
-            yield* Deferred.succeed(item.deferred, undefined)
             pending.delete(id)
+            yield* events
+              .publish(Event.Replied, {
+                sessionID: item.request.sessionID,
+                requestID: item.request.id,
+                reply: "always",
+              })
+              .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(id, item))))
+            yield* Deferred.succeed(item.deferred, undefined)
           }
         }),
       ),

--- a/packages/core/src/question.ts
+++ b/packages/core/src/question.ts
@@ -114,13 +114,15 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const existing = pending.get(input.requestID)
           if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
-          yield* events.publish(Event.Replied, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-            answers: input.answers.map((answer) => [...answer]),
-          })
-          yield* Deferred.succeed(existing.deferred, input.answers)
           pending.delete(input.requestID)
+          yield* events
+            .publish(Event.Replied, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+              answers: input.answers.map((answer) => [...answer]),
+            })
+            .pipe(Effect.onError(() => Effect.sync(() => pending.set(input.requestID, existing))))
+          yield* Deferred.succeed(existing.deferred, input.answers)
         }),
       ),
     )
@@ -130,12 +132,14 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const existing = pending.get(requestID)
           if (!existing) return yield* new NotFoundError({ requestID })
-          yield* events.publish(Event.Rejected, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-          })
-          yield* Deferred.fail(existing.deferred, new RejectedError())
           pending.delete(requestID)
+          yield* events
+            .publish(Event.Rejected, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+            })
+            .pipe(Effect.onError(() => Effect.sync(() => pending.set(requestID, existing))))
+          yield* Deferred.fail(existing.deferred, new RejectedError())
         }),
       ),
     )

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -265,6 +265,35 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("removes a pending request before publishing a reply", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const { service, fiber, request } = yield* waitForRequest()
+      const events = yield* EventV2.Service
+      const publishing = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const replied: EventV2.Payload[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type !== PermissionV2.Event.Replied.type) return
+          const count = replied.push(event)
+          if (count === 1) yield* Deferred.succeed(publishing, undefined).pipe(Effect.andThen(Deferred.await(release)))
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const first = yield* service.reply({ requestID: request.id, reply: "once" }).pipe(Effect.forkScoped)
+      yield* Deferred.await(publishing)
+
+      yield* Effect.sync(() => undefined).pipe(
+        Effect.andThen(service.list()),
+        Effect.andThen((pending) => Effect.sync(() => expect(pending).toEqual([]))),
+        Effect.ensuring(Deferred.succeed(release, undefined)),
+      )
+      yield* Fiber.join(first)
+      yield* Fiber.join(fiber)
+    }),
+  )
+
   it.effect("defects when an asked permission is declined", () =>
     Effect.gen(function* () {
       yield* setup()

--- a/packages/core/test/question.test.ts
+++ b/packages/core/test/question.test.ts
@@ -60,6 +60,35 @@ describe("QuestionV2", () => {
     }),
   )
 
+  it.effect("removes a pending request before publishing its reply", () =>
+    Effect.gen(function* () {
+      const service = yield* QuestionV2.Service
+      const events = yield* EventV2.Service
+      const publishing = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const replied: EventV2.Payload[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type !== QuestionV2.Event.Replied.type) return
+          const count = replied.push(event)
+          if (count === 1) yield* Deferred.succeed(publishing, undefined).pipe(Effect.andThen(Deferred.await(release)))
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const { fiber, request } = yield* waitForAsk(service, { sessionID, questions: [question] })
+      const first = yield* service.reply({ requestID: request.id, answers: [["One"]] }).pipe(Effect.forkScoped)
+      yield* Deferred.await(publishing)
+
+      yield* Effect.sync(() => undefined).pipe(
+        Effect.andThen(service.list()),
+        Effect.andThen((pending) => Effect.sync(() => expect(pending).toEqual([]))),
+        Effect.ensuring(Deferred.succeed(release, undefined)),
+      )
+      yield* Fiber.join(first)
+      expect(yield* Fiber.join(fiber)).toEqual([["One"]])
+    }),
+  )
+
   it.effect("publishes rejection, fails the ask, and rejects unknown IDs", () =>
     Effect.gen(function* () {
       const service = yield* QuestionV2.Service


### PR DESCRIPTION
## Summary
- Remove PermissionV2 and QuestionV2 pending entries before publishing reply/reject settlement events
- Roll back the pending entry if settlement event publication fails
- Add regression coverage for the inline publish window where pending state used to remain visible while settlement was already in progress

Refs #34853

## Test Plan
- `bun test test/question.test.ts --test-name-pattern "removes a pending request before publishing its reply"`
- `bun test test/permission.test.ts --test-name-pattern "removes a pending request before publishing a reply"`
- `bun test test/permission.test.ts test/question.test.ts`
- `cd packages/core && bun run typecheck`
- `bun run lint packages/core/src/permission.ts packages/core/src/question.ts packages/core/test/permission.test.ts packages/core/test/question.test.ts`
- `git diff --check`