### PR TITLE
fix: @ file mentions can't find new files; feat: refresh file index command

### DIFF
--- a/packages/app/src/components/index-progress-indicator.tsx
+++ b/packages/app/src/components/index-progress-indicator.tsx
@@ -1,0 +1,23 @@
+import { Show } from "solid-js"
+import { Portal } from "solid-js/web"
+import { LoaderV2 } from "@opencode-ai/ui/v2/loader-v2"
+import { useFile } from "@/context/file"
+import { useLanguage } from "@/context/language"
+
+export function IndexProgressIndicator() {
+  const file = useFile()
+  const language = useLanguage()
+
+  return (
+    <Portal>
+      <Show when={file.indexing()}>
+        <div class="pointer-events-none fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border-[0.5px] border-v2-border-border-base bg-v2-background-bg-layer-01 px-3 py-2 shadow-[var(--v2-elevation-raised)]">
+          <LoaderV2 class="h-4 w-4" />
+          <span class="text-[12px] leading-none text-v2-text-text-base">
+            {language.t("index.progress.refreshing")}
+          </span>
+        </div>
+      </Show>
+    </Portal>
+  )
+}

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -1,4 +1,4 @@
-import { batch, createEffect, createMemo, onCleanup } from "solid-js"
+import { batch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { showToast } from "@/utils/toast"
@@ -70,6 +70,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     )
 
     const inflight = new Map<string, Promise<void>>()
+    const [indexing, setIndexing] = createSignal(0)
     const [store, setStore] = createStore<{
       file: Record<string, FileState>
     }>({
@@ -204,18 +205,18 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     }
 
     const search = (query: string, dirs: "true" | "false", options?: { limit?: number; signal?: AbortSignal }) =>
-      serverSDK()
-        .api.file.find(
+      sdk()
+        .client.v2.fs.find(
           {
             location: { directory: sdk().directory },
             query,
-            type: dirs === "true" ? "directory" : "file",
-            limit: options?.limit,
+            ...(dirs === "false" ? { type: "file" } : {}),
+            ...(options?.limit ? { limit: String(options.limit) } : {}),
           },
           { signal: options?.signal },
         )
         .then(
-          (x) => x.data.map((entry) => path.normalize(entry.path)),
+          (x) => x.data.data.map((entry) => path.normalize(entry.path)),
           (error) => {
             if (options?.signal?.aborted) throw error
             return []
@@ -298,6 +299,21 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       searchFiles: (query: string, options?: { limit?: number; signal?: AbortSignal }) =>
         search(query, "false", options),
       searchFilesAndDirectories: (query: string) => search(query, "true"),
+      indexing: () => indexing() > 0,
+      refreshIndex: async () => {
+        setIndexing((value) => value + 1)
+        try {
+          await sdk()
+            .client.v2.fs.refresh({
+              location: {
+                directory: sdk().directory,
+              },
+            })
+            .then(() => tree.reset())
+        } finally {
+          setIndexing((value) => Math.max(0, value - 1))
+        }
+      },
     }
   },
 })

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -48,6 +48,8 @@ export const dict = {
   "command.session.new": "New session",
   "command.file.open": "Open file",
   "command.tab.close": "Close tab",
+  "command.file.refresh": "Refresh file index",
+  "index.progress.refreshing": "Refreshing file index…",
   "command.tab.reopenClosed": "Reopen closed tab",
   "command.context.addSelection": "Add selection to context",
   "command.context.addSelection.description": "Add selected lines from the current file",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -59,6 +59,8 @@ export const dict = {
   "command.file.open": "打开文件",
 
   "command.tab.close": "关闭标签页",
+  "command.file.refresh": "刷新文件索引",
+  "index.progress.refreshing": "正在刷新文件索引…",
   "command.tab.reopenClosed": "重新打开已关闭的标签页",
 
   "command.context.addSelection": "将所选内容添加到上下文",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -40,6 +40,7 @@ import { showToast } from "@/utils/toast"
 import { base64Encode, checksum } from "@opencode-ai/core/util/encode"
 import { useLocation, useNavigate, useParams, useSearchParams } from "@solidjs/router"
 import { NewSessionView, SessionHeader } from "@/components/session"
+import { IndexProgressIndicator } from "@/components/index-progress-indicator"
 import { ErrorPage } from "@/pages/error"
 import { CommentsProvider, useComments } from "@/context/comments"
 import { useCommand } from "@/context/command"
@@ -2382,6 +2383,7 @@ export default function Page() {
       <Show when={!newSessionDesign()}>
         <TerminalPanel />
       </Show>
+      <IndexProgressIndicator />
     </SessionRouteFrame>
   )
 }

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -471,6 +471,22 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
         slash: "open",
         onSelect: openFile,
       }),
+      fileCommand({
+        id: "file.refresh",
+        title: language.t("command.file.refresh"),
+        onSelect: () => {
+          void file
+            .refreshIndex()
+            .then(() => showToast({ variant: "success", title: language.t("command.file.refresh") }))
+            .catch(() =>
+              showToast({
+                variant: "error",
+                title: language.t("command.file.refresh"),
+                description: language.t("toast.file.listFailed.title"),
+              }),
+            )
+        },
+      }),
       tab &&
         fileCommand({
           id: "tab.close",

--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -492,7 +492,16 @@ const Endpoint10_1 = (raw: RawClient["server.fs"]) => (input: Endpoint10_1Input)
     query: { location: input["location"], query: input["query"], type: input["type"], limit: input["limit"] },
   }).pipe(Effect.mapError(mapClientError))
 
-const adaptGroup10 = (raw: RawClient["server.fs"]) => ({ list: Endpoint10_0(raw), find: Endpoint10_1(raw) })
+type Endpoint10_2Request = Parameters<RawClient["server.fs"]["fs.refresh"]>[0]
+type Endpoint10_2Input = { readonly location?: Endpoint10_2Request["query"]["location"] }
+const Endpoint10_2 = (raw: RawClient["server.fs"]) => (input?: Endpoint10_2Input) =>
+  raw["fs.refresh"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup10 = (raw: RawClient["server.fs"]) => ({
+  list: Endpoint10_0(raw),
+  find: Endpoint10_1(raw),
+  refresh: Endpoint10_2(raw),
+})
 
 type Endpoint11_0Request = Parameters<RawClient["server.command"]["command.list"]>[0]
 type Endpoint11_0Input = { readonly location?: Endpoint11_0Request["query"]["location"] }

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -81,6 +81,8 @@ import type {
   FilesListOutput,
   FilesFindInput,
   FilesFindOutput,
+  FilesRefreshInput,
+  FilesRefreshOutput,
   CommandsListInput,
   CommandsListOutput,
   SkillsListInput,
@@ -776,6 +778,18 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [401, 400],
             empty: false,
+          },
+          requestOptions,
+        ),
+      refresh: (input?: FilesRefreshInput, requestOptions?: RequestOptions) =>
+        request<FilesRefreshOutput>(
+          {
+            method: "POST",
+            path: `/api/fs/find/refresh`,
+            query: { location: input?.["location"] },
+            successStatus: 204,
+            declaredStatuses: [401, 400],
+            empty: true,
           },
           requestOptions,
         ),

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -2495,6 +2495,14 @@ export type FilesFindOutput = {
   readonly data: ReadonlyArray<{ readonly path: string; readonly type: "file" | "directory" }>
 }
 
+export type FilesRefreshInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type FilesRefreshOutput = void
+
 export type CommandsListInput = {
   readonly location?: {
     readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -34,7 +34,7 @@ test("exposes every standard HTTP API group", () => {
     "attemptComplete",
     "attemptCancel",
   ])
-  expect(Object.keys(client.files)).toEqual(["list", "find"])
+  expect(Object.keys(client.files)).toEqual(["list", "find", "refresh"])
   expect(Object.keys(client.ptys)).toEqual(["list", "create", "get", "update", "remove"])
 })
 

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -52,6 +52,7 @@ export interface Interface {
   readonly find: (input: FindInput) => Effect.Effect<Entry[]>
   readonly glob: (input: GlobInput) => Effect.Effect<readonly Entry[]>
   readonly grep: (input: GrepInput) => Effect.Effect<readonly Match[]>
+  readonly refresh: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/FileSystem") {}
@@ -75,6 +76,7 @@ const baseLayer = Layer.effect(
       find: search.find,
       glob: search.glob,
       grep: search.grep,
+      refresh: search.refresh,
       read: Effect.fn("FileSystem.read")(function* (input) {
         const target = yield* resolve(input.path)
         const info = yield* fs.stat(target.real).pipe(Effect.orDie)

--- a/packages/core/src/filesystem/fff.bun.ts
+++ b/packages/core/src/filesystem/fff.bun.ts
@@ -62,6 +62,7 @@ export interface Picker {
   destroy(): void
   isScanning(): boolean
   waitForScan(timeoutMs?: number): Promise<Result<boolean>>
+  scanFiles(): Result<void>
   refreshGitStatus(): Result<number>
   fileSearch(
     query: string,
@@ -125,6 +126,7 @@ export function create(opts: Init): Result<Picker> {
       destroy: () => pick.destroy(),
       isScanning: () => pick.isScanning(),
       waitForScan: (timeoutMs) => pick.waitForScan(timeoutMs),
+      scanFiles: () => pick.scanFiles(),
       refreshGitStatus: () => pick.refreshGitStatus(),
       fileSearch: (query, next) => pick.fileSearch(query, next),
       glob: (pattern, next) => pick.glob(pattern, next),

--- a/packages/core/src/filesystem/fff.node.ts
+++ b/packages/core/src/filesystem/fff.node.ts
@@ -78,6 +78,7 @@ export interface Picker {
   destroy(): void
   isScanning(): boolean
   waitForScan(timeoutMs?: number): Promise<Result<boolean>>
+  scanFiles(): Result<void>
   refreshGitStatus(): Result<number>
   fileSearch(
     query: string,

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -16,6 +16,7 @@ export interface Interface {
   readonly find: (input: FileSystem.FindInput) => Effect.Effect<FileSystem.Entry[]>
   readonly glob: (input: FileSystem.GlobInput) => Effect.Effect<readonly FileSystem.Entry[]>
   readonly grep: (input: FileSystem.GrepInput) => Effect.Effect<readonly FileSystem.Match[]>
+  readonly refresh: () => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/FileSystem/Search") {}
@@ -31,22 +32,34 @@ export const ripgrepLayer = Layer.effect(
       files: [] as string[],
       directories: [] as string[],
     }
-    const directories = new Set<string>()
-    yield* ripgrep
-      .find({
-        cwd: location.directory,
-        pattern: "*",
-        limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
-        onEntry: (entry) =>
-          Effect.sync(() => {
-            state.files.push(entry.path)
-            const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
-          }),
-      })
-      .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
+    let generation = 0
+    const scan = () => {
+      const current = ++generation
+      const directories = new Set<string>()
+      state.files = []
+      state.directories = []
+      return ripgrep
+        .find({
+          cwd: location.directory,
+          pattern: "*",
+          limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
+          onEntry: (entry) =>
+            Effect.sync(() => {
+              if (current !== generation) return
+              state.files.push(entry.path)
+              const parts = entry.path.split("/")
+              parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
+              state.directories = Array.from(directories)
+            }),
+        })
+        .pipe(
+          Effect.catch((error) => Effect.logWarning("ripgrep index scan failed", { error }).pipe(Effect.asVoid)),
+          Effect.asVoid,
+        )
+    }
+    yield* scan().pipe(Effect.forkIn(scope))
     return Service.of({
+      refresh: () => scan(),
       glob: (input) =>
         Effect.gen(function* () {
           const target = path.resolve(location.directory, input.path ?? ".")
@@ -141,10 +154,24 @@ export const fffLayer = Layer.effect(
         find: () => Effect.succeed([]),
         glob: () => Effect.succeed([]),
         grep: () => Effect.succeed([]),
+        refresh: () => Effect.void,
       })
     }
     yield* Effect.addFinalizer(() => Effect.sync(() => result.value.destroy()).pipe(Effect.ignore))
     return Service.of({
+      refresh: () =>
+        Effect.tryPromise(async () => {
+          const res = result.value.scanFiles()
+          if (!res.ok) throw new Error(res.error)
+          const deadline = Date.now() + 30_000
+          while (!result.value.isScanning() && Date.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, 25))
+          }
+          await result.value.waitForScan(Math.max(1_000, deadline - Date.now()))
+        }).pipe(
+          Effect.catch((error) => Effect.logWarning("failed to refresh fff index", { error })),
+          Effect.asVoid,
+        ),
       glob: (input) =>
         Effect.sync(() => {
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -66,4 +66,34 @@ describe("FileSystem", () => {
       }).pipe(provide(directory)),
     ),
   )
+
+  it.live("finds files created after startup once the index is refreshed", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        // Seed an initial file so the async index scan has a fence to wait on.
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "seed.txt"), "seed"))
+        const service = yield* FileSystem.Service
+        const waitFor = (name: string, maxAttempts = 50): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            if (maxAttempts <= 0) throw new Error(`Timed out waiting for ${name}`)
+            const found = yield* service.find({ query: name, type: "file" })
+            if (found.some((entry) => entry.path.endsWith(name))) return
+            yield* Effect.sleep("50 millis")
+            yield* waitFor(name, maxAttempts - 1)
+          })
+        yield* waitFor("seed.txt")
+
+        // A new file added after startup is not in the static snapshot yet.
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "fresh.ts"), "// fresh"))
+        const before = yield* service.find({ query: "fresh.ts", type: "file" })
+        expect(before.some((entry) => entry.path.endsWith("fresh.ts"))).toBe(false)
+
+        // Refreshing rebuilds the snapshot and makes the new file discoverable.
+        yield* service.refresh()
+        yield* waitFor("fresh.ts")
+        const after = yield* service.find({ query: "fresh.ts", type: "file" })
+        expect(after.some((entry) => entry.path.endsWith("fresh.ts"))).toBe(true)
+      }).pipe(provide(directory)),
+    ),
+  )
 })

--- a/packages/protocol/src/groups/fs.ts
+++ b/packages/protocol/src/groups/fs.ts
@@ -4,7 +4,6 @@ import { PositiveInt, RelativePath } from "@opencode-ai/schema/schema"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { LocationQuery, locationQueryOpenApi } from "./location"
-
 const ListQuery = Schema.Struct({
   ...LocationQuery.fields,
   path: RelativePath.pipe(Schema.optional),
@@ -57,6 +56,20 @@ export const FileSystemGroup = HttpApiGroup.make("server.fs")
           identifier: "v2.fs.find",
           summary: "Find files",
           description: "Find recursively ranked filesystem entries relative to the requested location.",
+        }),
+      ),
+  )
+  .add(
+    HttpApiEndpoint.post("fs.refresh", "/api/fs/find/refresh", {
+      query: LocationQuery,
+      success: HttpApiSchema.NoContent,
+    })
+      .annotateMerge(locationQueryOpenApi)
+      .annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.fs.refresh",
+          summary: "Refresh file index",
+          description: "Rescan the requested location and rebuild the file search index.",
         }),
       ),
   )

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -279,6 +279,8 @@ import type {
   V2FsListResponses,
   V2FsReadErrors,
   V2FsReadResponses,
+  V2FsRefreshErrors,
+  V2FsRefreshResponses,
   V2HealthGetErrors,
   V2HealthGetResponses,
   V2IntegrationAttemptCancelErrors,
@@ -6492,6 +6494,28 @@ export class Fs extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<V2FsFindResponses, V2FsFindErrors, ThrowOnError>({
       url: "/api/fs/find",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Refresh file index
+   *
+   * Rescan the requested location and rebuild the file search index.
+   */
+  public refresh<ThrowOnError extends boolean = false>(
+    parameters?: {
+      location?: {
+        directory?: string
+        workspace?: string
+      }
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "location" }] }])
+    return (options?.client ?? this.client).post<V2FsRefreshResponses, V2FsRefreshErrors, ThrowOnError>({
+      url: "/api/fs/find/refresh",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -12891,6 +12891,40 @@ export type V2FsFindResponses = {
 
 export type V2FsFindResponse = V2FsFindResponses[keyof V2FsFindResponses]
 
+export type V2FsRefreshData = {
+  body?: never
+  path?: never
+  query?: {
+    location?: {
+      directory?: string
+      workspace?: string
+    }
+  }
+  url: "/api/fs/find/refresh"
+}
+
+export type V2FsRefreshErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+}
+
+export type V2FsRefreshError = V2FsRefreshErrors[keyof V2FsRefreshErrors]
+
+export type V2FsRefreshResponses = {
+  /**
+   * <No Content>
+   */
+  204: void
+}
+
+export type V2FsRefreshResponse = V2FsRefreshResponses[keyof V2FsRefreshResponses]
+
 export type V2CommandListData = {
   body?: never
   path?: never

--- a/packages/server/src/handlers/fs.ts
+++ b/packages/server/src/handlers/fs.ts
@@ -2,7 +2,7 @@ import { FileSystem } from "@opencode-ai/core/filesystem"
 import { RelativePath } from "@opencode-ai/core/schema"
 import { Effect } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Api } from "../api"
 import { response } from "../location"
 
@@ -33,6 +33,11 @@ export const FileSystemHandler = HttpApiBuilder.group(Api, "server.fs", (handler
             const fs = yield* FileSystem.Service
             return yield* fs.find(ctx.query)
           }),
+        ),
+      )
+      .handle("fs.refresh", (ctx) =>
+        FileSystem.Service.use((fs) =>
+          fs.refresh().pipe(Effect.as(HttpApiSchema.NoContent.make())),
         ),
       )
   }),

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -36,7 +36,7 @@ import { SDKProvider, useSDK } from "./context/sdk"
 import { StartupLoading } from "./component/startup-loading"
 import { SyncProvider, useSync } from "./context/sync"
 import { DataProvider } from "./context/data"
-import { LocationProvider } from "./context/location"
+import { LocationProvider, useLocation } from "./context/location"
 import { LocalProvider, useLocal } from "./context/local"
 import { PermissionProvider } from "./context/permission"
 import { DialogModel } from "./component/dialog-model"
@@ -137,6 +137,7 @@ const appBindingCommands = [
   "app.toggle.diffwrap",
   "app.toggle.paste_summary",
   "app.toggle.session_directory_filter",
+  "fs.refresh",
 ] as const
 
 export type TuiInput = {
@@ -379,6 +380,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   const { theme, mode, setMode, locked, lock, unlock } = themeState
   const sync = useSync()
   const project = useProject()
+  const location = useLocation()
   const exit = useExit()
   const promptRef = usePromptRef()
   const pluginRuntime = usePluginRuntime()
@@ -951,6 +953,23 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         run: () => {
           local.permission.toggle()
           dialog.clear()
+        },
+      },
+      {
+        name: "fs.refresh",
+        title: "Refresh file index",
+        category: "System",
+        run: () => {
+          dialog.clear()
+          sdk.client.v2.fs
+            .refresh({
+              location: {
+                directory: location()?.directory,
+                workspace: location()?.workspaceID ?? project.workspace.current(),
+              },
+            })
+            .then(() => toast.show({ message: "File index refreshed", variant: "success" }))
+            .catch(() => toast.show({ message: "Failed to refresh file index", variant: "error" }))
         },
       },
     ].map((command) => ({

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -131,6 +131,7 @@ export const Definitions = {
   agent_cycle_reverse: keybind("shift+tab", "Previous agent"),
   variant_cycle: keybind("ctrl+t", "Cycle model variants"),
   variant_list: keybind("none", "List model variants"),
+  fs_refresh: keybind("f5", "Refresh file index"),
 
   messages_page_up: keybind("pageup,ctrl+alt+b", "Scroll messages up by one page"),
   messages_page_down: keybind("pagedown,ctrl+alt+f", "Scroll messages down by one page"),


### PR DESCRIPTION
## Summary

Fixes the `@` file mention so it can find newly added files, and adds a **Refresh file index** command that forces a rescan of the search index.

## Changes

### fix: `@` mentions + index refresh
- `searchFilesAndDirectories` no longer sends `type=directory`, so the server runs the mixed file + directory search and file names are matched again (regression from the v2 migration).
- `@` search now calls the v2 `fs.find` endpoint directly (same index family as `fs.refresh`) instead of going through the v1 `/find/file` compat path, which maintains a separate, never-rescanned index on the desktop side.
- ripgrep index refresh now waits for the rescan to complete instead of forking and returning immediately.
- fff index refresh now triggers a real rescan (`scanFiles`) instead of only waiting on an already-completed scan.

### feat: refresh command + loading indicator
- Server: location-scoped `POST /api/fs/find/refresh` that rescans and rebuilds the search index.
- Desktop app: `Refresh file index` command (command palette) with a loading indicator at the bottom-right while the rescan runs.
- TUI: `fs.refresh` command bound to F5.

Fixes #40391
Refs #40392