### PR TITLE
fix(app): use selected model for context usage

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -16,6 +16,7 @@ import { getSessionContext } from "@/components/session/session-context-metrics"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { useSettings } from "@/context/settings"
+import { useLocal } from "@/context/local"
 
 interface SessionContextUsageProps {
   variant?: "button" | "indicator"
@@ -50,6 +51,7 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   const language = useLanguage()
   const sdk = useSDK()
   const settings = useSettings()
+  const local = useLocal()
   const providers = useProviders(() => sdk().directory)
   const { params, tabs, view } = useSessionLayout()
   const isDesktop = createMediaQuery("(min-width: 768px)")
@@ -73,7 +75,14 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
       }),
   )
 
-  const context = createMemo(() => getSessionContext(messages(), [...providers.all().values()]))
+  const context = createMemo(() => {
+    const current = local.model.current()
+    return getSessionContext(
+      messages(),
+      [...providers.all().values()],
+      current ? { providerID: current.provider.id, modelID: current.id } : undefined,
+    )
+  })
   const cost = createMemo(() => {
     return usd().format(info()?.cost ?? 0)
   })

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -67,6 +67,27 @@ describe("getSessionContext", () => {
     expect(ctx?.modelLabel).toBe("GPT-4.1")
   })
 
+  test("uses the selected model limit when it differs from the last assistant model", () => {
+    const messages = [assistant("a1", { input: 300, output: 100, reasoning: 50, read: 25, write: 25 }, 1.25)]
+    const providers = [
+      {
+        id: "openai",
+        name: "OpenAI",
+        models: {
+          large: { name: "Large", limit: { context: 1000 } },
+          small: { name: "Small", limit: { context: 250 } },
+        },
+      },
+    ]
+
+    const ctx = getSessionContext(messages, providers, { providerID: "openai", modelID: "small" })
+
+    expect(ctx?.message.id).toBe("a1")
+    expect(ctx?.limit).toBe(250)
+    expect(ctx?.usage).toBe(200)
+    expect(ctx?.modelLabel).toBe("Small")
+  })
+
   test("preserves fallback labels and null usage when model metadata is missing", () => {
     const messages = [assistant("a1", { input: 40, output: 10, reasoning: 0, read: 0, write: 0 }, 0.1, "p-1", "m-1")]
     const providers = [{ id: "p-1", models: {} }]

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -13,6 +13,11 @@ type Model = {
   }
 }
 
+type ModelKey = {
+  providerID: string
+  modelID: string
+}
+
 type Context = {
   message: AssistantMessage
   provider?: Provider
@@ -36,14 +41,17 @@ const lastAssistantWithTokens = (messages: Message[]) => {
     if (tokenTotal(msg) <= 0) continue
     return msg
   }
+  return undefined
 }
 
-const build = (messages: Message[] = [], providers: Provider[] = []): Context | undefined => {
+const build = (messages: Message[] = [], providers: Provider[] = [], selected?: ModelKey): Context | undefined => {
   const message = lastAssistantWithTokens(messages)
   if (!message) return undefined
 
-  const provider = providers.find((item) => item.id === message.providerID)
-  const model = provider?.models[message.modelID]
+  const selectedProvider = selected ? providers.find((item) => item.id === selected.providerID) : undefined
+  const selectedModel = selectedProvider?.models[selected?.modelID ?? ""]
+  const provider = selectedModel ? selectedProvider : providers.find((item) => item.id === message.providerID)
+  const model = selectedModel ?? provider?.models[message.modelID]
   const limit = model?.limit.context
   const total = tokenTotal(message)
 
@@ -51,8 +59,8 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
     message,
     provider,
     model,
-    providerLabel: provider?.name ?? message.providerID,
-    modelLabel: model?.name ?? message.modelID,
+    providerLabel: provider?.name ?? selected?.providerID ?? message.providerID,
+    modelLabel: model?.name ?? selected?.modelID ?? message.modelID,
     limit,
     input: message.tokens.input,
     total,
@@ -60,6 +68,6 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
   }
 }
 
-export function getSessionContext(messages: Message[] = [], providers: Provider[] = []) {
-  return build(messages, providers)
+export function getSessionContext(messages: Message[] = [], providers: Provider[] = [], selected?: ModelKey) {
+  return build(messages, providers, selected)
 }


### PR DESCRIPTION
## Summary
- Prefer the currently selected session model when computing sidebar context usage percentages
- Fall back to the last assistant message model when no selected model metadata is available
- Add regression coverage for switching from a larger model to a smaller selected model

Fixes #35072

## Test Plan
- `bun test --conditions=solid --preload ./happydom.ts ./src/components/session/session-context-metrics.test.ts --test-name-pattern "uses the selected model limit"`
- `bun test --conditions=solid --preload ./happydom.ts ./src/components/session/session-context-metrics.test.ts`
- `bun run lint packages/app/src/components/session/session-context-metrics.ts packages/app/src/components/session/session-context-metrics.test.ts packages/app/src/components/session-context-usage.tsx`
- `git diff --check`

Note: `packages/app` typecheck currently fails on the existing `src/custom-elements.d.ts` placeholder (`../../ui/src/custom-elements.d.ts`), with no diff to that file in this branch.