### PR TITLE
fix(ui): correct TextMate scope typo "arbitrary-repitition"

### DIFF
--- a/packages/ui/src/context/marked-theme.tsx
+++ b/packages/ui/src/context/marked-theme.tsx
@@ -207,7 +207,7 @@ export const OpenCodeTheme = {
         "string.regexp.character-class",
         "string.regexp constant.character.escape",
         "string.regexp source.ruby.embedded",
-        "string.regexp string.regexp.arbitrary-repitition",
+        "string.regexp string.regexp.arbitrary-repetition",
         "string.regexp constant.character.escape",
       ],
       settings: {


### PR DESCRIPTION
### Issue for this PR

Closes #40366

### Type of change

- [x] Bug fix

### What does this PR do?

The issue reported a misspelled TextMate scope name (`arbitrary-repitition`) that should be `arbitrary-repetition`. The misspelled scope never matched the grammar rule, so regex highlighting did not apply to that scope.

Fixed it in `packages/ui/src/context/marked-theme.tsx` — note the actual location differs from the issue, which references `packages/ui/src/context/marked.tsx` (that typo no longer exists there on dev). This is a one-word spelling fix; the correct scope name is the standard TextMate `string.regexp string.regexp.arbitrary-repetition`.

### How did you verify your code works?

- `bun typecheck` in `packages/ui` passes
- Repo-wide typecheck passes (`bun turbo typecheck`, 36 packages)
- No remaining `repitition` matches in the repo

### Screenshots / recordings

Not applicable — this is a theme scope-name fix with no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
