### PR TITLE
fix(tui): include model variants in assistant footer

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1459,6 +1459,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
   const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
+  const variant = createMemo(() =>
+    props.message.variant && props.message.variant !== "default" ? ` (${props.message.variant})` : "",
+  )
 
   const final = createMemo(() => {
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
@@ -1546,7 +1549,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
                 ▣{" "}
               </span>{" "}
               <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
-              <span style={{ fg: theme.textMuted }}> · {model()}</span>
+              <span style={{ fg: theme.textMuted }}> · {model()}{variant()}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>

--- a/packages/tui/src/util/transcript.ts
+++ b/packages/tui/src/util/transcript.ts
@@ -77,8 +77,9 @@ export function formatAssistantHeader(
     msg.time.completed && msg.time.created ? ((msg.time.completed - msg.time.created) / 1000).toFixed(1) + "s" : ""
 
   const modelName = Model.name(providers, msg.providerID, msg.modelID)
+  const variant = msg.variant && msg.variant !== "default" ? ` (${msg.variant})` : ""
 
-  return `## Assistant (${Locale.titlecase(msg.agent)} · ${modelName}${duration ? ` · ${duration}` : ""})\n\n`
+  return `## Assistant (${Locale.titlecase(msg.agent)} · ${modelName}${variant}${duration ? ` · ${duration}` : ""})\n\n`
 }
 
 export function formatPart(part: Part, options: TranscriptOptions): string {

--- a/packages/tui/test/util/transcript.test.ts
+++ b/packages/tui/test/util/transcript.test.ts
@@ -88,6 +88,16 @@ describe("transcript", () => {
       expect(result).toBe("## Assistant (Build · Claude Sonnet 4 · 5.4s)\n\n")
     })
 
+    test("includes a non-default model variant", () => {
+      const result = formatAssistantHeader({ ...baseMsg, variant: "high" }, true, providers)
+      expect(result).toBe("## Assistant (Build · Claude Sonnet 4 (high) · 5.4s)\n\n")
+    })
+
+    test("omits the default model variant", () => {
+      const result = formatAssistantHeader({ ...baseMsg, variant: "default" }, true, providers)
+      expect(result).toBe("## Assistant (Build · Claude Sonnet 4 · 5.4s)\n\n")
+    })
+
     test("excludes metadata when disabled", () => {
       const result = formatAssistantHeader(baseMsg, false)
       expect(result).toBe("## Assistant\n\n")


### PR DESCRIPTION
### Issue for this PR

Closes #40412 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Displays the persisted non-default variant beside the model name in assistant message metadata and exported transcripts. Default remains hidden, matching model-switch notices.

### How did you verify your code works?
- Tested locally
- Ran Tests and Typecheck

### Screenshots / recordings
<img width="2536" height="1390" alt="screenshot-2026-08-04_16-48-32" src="https://github.com/user-attachments/assets/bf29bbdf-989d-493d-8200-0fe636f2a370" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
