### PR TITLE
docs: fix typo "whenver" in control-plane dev README

### DIFF
--- a/packages/opencode/src/control-plane/dev/README.md
+++ b/packages/opencode/src/control-plane/dev/README.md
@@ -16,4 +16,4 @@ How this works:
 
 - The workspace server needs to know the workspace id and port to run. It waits for this information to be written to a file and starts the server when the data is written.
 - The debug plugin writes this information in the `create` call to the workspace. So create a `debug` workspace will always kick off a new external server.
-- The server script watches for file changes, so whenver you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.
+- The server script watches for file changes, so whenever you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.


### PR DESCRIPTION
### Issue for this PR

Closes #40416

### Type of change

- [x] Documentation

### What does this PR do?

One-word typo fix in `packages/opencode/src/control-plane/dev/README.md:19`:

- Before: "so whenver you create a new `debug` workspace..."
- After: "so whenever you create a new `debug` workspace..."

No code or behavior change.

### How did you verify your code works?

- No remaining `whenver` matches in the repo (`grep`)

### Screenshots / recordings

Not applicable — README-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
