### PR TITLE
fix(app): correct "sesssion" typo in LayoutRoute tag

### DIFF
--- a/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
@@ -28,7 +28,7 @@ export const DialogSettings: Component<{
   const [tab, setTab] = createSignal(props.defaultValue ?? "general")
   const directory = createMemo(() => {
     const route = layout.route()
-    if (route.type === "dir-new-sesssion") return route.dir
+    if (route.type === "dir-new-session") return route.dir
     if (route.type === "draft") {
       const draft = tabs.store.find((item) => item.type === "draft" && item.draftID === route.draftID)
       return draft?.type === "draft" ? draft.directory : undefined

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -86,7 +86,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
   const path = () => `${location.pathname}${location.search}${location.hash}`
   const creating = createMemo(() => {
     const route = layout.route()
-    if (route.type === "draft" || route.type === "dir-new-sesssion") return true
+    if (route.type === "draft" || route.type === "dir-new-session") return true
     if (!params.dir) return false
     if (params.id) return false
     const parts = location.pathname.replace(/\/+$/, "").split("/")

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -92,7 +92,7 @@ export type ReviewPanelSource = "context-button" | "other"
 export type LayoutRoute =
   | { type: "home" }
   | { type: "draft"; draftID: string; server?: ServerConnection.Key }
-  | { type: "dir-new-sesssion"; dir: string; dirBase64: string; server?: ServerConnection.Key }
+  | { type: "dir-new-session"; dir: string; dirBase64: string; server?: ServerConnection.Key }
   | { type: "session"; sessionId: string; server?: ServerConnection.Key }
 
 const sessionPath = (key: string) => {
@@ -153,7 +153,7 @@ export const currentRoute = (pathname: string, search: string): LayoutRoute => {
 
   const id = parts[2]
   if (id) return { type: "session", sessionId: id }
-  return { type: "dir-new-sesssion", dir, dirBase64 }
+  return { type: "dir-new-session", dir, dirBase64 }
 }
 
 export const { use: useLayout, provider: LayoutProvider } = createSimpleContext({


### PR DESCRIPTION
### Issue for this PR

Closes #40421

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes a misspelled `LayoutRoute` discriminated-union tag: `dir-new-sesssion` (triple "s") -> `dir-new-session`, in `packages/app/src/context/layout.tsx` and its consumers.

The tag represents navigating to `/<dir>/session` without a session id (a new session about to be created in that directory). It is derived from the URL via `currentRoute()` on every render and is never persisted, so the rename is behavior-neutral — but any future consumer writing `dir-new-session` would silently never match the misspelled tag.

Changed 4 occurrences in 3 files:
- `packages/app/src/context/layout.tsx` (type definition + constructor)
- `packages/app/src/components/titlebar.tsx`
- `packages/app/src/components/settings-v2/dialog-settings-v2.tsx`

### How did you verify your code works?

- `bun typecheck` in `packages/app` passes
- Repo-wide typecheck passes (pre-push hook, 36 packages)
- No remaining `sesssion` matches in the repo

### Screenshots / recordings

Not applicable — internal identifier rename, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
