### PR TITLE
fix(plugin): skip mismatched kind in readV1Plugin detect mode

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -281,6 +281,8 @@ export function readV1Plugin(
     throw new TypeError(`Plugin ${spec} must default export an object with ${kind}()`)
   }
   if (mode === "detect" && !("id" in value) && !("server" in value) && !("tui" in value)) return
+  if (mode === "detect" && kind === "server" && !("server" in value)) return
+  if (mode === "detect" && kind === "tui" && !("tui" in value)) return
 
   const server = "server" in value ? value.server : undefined
   const tui = "tui" in value ? value.tui : undefined

--- a/packages/opencode/test/plugin/read-v1-plugin.test.ts
+++ b/packages/opencode/test/plugin/read-v1-plugin.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { readV1Plugin } from "../../src/plugin/shared"
+
+// Regression coverage for #31610:
+// readV1Plugin in "detect" mode must not throw when the plugin module
+// exports a default object that does not include the requested kind's
+// entrypoint (e.g. a TUI-only plugin scanned by the server loader).
+
+describe("plugin.shared.readV1Plugin detect mode", () => {
+  test("returns undefined when a TUI-only plugin is scanned for kind=server", () => {
+    // Given a plugin that only exports `tui` (no `server`)
+    const mod = {
+      default: {
+        id: "tui-only",
+        tui: () => ({}) as unknown,
+      },
+    }
+
+    // When the server loader asks to detect whether this is a server plugin
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "tui-only-plugin",
+      "server",
+      "detect",
+    )
+
+    // Then it should silently skip instead of throwing
+    expect(result).toBeUndefined()
+  })
+
+  test("returns undefined when a server-only plugin is scanned for kind=tui", () => {
+    const mod = {
+      default: {
+        id: "server-only",
+        server: () => ({}) as unknown,
+      },
+    }
+
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "server-only-plugin",
+      "tui",
+      "detect",
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  test("returns the value when the requested kind is present", () => {
+    const server = () => ({ ok: true })
+    const mod = {
+      default: {
+        id: "has-both-but-server",
+        server,
+      },
+    }
+
+    const result = readV1Plugin(
+      mod as unknown as Record<string, unknown>,
+      "plugin",
+      "server",
+      "detect",
+    )
+
+    expect(result).toEqual({ id: "has-both-but-server", server })
+  })
+
+  test("strict mode still throws for TUI-only plugins loaded as server", () => {
+    // Sanity check: strict mode is unchanged.
+    const mod = {
+      default: {
+        id: "tui-only",
+        tui: () => ({}) as unknown,
+      },
+    }
+
+    expect(() =>
+      readV1Plugin(
+        mod as unknown as Record<string, unknown>,
+        "tui-only-plugin",
+        "server",
+        "strict",
+      ),
+    ).toThrow(/must default export an object with server/)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31610

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `readV1Plugin` (`packages/opencode/src/plugin/shared.ts`), when the
server plugin loader calls it with `mode="detect"` and `kind="server"`,
a plugin module that exports only `tui` falls through to the
kind-specific check and throws `TypeError: Plugin ... must default
export an object with server()`. The error is caught and logged at
ERROR level on every startup for users with TUI-only plugins, which
is noisy and misleading.

The existing "all fields missing" guard does not fire because `id`
and `tui` are present. The fix mirrors that guard with two new
per-kind short-circuits so detect mode silently skips plugins that
don't expose the requested kind's entrypoint. The mirror for
`kind === "tui"` is included for symmetry even though the bug report
only mentioned the server path.

Strict mode is unchanged: a TUI-only plugin supplied as a server
plugin under strict mode still throws, which is the desired behavior.

### How did you verify your code works?

Added a regression test (`test/plugin/read-v1-plugin.test.ts`) with
four cases:

- TUI-only plugin scanned by server loader in detect mode -> returns undefined
- server-only plugin scanned by TUI loader in detect mode -> returns undefined
- plugin that exposes the requested kind -> returns the value
- strict mode still throws for mismatched kinds (unchanged behavior)

`bun test packages/opencode/test/plugin/read-v1-plugin.test.ts` -> 4/4 pass.

### Screenshots / recordings

Not applicable (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR