### PR TITLE
docs: fix typo "mulitplier" in Go subscription docs

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -187,7 +187,7 @@ For most models, we make this work through bulk discounts and reserved GPU capac
 
 For some models, we haven't had the opportunity to negotiate a discount or host them at a lower cost, either because the model is new or because their public pricing is already discounted.
 
-For these models, you still get a little more than if you paid the model providers directly; this is why their usage mulitplier is lower in the table above.
+For these models, you still get a little more than if you paid the model providers directly; this is why their usage multiplier is lower in the table above.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #40431

### Type of change

- [x] Documentation

### What does this PR do?

One-word typo fix in `packages/web/src/content/docs/go.mdx:190`:

- Before: "...this is why their usage mulitplier is lower in the table above."
- After: "...this is why their usage multiplier is lower in the table above."

The correct spelling is already used elsewhere on the same page (line 186: "We then pass those savings on to you through the 6x multiplier."). No content or behavior change.

### How did you verify your code works?

- No remaining `mulitplier` matches in the repo (`grep`)

### Screenshots / recordings

Not applicable — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
