### PR TITLE
fix(opencode): refresh MiniMax M3 pricing snapshot

### DIFF
--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -95294,25 +95294,9 @@
           "output": 128000
         },
         "cost": {
-          "input": 0.3,
-          "output": 1.2,
-          "cache_read": 0.06,
-          "tiers": [
-            {
-              "input": 0.6,
-              "output": 2.4,
-              "cache_read": 0.12,
-              "tier": {
-                "type": "context",
-                "size": 512000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 0.6,
-            "output": 2.4,
-            "cache_read": 0.12
-          }
+          "input": 0.6,
+          "output": 2.4,
+          "cache_read": 0.12
         }
       },
       "MiniMax-M2.7": {
@@ -169948,25 +169932,9 @@
           "output": 128000
         },
         "cost": {
-          "input": 0.3,
-          "output": 1.2,
-          "cache_read": 0.06,
-          "tiers": [
-            {
-              "input": 0.6,
-              "output": 2.4,
-              "cache_read": 0.12,
-              "tier": {
-                "type": "context",
-                "size": 512000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 0.6,
-            "output": 2.4,
-            "cache_read": 0.12
-          }
+          "input": 0.6,
+          "output": 2.4,
+          "cache_read": 0.12
         }
       },
       "MiniMax-M2.7": {


### PR DESCRIPTION
Reason: Refresh the committed MiniMax M3 catalog pricing to the flat target rates for both regional provider entries.

Updated the models.dev fixture so the global and China MiniMax M3 entries use flat input, output, and cache-read pricing without the obsolete context surcharge tier. Existing model capabilities, context limits, and regional endpoints are unchanged.

Checks:
- `node_modules/.bin/prettier --check packages/opencode/test/tool/fixtures/models-api.json`
- `bun test --timeout 30000 test/provider/provider.test.ts`
- `bun test --timeout 30000 test/tool/read.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bun turbo typecheck`
