### PR TITLE
fix(opencode): define OPENCODE_VERSION in the node server build

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -20,6 +20,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },


### PR DESCRIPTION
Closes #26003, #26085, #27676, #30197, #30908, #31708

### Type of change

- [x] Bug fix

### What does this PR do?

The Node server build (`packages/opencode/script/build-node.ts`) was missing the `OPENCODE_VERSION` compile-time define. This caused `InstallationVersion` (in `packages/core/src/installation/version.ts:6`) to fall back to `"local"`, making the config dependency installer request `@opencode-ai/plugin@local` — which doesn't exist on the npm registry.

The fix adds `OPENCODE_VERSION: \`'${Script.version}'\`` to the `define` block in `build-node.ts`, matching the existing Bun CLI build (`packages/opencode/script/build.ts:194`).

Single-line change.

### How did you verify your code works?

`Script.version` is already imported and used in `build-node.ts` (via `Script.channel` on line 24). The identical pattern is used in `build.ts:194`. No runtime verification possible without a full Desktop build pipeline, but the change is a straightforward mirror of an existing working pattern.

### Checklist

- [x] I have tested my changes locally (build script syntax verified)
- [x] I have not included unrelated changes in this PR
