### PR TITLE
fix(app): fall back to directory listing in project picker

### DIFF
--- a/packages/app/src/components/dialog-select-directory-v2.tsx
+++ b/packages/app/src/components/dialog-select-directory-v2.tsx
@@ -128,7 +128,7 @@ export function DialogSelectDirectoryV2(props: DialogSelectDirectoryV2Props) {
       loads.schedule(`${generation}:${key}`, eager ? "background" : "user", () => {
         if (!activeTreeNavigation(generation, navigation)) return Promise.resolve(undefined)
         return sdk.api.file
-          .list({ location: { directory: absolute } })
+          .list({ location: { directory: absolute }, path: "" })
           .then((result) =>
             result.data.map((entry) => ({
               name: getFilename(entry.path.replace(/[\\/]+$/, "")),

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -195,6 +195,9 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           )
         }}
       </List>
+      <div data-slot="directory-navigation-hint" class="px-3 pb-3 text-12-regular text-text-weak">
+        {language.t("dialog.directory.navigationHint")}
+      </div>
     </Dialog>
   )
 }

--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -139,6 +139,10 @@ test("resolves directory autocomplete from the current browser root", async () =
           directories.push(input.location?.directory ?? "")
           return Promise.resolve({ data: [] })
         },
+        list: (input: { location?: { directory?: string } }) => {
+          directories.push(input.location?.directory ?? "")
+          return Promise.resolve({ data: [] })
+        },
       },
     },
   } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
@@ -149,16 +153,37 @@ test("resolves directory autocomplete from the current browser root", async () =
   base = "/repo/src"
   await search("components")
 
-  expect(directories).toEqual(["/repo", "/repo/src"])
+  expect(directories).toEqual(["/repo", "/repo", "/repo/src", "/repo/src"])
 })
 
-test("searches from an absolute root without a default base", async () => {
-  const directories: string[] = []
+test("lists the current directory before relying on the search index", async () => {
+  const requests: Array<{ location?: { directory?: string }; path?: string }> = []
   const sdk = {
     api: {
       file: {
-        list: (input: { location?: { directory?: string } }) => {
-          directories.push(input.location?.directory ?? "")
+        list: (input: { location?: { directory?: string }; path?: string }) => {
+          requests.push(input)
+          return Promise.resolve({
+            data: [{ path: "projects/", type: "directory" as const }],
+          })
+        },
+        find: () => Promise.resolve({ data: [] }),
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/home/luke" })
+
+  expect(await search("")).toEqual(["/home/luke/projects"])
+  expect(requests).toEqual([{ location: { directory: "/home/luke" }, path: "" }])
+})
+
+test("searches from an absolute root without a default base", async () => {
+  const requests: Array<{ location?: { directory?: string }; path?: string }> = []
+  const sdk = {
+    api: {
+      file: {
+        list: (input: { location?: { directory?: string }; path?: string }) => {
+          requests.push(input)
           return Promise.resolve({
             data: [
               { path: "Users/", type: "directory" },
@@ -172,7 +197,98 @@ test("searches from an absolute root without a default base", async () => {
   const search = createDirectorySearch({ sdk, home: () => "", base: () => undefined })
 
   expect(await search("/")).toEqual(["/Users", "/tmp"])
-  expect(directories).toEqual(["/"])
+  expect(requests).toEqual([{ location: { directory: "/" }, path: "" }])
+})
+
+test("falls back to the current directory when the search index rejects", async () => {
+  const requests: Array<{ location?: { directory?: string }; path?: string }> = []
+  const sdk = {
+    api: {
+      file: {
+        find: () => Promise.reject(new Error("search index unavailable")),
+        list: (input: { location?: { directory?: string }; path?: string }) => {
+          requests.push(input)
+          return Promise.resolve({ data: [{ path: "components/", type: "directory" as const }] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  expect(await search("components")).toEqual(["/repo/components"])
+  expect(requests).toEqual([{ location: { directory: "/repo" }, path: "" }])
+})
+
+test("traverses nested directory input with root-relative list requests", async () => {
+  const requests: Array<{ location?: { directory?: string }; path?: string }> = []
+  const entries = new Map([
+    ["/repo", [{ path: "src/", type: "directory" as const }]],
+    ["/repo/src", [{ path: "components/", type: "directory" as const }]],
+    ["/repo/src/components", [{ path: "picker/", type: "directory" as const }]],
+  ])
+  const sdk = {
+    api: {
+      file: {
+        list: (input: { location?: { directory?: string }; path?: string }) => {
+          requests.push(input)
+          return Promise.resolve({ data: entries.get(input.location?.directory ?? "") ?? [] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  expect(await search("src/components/")).toEqual(["/repo/src/components/picker"])
+  expect(requests).toEqual([
+    { location: { directory: "/repo" }, path: "" },
+    { location: { directory: "/repo/src" }, path: "" },
+    { location: { directory: "/repo/src/components" }, path: "" },
+  ])
+})
+
+test("discards an old directory listing after a newer search starts", async () => {
+  const first = Promise.withResolvers<{ data: Array<{ path: string; type: "directory" }> }>()
+  const second = Promise.withResolvers<{ data: Array<{ path: string; type: "directory" }> }>()
+  let base = "/first"
+  const sdk = {
+    api: {
+      file: {
+        list: (input: { location?: { directory?: string } }) => {
+          if (input.location?.directory === "/first") return first.promise
+          return second.promise
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => base })
+
+  const old = search("")
+  base = "/second"
+  const current = search("")
+  second.resolve({ data: [{ path: "current/", type: "directory" }] })
+  expect(await current).toEqual(["/second/current"])
+  first.resolve({ data: [{ path: "stale/", type: "directory" }] })
+  expect(await old).toEqual([])
+})
+
+test("retries a directory listing after the first request fails", async () => {
+  let attempts = 0
+  const sdk = {
+    api: {
+      file: {
+        list: () => {
+          attempts++
+          if (attempts === 1) return Promise.reject(new Error("temporary failure"))
+          return Promise.resolve({ data: [{ path: "Users/", type: "directory" }] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "", base: () => undefined })
+
+  expect(await search("/")).toEqual([])
+  expect(await search("/")).toEqual(["/Users"])
+  expect(attempts).toBe(2)
 })
 
 test("identifies the next directory level to preload", () => {

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -343,7 +343,7 @@ export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string
     const existing = cache.get(key)
     if (existing) return existing
     const request = args.sdk.api.file
-      .list({ location: { directory: key } })
+      .list({ location: { directory: key }, path: "" })
       .then((result) => result.data)
       .catch(() => [])
       .then((nodes) =>
@@ -355,6 +355,14 @@ export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string
           }),
       )
     cache.set(key, request)
+    request.then(
+      () => {
+        if (cache.get(key) === request) cache.delete(key)
+      },
+      () => {
+        if (cache.get(key) === request) cache.delete(key)
+      },
+    )
     return request
   }
 
@@ -374,12 +382,20 @@ export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string
     const pathInput = raw.startsWith("~") || !!pickerRoot(raw) || raw.includes("/")
     const query = normalizePickerDrive(input.path)
     if (!pathInput) {
+      if (!query) {
+        const matches = await match(input.directory, "", 50)
+        if (!active()) return []
+        return matches
+      }
       const results = await args.sdk.api.file
         .find({ location: { directory: input.directory }, query, type: "directory", limit: 50 })
         .then((result) => result.data.map((entry) => entry.path))
         .catch(() => [])
       if (!active()) return []
-      return results.map((path) => joinPickerPath(input.directory, path)).slice(0, 50)
+      if (results.length > 0) return results.map((path) => joinPickerPath(input.directory, path)).slice(0, 50)
+      const matches = await match(input.directory, query, 50)
+      if (!active()) return []
+      return matches
     }
     const segments = query.replace(/^\/+/, "").split("/")
     const head = segments.slice(0, -1).filter((part) => part && part !== ".")

--- a/packages/app/src/components/directory-picker-search.test.ts
+++ b/packages/app/src/components/directory-picker-search.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "bun:test"
+import { createDirectorySearch } from "./directory-picker-domain"
+
+type ListRequest = { location?: { directory?: string }; path?: string }
+type FindRequest = { location?: { directory?: string }; query: string; type?: string; limit?: number }
+type DirectoryNode = { path: string; type: "directory" }
+
+test("refreshes the current directory for consecutive empty queries", async () => {
+  const requests: ListRequest[] = []
+  let finds = 0
+  const listings: DirectoryNode[][] = [
+    [{ path: "alpha/", type: "directory" }],
+    [{ path: "beta/", type: "directory" }],
+  ]
+  const sdk = {
+    api: {
+      file: {
+        list: (input: ListRequest) => {
+          requests.push(input)
+          return Promise.resolve({ data: listings[requests.length - 1] ?? [] })
+        },
+        find: () => {
+          finds++
+          return Promise.resolve({ data: [] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  expect(await search("")).toEqual(["/repo/alpha"])
+  expect(await search("")).toEqual(["/repo/beta"])
+  expect(requests).toEqual([
+    { location: { directory: "/repo" }, path: "" },
+    { location: { directory: "/repo" }, path: "" },
+  ])
+  expect(finds).toBe(0)
+})
+
+test("refreshes the current directory when file.find remains empty", async () => {
+  const finds: FindRequest[] = []
+  const lists: ListRequest[] = []
+  const listings: DirectoryNode[][] = [
+    [{ path: "alpha-project/", type: "directory" }],
+    [{ path: "beta-project/", type: "directory" }],
+  ]
+  const sdk = {
+    api: {
+      file: {
+        find: (input: FindRequest) => {
+          finds.push(input)
+          return Promise.resolve({ data: [] })
+        },
+        list: (input: ListRequest) => {
+          lists.push(input)
+          return Promise.resolve({ data: listings[lists.length - 1] ?? [] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  expect(await search("project")).toEqual(["/repo/alpha-project"])
+  expect(await search("project")).toEqual(["/repo/beta-project"])
+  expect(finds).toEqual([
+    { location: { directory: "/repo" }, query: "project", type: "directory", limit: 50 },
+    { location: { directory: "/repo" }, query: "project", type: "directory", limit: 50 },
+  ])
+  expect(lists).toEqual([
+    { location: { directory: "/repo" }, path: "" },
+    { location: { directory: "/repo" }, path: "" },
+  ])
+})
+
+test("deduplicates concurrent directory lists while keeping only the latest search result", async () => {
+  const listing = Promise.withResolvers<{ data: DirectoryNode[] }>()
+  const lists: ListRequest[] = []
+  const sdk = {
+    api: {
+      file: {
+        list: (input: ListRequest) => {
+          lists.push(input)
+          return listing.promise
+        },
+        find: () => Promise.resolve({ data: [] }),
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  const old = search("")
+  const latest = search("")
+  expect(lists).toEqual([{ location: { directory: "/repo" }, path: "" }])
+
+  listing.resolve({ data: [{ path: "alpha/", type: "directory" }] })
+  expect(await latest).toEqual(["/repo/alpha"])
+  expect(await old).toEqual([])
+  expect(lists).toEqual([{ location: { directory: "/repo" }, path: "" }])
+})

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -404,6 +404,7 @@ export const dict = {
   "dialog.fork.empty": "لا توجد رسائل للتفرع منها",
   "dialog.directory.search.placeholder": "البحث في المجلدات",
   "dialog.directory.empty": "لم يتم العثور على مجلدات",
+  "dialog.directory.navigationHint": "Tab: فتح مجلد فرعي · Enter: اختيار مجلد",
   "dialog.directory.action.selectFile": "اختيار ملف",
   "dialog.directory.action.selectFolder": "اختيار مجلد",
   "dialog.directory.root": "الجذر",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -402,6 +402,7 @@ export const dict = {
   "dialog.fork.empty": "Yeni sessiyaya ayırmaq üçün mesaj yoxdur",
   "dialog.directory.search.placeholder": "Qovluqları axtar",
   "dialog.directory.empty": "Qovluq tapılmadı",
+  "dialog.directory.navigationHint": "Tab: Alt qovluğa daxil ol · Enter: Qovluğu seç",
   "dialog.directory.action.selectFile": "Fayl seçin",
   "dialog.directory.action.selectFolder": "Qovluğu seçin",
   "dialog.directory.root": "Kök",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -406,6 +406,7 @@ export const dict = {
   "dialog.fork.empty": "Nenhuma mensagem para bifurcar",
   "dialog.directory.search.placeholder": "Buscar pastas",
   "dialog.directory.empty": "Nenhuma pasta encontrada",
+  "dialog.directory.navigationHint": "Tab: Entrar na subpasta · Enter: Selecionar pasta",
   "dialog.directory.action.selectFile": "Selecionar arquivo",
   "dialog.directory.action.selectFolder": "Selecionar pasta",
   "dialog.directory.root": "Raiz",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -432,6 +432,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Pretraži fascikle",
   "dialog.directory.empty": "Nema pronađenih fascikli",
+  "dialog.directory.navigationHint": "Tab: Otvori podfasciklu · Enter: Odaberi fasciklu",
   "dialog.directory.action.selectFile": "Odaberi datoteku",
   "dialog.directory.action.selectFolder": "Odaberi fasciklu",
   "dialog.directory.root": "Korijen",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -329,6 +329,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Søg mapper",
   "dialog.directory.empty": "Ingen mapper fundet",
+  "dialog.directory.navigationHint": "Tab: Åbn undermappe · Enter: Vælg mappe",
   "dialog.directory.action.selectFile": "Vælg fil",
   "dialog.directory.action.selectFolder": "Vælg mappe",
   "dialog.directory.root": "Rod",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -311,6 +311,7 @@ export const dict = {
   "dialog.fork.empty": "Keine Nachrichten zum Abzweigen vorhanden",
   "dialog.directory.search.placeholder": "Ordner durchsuchen",
   "dialog.directory.empty": "Keine Ordner gefunden",
+  "dialog.directory.navigationHint": "Tab: Unterordner öffnen · Enter: Ordner auswählen",
   "dialog.directory.action.selectFile": "Datei auswählen",
   "dialog.directory.action.selectFolder": "Ordner auswählen",
   "dialog.directory.root": "Stammverzeichnis",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -335,6 +335,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Search folders",
   "dialog.directory.empty": "No folders found",
+  "dialog.directory.navigationHint": "Tab: Enter subfolder · Enter: Select folder",
   "dialog.directory.action.selectFile": "Select file",
   "dialog.directory.action.selectFolder": "Select folder",
   "dialog.directory.root": "Root",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -433,6 +433,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Buscar carpetas",
   "dialog.directory.empty": "No se encontraron carpetas",
+  "dialog.directory.navigationHint": "Tab: Abrir subcarpeta · Enter: Seleccionar carpeta",
   "dialog.directory.action.selectFile": "Seleccionar archivo",
   "dialog.directory.action.selectFolder": "Seleccionar carpeta",
   "dialog.directory.root": "Raíz",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -306,6 +306,7 @@ export const dict = {
   "dialog.fork.empty": "Ei viestejä, joista voisi haarauttaa",
   "dialog.directory.search.placeholder": "Hae kansioita",
   "dialog.directory.empty": "Kansioita ei löytynyt",
+  "dialog.directory.navigationHint": "Tab: Avaa alikansio · Enter: Valitse kansio",
   "dialog.directory.action.selectFile": "Valitse tiedosto",
   "dialog.directory.action.selectFolder": "Valitse kansio",
   "dialog.directory.root": "Juuri",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -410,6 +410,7 @@ export const dict = {
   "dialog.fork.empty": "Aucun message à partir duquel bifurquer",
   "dialog.directory.search.placeholder": "Rechercher des dossiers",
   "dialog.directory.empty": "Aucun dossier trouvé",
+  "dialog.directory.navigationHint": "Tab : Ouvrir le sous-dossier · Enter : Sélectionner le dossier",
   "dialog.directory.action.selectFile": "Sélectionner le fichier",
   "dialog.directory.action.selectFolder": "Sélectionner le dossier",
   "dialog.directory.root": "Racine",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -406,6 +406,7 @@ export const dict = {
   "dialog.fork.empty": "फ़ोर्क करने के लिए कोई संदेश नहीं",
   "dialog.directory.search.placeholder": "फ़ोल्डर खोजें",
   "dialog.directory.empty": "कोई फ़ोल्डर नहीं मिला",
+  "dialog.directory.navigationHint": "Tab: सबफ़ोल्डर खोलें · Enter: फ़ोल्डर चुनें",
   "dialog.directory.action.selectFile": "फ़ाइल का चयन करें",
   "dialog.directory.action.selectFolder": "फ़ोल्डर चुनें",
   "dialog.directory.root": "रूट",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -432,6 +432,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Cari folder",
   "dialog.directory.empty": "Folder tidak ditemukan",
+  "dialog.directory.navigationHint": "Tab: Buka subfolder · Enter: Pilih folder",
   "dialog.directory.action.selectFile": "Pilih berkas",
   "dialog.directory.action.selectFolder": "Pilih folder",
   "dialog.directory.root": "Akar",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -308,6 +308,7 @@ export const dict = {
   "dialog.fork.empty": "Nessun messaggio da cui effettuare il fork",
   "dialog.directory.search.placeholder": "Cerca cartelle",
   "dialog.directory.empty": "Nessuna cartella trovata",
+  "dialog.directory.navigationHint": "Tab: Apri sottocartella · Enter: Seleziona cartella",
   "dialog.directory.action.selectFile": "Seleziona file",
   "dialog.directory.action.selectFolder": "Seleziona la cartella",
   "dialog.directory.root": "Radice",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -403,6 +403,7 @@ export const dict = {
   "dialog.fork.empty": "フォーク元のメッセージがありません",
   "dialog.directory.search.placeholder": "フォルダを検索",
   "dialog.directory.empty": "フォルダが見つかりません",
+  "dialog.directory.navigationHint": "Tab：サブフォルダを開く　·　Enter：フォルダを選択",
   "dialog.directory.action.selectFile": "ファイルを選択",
   "dialog.directory.action.selectFolder": "フォルダを選択",
   "dialog.directory.root": "ルート",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -292,6 +292,7 @@ export const dict = {
   "dialog.fork.empty": "분기할 메시지 없음",
   "dialog.directory.search.placeholder": "폴더 검색",
   "dialog.directory.empty": "폴더 없음",
+  "dialog.directory.navigationHint": "Tab: 하위 폴더 열기 · Enter: 폴더 선택",
   "dialog.directory.action.selectFile": "파일 선택",
   "dialog.directory.action.selectFolder": "폴더 선택",
   "dialog.directory.root": "루트",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -400,6 +400,7 @@ export const dict = {
   "dialog.fork.empty": "Geen berichten om van af te splitsen",
   "dialog.directory.search.placeholder": "Zoek in mappen",
   "dialog.directory.empty": "Geen mappen gevonden",
+  "dialog.directory.navigationHint": "Tab: Submap openen · Enter: Map selecteren",
   "dialog.directory.action.selectFile": "Selecteer bestand",
   "dialog.directory.action.selectFolder": "Selecteer map",
   "dialog.directory.root": "Hoofdmap",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -422,6 +422,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Søk etter mapper",
   "dialog.directory.empty": "Ingen mapper funnet",
+  "dialog.directory.navigationHint": "Tab: Åpne undermappe · Enter: Velg mappe",
   "dialog.directory.action.selectFile": "Velg fil",
   "dialog.directory.action.selectFolder": "Velg mappe",
   "dialog.directory.root": "Rot",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -406,6 +406,7 @@ export const dict = {
   "dialog.fork.empty": "فورک کرن لئی کوئی پیغام نئیں",
   "dialog.directory.search.placeholder": "فولڈراں نوں لبھو",
   "dialog.directory.empty": "کوئی فولڈر نئیں لبیا",
+  "dialog.directory.navigationHint": "Tab: ذیلی فولڈر کھولو · Enter: فولڈر چنو",
   "dialog.directory.action.selectFile": "فائل چنو",
   "dialog.directory.action.selectFolder": "فولڈر چنو",
   "dialog.directory.root": "Root",

--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -172,7 +172,9 @@ test("directory navigation hint is available in every app locale", async () => {
   const key = "dialog.directory.navigationHint"
   for (const locale of ["en", ...appLocales]) {
     const target = await dictionary(`./${locale}.ts`)
-    expect({ locale, value: target[key] }).toEqual({ locale, value: expect.any(String) })
+    const value = target[key]
+    expect({ locale, value }).toEqual({ locale, value: expect.any(String) })
+    expect({ locale, value: value.trim() }).toEqual({ locale, value: expect.stringMatching(/\S/) })
   }
 })
 

--- a/packages/app/src/i18n/parity.test.ts
+++ b/packages/app/src/i18n/parity.test.ts
@@ -168,6 +168,14 @@ describe("i18n plural parity", () => {
   })
 })
 
+test("directory navigation hint is available in every app locale", async () => {
+  const key = "dialog.directory.navigationHint"
+  for (const locale of ["en", ...appLocales]) {
+    const target = await dictionary(`./${locale}.ts`)
+    expect({ locale, value: target[key] }).toEqual({ locale, value: expect.any(String) })
+  }
+})
+
 async function dictionary(file: string) {
   const module: unknown = await import(file)
   if (typeof module !== "object" || module === null || !("dict" in module) || !isDictionary(module.dict)) {

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -406,6 +406,7 @@ export const dict = {
   "dialog.fork.empty": "Brak wiadomości do rozwidlenia",
   "dialog.directory.search.placeholder": "Szukaj folderów",
   "dialog.directory.empty": "Nie znaleziono folderów",
+  "dialog.directory.navigationHint": "Tab: Otwórz podfolder · Enter: Wybierz folder",
   "dialog.directory.action.selectFile": "Wybierz plik",
   "dialog.directory.action.selectFolder": "Wybierz folder",
   "dialog.directory.root": "Katalog główny",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -430,6 +430,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Поиск папок",
   "dialog.directory.empty": "Папки не найдены",
+  "dialog.directory.navigationHint": "Tab: Открыть подпапку · Enter: Выбрать папку",
   "dialog.directory.action.selectFile": "Выбрать файл",
   "dialog.directory.action.selectFolder": "Выбрать папку",
   "dialog.directory.root": "Корень",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -400,6 +400,7 @@ export const dict = {
   "dialog.fork.empty": "Inga meddelanden att förgrena från",
   "dialog.directory.search.placeholder": "Sök i mappar",
   "dialog.directory.empty": "Inga mappar hittades",
+  "dialog.directory.navigationHint": "Tab: Öppna undermapp · Enter: Välj mapp",
   "dialog.directory.action.selectFile": "Välj fil",
   "dialog.directory.action.selectFolder": "Välj mapp",
   "dialog.directory.root": "Rotmapp",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -429,6 +429,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "ค้นหาโฟลเดอร์",
   "dialog.directory.empty": "ไม่พบโฟลเดอร์",
+  "dialog.directory.navigationHint": "Tab: เปิดโฟลเดอร์ย่อย · Enter: เลือกโฟลเดอร์",
   "dialog.directory.action.selectFile": "เลือกไฟล์",
   "dialog.directory.action.selectFolder": "เลือกโฟลเดอร์",
   "dialog.directory.root": "โฟลเดอร์ราก",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -436,6 +436,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Klasör ara",
   "dialog.directory.empty": "Klasör bulunamadı",
+  "dialog.directory.navigationHint": "Tab: Alt klasörü aç · Enter: Klasörü seç",
   "dialog.directory.action.selectFile": "Dosya seç",
   "dialog.directory.action.selectFolder": "Klasör seç",
   "dialog.directory.root": "Kök",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -433,6 +433,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "Пошук папок",
   "dialog.directory.empty": "Папок не знайдено",
+  "dialog.directory.navigationHint": "Tab: Відкрити підпапку · Enter: Вибрати папку",
   "dialog.directory.action.selectFile": "Вибрати файл",
   "dialog.directory.action.selectFolder": "Вибрати папку",
   "dialog.directory.root": "Корінь",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -408,6 +408,7 @@ export const dict = {
   "dialog.fork.empty": "کوئی پیغامات نہیں ہیں جن سے فورک کیا جائے۔",
   "dialog.directory.search.placeholder": "فولڈرز تلاش کریں۔",
   "dialog.directory.empty": "کوئی فولڈر نہیں ملا",
+  "dialog.directory.navigationHint": "Tab: ذیلی فولڈر کھولیں · Enter: فولڈر منتخب کریں",
   "dialog.directory.action.selectFile": "فائل منتخب کریں۔",
   "dialog.directory.action.selectFolder": "فولڈر منتخب کریں۔",
   "dialog.directory.root": "بنیادی فولڈر",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -406,6 +406,7 @@ export const dict = {
   "dialog.fork.empty": "Không có tin nhắn nào để phân nhánh",
   "dialog.directory.search.placeholder": "Tìm kiếm thư mục",
   "dialog.directory.empty": "Không tìm thấy thư mục nào",
+  "dialog.directory.navigationHint": "Tab: Mở thư mục con · Enter: Chọn thư mục",
   "dialog.directory.action.selectFile": "Chọn tệp",
   "dialog.directory.action.selectFolder": "Chọn thư mục",
   "dialog.directory.root": "Gốc",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -449,6 +449,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "搜索文件夹",
   "dialog.directory.empty": "未找到文件夹",
+  "dialog.directory.navigationHint": "Tab：进入子目录　·　Enter：选择目录",
   "dialog.directory.action.selectFile": "选择文件",
   "dialog.directory.action.selectFolder": "选择文件夹",
   "dialog.directory.root": "根目录",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -429,6 +429,7 @@ export const dict = {
 
   "dialog.directory.search.placeholder": "搜尋資料夾",
   "dialog.directory.empty": "找不到資料夾",
+  "dialog.directory.navigationHint": "Tab：進入子目錄　·　Enter：選擇目錄",
   "dialog.directory.action.selectFile": "選擇檔案",
   "dialog.directory.action.selectFolder": "選擇資料夾",
   "dialog.directory.root": "根目錄",


### PR DESCRIPTION
### Issue for this PR

Closes #37005

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Web app's "Open Project" dialog can be completely blocked for first-time users because, since commit b9aad20, the legacy picker prefers `$HOME` over the current project directory. Since FFF cannot initialize in `$HOME` or filesystem roots, `file.find` returns no directories, leaving users unable to select a project, create a session, or reach the app's primary workflow.

<details>
<summary><strong>Original FFF Error Log</strong></summary>

```text
timestamp=2026-07-15T02:53:14.870Z level=INFO run=5bbf053c
message="creating instance" directory=/home/anders

timestamp=2026-07-15T02:53:14.968Z level=WARN run=5bbf053c
message="failed to initialize fff"
error="Failed to init file picker: Can not run certain FFF features in a file system root or home directories. Consider smaller per-project directories."

timestamp=2026-07-15T02:53:15.004Z level=INFO run=5bbf053c
message="find file" query="" type=directory directory=/home/anders limit=50 results=0 duration=87
```

</details>

To fix this, the picker now uses `file.list` for empty queries and falls back to it when `file.find` fails or returns no results. It lists immediate subdirectories and performs client-side fuzzy matching, while preserving recursive search through `file.find` when the FFF index is available.

Additionally, this PR:

* Deduplicates concurrent `file.list` requests and discards stale search results to prevent race conditions.
* Adds persistent `Tab` (enter subdirectory) and `Enter` (select directory) keyboard shortcut hints to the legacy browser directory picker.

### How did you verify your code works?

* Manually tested in the Web app with cleared site data/fresh user state, starting from `$HOME` to simulate the issue.
* Verified the picker successfully loads immediate subdirectories via `file.list` instead of showing an empty state.
* Verified search fallback (client-side fuzzy matching) works correctly when FFF is unavailable.
* Confirmed `Tab` and `Enter` shortcuts function correctly in the legacy picker.
* Ran and passed all 34 related directory picker/i18n tests, `packages/app` type checks, and `git diff --check`.

### Screenshots / recordings

**Before:**
<img width="1260" height="642" alt="2026-08-04_22-56-55-0" src="https://github.com/user-attachments/assets/5faaf0ca-e38c-419d-bb7a-99310c883ed4" />
<img width="1141" height="592" alt="PixPin_2026-08-04_22-57-19" src="https://github.com/user-attachments/assets/d66e0e28-afb5-41c5-aa68-fe87980a5dac" />

**After:**
<img width="986" height="697" alt="PixPin_2026-08-04_19-04-48" src="https://github.com/user-attachments/assets/091ada61-3e7c-477c-9bf8-12682cc78949" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR