### PR TITLE
fix: keep sessions discoverable for non-git projects on Windows

### DIFF
--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -40,5 +40,6 @@ export const migrations = (
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
     import("./migration/20260622202450_simplify_session_input"),
+    import("./migration/20260804120000_normalize_session_path"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260804120000_normalize_session_path.ts
+++ b/packages/core/src/database/migration/20260804120000_normalize_session_path.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260804120000_normalize_session_path",
+  up(tx) {
+    return Effect.gen(function* () {
+      // Sessions created on Windows in non-git projects (worktree "/")
+      // stored an absolute path because `path.resolve("/")` resolves to the
+      // current process drive root. Those paths can never match the
+      // worktree-relative path used by the session list query, which hides
+      // the sessions from the picker. NULL them so the list query's
+      // directory-based fallback (`path IS NULL AND directory = ?`) matches
+      // them again. Empty paths from older migrations have the same problem.
+      yield* tx.run(
+        `UPDATE \`session\` SET \`path\` = NULL WHERE \`path\` = '' OR \`path\` LIKE '/%' OR \`path\` LIKE '_:/%'`,
+      )
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -168,8 +168,22 @@ function getForkedTitle(title: string): string {
   return `${title} (fork #1)`
 }
 
-function sessionPath(worktree: string, cwd: string) {
-  return path.relative(path.resolve(worktree), cwd).replaceAll("\\", "/")
+/**
+ * Compute the session path relative to the project worktree.
+ *
+ * Returns `undefined` when the directory is not inside the worktree. This
+ * happens for non-git projects, which use worktree "/" (see
+ * `Project.fromDirectory`): `path.resolve("/")` resolves to the drive root
+ * of the current process, so on Windows the "relative" result is actually a
+ * machine-dependent absolute path (e.g. "D:/repo" or "C:/repo") that the
+ * session list query can never match. Storing no path lets `listByProject`
+ * fall back to directory-based scoping, which is unambiguous.
+ *
+ * @param p Path module override for tests (e.g. `path.win32`).
+ */
+export function sessionPath(worktree: string, cwd: string, p: typeof path = path) {
+  const rel = p.relative(p.resolve(worktree), cwd).replaceAll("\\", "/")
+  return p.isAbsolute(rel) ? undefined : rel
 }
 
 const Summary = Schema.Struct({

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -88,6 +88,39 @@ describe("session.list", () => {
     { git: true },
   )
 
+  it.instance(
+    "matches sessions with no path via the directory fallback",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const dir = path.join(test.directory, "packages", "opencode")
+        yield* Effect.promise(() => mkdir(dir, { recursive: true }))
+
+        const created = yield* withSession({ title: "no-path" }).pipe(provideInstance(dir))
+
+        // Simulate a legacy row (or a Windows non-git session) whose path
+        // could not be expressed relative to the worktree and is NULL.
+        yield* Database.Service.use(({ db }) =>
+          db.run(`UPDATE session SET path = NULL WHERE id = '${created.id}'`),
+        )
+
+        // With directory present, the list query falls back to directory
+        // scoping for NULL-path rows.
+        const withDirectory = (yield* SessionNs.Service.use((session) =>
+          session.list({ directory: dir, path: "unrelated/path" }),
+        )).map((session) => session.id)
+        expect(withDirectory).toContain(created.id)
+
+        // Without directory there is no way to scope a NULL-path row inside
+        // the (possibly global) project, so it stays hidden.
+        const pathOnly = (yield* SessionNs.Service.use((session) =>
+          session.list({ path: "unrelated/path" }),
+        )).map((session) => session.id)
+        expect(pathOnly).not.toContain(created.id)
+      }),
+    { git: true },
+  )
+
   itWorkspaces.instance(
     "filters by directory when experimental workspaces are enabled",
     () =>

--- a/packages/opencode/test/session/session-path.test.ts
+++ b/packages/opencode/test/session/session-path.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { sessionPath } from "@/session/session"
+
+describe("sessionPath", () => {
+  test("returns the worktree-relative path for git projects", () => {
+    expect(sessionPath("D:\\repo", "D:\\repo\\sub\\dir", path.win32)).toBe("sub/dir")
+    expect(sessionPath("/repo", "/repo/src", path.posix)).toBe("src")
+  })
+
+  test("returns undefined when the directory is on a different volume than the worktree", () => {
+    // A cross-volume directory cannot be expressed relative to the
+    // worktree; the relative() result is an absolute path that the session
+    // list query can never match.
+    expect(sessionPath("C:\\", "D:\\repo", path.win32)).toBeUndefined()
+    expect(sessionPath("C:\\", "//server/share", path.win32)).toBeUndefined()
+  })
+
+  test("keeps same-volume relative results", () => {
+    // When the directory shares the worktree root, the result is a
+    // consistent relative path and is preserved.
+    expect(sessionPath("C:\\", "C:\\Users\\me\\proj", path.win32)).toBe("Users/me/proj")
+  })
+
+  test("keeps POSIX non-git behavior unchanged", () => {
+    // POSIX has a single root, so worktree "/" resolves deterministically
+    // and the relative result is consistent.
+    expect(sessionPath("/", "/workspace", path.posix)).toBe("workspace")
+  })
+
+  test("returns an empty path for the worktree root itself", () => {
+    expect(sessionPath("/repo", "/repo", path.posix)).toBe("")
+  })
+})

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -19,7 +19,7 @@ import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { useCommandShortcut } from "../keymap"
 import { useEvent } from "../context/event"
 
-type SessionListFilter = { scope?: "project"; path?: string }
+type SessionListFilter = { scope?: "project"; path?: string; directory?: string }
 
 export function createDialogSessionListQuery(input: { search?: string; filter: SessionListFilter }) {
   const search = input.search?.trim()

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -151,10 +151,15 @@ export const {
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
+    function sessionListQuery(): { scope?: "project"; path?: string; directory?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
       if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
+      // Always pass directory alongside path. Sessions in non-git projects
+      // (worktree "/") have no reliable relative path on Windows — the
+      // worktree-relative computation resolves against the current drive
+      // root — so the server matches them by directory instead.
       return {
+        directory: project.data.instance.path.directory,
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
           .replaceAll("\\", "/"),


### PR DESCRIPTION
### Issue for this PR

Closes #35750

### Type of change

- [x] Bug fix

### What does this PR do?

Sessions created in non-git projects on Windows can disappear from the session picker.

Non-git projects use worktree `"/"` (set in `Project.fromDirectory`). On Windows, `path.resolve("/")` resolves to the drive root of the **current process**, so `sessionPath()` produced a machine-dependent absolute path like `D:/repo` and stored it in `session.path`. The session list query matches paths relative to the worktree, so those rows never matched and the sessions vanished from the picker. Which sessions were visible depended on which drive root the server process happened to be rooted at. Related reports: #37041, #37353, #38780.

Changes:

- `sessionPath()` returns `undefined` when the worktree-relative result is absolute (cross-volume, which is what happens for non-git worktrees on Windows). Sessions without a usable path fall back to the existing directory-based scoping in `listByProject` (`path IS NULL AND directory = ?`).
- The TUI session list query now passes `directory` alongside `path`, which is what makes the directory fallback reachable for project instances. POSIX behavior and git-project behavior are unchanged (the path condition still matches first).
- Migration `20260804120000_normalize_session_path` NULLs out legacy absolute/empty paths so existing sessions become visible again after upgrade.

### How did you verify your code works?

- New unit tests for `sessionPath` (win32 cross-volume returns undefined, same-volume keeps relative, posix unchanged) in `packages/opencode/test/session/session-path.test.ts`.
- New server test in `packages/opencode/test/server/session-list.test.ts`: a NULL-path session is listed when `directory` is provided and stays hidden without it. 12/12 pass in that file.
- `tsgo --noEmit` passes for `opencode`, `tui`, and `core`; oxlint clean on changed files.
- Real-machine check on Windows (non-git directory `D:\BB84.ai`): built the fork binary, pointed it at a snapshot copy of a real production DB (16,873 sessions, including rows with stored absolute paths like `D:/BB84.ai` and empty paths), enabled session directory filtering in the TUI, and confirmed sessions remain visible instead of being lost. The migration was exercised on the snapshot only; the production DB was not modified.

### Screenshots / recordings

No screenshots - verification was done interactively in the TUI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
