### PR TITLE
fix(app): prevent prompt footer overflow

### DIFF
--- a/packages/app/e2e/regression/prompt-input-v2-footer-overflow.spec.ts
+++ b/packages/app/e2e/regression/prompt-input-v2-footer-overflow.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+const directory = "C:/OpenCode/PromptInputV2FooterOverflow"
+const projectID = "proj_prompt_input_v2_footer_overflow"
+const sessionID = "ses_prompt_input_v2_footer_overflow"
+const modelName = "A model name that is intentionally long for narrow footer layouts"
+const variantName = "thinking-with-an-intentionally-long-label"
+const profiles = [
+  { name: "LTR narrow", locale: "en", width: 320, expectOverflow: true },
+  { name: "RTL narrow", locale: "ar", width: 320, expectOverflow: true },
+  { name: "LTR desktop", locale: "en", width: 1280, expectOverflow: false },
+] as const
+
+for (const profile of profiles) {
+  test(`${profile.name} keeps the V2 prompt submit button clear of overflowing controls`, async ({ page }) => {
+    await mockOpenCodeServer(page, {
+      directory,
+      project: {
+        id: projectID,
+        worktree: directory,
+        vcs: "git",
+        name: "prompt-input-v2-footer-overflow",
+        time: { created: 1700000000000, updated: 1700000000000 },
+        sandboxes: [],
+      },
+      provider: {
+        all: [
+          {
+            id: "opencode",
+            name: "OpenCode",
+            models: {
+              "long-model": {
+                id: "long-model",
+                name: modelName,
+                limit: { context: 200_000 },
+                variants: { [variantName]: {} },
+              },
+            },
+          },
+        ],
+        connected: ["opencode"],
+        default: { providerID: "opencode", modelID: "long-model" },
+      },
+      sessions: [
+        {
+          id: sessionID,
+          slug: "prompt-input-v2-footer-overflow",
+          projectID,
+          directory,
+          title: "Prompt input V2 footer overflow",
+          version: "dev",
+          time: { created: 1700000000000, updated: 1700000000000 },
+        },
+      ],
+      pageMessages: () => ({ items: [] }),
+    })
+    await page.addInitScript((value) => {
+      localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+      localStorage.setItem("opencode.global.dat:language", JSON.stringify({ locale: value }))
+    }, profile.locale)
+
+    await page.setViewportSize({ width: profile.width, height: 800 })
+    await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+    await expect(page.locator("html")).toHaveAttribute("dir", profile.locale === "ar" ? "rtl" : "ltr")
+
+    const composer = page.locator('[data-component="prompt-input-v2"]')
+    const form = composer.locator('form[data-component="prompt-input-v2"]')
+    const controls = composer.locator('[data-slot="prompt-input-controls"]')
+    const input = composer.locator('[data-component="prompt-input"]')
+    const model = composer.locator('[data-action="prompt-model"]')
+    const submit = composer.locator('[data-action="prompt-submit"]')
+    const variant = controls.locator('[data-action="prompt-variant"]')
+    await expectAppVisible(composer)
+    await expect(controls).toBeVisible()
+    await expect(model).toContainText(modelName)
+    await model.scrollIntoViewIfNeeded()
+    await expect(variant).toBeVisible()
+    await input.fill("keep the submit button clear")
+    await expect(submit).toBeEnabled()
+
+    await variant.click()
+    await page.getByRole("menuitemradio", { name: variantName }).click()
+    await expect(variant).toContainText(variantName)
+    await variant.evaluate((element) => element.scrollIntoView({ block: "nearest", inline: "end" }))
+    await variant.focus()
+    await page.keyboard.press("Tab")
+    await page.keyboard.press("Shift+Tab")
+    await expect(variant).toBeFocused()
+    await submit.click({ trial: true })
+
+    const layout = await form.evaluate((element) => {
+      const controls = element.querySelector<HTMLElement>('[data-slot="prompt-input-controls"]')!
+      const submit = element.querySelector<HTMLElement>('[data-action="prompt-submit"]')!
+      const formBox = element.getBoundingClientRect()
+      const controlsBox = controls.getBoundingClientRect()
+      const submitBox = submit.getBoundingClientRect()
+      const variant = controls.querySelector<HTMLElement>('[data-action="prompt-variant"]')!
+      const variantBox = variant.getBoundingClientRect()
+      const controlsStyle = getComputedStyle(controls)
+      const variantStyle = getComputedStyle(variant)
+      const focusExtent =
+        Number.parseFloat(variantStyle.outlineWidth) + Number.parseFloat(variantStyle.outlineOffset)
+      const logicalEndClearance =
+        controlsStyle.direction === "rtl"
+          ? variantBox.left - controlsBox.left
+          : controlsBox.right - variantBox.right
+      const overlap = Math.max(
+        0,
+        Math.min(controlsBox.right, submitBox.right) - Math.max(controlsBox.left, submitBox.left),
+      )
+      const target = document.elementFromPoint(
+        submitBox.left + submitBox.width / 2,
+        submitBox.top + submitBox.height / 2,
+      )
+      return {
+        controlsOverflow: controls.scrollWidth > controls.clientWidth,
+        controlsOverflowX: controlsStyle.overflowX,
+        focusVisible: variant.matches(":focus-visible"),
+        focusExtent,
+        logicalEndClearance,
+        focusOutlineInsideControls:
+          variantBox.left - focusExtent >= controlsBox.left &&
+          variantBox.right + focusExtent <= controlsBox.right &&
+          variantBox.top - focusExtent >= controlsBox.top &&
+          variantBox.bottom + focusExtent <= controlsBox.bottom,
+        variantInsideControls:
+          variantBox.left >= controlsBox.left &&
+          variantBox.right <= controlsBox.right &&
+          variantBox.top >= controlsBox.top &&
+          variantBox.bottom <= controlsBox.bottom,
+        submitInsideControls: controls.contains(submit),
+        submitInsideForm:
+          submitBox.left >= formBox.left &&
+          submitBox.right <= formBox.right &&
+          submitBox.top >= formBox.top &&
+          submitBox.bottom <= formBox.bottom,
+        submitOverlap: overlap,
+        submitTarget: target instanceof Node && submit.contains(target),
+      }
+    })
+
+    expect(layout.controlsOverflow).toBe(profile.expectOverflow)
+    expect(layout.controlsOverflowX).toBe("auto")
+    expect(layout.focusVisible).toBe(true)
+    expect(layout.focusExtent).toBeGreaterThan(0)
+    expect(layout.logicalEndClearance).toBeGreaterThanOrEqual(layout.focusExtent)
+    expect(layout.focusOutlineInsideControls).toBe(true)
+    expect(layout.variantInsideControls).toBe(true)
+    expect(layout.submitInsideControls).toBe(false)
+    expect(layout.submitInsideForm).toBe(true)
+    expect(layout.submitOverlap).toBe(0)
+    expect(layout.submitTarget).toBe(true)
+  })
+}

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -491,8 +491,8 @@ function PromptInputV2ModelControl(props: {
           />
         )}
       </Show>
-      <span class="truncate leading-4">{props.modelName}</span>
-      <span class="-ml-0.5 -mr-1 flex shrink-0">
+      <span class="min-w-0 truncate leading-4">{props.modelName}</span>
+      <span class="-ms-0.5 -me-1 flex shrink-0">
         <Icon name="chevron-down" />
       </span>
     </>
@@ -500,6 +500,7 @@ function PromptInputV2ModelControl(props: {
   return (
     <Show when={!props.loading}>
       <TooltipV2
+        class="shrink-0"
         placement="top"
         gutter={4}
         value={

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -195,9 +195,10 @@ export function PromptInputV2(props: PromptInputV2Props) {
           </Show>
         </div>
 
-        <div class="flex h-11 items-center px-2">
+        <div data-slot="prompt-input-footer" class="flex h-11 min-w-0 items-center ps-0 pe-2">
           <div
-            class="flex min-w-0 flex-1 items-center gap-1"
+            data-slot="prompt-input-controls"
+            class="flex min-w-0 flex-1 flex-nowrap items-center gap-1 overflow-x-auto no-scrollbar px-2 py-2"
             aria-hidden={state.mode === "shell"}
             inert={state.mode === "shell" ? true : undefined}
             style={buttons()}
@@ -248,6 +249,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
                   <PromptInputV2ConfiguredSelect
                     title={i18n.t("ui.promptInput.chooseVariant")}
                     keybind={["Shift", "Mod", "D"]}
+                    dataAction="prompt-variant"
                     control={control}
                   />
                 </Show>
@@ -483,6 +485,7 @@ export function PromptInputV2AddMenu(props: {
 }) {
   return (
     <TooltipV2
+      class="shrink-0"
       placement="top"
       value={
         <>
@@ -527,6 +530,7 @@ export function PromptInputV2AddMenu(props: {
 function PromptInputV2ConfiguredSelect(props: {
   title: string
   keybind?: string[]
+  dataAction?: string
   control: PromptInputV2SelectControl
   model?: boolean
 }) {
@@ -536,6 +540,7 @@ function PromptInputV2ConfiguredSelect(props: {
     <PromptInputV2Select
       title={props.title}
       keybind={props.control.keybind?.() ?? props.keybind}
+      dataAction={props.dataAction}
       options={props.control.options()}
       current={current()}
       currentIcon={
@@ -551,6 +556,7 @@ function PromptInputV2ConfiguredSelect(props: {
 export function PromptInputV2Select(props: {
   title: string
   keybind?: string[]
+  dataAction?: string
   options: PromptInputV2Option[]
   current: string
   currentIcon?: JSX.Element
@@ -560,6 +566,7 @@ export function PromptInputV2Select(props: {
 }) {
   return (
     <TooltipV2
+      class="shrink-0"
       placement="top"
       value={
         <>
@@ -571,13 +578,14 @@ export function PromptInputV2Select(props: {
       <MenuV2 gutter={6} modal={false} placement="top-start" onOpenChange={props.onOpenChange}>
         <MenuV2.Trigger
           as={ButtonV2}
+          data-action={props.dataAction}
           variant="ghost-muted"
           size="normal"
-          class={`max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
+          class={`min-w-0 max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
           aria-label={props.title}
         >
           {props.currentIcon}
-          <span class="truncate capitalize leading-5">
+          <span class="min-w-0 truncate capitalize leading-5">
             {props.options.find((option) => option.id === props.current)?.label ?? props.current}
           </span>
           <span class="-ms-0.5 -me-1 flex shrink-0">
@@ -680,6 +688,7 @@ export function PromptInputV2SubmitButton(props: {
 }) {
   return (
     <TooltipV2
+      class="shrink-0"
       placement="top"
       inactive={!props.stopping && props.disabled}
       value={props.stopping ? props.stopLabel : props.sendLabel}
@@ -691,7 +700,7 @@ export function PromptInputV2SubmitButton(props: {
         tabIndex={props.mode === "normal" ? undefined : -1}
         icon={props.stopping ? "stop" : props.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
         variant="primary"
-        class="size-7 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50"
+        class="size-7 shrink-0 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50"
         style={{
           "background-image":
             "linear-gradient(180deg,var(--v2-alpha-light-20) 0%,var(--v2-alpha-light-0) 100%),linear-gradient(90deg,var(--v2-background-bg-contrast) 0%,var(--v2-background-bg-contrast) 100%)",


### PR DESCRIPTION
## What
- Keep the V2 prompt submit button visible while model and variant controls overflow horizontally.
- Preserve focus-ring clearance and logical RTL spacing, with narrow and desktop regression coverage.

## Why
- A dedicated scrollable control strip keeps every selector reachable without allowing it to overlap the non-shrinking submit action.

## Test Plan
- `git diff --check origin/dev...HEAD` - passed.
- Not run: Bun, Playwright, and package typechecks are unavailable in this environment.