### PR TITLE
fix(opencode): add model attribution to run --format json events

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -731,8 +731,10 @@ export const RunCommand = effectCmd({
               const part = event.properties.part
               if (part.sessionID !== sessionID) continue
 
+              const model = models.get(part.messageID)
+
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
-                if (emit("tool_use", { part })) continue
+                if (emit("tool_use", { part, ...model })) continue
                 if (part.state.status === "completed") {
                   await tool(part)
                   continue
@@ -753,15 +755,15 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "step-start") {
-                if (emit("step_start", { part, ...models.get(part.messageID) })) continue
+                if (emit("step_start", { part, ...model })) continue
               }
 
               if (part.type === "step-finish") {
-                if (emit("step_finish", { part, ...models.get(part.messageID) })) continue
+                if (emit("step_finish", { part, ...model })) continue
               }
 
               if (part.type === "text" && part.time?.end) {
-                if (emit("text", { part })) continue
+                if (emit("text", { part, ...model })) continue
                 const text = part.text.trim()
                 if (!text) continue
                 if (!process.stdout.isTTY) {
@@ -774,7 +776,7 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "reasoning" && part.time?.end && thinking) {
-                if (emit("reasoning", { part })) continue
+                if (emit("reasoning", { part, ...model })) continue
                 const text = part.text.trim()
                 if (!text) continue
                 const line = `Thinking: ${text}`

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -697,6 +697,9 @@ export const RunCommand = effectCmd({
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
           const sessions = new Set([sessionID])
+          // messageID -> model that produced it, so step events can carry the
+          // attribution that only lives on the assistant message.
+          const models = new Map<string, { providerID: string; modelID: string }>()
           let error: string | undefined
 
           for await (const event of events.stream) {
@@ -707,14 +710,18 @@ export const RunCommand = effectCmd({
             if (
               event.type === "message.updated" &&
               event.properties.sessionID === sessionID &&
-              event.properties.info.role === "assistant" &&
-              args.format !== "json" &&
-              toggles.get("start") !== true
+              event.properties.info.role === "assistant"
             ) {
-              UI.empty()
-              UI.println(`> ${event.properties.info.agent} · ${event.properties.info.modelID}`)
-              UI.empty()
-              toggles.set("start", true)
+              models.set(event.properties.info.id, {
+                providerID: event.properties.info.providerID,
+                modelID: event.properties.info.modelID,
+              })
+              if (args.format !== "json" && toggles.get("start") !== true) {
+                UI.empty()
+                UI.println(`> ${event.properties.info.agent} · ${event.properties.info.modelID}`)
+                UI.empty()
+                toggles.set("start", true)
+              }
             }
 
             if (event.type === "message.part.updated") {
@@ -743,11 +750,11 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "step-start") {
-                if (emit("step_start", { part })) continue
+                if (emit("step_start", { part, ...models.get(part.messageID) })) continue
               }
 
               if (part.type === "step-finish") {
-                if (emit("step_finish", { part })) continue
+                if (emit("step_finish", { part, ...models.get(part.messageID) })) continue
               }
 
               if (part.type === "text" && part.time?.end) {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -698,7 +698,10 @@ export const RunCommand = effectCmd({
           const toggles = new Map<string, boolean>()
           const sessions = new Set([sessionID])
           // messageID -> model that produced it, so step events can carry the
-          // attribution that only lives on the assistant message.
+          // attribution that only lives on the assistant message. Only filled from
+          // messages seen on this stream, so a step for a message created before
+          // this subscription (attaching to a turn already in flight) emits
+          // without the fields rather than guessing.
           const models = new Map<string, { providerID: string; modelID: string }>()
           let error: string | undefined
 

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -133,6 +133,8 @@ describe("opencode run (non-interactive subprocess)", () => {
           {
             type: "text",
             part: expect.objectContaining({ type: "text", text: "structured output" }),
+            providerID: provider,
+            modelID: model,
           },
           {
             type: "step_finish",
@@ -152,24 +154,31 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
-  // The model only exists on the assistant message, so a step event has to pick
-  // it up from there. Running a non-default model proves the attribution follows
-  // the model that produced the step instead of a fixed value.
+  // The model only exists on the assistant message, so the events have to pick it
+  // up from there. Running a non-default model proves the attribution follows the
+  // model that produced the part instead of a fixed value, and a tool call makes
+  // the run span several part types.
   cliIt.concurrent(
-    "--format json attributes step events to the model that produced them",
+    "--format json attributes every part-bearing event to the model that produced it",
     ({ llm, opencode }) =>
       Effect.gen(function* () {
-        yield* llm.text("from the alt model")
+        yield* llm.push(
+          reply().text("before tool").tool("bash", {
+            command: "printf tool-output",
+            description: "Print deterministic output",
+          }),
+        )
+        yield* llm.text("after tool")
         const result = yield* opencode.run("say hi", { format: "json", model: "test/test-model-alt" })
         opencode.expectExit(result, 0)
 
-        const steps = opencode
-          .parseJsonEvents(result.stdout)
-          .filter((event) => event.type === "step_start" || event.type === "step_finish")
-        expect(steps.length).toBeGreaterThan(0)
-        for (const step of steps) {
-          expect(step.providerID).toBe("test")
-          expect(step.modelID).toBe("test-model-alt")
+        const events = opencode.parseJsonEvents(result.stdout)
+        expect(new Set(events.map((event) => event.type))).toEqual(
+          new Set(["step_start", "text", "tool_use", "step_finish"]),
+        )
+        for (const event of events) {
+          expect(event.providerID).toBe("test")
+          expect(event.modelID).toBe("test-model-alt")
         }
       }),
     60_000,

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -188,6 +188,28 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // Every other test passes --model, so they can't tell the model being read off
+  // the message from one read off the argv. Without --model the server resolves
+  // the configured default and the argv holds nothing, so this run only reports
+  // a model if it really comes from the assistant message.
+  cliIt.concurrent(
+    "--format json attributes events to the resolved default model without --model",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("default model run")
+        const result = yield* opencode.spawn(["run", "--format", "json", "say hi"])
+        opencode.expectExit(result, 0)
+
+        const events = opencode.parseJsonEvents(result.stdout)
+        expect(events.length).toBeGreaterThan(0)
+        for (const event of events) {
+          expect(event.providerID).toBe("test")
+          expect(event.modelID).toBe("test-model")
+        }
+      }),
+    60_000,
+  )
+
   cliIt.concurrent(
     "--format json emits a pure error record for a rejected prompt request",
     ({ opencode }) =>

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -163,18 +163,22 @@ describe("opencode run (non-interactive subprocess)", () => {
     ({ llm, opencode }) =>
       Effect.gen(function* () {
         yield* llm.push(
-          reply().text("before tool").tool("bash", {
+          reply().reason("thinking it over").text("before tool").tool("bash", {
             command: "printf tool-output",
             description: "Print deterministic output",
           }),
         )
         yield* llm.text("after tool")
-        const result = yield* opencode.run("say hi", { format: "json", model: "test/test-model-alt" })
+        const result = yield* opencode.run("say hi", {
+          format: "json",
+          model: "test/test-model-alt",
+          extraArgs: ["--thinking"],
+        })
         opencode.expectExit(result, 0)
 
         const events = opencode.parseJsonEvents(result.stdout)
         expect(new Set(events.map((event) => event.type))).toEqual(
-          new Set(["step_start", "text", "tool_use", "step_finish"]),
+          new Set(["step_start", "reasoning", "text", "tool_use", "step_finish"]),
         )
         for (const event of events) {
           expect(event.providerID).toBe("test")

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { reply } from "../../lib/llm-server"
-import { cliIt } from "../../lib/cli-process"
+import { cliIt, testModelID } from "../../lib/cli-process"
 
 describe("opencode run (non-interactive subprocess)", () => {
   // Happy path: prompt completes, output reaches stdout, process exits 0.
@@ -122,13 +122,24 @@ describe("opencode run (non-interactive subprocess)", () => {
           expect(typeof evt.sessionID).toBe("string")
         }
         expect(events.map((event) => event.type)).toEqual(["step_start", "text", "step_finish"])
+        const [provider, model] = testModelID.split("/")
         expect(events.map(({ timestamp: _, sessionID: __, ...event }) => event)).toEqual([
-          { type: "step_start", part: expect.objectContaining({ type: "step-start" }) },
+          {
+            type: "step_start",
+            part: expect.objectContaining({ type: "step-start" }),
+            providerID: provider,
+            modelID: model,
+          },
           {
             type: "text",
             part: expect.objectContaining({ type: "text", text: "structured output" }),
           },
-          { type: "step_finish", part: expect.objectContaining({ type: "step-finish" }) },
+          {
+            type: "step_finish",
+            part: expect.objectContaining({ type: "step-finish" }),
+            providerID: provider,
+            modelID: model,
+          },
         ])
         expect(result.stdout.endsWith("\n")).toBe(true)
         expect(

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -152,6 +152,29 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // The model only exists on the assistant message, so a step event has to pick
+  // it up from there. Running a non-default model proves the attribution follows
+  // the model that produced the step instead of a fixed value.
+  cliIt.concurrent(
+    "--format json attributes step events to the model that produced them",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("from the alt model")
+        const result = yield* opencode.run("say hi", { format: "json", model: "test/test-model-alt" })
+        opencode.expectExit(result, 0)
+
+        const steps = opencode
+          .parseJsonEvents(result.stdout)
+          .filter((event) => event.type === "step_start" || event.type === "step_finish")
+        expect(steps.length).toBeGreaterThan(0)
+        for (const step of steps) {
+          expect(step.providerID).toBe("test")
+          expect(step.modelID).toBe("test-model-alt")
+        }
+      }),
+    60_000,
+  )
+
   cliIt.concurrent(
     "--format json emits a pure error record for a rejected prompt request",
     ({ opencode }) =>

--- a/packages/opencode/test/lib/test-provider.ts
+++ b/packages/opencode/test/lib/test-provider.ts
@@ -1,7 +1,8 @@
 // Shared provider config for tests that need opencode to talk to a fake LLM
-// over a real HTTP endpoint. Registers a single provider `test` with a single
-// model `test-model` (i.e. `--model test/test-model`), pointed at the URL the
-// caller supplies (typically a TestLLMServer instance).
+// over a real HTTP endpoint. Registers a single provider `test` with two models,
+// `test-model` (the default `--model test/test-model`) and `test-model-alt`, for
+// tests that need output attributed to a specific model. Both point at the URL
+// the caller supplies (typically a TestLLMServer instance).
 //
 // Used by:
 //   - test/lib/run-process.ts          (subprocess CLI tests)

--- a/packages/opencode/test/lib/test-provider.ts
+++ b/packages/opencode/test/lib/test-provider.ts
@@ -11,6 +11,9 @@ export function testProviderConfig(llmUrl: string) {
   return {
     formatter: false,
     lsp: false,
+    // Default model, so a run without --model still resolves one and tests can
+    // tell a value read off the message from one read off the argv.
+    model: "test/test-model",
     provider: {
       test: {
         name: "Test",

--- a/packages/opencode/test/lib/test-provider.ts
+++ b/packages/opencode/test/lib/test-provider.ts
@@ -29,6 +29,20 @@ export function testProviderConfig(llmUrl: string) {
             cost: { input: 0, output: 0 },
             options: {},
           },
+          // Second model so tests can assert output is attributed to the model
+          // that produced it, not to a hardcoded default.
+          "test-model-alt": {
+            id: "test-model-alt",
+            name: "Test Model Alt",
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: true,
+            release_date: "2025-01-01",
+            limit: { context: 100_000, output: 10_000 },
+            cost: { input: 0, output: 0 },
+            options: {},
+          },
         },
         options: { apiKey: "test-key", baseURL: llmUrl },
       },


### PR DESCRIPTION
### Issue for this PR

Closes #40544

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`run --format json` events carry no model, so a headless consumer can't attribute tokens or cost — with two models in one session the events are identical apart from ids.

The value was already in the same loop: the default format reads `info.modelID` off `message.updated` to print the model header, but it never reached the JSON path. So I track providerID/modelID per messageID as those events arrive and stamp them onto every part-bearing event (`step_start`, `step_finish`, `text`, `reasoning`, `tool_use`). That works because `message.updated` for an assistant message is published before that message's parts, so the map is filled by the time a part arrives.

Additive: no existing field changes, the `part` payload is untouched, and default-format output is unchanged.

### How did you verify your code works?

- The existing `--format json` shape test now asserts the two new fields; reverting only `run.ts` makes it fail on exactly those.
- A new test runs a non-default model through a tool call, so `step_start`/`text`/`tool_use`/`step_finish` all report that model — returning a fixed value can't pass it.
- A new test runs **without** `--model`, because every other test passes the flag, so an implementation reading the model off argv passed the whole suite. Confirmed that one now fails only this test.
- `bun test test/cli/run/run-process.test.ts` → 15 pass. Live, two models in one session: `step_finish` reports `ling-3.0-flash-free` on the first turn and `mimo-v2.5-free` on the second; before they were indistinguishable.

To reproduce: `bun dev run --format json -m <model-a> "hi"`, then the same with `--session <id> -m <model-b>`.

The multi-turn case is verified live but not in the suite — the CLI test harness can't continue a session across processes.

A step whose message was created before the subscription emits without the fields rather than guessing. Happy to emit explicit `null`s if you'd rather the shape stay fixed.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

The wider stamping came from @rawsun007, who hit this independently and closed #40581 in favour of this one. Note for whichever lands second: #38504 adds a `part_delta` event with the same map-in-the-loop shape and would want these fields too.
