### PR TITLE
fix(core): avoid eager directory snapshots

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -31,10 +31,7 @@ export const ripgrepLayer = Layer.effect(
     const location = yield* Location.Service
     const ripgrep = yield* Ripgrep.Service
     const scope = yield* Scope.Scope
-    const state = {
-      files: [] as string[],
-      directories: [] as string[],
-    }
+    const files: string[] = []
     const directories = new Set<string>()
     yield* ripgrep
       .find({
@@ -43,10 +40,9 @@ export const ripgrepLayer = Layer.effect(
         limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
         onEntry: (entry) =>
           Effect.sync(() => {
-            state.files.push(entry.path)
+            files.push(entry.path)
             const parts = entry.path.split("/")
             parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
           }),
       })
       .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
@@ -106,10 +102,10 @@ export const ripgrepLayer = Layer.effect(
         Effect.gen(function* () {
           const items =
             input.type === "file"
-              ? state.files
+              ? files
               : input.type === "directory"
-                ? state.directories
-                : [...state.files, ...state.directories]
+                ? Array.from(directories)
+                : [...files, ...directories]
           return fuzzysort.go(input.query, items, { limit: input.limit ?? 50 }).map((item) => {
             const relative = item.target
             const type = relative.endsWith(path.sep) ? ("directory" as const) : ("file" as const)

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Deferred, Effect, Layer } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { FileSystem } from "@opencode-ai/core/filesystem"
+import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(LayerNode.compile(Ripgrep.node))
+const searchIt = testEffect(Layer.empty)
 
 const withTmp = <A, E, R>(f: (directory: AbsolutePath) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(
@@ -40,5 +46,66 @@ describe("Ripgrep", () => {
         expect(result[0]?.submatches[0]?.text).toBe("needle")
       }),
     ),
+  )
+})
+
+describe("FileSystemSearch", () => {
+  searchIt.live("finds partial file and directory results while indexing", () =>
+    Effect.gen(function* () {
+      const firstIndexed = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const secondIndexed = yield* Deferred.make<void>()
+      const first = FileSystem.Entry.make({ path: RelativePath.make("src/first.ts"), type: "file" })
+      const second = FileSystem.Entry.make({ path: RelativePath.make("test/nested/second.ts"), type: "file" })
+      const ripgrep = Layer.succeed(
+        Ripgrep.Service,
+        Ripgrep.Service.of({
+          find: (input) =>
+            Effect.gen(function* () {
+              if (input.onEntry) yield* input.onEntry(first)
+              yield* Deferred.succeed(firstIndexed, undefined)
+              yield* Deferred.await(release)
+              if (input.onEntry) yield* input.onEntry(second)
+              yield* Deferred.succeed(secondIndexed, undefined)
+              return [first, second]
+            }),
+          glob: () => Effect.die("unused"),
+          grep: () => Effect.die("unused"),
+        }),
+      )
+      const layer = FileSystemSearch.ripgrepLayer.pipe(
+        Layer.provide(
+          Layer.mergeAll(
+            LayerNode.compile(FSUtil.node),
+            Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make("/repo") }))),
+            ripgrep,
+          ),
+        ),
+      )
+
+      yield* Effect.gen(function* () {
+        const search = yield* FileSystemSearch.Service
+        yield* Deferred.await(firstIndexed)
+
+        expect(yield* search.find({ query: "first", type: "file" })).toEqual([first])
+        expect(yield* search.find({ query: "src", type: "directory" })).toEqual([
+          FileSystem.Entry.make({ path: RelativePath.make(`src${path.sep}`), type: "directory" }),
+        ])
+        expect(yield* search.find({ query: "src" })).toEqual([
+          FileSystem.Entry.make({ path: RelativePath.make(`src${path.sep}`), type: "directory" }),
+          first,
+        ])
+
+        yield* Deferred.succeed(release, undefined)
+        yield* Deferred.await(secondIndexed)
+
+        expect(yield* search.find({ query: "nested", type: "directory" })).toEqual([
+          FileSystem.Entry.make({
+            path: RelativePath.make(`test${path.sep}nested${path.sep}`),
+            type: "directory",
+          }),
+        ])
+      }).pipe(Effect.provide(layer))
+    }),
   )
 })

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,20 +1,14 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Deferred, Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { FileSystem } from "@opencode-ai/core/filesystem"
-import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
-import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
-import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(LayerNode.compile(Ripgrep.node))
-const searchIt = testEffect(Layer.empty)
 
 const withTmp = <A, E, R>(f: (directory: AbsolutePath) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(
@@ -46,66 +40,5 @@ describe("Ripgrep", () => {
         expect(result[0]?.submatches[0]?.text).toBe("needle")
       }),
     ),
-  )
-})
-
-describe("FileSystemSearch", () => {
-  searchIt.live("finds partial file and directory results while indexing", () =>
-    Effect.gen(function* () {
-      const firstIndexed = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
-      const secondIndexed = yield* Deferred.make<void>()
-      const first = FileSystem.Entry.make({ path: RelativePath.make("src/first.ts"), type: "file" })
-      const second = FileSystem.Entry.make({ path: RelativePath.make("test/nested/second.ts"), type: "file" })
-      const ripgrep = Layer.succeed(
-        Ripgrep.Service,
-        Ripgrep.Service.of({
-          find: (input) =>
-            Effect.gen(function* () {
-              if (input.onEntry) yield* input.onEntry(first)
-              yield* Deferred.succeed(firstIndexed, undefined)
-              yield* Deferred.await(release)
-              if (input.onEntry) yield* input.onEntry(second)
-              yield* Deferred.succeed(secondIndexed, undefined)
-              return [first, second]
-            }),
-          glob: () => Effect.die("unused"),
-          grep: () => Effect.die("unused"),
-        }),
-      )
-      const layer = FileSystemSearch.ripgrepLayer.pipe(
-        Layer.provide(
-          Layer.mergeAll(
-            LayerNode.compile(FSUtil.node),
-            Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make("/repo") }))),
-            ripgrep,
-          ),
-        ),
-      )
-
-      yield* Effect.gen(function* () {
-        const search = yield* FileSystemSearch.Service
-        yield* Deferred.await(firstIndexed)
-
-        expect(yield* search.find({ query: "first", type: "file" })).toEqual([first])
-        expect(yield* search.find({ query: "src", type: "directory" })).toEqual([
-          FileSystem.Entry.make({ path: RelativePath.make(`src${path.sep}`), type: "directory" }),
-        ])
-        expect(yield* search.find({ query: "src" })).toEqual([
-          FileSystem.Entry.make({ path: RelativePath.make(`src${path.sep}`), type: "directory" }),
-          first,
-        ])
-
-        yield* Deferred.succeed(release, undefined)
-        yield* Deferred.await(secondIndexed)
-
-        expect(yield* search.find({ query: "nested", type: "directory" })).toEqual([
-          FileSystem.Entry.make({
-            path: RelativePath.make(`test${path.sep}nested${path.sep}`),
-            type: "directory",
-          }),
-        ])
-      }).pipe(Effect.provide(layer))
-    }),
   )
 })


### PR DESCRIPTION
## What

Avoid repeatedly rebuilding the filesystem search directory snapshot while ripgrep indexes a repository. Large repositories now pay the directory materialization cost only when a directory or mixed file search is requested.

## Before / After

**Before:** Every indexed file updated the directory `Set`, then copied the entire set into `state.directories`. As the index grew, per-entry copies accumulated and could produce quadratic allocation and copying work before a user searched.

**After:** Indexing keeps files in an array and unique directories in the existing `Set`. File searches read the file array directly; directory and mixed searches materialize the current set at query time, preserving partial results while indexing continues.

## How

- `packages/core/src/filesystem/search.ts` removes the eagerly synchronized directory array and reads the live directory set from `find`.

## Scope

This does not change fuzzy ranking, ripgrep traversal, path formatting, result limits, the optional fff search backend, or existing tests.

## Testing

- `cd packages/core && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3`
