### PR TITLE
feat(core): preserve compaction tail media

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -764,6 +764,7 @@ export type Endpoint5_26Output =
             readonly reason: "auto" | "manual"
             readonly text: string
             readonly recent: string
+            readonly images?: ReadonlyArray<SessionMessage.CompactionImage> | undefined
           }
         }
       | {

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -764,7 +764,7 @@ export type Endpoint5_26Output =
             readonly reason: "auto" | "manual"
             readonly text: string
             readonly recent: string
-            readonly images?: ReadonlyArray<SessionMessage.CompactionImage> | undefined
+            readonly media?: ReadonlyArray<SessionMessage.CompactionMedia> | undefined
           }
         }
       | {

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -764,7 +764,14 @@ export type Endpoint5_26Output =
             readonly reason: "auto" | "manual"
             readonly text: string
             readonly recent: string
-            readonly media?: ReadonlyArray<SessionMessage.CompactionMedia> | undefined
+            readonly media?:
+              | ReadonlyArray<{
+                  readonly type: "file"
+                  readonly uri: string
+                  readonly mime: string
+                  readonly name?: string | undefined
+                }>
+              | undefined
           }
         }
       | {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -121,16 +121,7 @@ export type SessionMessageCompactionRunning = {
   recent: string
 }
 
-export type SessionMessageCompactionCompleted = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "completed"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-}
+export type SessionMessageCompactionImage = { label: string; uri: string; mime: string; name?: string }
 
 export type InstructionEntryKey = string
 
@@ -777,16 +768,6 @@ export type SessionCompactionStarted = {
   data: { sessionID: string; reason: "auto" | "manual"; recent: string; inputID?: string }
 }
 
-export type SessionCompactionEnded = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.compaction.ended"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; reason: "auto" | "manual"; text: string; recent: string }
-}
-
 export type SessionRevertCleared = {
   id: string
   created: number
@@ -1285,6 +1266,34 @@ export type SessionCompactionFailed = {
   durable: { aggregateID: string; seq: number; version: 1 }
   location?: LocationRef
   data: { sessionID: string; reason: "auto" | "manual"; error: SessionStructuredError; inputID?: string }
+}
+
+export type SessionMessageCompactionCompleted = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "completed"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+  images?: Array<SessionMessageCompactionImage>
+}
+
+export type SessionCompactionEnded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.compaction.ended"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    reason: "auto" | "manual"
+    text: string
+    recent: string
+    images?: Array<SessionMessageCompactionImage>
+  }
 }
 
 export type InstructionEntryInfo = { key: InstructionEntryKey; value: JsonValue }

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -121,7 +121,7 @@ export type SessionMessageCompactionRunning = {
   recent: string
 }
 
-export type SessionMessageCompactionImage = { label: string; uri: string; mime: string; name?: string }
+export type SessionMessageCompactionMedia = { uri: string; mime: string; name?: string }
 
 export type InstructionEntryKey = string
 
@@ -1277,7 +1277,7 @@ export type SessionMessageCompactionCompleted = {
   reason: "auto" | "manual"
   summary: string
   recent: string
-  images?: Array<SessionMessageCompactionImage>
+  media?: Array<SessionMessageCompactionMedia>
 }
 
 export type SessionCompactionEnded = {
@@ -1292,7 +1292,7 @@ export type SessionCompactionEnded = {
     reason: "auto" | "manual"
     text: string
     recent: string
-    images?: Array<SessionMessageCompactionImage>
+    media?: Array<SessionMessageCompactionMedia>
   }
 }
 

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -121,8 +121,6 @@ export type SessionMessageCompactionRunning = {
   recent: string
 }
 
-export type SessionMessageCompactionMedia = { uri: string; mime: string; name?: string }
-
 export type InstructionEntryKey = string
 
 export type SessionGenerateResponse = { data: { text: string } }
@@ -1208,6 +1206,18 @@ export type SessionMessageAssistantReasoning = {
 
 export type ToolContent = ToolTextContent | ToolFileContent
 
+export type SessionMessageCompactionCompleted = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "completed"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+  media?: Array<ToolFileContent>
+}
+
 export type SessionMessageAssistantRetry = { attempt: number; at: number; error: SessionStructuredError }
 
 export type SessionMessageCompactionFailed = {
@@ -1266,34 +1276,6 @@ export type SessionCompactionFailed = {
   durable: { aggregateID: string; seq: number; version: 1 }
   location?: LocationRef
   data: { sessionID: string; reason: "auto" | "manual"; error: SessionStructuredError; inputID?: string }
-}
-
-export type SessionMessageCompactionCompleted = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "completed"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-  media?: Array<SessionMessageCompactionMedia>
-}
-
-export type SessionCompactionEnded = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.compaction.ended"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    reason: "auto" | "manual"
-    text: string
-    recent: string
-    media?: Array<SessionMessageCompactionMedia>
-  }
 }
 
 export type InstructionEntryInfo = { key: InstructionEntryKey; value: JsonValue }
@@ -1397,6 +1379,16 @@ export type SessionToolCalled = {
 }
 
 export type ToolContent1 = ToolTextContent | ToolFileContent1
+
+export type SessionCompactionEnded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.compaction.ended"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; reason: "auto" | "manual"; text: string; recent: string; media?: Array<ToolFileContent1> }
+}
 
 export type ModelCompatibility = { reasoningField?: ModelReasoningField }
 

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -23,7 +23,7 @@ const DEFAULT_BUFFER = 20_000
 const DEFAULT_KEEP_TOKENS = 15_000
 const OUTPUT_TOKEN_MAX = 32_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
-const IMAGE_TOKEN_ESTIMATE = 2_000
+const MEDIA_TOKEN_ESTIMATE = 1_500
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
 <template>
 ## Objective
@@ -127,9 +127,12 @@ export const serializeToolContent = (content: SessionMessage.ToolStateCompleted[
     )
     .join("\n")
 
-export const estimateImageTokens = (message: SessionMessage.Info) => {
+const isEstimatedMedia = (mime: string) =>
+  mime.toLowerCase().startsWith("image/") || mime.toLowerCase() === "application/pdf"
+
+export const estimateMediaTokens = (message: SessionMessage.Info) => {
   if (message.type === "user")
-    return (message.files?.filter((file) => file.mime.toLowerCase().startsWith("image/")).length ?? 0) * IMAGE_TOKEN_ESTIMATE
+    return (message.files?.filter((file) => isEstimatedMedia(file.mime)).length ?? 0) * MEDIA_TOKEN_ESTIMATE
   if (message.type !== "assistant") return 0
   return (
     message.content
@@ -138,8 +141,7 @@ export const estimateImageTokens = (message: SessionMessage.Info) => {
           ? (part.state.content ?? [])
           : [],
       )
-      .filter((content) => content.type === "file" && content.mime.toLowerCase().startsWith("image/")).length *
-    IMAGE_TOKEN_ESTIMATE
+      .filter((content) => content.type === "file" && isEstimatedMedia(content.mime)).length * MEDIA_TOKEN_ESTIMATE
   )
 }
 
@@ -205,7 +207,7 @@ const select = (
   let total = 0
   let split = conversation.length
   for (let index = conversation.length - 1; index >= 0; index--) {
-    const next = total + Token.estimate(conversation[index].text) + estimateImageTokens(conversation[index].message)
+    const next = total + Token.estimate(conversation[index].text) + estimateMediaTokens(conversation[index].message)
     if (split < conversation.length && next > tokens) break
     total = next
     split = index

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -23,6 +23,7 @@ const DEFAULT_BUFFER = 20_000
 const DEFAULT_KEEP_TOKENS = 15_000
 const OUTPUT_TOKEN_MAX = 32_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
+const IMAGE_TOKEN_ESTIMATE = 2_000
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
 <template>
 ## Objective
@@ -126,6 +127,22 @@ export const serializeToolContent = (content: SessionMessage.ToolStateCompleted[
     )
     .join("\n")
 
+export const estimateImageTokens = (message: SessionMessage.Info) => {
+  if (message.type === "user")
+    return (message.files?.filter((file) => file.mime.toLowerCase().startsWith("image/")).length ?? 0) * IMAGE_TOKEN_ESTIMATE
+  if (message.type !== "assistant") return 0
+  return (
+    message.content
+      .flatMap((part) =>
+        part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")
+          ? (part.state.content ?? [])
+          : [],
+      )
+      .filter((content) => content.type === "file" && content.mime.toLowerCase().startsWith("image/")).length *
+    IMAGE_TOKEN_ESTIMATE
+  )
+}
+
 const serialize = (message: SessionMessage.Info) => {
   if (message.type === "user") {
     const files =
@@ -188,7 +205,7 @@ const select = (
   let total = 0
   let split = conversation.length
   for (let index = conversation.length - 1; index >= 0; index--) {
-    const next = total + Token.estimate(conversation[index].text)
+    const next = total + Token.estimate(conversation[index].text) + estimateImageTokens(conversation[index].message)
     if (split < conversation.length && next > tokens) break
     total = next
     split = index

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -2,6 +2,7 @@ export * as SessionCompaction from "./compaction"
 
 import { LLM, LLMClient, AIError, LLMEvent, Message, type LLMRequest, type LanguageModel } from "@opencode-ai/ai"
 import { SessionError } from "@opencode-ai/schema/session-error"
+import { Tool } from "@opencode-ai/schema/tool"
 import { Context, Effect, Layer, Stream } from "effect"
 import { Config } from "../config"
 import { Bus } from "../bus"
@@ -90,7 +91,7 @@ type Plan = {
   readonly reason: SessionMessage.Compaction["reason"]
   readonly prompt: string
   readonly recent: string
-  readonly media: readonly SessionMessage.CompactionMedia[]
+  readonly media: readonly Tool.FileContent[]
   readonly inputID?: SessionMessage.ID
 }
 
@@ -109,8 +110,6 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 const truncate = (value: string) =>
   value.length <= TOOL_OUTPUT_MAX_CHARS ? value : `${value.slice(0, TOOL_OUTPUT_MAX_CHARS)}\n[truncated]`
 
-type Media = SessionMessage.CompactionMedia
-
 const isMedia = (mime: string) => {
   const value = mime.toLowerCase()
   return (
@@ -120,48 +119,20 @@ const isMedia = (mime: string) => {
     value === "application/pdf"
   )
 }
-const mediaMarker = (media: Media) =>
-  `[Attached ${media.mime}${media.name === undefined ? "" : `: ${media.name}`}]`
-
-export const serializeToolContent = (
-  content: SessionMessage.ToolStateCompleted["content"],
-  retain?: (media: Media) => string,
-) =>
+export const serializeToolContent = (content: SessionMessage.ToolStateCompleted["content"]) =>
   content
     .map((item) =>
-      item.type === "text"
-        ? item.text
-        : retain && isMedia(item.mime)
-          ? retain({ uri: item.uri, mime: item.mime, name: item.name })
-          : mediaMarker(item),
+      item.type === "text" ? item.text : `[Attached ${item.mime}${item.name === undefined ? "" : `: ${item.name}`}]`,
     )
     .join("\n")
 
-const serializeToolResult = (
-  content: SessionMessage.ToolStateCompleted["content"],
-  retain?: (media: Media) => string,
-) => {
-  if (!retain) return truncate(serializeToolContent(content))
-  const markers: string[] = []
-  const result = truncate(
-    serializeToolContent(content, (media) => {
-      const marker = retain(media)
-      markers.push(marker)
-      return marker
-    }),
-  )
-  return [result, ...markers.filter((marker) => !result.includes(marker))].join("\n")
-}
-
-const serialize = (message: SessionMessage.Info, retain?: (media: Media) => string) => {
+const serialize = (message: SessionMessage.Info) => {
   if (message.type === "user") {
     const files =
-      message.files?.map((file) => {
-        const name = file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")
-        if (retain && isMedia(file.mime))
-          return retain({ uri: `data:${file.mime};base64,${file.data}`, mime: file.mime, name })
-        return mediaMarker({ uri: "", mime: file.mime, name })
-      }) ?? []
+      message.files?.map(
+        (file) =>
+          `[Attached ${file.mime}: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}]`,
+      ) ?? []
     return [`[User]: ${message.text}`, ...files].join("\n")
   }
   if (message.type === "assistant") {
@@ -173,14 +144,10 @@ const serialize = (message: SessionMessage.Info, retain?: (media: Media) => stri
         if (part.state.status === "completed")
           return [
             `[Assistant tool call]: ${part.name}(${input})`,
-            `[Tool result]: ${serializeToolResult(part.state.content, retain)}`,
+            `[Tool result]: ${truncate(serializeToolContent(part.state.content))}`,
           ]
         if (part.state.status === "error")
-          return [
-            `[Assistant tool call]: ${part.name}(${input})`,
-            `[Tool error]: ${part.state.error.message}`,
-            ...(part.state.content ? [`[Tool result]: ${serializeToolResult(part.state.content, retain)}`] : []),
-          ]
+          return [`[Assistant tool call]: ${part.name}(${input})`, `[Tool error]: ${part.state.error.message}`]
         return [`[Assistant tool call]: ${part.name}(${input})`]
       })
       .join("\n")
@@ -209,7 +176,7 @@ const select = (
 ): {
   readonly head: string
   readonly recent: string
-  readonly media: readonly SessionMessage.CompactionMedia[]
+  readonly media: readonly Tool.FileContent[]
 } | undefined => {
   const conversation = messages
     .filter((message) => message.type !== "compaction" && message.type !== "system")
@@ -231,22 +198,33 @@ const select = (
     const latestUser = conversation.findLastIndex((item) => item.message.type === "user")
     if (latestUser > 0) split = latestUser
   }
-  const media: SessionMessage.CompactionMedia[] = []
-  const retain = (item: Media) => {
-    const label = `Retained media ${media.length + 1}`
-    media.push(item)
-    return `[${label} (${item.mime})${item.name === undefined ? "" : `: ${item.name}`}]`
-  }
+  const tail = conversation.slice(split)
   return {
     head: conversation
       .slice(0, split)
       .map((item) => item.text)
       .join("\n\n"),
-    recent: conversation
-      .slice(split)
-      .map((item) => serialize(item.message, retain))
-      .join("\n\n"),
-    media,
+    recent: tail.map((item) => item.text).join("\n\n"),
+    media: tail.flatMap((item) => {
+      if (item.message.type === "user")
+        return (
+          item.message.files
+            ?.filter((file) => isMedia(file.mime))
+            .map((file) => ({
+              type: "file" as const,
+              uri: `data:${file.mime};base64,${file.data}`,
+              mime: file.mime,
+              name: file.name,
+            })) ?? []
+        )
+      if (item.message.type !== "assistant") return []
+      return item.message.content.flatMap((part) => {
+        if (part.type !== "tool" || (part.state.status !== "completed" && part.state.status !== "error")) return []
+        return (part.state.content ?? []).flatMap((content) =>
+          content.type === "file" && isMedia(content.mime) ? [content] : [],
+        )
+      })
+    }),
   }
 }
 

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -90,7 +90,7 @@ type Plan = {
   readonly reason: SessionMessage.Compaction["reason"]
   readonly prompt: string
   readonly recent: string
-  readonly images: readonly SessionMessage.CompactionImage[]
+  readonly media: readonly SessionMessage.CompactionMedia[]
   readonly inputID?: SessionMessage.ID
 }
 
@@ -109,35 +109,43 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 const truncate = (value: string) =>
   value.length <= TOOL_OUTPUT_MAX_CHARS ? value : `${value.slice(0, TOOL_OUTPUT_MAX_CHARS)}\n[truncated]`
 
-type Image = Omit<SessionMessage.CompactionImage, "label">
+type Media = SessionMessage.CompactionMedia
 
-const isImage = (mime: string) => mime.toLowerCase().startsWith("image/")
-const imageMarker = (image: Image) =>
-  `[Attached ${image.mime}${image.name === undefined ? "" : `: ${image.name}`}]`
+const isMedia = (mime: string) => {
+  const value = mime.toLowerCase()
+  return (
+    value.startsWith("image/") ||
+    value.startsWith("audio/") ||
+    value.startsWith("video/") ||
+    value === "application/pdf"
+  )
+}
+const mediaMarker = (media: Media) =>
+  `[Attached ${media.mime}${media.name === undefined ? "" : `: ${media.name}`}]`
 
 export const serializeToolContent = (
   content: SessionMessage.ToolStateCompleted["content"],
-  retain?: (image: Image) => string,
+  retain?: (media: Media) => string,
 ) =>
   content
     .map((item) =>
       item.type === "text"
         ? item.text
-        : retain && isImage(item.mime)
+        : retain && isMedia(item.mime)
           ? retain({ uri: item.uri, mime: item.mime, name: item.name })
-          : imageMarker(item),
+          : mediaMarker(item),
     )
     .join("\n")
 
 const serializeToolResult = (
   content: SessionMessage.ToolStateCompleted["content"],
-  retain?: (image: Image) => string,
+  retain?: (media: Media) => string,
 ) => {
   if (!retain) return truncate(serializeToolContent(content))
   const markers: string[] = []
   const result = truncate(
-    serializeToolContent(content, (image) => {
-      const marker = retain(image)
+    serializeToolContent(content, (media) => {
+      const marker = retain(media)
       markers.push(marker)
       return marker
     }),
@@ -145,14 +153,14 @@ const serializeToolResult = (
   return [result, ...markers.filter((marker) => !result.includes(marker))].join("\n")
 }
 
-const serialize = (message: SessionMessage.Info, retain?: (image: Image) => string) => {
+const serialize = (message: SessionMessage.Info, retain?: (media: Media) => string) => {
   if (message.type === "user") {
     const files =
       message.files?.map((file) => {
         const name = file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")
-        if (retain && isImage(file.mime))
+        if (retain && isMedia(file.mime))
           return retain({ uri: `data:${file.mime};base64,${file.data}`, mime: file.mime, name })
-        return imageMarker({ uri: "", mime: file.mime, name })
+        return mediaMarker({ uri: "", mime: file.mime, name })
       }) ?? []
     return [`[User]: ${message.text}`, ...files].join("\n")
   }
@@ -201,7 +209,7 @@ const select = (
 ): {
   readonly head: string
   readonly recent: string
-  readonly images: readonly SessionMessage.CompactionImage[]
+  readonly media: readonly SessionMessage.CompactionMedia[]
 } | undefined => {
   const conversation = messages
     .filter((message) => message.type !== "compaction" && message.type !== "system")
@@ -223,11 +231,11 @@ const select = (
     const latestUser = conversation.findLastIndex((item) => item.message.type === "user")
     if (latestUser > 0) split = latestUser
   }
-  const images: SessionMessage.CompactionImage[] = []
-  const retain = (image: Image) => {
-    const label = `Retained image ${images.length + 1}`
-    images.push({ label, ...image })
-    return `[${label} (${image.mime})${image.name === undefined ? "" : `: ${image.name}`}]`
+  const media: SessionMessage.CompactionMedia[] = []
+  const retain = (item: Media) => {
+    const label = `Retained media ${media.length + 1}`
+    media.push(item)
+    return `[${label} (${item.mime})${item.name === undefined ? "" : `: ${item.name}`}]`
   }
   return {
     head: conversation
@@ -238,7 +246,7 @@ const select = (
       .slice(split)
       .map((item) => serialize(item.message, retain))
       .join("\n\n"),
-    images,
+    media,
   }
 }
 
@@ -266,7 +274,7 @@ const planContent = (messages: readonly SessionMessage.Info[], tokens: number) =
       context: summarizeRecent ? [selected.recent] : [previousRecent, selected.head].filter(Boolean),
     }),
     recent: summarizeRecent ? "" : selected.recent,
-    images: summarizeRecent ? [] : selected.images,
+    media: summarizeRecent ? [] : selected.media,
   }
 }
 
@@ -366,7 +374,7 @@ const make = (dependencies: Dependencies) => {
       reason: plan.reason,
       text: summary,
       recent: plan.recent,
-      images: plan.images,
+      media: plan.media,
     })
     return { status: "completed" as const }
   })

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -19,7 +19,7 @@ import type { Info } from "../model"
 import { SessionUsage } from "./usage"
 
 const DEFAULT_BUFFER = 20_000
-const DEFAULT_KEEP_TOKENS = 8_000
+const DEFAULT_KEEP_TOKENS = 15_000
 const OUTPUT_TOKEN_MAX = 32_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
@@ -90,6 +90,7 @@ type Plan = {
   readonly reason: SessionMessage.Compaction["reason"]
   readonly prompt: string
   readonly recent: string
+  readonly images: readonly SessionMessage.CompactionImage[]
   readonly inputID?: SessionMessage.ID
 }
 
@@ -108,20 +109,51 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Se
 const truncate = (value: string) =>
   value.length <= TOOL_OUTPUT_MAX_CHARS ? value : `${value.slice(0, TOOL_OUTPUT_MAX_CHARS)}\n[truncated]`
 
-export const serializeToolContent = (content: SessionMessage.ToolStateCompleted["content"]) =>
+type Image = Omit<SessionMessage.CompactionImage, "label">
+
+const isImage = (mime: string) => mime.toLowerCase().startsWith("image/")
+const imageMarker = (image: Image) =>
+  `[Attached ${image.mime}${image.name === undefined ? "" : `: ${image.name}`}]`
+
+export const serializeToolContent = (
+  content: SessionMessage.ToolStateCompleted["content"],
+  retain?: (image: Image) => string,
+) =>
   content
     .map((item) =>
-      item.type === "text" ? item.text : `[Attached ${item.mime}${item.name === undefined ? "" : `: ${item.name}`}]`,
+      item.type === "text"
+        ? item.text
+        : retain && isImage(item.mime)
+          ? retain({ uri: item.uri, mime: item.mime, name: item.name })
+          : imageMarker(item),
     )
     .join("\n")
 
-const serialize = (message: SessionMessage.Info) => {
+const serializeToolResult = (
+  content: SessionMessage.ToolStateCompleted["content"],
+  retain?: (image: Image) => string,
+) => {
+  if (!retain) return truncate(serializeToolContent(content))
+  const markers: string[] = []
+  const result = truncate(
+    serializeToolContent(content, (image) => {
+      const marker = retain(image)
+      markers.push(marker)
+      return marker
+    }),
+  )
+  return [result, ...markers.filter((marker) => !result.includes(marker))].join("\n")
+}
+
+const serialize = (message: SessionMessage.Info, retain?: (image: Image) => string) => {
   if (message.type === "user") {
     const files =
-      message.files?.map(
-        (file) =>
-          `[Attached ${file.mime}: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}]`,
-      ) ?? []
+      message.files?.map((file) => {
+        const name = file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")
+        if (retain && isImage(file.mime))
+          return retain({ uri: `data:${file.mime};base64,${file.data}`, mime: file.mime, name })
+        return imageMarker({ uri: "", mime: file.mime, name })
+      }) ?? []
     return [`[User]: ${message.text}`, ...files].join("\n")
   }
   if (message.type === "assistant") {
@@ -133,10 +165,14 @@ const serialize = (message: SessionMessage.Info) => {
         if (part.state.status === "completed")
           return [
             `[Assistant tool call]: ${part.name}(${input})`,
-            `[Tool result]: ${truncate(serializeToolContent(part.state.content))}`,
+            `[Tool result]: ${serializeToolResult(part.state.content, retain)}`,
           ]
         if (part.state.status === "error")
-          return [`[Assistant tool call]: ${part.name}(${input})`, `[Tool error]: ${part.state.error.message}`]
+          return [
+            `[Assistant tool call]: ${part.name}(${input})`,
+            `[Tool error]: ${part.state.error.message}`,
+            ...(part.state.content ? [`[Tool result]: ${serializeToolResult(part.state.content, retain)}`] : []),
+          ]
         return [`[Assistant tool call]: ${part.name}(${input})`]
       })
       .join("\n")
@@ -162,7 +198,11 @@ const settings = (documents: readonly Config.Entry[]) => {
 const select = (
   messages: readonly SessionMessage.Info[],
   tokens: number,
-): { readonly head: string; readonly recent: string } | undefined => {
+): {
+  readonly head: string
+  readonly recent: string
+  readonly images: readonly SessionMessage.CompactionImage[]
+} | undefined => {
   const conversation = messages
     .filter((message) => message.type !== "compaction" && message.type !== "system")
     .flatMap((message) => {
@@ -183,6 +223,12 @@ const select = (
     const latestUser = conversation.findLastIndex((item) => item.message.type === "user")
     if (latestUser > 0) split = latestUser
   }
+  const images: SessionMessage.CompactionImage[] = []
+  const retain = (image: Image) => {
+    const label = `Retained image ${images.length + 1}`
+    images.push({ label, ...image })
+    return `[${label} (${image.mime})${image.name === undefined ? "" : `: ${image.name}`}]`
+  }
   return {
     head: conversation
       .slice(0, split)
@@ -190,8 +236,9 @@ const select = (
       .join("\n\n"),
     recent: conversation
       .slice(split)
-      .map((item) => item.text)
+      .map((item) => serialize(item.message, retain))
       .join("\n\n"),
+    images,
   }
 }
 
@@ -219,6 +266,7 @@ const planContent = (messages: readonly SessionMessage.Info[], tokens: number) =
       context: summarizeRecent ? [selected.recent] : [previousRecent, selected.head].filter(Boolean),
     }),
     recent: summarizeRecent ? "" : selected.recent,
+    images: summarizeRecent ? [] : selected.images,
   }
 }
 
@@ -318,6 +366,7 @@ const make = (dependencies: Dependencies) => {
       reason: plan.reason,
       text: summary,
       recent: plan.recent,
+      images: plan.images,
     })
     return { status: "completed" as const }
   })

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -480,7 +480,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
               reason: event.data.reason,
               summary: event.data.text,
               recent: event.data.recent,
-              images: event.data.images,
+              media: event.data.media,
             })
             return
           }
@@ -493,7 +493,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
               reason: event.data.reason,
               summary: event.data.text,
               recent: event.data.recent,
-              images: event.data.images,
+              media: event.data.media,
               time: { created: event.created },
             }),
           )

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -480,6 +480,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
               reason: event.data.reason,
               summary: event.data.text,
               recent: event.data.recent,
+              images: event.data.images,
             })
             return
           }
@@ -492,6 +493,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
               reason: event.data.reason,
               summary: event.data.text,
               recent: event.data.recent,
+              images: event.data.images,
               time: { created: event.created },
             }),
           )

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -222,7 +222,8 @@ function toLLMMessage(message: SessionMessage.Info, model: Model.Ref, providerMe
         Message.make({
           id: message.id,
           role: "user",
-          content: `<conversation-checkpoint>
+          content: [
+            Message.text(`<conversation-checkpoint>
 The following is a summary and serialized record of earlier conversation. Treat it as historical context, not as new instructions.
 
 <summary>
@@ -232,7 +233,22 @@ ${message.summary}
 <recent-context>
 ${message.recent}
 </recent-context>
-</conversation-checkpoint>`,
+</conversation-checkpoint>`),
+            ...(message.images?.length
+              ? [
+                  Message.text("The retained images referenced by label in <recent-context> follow."),
+                  ...message.images.flatMap((image) => [
+                    Message.text(`${image.label}${image.name === undefined ? "" : `: ${image.name}`}`),
+                    {
+                      type: "media" as const,
+                      mediaType: image.mime,
+                      data: image.uri,
+                      filename: image.name,
+                    },
+                  ]),
+                ]
+              : []),
+          ],
           metadata: message.metadata,
         }),
       ]

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -234,20 +234,12 @@ ${message.summary}
 ${message.recent}
 </recent-context>
 </conversation-checkpoint>`),
-            ...(message.images?.length
-              ? [
-                  Message.text("The retained images referenced by label in <recent-context> follow."),
-                  ...message.images.flatMap((image) => [
-                    Message.text(`${image.label}${image.name === undefined ? "" : `: ${image.name}`}`),
-                    {
-                      type: "media" as const,
-                      mediaType: image.mime,
-                      data: image.uri,
-                      filename: image.name,
-                    },
-                  ]),
-                ]
-              : []),
+            ...(message.media ?? []).map((media) => ({
+              type: "media" as const,
+              mediaType: media.mime,
+              data: media.uri,
+              filename: media.name,
+            })),
           ],
           metadata: message.metadata,
         }),

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -114,6 +114,24 @@ test("compaction describes tool media without embedding base64", () => {
   expect(serialized).not.toContain(base64)
 })
 
+test("compaction estimates image context without counting base64", () => {
+  const image = FileAttachment.make({
+    data: Base64.make("a".repeat(10_000)),
+    mime: "image/png",
+    source: { type: "inline" },
+    name: "image.png",
+  })
+  const message = SessionMessage.User.make({
+    id: SessionMessage.ID.create(),
+    type: "user",
+    text: "Compare these images.",
+    files: [image, image],
+    time: { created: DateTime.makeUnsafe(0) },
+  })
+
+  expect(SessionCompaction.estimateImageTokens(message)).toBe(4_000)
+})
+
 test("compaction prompt requires the checkpoint headings in order", () => {
   const prompt = SessionCompaction.buildPrompt({ context: ["Conversation history"] })
   expect(prompt.match(/^#{2,3} .+$/gm)).toEqual([

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -21,7 +21,10 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { App } from "@opencode-ai/core/app"
 import { Agent } from "@opencode-ai/core/agent"
 import { Location } from "@opencode-ai/core/location"
+import { Model } from "@opencode-ai/core/model"
+import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Base64, FileAttachment } from "@opencode-ai/schema/prompt"
 import { Money } from "@opencode-ai/schema/money"
 import { DateTime, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { asc, eq } from "drizzle-orm"
@@ -193,6 +196,48 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
       text: "Manual compaction should include this short conversation.",
       time: { created: DateTime.makeUnsafe(0) },
     }
+    const recentMessage = SessionMessage.User.make({
+      id: SessionMessage.ID.create(),
+      type: "user",
+      text: "Compare the retained images.",
+      files: [
+        FileAttachment.make({
+          data: Base64.make("aW1hZ2U="),
+          mime: "image/png",
+          source: { type: "inline" },
+          name: "prompt.png",
+        }),
+      ],
+      time: { created: DateTime.makeUnsafe(1) },
+    })
+    const assistantMessage = SessionMessage.Assistant.make({
+      id: SessionMessage.ID.create(),
+      type: "assistant",
+      agent: Agent.defaultID,
+      model: { id: Model.ID.make("summary-model"), providerID: Provider.ID.make("test") },
+      content: [
+        SessionMessage.AssistantTool.make({
+          type: "tool",
+          id: "tool_image",
+          name: "read",
+          state: SessionMessage.ToolStateCompleted.make({
+            status: "completed",
+            input: {},
+            content: [
+              { type: "text", text: "x".repeat(2_100) },
+              {
+                type: "file",
+                uri: "data:image/png;base64,dG9vbC1pbWFnZQ==",
+                mime: "image/png",
+                name: "tool.png",
+              },
+            ],
+          }),
+          time: { created: DateTime.makeUnsafe(2), completed: DateTime.makeUnsafe(2) },
+        }),
+      ],
+      time: { created: DateTime.makeUnsafe(2), completed: DateTime.makeUnsafe(2) },
+    })
     yield* db
       .insert(ProjectTable)
       .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
@@ -228,7 +273,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(
       yield* compaction.compactManual({
         session,
-        messages: [userMessage],
+        messages: [userMessage, recentMessage, assistantMessage],
         inputID: SessionMessage.ID.make("msg_manual_compaction"),
       }),
     ).toEqual({ status: "completed" })
@@ -247,7 +292,28 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(requests[0]?.generation).toBeUndefined()
     expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this short conversation.")
     expect(yield* store.context(sessionID)).toMatchObject([
-      { type: "compaction", reason: "manual", summary: "manual summary", recent: "" },
+      {
+        type: "compaction",
+        reason: "manual",
+        summary: "manual summary",
+        recent: expect.stringMatching(
+          /\[Retained image 1 \(image\/png\): prompt\.png\].*\[Retained image 2 \(image\/png\): tool\.png\]/s,
+        ),
+        images: [
+          {
+            label: "Retained image 1",
+            uri: "data:image/png;base64,aW1hZ2U=",
+            mime: "image/png",
+            name: "prompt.png",
+          },
+          {
+            label: "Retained image 2",
+            uri: "data:image/png;base64,dG9vbC1pbWFnZQ==",
+            mime: "image/png",
+            name: "tool.png",
+          },
+        ],
+      },
     ])
     expect(yield* store.get(sessionID)).toMatchObject({
       cost: 0.0000233,

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -199,13 +199,13 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     const recentMessage = SessionMessage.User.make({
       id: SessionMessage.ID.create(),
       type: "user",
-      text: "Compare the retained images.",
+      text: "Compare the retained media.",
       files: [
         FileAttachment.make({
           data: Base64.make("aW1hZ2U="),
-          mime: "image/png",
+          mime: "application/pdf",
           source: { type: "inline" },
-          name: "prompt.png",
+          name: "prompt.pdf",
         }),
       ],
       time: { created: DateTime.makeUnsafe(1) },
@@ -297,17 +297,15 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
         reason: "manual",
         summary: "manual summary",
         recent: expect.stringMatching(
-          /\[Retained image 1 \(image\/png\): prompt\.png\].*\[Retained image 2 \(image\/png\): tool\.png\]/s,
+          /\[Retained media 1 \(application\/pdf\): prompt\.pdf\].*\[Retained media 2 \(image\/png\): tool\.png\]/s,
         ),
-        images: [
+        media: [
           {
-            label: "Retained image 1",
-            uri: "data:image/png;base64,aW1hZ2U=",
-            mime: "image/png",
-            name: "prompt.png",
+            uri: "data:application/pdf;base64,aW1hZ2U=",
+            mime: "application/pdf",
+            name: "prompt.pdf",
           },
           {
-            label: "Retained image 2",
             uri: "data:image/png;base64,dG9vbC1pbWFnZQ==",
             mime: "image/png",
             name: "tool.png",

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -114,7 +114,7 @@ test("compaction describes tool media without embedding base64", () => {
   expect(serialized).not.toContain(base64)
 })
 
-test("compaction estimates image context without counting base64", () => {
+test("compaction estimates media context without counting base64", () => {
   const image = FileAttachment.make({
     data: Base64.make("a".repeat(10_000)),
     mime: "image/png",
@@ -125,11 +125,11 @@ test("compaction estimates image context without counting base64", () => {
     id: SessionMessage.ID.create(),
     type: "user",
     text: "Compare these images.",
-    files: [image, image],
+    files: [image, image, FileAttachment.make({ ...image, mime: "application/pdf" })],
     time: { created: DateTime.makeUnsafe(0) },
   })
 
-  expect(SessionCompaction.estimateImageTokens(message)).toBe(4_000)
+  expect(SessionCompaction.estimateMediaTokens(message)).toBe(4_500)
 })
 
 test("compaction prompt requires the checkpoint headings in order", () => {
@@ -197,7 +197,7 @@ it.effect("auto compaction reserves a buffer below the prompt ceiling", () =>
   }),
 )
 
-it.effect("manual compaction summarizes short context instead of no-op", () =>
+it.effect("manual compaction preserves ordered media in the retained tail", () =>
   Effect.gen(function* () {
     requests = []
     const db = (yield* Database.Service).db
@@ -209,7 +209,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     const userMessage = {
       id: SessionMessage.ID.create(),
       type: "user" as const,
-      text: "Manual compaction should include this short conversation.",
+      text: `Manual compaction should include this older conversation. ${"older context ".repeat(4_500)}`,
       time: { created: DateTime.makeUnsafe(0) },
     }
     const recentMessage = SessionMessage.User.make({
@@ -223,8 +223,20 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
           source: { type: "inline" },
           name: "prompt.pdf",
         }),
+        FileAttachment.make({
+          data: Base64.make("aW1hZ2U="),
+          mime: "image/png",
+          source: { type: "inline" },
+          name: "prompt.png",
+        }),
       ],
       time: { created: DateTime.makeUnsafe(1) },
+    })
+    const latestMessage = SessionMessage.User.make({
+      id: SessionMessage.ID.create(),
+      type: "user",
+      text: "Newest text after the retained media.",
+      time: { created: DateTime.makeUnsafe(2) },
     })
     yield* db
       .insert(ProjectTable)
@@ -261,7 +273,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(
       yield* compaction.compactManual({
         session,
-        messages: [userMessage, recentMessage],
+        messages: [userMessage, recentMessage, latestMessage],
         inputID: SessionMessage.ID.make("msg_manual_compaction"),
       }),
     ).toEqual({ status: "completed" })
@@ -278,19 +290,27 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
       "x-opencode-client": "opencode",
     })
     expect(requests[0]?.generation).toBeUndefined()
-    expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this short conversation.")
+    expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this older conversation.")
     expect(yield* store.context(sessionID)).toMatchObject([
       {
         type: "compaction",
         reason: "manual",
         summary: "manual summary",
-        recent: expect.stringContaining("[Attached application/pdf: prompt.pdf]"),
+        recent: expect.stringMatching(
+          /\[User\]: Compare the retained media\.\n\[Attached application\/pdf: prompt\.pdf\]\n\[Attached image\/png: prompt\.png\]\n\n\[User\]: Newest text after the retained media\./,
+        ),
         media: [
           {
             type: "file",
             uri: "data:application/pdf;base64,aW1hZ2U=",
             mime: "application/pdf",
             name: "prompt.pdf",
+          },
+          {
+            type: "file",
+            uri: "data:image/png;base64,aW1hZ2U=",
+            mime: "image/png",
+            name: "prompt.png",
           },
         ],
       },

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -21,8 +21,6 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { App } from "@opencode-ai/core/app"
 import { Agent } from "@opencode-ai/core/agent"
 import { Location } from "@opencode-ai/core/location"
-import { Model } from "@opencode-ai/core/model"
-import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Base64, FileAttachment } from "@opencode-ai/schema/prompt"
 import { Money } from "@opencode-ai/schema/money"
@@ -210,34 +208,6 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
       ],
       time: { created: DateTime.makeUnsafe(1) },
     })
-    const assistantMessage = SessionMessage.Assistant.make({
-      id: SessionMessage.ID.create(),
-      type: "assistant",
-      agent: Agent.defaultID,
-      model: { id: Model.ID.make("summary-model"), providerID: Provider.ID.make("test") },
-      content: [
-        SessionMessage.AssistantTool.make({
-          type: "tool",
-          id: "tool_image",
-          name: "read",
-          state: SessionMessage.ToolStateCompleted.make({
-            status: "completed",
-            input: {},
-            content: [
-              { type: "text", text: "x".repeat(2_100) },
-              {
-                type: "file",
-                uri: "data:image/png;base64,dG9vbC1pbWFnZQ==",
-                mime: "image/png",
-                name: "tool.png",
-              },
-            ],
-          }),
-          time: { created: DateTime.makeUnsafe(2), completed: DateTime.makeUnsafe(2) },
-        }),
-      ],
-      time: { created: DateTime.makeUnsafe(2), completed: DateTime.makeUnsafe(2) },
-    })
     yield* db
       .insert(ProjectTable)
       .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
@@ -273,7 +243,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(
       yield* compaction.compactManual({
         session,
-        messages: [userMessage, recentMessage, assistantMessage],
+        messages: [userMessage, recentMessage],
         inputID: SessionMessage.ID.make("msg_manual_compaction"),
       }),
     ).toEqual({ status: "completed" })
@@ -296,19 +266,13 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
         type: "compaction",
         reason: "manual",
         summary: "manual summary",
-        recent: expect.stringMatching(
-          /\[Retained media 1 \(application\/pdf\): prompt\.pdf\].*\[Retained media 2 \(image\/png\): tool\.png\]/s,
-        ),
+        recent: expect.stringContaining("[Attached application/pdf: prompt.pdf]"),
         media: [
           {
+            type: "file",
             uri: "data:application/pdf;base64,aW1hZ2U=",
             mime: "application/pdf",
             name: "prompt.pdf",
-          },
-          {
-            uri: "data:image/png;base64,dG9vbC1pbWFnZQ==",
-            mime: "image/png",
-            name: "tool.png",
           },
         ],
       },

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -102,7 +102,15 @@ describe("toLLMMessages", () => {
           status: "completed",
           reason: "auto",
           summary: "Earlier work",
-          recent: "Recent work",
+          recent: "Recent work\n[Retained image 1 (image/png): retained.png]",
+          images: [
+            {
+              label: "Retained image 1",
+              uri: "data:image/png;base64,aGVsbG8=",
+              mime: "image/png",
+              name: "retained.png",
+            },
+          ],
           time: { created },
         }),
       ],
@@ -142,8 +150,17 @@ Earlier work
 
 <recent-context>
 Recent work
+[Retained image 1 (image/png): retained.png]
 </recent-context>
 </conversation-checkpoint>`,
+        },
+        { type: "text", text: "The retained images referenced by label in <recent-context> follow." },
+        { type: "text", text: "Retained image 1: retained.png" },
+        {
+          type: "media",
+          mediaType: "image/png",
+          data: "data:image/png;base64,aGVsbG8=",
+          filename: "retained.png",
         },
       ],
     ])

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -102,10 +102,9 @@ describe("toLLMMessages", () => {
           status: "completed",
           reason: "auto",
           summary: "Earlier work",
-          recent: "Recent work\n[Retained image 1 (image/png): retained.png]",
-          images: [
+          recent: "Recent work\n[Retained media 1 (image/png): retained.png]",
+          media: [
             {
-              label: "Retained image 1",
               uri: "data:image/png;base64,aGVsbG8=",
               mime: "image/png",
               name: "retained.png",
@@ -150,12 +149,10 @@ Earlier work
 
 <recent-context>
 Recent work
-[Retained image 1 (image/png): retained.png]
+[Retained media 1 (image/png): retained.png]
 </recent-context>
 </conversation-checkpoint>`,
         },
-        { type: "text", text: "The retained images referenced by label in <recent-context> follow." },
-        { type: "text", text: "Retained image 1: retained.png" },
         {
           type: "media",
           mediaType: "image/png",

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -102,9 +102,10 @@ describe("toLLMMessages", () => {
           status: "completed",
           reason: "auto",
           summary: "Earlier work",
-          recent: "Recent work\n[Retained media 1 (image/png): retained.png]",
+          recent: "Recent work\n[Attached image/png: retained.png]",
           media: [
             {
+              type: "file",
               uri: "data:image/png;base64,aGVsbG8=",
               mime: "image/png",
               name: "retained.png",
@@ -149,7 +150,7 @@ Earlier work
 
 <recent-context>
 Recent work
-[Retained media 1 (image/png): retained.png]
+[Attached image/png: retained.png]
 </recent-context>
 </conversation-checkpoint>`,
         },

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -515,6 +515,7 @@ export namespace Compaction {
       reason: Started.data.fields.reason,
       text: Schema.String,
       recent: Schema.String,
+      images: Schema.Array(SessionMessage.CompactionImage).pipe(optional),
     },
   })
   export type Ended = typeof Ended.Type

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -515,7 +515,7 @@ export namespace Compaction {
       reason: Started.data.fields.reason,
       text: Schema.String,
       recent: Schema.String,
-      images: Schema.Array(SessionMessage.CompactionImage).pipe(optional),
+      media: Schema.Array(SessionMessage.CompactionMedia).pipe(optional),
     },
   })
   export type Ended = typeof Ended.Type

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -4,7 +4,7 @@ import { Schema } from "effect"
 import { optional } from "./schema.js"
 import { Event } from "./event.js"
 import { FinishReason } from "./llm.js"
-import { Content } from "./tool.js"
+import { Content, FileContent } from "./tool.js"
 import { Model } from "./model.js"
 import { NonNegativeInt, PositiveInt, RelativePath } from "./schema.js"
 import { FileAttachment } from "./prompt.js"
@@ -515,7 +515,7 @@ export namespace Compaction {
       reason: Started.data.fields.reason,
       text: Schema.String,
       recent: Schema.String,
-      media: Schema.Array(SessionMessage.CompactionMedia).pipe(optional),
+      media: Schema.Array(FileContent).pipe(optional),
     },
   })
   export type Ended = typeof Ended.Type

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -2,7 +2,7 @@ export * as SessionMessage from "./session-message.js"
 
 import { Schema } from "effect"
 import { optional } from "./schema.js"
-import { Content } from "./tool.js"
+import { Content, FileContent } from "./tool.js"
 import { Model } from "./model.js"
 import { Prompt } from "./prompt.js"
 import { DateTimeUtcFromMillis, PositiveInt, RelativePath, statics } from "./schema.js"
@@ -206,13 +206,6 @@ export const Assistant = Schema.Struct({
 
 const CompactionBase = { type: Schema.tag("compaction"), ...Base }
 
-export interface CompactionMedia extends Schema.Schema.Type<typeof CompactionMedia> {}
-export const CompactionMedia = Schema.Struct({
-  uri: Schema.String,
-  mime: Schema.String,
-  name: Schema.String.pipe(optional),
-}).annotate({ identifier: "Session.Message.Compaction.Media" })
-
 export interface CompactionRunning extends Schema.Schema.Type<typeof CompactionRunning> {}
 export const CompactionRunning = Schema.Struct({
   ...CompactionBase,
@@ -229,7 +222,7 @@ export const CompactionCompleted = Schema.Struct({
   reason: Schema.Literals(["auto", "manual"]),
   summary: Schema.String,
   recent: Schema.String,
-  media: Schema.Array(CompactionMedia).pipe(optional),
+  media: Schema.Array(FileContent).pipe(optional),
 }).annotate({ identifier: "Session.Message.Compaction.Completed" })
 
 export interface CompactionFailed extends Schema.Schema.Type<typeof CompactionFailed> {}

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -206,13 +206,12 @@ export const Assistant = Schema.Struct({
 
 const CompactionBase = { type: Schema.tag("compaction"), ...Base }
 
-export interface CompactionImage extends Schema.Schema.Type<typeof CompactionImage> {}
-export const CompactionImage = Schema.Struct({
-  label: Schema.String,
+export interface CompactionMedia extends Schema.Schema.Type<typeof CompactionMedia> {}
+export const CompactionMedia = Schema.Struct({
   uri: Schema.String,
   mime: Schema.String,
   name: Schema.String.pipe(optional),
-}).annotate({ identifier: "Session.Message.Compaction.Image" })
+}).annotate({ identifier: "Session.Message.Compaction.Media" })
 
 export interface CompactionRunning extends Schema.Schema.Type<typeof CompactionRunning> {}
 export const CompactionRunning = Schema.Struct({
@@ -230,7 +229,7 @@ export const CompactionCompleted = Schema.Struct({
   reason: Schema.Literals(["auto", "manual"]),
   summary: Schema.String,
   recent: Schema.String,
-  images: Schema.Array(CompactionImage).pipe(optional),
+  media: Schema.Array(CompactionMedia).pipe(optional),
 }).annotate({ identifier: "Session.Message.Compaction.Completed" })
 
 export interface CompactionFailed extends Schema.Schema.Type<typeof CompactionFailed> {}

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -206,6 +206,14 @@ export const Assistant = Schema.Struct({
 
 const CompactionBase = { type: Schema.tag("compaction"), ...Base }
 
+export interface CompactionImage extends Schema.Schema.Type<typeof CompactionImage> {}
+export const CompactionImage = Schema.Struct({
+  label: Schema.String,
+  uri: Schema.String,
+  mime: Schema.String,
+  name: Schema.String.pipe(optional),
+}).annotate({ identifier: "Session.Message.Compaction.Image" })
+
 export interface CompactionRunning extends Schema.Schema.Type<typeof CompactionRunning> {}
 export const CompactionRunning = Schema.Struct({
   ...CompactionBase,
@@ -222,6 +230,7 @@ export const CompactionCompleted = Schema.Struct({
   reason: Schema.Literals(["auto", "manual"]),
   summary: Schema.String,
   recent: Schema.String,
+  images: Schema.Array(CompactionImage).pipe(optional),
 }).annotate({ identifier: "Session.Message.Compaction.Completed" })
 
 export interface CompactionFailed extends Schema.Schema.Type<typeof CompactionFailed> {}

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -110,8 +110,8 @@ and relevant files.
 
 The newest serialized context up to `keep.tokens` is retained separately. This
 is not a byte-for-byte transcript: tool output is limited to 2000 characters,
-and non-image attachments become textual descriptors. Images in the retained
-context are labeled in the serialized history and attached to the checkpoint
+and non-media attachments become textual descriptors. Media in the retained
+context is labeled in the serialized history and attached to the checkpoint
 under matching labels. On later compactions, V2 updates the previous summary
 and carries forward its retained recent context before selecting a new tail.
 

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -111,7 +111,9 @@ and relevant files.
 The newest serialized context up to `keep.tokens` is retained separately. This
 is not a byte-for-byte transcript: tool output is limited to 2000 characters,
 and non-media attachments become textual descriptors. Media in the retained
-context is attached to the checkpoint in the same order as its descriptors. On
+context is attached to the checkpoint in the same order as its descriptors.
+Tail selection budgets 2000 additional tokens per image as a provider-neutral
+planning estimate; it does not count base64 request bytes as text tokens. On
 later compactions, V2 updates the previous summary and carries forward its
 retained recent context before selecting a new tail.
 

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -111,9 +111,9 @@ and relevant files.
 The newest serialized context up to `keep.tokens` is retained separately. This
 is not a byte-for-byte transcript: tool output is limited to 2000 characters,
 and non-media attachments become textual descriptors. Media in the retained
-context is labeled in the serialized history and attached to the checkpoint
-under matching labels. On later compactions, V2 updates the previous summary
-and carries forward its retained recent context before selecting a new tail.
+context is attached to the checkpoint in the same order as its descriptors. On
+later compactions, V2 updates the previous summary and carries forward its
+retained recent context before selecting a new tail.
 
 The completed compaction is presented to the model as historical conversation
 context, explicitly not as new instructions. Running and failed compactions are

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -83,7 +83,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
     "auto": true,
     "prune": false,
     "keep": {
-      "tokens": 8000
+      "tokens": 15000
     },
     "buffer": 20000
   }
@@ -94,7 +94,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
 | --- | ---: | --- |
 | `auto` | `true` | Runs the preflight context-size check. It does not disable manual compaction or one-shot provider-overflow recovery. |
 | `prune` | None | Accepted by the V2 schema, but currently has no runtime effect. V2 does not prune old tool outputs in place. |
-| `keep.tokens` | `8000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
+| `keep.tokens` | `15000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
 | `buffer` | `20000` | Safety reserve below an explicit input limit. Without one, it is the minimum context reserve and the model output allowance wins when larger. |
 
 `keep.tokens` and `buffer` accept non-negative integers. Larger `keep.tokens`
@@ -110,9 +110,10 @@ and relevant files.
 
 The newest serialized context up to `keep.tokens` is retained separately. This
 is not a byte-for-byte transcript: tool output is limited to 2000 characters,
-and file or media attachments become textual descriptors rather than embedded
-data. On later compactions, V2 updates the previous summary and carries forward
-its retained recent context before selecting a new tail.
+and non-image attachments become textual descriptors. Images in the retained
+context are labeled in the serialized history and attached to the checkpoint
+under matching labels. On later compactions, V2 updates the previous summary
+and carries forward its retained recent context before selecting a new tail.
 
 The completed compaction is presented to the model as historical conversation
 context, explicitly not as new instructions. Running and failed compactions are

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -112,10 +112,10 @@ The newest serialized context up to `keep.tokens` is retained separately. This
 is not a byte-for-byte transcript: tool output is limited to 2000 characters,
 and non-media attachments become textual descriptors. Media in the retained
 context is attached to the checkpoint in the same order as its descriptors.
-Tail selection budgets 2000 additional tokens per image as a provider-neutral
-planning estimate; it does not count base64 request bytes as text tokens. On
-later compactions, V2 updates the previous summary and carries forward its
-retained recent context before selecting a new tail.
+Tail selection budgets 1500 additional tokens per image or PDF as a
+provider-neutral planning estimate; it does not count base64 request bytes as
+text tokens. On later compactions, V2 updates the previous summary and carries
+forward its retained recent context before selecting a new tail.
 
 The completed compaction is presented to the model as historical conversation
 context, explicitly not as new instructions. Running and failed compactions are

--- a/packages/www/content/docs/config.mdx
+++ b/packages/www/content/docs/config.mdx
@@ -329,7 +329,7 @@ Control automatic context compaction and how much recent context it preserves.
   "compaction": {
     "auto": true,
     "keep": {
-      "tokens": 8000
+      "tokens": 15000
     },
     "buffer": 20000
   }


### PR DESCRIPTION
## Summary
- raise the default retained compaction context from 8K to 15K tokens
- preserve image, audio, video, and PDF media selected into the retained tail
- append retained media directly to the checkpoint user message in descriptor order
- reuse the existing file-content contract and update generated clients, tests, and documentation

## Testing
- `bun typecheck` in `packages/schema`, `packages/client`, `packages/core`, `packages/protocol`, `packages/server`, and `packages/sdk-next`
- `bun test test/session-compaction.test.ts test/session-runner-message.test.ts test/session-projector.test.ts` in `packages/core`
- `bun typecheck`, `bun validate`, and `bun run build` in `packages/www`