### PR TITLE
fix(app): keep home sessions without opened projects

### DIFF
--- a/packages/app/src/pages/home/home-session-records.ts
+++ b/packages/app/src/pages/home/home-session-records.ts
@@ -1,0 +1,37 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import type { LocalProject } from "@/context/layout"
+import { displayName, projectForSession } from "@/pages/layout/helpers"
+import { pathKey } from "@/utils/path-key"
+
+export type HomeSessionRecord = {
+  session: Session
+  project: LocalProject
+  projectName: string
+}
+
+export function buildHomeSessionRecords(input: {
+  sessions: () => Session[]
+  projectDirectories: () => string[]
+  projects: () => LocalProject[]
+  projectByID: () => Map<string, LocalProject>
+}) {
+  const projectDirectories = input.projectDirectories()
+  const directories = new Set(projectDirectories.map(pathKey))
+  const sessions = projectDirectories.length
+    ? input.sessions().filter((session) => directories.has(pathKey(session.directory)))
+    : input.sessions()
+  return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
+    .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
+    .flatMap((session) => {
+      const directory = pathKey(session.directory)
+      const project =
+        input
+          .projects()
+          .find(
+            (item) =>
+              pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
+          ) ??
+        projectForSession(session, input.projects(), input.projectByID()) ?? { worktree: session.directory, expanded: false }
+      return { session, project, projectName: displayName(project) }
+    })
+}

--- a/packages/app/src/pages/home/home-sessions-controller.test.ts
+++ b/packages/app/src/pages/home/home-sessions-controller.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { buildHomeSessionRecords } from "./home-session-records"
+
+const session = (id: string, directory: string, projectID = "project") =>
+  ({
+    id,
+    projectID,
+    directory,
+    title: id,
+    time: { created: 1, updated: 2 },
+  }) as Session
+
+describe("buildHomeSessionRecords", () => {
+  test("keeps sessions when no projects have been opened locally", () => {
+    const records = buildHomeSessionRecords({
+      sessions: () => [session("ses_1", "/workspace/demo")],
+      projectDirectories: () => [],
+      projects: () => [],
+      projectByID: () => new Map(),
+    })
+
+    expect(records).toHaveLength(1)
+    expect(records[0]?.session.id).toBe("ses_1")
+    expect(records[0]?.project.worktree).toBe("/workspace/demo")
+    expect(records[0]?.projectName).toBe("demo")
+  })
+
+  test("filters sessions when project directories are selected", () => {
+    const records = buildHomeSessionRecords({
+      sessions: () => [session("ses_1", "/workspace/one"), session("ses_2", "/workspace/two")],
+      projectDirectories: () => ["/workspace/two"],
+      projects: () => [{ id: "two", worktree: "/workspace/two", expanded: true }],
+      projectByID: () => new Map([["two", { id: "two", worktree: "/workspace/two", expanded: true }]]),
+    })
+
+    expect(records.map((record) => record.session.id)).toEqual(["ses_2"])
+  })
+})

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -15,21 +15,16 @@ import type { LocalProject } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { sessionHasOpenTab, useTabs } from "@/context/tabs"
-import { displayName, errorMessage, projectForSession } from "@/pages/layout/helpers"
+import { errorMessage, projectForSession } from "@/pages/layout/helpers"
 import { useSessionTabAvatarState } from "@/pages/layout/project-avatar-state"
 import { pathKey } from "@/utils/path-key"
 import { showToast } from "@/utils/toast"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { archiveHomeSession } from "../home-session-archive"
 import type { HomeController } from "./home-controller"
+import { buildHomeSessionRecords, type HomeSessionRecord } from "./home-session-records"
 
 const HOME_SESSION_LIMIT = 64
-export type HomeSessionRecord = {
-  session: Session
-  project: LocalProject
-  projectName: string
-}
-
 export type HomeSessionGroup = {
   id: "today" | "yesterday" | "older"
   title: string
@@ -243,30 +238,6 @@ export function createHomeSessionsController(home: HomeController) {
 
 function directories(project: LocalProject) {
   return [project.worktree, ...(project.sandboxes ?? [])]
-}
-
-function buildHomeSessionRecords(input: {
-  sessions: () => Session[]
-  projectDirectories: () => string[]
-  projects: () => LocalProject[]
-  projectByID: () => Map<string, LocalProject>
-}) {
-  const directories = new Set(input.projectDirectories().map(pathKey))
-  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
-  return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
-    .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
-    .flatMap((session) => {
-      const directory = pathKey(session.directory)
-      const project =
-        input
-          .projects()
-          .find(
-            (item) =>
-              pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
-          ) ?? projectForSession(session, input.projects(), input.projectByID())
-      if (!project) return []
-      return { session, project, projectName: displayName(project) }
-    })
 }
 
 export function homeSessionSearchKey(record: HomeSessionRecord) {


### PR DESCRIPTION
## Summary
- Extract the home session record builder into a pure helper for regression coverage
- Keep unfiltered home sessions when no projects have been opened locally, instead of dropping the entire list
- Use the session directory as fallback project metadata when no local project record matches

Refs #27837

## Test Plan
- `bun test --conditions=solid --preload ./happydom.ts ./src/pages/home/home-sessions-controller.test.ts --test-name-pattern "keeps sessions when no projects have been opened locally"`
- `bun test --conditions=solid --preload ./happydom.ts ./src/pages/home/home-sessions-controller.test.ts`
- `bun run lint packages/app/src/pages/home/home-session-records.ts packages/app/src/pages/home/home-sessions-controller.tsx packages/app/src/pages/home/home-sessions-controller.test.ts`
- `git diff --check`

Note: `packages/app` typecheck currently fails on the existing `src/custom-elements.d.ts` placeholder (`../../ui/src/custom-elements.d.ts`), with no diff to that file in this branch.