### PR TITLE
fix(core): continue interrupted responses

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -36,7 +36,8 @@ import { SessionUsage } from "../usage"
 /** How one model call ended: settled, awaiting a scheduled retry, or restarted by compaction. */
 type CallOutcome = Data.TaggedEnum<{
   Completed: { readonly needsContinuation: boolean; readonly step: number }
-  Retry: { readonly step: number; readonly mode: SessionRunnerRetry.RetryableFailure["mode"] }
+  Retry: { readonly step: number }
+  Continue: { readonly cause: AIError; readonly error: SessionRunnerRetry.RetryableFailure["error"]; readonly step: number }
   Restart: { readonly step: number; readonly recoveredOverflow: boolean }
 }>
 const CallOutcome = Data.taggedEnum<CallOutcome>()
@@ -165,17 +166,15 @@ const layer = Layer.effect(
        */
       const waitForRetry = (failure: SessionRunnerRetry.RetryableFailure) =>
         retry(failure).pipe(
-          Effect.as(CallOutcome.Retry({ step: failure.step, mode: failure.mode })),
+          Effect.as(CallOutcome.Retry({ step: failure.step })),
           Pull.catchDone(() =>
-            failure.mode === "continue"
-              ? Effect.fail(failure.cause)
-              : bus
-                  .publish(SessionEvent.Step.Failed, {
-                    sessionID,
-                    assistantMessageID,
-                    error: failure.error,
-                  })
-                  .pipe(Effect.andThen(Effect.fail(failure.cause))),
+            bus
+              .publish(SessionEvent.Step.Failed, {
+                sessionID,
+                assistantMessageID,
+                error: failure.error,
+              })
+              .pipe(Effect.andThen(Effect.fail(failure.cause))),
           ),
         )
       let currentPromotable: SessionPending.Promotable | undefined = promotable
@@ -191,7 +190,14 @@ const layer = Layer.effect(
           assistantMessageID,
         ).pipe(Effect.catchTag("SessionRunner.RetryableFailure", waitForRetry))
         if (outcome._tag === "Completed") return { needsContinuation: outcome.needsContinuation, step: outcome.step }
-        if (outcome._tag === "Retry" && outcome.mode === "continue") {
+        if (outcome._tag === "Continue") {
+          yield* retry(
+            new SessionRunnerRetry.RetryableFailure({
+              cause: outcome.cause,
+              error: outcome.error,
+              step: outcome.step,
+            }),
+          ).pipe(Pull.catchDone(() => Effect.fail(outcome.cause)))
           yield* bus.publish(SessionEvent.Synthetic, {
             sessionID,
             text: CONTINUE_AFTER_INCOMPLETE_STREAM,
@@ -393,7 +399,6 @@ const layer = Layer.effect(
               cause: llmFailure,
               error: llmError,
               step: currentStep,
-              mode: "retry",
             })
           }
           if (llmError) yield* publisher.failAssistant(llmError)
@@ -441,17 +446,17 @@ const layer = Layer.effect(
           if (
             llmFailure &&
             llmError &&
-            SessionRunnerRetry.isIncompleteStream(llmFailure) &&
+            llmFailure.reason._tag === "InvalidProviderOutput" &&
+            llmFailure.reason.classification === "incomplete-stream" &&
             record.outputStarted &&
             tools.declines.length === 0 &&
             !tools.interrupted &&
             tools.failure === undefined
           )
-            return yield* new SessionRunnerRetry.RetryableFailure({
+            return CallOutcome.Continue({
               cause: llmFailure,
               error: llmError,
               step: currentStep,
-              mode: "continue",
             })
 
           if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -443,16 +443,11 @@ const layer = Layer.effect(
             })
           }
 
-          if (
-            llmFailure &&
-            llmError &&
-            llmFailure.reason._tag === "InvalidProviderOutput" &&
-            llmFailure.reason.classification === "incomplete-stream" &&
-            record.outputStarted &&
-            tools.declines.length === 0 &&
-            !tools.interrupted &&
-            tools.failure === undefined
-          )
+          const incompleteStream =
+            llmFailure?.reason._tag === "InvalidProviderOutput" &&
+            llmFailure.reason.classification === "incomplete-stream"
+          const toolsAllowContinuation = tools.declines.length === 0 && !tools.interrupted
+          if (llmError && incompleteStream && record.outputStarted && toolsAllowContinuation)
             return CallOutcome.Continue({
               cause: llmFailure,
               error: llmError,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -36,7 +36,7 @@ import { SessionUsage } from "../usage"
 /** How one model call ended: settled, awaiting a scheduled retry, or restarted by compaction. */
 type CallOutcome = Data.TaggedEnum<{
   Completed: { readonly needsContinuation: boolean; readonly step: number }
-  Retry: { readonly step: number }
+  Retry: { readonly step: number; readonly mode: SessionRunnerRetry.RetryableFailure["mode"] }
   Restart: { readonly step: number; readonly recoveredOverflow: boolean }
 }>
 const CallOutcome = Data.taggedEnum<CallOutcome>()
@@ -91,6 +91,8 @@ const classifyToolExits = (
 const TOOLS_INTERRUPTED = { type: "aborted", message: "Tool execution interrupted" } as const
 const STEP_INTERRUPTED = { type: "aborted", message: "Step interrupted" } as const
 const RESULT_MISSING = { type: "tool.result-missing", message: "Provider did not return a tool result" } as const
+const CONTINUE_AFTER_INCOMPLETE_STREAM =
+  "The previous response was interrupted. Continue from where you left off without repeating completed content."
 
 const layer = Layer.effect(
   Service,
@@ -163,15 +165,17 @@ const layer = Layer.effect(
        */
       const waitForRetry = (failure: SessionRunnerRetry.RetryableFailure) =>
         retry(failure).pipe(
-          Effect.as(CallOutcome.Retry({ step: failure.step })),
+          Effect.as(CallOutcome.Retry({ step: failure.step, mode: failure.mode })),
           Pull.catchDone(() =>
-            bus
-              .publish(SessionEvent.Step.Failed, {
-                sessionID,
-                assistantMessageID,
-                error: failure.error,
-              })
-              .pipe(Effect.andThen(Effect.fail(failure.cause))),
+            failure.mode === "continue"
+              ? Effect.fail(failure.cause)
+              : bus
+                  .publish(SessionEvent.Step.Failed, {
+                    sessionID,
+                    assistantMessageID,
+                    error: failure.error,
+                  })
+                  .pipe(Effect.andThen(Effect.fail(failure.cause))),
           ),
         )
       let currentPromotable: SessionPending.Promotable | undefined = promotable
@@ -187,6 +191,13 @@ const layer = Layer.effect(
           assistantMessageID,
         ).pipe(Effect.catchTag("SessionRunner.RetryableFailure", waitForRetry))
         if (outcome._tag === "Completed") return { needsContinuation: outcome.needsContinuation, step: outcome.step }
+        if (outcome._tag === "Retry" && outcome.mode === "continue") {
+          yield* bus.publish(SessionEvent.Synthetic, {
+            sessionID,
+            text: CONTINUE_AFTER_INCOMPLETE_STREAM,
+          })
+          assistantMessageID = SessionMessage.ID.create()
+        }
         if (outcome._tag === "Restart") {
           if (outcome.recoveredOverflow) recoverOverflow = false
           assistantMessageID = SessionMessage.ID.create()
@@ -382,6 +393,7 @@ const layer = Layer.effect(
               cause: llmFailure,
               error: llmError,
               step: currentStep,
+              mode: "retry",
             })
           }
           if (llmError) yield* publisher.failAssistant(llmError)
@@ -425,6 +437,22 @@ const layer = Layer.effect(
               ...end,
             })
           }
+
+          if (
+            llmFailure &&
+            llmError &&
+            SessionRunnerRetry.isIncompleteStream(llmFailure) &&
+            record.outputStarted &&
+            tools.declines.length === 0 &&
+            !tools.interrupted &&
+            tools.failure === undefined
+          )
+            return yield* new SessionRunnerRetry.RetryableFailure({
+              cause: llmFailure,
+              error: llmError,
+              step: currentStep,
+              mode: "continue",
+            })
 
           if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)
           if (tools.declines.length > 0) return yield* Effect.interrupt

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -12,11 +12,7 @@ export class RetryableFailure extends Data.TaggedError("SessionRunner.RetryableF
   readonly cause: AIError
   readonly error: SessionError.Error
   readonly step: number
-  readonly mode: "retry" | "continue"
 }> {}
-
-export const isIncompleteStream = (error: AIError) =>
-  error.reason._tag === "InvalidProviderOutput" && error.reason.classification === "incomplete-stream"
 
 export function isRetryable(error: AIError) {
   switch (error.reason._tag) {
@@ -25,7 +21,7 @@ export function isRetryable(error: AIError) {
     case "Transport":
       return true
     case "InvalidProviderOutput":
-      return isIncompleteStream(error)
+      return error.reason.classification === "incomplete-stream"
     case "Authentication":
     case "QuotaExceeded":
     case "ContentPolicy":

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -12,7 +12,11 @@ export class RetryableFailure extends Data.TaggedError("SessionRunner.RetryableF
   readonly cause: AIError
   readonly error: SessionError.Error
   readonly step: number
+  readonly mode: "retry" | "continue"
 }> {}
+
+export const isIncompleteStream = (error: AIError) =>
+  error.reason._tag === "InvalidProviderOutput" && error.reason.classification === "incomplete-stream"
 
 export function isRetryable(error: AIError) {
   switch (error.reason._tag) {
@@ -21,7 +25,7 @@ export function isRetryable(error: AIError) {
     case "Transport":
       return true
     case "InvalidProviderOutput":
-      return error.reason.classification === "incomplete-stream"
+      return isIncompleteStream(error)
     case "Authentication":
     case "QuotaExceeded":
     case "ContentPolicy":

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -523,6 +523,9 @@ const incompleteStream = () =>
     }),
   })
 
+const INCOMPLETE_STREAM_CONTINUATION =
+  "The previous response was interrupted. Continue from where you left off without repeating completed content."
+
 const invalidRequest = () =>
   new AIError({
     module: "test",
@@ -3996,10 +3999,11 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("does not retry eligible failures after observable output", () =>
+  it.effect("continues an incomplete stream after observable text", () =>
     Effect.gen(function* () {
       const session = yield* setup
       const failure = incompleteStream()
+      yield* admit(session, "Continue partial output")
       yield* TestLLM.push(
         TestLLM.failAfter(
           failure,
@@ -4008,19 +4012,156 @@ describe("SessionRunnerLLM", () => {
           LLMEvent.textDelta({ id: "partial-rate-limit", text: "Partial" }),
         ),
       )
+      yield* TestLLM.push(TestLLM.text(" continuation", "continued-text"))
 
-      expect(yield* runPrompt(session, "Do not replay partial output").pipe(Effect.flip)).toBe(failure)
-      expect(requests).toHaveLength(1)
-      expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
-      expect(yield* session.context(sessionID)).toMatchObject([
-        { type: "user" },
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      yield* TestClock.adjust("2 seconds")
+      yield* Fiber.join(run)
+
+      expect(requests).toHaveLength(2)
+      expect(requests[1]?.messages.at(-2)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "Partial" }],
+      })
+      expect(requests[1]?.messages.at(-1)).toMatchObject({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: INCOMPLETE_STREAM_CONTINUATION,
+          },
+        ],
+      })
+      const context = yield* session.context(sessionID)
+      expect(context).toMatchObject([
+        { type: "user", text: "Continue partial output" },
         {
           type: "assistant",
           finish: "error",
           error: { type: "provider.invalid-output" },
           content: [{ type: "text", text: "Partial" }],
         },
+        {
+          type: "synthetic",
+          text: INCOMPLETE_STREAM_CONTINUATION,
+        },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: " continuation" }] },
       ])
+      const assistants = context.filter((message) => message.type === "assistant")
+      expect(new Set(assistants.map((message) => message.id)).size).toBe(2)
+      expect(context.find((message) => message.type === "synthetic")?.description).toBeUndefined()
+      expect(yield* recordedEventTypes(sessionID)).toContain("session.retry.scheduled.1")
+      yield* replaySessionProjection(sessionID)
+      expect(yield* session.context(sessionID)).toMatchObject(context)
+    }),
+  )
+
+  it.effect("lowers interrupted reasoning before continuing an incomplete stream", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Continue interrupted reasoning")
+      yield* TestLLM.push(
+        TestLLM.failAfter(
+          incompleteStream(),
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.reasoningStart({ id: "partial-reasoning" }),
+          LLMEvent.reasoningDelta({ id: "partial-reasoning", text: "Partial thought" }),
+        ),
+      )
+      yield* TestLLM.push(TestLLM.text("Recovered", "reasoning-recovery"))
+
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      yield* TestClock.adjust("2 seconds")
+      yield* Fiber.join(run)
+
+      expect(requests[1]?.messages.at(-2)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "Partial thought" }],
+      })
+      expect(requests[1]?.messages.at(-1)).toMatchObject({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: INCOMPLETE_STREAM_CONTINUATION,
+          },
+        ],
+      })
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user" },
+        { type: "assistant", finish: "error", content: [{ type: "reasoning", text: "Partial thought" }] },
+        { type: "synthetic" },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Recovered" }] },
+      ])
+    }),
+  )
+
+  it.effect("continues an incomplete stream after settling a local tool", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Continue after tool")
+      yield* TestLLM.push(
+        TestLLM.failAfter(
+          incompleteStream(),
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({ id: "call-before-close", name: "echo", input: { text: "settled" } }),
+        ),
+      )
+      yield* TestLLM.push(TestLLM.text("Recovered", "tool-recovery"))
+
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      while (!(yield* recordedEventTypes(sessionID)).includes("session.retry.scheduled.1")) yield* Effect.yieldNow
+      yield* TestClock.adjust("2 seconds")
+      yield* Fiber.join(run)
+
+      expect(executions).toEqual(["settled"])
+      expect(requests[1]?.messages.slice(-3)).toMatchObject([
+        {
+          role: "assistant",
+          content: [{ type: "tool-call", id: "call-before-close", name: "echo", input: { text: "settled" } }],
+        },
+        { role: "tool", content: [{ type: "tool-result", id: "call-before-close" }] },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: INCOMPLETE_STREAM_CONTINUATION,
+            },
+          ],
+        },
+      ])
+    }),
+  )
+
+  it.effect("stops incomplete stream continuations after five total attempts", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Exhaust partial continuations")
+      const failure = incompleteStream()
+      yield* TestLLM.always(
+        TestLLM.failAfter(
+          failure,
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "partial-exhaustion" }),
+          LLMEvent.textDelta({ id: "partial-exhaustion", text: "Partial" }),
+        ),
+      )
+
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      for (const [index, delay] of [2_000, 4_000, 8_000, 16_000].entries()) {
+        yield* TestClock.adjust(delay)
+        yield* TestLLM.wait(index + 2)
+      }
+      expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(failure)
+      expect(requests).toHaveLength(5)
+      const context = yield* session.context(sessionID)
+      expect(context.filter((message) => message.type === "assistant")).toHaveLength(5)
+      expect(context.filter((message) => message.type === "synthetic")).toHaveLength(4)
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -4137,6 +4137,44 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("continues an incomplete stream after settling a local tool defect", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Continue after tool defect")
+      yield* TestLLM.push(
+        TestLLM.failAfter(
+          incompleteStream(),
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({ id: "call-defect-before-close", name: "defect", input: {} }),
+        ),
+      )
+      yield* TestLLM.push(TestLLM.text("Recovered", "tool-defect-recovery"))
+
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      while (!(yield* recordedEventTypes(sessionID)).includes("session.retry.scheduled.1")) yield* Effect.yieldNow
+      yield* TestClock.adjust("2 seconds")
+      yield* Fiber.join(run)
+
+      expect(messageRoles(requests[1])).toEqual(["user", "assistant", "tool", "user"])
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user" },
+        {
+          type: "assistant",
+          content: [
+            {
+              type: "tool",
+              id: "call-defect-before-close",
+              state: { status: "error", error: { type: "unknown", message: "unexpected tool defect" } },
+            },
+          ],
+        },
+        { type: "synthetic", text: INCOMPLETE_STREAM_CONTINUATION },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Recovered" }] },
+      ])
+    }),
+  )
+
   it.effect("stops incomplete stream continuations after five total attempts", () =>
     Effect.gen(function* () {
       const session = yield* setup


### PR DESCRIPTION
## Summary

- preserve output-bearing attempts when a provider response ends unexpectedly
- settle the failed assistant and its tools before scheduling continuation
- append a durable, UI-hidden synthetic user message asking the model to continue without repeating completed content
- write continuation output to a new assistant message while sharing the existing five-attempt retry budget
- retain transparent same-message retries for incomplete streams that produced no output

## Testing

- `bun typecheck` in `packages/core`
- `bun test test/session-runner.test.ts` in `packages/core` (142 pass)
- focused continuation matrix covering text, reasoning, settled tools, projection replay, and retry exhaustion