### PR TITLE
fix(opencode): report the model in run --format json events

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -696,20 +696,36 @@ export const RunCommand = effectCmd({
         // created, and replies issued from inside the loop must use that client.
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
+          // Assistant messages carry the model, the parts they produce do not, so
+          // remember it per message to attribute each emitted part to a model.
+          const models = new Map<string, { providerID: string; modelID: string; agent: string }>()
           let error: string | undefined
+
+          // Same as emit(), plus the model that produced the part. Sessions can
+          // switch models mid-run, so this is resolved per message, not per run.
+          function emitPart(type: string, part: { messageID: string }) {
+            return emit(type, { part, ...models.get(part.messageID) })
+          }
 
           for await (const event of events.stream) {
             if (
               event.type === "message.updated" &&
               event.properties.sessionID === sessionID &&
-              event.properties.info.role === "assistant" &&
-              args.format !== "json" &&
-              toggles.get("start") !== true
+              event.properties.info.role === "assistant"
             ) {
-              UI.empty()
-              UI.println(`> ${event.properties.info.agent} · ${event.properties.info.modelID}`)
-              UI.empty()
-              toggles.set("start", true)
+              const info = event.properties.info
+              models.set(info.id, {
+                providerID: info.providerID,
+                modelID: info.modelID,
+                agent: info.agent,
+              })
+
+              if (args.format !== "json" && toggles.get("start") !== true) {
+                UI.empty()
+                UI.println(`> ${info.agent} · ${info.modelID}`)
+                UI.empty()
+                toggles.set("start", true)
+              }
             }
 
             if (event.type === "message.part.updated") {
@@ -717,7 +733,7 @@ export const RunCommand = effectCmd({
               if (part.sessionID !== sessionID) continue
 
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
-                if (emit("tool_use", { part })) continue
+                if (emitPart("tool_use", part)) continue
                 if (part.state.status === "completed") {
                   await tool(part)
                   continue
@@ -738,15 +754,15 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "step-start") {
-                if (emit("step_start", { part })) continue
+                if (emitPart("step_start", part)) continue
               }
 
               if (part.type === "step-finish") {
-                if (emit("step_finish", { part })) continue
+                if (emitPart("step_finish", part)) continue
               }
 
               if (part.type === "text" && part.time?.end) {
-                if (emit("text", { part })) continue
+                if (emitPart("text", part)) continue
                 const text = part.text.trim()
                 if (!text) continue
                 if (!process.stdout.isTTY) {
@@ -759,7 +775,7 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "reasoning" && part.time?.end && thinking) {
-                if (emit("reasoning", { part })) continue
+                if (emitPart("reasoning", part)) continue
                 const text = part.text.trim()
                 if (!text) continue
                 const line = `Thinking: ${text}`

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -121,13 +121,17 @@ describe("opencode run (non-interactive subprocess)", () => {
           expect(typeof evt.sessionID).toBe("string")
         }
         expect(events.map((event) => event.type)).toEqual(["step_start", "text", "step_finish"])
+        // Every part-bearing event names the model that produced it, otherwise a
+        // headless consumer cannot attribute tokens or cost (#40544).
+        const model = { providerID: "test", modelID: "test-model", agent: "build" }
         expect(events.map(({ timestamp: _, sessionID: __, ...event }) => event)).toEqual([
-          { type: "step_start", part: expect.objectContaining({ type: "step-start" }) },
+          { type: "step_start", ...model, part: expect.objectContaining({ type: "step-start" }) },
           {
             type: "text",
+            ...model,
             part: expect.objectContaining({ type: "text", text: "structured output" }),
           },
-          { type: "step_finish", part: expect.objectContaining({ type: "step-finish" }) },
+          { type: "step_finish", ...model, part: expect.objectContaining({ type: "step-finish" }) },
         ])
         expect(result.stdout.endsWith("\n")).toBe(true)
         expect(
@@ -138,6 +142,35 @@ describe("opencode run (non-interactive subprocess)", () => {
         ).toBe(true)
       }),
     60_000,
+  )
+
+  // Regression for #40544: the model reported for a part comes from the message
+  // that produced it, so a second run on a different model reports that model.
+  cliIt.concurrent(
+    "--format json reports the model that produced each event",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("first")
+        const first = yield* opencode.run("say first", { format: "json" })
+        opencode.expectExit(first, 0)
+
+        const firstEvents = opencode.parseJsonEvents(first.stdout)
+        expect(firstEvents.length).toBeGreaterThan(0)
+        expect(new Set(firstEvents.map((event) => event.modelID))).toEqual(new Set(["test-model"]))
+
+        yield* llm.text("second")
+        const second = yield* opencode.run("say second", {
+          format: "json",
+          model: "test/test-model-alt",
+        })
+        opencode.expectExit(second, 0)
+
+        const secondEvents = opencode.parseJsonEvents(second.stdout)
+        expect(secondEvents.length).toBeGreaterThan(0)
+        expect(new Set(secondEvents.map((event) => event.modelID))).toEqual(new Set(["test-model-alt"]))
+        expect(new Set(secondEvents.map((event) => event.providerID))).toEqual(new Set(["test"]))
+      }),
+    120_000,
   )
 
   cliIt.concurrent(

--- a/packages/opencode/test/lib/test-provider.ts
+++ b/packages/opencode/test/lib/test-provider.ts
@@ -1,7 +1,7 @@
 // Shared provider config for tests that need opencode to talk to a fake LLM
-// over a real HTTP endpoint. Registers a single provider `test` with a single
-// model `test-model` (i.e. `--model test/test-model`), pointed at the URL the
-// caller supplies (typically a TestLLMServer instance).
+// over a real HTTP endpoint. Registers a single provider `test` with the models
+// `test-model` and `test-model-alt` (i.e. `--model test/test-model`), pointed at
+// the URL the caller supplies (typically a TestLLMServer instance).
 //
 // Used by:
 //   - test/lib/run-process.ts          (subprocess CLI tests)
@@ -20,6 +20,19 @@ export function testProviderConfig(llmUrl: string) {
           "test-model": {
             id: "test-model",
             name: "Test Model",
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: true,
+            release_date: "2025-01-01",
+            limit: { context: 100_000, output: 10_000 },
+            cost: { input: 0, output: 0 },
+            options: {},
+          },
+          // Second model, so a test can switch models inside one session.
+          "test-model-alt": {
+            id: "test-model-alt",
+            name: "Test Model Alt",
             attachment: false,
             reasoning: false,
             temperature: false,


### PR DESCRIPTION
Fixes #40544

### Problem

`opencode run --format json` emits `step_start` / `step_finish` / `text` / `reasoning` / `tool_use` with tokens and cost, but nothing in the stream says which model produced them. A headless consumer can't attribute usage or cost, and turns from different models are indistinguishable. Today the only way to recover it is a second `opencode export` after the run, which is no use to a live consumer.

### Change

The model lives on the assistant message, not on the parts it produces, so the event loop in `run.ts` now records `providerID` / `modelID` / `agent` per assistant message id and stamps them onto every part-bearing event.

- The `message.updated` branch no longer bails out early on `--format json`; it records the model for the message, and the existing non-JSON header print keeps its own condition.
- `emitPart` wraps `emit` and resolves the model by `part.messageID`. Keying on the message rather than on the run's `--model` is what makes a session that switches models mid-run attribute each turn correctly.

Events gain three top-level keys next to the existing `sessionID`:

```json
{"type":"step_finish","timestamp":1234,"sessionID":"ses_…","providerID":"opencode","modelID":"mimo-v2.5-free","agent":"build","part":{…}}
```

Nothing is removed or renamed, so existing consumers keep working.

### Tests

`packages/opencode/test/cli/run/run-process.test.ts`:

- the existing `--format json` shape assertion is exact-match, so it now pins the three new keys;
- a new case runs two prompts on different models and asserts each run's events report the model that produced them.

`test-model-alt` was added to the shared test provider config for the second model.

```
bun test test/cli/run/run-process.test.ts
 14 pass
 0 fail
```

With `src/cli/cmd/run.ts` reverted and the tests kept, the behaviour they describe is gone:

```
 12 pass
 2 fail
```

`tsgo --noEmit` on `packages/opencode` is clean, and `bun run lint` reports the same single pre-existing error as on a clean `dev` checkout (unrelated file).

### Note on the harness

I wanted a test that switches models inside one session, matching the issue's repro. The CLI test harness runs with `OPENCODE_PURE=1`, so a session from one `opencode run` process is not visible to the next: `--session <id>` reports "Session not found" and `--continue` starts a fresh session. The two-run test above is the closest equivalent that the harness supports; the mid-session case is handled by resolving the model per `messageID` rather than per run.
