### PR TITLE
feat(desktop): add inline conversation visualizations

### DIFF
--- a/packages/app/e2e/performance/timeline-stability/fixture.ts
+++ b/packages/app/e2e/performance/timeline-stability/fixture.ts
@@ -67,7 +67,7 @@ type ToolOptions<State extends ToolStatus> = State extends "pending"
     ? { title?: string; metadata?: Record<string, unknown>; output?: never; error?: never }
     : State extends "error"
       ? { error?: string; metadata?: Record<string, unknown>; output?: never; title?: never }
-      : { output?: string; title?: string; metadata?: Record<string, unknown>; error?: never }
+      : { output?: string; title?: string; metadata?: Record<string, unknown>; structured?: unknown; error?: never }
 
 const decodeOptions = { errors: "all", onExcessProperty: "error" } as const
 const decodeMessage = Schema.decodeUnknownSync(SessionV1.WithParts)
@@ -98,6 +98,7 @@ export async function setupTimeline(
     deviceScaleFactor?: number
     seedHistory?: boolean
     protocol?: "v1" | "v2"
+    onPrompt?: (input: { sessionID: string; body: unknown }) => void
   } = {},
 ) {
   const sessions = input.sessions ?? [session()]
@@ -121,6 +122,7 @@ export async function setupTimeline(
     provider: provider(),
     sessions,
     sessionStatus: { [sessionID]: initialStatus },
+    onPrompt: input.onPrompt,
     pageMessages: () => ({
       items: messages,
     }),
@@ -486,7 +488,7 @@ export function toolPart(
         time: { start: 1700000001000, end: 1700000002000 },
       },
     }
-  return {
+  const completed = {
     ...base,
     state: {
       status: state,
@@ -497,6 +499,8 @@ export function toolPart(
       time: { start: 1700000001000, end: 1700000002000 },
     },
   }
+  if (!Object.hasOwn(options, "structured")) return completed
+  return { ...completed, metadata: { __testStructured: options.structured } }
 }
 
 export function shell(

--- a/packages/app/e2e/regression/session-inline-visualization.spec.ts
+++ b/packages/app/e2e/regression/session-inline-visualization.spec.ts
@@ -1,0 +1,421 @@
+import { expect, test, type Page } from "@playwright/test"
+import {
+  assistantMessage,
+  sessionID,
+  setupTimeline,
+  textPart,
+  toolPart,
+  userMessage,
+} from "../performance/timeline-stability/fixture"
+
+const visualizationTool = "visualization_create"
+const visualizationTitle = "Choose a layout"
+const followUpPrompt = "/not-a-command use compact layout"
+
+test("fails closed on the web without rendering or executing visualization HTML", async ({ page }) => {
+  const partID = "prt_visualization_web_disabled"
+  const security = await observeVisualizationSecurity(page)
+  await setupTimeline(page, {
+    protocol: "v2",
+    messages: [
+      userMessage(),
+      assistantMessage([
+        toolPart(
+          partID,
+          visualizationTool,
+          "completed",
+          {},
+          {
+            structured: visualization({
+              html: `<span>web visualization sentinel</span><script>fetch("https://visualization-e2e.invalid/probe")</script>`,
+            }),
+          },
+        ),
+      ]),
+    ],
+  })
+
+  const tool = page.locator(`[data-timeline-part-id="${partID}"]`)
+  await expect(tool.locator('[data-state="invalid"]')).toBeVisible()
+  await expect(tool.locator("iframe")).toHaveCount(0)
+  await expect(page.getByText("web visualization sentinel", { exact: true })).toHaveCount(0)
+  expect(security.externalRequests).toEqual([])
+  expect(security.externalResponses).toEqual([])
+  expect(security.externalNavigations).toEqual([])
+})
+
+test.describe.skip("Desktop visualization integration fixture (requires Electron navigation policy)", () => {
+  test("renders a sandboxed visualization and sends its confirmed follow-up as a normal prompt", async ({ page }) => {
+    const prompts: { sessionID: string; body: unknown }[] = []
+    const partID = "prt_visualization_follow_up"
+    await setupTimeline(page, {
+      protocol: "v2",
+      onPrompt: (input) => prompts.push(input),
+      messages: [
+        userMessage(),
+        assistantMessage([
+          toolPart(
+            partID,
+            visualizationTool,
+            "completed",
+            {},
+            {
+              structured: visualization({
+                html: `<button id="send">Use compact layout</button>
+              <script>
+                document.querySelector("#send").onclick = () =>
+                  window.opencode.visualization.sendFollowUp({ prompt: ${JSON.stringify(followUpPrompt)} })
+              </script>`,
+              }),
+            },
+          ),
+        ]),
+      ],
+    })
+
+    const tool = page.locator(`[data-timeline-part-id="${partID}"]`)
+    const frame = tool.locator('[data-slot="visualization-frame"]')
+    await expect(frame).toHaveAttribute("sandbox", "allow-scripts")
+    await expect(frame).toHaveAttribute("title", visualizationTitle)
+    await expect(frame).toHaveAttribute("loading", "lazy")
+    await expect(frame).toHaveAttribute("srcdoc", /Use compact layout/)
+
+    const content = page.frameLocator(`[data-timeline-part-id="${partID}"] iframe`)
+    await content.getByRole("button", { name: "Use compact layout" }).click()
+    const dialog = page.locator('[data-component="dialog"]')
+    await expect(dialog).toContainText(visualizationTitle)
+    await expect(dialog).toContainText(followUpPrompt)
+    await dialog.getByRole("button", { name: "Cancel" }).click()
+    await expect(dialog).toHaveCount(0)
+    expect(prompts).toEqual([])
+
+    await content.getByRole("button", { name: "Use compact layout" }).click()
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole("button", { name: "Send" }).click()
+    await expect.poll(() => prompts).toHaveLength(1)
+    expect(prompts[0]).toMatchObject({ sessionID, body: expect.objectContaining({ text: followUpPrompt }) })
+    expect(JSON.stringify(prompts[0]?.body)).not.toContain('"command"')
+  })
+
+  test("clamps visualization height while preserving the frame and range state through theme changes", async ({
+    page,
+  }) => {
+    const partID = "prt_visualization_height_theme"
+    await setupTimeline(page, {
+      protocol: "v2",
+      messages: [
+        userMessage(),
+        assistantMessage([
+          toolPart(
+            partID,
+            visualizationTool,
+            "completed",
+            {},
+            {
+              structured: visualization({
+                html: `<label>Density <input id="density" type="range" min="0" max="100" value="37"></label>
+              <button id="grow">Grow</button><div id="content"></div>
+              <script>
+                document.querySelector("#grow").onclick = () => {
+                  document.querySelector("#content").style.height = "6000px"
+                }
+              </script>`,
+              }),
+            },
+          ),
+        ]),
+      ],
+    })
+
+    const tool = page.locator(`[data-timeline-part-id="${partID}"]`)
+    const frame = tool.locator('[data-slot="visualization-frame"]')
+    const content = page.frameLocator(`[data-timeline-part-id="${partID}"] iframe`)
+    await content.locator("#density").evaluate((element) => {
+      const input = element as HTMLInputElement
+      input.value = "73"
+      input.dispatchEvent(new Event("input", { bubbles: true }))
+    })
+    const identity = await frame.evaluate((element) => {
+      const node = element as HTMLIFrameElement & { visualizationE2EIdentity?: string }
+      node.visualizationE2EIdentity ??= crypto.randomUUID()
+      return node.visualizationE2EIdentity
+    })
+
+    await content.getByRole("button", { name: "Grow" }).click()
+    const container = tool.locator('[data-slot="visualization-frame-container"]')
+    await expect(container).toHaveCSS("height", "720px")
+    await tool.getByRole("button", { name: "Expand" }).click()
+    await expect(container).toHaveCSS("height", "4096px")
+
+    await page.locator("html").evaluate((element) => element.setAttribute("data-theme", "visualization-e2e"))
+    await page.waitForTimeout(100)
+    expect(
+      await frame.evaluate(
+        (element) => (element as HTMLIFrameElement & { visualizationE2EIdentity?: string }).visualizationE2EIdentity,
+      ),
+    ).toBe(identity)
+    await expect(content.locator("#density")).toHaveValue("73")
+  })
+
+  test("keeps historical and loading content independent when one visualization result is invalid", async ({
+    page,
+  }) => {
+    const historicalUserID = "msg_visualization_history_user"
+    const historicalFrameID = "prt_visualization_history_valid"
+    const loadingID = "prt_visualization_loading"
+    const validID = "prt_visualization_current_valid"
+    const invalidID = "prt_visualization_current_invalid"
+    const historicalUser = userMessage(undefined, { id: historicalUserID, created: 1_700_000_000_000 })
+    const historicalAssistant = assistantMessage(
+      [
+        toolPart(
+          historicalFrameID,
+          visualizationTool,
+          "completed",
+          {},
+          {
+            structured: visualization({
+              title: "Historical visualization",
+              html: `<span>Historical visualization</span>`,
+            }),
+          },
+        ),
+      ],
+      { id: "msg_visualization_history_assistant", parentID: historicalUserID, created: 1_700_000_001_000 },
+    )
+    const currentUser = userMessage(undefined, { id: "msg_visualization_current_user", created: 1_700_000_002_000 })
+    const currentAssistant = assistantMessage(
+      [
+        textPart("prt_visualization_plain_text", "Ordinary timeline content remains visible."),
+        toolPart(
+          invalidID,
+          visualizationTool,
+          "completed",
+          {},
+          {
+            structured: { version: 2, title: visualizationTitle, html: "<div>Unsupported version</div>" },
+          },
+        ),
+        toolPart(
+          validID,
+          visualizationTool,
+          "completed",
+          {},
+          {
+            structured: visualization({ title: "Current visualization", html: `<span>Current visualization</span>` }),
+          },
+        ),
+        toolPart(loadingID, visualizationTool, "pending", {}),
+      ],
+      {
+        id: "msg_visualization_current_assistant",
+        parentID: currentUser.info.id,
+        completed: false,
+        created: 1_700_000_003_000,
+      },
+    )
+    await setupTimeline(page, {
+      protocol: "v2",
+      messages: [historicalUser, historicalAssistant, currentUser, currentAssistant],
+    })
+
+    await expect(page.locator(`[data-timeline-part-id="${historicalFrameID}"] iframe`)).toBeVisible()
+    await expect(page.locator(`[data-timeline-part-id="${validID}"] iframe`)).toBeVisible()
+    await expect(page.locator(`[data-timeline-part-id="${invalidID}"] [data-state="invalid"]`)).toBeVisible()
+    await expect(page.getByText("Ordinary timeline content remains visible.", { exact: true })).toBeVisible()
+    await expect(page.locator(`[data-timeline-part-id="${loadingID}"] [data-state="thinking"]`)).toBeVisible()
+  })
+
+  test("isolates visualization scripts from the host, Electron bridge, navigation, downloads, and external network", async ({
+    page,
+  }) => {
+    const partID = "prt_visualization_security"
+    const security = await observeVisualizationSecurity(page)
+
+    await setupTimeline(page, {
+      protocol: "v2",
+      messages: [
+        userMessage(),
+        assistantMessage([
+          toolPart(
+            partID,
+            visualizationTool,
+            "completed",
+            {},
+            {
+              structured: visualization({
+                title: "Security probe",
+                html: `<button id="attack">Run isolation probe</button><output id="result"></output>
+              <script>
+                document.querySelector("#attack").onclick = () => {
+                  let parentDom = false
+                  let api = false
+                  try { parent.document.documentElement.setAttribute("data-visualization-attack", "changed"); parentDom = true } catch (_) {}
+                  try { parent.api = { changed: true }; api = true } catch (_) {}
+                  document.querySelector("#result").textContent = "parent:" + parentDom + " api:" + api
+                  const remote = "https://visualization-e2e.invalid/probe"
+                  fetch(remote).then(
+                    () => { document.body.dataset.fetch = "resolved" },
+                    (error) => { document.body.dataset.fetch = error.name + ":" + error.message },
+                  )
+                  const xhr = new XMLHttpRequest(); xhr.open("GET", remote + "/xhr"); xhr.send()
+                  try { new WebSocket("wss://visualization-e2e.invalid/socket") } catch (_) {}
+                  const image = new Image(); image.src = remote + "/image"; document.body.append(image)
+                  try { window.open(remote + "/popup") } catch (_) {}
+                }
+              </script>`,
+              }),
+            },
+          ),
+        ]),
+      ],
+    })
+
+    const frame = page.frameLocator(`[data-timeline-part-id="${partID}"] iframe`)
+    const main = await page.evaluate(() => ({
+      url: location.href,
+      bridge: typeof (window as Window & { api?: unknown }).api,
+      attack: document.documentElement.getAttribute("data-visualization-attack"),
+    }))
+    const frameBeforeAttack = await frame.locator("html").evaluate(() => ({
+      url: document.URL,
+      origin: location.origin,
+      csp: document.querySelector('meta[http-equiv="Content-Security-Policy"]')?.getAttribute("content"),
+    }))
+    await frame.getByRole("button", { name: "Run isolation probe" }).click()
+    await expect(frame.locator("#result")).toHaveText("parent:false api:false")
+    await page.waitForTimeout(500)
+
+    expect(
+      security.externalResponses,
+      JSON.stringify({
+        frame: frameBeforeAttack,
+        fetch: await frame.locator("body").evaluate((element) => element.dataset.fetch),
+        console: security.console,
+      }),
+    ).toEqual([])
+    expect(security.externalNavigations).toEqual([])
+    expect(security.popups).toEqual([])
+    expect(security.downloads).toEqual([])
+    expect(page.url()).toBe(main.url)
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          bridge: typeof (window as Window & { api?: unknown }).api,
+          attack: document.documentElement.getAttribute("data-visualization-attack"),
+        })),
+      )
+      .toEqual({ bridge: main.bridge, attack: main.attack })
+  })
+
+  for (const probe of [
+    {
+      name: "form submission",
+      script: `const form = document.createElement("form"); form.action = remote + "/form"; document.body.append(form); form.submit()`,
+    },
+    {
+      name: "download",
+      script: `const download = document.createElement("a"); download.href = remote + "/download"; download.download = "probe.txt"; document.body.append(download); download.click()`,
+    },
+    { name: "top navigation", script: `top.location.href = remote + "/top"` },
+    { name: "self navigation", script: `location.href = remote + "/self"` },
+  ]) {
+    test(`blocks visualization ${probe.name}`, async ({ page }) => {
+      const partID = `prt_visualization_${probe.name.replaceAll(" ", "_")}`
+      const security = await observeVisualizationSecurity(page)
+      await setupTimeline(page, {
+        protocol: "v2",
+        messages: [
+          userMessage(),
+          assistantMessage([
+            toolPart(
+              partID,
+              visualizationTool,
+              "completed",
+              {},
+              {
+                structured: visualization({
+                  title: `Security ${probe.name}`,
+                  html: `<button id="attack">Run ${probe.name}</button>
+                <script>
+                  document.querySelector("#attack").onclick = () => {
+                    const remote = "https://visualization-e2e.invalid/probe"
+                    try { ${probe.script} } catch (_) {}
+                  }
+                </script>`,
+                }),
+              },
+            ),
+          ]),
+        ],
+      })
+
+      const frame = page.frameLocator(`[data-timeline-part-id="${partID}"] iframe`)
+      const mainURL = page.url()
+      await frame.getByRole("button", { name: `Run ${probe.name}` }).click()
+      await page.waitForTimeout(500)
+      expect(security.externalResponses).toEqual([])
+      expect(security.externalNavigations).toEqual([])
+      expect(security.popups).toEqual([])
+      expect(security.downloads).toEqual([])
+      expect(page.url()).toBe(mainURL)
+      await expect(frame.getByRole("button", { name: `Run ${probe.name}` })).toBeVisible()
+    })
+  }
+})
+
+function visualization(input: { title?: string; html: string }) {
+  return { version: 1, title: input.title ?? visualizationTitle, html: input.html }
+}
+
+async function observeVisualizationSecurity(page: Page) {
+  const externalRequests: { url: string; resourceType: string; navigation: boolean }[] = []
+  const externalResponses: { url: string; status: number }[] = []
+  const externalNavigations: string[] = []
+  const popups: string[] = []
+  const downloads: string[] = []
+  const console: { type: string; text: string; url: string }[] = []
+  const appOrigin = new URL(
+    process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${process.env.PLAYWRIGHT_PORT ?? "3000"}`,
+  ).origin
+  const serverOrigin = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+  const isExternal = (url: string) => {
+    const parsed = new URL(url)
+    return (
+      ["http:", "https:", "ws:", "wss:"].includes(parsed.protocol) &&
+      parsed.origin !== appOrigin &&
+      parsed.origin !== serverOrigin
+    )
+  }
+
+  page.on("request", (request) => {
+    if (isExternal(request.url())) {
+      externalRequests.push({
+        url: request.url(),
+        resourceType: request.resourceType(),
+        navigation: request.isNavigationRequest(),
+      })
+    }
+  })
+  page.on("console", (message) => {
+    if (message.type() !== "error") return
+    console.push({ type: message.type(), text: message.text(), url: message.location().url })
+  })
+  page.on("response", (response) => {
+    if (isExternal(response.url())) externalResponses.push({ url: response.url(), status: response.status() })
+  })
+  page.on("framenavigated", (frame) => {
+    if (isExternal(frame.url())) externalNavigations.push(frame.url())
+  })
+  page.context().on("page", (popup) => {
+    popups.push(popup.url())
+    void popup.close()
+  })
+  page.on("download", (download) => downloads.push(download.suggestedFilename()))
+  await page.route("**/*", async (route) => {
+    if (isExternal(route.request().url())) return route.abort()
+    return route.fallback()
+  })
+
+  return { externalRequests, externalResponses, externalNavigations, popups, downloads, console }
+}

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -8,6 +8,7 @@ export interface MockServerConfig {
   provider: unknown | (() => unknown)
   integrationMethods?: Record<string, unknown[]>
   onConnectKey?: (input: { integrationID: string; body: unknown }) => void
+  onPrompt?: (input: { sessionID: string; body: unknown }) => void
   onInstanceDispose?: () => void
   directory: string
   project: unknown
@@ -120,6 +121,10 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
         },
         data: [],
       })
+    if (path === "/api/provider") return json(route, { location: location(config), data: currentProviders(config) })
+    if (path === "/api/model") return json(route, { location: location(config), data: currentModels(config) })
+    if (path === "/api/model/default")
+      return json(route, { location: location(config), data: currentDefaultModel(config) })
     if (path === "/api/agent")
       return json(route, {
         location: location(config),
@@ -220,6 +225,11 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     if (/^\/api\/session\/[^/]+\/shell$/.test(path) && route.request().method() === "POST") {
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
     }
+    const promptMatch = path.match(/^\/api\/session\/([^/]+)\/prompt$/)
+    if (promptMatch && route.request().method() === "POST") {
+      config.onPrompt?.({ sessionID: promptMatch[1]!, body: route.request().postDataJSON() })
+      return json(route, { data: {} })
+    }
     if (/^\/api\/session\/[^/]+\/question\/[^/]+\/(reply|reject)$/.test(path) && route.request().method() === "POST") {
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
     }
@@ -287,7 +297,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       const cursor = pageData.cursor ? `cursor_${++nextCursor}` : undefined
       if (cursor) cursors.set(cursor, pageData.cursor!)
       return json(route, {
-        data: pageData.items.map(currentMessage).reverse(),
+        data: pageData.items.map((item) => currentMessage(item, config.protocol)).reverse(),
         cursor: { next: cursor },
       })
     }
@@ -319,6 +329,61 @@ function location(config: MockServerConfig) {
     directory: config.directory,
     project: { id: (config.project as { id?: string }).id, directory: config.directory },
   }
+}
+
+function currentProviders(config: MockServerConfig) {
+  return providerCatalog(config).flatMap((provider) => {
+    if (typeof provider.id !== "string" || typeof provider.name !== "string") return []
+    return [{ id: provider.id, name: provider.name, settings: {} }]
+  })
+}
+
+function currentModels(config: MockServerConfig) {
+  return providerCatalog(config).flatMap((provider) => {
+    if (typeof provider.id !== "string" || !provider.models || typeof provider.models !== "object") return []
+    return Object.values(provider.models).flatMap((model) => {
+      if (!model || typeof model !== "object") return []
+      const value = model as Record<string, unknown>
+      const id = typeof value.id === "string" ? value.id : undefined
+      if (!id) return []
+      const limit = value.limit && typeof value.limit === "object" ? (value.limit as Record<string, unknown>) : {}
+      return [
+        {
+          id,
+          providerID: provider.id,
+          modelID: id,
+          package: provider.id,
+          name: typeof value.name === "string" ? value.name : id,
+          capabilities: { tools: true, input: ["text"], output: ["text"] },
+          variants: [],
+          time: { released: 0 },
+          cost: [],
+          status: "active",
+          enabled: true,
+          limit: { context: typeof limit.context === "number" ? limit.context : 200_000, output: 8_192 },
+        },
+      ]
+    })
+  })
+}
+
+function currentDefaultModel(config: MockServerConfig) {
+  const provider = typeof config.provider === "function" ? config.provider() : config.provider
+  if (!provider || typeof provider !== "object" || Array.isArray(provider)) return null
+  const value = provider as Record<string, unknown>
+  const defaultModel = value.default
+  if (!defaultModel || typeof defaultModel !== "object" || Array.isArray(defaultModel)) return null
+  const model = defaultModel as Record<string, unknown>
+  return typeof model.providerID === "string" && typeof model.modelID === "string" ? model : null
+}
+
+function providerCatalog(config: MockServerConfig) {
+  const provider = typeof config.provider === "function" ? config.provider() : config.provider
+  if (!provider || typeof provider !== "object" || Array.isArray(provider)) return []
+  const all = (provider as Record<string, unknown>).all
+  return Array.isArray(all)
+    ? all.filter((item): item is Record<string, unknown> => !!item && typeof item === "object")
+    : []
 }
 
 function currentPermission(value: unknown) {
@@ -364,7 +429,7 @@ export function currentSession(session: { id: string } & Record<string, unknown>
   }
 }
 
-function currentMessage(value: unknown) {
+function currentMessage(value: unknown, protocol?: "v1" | "v2") {
   const item = value as {
     info: Record<string, unknown> & { id: string; role: "user" | "assistant"; time: { created: number } }
     parts: Array<Record<string, unknown> & { type: string }>
@@ -392,6 +457,18 @@ function currentMessage(value: unknown) {
       if (part.type === "text" || part.type === "reasoning") return [{ type: part.type, text: part.text ?? "" }]
       if (part.type !== "tool") return []
       const state = part.state as Record<string, unknown>
+      const metadata = part.metadata
+      const testStructured =
+        metadata &&
+        typeof metadata === "object" &&
+        !Array.isArray(metadata) &&
+        Object.hasOwn(metadata, "__testStructured")
+          ? (metadata as Record<string, unknown>).__testStructured
+          : undefined
+      const structured =
+        protocol === "v2" && metadata && typeof metadata === "object" && Object.hasOwn(metadata, "__testStructured")
+          ? testStructured
+          : (state.metadata ?? {})
       return [
         {
           type: "tool",
@@ -405,18 +482,18 @@ function currentMessage(value: unknown) {
                 ? {
                     status: "completed",
                     input: state.input ?? {},
-                    structured: state.metadata ?? {},
+                    structured,
                     content: [{ type: "text", text: state.output ?? "" }],
                   }
                 : state.status === "error"
                   ? {
                       status: "error",
                       input: state.input ?? {},
-                      structured: state.metadata ?? {},
+                      structured,
                       content: [],
                       error: { type: "ToolError", message: state.error ?? "Tool failed" },
                     }
-                  : { status: "running", input: state.input ?? {}, structured: state.metadata ?? {}, content: [] },
+                  : { status: "running", input: state.input ?? {}, structured, content: [] },
         },
       ]
     }),

--- a/packages/app/src/components/dialog-visualization-followup.tsx
+++ b/packages/app/src/components/dialog-visualization-followup.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@opencode-ai/ui/button"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { useLanguage } from "@/context/language"
+
+export type VisualizationFollowupDialogResult = "confirmed" | "cancelled"
+
+type DialogVisualizationFollowupProps = {
+  title?: string
+  prompt: string
+  onResult: (result: VisualizationFollowupDialogResult) => void
+  close?: () => void
+}
+
+export function createVisualizationFollowupDialogActions(input: {
+  onResult: (result: VisualizationFollowupDialogResult) => void
+  close?: () => void
+}) {
+  let settled = false
+
+  const settle = (result: VisualizationFollowupDialogResult) => {
+    if (settled) return
+    settled = true
+    input.onResult(result)
+    input.close?.()
+  }
+
+  return {
+    confirm: () => settle("confirmed"),
+    cancel: () => settle("cancelled"),
+  }
+}
+
+export function DialogVisualizationFollowup(props: DialogVisualizationFollowupProps) {
+  const language = useLanguage()
+  const actions = createVisualizationFollowupDialogActions({
+    onResult: props.onResult,
+    close: props.close,
+  })
+
+  return (
+    <Dialog title={<span>{props.title}</span>}>
+      <div class="flex flex-col gap-4 px-6 pb-4">
+        <div class="whitespace-pre-wrap break-words text-14-regular text-text-base">{props.prompt}</div>
+        <div class="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="large" onClick={actions.cancel}>
+            {language.t("common.cancel")}
+          </Button>
+          <Button type="button" variant="primary" size="large" onClick={actions.confirm}>
+            {language.t("ui.promptInput.send")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -2,8 +2,10 @@ import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
 import { createStore } from "solid-js/store"
 import type { Prompt, PromptStore } from "@/context/prompt"
 import type { ModelSelection } from "@/context/local"
+import type { FollowupSendInput } from "./submit"
 
 let createPromptSubmit: typeof import("./submit").createPromptSubmit
+let sendFollowupDraft: typeof import("./submit").sendFollowupDraft
 
 const createdClients: string[] = []
 const createdSessions: string[] = []
@@ -31,7 +33,7 @@ const promotedDrafts: Array<{ draftID: string; server: string; sessionId: string
 const sentPrompts: string[] = []
 const promptInputs: unknown[] = []
 const sentCommands: unknown[] = []
-const commands: Array<{ name: string }> = []
+const commands: FollowupSendInput["sync"]["data"]["command"] = []
 let serverSessionSyncs = 0
 
 let params: { id?: string } = {}
@@ -70,6 +72,16 @@ const prompt = {
   capture: () => prompt,
 }
 
+const pendingUser = () => ({
+  admittedSeq: 0,
+  id: "message",
+  sessionID: "session",
+  timeCreated: 0,
+  type: "user" as const,
+  data: { text: "" },
+  delivery: "steer" as const,
+})
+
 const clientFor = (directory: string) => {
   createdClients.push(directory)
   return {
@@ -95,10 +107,11 @@ const clientFor = (directory: string) => {
         prompt: async (input: unknown) => {
           sentPrompts.push(directory)
           promptInputs.push(input)
-          return { data: undefined }
+          return pendingUser()
         },
         command: async (input: unknown) => {
           sentCommands.push(input)
+          return pendingUser()
         },
         shell: async (input: { sessionID: string; id?: string; command: string }) => {
           sentShell.push(input)
@@ -135,6 +148,11 @@ beforeAll(async () => {
   mock.module("@opencode-ai/ui/toast", () => ({
     Toast: { Region: () => null },
     showToast: () => 0,
+    toaster: {
+      show: () => 0,
+      promise: () => 0,
+      dismiss: () => undefined,
+    },
   }))
 
   mock.module("@opencode-ai/core/util/encode", () => ({
@@ -276,6 +294,7 @@ beforeAll(async () => {
 
   const mod = await import("./submit")
   createPromptSubmit = mod.createPromptSubmit
+  sendFollowupDraft = mod.sendFollowupDraft
 })
 
 beforeEach(() => {
@@ -497,7 +516,7 @@ describe("prompt submit worktree selection", () => {
   test("submits slash commands through the current session API", async () => {
     params = { id: "session-1" }
     variant = "high"
-    commands.push({ name: "review" })
+    commands.push({ name: "review", template: "" })
     promptValue = [{ type: "text", content: "/review staged changes", start: 0, end: 22 }]
 
     const submit = createPromptSubmit({
@@ -531,6 +550,43 @@ describe("prompt submit worktree selection", () => {
       },
     ])
     expect(serverSessionSyncs).toBe(0)
+  })
+
+  test("sends slash-like visualization follow-ups as ordinary prompts when commands are disabled", async () => {
+    commands.push({ name: "review", template: "" })
+
+    const input = {
+      api: clientFor("/repo/main").api.session,
+      sync: {
+        data: { command: commands },
+        session: {
+          optimistic: {
+            add: () => undefined,
+            remove: () => undefined,
+          },
+        },
+      },
+      serverSync: {
+        session: {
+          set: () => undefined,
+        },
+      },
+      draft: {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        prompt: [{ type: "text", content: "/review current selection", start: 0, end: 25 }],
+        context: [],
+        agent: "agent",
+        model: { providerID: "provider", modelID: "model" },
+      },
+      allowCommand: false,
+    } satisfies FollowupSendInput
+
+    await sendFollowupDraft(input)
+
+    expect(sentCommands).toHaveLength(0)
+    expect(promptInputs).toHaveLength(1)
+    expect(promptInputs[0]).toMatchObject({ text: "/review current selection" })
   })
 
   test("uses an injected model selection", async () => {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -41,12 +41,20 @@ export type FollowupDraft = {
   variant?: string
 }
 
-type FollowupSendInput = {
-  api: DirectorySDK["api"]["session"]
-  serverSync: ServerSync
-  sync: DirectorySync
+export type FollowupSendInput = {
+  api: Pick<DirectorySDK["api"]["session"], "command" | "prompt">
+  serverSync: {
+    session: Pick<ServerSync["session"], "set">
+  }
+  sync: {
+    data: Pick<DirectorySync["data"], "command">
+    session: {
+      optimistic: Pick<DirectorySync["session"]["optimistic"], "add" | "remove">
+    }
+  }
   draft: FollowupDraft
   messageID?: string
+  allowCommand?: boolean
   optimisticBusy?: boolean
   before?: () => Promise<boolean> | boolean
 }
@@ -76,7 +84,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
 
   const [head, ...tail] = text.split(" ")
   const cmd = head?.startsWith("/") ? head.slice(1) : undefined
-  if (cmd && input.sync.data.command.find((item) => item.name === cmd)) {
+  if (input.allowCommand !== false && cmd && input.sync.data.command.find((item) => item.name === cmd)) {
     setBusy()
     try {
       if (!(await wait())) {

--- a/packages/app/src/context/server-session-v2-reducer.test.ts
+++ b/packages/app/src/context/server-session-v2-reducer.test.ts
@@ -140,6 +140,290 @@ describe("v2 session reducer", () => {
     })
   })
 
+  test("preserves current structured progress and success payloads", () => {
+    const reducer = createV2SessionReducer()
+    let messages: SessionMessageInfo[] = []
+    const apply = (input: object) => {
+      const result = reducer.reduce(messages, event(input))
+      if (result) messages = result.messages
+    }
+
+    apply({
+      ...base,
+      id: "evt_step",
+      type: "session.step.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_start",
+      type: "session.tool.input.started",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", name: "visualization_create" },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_called",
+      type: "session.tool.called",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", input: {}, executed: true },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_progress",
+      type: "session.tool.progress",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        structured: { version: 1, title: "Loading" },
+        metadata: { legacy: "progress" },
+      },
+    })
+
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      content: [{ type: "tool", state: { status: "running", structured: { version: 1, title: "Loading" } } }],
+    })
+    const progress = messages[0]?.type === "assistant" ? messages[0].content[0] : undefined
+    expect(progress).toMatchObject({ executed: true, time: { created: 1, ran: 1 } })
+    expect<unknown>(progress?.type === "tool" ? progress.state : undefined).toEqual({
+      status: "running",
+      input: {},
+      structured: { version: 1, title: "Loading" },
+      metadata: { legacy: "progress" },
+    })
+
+    apply({
+      ...base,
+      id: "evt_tool_success",
+      type: "session.tool.success",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        structured: { version: 1, title: "Chart", html: "<div>chart</div>" },
+        metadata: { legacy: "success" },
+        content: [{ type: "text", text: "Visualization created" }],
+        executed: true,
+      },
+    })
+
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      content: [
+        {
+          type: "tool",
+          state: {
+            status: "completed",
+            structured: { version: 1, title: "Chart", html: "<div>chart</div>" },
+            metadata: { legacy: "success" },
+          },
+        },
+      ],
+    })
+    const success = messages[0]?.type === "assistant" ? messages[0].content[0] : undefined
+    expect(success).toMatchObject({ executed: true, time: { created: 1, ran: 1, completed: 1 } })
+    expect<unknown>(success?.type === "tool" ? success.state : undefined).toEqual({
+      status: "completed",
+      input: {},
+      structured: { version: 1, title: "Chart", html: "<div>chart</div>" },
+      metadata: { legacy: "success" },
+      content: [{ type: "text", text: "Visualization created" }],
+    })
+  })
+
+  test("uses legacy metadata as structured tool data", () => {
+    const reducer = createV2SessionReducer()
+    let messages: SessionMessageInfo[] = []
+    const apply = (input: object) => {
+      const result = reducer.reduce(messages, event(input))
+      if (result) messages = result.messages
+    }
+
+    apply({
+      ...base,
+      id: "evt_step",
+      type: "session.step.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_start",
+      type: "session.tool.input.started",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", name: "legacy" },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_called",
+      type: "session.tool.called",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", input: {}, executed: true },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_success",
+      type: "session.tool.success",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        metadata: { legacy: true },
+        content: [{ type: "text", text: "done" }],
+        executed: true,
+      },
+    })
+
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      content: [{ type: "tool", state: { status: "completed", structured: { legacy: true } } }],
+    })
+  })
+
+  test("keeps running structured data when a tool fails", () => {
+    const reducer = createV2SessionReducer()
+    let messages: SessionMessageInfo[] = []
+    const apply = (input: object) => {
+      const result = reducer.reduce(messages, event(input))
+      if (result) messages = result.messages
+    }
+
+    apply({
+      ...base,
+      id: "evt_step",
+      type: "session.step.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_start",
+      type: "session.tool.input.started",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", name: "visualization_create" },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_called",
+      type: "session.tool.called",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        input: {},
+        metadata: { phase: "called" },
+        executed: true,
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_progress",
+      type: "session.tool.progress",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        structured: { version: 1, title: "Partial" },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_failed",
+      type: "session.tool.failed",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        metadata: { provider: "failure" },
+        content: [{ type: "text", text: "partial" }],
+        error: { type: "unknown", message: "failed" },
+        executed: true,
+      },
+    })
+
+    expect(messages[0]).toMatchObject({
+      type: "assistant",
+      content: [
+        {
+          type: "tool",
+          state: {
+            status: "error",
+            structured: { version: 1, title: "Partial" },
+            metadata: { provider: "failure" },
+          },
+        },
+      ],
+    })
+  })
+
+  test("uses failed legacy metadata when called state has no explicit structured field", () => {
+    const reducer = createV2SessionReducer()
+    let messages: SessionMessageInfo[] = []
+    const apply = (input: object) => {
+      const result = reducer.reduce(messages, event(input))
+      if (result) messages = result.messages
+    }
+
+    apply({
+      ...base,
+      id: "evt_step",
+      type: "session.step.started",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_start",
+      type: "session.tool.input.started",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", name: "legacy" },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_called",
+      type: "session.tool.called",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", input: {}, executed: true },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_failed",
+      type: "session.tool.failed",
+      data: {
+        sessionID: "ses_1",
+        assistantMessageID: "msg_assistant",
+        callID: "call_1",
+        metadata: { legacy: true },
+        content: [{ type: "text", text: "failed output" }],
+        error: { type: "unknown", message: "failed" },
+        executed: true,
+      },
+    })
+
+    const failed = messages[0]?.type === "assistant" ? messages[0].content[0] : undefined
+    expect(failed).toMatchObject({ executed: true, time: { created: 1, ran: 1, completed: 1 } })
+    expect<unknown>(failed?.type === "tool" ? failed.state : undefined).toEqual({
+      status: "error",
+      input: {},
+      structured: { legacy: true },
+      metadata: { legacy: true },
+      content: [{ type: "text", text: "failed output" }],
+      error: { type: "unknown", message: "failed" },
+    })
+  })
+
   test("requests hydration when promotion admission was missed", () => {
     const result = createV2SessionReducer().reduce(
       [],

--- a/packages/app/src/context/server-session-v2-reducer.ts
+++ b/packages/app/src/context/server-session-v2-reducer.ts
@@ -1,8 +1,15 @@
-import type { OpenCodeEvent, SessionMessageInfo, SessionPendingMessage } from "@opencode-ai/client/promise"
+import type { JsonValue, OpenCodeEvent, SessionMessageInfo, SessionPendingMessage } from "@opencode-ai/client/promise"
+import {
+  attachToolStructured,
+  hasToolStructured,
+  readToolRendererMetadata,
+  readToolStructured,
+} from "../utils/session-tool-structured"
 
 type Assistant = Extract<SessionMessageInfo, { type: "assistant" }>
 type Compaction = Extract<SessionMessageInfo, { type: "compaction" }>
 type Shell = Extract<SessionMessageInfo, { type: "shell" }>
+type ToolMetadata = Record<string, JsonValue>
 
 export type V2SessionReduction = {
   sessionID: string
@@ -269,8 +276,10 @@ export function createV2SessionReducer() {
           ...tool,
           executed: event.data.executed,
           providerState: event.data.state,
-          // structured: {}, content: []
-          state: { status: "running", input: event.data.input, metadata: {} },
+          state: attachToolStructured(
+            { status: "running", input: event.data.input, metadata: {} },
+            readToolStructured(event.data),
+          ),
           time: { ...tool.time, ran: event.created },
         }))
       case "session.tool.progress":
@@ -278,8 +287,10 @@ export function createV2SessionReducer() {
           tool.state.status === "running"
             ? {
                 ...tool,
-                // state: { ...tool.state, structured: event.data.structured, content: event.data.content },
-                state: { ...tool.state, metadata: event.data.metadata },
+                state: attachToolStructured(
+                  { ...tool.state, metadata: rendererMetadata(tool.name, event.data) ?? {} },
+                  readToolStructured(event.data),
+                ),
               }
             : tool,
         )
@@ -290,14 +301,15 @@ export function createV2SessionReducer() {
             ...tool,
             executed: event.data.executed || tool.executed === true,
             providerResultState: event.data.resultState,
-            state: {
-              status: "completed",
-              input: tool.state.input,
-              // structured: event.data.structured,
-              metadata: event.data.metadata,
-              content: event.data.content,
-              // result: event.data.result,
-            },
+            state: attachToolStructured(
+              {
+                status: "completed",
+                input: tool.state.input,
+                metadata: rendererMetadata(tool.name, event.data) ?? {},
+                content: event.data.content,
+              },
+              readToolStructured(event.data),
+            ),
             time: { ...tool.time, completed: event.created },
           }
         })
@@ -308,15 +320,21 @@ export function createV2SessionReducer() {
             ...tool,
             executed: event.data.executed || tool.executed === true,
             providerResultState: event.data.resultState,
-            state: {
-              status: "error",
-              input: typeof tool.state.input === "string" ? {} : tool.state.input,
-              // structured: tool.state.status === "running" ? tool.state.structured : {},
-              metadata: event.data.metadata ?? (tool.state.status === "running" ? tool.state.metadata : {}),
-              content: event.data.content,
-              error: event.data.error,
-              // result: event.data.result,
-            },
+            state: attachToolStructured(
+              {
+                status: "error",
+                input: typeof tool.state.input === "string" ? {} : tool.state.input,
+                metadata:
+                  rendererMetadata(tool.name, event.data) ??
+                  (tool.state.status === "running" ? rendererMetadata(tool.name, tool.state) : undefined) ??
+                  {},
+                content: event.data.content,
+                error: event.data.error,
+              },
+              tool.state.status === "running" && hasToolStructured(tool.state)
+                ? tool.state.structured
+                : readToolStructured(event.data),
+            ),
             time: { ...tool.time, completed: event.created },
           }
         })
@@ -414,6 +432,10 @@ export function createV2SessionReducer() {
       }
     },
   }
+}
+
+function rendererMetadata(toolName: string, value: unknown) {
+  return readToolRendererMetadata(toolName, value) as ToolMetadata | undefined
 }
 
 function key(sessionID: string, inputID: string) {

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -12,6 +12,7 @@ import { Schema } from "effect"
 import type { ServerConnection } from "@/context/server"
 import { sessionHref } from "@/utils/session-route"
 import { useServerSync } from "@/context/server-sync"
+import { DirectoryVisualizationProvider } from "./directory-visualization-provider"
 
 export function DirectoryDataProvider(
   props: ParentProps<{
@@ -67,7 +68,9 @@ export function DirectoryDataProvider(
           onNavigateToSession={(sessionID: string) => navigate(href(sessionID))}
           onSessionHref={href}
         >
-          <LocalProvider>{props.children}</LocalProvider>
+          <LocalProvider>
+            <DirectoryVisualizationProvider>{props.children}</DirectoryVisualizationProvider>
+          </LocalProvider>
         </DataProvider>
       )}
     </Show>

--- a/packages/app/src/pages/directory-visualization-provider.test.tsx
+++ b/packages/app/src/pages/directory-visualization-provider.test.tsx
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "bun:test"
+import {
+  createDirectoryVisualizationFollowUp,
+  isVisualizationEnabled,
+  type VisualizationDialogStack,
+  requestVisualizationFollowUp,
+} from "./directory-visualization-provider"
+import { createVisualizationFollowupDialogActions } from "@/components/dialog-visualization-followup"
+
+type Selection = {
+  agent?: { name: string }
+  model?: { id: string; provider: { id: string } }
+  variant?: string
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function setup(
+  input: {
+    confirmation?: () => Promise<"confirmed" | "cancelled">
+    send?: () => Promise<boolean>
+    selection?: Selection | null
+  } = {},
+) {
+  let sessionID: string | undefined = "session-1"
+  let active = true
+  let selection: Selection | undefined =
+    input.selection === undefined
+      ? {
+          agent: { name: "build" },
+          model: { id: "gpt-5.4", provider: { id: "openai" } },
+          variant: "high",
+        }
+      : (input.selection ?? undefined)
+  const sent: unknown[] = []
+  const errors: unknown[] = []
+  const followUp = createDirectoryVisualizationFollowUp({
+    currentSessionID: () => sessionID,
+    directory: () => "/repo/main",
+    selection: () => selection,
+    isActive: () => active,
+    confirm: input.confirmation ?? (() => Promise.resolve("confirmed")),
+    send: async (draft) => {
+      sent.push(draft)
+      return input.send?.() ?? true
+    },
+    onError: (error) => errors.push(error),
+  })
+
+  return {
+    followUp,
+    sent,
+    errors,
+    session: (value: string | undefined) => {
+      sessionID = value
+    },
+    selection: (value: Selection | undefined) => {
+      selection = value
+    },
+    active: (value: boolean) => {
+      active = value
+    },
+  }
+}
+
+describe("directory visualization follow-up", () => {
+  test("enables visualization rendering only for the desktop platform", () => {
+    expect(isVisualizationEnabled("web")).toBe(false)
+    expect(isVisualizationEnabled("desktop")).toBe(true)
+  })
+
+  test("rejects a request for a session that is no longer current", async () => {
+    const subject = setup()
+
+    await expect(subject.followUp({ sessionID: "session-2", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(subject.sent).toEqual([])
+  })
+
+  test("does not send after cancelling confirmation", async () => {
+    const subject = setup({ confirmation: () => Promise.resolve("cancelled") })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("cancelled")
+    expect(subject.sent).toEqual([])
+  })
+
+  test("sends a pure text draft using the current local selection", async () => {
+    const subject = setup()
+
+    await expect(
+      subject.followUp({ sessionID: "session-1", title: "Choose a layout", prompt: "/review current selection" }),
+    ).resolves.toBe("sent")
+    expect(subject.sent).toEqual([
+      {
+        sessionID: "session-1",
+        sessionDirectory: "/repo/main",
+        prompt: [{ type: "text", content: "/review current selection", start: 0, end: 25 }],
+        context: [],
+        agent: "build",
+        model: { providerID: "openai", modelID: "gpt-5.4" },
+        variant: "high",
+      },
+    ])
+  })
+
+  test("uses UTF-16 indexes for emoji prompt text", async () => {
+    const subject = setup()
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "/review 🚀" })).resolves.toBe("sent")
+    expect(subject.sent[0]).toMatchObject({
+      prompt: [{ type: "text", content: "/review 🚀", start: 0, end: 10 }],
+    })
+  })
+
+  test("rejects and reports a sending failure", async () => {
+    const failure = new Error("offline")
+    const subject = setup({ send: () => Promise.reject(failure) })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(subject.errors).toEqual([failure])
+  })
+
+  test("rejects if the current session changes while confirmation is open", async () => {
+    let subject: ReturnType<typeof setup>
+    subject = setup({
+      confirmation: async () => {
+        subject.session("session-2")
+        return "confirmed"
+      },
+    })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(subject.sent).toEqual([])
+  })
+
+  test("rejects if the provider is disposed after confirmation", async () => {
+    let subject: ReturnType<typeof setup>
+    subject = setup({
+      confirmation: async () => {
+        subject.active(false)
+        return "confirmed"
+      },
+    })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(subject.sent).toEqual([])
+  })
+
+  test("does not submit if the provider becomes inactive while preparing the draft", async () => {
+    let active = true
+    let sends = 0
+    const followUp = createDirectoryVisualizationFollowUp({
+      currentSessionID: () => "session-1",
+      directory: () => "/repo/main",
+      isActive: () => active,
+      confirm: () => Promise.resolve("confirmed"),
+      selection: () => {
+        active = false
+        return {
+          agent: { name: "build" },
+          model: { id: "gpt-5.4", provider: { id: "openai" } },
+        }
+      },
+      send: async () => {
+        sends++
+        return true
+      },
+      onError: () => undefined,
+    })
+
+    await expect(followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(sends).toBe(0)
+  })
+
+  test("does not submit if the provider becomes inactive before sending", async () => {
+    let active = true
+    let submissions = 0
+    const followUp = createDirectoryVisualizationFollowUp({
+      currentSessionID: () => "session-1",
+      directory: () => "/repo/main",
+      isActive: () => active,
+      confirm: () => Promise.resolve("confirmed"),
+      selection: () => ({
+        agent: { name: "build" },
+        model: { id: "gpt-5.4", provider: { id: "openai" } },
+      }),
+      send: async (_draft, before) => {
+        active = false
+        if (!before()) return false
+        submissions++
+        return true
+      },
+      onError: () => undefined,
+    })
+
+    await expect(followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(submissions).toBe(0)
+  })
+
+  test("rejects when the current local agent or model is unavailable", async () => {
+    const subject = setup({ selection: null })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+    expect(subject.sent).toEqual([])
+  })
+
+  test("immediately rejects a second request while one confirmation is pending", async () => {
+    const confirmation = createDeferred<"confirmed" | "cancelled">()
+    const subject = setup({ confirmation: () => confirmation.promise })
+    const first = subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })
+
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use spacious layout" })).resolves.toBe("rejected")
+    confirmation.resolve("confirmed")
+    await expect(first).resolves.toBe("sent")
+    expect(subject.sent).toHaveLength(1)
+  })
+
+  test("settles dialog close only once", async () => {
+    let onClose: (() => void) | undefined
+    const handle = {
+      id: "A",
+      close: () => onClose?.(),
+    }
+    const dialog: VisualizationDialogStack = {
+      push: (_element, close) => {
+        onClose = close
+        return handle
+      },
+    }
+
+    const request = requestVisualizationFollowUp(dialog, { sessionID: "session-1", prompt: "Use compact layout" })
+    expect(request).toHaveProperty("promise")
+    if (!("promise" in request) || !(request.promise instanceof Promise)) return
+
+    onClose?.()
+    onClose?.()
+
+    await expect(request.promise).resolves.toBe("cancelled")
+  })
+
+  test("allows another request after an external dialog cancellation", async () => {
+    let onClose: (() => void) | undefined
+    let active = "A"
+    let firstClosed = 0
+    let replacementClosed = 0
+    const dialog: VisualizationDialogStack = {
+      push: (_element, close) => {
+        onClose = close
+        return {
+          id: "A",
+          close: () => {
+            if (active === "A") {
+              firstClosed++
+              onClose?.()
+            }
+          },
+        }
+      },
+    }
+    const request = requestVisualizationFollowUp(dialog, { sessionID: "session-1", prompt: "Use compact layout" })
+    let confirmations = 0
+    const subject = setup({
+      confirmation: () =>
+        confirmations++ === 0 && "promise" in request ? request.promise : Promise.resolve("confirmed"),
+    })
+    const first = subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })
+
+    expect(request).toHaveProperty("cancel")
+    if (!("cancel" in request) || typeof request.cancel !== "function") return
+    active = "B"
+    request.cancel()
+
+    await expect(first).resolves.toBe("cancelled")
+    expect(firstClosed).toBe(0)
+    expect(replacementClosed).toBe(0)
+    await expect(subject.followUp({ sessionID: "session-1", prompt: "Use spacious layout" })).resolves.toBe("sent")
+    expect(subject.sent).toHaveLength(1)
+    onClose?.()
+  })
+
+  test("cancellation closes its own dialog handle", async () => {
+    let onClose: (() => void) | undefined
+    let closes = 0
+    const dialog: VisualizationDialogStack = {
+      push: (_element, close) => {
+        onClose = close
+        return {
+          id: "A",
+          close: () => {
+            closes++
+            onClose?.()
+          },
+        }
+      },
+    }
+    const request = requestVisualizationFollowUp(dialog, { sessionID: "session-1", prompt: "Use compact layout" })
+
+    request.cancel()
+
+    await expect(request.promise).resolves.toBe("cancelled")
+    expect(closes).toBe(1)
+  })
+
+  test("confirmation without an injected close callback settles without closing another dialog", () => {
+    const settled: string[] = []
+    const actions = createVisualizationFollowupDialogActions({
+      onResult: (result) => settled.push(result),
+    })
+
+    actions.confirm()
+
+    expect(settled).toEqual(["confirmed"])
+  })
+
+  test("confirmation closes only its own handle and still sends the follow-up", async () => {
+    const confirmation = createDeferred<"confirmed" | "cancelled">()
+    const subject = setup({ confirmation: () => confirmation.promise })
+    const first = subject.followUp({ sessionID: "session-1", prompt: "Use compact layout" })
+    let firstClosed = 0
+    let secondClosed = 0
+    const actions = createVisualizationFollowupDialogActions({
+      onResult: confirmation.resolve,
+      close: () => {
+        firstClosed++
+      },
+    })
+
+    actions.confirm()
+
+    await expect(first).resolves.toBe("sent")
+    expect(firstClosed).toBe(1)
+    expect(secondClosed).toBe(0)
+    expect(subject.sent).toHaveLength(1)
+  })
+
+  test("settles and closes dialog actions only once", () => {
+    const settled: string[] = []
+    let closes = 0
+    const actions = createVisualizationFollowupDialogActions({
+      onResult: (result) => settled.push(result),
+      close: () => {
+        closes++
+      },
+    })
+
+    actions.confirm()
+    actions.cancel()
+
+    expect(settled).toEqual(["confirmed"])
+    expect(closes).toBe(1)
+  })
+})

--- a/packages/app/src/pages/directory-visualization-provider.tsx
+++ b/packages/app/src/pages/directory-visualization-provider.tsx
@@ -1,0 +1,180 @@
+import { onCleanup, type JSX, type ParentProps } from "solid-js"
+import { useParams } from "@solidjs/router"
+import {
+  VisualizationProvider,
+  type VisualizationFollowUpInput,
+  type VisualizationFollowUpResult,
+} from "@opencode-ai/session-ui/context"
+import { type DialogHandle, useDialog } from "@opencode-ai/ui/context/dialog"
+import { showToast } from "@/utils/toast"
+import { useLanguage } from "@/context/language"
+import { useLocal } from "@/context/local"
+import { usePlatform } from "@/context/platform"
+import { useSDK } from "@/context/sdk"
+import { useServerSync } from "@/context/server-sync"
+import { useSync } from "@/context/sync"
+import { type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
+import {
+  DialogVisualizationFollowup,
+  type VisualizationFollowupDialogResult,
+} from "@/components/dialog-visualization-followup"
+import { formatServerError } from "@/utils/server-errors"
+
+type LocalSelection = {
+  agent?: { name: string }
+  model?: { id: string; provider: { id: string } }
+  variant?: string
+}
+
+type DirectoryVisualizationFollowUpInput = {
+  currentSessionID: () => string | undefined
+  directory: () => string
+  selection: () => LocalSelection | undefined
+  isActive: () => boolean
+  confirm: (input: VisualizationFollowUpInput) => Promise<VisualizationFollowupDialogResult>
+  send: (draft: FollowupDraft, before: () => Promise<boolean> | boolean) => Promise<boolean>
+  onError: (error: unknown) => void
+}
+
+export type VisualizationDialogStack = {
+  push: (element: () => JSX.Element, onClose?: () => void) => DialogHandle
+}
+
+export type VisualizationFollowUpRequest = {
+  promise: Promise<VisualizationFollowupDialogResult>
+  cancel: () => void
+}
+
+export function isVisualizationEnabled(platform: "web" | "desktop") {
+  return platform === "desktop"
+}
+
+export function requestVisualizationFollowUp(
+  dialog: VisualizationDialogStack,
+  input: VisualizationFollowUpInput,
+): VisualizationFollowUpRequest {
+  let settled = false
+  let resolve: (result: VisualizationFollowupDialogResult) => void = () => undefined
+  let handle: DialogHandle | undefined
+  const settle = (result: VisualizationFollowupDialogResult) => {
+    if (settled) return
+    settled = true
+    resolve(result)
+  }
+  const promise = new Promise<VisualizationFollowupDialogResult>((next) => {
+    resolve = next
+  })
+  const close = () => handle?.close()
+
+  handle = dialog.push(
+    () => <DialogVisualizationFollowup title={input.title} prompt={input.prompt} onResult={settle} close={close} />,
+    () => settle("cancelled"),
+  )
+
+  return {
+    promise,
+    cancel: () => {
+      handle?.close()
+      settle("cancelled")
+    },
+  }
+}
+
+export function createDirectoryVisualizationFollowUp(input: DirectoryVisualizationFollowUpInput) {
+  let pending = false
+
+  return async (followUp: VisualizationFollowUpInput): Promise<VisualizationFollowUpResult> => {
+    if (!input.isActive()) return "rejected"
+    if (pending) return "rejected"
+    if (input.currentSessionID() !== followUp.sessionID) return "rejected"
+
+    pending = true
+    try {
+      if ((await input.confirm(followUp)) === "cancelled") return "cancelled"
+      if (!input.isActive()) return "rejected"
+      if (input.currentSessionID() !== followUp.sessionID) return "rejected"
+
+      if (!input.isActive()) return "rejected"
+      const selection = input.selection()
+      if (!input.isActive()) return "rejected"
+      if (!selection?.agent || !selection.model) return "rejected"
+
+      const draft: FollowupDraft = {
+        sessionID: followUp.sessionID,
+        sessionDirectory: input.directory(),
+        prompt: [{ type: "text", content: followUp.prompt, start: 0, end: followUp.prompt.length }],
+        context: [],
+        agent: selection.agent.name,
+        model: { providerID: selection.model.provider.id, modelID: selection.model.id },
+        variant: selection.variant,
+      }
+      const sent = await input.send(draft, () => input.isActive() && input.currentSessionID() === followUp.sessionID)
+      return sent ? "sent" : "rejected"
+    } catch (error) {
+      input.onError(error)
+      return "rejected"
+    } finally {
+      pending = false
+    }
+  }
+}
+
+export function DirectoryVisualizationProvider(props: ParentProps) {
+  const params = useParams()
+  const dialog = useDialog()
+  const language = useLanguage()
+  const local = useLocal()
+  const platform = usePlatform()
+  const sdk = useSDK()
+  const sync = useSync()
+  const serverSync = useServerSync()
+  let disposed = false
+  let cancel: (() => void) | undefined
+  onCleanup(() => {
+    disposed = true
+    cancel?.()
+  })
+  const followUp = createDirectoryVisualizationFollowUp({
+    currentSessionID: () => params.id,
+    directory: () => sdk().directory,
+    isActive: () => !disposed,
+    selection: () => ({
+      agent: local.agent.current(),
+      model: local.model.current(),
+      variant: local.model.variant.current(),
+    }),
+    confirm: (input) => {
+      const request = requestVisualizationFollowUp(dialog, input)
+      cancel = request.cancel
+      return request.promise.finally(() => {
+        if (cancel === request.cancel) cancel = undefined
+      })
+    },
+    send: (draft, before) =>
+      sendFollowupDraft({
+        api: sdk().api.session,
+        serverSync: serverSync(),
+        sync: sync(),
+        draft,
+        allowCommand: false,
+        optimisticBusy: true,
+        before: async () => {
+          await Promise.resolve()
+          return before()
+        },
+      }),
+    onError: (error) => {
+      showToast({
+        variant: "error",
+        title: language.t("prompt.toast.promptSendFailed.title"),
+        description: formatServerError(error, language.t),
+      })
+    },
+  })
+
+  return (
+    <VisualizationProvider enabled={isVisualizationEnabled(platform.platform)} followUp={followUp}>
+      {props.children}
+    </VisualizationProvider>
+  )
+}

--- a/packages/app/src/utils/session-message.test.ts
+++ b/packages/app/src/utils/session-message.test.ts
@@ -211,4 +211,206 @@ describe("normalizeSessionMessages", () => {
       }),
     ])
   })
+
+  test("preserves completed visualization structured data without moving it into metadata", () => {
+    const structured = { version: 1, title: "Chart", html: "<section>chart</section>" }
+    const source = [
+      { id: "msg_user", type: "user", text: "show chart", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_visualization",
+            name: "visualization_create",
+            state: {
+              status: "completed",
+              input: { title: "Chart" },
+              structured,
+              metadata: { renderer: "legacy" },
+              content: [{ type: "text", text: "Visualization created" }],
+            },
+            time: { created: 2, ran: 3, completed: 4 },
+          },
+        ],
+        time: { created: 2, completed: 4 },
+      },
+    ] as unknown as SessionMessageInfo[]
+
+    const part = normalizeSessionMessages("ses_1", source).parts.get("msg_assistant")?.[0]
+
+    expect(part).toMatchObject({
+      type: "tool",
+      state: {
+        status: "completed",
+        structured,
+        metadata: { renderer: "legacy" },
+      },
+    })
+    expect(part).not.toHaveProperty("state.metadata.html")
+  })
+
+  test("projects legacy tool metadata as structured data while preserving renderer metadata", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "show chart", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_visualization",
+            name: "visualization_create",
+            state: {
+              status: "completed",
+              input: { title: "Legacy" },
+              metadata: { version: 1, title: "Legacy", html: "<section>legacy</section>" },
+              content: [{ type: "text", text: "Visualization created" }],
+            },
+            time: { created: 2, ran: 3, completed: 4 },
+          },
+        ],
+        time: { created: 2, completed: 4 },
+      },
+    ] satisfies SessionMessageInfo[]
+
+    const part = normalizeSessionMessages("ses_1", source).parts.get("msg_assistant")?.[0]
+
+    expect(part).toMatchObject({
+      type: "tool",
+      state: {
+        status: "completed",
+        structured: { version: 1, title: "Legacy", html: "<section>legacy</section>" },
+        metadata: { version: 1, title: "Legacy", html: "<section>legacy</section>" },
+      },
+    })
+  })
+
+  test("preserves structured data for running and error history states", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "run tools", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_running",
+            name: "visualization_create",
+            state: {
+              status: "running",
+              input: {},
+              structured: { phase: "running" },
+              metadata: { renderer: "running" },
+            },
+            time: { created: 2, ran: 3 },
+          },
+          {
+            type: "tool",
+            id: "call_error",
+            name: "visualization_create",
+            state: {
+              status: "error",
+              input: {},
+              structured: { phase: "error" },
+              metadata: { renderer: "error" },
+              error: { type: "unknown", message: "failed" },
+            },
+            time: { created: 4, ran: 5, completed: 6 },
+          },
+        ],
+        time: { created: 2, completed: 6 },
+      },
+    ] as unknown as SessionMessageInfo[]
+
+    expect(normalizeSessionMessages("ses_1", source).parts.get("msg_assistant")).toEqual([
+      expect.objectContaining({
+        state: expect.objectContaining({ status: "running", structured: { phase: "running" } }),
+      }),
+      expect.objectContaining({ state: expect.objectContaining({ status: "error", structured: { phase: "error" } }) }),
+    ])
+  })
+
+  test("uses current edit structured data as legacy renderer metadata", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "edit it", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_edit",
+            name: "edit",
+            state: {
+              status: "completed",
+              input: { path: "/repo/README.md", oldString: "old", newString: "new" },
+              structured: {
+                files: [
+                  {
+                    file: "README.md",
+                    patch: "@@ -1 +1 @@\n-old\n+new",
+                    additions: 1,
+                    deletions: 1,
+                  },
+                ],
+                replacements: 1,
+              },
+              content: [{ type: "text", text: "Edited file successfully" }],
+            },
+            time: { created: 2, ran: 3, completed: 4 },
+          },
+        ],
+        time: { created: 2, completed: 4 },
+      },
+    ] as unknown as SessionMessageInfo[]
+
+    const part = normalizeSessionMessages("ses_1", source).parts.get("msg_assistant")?.[0]
+
+    expect<unknown>(part?.type === "tool" ? part.state : undefined).toEqual({
+      status: "completed",
+      input: { path: "/repo/README.md", filePath: "/repo/README.md", oldString: "old", newString: "new" },
+      output: "Edited file successfully",
+      title: "edit",
+      structured: {
+        files: [
+          {
+            file: "README.md",
+            patch: "@@ -1 +1 @@\n-old\n+new",
+            additions: 1,
+            deletions: 1,
+          },
+        ],
+        replacements: 1,
+      },
+      metadata: {
+        files: [
+          {
+            file: "README.md",
+            patch: "@@ -1 +1 @@\n-old\n+new",
+            additions: 1,
+            deletions: 1,
+          },
+        ],
+        replacements: 1,
+        filediff: {
+          file: "README.md",
+          patch: "@@ -1 +1 @@\n-old\n+new",
+          additions: 1,
+          deletions: 1,
+        },
+      },
+      time: { start: 3, end: 4 },
+      attachments: undefined,
+    })
+  })
 })

--- a/packages/app/src/utils/session-message.ts
+++ b/packages/app/src/utils/session-message.ts
@@ -7,6 +7,7 @@ import type {
 } from "@opencode-ai/client/promise"
 import type { AssistantMessage, FilePart, Message, Part, ToolPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { Option, Schema } from "effect"
+import { attachToolStructured, readToolRendererMetadata, readToolStructured } from "./session-tool-structured"
 
 const emptyTokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
 const emptyModel: { id: string; providerID: string; variant?: string } = { id: "", providerID: "" }
@@ -301,23 +302,27 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
       return { status: "pending" as const, input, raw: tool.state.input }
     }
     if (tool.state.status === "running") {
-      return {
-        status: "running" as const,
-        input: normalizeToolInput(tool.name, tool.state.input),
-        // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-        metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
-        time: { start },
-      }
+      return attachToolStructured(
+        {
+          status: "running" as const,
+          input: normalizeToolInput(tool.name, tool.state.input),
+          metadata: normalizeToolMetadata(tool.name, readToolRendererMetadata(tool.name, tool.state) ?? {}),
+          time: { start },
+        },
+        readToolStructured(tool.state),
+      )
     }
     if (tool.state.status === "error") {
-      return {
-        status: "error" as const,
-        input: normalizeToolInput(tool.name, tool.state.input),
-        error: tool.state.error.message,
-        // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-        metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
-        time: { start, end: tool.time.completed ?? start },
-      }
+      return attachToolStructured(
+        {
+          status: "error" as const,
+          input: normalizeToolInput(tool.name, tool.state.input),
+          error: tool.state.error.message,
+          metadata: normalizeToolMetadata(tool.name, readToolRendererMetadata(tool.name, tool.state) ?? {}),
+          time: { start, end: tool.time.completed ?? start },
+        },
+        readToolStructured(tool.state),
+      )
     }
     const attachments = tool.state.content.flatMap((item, index): FilePart[] =>
       item.type === "file"
@@ -334,16 +339,18 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
           ]
         : [],
     )
-    return {
-      status: "completed" as const,
-      input: normalizeToolInput(tool.name, tool.state.input),
-      output: tool.state.content.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n"),
-      title: tool.name,
-      // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-      metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
-      time: { start, end: tool.time.completed ?? start },
-      attachments: attachments.length ? attachments : undefined,
-    }
+    return attachToolStructured(
+      {
+        status: "completed" as const,
+        input: normalizeToolInput(tool.name, tool.state.input),
+        output: tool.state.content.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n"),
+        title: tool.name,
+        metadata: normalizeToolMetadata(tool.name, readToolRendererMetadata(tool.name, tool.state) ?? {}),
+        time: { start, end: tool.time.completed ?? start },
+        attachments: attachments.length ? attachments : undefined,
+      },
+      readToolStructured(tool.state),
+    )
   })()
   return {
     id: tool.id,

--- a/packages/app/src/utils/session-tool-structured.test.ts
+++ b/packages/app/src/utils/session-tool-structured.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import {
+  attachToolStructured,
+  hasToolStructured,
+  readToolRendererMetadata,
+  readToolStructured,
+} from "./session-tool-structured"
+
+describe("session tool structured projection", () => {
+  test("prefers a current structured value over legacy metadata", () => {
+    expect(readToolStructured({ structured: { version: 1 }, metadata: { legacy: true } })).toEqual({ version: 1 })
+    expect(readToolStructured({ structured: undefined, metadata: { legacy: true } })).toBeUndefined()
+    expect(readToolStructured({ structured: null, metadata: { legacy: true } })).toBeNull()
+  })
+
+  test("falls back to legacy metadata when structured is absent", () => {
+    expect(readToolStructured({ metadata: { legacy: true } })).toEqual({ legacy: true })
+  })
+
+  test("rejects null and array containers", () => {
+    expect(readToolStructured(null)).toBeUndefined()
+    expect(readToolStructured([])).toBeUndefined()
+  })
+
+  test("does not attach an undefined structured value", () => {
+    expect(attachToolStructured({ status: "running" }, undefined)).toEqual({ status: "running" })
+    expect(attachToolStructured({ status: "running" }, null)).toEqual({ status: "running", structured: null })
+    expect(attachToolStructured({ status: "running" }, { version: 1 })).toEqual({
+      status: "running",
+      structured: { version: 1 },
+    })
+  })
+
+  test("distinguishes an explicit structured field from a legacy metadata fallback", () => {
+    expect(hasToolStructured({ metadata: {} })).toBeFalse()
+    expect(hasToolStructured({ structured: undefined })).toBeTrue()
+    expect(hasToolStructured({ structured: null })).toBeTrue()
+  })
+
+  test("keeps renderer metadata and only falls back to structured data for ordinary tools", () => {
+    expect(
+      readToolRendererMetadata("edit", {
+        metadata: { source: "legacy" },
+        structured: { source: "current" },
+      }),
+    ).toEqual({ source: "legacy" })
+    expect(readToolRendererMetadata("edit", { structured: { source: "current" } })).toEqual({ source: "current" })
+    expect(
+      readToolRendererMetadata("visualization_create", {
+        structured: { version: 1, title: "Chart", html: "<section>chart</section>" },
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/packages/app/src/utils/session-tool-structured.ts
+++ b/packages/app/src/utils/session-tool-structured.ts
@@ -1,0 +1,24 @@
+function record(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+export function readToolStructured(value: unknown) {
+  if (!record(value)) return
+  if ("structured" in value) return value.structured
+  return value.metadata
+}
+
+export function hasToolStructured(value: unknown): value is Record<string, unknown> & { structured: unknown } {
+  return record(value) && "structured" in value
+}
+
+export function readToolRendererMetadata(toolName: string, value: unknown) {
+  if (!record(value)) return
+  if (record(value.metadata)) return value.metadata
+  if (toolName !== "visualization_create" && record(value.structured)) return value.structured
+}
+
+export function attachToolStructured<T extends object>(state: T, structured: unknown): T & { structured?: unknown } {
+  if (structured === undefined) return state
+  return { ...state, structured }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import * as Effect from "effect/Effect"
 import { Commands } from "./commands/commands"
 import { Runtime } from "./framework/runtime"
 import { Daemon } from "./services/daemon"
+import { CLI_RUNTIME_VERSION } from "./version"
 
 const Handlers = Runtime.handlers(Commands, {
   $: () => import("./commands/handlers/default"),
@@ -24,7 +25,7 @@ const Handlers = Runtime.handlers(Commands, {
   serve: () => import("./commands/handlers/serve"),
 })
 
-Runtime.run(Commands, Handlers, { version: "local" }).pipe(
+Runtime.run(Commands, Handlers, { version: CLI_RUNTIME_VERSION }).pipe(
   Effect.provide(Daemon.layer),
   Effect.provide(NodeServices.layer),
   Effect.scoped,

--- a/packages/cli/src/version.test.ts
+++ b/packages/cli/src/version.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+
+import { CLI_RUNTIME_VERSION } from "./version"
+
+test("uses the installation version for the CLI runtime", () => {
+  expect(CLI_RUNTIME_VERSION).toBe(InstallationVersion)
+})

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,3 @@
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+
+export const CLI_RUNTIME_VERSION = InstallationVersion

--- a/packages/core/src/tool/builtins.ts
+++ b/packages/core/src/tool/builtins.ts
@@ -11,6 +11,7 @@ import { QuestionTool } from "./question"
 import { ReadTool } from "./read"
 import { SkillTool } from "./skill"
 import { TodoWriteTool } from "./todowrite"
+import { VisualizationTool } from "./visualization"
 import { WebFetchTool } from "./webfetch"
 import { WebSearchTool } from "./websearch"
 import { WriteTool } from "./write"
@@ -41,6 +42,7 @@ export const node = makeLocationNode({
     ReadTool.node,
     SkillTool.node,
     TodoWriteTool.node,
+    VisualizationTool.node,
     WebFetchTool.node,
     WebSearchTool.node,
     WriteTool.node,

--- a/packages/core/src/tool/visualization.ts
+++ b/packages/core/src/tool/visualization.ts
@@ -1,0 +1,94 @@
+export * as VisualizationTool from "./visualization"
+
+import { ToolFailure } from "@opencode-ai/llm"
+import { Effect, Layer, Schema } from "effect"
+import { Parser } from "htmlparser2"
+import { makeLocationNode } from "../effect/app-node"
+import { ToolRegistry } from "./registry"
+import { Tool } from "./tool"
+import { Tools } from "./tools"
+
+export const name = "visualization_create"
+export const MODEL_OUTPUT = "Visualization created"
+export const MAX_TITLE_LENGTH = 120
+export const MAX_HTML_BYTES = 128 * 1024
+
+export const Input = Schema.Struct({
+  title: Schema.String.annotate({ description: "A concise title for the visualization" }),
+  html: Schema.String.annotate({ description: "An HTML fragment containing the visualization" }),
+})
+
+export const Output = Schema.Struct({
+  version: Schema.Literal(1),
+  title: Schema.String,
+  html: Schema.String,
+})
+export type Output = typeof Output.Type
+
+const documentRoots = new Set(["html", "head", "body"])
+
+const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const tools = yield* Tools.Service
+
+    yield* tools
+      .register({
+        [name]: Tool.make({
+          description:
+            "Create an interactive visualization from a self-contained HTML fragment hosted on a transparent conversation background. Do not set a background on html, body, or a full-viewport wrapper. Do not use 100vh or negative page margins; put intentional backgrounds only on bounded visual elements such as cards, charts, and clock faces.",
+          input: Input,
+          output: Output,
+          toModelOutput: () => [{ type: "text", text: MODEL_OUTPUT }],
+          execute: (input) => {
+            const title = input.title.trim()
+            const titleLength = Array.from(title).length
+            if (titleLength < 1 || titleLength > MAX_TITLE_LENGTH)
+              return Effect.fail(
+                new ToolFailure({
+                  message: `Visualization title must contain 1 to ${MAX_TITLE_LENGTH} Unicode characters`,
+                }),
+              )
+            if (!input.html.trim())
+              return Effect.fail(new ToolFailure({ message: "Visualization HTML must not be empty" }))
+            if (Buffer.byteLength(input.html, "utf-8") > MAX_HTML_BYTES)
+              return Effect.fail(
+                new ToolFailure({
+                  message: `Visualization HTML must not exceed ${MAX_HTML_BYTES / 1024} KiB in UTF-8`,
+                }),
+              )
+            return Effect.try({
+              try: () => {
+                if (!isFragment(input.html)) throw new Error("document root")
+                return { version: 1 as const, title, html: input.html }
+              },
+              catch: () => new ToolFailure({ message: "Visualization HTML must be a fragment" }),
+            })
+          },
+        }),
+      })
+      .pipe(Effect.orDie)
+  }),
+)
+
+export const node = makeLocationNode({
+  name: "tool/visualization",
+  layer,
+  deps: [ToolRegistry.node],
+})
+
+function isFragment(html: string) {
+  let valid = true
+  const parser = new Parser(
+    {
+      onprocessinginstruction(name) {
+        if (name.toLowerCase() === "!doctype") valid = false
+      },
+      onopentag(name) {
+        if (documentRoots.has(name.toLowerCase())) valid = false
+      },
+    },
+    { recognizeSelfClosing: true },
+  )
+  parser.end(html)
+  return valid
+}

--- a/packages/core/test/tool-visualization.test.ts
+++ b/packages/core/test/tool-visualization.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { BuiltInTools } from "@opencode-ai/core/tool/builtins"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { VisualizationTool } from "@opencode-ai/core/tool/visualization"
+import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
+import { testEffect } from "./lib/effect"
+import { executeTool, settleTool, toolDefinitions, toolIdentity } from "./lib/tool"
+
+const sessionID = SessionV2.ID.make("ses_visualization_tool_test")
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, VisualizationTool.node]), [
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ]),
+)
+
+const call = (input: { readonly title: string; readonly html: string }, id = "call-visualization") => ({
+  sessionID,
+  ...toolIdentity,
+  call: { type: "tool-call" as const, id, name: VisualizationTool.name, input },
+})
+
+describe("VisualizationTool registration", () => {
+  it.effect("registers and returns trimmed structured output with a fixed model-visible result", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const html = '<section data-kind="chart">hello</section>'
+
+      const definitions = yield* toolDefinitions(registry)
+      expect(definitions.map((tool) => tool.name)).toEqual([VisualizationTool.name])
+      expect(definitions[0]?.description).toContain("transparent conversation background")
+      expect(definitions[0]?.description).toContain("100vh")
+      expect(definitions[0]?.description).toContain("negative page margins")
+      expect(yield* settleTool(registry, call({ title: "  Quarterly chart  ", html }))).toEqual({
+        result: { type: "text", value: VisualizationTool.MODEL_OUTPUT },
+        output: {
+          structured: { version: 1, title: "Quarterly chart", html },
+          content: [{ type: "text", text: VisualizationTool.MODEL_OUTPUT }],
+        },
+      })
+    }),
+  )
+
+  it.effect("is hidden from the catalog when its whole default action is denied", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      expect(
+        yield* toolDefinitions(registry, [{ action: VisualizationTool.name, resource: "*", effect: "deny" }]),
+      ).toEqual([])
+    }),
+  )
+
+  test("is included in the shipped built-in dependency catalog", () => {
+    expect(BuiltInTools.node.dependencies).toContain(VisualizationTool.node)
+  })
+})
+
+describe("VisualizationTool validation", () => {
+  it.effect("counts trimmed titles by Unicode code point", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ascii = "a".repeat(VisualizationTool.MAX_TITLE_LENGTH)
+      const emoji = "😀".repeat(VisualizationTool.MAX_TITLE_LENGTH)
+
+      expect(yield* executeTool(registry, call({ title: ` ${ascii} `, html: "<div />" }, "call-ascii"))).toEqual({
+        type: "text",
+        value: VisualizationTool.MODEL_OUTPUT,
+      })
+      expect(yield* executeTool(registry, call({ title: ` ${emoji} `, html: "<div />" }, "call-emoji"))).toEqual({
+        type: "text",
+        value: VisualizationTool.MODEL_OUTPUT,
+      })
+      expect(
+        yield* executeTool(
+          registry,
+          call({ title: "😀".repeat(VisualizationTool.MAX_TITLE_LENGTH + 1), html: "<div />" }, "call-too-long"),
+        ),
+      ).toEqual({
+        type: "error",
+        value: `Visualization title must contain 1 to ${VisualizationTool.MAX_TITLE_LENGTH} Unicode characters`,
+      })
+    }),
+  )
+
+  it.effect("enforces the HTML limit in UTF-8 bytes", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const available = VisualizationTool.MAX_HTML_BYTES - Buffer.byteLength("<p></p>", "utf-8")
+      const content = "界".repeat(Math.floor(available / 3)) + "a".repeat(available % 3)
+      const boundary = `<p>${content}</p>`
+      const oversized = `<p>${content}😀</p>`
+
+      expect(Buffer.byteLength(boundary, "utf-8")).toBe(VisualizationTool.MAX_HTML_BYTES)
+      expect(yield* executeTool(registry, call({ title: "Boundary", html: boundary }, "call-boundary"))).toEqual({
+        type: "text",
+        value: VisualizationTool.MODEL_OUTPUT,
+      })
+      expect(yield* executeTool(registry, call({ title: "Oversized", html: oversized }, "call-oversized"))).toEqual({
+        type: "error",
+        value: `Visualization HTML must not exceed ${VisualizationTool.MAX_HTML_BYTES / 1024} KiB in UTF-8`,
+      })
+    }),
+  )
+
+  it.effect("rejects empty titles and HTML", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ title: "   ", html: "<div />" }, "call-empty-title"))).toEqual({
+        type: "error",
+        value: `Visualization title must contain 1 to ${VisualizationTool.MAX_TITLE_LENGTH} Unicode characters`,
+      })
+      expect(yield* executeTool(registry, call({ title: "Empty", html: "" }, "call-empty-html"))).toEqual({
+        type: "error",
+        value: "Visualization HTML must not be empty",
+      })
+      expect(yield* executeTool(registry, call({ title: "Blank", html: " \n\t " }, "call-blank-html"))).toEqual({
+        type: "error",
+        value: "Visualization HTML must not be empty",
+      })
+    }),
+  )
+
+  it.effect("rejects document tokens nested inside fragments, including unclosed nested doctypes", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const adversarial = [
+        "<div><HtMl><p>secret-nested-html</p></hTmL></div>",
+        "<section><HEAD><title>secret-nested-head</title></head></section>",
+        "<main><BoDy><p>secret-nested-body</p></bOdY></main>",
+        "<div><span><!DoCtYpE html>secret-unclosed-doctype",
+      ]
+
+      for (const [index, html] of adversarial.entries()) {
+        const result = yield* executeTool(registry, call({ title: "Nested document", html }, `call-nested-${index}`))
+        expect(result).toEqual({ type: "error", value: "Visualization HTML must be a fragment" })
+        expect(result.value).not.toContain("secret-")
+        expect(result.value).not.toContain(html)
+      }
+    }),
+  )
+
+  it.effect("rejects document roots regardless of case, comments, or surrounding whitespace", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const documents = [
+        " \n<!-- before --><!DoCtYpE html><main>secret-doctype</main>",
+        "\t<!-- before --><HtMl><div>secret-html</div></hTmL>",
+        " <!-- before --><HEAD><title>secret-head</title></head>",
+        "\n<!-- before --><BoDy><p>secret-body</p></bOdY>",
+      ]
+
+      for (const [index, html] of documents.entries()) {
+        const result = yield* executeTool(registry, call({ title: "Document", html }, `call-document-${index}`))
+        expect(result).toEqual({ type: "error", value: "Visualization HTML must be a fragment" })
+        expect(result.value).not.toContain("secret-")
+        expect(result.value).not.toContain(html)
+      }
+    }),
+  )
+
+  it.effect("allows document-like text inside a script string", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const html = '<script>const template = "<body><main>chart</main></body>"</script><div id="chart"></div>'
+
+      expect(yield* settleTool(registry, call({ title: "Script fragment", html }))).toEqual({
+        result: { type: "text", value: VisualizationTool.MODEL_OUTPUT },
+        output: {
+          structured: { version: 1, title: "Script fragment", html },
+          content: [{ type: "text", text: VisualizationTool.MODEL_OUTPUT }],
+        },
+      })
+    }),
+  )
+})

--- a/packages/desktop/scripts/utils.test.ts
+++ b/packages/desktop/scripts/utils.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+
+import { resolveCliSource } from "./utils"
+
+test("uses the configured local CLI path", () => {
+  expect(resolveCliSource({ OPENCODE_DESKTOP_CLI_PATH: "/tmp/opencode-cli" })).toEqual({
+    type: "local",
+    path: "/tmp/opencode-cli",
+  })
+})
+
+test("uses the remote CLI when no local path is configured", () => {
+  expect(resolveCliSource({})).toEqual({ type: "remote" })
+})

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -69,18 +69,29 @@ export function getCurrentCli(target = RUST_TARGET ?? nativeTarget()) {
   return binaryConfig
 }
 
+export function resolveCliSource(env = Bun.env) {
+  const path = env.OPENCODE_DESKTOP_CLI_PATH
+  if (path) return { type: "local" as const, path }
+  return { type: "remote" as const }
+}
+
 export async function downloadCliToResources() {
-  const cli = getCurrentCli()
-  const directory = await mkdtemp(join(tmpdir(), "opencode-cli-"))
+  const source = resolveCliSource()
   const dest = windowsify("resources/opencode-cli")
-  try {
-    await $`bun install --no-save --cwd ${directory} ${`${cli.package}@${CLI_VERSION}`} ${`--os=${cli.os}`} ${`--cpu=${cli.cpu}`}`
-    await copyFile(
-      join(directory, "node_modules", cli.package, "bin", cli.os === "win32" ? "opencode2.exe" : "opencode2"),
-      dest,
-    )
-  } finally {
-    await rm(directory, { recursive: true, force: true })
+  if (source.type === "local") {
+    await copyFile(source.path, dest)
+  } else {
+    const cli = getCurrentCli()
+    const directory = await mkdtemp(join(tmpdir(), "opencode-cli-"))
+    try {
+      await $`bun install --no-save --cwd ${directory} ${`${cli.package}@${CLI_VERSION}`} ${`--os=${cli.os}`} ${`--cpu=${cli.cpu}`}`
+      await copyFile(
+        join(directory, "node_modules", cli.package, "bin", cli.os === "win32" ? "opencode2.exe" : "opencode2"),
+        dest,
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   }
   if (process.platform !== "win32") await chmod(dest, 0o755)
   if (process.platform === "win32" && process.env.GITHUB_ACTIONS === "true") {
@@ -88,7 +99,9 @@ export async function downloadCliToResources() {
   }
   if (process.platform === "darwin") await $`codesign --force --sign - ${dest}`
 
-  console.log(`Copied ${cli.package} to ${dest}`)
+  console.log(
+    `Copied ${source.type === "local" ? `local CLI from ${source.path}` : getCurrentCli().package} to ${dest}`,
+  )
 }
 
 export function windowsify(path: string) {

--- a/packages/desktop/src/main/background-cli-command.ts
+++ b/packages/desktop/src/main/background-cli-command.ts
@@ -1,0 +1,1 @@
+export const BACKGROUND_CLI_PASSWORD_ARGS = ["service", "password"]

--- a/packages/desktop/src/main/background-cli.test.ts
+++ b/packages/desktop/src/main/background-cli.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+
+import { BACKGROUND_CLI_PASSWORD_ARGS } from "./background-cli-command"
+
+test("uses the current v2 CLI password command", () => {
+  expect(BACKGROUND_CLI_PASSWORD_ARGS).toEqual(["service", "password"])
+})

--- a/packages/desktop/src/main/background-cli.ts
+++ b/packages/desktop/src/main/background-cli.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 import { app } from "electron"
+import { BACKGROUND_CLI_PASSWORD_ARGS } from "./background-cli-command"
 
 const execFileAsync = promisify(execFile)
 const root = dirname(fileURLToPath(import.meta.url))
@@ -41,7 +42,7 @@ export async function startBackgroundCli(logger: Logger, shellStateHome?: string
 
   const daemonStateHome = found?.stateHome ?? stateHome
   const url = await run(binary, ["service", "start"], logger, { stateHome: daemonStateHome })
-  const password = await run(binary, ["service", "get", "password"], logger, {
+  const password = await run(binary, BACKGROUND_CLI_PASSWORD_ARGS, logger, {
     redact: true,
     stateHome: daemonStateHome,
   })

--- a/packages/desktop/src/main/navigation-policy.test.ts
+++ b/packages/desktop/src/main/navigation-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+import { wireNavigationPolicy } from "./navigation-policy"
+
+function setup() {
+  const listeners = new Map<string, (...args: never[]) => void>()
+  const opened: string[] = []
+  wireNavigationPolicy(
+    {
+      setWindowOpenHandler: () => ({ action: "deny" as const }),
+      on: (event, listener) => {
+        listeners.set(event, listener as (...args: never[]) => void)
+      },
+    } as never,
+    {
+      isRendererUrl: (url) => url === "oc://renderer/index.html",
+      openExternal: (url) => opened.push(url),
+    },
+  )
+
+  const frame = (url: string, isMainFrame: boolean) => {
+    const event = {
+      url,
+      isMainFrame,
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    listeners.get("will-frame-navigate")?.(event as never)
+    return event
+  }
+  const navigate = (url: string) => {
+    const event = {
+      prevented: false,
+      preventDefault() {
+        this.prevented = true
+      },
+    }
+    listeners.get("will-navigate")?.(event as never, url as never)
+    return event
+  }
+
+  return { frame, navigate, opened }
+}
+
+describe("window navigation policy", () => {
+  test("blocks every untrusted subframe navigation without opening it while preserving main-frame handling", () => {
+    const subject = setup()
+
+    for (const url of [
+      "https://visualization-e2e.invalid/self",
+      "data:text/html,<script>location='https://visualization-e2e.invalid'</script>",
+      "blob:https://visualization-e2e.invalid/id",
+      "javascript:location='https://visualization-e2e.invalid'",
+      "about:blank",
+    ]) {
+      expect(subject.frame(url, false).prevented).toBe(true)
+    }
+    expect(subject.opened).toEqual([])
+    expect(subject.frame("https://visualization-e2e.invalid/main", true).prevented).toBe(false)
+    expect(subject.navigate("https://visualization-e2e.invalid/main").prevented).toBe(true)
+    expect(subject.opened).toEqual(["https://visualization-e2e.invalid/main"])
+    expect(subject.frame("about:srcdoc", false).prevented).toBe(false)
+    expect(subject.frame("oc://renderer/index.html", false).prevented).toBe(true)
+  })
+})

--- a/packages/desktop/src/main/navigation-policy.ts
+++ b/packages/desktop/src/main/navigation-policy.ts
@@ -1,0 +1,27 @@
+import type { WebContents } from "electron"
+
+type NavigationPolicyDependencies = {
+  isRendererUrl: (url: string) => boolean
+  openExternal: (url: string) => void
+}
+
+export function wireNavigationPolicy(
+  webContents: Pick<WebContents, "setWindowOpenHandler" | "on">,
+  dependencies: NavigationPolicyDependencies,
+) {
+  webContents.setWindowOpenHandler(({ url }) => {
+    if (!dependencies.isRendererUrl(url)) dependencies.openExternal(url)
+    return { action: "deny" }
+  })
+  // Renderer reloads (window.location.reload) navigate to the app's own URL
+  // and must stay in-window; everything else leaves through the OS.
+  webContents.on("will-navigate", (event, url) => {
+    if (dependencies.isRendererUrl(url)) return
+    event.preventDefault()
+    dependencies.openExternal(url)
+  })
+  webContents.on("will-frame-navigate", (details) => {
+    if (details.isMainFrame || details.url === "about:srcdoc") return
+    details.preventDefault()
+  })
+}

--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -16,6 +16,7 @@ import { nativeT } from "./native-translations"
 import { createWindowRegistry } from "./window-registry"
 import { safeWindowURL } from "./window-state"
 import { resolveExternalURL, resolveLocalFilePath } from "./external-url"
+import { wireNavigationPolicy } from "./navigation-policy"
 
 const root = dirname(fileURLToPath(import.meta.url))
 const rendererRoot = join(root, "../renderer")
@@ -206,7 +207,7 @@ export function createMainWindow(id: string = randomUUID()) {
 
   allowRendererPermissions(win)
   wireWindowRecovery(win, id)
-  wireNavigationPolicy(win)
+  wireNavigationPolicy(win.webContents, { isRendererUrl, openExternal: openExternalURL })
 
   win.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
     const { requestHeaders } = details
@@ -250,20 +251,6 @@ export function openLocalFileURL(value: string) {
   }
   void shell.openPath(path).then((error) => {
     if (error) writeLog("window", "failed to open local file", { path, error }, "error")
-  })
-}
-
-function wireNavigationPolicy(win: BrowserWindow) {
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    if (!isRendererUrl(url)) openExternalURL(url)
-    return { action: "deny" }
-  })
-  // Renderer reloads (window.location.reload) navigate to the app's own URL
-  // and must stay in-window; everything else leaves through the OS.
-  win.webContents.on("will-navigate", (event, url) => {
-    if (isRendererUrl(url)) return
-    event.preventDefault()
-    openExternalURL(url)
   })
 }
 

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -10,6 +10,7 @@ import { Skill } from "../skill"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 import { LegacyEvent } from "@opencode-ai/schema/legacy-event"
+import * as Visualize from "./visualize"
 
 type State = {
   commands: Record<string, Info>
@@ -28,6 +29,7 @@ export const Info = Schema.Struct({
   // Some command templates are lazy promises from MCP prompt resolution.
   template: Schema.Unknown,
   subtask: Schema.optional(Schema.Boolean),
+  visualization: Schema.optional(Schema.Boolean),
   hints: Schema.Array(Schema.String),
 }).annotate({ identifier: "Command" })
 
@@ -46,6 +48,7 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  VISUALIZE: Visualize.name,
 } as const
 
 export interface Interface {
@@ -85,6 +88,14 @@ const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.VISUALIZE] = {
+        name: Default.VISUALIZE,
+        description: Visualize.description,
+        source: "command",
+        template: "$ARGUMENTS",
+        visualization: true,
+        hints: ["$ARGUMENTS"],
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {

--- a/packages/opencode/src/command/visualize.ts
+++ b/packages/opencode/src/command/visualize.ts
@@ -1,0 +1,16 @@
+export const name = "visualize"
+export const toolID = "visualization_create"
+export const description = "create an interactive visualization in the current conversation"
+
+export const system = [
+  "Create the requested interactive visualization directly in this conversation.",
+  "You MUST call visualization_create on your next turn.",
+  "The HTML fragment is hosted on a transparent conversation background.",
+  "Do not set a background on html, body, or a full-viewport wrapper. Do not use 100vh or negative page margins.",
+  "Put intentional backgrounds only on bounded visual elements such as cards, charts, and clock faces.",
+  "Do not use shell commands, create files, or open a browser.",
+].join("\n")
+
+export function isSystem(value: unknown) {
+  return value === system
+}

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -17,6 +17,10 @@ function mimeToModality(mime: string): Modality | undefined {
 
 export const OUTPUT_TOKEN_MAX = 32_000
 
+export function supportsToolChoice(model: Pick<Provider.Model, "id" | "api">) {
+  return ![model.id, model.api.id].some((id) => id.toLowerCase().includes("deepseek-v4"))
+}
+
 // OpenAI Responses `include` value that returns the encrypted reasoning state
 // needed for stateless multi-turn reasoning (store: false). Hoisted so every
 // branch that requests it stays in lockstep.

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -231,7 +231,7 @@ const live: Layer.Layer<
           llmClient,
           messages: prepared.messages,
           tools: prepared.tools,
-          toolChoice: input.toolChoice,
+          toolChoice: ProviderTransform.supportsToolChoice(input.model) ? input.toolChoice : undefined,
           temperature: prepared.params.temperature,
           topP: prepared.params.topP,
           topK: prepared.params.topK,
@@ -328,6 +328,7 @@ const live: Layer.Layer<
               {
                 specificationVersion: "v3" as const,
                 async transformParams(args) {
+                  if (!ProviderTransform.supportsToolChoice(input.model)) args.params.toolChoice = undefined
                   if (args.type === "stream") {
                     // @ts-expect-error
                     args.params.prompt = ProviderTransform.message(

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -43,6 +43,10 @@ type StreamInput = {
   readonly abort: AbortSignal
 }
 
+type ToolWithModelOutput = Tool & {
+  __opencodeToModelOutput?: (output: unknown) => string
+}
+
 export function status(input: Pick<StreamInput, "model" | "provider" | "auth">): RuntimeStatus {
   return statusWithFetch(input, providerFetch(input))
 }
@@ -166,7 +170,10 @@ function nativeSchema(value: unknown): JsonSchema {
   return asSchema(value as Parameters<typeof asSchema>[0]).jsonSchema as JsonSchema
 }
 
-export function nativeTools(tools: Record<string, Tool>, input: Pick<StreamInput, "messages" | "abort">) {
+export function nativeTools(
+  tools: Record<string, ToolWithModelOutput>,
+  input: Pick<StreamInput, "messages" | "abort">,
+) {
   return Object.fromEntries(
     Object.entries(tools).map(([name, item]) => [
       name,
@@ -175,7 +182,12 @@ export function nativeTools(tools: Record<string, Tool>, input: Pick<StreamInput
       NativeTool.make({
         description: item.description ?? "",
         jsonSchema: nativeSchema(item.inputSchema),
-        execute: (args: unknown, ctx) =>
+        toModelOutput: item.__opencodeToModelOutput
+          ? ({ output }: { output: unknown }) => [
+              { type: "text" as const, text: item.__opencodeToModelOutput!(output) },
+            ]
+          : undefined,
+        execute: (args: unknown, ctx?: { id: string }) =>
           Effect.tryPromise({
             try: () => {
               if (!item.execute) throw new Error(`Tool has no execute handler: ${name}`)

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -257,6 +257,15 @@ const layer = Layer.effect(
       const toolResultOutput = (
         value: Extract<StreamEvent, { type: "tool-result" }>,
       ): { title: string; metadata: Record<string, any>; output: string; attachments?: SessionV1.FilePart[] } => {
+        const structured = value.output?.structured
+        if (isRecord(structured) && typeof structured.output === "string") {
+          return {
+            title: typeof structured.title === "string" ? structured.title : value.name,
+            metadata: isRecord(structured.metadata) ? structured.metadata : {},
+            output: structured.output,
+            attachments: Array.isArray(structured.attachments) ? structured.attachments.filter(isFilePart) : undefined,
+          }
+        }
         if (isRecord(value.result.value) && typeof value.result.value.output === "string") {
           return {
             title: typeof value.result.value.title === "string" ? value.result.value.title : value.name,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -47,6 +47,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { TaskTool, type TaskPromptOps } from "@/tool/task"
 import { SessionRunState } from "./run-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import * as Visualize from "@/command/visualize"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -1096,6 +1097,7 @@ const layer = Layer.effect(
           const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
 
           if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+          const visualization = Visualize.isSystem(lastUser.system)
 
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
@@ -1231,6 +1233,7 @@ const layer = Layer.effect(
               bypassAgentCheck,
               messages: msgs,
               promptOps,
+              only: visualization && step === 1 ? [Visualize.toolID] : undefined,
             }).pipe(
               Effect.provideService(Plugin.Service, plugin),
               Effect.provideService(Permission.Service, permission),
@@ -1282,7 +1285,8 @@ const layer = Layer.effect(
               ],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? "required" : undefined,
+              toolChoice:
+                visualization && step === 1 ? "required" : format.type === "json_schema" ? "required" : undefined,
             })
 
             if (structured !== undefined) {
@@ -1469,6 +1473,7 @@ const layer = Layer.effect(
         model: userModel,
         agent: userAgent,
         parts,
+        system: cmd.visualization ? Visualize.system : undefined,
         variant: input.variant,
       })
       yield* events.publish(Command.Event.Executed, {

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -24,6 +24,10 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { isRecord } from "@/util/record"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
+type ToolWithModelOutput = AITool & {
+  __opencodeToModelOutput?: (output: unknown) => string
+}
+
 const MCP_RESOURCE_TOOLS = {
   list: "list_mcp_resources",
   listTemplates: "list_mcp_resource_templates",
@@ -46,6 +50,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   bypassAgentCheck: boolean
   messages: SessionV1.WithParts[]
   promptOps: TaskPromptOps
+  only?: readonly string[]
 }) {
   const tools: Record<string, AITool> = {}
   const run = yield* EffectBridge.make()
@@ -95,10 +100,16 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     agent: input.agent,
     permission: input.session.permission,
   })) {
+    if (input.only && !input.only.includes(item.id)) continue
     const schema = ProviderTransform.schema(input.model, ToolJsonSchema.fromTool(item))
-    tools[item.id] = tool({
+    const resolved: ToolWithModelOutput = tool({
       description: item.description,
       inputSchema: jsonSchema(schema),
+      ...(item.toModelOutput
+        ? {
+            toModelOutput: ({ output }) => ({ type: "text" as const, value: item.toModelOutput!(output) }),
+          }
+        : {}),
       execute(args, options) {
         return run.promise(
           Effect.gen(function* () {
@@ -131,7 +142,11 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         )
       },
     })
+    if (item.toModelOutput) resolved.__opencodeToModelOutput = (output) => item.toModelOutput!(output as never)
+    tools[item.id] = resolved
   }
+
+  if (input.only) return tools
 
   const hasMcpResourceServer = Object.values(yield* mcp.clients()).some(
     (client) => !!client.getServerCapabilities()?.resources,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -29,6 +29,7 @@ import { WebSearchTool } from "./websearch"
 import { LspTool } from "./lsp"
 import * as Truncate from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
+import { VisualizationTool } from "./visualization"
 import { Glob } from "@opencode-ai/core/util/glob"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -109,6 +110,7 @@ const layer = Layer.effect(
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const visualization = yield* VisualizationTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -218,6 +220,7 @@ const layer = Layer.effect(
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          visualization: Tool.init(visualization),
           ...(codeModeTool ? { execute: Tool.init(codeModeTool) } : {}),
         })
 
@@ -241,6 +244,7 @@ const layer = Layer.effect(
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
+            tool.visualization,
           ],
           task: tool.task,
           read: tool.read,
@@ -327,6 +331,7 @@ const layer = Layer.effect(
             parameters: output.parameters,
             jsonSchema,
             execute: tool.execute,
+            toModelOutput: tool.toModelOutput,
             formatValidationError: tool.formatValidationError,
           }
         }),

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -61,6 +61,7 @@ export interface Def<
   parameters: Parameters
   jsonSchema?: JSONSchema7
   execute(args: Schema.Schema.Type<Parameters>, ctx: Context): Effect.Effect<ExecuteResult<M>>
+  toModelOutput?(result: ExecuteResult<M>): string
   formatValidationError?(error: unknown): string
 }
 export type DefWithoutID<

--- a/packages/opencode/src/tool/visualization.ts
+++ b/packages/opencode/src/tool/visualization.ts
@@ -1,0 +1,69 @@
+import { Effect, Schema } from "effect"
+import { Parser } from "htmlparser2"
+import * as Tool from "./tool"
+
+export const MODEL_OUTPUT = "Visualization created"
+export const MAX_TITLE_LENGTH = 120
+export const MAX_HTML_BYTES = 128 * 1024
+
+export const Parameters = Schema.Struct({
+  title: Schema.String.annotate({ description: "A concise title for the visualization" }),
+  html: Schema.String.annotate({ description: "An HTML fragment containing the visualization" }),
+})
+
+type Metadata = {
+  version: 1
+  title: string
+  html: string
+  truncated?: boolean
+}
+
+const documentRoots = new Set(["html", "head", "body"])
+
+export const VisualizationTool = Tool.define<typeof Parameters, Metadata, never>(
+  "visualization_create",
+  Effect.succeed({
+    description:
+      "Render a self-contained interactive HTML visualization inline on a transparent conversation background in the current Desktop conversation. Do not set a background on html, body, or a full-viewport wrapper. Do not use 100vh or negative page margins; put intentional backgrounds only on bounded visual elements such as cards, charts, and clock faces. Use this whenever the user asks to view, preview, explore, simulate, plot, or adjust an interactive visual in the chat. Do not use Shell or create/open an HTML file for those requests unless the user explicitly asks for a file or browser.",
+    parameters: Parameters,
+    toModelOutput: () => MODEL_OUTPUT,
+    execute: (input) =>
+      Effect.sync(() => {
+        const metadata = validate(input)
+        return {
+          title: metadata.title,
+          output: MODEL_OUTPUT,
+          metadata,
+        }
+      }),
+  }),
+)
+
+function validate(input: Schema.Schema.Type<typeof Parameters>): Metadata {
+  const title = input.title.trim()
+  const titleLength = Array.from(title).length
+  if (titleLength < 1 || titleLength > MAX_TITLE_LENGTH)
+    throw new Error(`Visualization title must contain 1 to ${MAX_TITLE_LENGTH} Unicode characters`)
+  if (!input.html.trim()) throw new Error("Visualization HTML must not be empty")
+  if (Buffer.byteLength(input.html, "utf-8") > MAX_HTML_BYTES)
+    throw new Error(`Visualization HTML must not exceed ${MAX_HTML_BYTES / 1024} KiB in UTF-8`)
+  if (!isFragment(input.html)) throw new Error("Visualization HTML must be a fragment")
+  return { version: 1, title, html: input.html }
+}
+
+function isFragment(html: string) {
+  let valid = true
+  const parser = new Parser(
+    {
+      onprocessinginstruction(name) {
+        if (name.toLowerCase() === "!doctype") valid = false
+      },
+      onopentag(name) {
+        if (documentRoots.has(name.toLowerCase())) valid = false
+      },
+    },
+    { recognizeSelfClosing: true },
+  )
+  parser.end(html)
+  return valid
+}

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1776,6 +1776,88 @@ unix(
   30_000,
 )
 
+it.instance("visualize command requires only the visualization tool on its first turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, chat } = yield* boot()
+    yield* llm.tool("visualization_create", { title: "Clock", html: '<div id="clock"></div>' })
+    yield* llm.text("done")
+
+    const result = yield* prompt.command({
+      sessionID: chat.id,
+      command: "visualize",
+      arguments: "在会话中预览个时钟",
+    })
+
+    expect(result.info.role).toBe("assistant")
+    const request = (yield* llm.inputs).find((input) => input.tool_choice === "required")
+    expect(request?.tool_choice).toBe("required")
+    expect(request?.tools).toEqual([
+      expect.objectContaining({ function: expect.objectContaining({ name: "visualization_create" }) }),
+    ])
+    expect(JSON.stringify(request?.messages)).toContain("transparent conversation background")
+    expect(JSON.stringify(request?.messages)).toContain("100vh")
+    expect(JSON.stringify(request?.messages)).toContain("negative page margins")
+    const inputs = yield* llm.inputs
+    expect(JSON.stringify(inputs)).toContain("Visualization created")
+    expect(JSON.stringify(inputs)).not.toContain('id=\\"clock\\"')
+
+    const tool = (yield* MessageV2.filterCompactedEffect(chat.id))
+      .flatMap((message) => message.parts)
+      .find((part): part is CompletedToolPart => part.type === "tool" && part.tool === "visualization_create")
+    expect(tool?.state).toMatchObject({
+      status: "completed",
+      output: "Visualization created",
+      metadata: { version: 1, title: "Clock", html: '<div id="clock"></div>' },
+    })
+  }),
+)
+
+it.instance("visualize omits required tool choice for DeepSeek V4 thinking models", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => {
+      const config = providerCfg(url)
+      return {
+        ...config,
+        provider: {
+          test: {
+            ...config.provider.test,
+            models: {
+              "deepseek-v4-flash": {
+                ...cfg.provider.test.models["test-model"],
+                id: "deepseek-v4-flash",
+                name: "DeepSeek V4 Flash",
+                reasoning: true,
+              },
+            },
+          },
+        },
+      }
+    })
+    const { prompt, chat } = yield* boot()
+    yield* llm.tool("visualization_create", { title: "Clock", html: '<div id="clock"></div>' })
+    yield* llm.text("done")
+
+    const result = yield* prompt.command({
+      sessionID: chat.id,
+      command: "visualize",
+      arguments: "在会话中预览个时钟",
+    })
+
+    expect(result.info.role).toBe("assistant")
+    const request = (yield* llm.inputs).find(
+      (input) =>
+        Array.isArray(input.tools) &&
+        input.tools.length === 1 &&
+        JSON.stringify(input.tools).includes("visualization_create"),
+    )
+    expect(request?.tool_choice).toBeUndefined()
+    expect(request?.tools).toEqual([
+      expect.objectContaining({ function: expect.objectContaining({ name: "visualization_create" }) }),
+    ])
+  }),
+)
+
 unixNoLLMServer(
   "cancel interrupts shell and resolves cleanly",
   () =>

--- a/packages/opencode/test/tool/visualization.test.ts
+++ b/packages/opencode/test/tool/visualization.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { Truncate } from "../../src/tool/truncate"
+import { VisualizationTool } from "../../src/tool/visualization"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(LayerNode.group([Truncate.node, Agent.node])))
+
+const ctx = {
+  sessionID: SessionID.make("ses_visualization"),
+  messageID: MessageID.make("msg_visualization"),
+  callID: "call_visualization",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+describe("tool.visualization", () => {
+  it.instance("returns inline preview metadata while hiding HTML from model output", () =>
+    Effect.gen(function* () {
+      const info = yield* VisualizationTool
+      const tool = yield* info.init()
+      const html = '<section data-kind="clock">10:21</section>'
+
+      expect(tool.description).toContain("transparent conversation background")
+      expect(tool.description).toContain("100vh")
+      expect(tool.description).toContain("negative page margins")
+
+      const result = yield* tool.execute({ title: "  Clock  ", html }, ctx)
+
+      expect(result).toEqual({
+        title: "Clock",
+        output: "Visualization created",
+        metadata: { version: 1, title: "Clock", html, truncated: false },
+      })
+    }),
+  )
+})

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -42,6 +42,7 @@ import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import { ToolErrorCard } from "./tool-error-card"
+import { VisualizationTool } from "./visualization-tool"
 import { Checkbox } from "@opencode-ai/ui/checkbox"
 import { DiffChanges } from "@opencode-ai/ui/diff-changes"
 import { Markdown } from "./markdown"
@@ -1456,6 +1457,7 @@ export function Part(props: MessagePartProps) {
 export interface ToolProps {
   input: Record<string, any>
   metadata: Record<string, any>
+  structured?: unknown
   tool: string
   sessionID?: string
   output?: string
@@ -1494,6 +1496,8 @@ export const ToolRegistry = {
   register: registerTool,
   render: getTool,
 }
+
+ToolRegistry.register({ name: "visualization_create", render: VisualizationTool })
 
 function ToolFileAccordion(props: { path: string; actions?: JSX.Element; children: JSX.Element }) {
   const value = createMemo(() => props.path || "tool-file")
@@ -1543,10 +1547,12 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
 
   const emptyInput: Record<string, any> = {}
   const emptyMetadata: Record<string, any> = {}
+  type StructuredToolState = ToolPart["state"] & { structured?: unknown }
 
   const input = () => part().state?.input ?? emptyInput
   // @ts-expect-error
   const partMetadata = () => part().state?.metadata ?? emptyMetadata
+  const structured = () => (part().state as StructuredToolState).structured
   const taskId = createMemo(() => {
     if (part().tool !== "task") return
     const value = partMetadata().sessionId
@@ -1614,6 +1620,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               tool={part().tool}
               sessionID={part().sessionID}
               metadata={partMetadata()}
+              structured={structured()}
               // @ts-expect-error
               output={part().state.output}
               status={part().state.status}

--- a/packages/session-ui/src/components/visualization-document.test.ts
+++ b/packages/session-ui/src/components/visualization-document.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test"
+import { createVisualizationDocument } from "./visualization-document"
+
+const CSP =
+  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; media-src data: blob:; object-src 'none'; frame-src 'none'; worker-src 'none'; form-action 'none'; base-uri 'none';"
+
+describe("createVisualizationDocument", () => {
+  const html = '<button id="go">Go</button><script>window.demo = true</script>'
+
+  test("returns a deterministic full document with CSP as the first head item", () => {
+    const first = createVisualizationDocument(html)
+    const second = createVisualizationDocument(html)
+    expect(first).toBe(second)
+    expect(first).toStartWith('<!doctype html><html style="background: transparent !important"><head><meta')
+    expect(first).toContain(`http-equiv="Content-Security-Policy" content="${CSP}"`)
+    expect(first.indexOf("Content-Security-Policy")).toBeLessThan(first.indexOf(html))
+    expect(first).not.toContain("http:")
+    expect(first).not.toContain("https:")
+  })
+
+  test("places the bridge before the unchanged agent fragment exactly once", () => {
+    const document = createVisualizationDocument(html)
+    expect(document.indexOf("window.opencode")).toBeLessThan(document.indexOf(html))
+    expect(document.split(html)).toHaveLength(2)
+    expect(document).not.toContain("sessionID")
+    expect(document).not.toContain("__TOKEN__")
+  })
+
+  test("wraps the fragment in a Codex-style transparent host canvas", () => {
+    const fragment =
+      '<style>html, body { background: white !important }</style><main style="background: red">Card</main>'
+    const document = createVisualizationDocument(fragment)
+
+    expect(document).toStartWith('<!doctype html><html style="background: transparent !important"><head>')
+    expect(document).toContain('<body style="margin: 0; background: transparent !important">')
+    expect(document).toContain(":root {\n  color-scheme: light dark;\n  background: transparent !important;")
+    expect(document).toContain("--background: var(--v2-background-bg-base, transparent);")
+    expect(document).toContain("--foreground: var(--v2-text-text-base, currentColor);")
+    expect(document).toContain("html > body")
+    expect(document).toContain("#widget {\n  display: flex;")
+    expect(document).toContain("#widget > :not(.card)")
+    expect(document).toContain("background: transparent !important;")
+    expect(document).toContain("box-shadow: none !important;")
+    expect(document).toContain(`<div id="widget">${fragment}</div>`)
+    expect(document.split(fragment)).toHaveLength(2)
+  })
+
+  test("installs only the follow-up public bridge before initialization", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain("window.opencode.visualization.sendFollowUp")
+    expect(document).toContain("await waitForInitialization()")
+    expect(document).not.toContain("window.opencode.visualization.resize")
+    expect(document).not.toContain("window.opencode.visualization.rpc")
+  })
+
+  test("contains the bounded source-checked message protocol", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain("event.source !== parent")
+    expect(document).toContain('message.type === "init"')
+    expect(document).toContain('message.type === "theme"')
+    expect(document).toContain('message.type === "followup-result"')
+    expect(document).toContain('type: "ready"')
+    expect(document).toContain('type: "resize"')
+    expect(document).toContain('type: "followup"')
+    expect(document).toContain('type: "error"')
+    expect(document).toContain('status === "sent"')
+    expect(document).toContain('status === "cancelled"')
+    expect(document).toContain('status === "rejected"')
+  })
+
+  test("defers the last pre-init error until after ready without posting tokenless messages", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain("let deferredError")
+    expect(document).toContain("if (!token) {\n      deferredError = message")
+    expect(document).toContain('post({ type: "ready" })')
+    expect(document).toContain('post({ type: "error", message: deferredError })')
+    expect(document.indexOf('post({ type: "ready" })')).toBeLessThan(
+      document.indexOf('post({ type: "error", message: deferredError })'),
+    )
+  })
+
+  test("bounds initialization and follow-up waits and settles lifecycle cleanup", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain("initTimeout: 10000")
+    expect(document).toContain("responseTimeout: 30000")
+    expect(document).toContain('resolve({ status: "rejected" })')
+    expect(document).toContain("clearTimeout(pendingFollowUp.timer)")
+    expect(document).toContain('addEventListener("pagehide", dispose')
+    expect(document).toContain('addEventListener("beforeunload", dispose')
+  })
+
+  test("coalesces resize reports with ResizeObserver and requestAnimationFrame", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain("new ResizeObserver(scheduleResize)")
+    expect(document).toContain("cancelAnimationFrame(resizeFrame)")
+    expect(document).toContain("requestAnimationFrame(reportResize)")
+    expect(document).toContain("let lastReportedHeight")
+    expect(document).toContain("height === lastReportedHeight")
+    expect(document).toContain("Number.isFinite(height)")
+  })
+
+  test("applies only the fixed theme variables", () => {
+    const document = createVisualizationDocument(html)
+    for (const name of [
+      "--v2-background-bg-base",
+      "--v2-background-bg-layer-01",
+      "--v2-text-text-base",
+      "--v2-text-text-muted",
+      "--v2-border-border-base",
+      "--v2-text-text-accent",
+      "--font-family-sans",
+      "--font-family-mono",
+    ]) {
+      expect(document).toContain(`"${name}"`)
+    }
+    expect(document).toContain("Array.from(value).length <= config.themeValueLimit")
+  })
+
+  test("bounds runtime error and rejection reports", () => {
+    const document = createVisualizationDocument(html)
+    expect(document).toContain('addEventListener("error"')
+    expect(document).toContain('addEventListener("unhandledrejection"')
+    expect(document).toContain("Array.from(cleaned).slice(0, config.errorLimit).join")
+    expect(document).toContain('replace(/\\s+/g, " ")')
+  })
+})

--- a/packages/session-ui/src/components/visualization-document.ts
+++ b/packages/session-ui/src/components/visualization-document.ts
@@ -1,0 +1,265 @@
+import {
+  FOLLOW_UP_INIT_TIMEOUT_MS,
+  FOLLOW_UP_RESPONSE_TIMEOUT_MS,
+  MAX_ERROR_CODE_POINTS,
+  MAX_PROMPT_CODE_POINTS,
+  MAX_THEME_VALUE_CODE_POINTS,
+  MAX_TITLE_CODE_POINTS,
+  MAX_TOKEN_CODE_POINTS,
+  VISUALIZATION_FOLLOW_UP_STATUSES,
+  VISUALIZATION_THEME_VARIABLES,
+  VISUALIZATION_VERSION,
+} from "./visualization-schema"
+
+const CONTENT_SECURITY_POLICY =
+  "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; media-src data: blob:; object-src 'none'; frame-src 'none'; worker-src 'none'; form-action 'none'; base-uri 'none';"
+
+const HOST_CANVAS_STYLE = String.raw`:root {
+  color-scheme: light dark;
+  background: transparent !important;
+  --background: var(--v2-background-bg-base, transparent);
+  --foreground: var(--v2-text-text-base, currentColor);
+  --card: var(--v2-background-bg-layer-01, transparent);
+  --card-foreground: var(--foreground);
+  --muted-foreground: var(--v2-text-text-muted, var(--foreground));
+  --border: var(--v2-border-border-base, transparent);
+  --primary: var(--v2-text-text-accent, var(--foreground));
+  --font-sans: var(--font-family-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  --font-mono: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+html > body {
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+}
+
+html > body {
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  overflow: visible;
+}
+
+#widget {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-direction: column;
+  background: transparent !important;
+}
+
+#widget > :not(.card) {
+  width: 100% !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+svg,
+canvas,
+img {
+  max-width: 100%;
+}`
+
+const BRIDGE_BOOTSTRAP = String.raw`(() => {
+  "use strict";
+  const config = {
+    version: ${VISUALIZATION_VERSION},
+    themeVariables: ${JSON.stringify(VISUALIZATION_THEME_VARIABLES)},
+    statuses: ${JSON.stringify(VISUALIZATION_FOLLOW_UP_STATUSES)},
+    tokenLimit: ${MAX_TOKEN_CODE_POINTS},
+    themeValueLimit: ${MAX_THEME_VALUE_CODE_POINTS},
+    titleLimit: ${MAX_TITLE_CODE_POINTS},
+    promptLimit: ${MAX_PROMPT_CODE_POINTS},
+    errorLimit: ${MAX_ERROR_CODE_POINTS},
+    initTimeout: ${FOLLOW_UP_INIT_TIMEOUT_MS},
+    responseTimeout: ${FOLLOW_UP_RESPONSE_TIMEOUT_MS}
+  };
+  let token;
+  let settleInitialized;
+  let initializationSettled = false;
+  const initialized = new Promise((resolve) => { settleInitialized = resolve; });
+  let requestSequence = 0;
+  let followUpActive = false;
+  let pendingFollowUp;
+  let resizeFrame = 0;
+  let lastReportedHeight;
+  let deferredError;
+  let disposed = false;
+
+  const record = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+  const bounded = (value, maximum) => {
+    if (typeof value !== "string") return;
+    const trimmed = value.trim();
+    if (!trimmed || Array.from(trimmed).length > maximum) return;
+    return trimmed;
+  };
+  const applyTheme = (theme) => {
+    if (!record(theme)) return;
+    for (const name of config.themeVariables) {
+      const value = theme[name];
+      if (value === undefined) continue;
+      if (typeof value !== "string") continue;
+      if (!(Array.from(value).length <= config.themeValueLimit)) continue;
+      document.documentElement.style.setProperty(name, value);
+    }
+  };
+  const post = (message) => {
+    if (!token || disposed) return false;
+    parent.postMessage({ version: config.version, token, ...message }, "*");
+    return true;
+  };
+  const cleanError = (value) => {
+    const text = typeof value === "string" ? value : "Visualization error";
+    const cleaned = text.replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ").replace(/\s+/g, " ").trim();
+    return Array.from(cleaned).slice(0, config.errorLimit).join("") || "Visualization error";
+  };
+  const reportError = (value) => {
+    if (disposed) return;
+    const message = cleanError(value);
+    if (!token) {
+      deferredError = message;
+      return;
+    }
+    post({ type: "error", message });
+  };
+  const reportResize = () => {
+    resizeFrame = 0;
+    const bodyHeight = document.body ? document.body.scrollHeight : 0;
+    const height = Math.max(document.documentElement.scrollHeight, bodyHeight);
+    if (!Number.isFinite(height) || height === lastReportedHeight) return;
+    if (post({ type: "resize", height })) lastReportedHeight = height;
+  };
+  const scheduleResize = () => {
+    if (disposed) return;
+    if (resizeFrame) cancelAnimationFrame(resizeFrame);
+    resizeFrame = requestAnimationFrame(reportResize);
+  };
+  const settleInitialization = (value) => {
+    if (initializationSettled) return;
+    initializationSettled = true;
+    settleInitialized(value);
+  };
+  const waitForInitialization = () => new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(false), config.initTimeout);
+    initialized.then(finish);
+  });
+  const waitForFollowUp = (requestID) => new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      if (!pendingFollowUp || pendingFollowUp.requestID !== requestID) return;
+      pendingFollowUp = undefined;
+      resolve({ status: "rejected" });
+    }, config.responseTimeout);
+    pendingFollowUp = { requestID, resolve, timer };
+  });
+  const sendFollowUp = async (input) => {
+    if (!record(input)) throw new TypeError("Follow-up input must be an object");
+    const prompt = bounded(input.prompt, config.promptLimit);
+    if (!prompt) throw new TypeError("Follow-up prompt is invalid");
+    const title = input.title === undefined ? undefined : bounded(input.title, config.titleLimit);
+    if (input.title !== undefined && !title) throw new TypeError("Follow-up title is invalid");
+    if (followUpActive || disposed) return { status: "rejected" };
+    followUpActive = true;
+    try {
+      const ready = await waitForInitialization();
+      if (!ready || !token || disposed) return { status: "rejected" };
+      const requestID = String(++requestSequence);
+      const result = waitForFollowUp(requestID);
+      post({ type: "followup", requestID, ...(title ? { title } : {}), prompt });
+      return await result;
+    } finally {
+      if (pendingFollowUp) clearTimeout(pendingFollowUp.timer);
+      pendingFollowUp = undefined;
+      followUpActive = false;
+    }
+  };
+
+  window.opencode = { visualization: {} };
+  window.opencode.visualization.sendFollowUp = sendFollowUp;
+  Object.freeze(window.opencode.visualization);
+  Object.freeze(window.opencode);
+
+  addEventListener("message", (event) => {
+    if (event.source !== parent || disposed) return;
+    const message = event.data;
+    if (!record(message) || message.version !== config.version) return;
+    if (message.type === "init") {
+      if (token) return;
+      const nextToken = bounded(message.token, config.tokenLimit);
+      if (!nextToken) return;
+      token = nextToken;
+      applyTheme(message.theme);
+      settleInitialization(true);
+      post({ type: "ready" });
+      if (deferredError) {
+        post({ type: "error", message: deferredError });
+        deferredError = undefined;
+      }
+      scheduleResize();
+      return;
+    }
+    if (!token || message.token !== token) return;
+    if (message.type === "theme") {
+      applyTheme(message.theme);
+      scheduleResize();
+      return;
+    }
+    if (message.type === "followup-result") {
+      if (!pendingFollowUp || message.requestID !== pendingFollowUp.requestID) return;
+      const status = message.status;
+      if (!(status === "sent" || status === "cancelled" || status === "rejected")) return;
+      if (!config.statuses.includes(status)) return;
+      const current = pendingFollowUp;
+      pendingFollowUp = undefined;
+      clearTimeout(current.timer);
+      current.resolve({ status });
+    }
+  });
+  addEventListener("error", (event) => reportError(event.message));
+  addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    reportError(reason && typeof reason.message === "string" ? reason.message : reason);
+  });
+
+  const resizeObserver = new ResizeObserver(scheduleResize);
+  resizeObserver.observe(document.documentElement);
+  if (document.body) resizeObserver.observe(document.body);
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    settleInitialization(false);
+    if (resizeFrame) cancelAnimationFrame(resizeFrame);
+    resizeObserver.disconnect();
+    if (!pendingFollowUp) return;
+    const current = pendingFollowUp;
+    pendingFollowUp = undefined;
+    clearTimeout(current.timer);
+    current.resolve({ status: "rejected" });
+  };
+  addEventListener("DOMContentLoaded", scheduleResize, { once: true });
+  addEventListener("pagehide", dispose, { once: true });
+  addEventListener("beforeunload", dispose, { once: true });
+})();`
+
+export function createVisualizationDocument(html: string) {
+  return `<!doctype html><html style="background: transparent !important"><head><meta http-equiv="Content-Security-Policy" content="${CONTENT_SECURITY_POLICY}"><style>${HOST_CANVAS_STYLE}</style></head><body style="margin: 0; background: transparent !important"><script>${BRIDGE_BOOTSTRAP}</script><div id="widget">${html}</div></body></html>`
+}

--- a/packages/session-ui/src/components/visualization-frame.stories.tsx
+++ b/packages/session-ui/src/components/visualization-frame.stories.tsx
@@ -1,0 +1,66 @@
+import { VisualizationProvider } from "../context/visualization"
+import { VisualizationFrame } from "./visualization-frame"
+import { VisualizationTool } from "./visualization-tool"
+
+const controls = {
+  version: 1 as const,
+  title: "Motion controls",
+  html: `<main style="font: 14px system-ui; color: var(--v2-text-text-base); padding: 20px; display: grid; gap: 16px">
+  <svg viewBox="0 0 240 80" role="img" aria-label="Wave"><path d="M0 40 Q30 5 60 40 T120 40 T180 40 T240 40" fill="none" stroke="var(--v2-text-text-accent)" stroke-width="4"/></svg>
+  <label>Speed <input id="speed" type="range" min="0" max="100" value="50"></label>
+  <button id="send">Use this motion</button>
+  <script>document.querySelector('#send').onclick = () => window.opencode.visualization.sendFollowUp({ prompt: 'Use this motion' })</script>
+</main>`,
+}
+
+const long = {
+  version: 1 as const,
+  title: "Long visualization",
+  html: `<div style="height: 1100px; padding: 20px">Long content that can be expanded</div>`,
+}
+
+function FrameStory(props: { value: typeof controls | typeof long; dark?: boolean }) {
+  return (
+    <div
+      style={{
+        padding: "20px",
+        background: props.dark ? "#111" : "#fff",
+        "--v2-background-bg-base": props.dark ? "#111" : "#fff",
+        "--v2-background-bg-layer-01": props.dark ? "#1a1a1a" : "#f5f5f5",
+        "--v2-text-text-base": props.dark ? "#f5f5f5" : "#111",
+        "--v2-text-text-muted": props.dark ? "#b5b5b5" : "#666",
+        "--v2-border-border-base": props.dark ? "#444" : "#ddd",
+        "--v2-text-text-accent": "#5b7cfa",
+        "--font-family-sans": "system-ui, sans-serif",
+        "--font-family-mono": "ui-monospace, monospace",
+      }}
+    >
+      <VisualizationProvider enabled followUp={async () => "cancelled"}>
+        <VisualizationFrame value={props.value} sessionID="story-session" />
+      </VisualizationProvider>
+    </div>
+  )
+}
+
+export default {
+  title: "UI/Visualization Frame",
+  id: "components-visualization-frame",
+  component: VisualizationFrame,
+  tags: ["autodocs"],
+}
+
+export const Controls = {
+  render: () => <FrameStory value={controls} />,
+}
+
+export const LongCollapsed = {
+  render: () => <FrameStory value={long} />,
+}
+
+export const InvalidStructured = {
+  render: () => <VisualizationTool status="completed" structured={{ version: 1, title: "Invalid", html: "" }} />,
+}
+
+export const Dark = {
+  render: () => <FrameStory value={controls} dark />,
+}

--- a/packages/session-ui/src/components/visualization-frame.test.tsx
+++ b/packages/session-ui/src/components/visualization-frame.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { useVisualization } from "../context/visualization"
+import {
+  displayVisualizationHeight,
+  filterVisualizationMessage,
+  resolveVisualizationFrameHeight,
+} from "./visualization-frame"
+import { visualizationStructured, visualizationToolState } from "./visualization-tool"
+import { COLLAPSED_HEIGHT, MAX_HEIGHT, MIN_HEIGHT } from "./visualization-schema"
+
+describe("Visualization context", () => {
+  test("disables visualizations and rejects follow-ups without an App provider", async () => {
+    const result = createRoot(() => useVisualization())
+
+    expect(result.enabled).toBe(false)
+    await expect(result.followUp({ sessionID: "session-1", prompt: "Use compact layout" })).resolves.toBe("rejected")
+  })
+})
+
+describe("Visualization tool renderer state", () => {
+  test("uses a compact thinking state until a completed result is available", () => {
+    expect(visualizationToolState("pending")).toEqual({ type: "thinking" })
+    expect(visualizationToolState("running")).toEqual({ type: "thinking" })
+  })
+
+  test("requires an explicit desktop capability before rendering a decoded completed structured result", () => {
+    const value = { version: 1 as const, title: "Controls", html: "<button>Use</button>" }
+
+    expect(visualizationToolState("completed", value)).toEqual({ type: "invalid" })
+    expect(visualizationToolState("completed", value, true)).toEqual({ type: "frame", value })
+    expect(visualizationToolState("completed", { version: 1, title: "Controls", html: "" }, true)).toEqual({
+      type: "invalid",
+    })
+  })
+
+  test("uses legacy v1 metadata only when structured output is absent", () => {
+    const legacy = { version: 1 as const, title: "Clock", html: "<div>clock</div>" }
+
+    expect(visualizationStructured(undefined, legacy)).toEqual(legacy)
+    expect(visualizationStructured({ version: 1, title: "Current", html: "<div>current</div>" }, legacy)).toEqual({
+      version: 1,
+      title: "Current",
+      html: "<div>current</div>",
+    })
+    expect(visualizationStructured(null, legacy)).toBeNull()
+  })
+})
+
+describe("Visualization frame host protocol", () => {
+  test("accepts only the current iframe source, token, and generation", () => {
+    const frameWindow = {} as WindowProxy
+    const input = {
+      frameWindow,
+      token: "current-token",
+      generation: 2,
+      currentGeneration: 2,
+      data: { version: 1, type: "ready", token: "current-token" } as const,
+    }
+
+    expect(filterVisualizationMessage({ ...input, source: {} as MessageEventSource })).toBeUndefined()
+    expect(
+      filterVisualizationMessage({ ...input, source: frameWindow, data: { ...input.data, token: "old-token" } }),
+    ).toBeUndefined()
+    expect(filterVisualizationMessage({ ...input, source: frameWindow, generation: 1 })).toBeUndefined()
+    expect(filterVisualizationMessage({ ...input, source: frameWindow })).toEqual(input.data)
+  })
+
+  test("clamps received and displayed heights without exceeding collapse or maximum limits", () => {
+    expect(resolveVisualizationFrameHeight(1)).toBe(MIN_HEIGHT)
+    expect(resolveVisualizationFrameHeight(MAX_HEIGHT + 1)).toBe(MAX_HEIGHT)
+    expect(displayVisualizationHeight(MAX_HEIGHT, false)).toBe(COLLAPSED_HEIGHT)
+    expect(displayVisualizationHeight(MAX_HEIGHT, true)).toBe(MAX_HEIGHT)
+  })
+})

--- a/packages/session-ui/src/components/visualization-frame.tsx
+++ b/packages/session-ui/src/components/visualization-frame.tsx
@@ -1,0 +1,298 @@
+import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show } from "solid-js"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { useI18n } from "@opencode-ai/ui/context/i18n"
+import { useVisualization } from "../context/visualization"
+import { createVisualizationDocument } from "./visualization-document"
+import {
+  COLLAPSED_HEIGHT,
+  FOLLOW_UP_INIT_TIMEOUT_MS,
+  INITIAL_HEIGHT,
+  MAX_THEME_VALUE_CODE_POINTS,
+  VISUALIZATION_THEME_VARIABLES,
+  clampVisualizationHeight,
+  decodeVisualizationMessage,
+  type VisualizationHostMessage,
+  type VisualizationMessage,
+  type VisualizationResult,
+  type VisualizationTheme,
+} from "./visualization-schema"
+
+export type VisualizationFrameProps = {
+  value: VisualizationResult
+  sessionID?: string
+  onContentRendered?: () => void
+}
+
+export function filterVisualizationMessage(input: {
+  source: MessageEventSource | null
+  frameWindow: MessageEventSource | null
+  data: unknown
+  token: string
+  generation: number
+  currentGeneration: number
+}): VisualizationMessage | undefined {
+  if (!input.frameWindow || input.source !== input.frameWindow) return
+  if (input.generation !== input.currentGeneration) return
+  const message = decodeVisualizationMessage(input.data)
+  if (!message || message.token !== input.token) return
+  return message
+}
+
+export function resolveVisualizationFrameHeight(value: number) {
+  return clampVisualizationHeight(value)
+}
+
+export function displayVisualizationHeight(value: number, expanded: boolean) {
+  const height = resolveVisualizationFrameHeight(value) ?? INITIAL_HEIGHT
+  if (expanded) return height
+  return Math.min(height, COLLAPSED_HEIGHT)
+}
+
+export function VisualizationFrame(props: VisualizationFrameProps) {
+  const i18n = useI18n()
+  const visualization = useVisualization()
+  const source = createMemo(() => createVisualizationDocument(props.value.html))
+  const [generation, setGeneration] = createSignal(0)
+  const [height, setHeight] = createSignal(INITIAL_HEIGHT)
+  const [expanded, setExpanded] = createSignal(false)
+  const [ready, setReady] = createSignal(false)
+  const [failed, setFailed] = createSignal(false)
+  let iframe: HTMLIFrameElement | undefined
+  let currentGeneration = 0
+  let token = ""
+  let mounted = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let heightFrame: number | undefined
+  let pendingHeight: number | undefined
+  let observer: MutationObserver | undefined
+  let followUpGeneration: number | undefined
+
+  const clearPending = () => {
+    if (timeout) clearTimeout(timeout)
+    timeout = undefined
+    if (heightFrame !== undefined) cancelAnimationFrame(heightFrame)
+    heightFrame = undefined
+    pendingHeight = undefined
+  }
+
+  const createToken = () => {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID()
+    const values = new Uint32Array(4)
+    if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+      crypto.getRandomValues(values)
+      return Array.from(values, (value) => value.toString(36)).join("-")
+    }
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+
+  const theme = (): VisualizationTheme => {
+    if (typeof document === "undefined" || typeof getComputedStyle === "undefined") return {}
+    const style = getComputedStyle(document.documentElement)
+    return VISUALIZATION_THEME_VARIABLES.reduce<VisualizationTheme>((result, name) => {
+      const value = style.getPropertyValue(name).trim()
+      if (Array.from(value).length <= MAX_THEME_VALUE_CODE_POINTS) result[name] = value
+      return result
+    }, {})
+  }
+
+  const post = (targetGeneration: number, message: VisualizationHostMessage) => {
+    if (!mounted || failed() || targetGeneration !== currentGeneration) return false
+    const target = iframe?.contentWindow
+    if (!target) return false
+    target.postMessage(message, "*")
+    return true
+  }
+
+  const fail = (targetGeneration: number) => {
+    if (!mounted || targetGeneration !== currentGeneration) return
+    clearPending()
+    setReady(false)
+    setFailed(true)
+  }
+
+  const startTimeout = (targetGeneration: number) => {
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(() => fail(targetGeneration), FOLLOW_UP_INIT_TIMEOUT_MS)
+  }
+
+  const postTheme = () => {
+    if (!ready()) return
+    post(currentGeneration, { version: 1, type: "theme", token, theme: theme() })
+  }
+
+  const queueHeight = (next: number) => {
+    const value = resolveVisualizationFrameHeight(next)
+    if (value === undefined) return
+    pendingHeight = value
+    if (heightFrame !== undefined) return
+    heightFrame = requestAnimationFrame(() => {
+      heightFrame = undefined
+      const value = pendingHeight
+      pendingHeight = undefined
+      if (!mounted || failed() || value === undefined || value === height()) return
+      setHeight(value)
+      props.onContentRendered?.()
+    })
+  }
+
+  const settleFollowUp = (targetGeneration: number, requestID: string, status: "sent" | "cancelled" | "rejected") => {
+    if (!mounted || failed() || targetGeneration !== currentGeneration || followUpGeneration !== targetGeneration)
+      return
+    followUpGeneration = undefined
+    post(targetGeneration, { version: 1, type: "followup-result", token, requestID, status })
+  }
+
+  const handleFollowUp = (message: Extract<VisualizationMessage, { type: "followup" }>) => {
+    const targetGeneration = currentGeneration
+    if (followUpGeneration === targetGeneration || !props.sessionID) {
+      post(targetGeneration, {
+        version: 1,
+        type: "followup-result",
+        token,
+        requestID: message.requestID,
+        status: "rejected",
+      })
+      return
+    }
+    followUpGeneration = targetGeneration
+    void visualization
+      .followUp({
+        sessionID: props.sessionID,
+        title: message.title ?? props.value.title,
+        prompt: message.prompt,
+      })
+      .then(
+        (status) => settleFollowUp(targetGeneration, message.requestID, status),
+        () => settleFollowUp(targetGeneration, message.requestID, "rejected"),
+      )
+  }
+
+  const onMessage = (event: MessageEvent) => {
+    if (!mounted || failed()) return
+    const message = filterVisualizationMessage({
+      source: event.source,
+      frameWindow: iframe?.contentWindow ?? null,
+      data: event.data,
+      token,
+      generation: currentGeneration,
+      currentGeneration: generation(),
+    })
+    if (!message) return
+    if (message.type === "ready") {
+      if (timeout) clearTimeout(timeout)
+      timeout = undefined
+      setReady(true)
+      return
+    }
+    if (message.type === "resize") {
+      queueHeight(message.height)
+      return
+    }
+    if (message.type === "followup") {
+      handleFollowUp(message)
+      return
+    }
+    if (message.type === "error") fail(currentGeneration)
+  }
+
+  const onLoad = (targetGeneration: number) => {
+    if (!mounted || failed() || targetGeneration !== currentGeneration) return
+    if (!post(targetGeneration, { version: 1, type: "init", token, theme: theme() })) return
+    startTimeout(targetGeneration)
+  }
+
+  const start = () => {
+    clearPending()
+    currentGeneration += 1
+    token = createToken()
+    followUpGeneration = undefined
+    setHeight(INITIAL_HEIGHT)
+    setExpanded(false)
+    setReady(false)
+    setFailed(false)
+    setGeneration(currentGeneration)
+  }
+
+  onMount(() => {
+    mounted = true
+    window.addEventListener("message", onMessage)
+    if (typeof MutationObserver !== "undefined") {
+      observer = new MutationObserver(postTheme)
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["class", "style", "data-theme", "data-color-scheme"],
+      })
+    }
+    start()
+  })
+
+  createEffect(
+    on(
+      () => source(),
+      () => {
+        if (mounted) start()
+      },
+      { defer: true },
+    ),
+  )
+
+  onCleanup(() => {
+    mounted = false
+    currentGeneration += 1
+    followUpGeneration = undefined
+    clearPending()
+    observer?.disconnect()
+    window.removeEventListener("message", onMessage)
+  })
+
+  return (
+    <div data-component="visualization-frame" data-expanded={expanded() ? "true" : "false"}>
+      <Show
+        when={!failed()}
+        fallback={
+          <div data-slot="visualization-frame-failed">
+            <span>{i18n.t("ui.toolErrorCard.failed")}</span>
+            <IconButton
+              icon="reset"
+              size="small"
+              variant="ghost"
+              aria-label={i18n.t("ui.sessionTurn.retry.retrying")}
+              onClick={start}
+            />
+          </div>
+        }
+      >
+        <div
+          data-slot="visualization-frame-container"
+          style={{ height: `${displayVisualizationHeight(height(), expanded())}px` }}
+        >
+          <Show when={generation()} keyed>
+            {(value) => (
+              <iframe
+                ref={(element) => (iframe = element)}
+                data-slot="visualization-frame"
+                title={props.value.title}
+                sandbox="allow-scripts"
+                loading="lazy"
+                srcdoc={source()}
+                onLoad={() => onLoad(value)}
+                onError={() => fail(value)}
+              />
+            )}
+          </Show>
+        </div>
+        <Show when={height() > COLLAPSED_HEIGHT}>
+          <div data-slot="visualization-frame-actions">
+            <IconButton
+              icon={expanded() ? "collapse" : "expand"}
+              size="small"
+              variant="ghost"
+              aria-label={i18n.t(expanded() ? "ui.message.collapse" : "ui.message.expand")}
+              onClick={() => setExpanded((value) => !value)}
+            />
+          </div>
+        </Show>
+      </Show>
+    </div>
+  )
+}

--- a/packages/session-ui/src/components/visualization-schema.test.ts
+++ b/packages/session-ui/src/components/visualization-schema.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, test } from "bun:test"
+import {
+  COLLAPSED_HEIGHT,
+  FOLLOW_UP_INIT_TIMEOUT_MS,
+  FOLLOW_UP_RESPONSE_TIMEOUT_MS,
+  INITIAL_HEIGHT,
+  MAX_ERROR_CODE_POINTS,
+  MAX_HEIGHT,
+  MAX_HTML_BYTES,
+  MAX_PROMPT_CODE_POINTS,
+  MAX_REQUEST_ID_CODE_POINTS,
+  MAX_THEME_VALUE_CODE_POINTS,
+  MAX_TITLE_CODE_POINTS,
+  MAX_TOKEN_CODE_POINTS,
+  MIN_HEIGHT,
+  VISUALIZATION_VERSION,
+  clampVisualizationHeight,
+  decodeVisualizationHostMessage,
+  decodeVisualizationMessage,
+  decodeVisualizationResult,
+} from "./visualization-schema"
+
+describe("visualization result", () => {
+  test("exports the fixed protocol and layout limits", () => {
+    expect(VISUALIZATION_VERSION).toBe(1)
+    expect(MAX_TITLE_CODE_POINTS).toBe(120)
+    expect(MAX_HTML_BYTES).toBe(128 * 1024)
+    expect(MAX_PROMPT_CODE_POINTS).toBe(4_000)
+    expect(MAX_ERROR_CODE_POINTS).toBe(500)
+    expect(MAX_TOKEN_CODE_POINTS).toBe(256)
+    expect(MAX_REQUEST_ID_CODE_POINTS).toBe(128)
+    expect(MAX_THEME_VALUE_CODE_POINTS).toBe(256)
+    expect(FOLLOW_UP_INIT_TIMEOUT_MS).toBe(10_000)
+    expect(FOLLOW_UP_RESPONSE_TIMEOUT_MS).toBe(30_000)
+    expect(INITIAL_HEIGHT).toBe(160)
+    expect(MIN_HEIGHT).toBe(48)
+    expect(COLLAPSED_HEIGHT).toBe(720)
+    expect(MAX_HEIGHT).toBe(4_096)
+  })
+
+  test("normalizes a valid V1 result and ignores extra fields", () => {
+    expect(decodeVisualizationResult({ version: 1, title: "  Demo ", html: "<div>ok</div>", dangerous: true })).toEqual(
+      { version: 1, title: "Demo", html: "<div>ok</div>" },
+    )
+  })
+
+  test("counts title limits by Unicode code point", () => {
+    expect(decodeVisualizationResult({ version: 1, title: "😀".repeat(120), html: "<svg />" })?.title).toBe(
+      "😀".repeat(120),
+    )
+    expect(decodeVisualizationResult({ version: 1, title: "😀".repeat(121), html: "<svg />" })).toBeUndefined()
+  })
+
+  test("enforces the HTML UTF-8 byte boundary", () => {
+    expect(decodeVisualizationResult({ version: 1, title: "Demo", html: "a".repeat(MAX_HTML_BYTES) })).toBeDefined()
+    expect(
+      decodeVisualizationResult({ version: 1, title: "Demo", html: `${"a".repeat(MAX_HTML_BYTES - 1)}é` }),
+    ).toBeUndefined()
+  })
+
+  test("rejects invalid versions and empty fields without throwing", () => {
+    expect(decodeVisualizationResult({ version: 2, title: "Demo", html: "<div />" })).toBeUndefined()
+    expect(decodeVisualizationResult({ version: 1, title: "   ", html: "<div />" })).toBeUndefined()
+    expect(decodeVisualizationResult({ version: 1, title: "Demo", html: "  " })).toBeUndefined()
+    expect(decodeVisualizationResult(null)).toBeUndefined()
+    expect(() => decodeVisualizationResult(Object.create(null))).not.toThrow()
+  })
+
+  test("rejects obvious full documents after leading whitespace and comments", () => {
+    const invalid = [
+      "<!doctype html><p>x</p>",
+      " \n<!-- lead --><! DOCTYPE html><p>x</p>",
+      "<!-- a --><!-- b --> <HTML lang=en></HTML>",
+      "\n< head><title>x</title></head>",
+      "<!-- lead --> <BoDy >x</body>",
+    ]
+    for (const html of invalid) expect(decodeVisualizationResult({ version: 1, title: "Demo", html })).toBeUndefined()
+  })
+
+  test("rejects document tokens anywhere outside comments and raw text", () => {
+    const invalid = [
+      "<div>x</div><body>late body</body>",
+      "<section>x</section><HEAD><title>x</title></HEAD>",
+      "<div>x</div><!doctype html>",
+      "<svg><foreignObject><html><body>x</body></html></foreignObject></svg>",
+      '<script>const value = "</script><body>real body</body><script>"</script>',
+    ]
+    for (const html of invalid) expect(decodeVisualizationResult({ version: 1, title: "Demo", html })).toBeUndefined()
+  })
+
+  test("ignores document-like text in comments, quoted attributes, script, and style", () => {
+    const valid = [
+      "<!-- <html><body>comment</body></html> --><div>ok</div>",
+      '<div data-example="<body>not a tag</body>">ok</div>',
+      '<script>const example = "<body>not a tag</body>"</script><div>ok</div>',
+      '<style>.demo::before { content: "<html>"; }</style><div class="demo">ok</div>',
+    ]
+    for (const html of valid) expect(decodeVisualizationResult({ version: 1, title: "Demo", html })).toBeDefined()
+  })
+
+  test("accepts supported interactive fragments", () => {
+    const valid = [
+      '<svg viewBox="0 0 10 10"><circle r="4" /></svg>',
+      '<canvas id="chart"></canvas>',
+      '<form><input type="range"></form>',
+      "<script>window.demo = true</script>",
+    ]
+    for (const html of valid) expect(decodeVisualizationResult({ version: 1, title: "Demo", html })).toBeDefined()
+  })
+
+  test("returns undefined when untrusted result properties throw", () => {
+    const poisoned = {
+      version: 1,
+      get title(): string {
+        throw new Error("poisoned title")
+      },
+      html: "<div />",
+    }
+    const proxy = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("poisoned proxy")
+        },
+      },
+    )
+    expect(() => decodeVisualizationResult(poisoned)).not.toThrow()
+    expect(decodeVisualizationResult(poisoned)).toBeUndefined()
+    expect(() => decodeVisualizationResult(proxy)).not.toThrow()
+    expect(decodeVisualizationResult(proxy)).toBeUndefined()
+  })
+})
+
+describe("visualization iframe messages", () => {
+  test("decodes and normalizes every iframe to host message", () => {
+    expect(decodeVisualizationMessage({ version: 1, type: "ready", token: " token ", extra: "ignored" })).toEqual({
+      version: 1,
+      type: "ready",
+      token: "token",
+    })
+    expect(decodeVisualizationMessage({ version: 1, type: "resize", token: "token", height: 240.5 })).toEqual({
+      version: 1,
+      type: "resize",
+      token: "token",
+      height: 240.5,
+    })
+    expect(
+      decodeVisualizationMessage({
+        version: 1,
+        type: "followup",
+        token: "token",
+        requestID: "request-1",
+        title: "  Choice ",
+        prompt: "  use option A  ",
+      }),
+    ).toEqual({
+      version: 1,
+      type: "followup",
+      token: "token",
+      requestID: "request-1",
+      title: "Choice",
+      prompt: "use option A",
+    })
+    expect(
+      decodeVisualizationMessage({ version: 1, type: "error", token: "token", message: " bad\u0000\n error " }),
+    ).toEqual({ version: 1, type: "error", token: "token", message: "bad error" })
+  })
+
+  test("enforces follow-up and identifier boundaries", () => {
+    const base = { version: 1, type: "followup", token: "t", requestID: "r" }
+    expect(decodeVisualizationMessage({ ...base, prompt: "😀".repeat(4_000), title: "😀".repeat(120) })).toBeDefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "😀".repeat(4_001) })).toBeUndefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "  " })).toBeUndefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "ok", title: "  " })).toBeUndefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "ok", title: "x".repeat(121) })).toBeUndefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "ok", token: "t".repeat(257) })).toBeUndefined()
+    expect(decodeVisualizationMessage({ ...base, prompt: "ok", requestID: "r".repeat(129) })).toBeUndefined()
+  })
+
+  test("rejects invalid heights, versions, types, and dangerous payload shapes", () => {
+    expect(decodeVisualizationMessage({ version: 1, type: "resize", token: "t", height: Number.NaN })).toBeUndefined()
+    expect(decodeVisualizationMessage({ version: 1, type: "resize", token: "t", height: Infinity })).toBeUndefined()
+    expect(decodeVisualizationMessage({ version: 1, type: "resize", token: "t", height: -1 })).toBeUndefined()
+    expect(decodeVisualizationMessage({ version: 2, type: "ready", token: "t" })).toBeUndefined()
+    expect(decodeVisualizationMessage({ version: 1, type: "rpc", token: "t", method: "readFile" })).toBeUndefined()
+    expect(decodeVisualizationMessage([])).toBeUndefined()
+  })
+
+  test("cleans and bounds iframe error summaries", () => {
+    const decoded = decodeVisualizationMessage({
+      version: 1,
+      type: "error",
+      token: "t",
+      message: `  ${"x".repeat(600)}  `,
+    })
+    expect(decoded?.type).toBe("error")
+    if (decoded?.type !== "error") throw new Error("Expected an error message")
+    expect(Array.from(decoded.message)).toHaveLength(500)
+  })
+
+  test("returns undefined when untrusted iframe message properties throw", () => {
+    const poisoned = {
+      version: 1,
+      get token(): string {
+        throw new Error("poisoned token")
+      },
+      type: "ready",
+    }
+    const proxy = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("poisoned proxy")
+        },
+      },
+    )
+    expect(() => decodeVisualizationMessage(poisoned)).not.toThrow()
+    expect(decodeVisualizationMessage(poisoned)).toBeUndefined()
+    expect(() => decodeVisualizationMessage(proxy)).not.toThrow()
+    expect(decodeVisualizationMessage(proxy)).toBeUndefined()
+  })
+})
+
+describe("visualization host messages", () => {
+  const theme = {
+    "--v2-background-bg-base": "#fff",
+    "--v2-background-bg-layer-01": "#f5f5f5",
+    "--v2-text-text-base": "#111",
+    "--v2-text-text-muted": "#666",
+    "--v2-border-border-base": "#ddd",
+    "--v2-text-text-accent": "#06f",
+    "--font-family-sans": "sans-serif",
+    "--font-family-mono": "monospace",
+  }
+
+  test("normalizes only whitelisted theme variables", () => {
+    expect(
+      decodeVisualizationHostMessage({
+        version: 1,
+        type: "theme",
+        token: "token",
+        theme: { ...theme, "--danger": "url(https://example.com)" },
+      }),
+    ).toEqual({ version: 1, type: "theme", token: "token", theme })
+  })
+
+  test("counts theme limits by Unicode code point", () => {
+    const value = "😀".repeat(129)
+    expect(value.length).toBe(258)
+    expect(
+      decodeVisualizationHostMessage({
+        version: 1,
+        type: "theme",
+        token: "token",
+        theme: { "--v2-text-text-base": value },
+      }),
+    ).toEqual({
+      version: 1,
+      type: "theme",
+      token: "token",
+      theme: { "--v2-text-text-base": value },
+    })
+  })
+
+  test("accepts only fixed follow-up result statuses", () => {
+    for (const status of ["sent", "cancelled", "rejected"] as const) {
+      expect(
+        decodeVisualizationHostMessage({
+          version: 1,
+          type: "followup-result",
+          token: "token",
+          requestID: "request",
+          status,
+        }),
+      ).toEqual({ version: 1, type: "followup-result", token: "token", requestID: "request", status })
+    }
+    expect(
+      decodeVisualizationHostMessage({
+        version: 1,
+        type: "followup-result",
+        token: "token",
+        requestID: "request",
+        status: "approved",
+      }),
+    ).toBeUndefined()
+    expect(decodeVisualizationHostMessage({ version: 1, type: "unknown", token: "token" })).toBeUndefined()
+  })
+
+  test("rejects oversized theme values", () => {
+    expect(
+      decodeVisualizationHostMessage({
+        version: 1,
+        type: "init",
+        token: "token",
+        theme: { ...theme, "--v2-text-text-base": "x".repeat(257) },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("returns undefined when untrusted host message properties throw", () => {
+    const poisoned = {
+      version: 1,
+      type: "theme",
+      token: "token",
+      get theme(): unknown {
+        throw new Error("poisoned theme")
+      },
+    }
+    const proxy = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("poisoned proxy")
+        },
+      },
+    )
+    expect(() => decodeVisualizationHostMessage(poisoned)).not.toThrow()
+    expect(decodeVisualizationHostMessage(poisoned)).toBeUndefined()
+    expect(() => decodeVisualizationHostMessage(proxy)).not.toThrow()
+    expect(decodeVisualizationHostMessage(proxy)).toBeUndefined()
+  })
+})
+
+describe("visualization height", () => {
+  test("rejects invalid values and clamps finite heights", () => {
+    expect(clampVisualizationHeight(Number.NaN)).toBeUndefined()
+    expect(clampVisualizationHeight(Infinity)).toBeUndefined()
+    expect(clampVisualizationHeight(-1)).toBeUndefined()
+    expect(clampVisualizationHeight(0)).toBe(MIN_HEIGHT)
+    expect(clampVisualizationHeight(MIN_HEIGHT)).toBe(MIN_HEIGHT)
+    expect(clampVisualizationHeight(48.1)).toBe(49)
+    expect(clampVisualizationHeight(MAX_HEIGHT)).toBe(MAX_HEIGHT)
+    expect(clampVisualizationHeight(MAX_HEIGHT + 1)).toBe(MAX_HEIGHT)
+  })
+})

--- a/packages/session-ui/src/components/visualization-schema.ts
+++ b/packages/session-ui/src/components/visualization-schema.ts
@@ -1,0 +1,257 @@
+export const VISUALIZATION_VERSION = 1
+export const MAX_TITLE_CODE_POINTS = 120
+export const MAX_HTML_BYTES = 128 * 1024
+export const MAX_PROMPT_CODE_POINTS = 4_000
+export const MAX_ERROR_CODE_POINTS = 500
+export const MAX_TOKEN_CODE_POINTS = 256
+export const MAX_REQUEST_ID_CODE_POINTS = 128
+export const MAX_THEME_VALUE_CODE_POINTS = 256
+export const FOLLOW_UP_INIT_TIMEOUT_MS = 10_000
+export const FOLLOW_UP_RESPONSE_TIMEOUT_MS = 30_000
+export const INITIAL_HEIGHT = 160
+export const MIN_HEIGHT = 48
+export const COLLAPSED_HEIGHT = 720
+export const MAX_HEIGHT = 4_096
+
+export const VISUALIZATION_THEME_VARIABLES = [
+  "--v2-background-bg-base",
+  "--v2-background-bg-layer-01",
+  "--v2-text-text-base",
+  "--v2-text-text-muted",
+  "--v2-border-border-base",
+  "--v2-text-text-accent",
+  "--font-family-sans",
+  "--font-family-mono",
+] as const
+
+export const VISUALIZATION_FOLLOW_UP_STATUSES = ["sent", "cancelled", "rejected"] as const
+
+export type VisualizationResult = {
+  version: 1
+  title: string
+  html: string
+}
+
+export type VisualizationMessage =
+  | { version: 1; type: "ready"; token: string }
+  | { version: 1; type: "resize"; token: string; height: number }
+  | { version: 1; type: "followup"; token: string; requestID: string; title?: string; prompt: string }
+  | { version: 1; type: "error"; token: string; message: string }
+
+export type VisualizationThemeVariable = (typeof VISUALIZATION_THEME_VARIABLES)[number]
+export type VisualizationTheme = Partial<Record<VisualizationThemeVariable, string>>
+export type VisualizationFollowUpStatus = (typeof VISUALIZATION_FOLLOW_UP_STATUSES)[number]
+
+export type VisualizationHostMessage =
+  | { version: 1; type: "init"; token: string; theme?: VisualizationTheme }
+  | { version: 1; type: "theme"; token: string; theme: VisualizationTheme }
+  | {
+      version: 1
+      type: "followup-result"
+      token: string
+      requestID: string
+      status: VisualizationFollowUpStatus
+    }
+
+export function decodeVisualizationResult(value: unknown): VisualizationResult | undefined {
+  const input = readProperties(value, ["version", "title", "html"] as const)
+  if (!input || input.version !== VISUALIZATION_VERSION) return
+  const title = boundedTrimmed(input.title, MAX_TITLE_CODE_POINTS)
+  if (!title || typeof input.html !== "string" || !input.html.trim()) return
+  if (new TextEncoder().encode(input.html).byteLength > MAX_HTML_BYTES) return
+  if (documentRoot(input.html)) return
+  return { version: VISUALIZATION_VERSION, title, html: input.html }
+}
+
+export function decodeVisualizationMessage(value: unknown): VisualizationMessage | undefined {
+  const input = readProperties(value, [
+    "version",
+    "type",
+    "token",
+    "height",
+    "requestID",
+    "title",
+    "prompt",
+    "message",
+  ] as const)
+  if (!input || input.version !== VISUALIZATION_VERSION) return
+  const token = boundedTrimmed(input.token, MAX_TOKEN_CODE_POINTS)
+  if (!token) return
+  if (input.type === "ready") return { version: VISUALIZATION_VERSION, type: "ready", token }
+  if (input.type === "resize") {
+    if (typeof input.height !== "number" || !Number.isFinite(input.height) || input.height < 0) return
+    return { version: VISUALIZATION_VERSION, type: "resize", token, height: input.height }
+  }
+  if (input.type === "followup") return decodeFollowUp(input, token)
+  if (input.type === "error") {
+    const message = cleanError(input.message)
+    if (!message) return
+    return { version: VISUALIZATION_VERSION, type: "error", token, message }
+  }
+}
+
+export function decodeVisualizationHostMessage(value: unknown): VisualizationHostMessage | undefined {
+  const input = readProperties(value, ["version", "type", "token", "theme", "requestID", "status"] as const)
+  if (!input || input.version !== VISUALIZATION_VERSION) return
+  const token = boundedTrimmed(input.token, MAX_TOKEN_CODE_POINTS)
+  if (!token) return
+  if (input.type === "init") {
+    if (input.theme === undefined) return { version: VISUALIZATION_VERSION, type: "init", token }
+    const theme = decodeTheme(input.theme)
+    if (!theme) return
+    return { version: VISUALIZATION_VERSION, type: "init", token, theme }
+  }
+  if (input.type === "theme") {
+    const theme = decodeTheme(input.theme)
+    if (!theme) return
+    return { version: VISUALIZATION_VERSION, type: "theme", token, theme }
+  }
+  if (input.type !== "followup-result") return
+  const requestID = boundedTrimmed(input.requestID, MAX_REQUEST_ID_CODE_POINTS)
+  if (!requestID || !followUpStatus(input.status)) return
+  return { version: VISUALIZATION_VERSION, type: "followup-result", token, requestID, status: input.status }
+}
+
+export function clampVisualizationHeight(value: number) {
+  if (!Number.isFinite(value) || value < 0) return
+  return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, Math.ceil(value)))
+}
+
+function decodeFollowUp(value: Record<string, unknown>, token: string): VisualizationMessage | undefined {
+  const requestID = boundedTrimmed(value.requestID, MAX_REQUEST_ID_CODE_POINTS)
+  const prompt = boundedTrimmed(value.prompt, MAX_PROMPT_CODE_POINTS)
+  if (!requestID || !prompt) return
+  if (value.title === undefined) {
+    return { version: VISUALIZATION_VERSION, type: "followup", token, requestID, prompt }
+  }
+  const title = boundedTrimmed(value.title, MAX_TITLE_CODE_POINTS)
+  if (!title) return
+  return { version: VISUALIZATION_VERSION, type: "followup", token, requestID, title, prompt }
+}
+
+function decodeTheme(value: unknown): VisualizationTheme | undefined {
+  const input = readProperties(value, VISUALIZATION_THEME_VARIABLES)
+  if (!input) return
+  const entries = VISUALIZATION_THEME_VARIABLES.flatMap((name) => {
+    const item = input[name]
+    if (item === undefined) return []
+    if (typeof item !== "string" || codePoints(item) > MAX_THEME_VALUE_CODE_POINTS) return [undefined]
+    return [[name, item] as const]
+  })
+  if (entries.some((entry) => entry === undefined)) return
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined))
+}
+
+function cleanError(value: unknown) {
+  if (typeof value !== "string") return
+  const cleaned = value
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!cleaned) return
+  return Array.from(cleaned).slice(0, MAX_ERROR_CODE_POINTS).join("")
+}
+
+function boundedTrimmed(value: unknown, maximum: number) {
+  if (typeof value !== "string") return
+  const trimmed = value.trim()
+  if (!trimmed || codePoints(trimmed) > maximum) return
+  return trimmed
+}
+
+function documentRoot(html: string) {
+  const roots = new Set(["html", "head", "body"])
+  const rawText = new Set(["script", "style"])
+  let index = 0
+  let raw: string | undefined
+  while (index < html.length) {
+    const start = html.indexOf("<", index)
+    if (start < 0) return false
+    const token = readTag(html, start)
+    if (raw) {
+      if (token?.closing && token.name === raw) raw = undefined
+      index = token?.end ?? start + 1
+      continue
+    }
+    if (html.startsWith("<!--", start)) {
+      const end = html.indexOf("-->", start + 4)
+      if (end < 0) return false
+      index = end + 3
+      continue
+    }
+    if (!token) {
+      index = start + 1
+      continue
+    }
+    if (token.doctype || (token.name && roots.has(token.name))) return true
+    if (!token.closing && token.name && rawText.has(token.name)) raw = token.name
+    index = token.end
+  }
+  return false
+}
+
+function followUpStatus(value: unknown): value is VisualizationFollowUpStatus {
+  return VISUALIZATION_FOLLOW_UP_STATUSES.some((status) => status === value)
+}
+
+function readTag(html: string, start: number) {
+  let quote: '"' | "'" | undefined
+  let cursor = start + 1
+  while (cursor < html.length) {
+    const character = html[cursor]
+    if (quote) {
+      if (character === quote) quote = undefined
+      cursor++
+      continue
+    }
+    if (character === '"' || character === "'") {
+      quote = character
+      cursor++
+      continue
+    }
+    if (character === ">") break
+    cursor++
+  }
+  const source = html.slice(start + 1, cursor).trimStart()
+  if (/^!\s*doctype(?:\s|$)/i.test(source)) return { end: Math.min(cursor + 1, html.length), doctype: true }
+  const match = source.match(/^(\/)?\s*([a-z][a-z0-9:-]*)(?=[\s/>]|$)/i)
+  if (!match) return
+  return {
+    end: Math.min(cursor + 1, html.length),
+    closing: !!match[1],
+    name: match[2].toLowerCase(),
+    doctype: false,
+  }
+}
+
+function codePoints(value: string) {
+  return Array.from(value).length
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value)
+}
+
+function readProperties<const Keys extends readonly string[]>(value: unknown, keys: Keys) {
+  const input = readRecord(value)
+  if (!input) return
+  const entries = keys.map((key) => readProperty(input, key))
+  if (entries.some((entry) => entry === undefined)) return
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined)) as Record<Keys[number], unknown>
+}
+
+function readRecord(value: unknown) {
+  try {
+    if (record(value)) return value
+  } catch {
+    return
+  }
+}
+
+function readProperty(value: Record<string, unknown>, key: string) {
+  try {
+    return [key, value[key]] as const
+  } catch {
+    return
+  }
+}

--- a/packages/session-ui/src/components/visualization-tool.tsx
+++ b/packages/session-ui/src/components/visualization-tool.tsx
@@ -1,0 +1,72 @@
+import { type Component, createMemo, Match, Switch } from "solid-js"
+import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
+import { useI18n } from "@opencode-ai/ui/context/i18n"
+import type { ToolProps } from "./message-part"
+import { useVisualization } from "../context/visualization"
+import { VisualizationFrame } from "./visualization-frame"
+import { decodeVisualizationResult, type VisualizationResult } from "./visualization-schema"
+
+export type VisualizationToolState =
+  | { type: "thinking" }
+  | { type: "frame"; value: VisualizationResult }
+  | { type: "invalid" }
+  | { type: "empty" }
+
+export function visualizationStructured(structured: unknown, metadata: unknown) {
+  return structured === undefined ? metadata : structured
+}
+
+export function visualizationToolState(
+  status: string | undefined,
+  structured?: unknown,
+  enabled = false,
+): VisualizationToolState {
+  if (status === "pending" || status === "running") return { type: "thinking" }
+  if (status !== "completed") return { type: "empty" }
+  if (!enabled) return { type: "invalid" }
+  const value = decodeVisualizationResult(structured)
+  if (!value) return { type: "invalid" }
+  return { type: "frame", value }
+}
+
+export const VisualizationTool: Component<ToolProps> = (props) => {
+  const i18n = useI18n()
+  const visualization = useVisualization()
+  const state = createMemo(() =>
+    visualizationToolState(
+      props.status,
+      visualizationStructured(props.structured, props.metadata),
+      visualization.enabled,
+    ),
+  )
+  const value = createMemo(() => {
+    const current = state()
+    if (current.type === "frame") return current.value
+  })
+
+  return (
+    <Switch>
+      <Match when={state().type === "thinking"}>
+        <div data-component="visualization-tool" data-state="thinking">
+          <TextShimmer text={i18n.t("ui.sessionTurn.status.thinking")} active />
+        </div>
+      </Match>
+      <Match when={value()}>
+        {(value) => (
+          <div data-component="visualization-tool" data-state="frame">
+            <VisualizationFrame
+              value={value()}
+              sessionID={props.sessionID}
+              onContentRendered={props.onContentRendered}
+            />
+          </div>
+        )}
+      </Match>
+      <Match when={state().type === "invalid"}>
+        <div data-component="visualization-tool" data-state="invalid">
+          <span>{i18n.t("ui.toolErrorCard.failed")}</span>
+        </div>
+      </Match>
+    </Switch>
+  )
+}

--- a/packages/session-ui/src/components/visualization.css
+++ b/packages/session-ui/src/components/visualization.css
@@ -1,0 +1,40 @@
+[data-component="visualization-tool"],
+[data-component="visualization-frame"],
+[data-slot="visualization-frame-container"] {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+[data-component="visualization-tool"][data-state="thinking"],
+[data-component="visualization-tool"][data-state="invalid"],
+[data-slot="visualization-frame-failed"] {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  color: var(--v2-text-text-muted);
+}
+
+[data-component="visualization-tool"][data-state="invalid"],
+[data-slot="visualization-frame-failed"] {
+  color: var(--v2-text-text-base);
+}
+
+[data-slot="visualization-frame-container"] {
+  max-height: 4096px;
+}
+
+[data-slot="visualization-frame"] {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: transparent;
+}
+
+[data-slot="visualization-frame-actions"] {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}

--- a/packages/session-ui/src/context/index.ts
+++ b/packages/session-ui/src/context/index.ts
@@ -1,1 +1,2 @@
 export * from "./data"
+export * from "./visualization"

--- a/packages/session-ui/src/context/visualization.tsx
+++ b/packages/session-ui/src/context/visualization.tsx
@@ -1,0 +1,36 @@
+import { createSimpleContext } from "@opencode-ai/ui/context"
+
+export type VisualizationFollowUpInput = {
+  sessionID: string
+  title?: string
+  prompt: string
+}
+
+export type VisualizationFollowUpResult = "sent" | "cancelled" | "rejected"
+
+export type VisualizationFollowUp = (input: VisualizationFollowUpInput) => Promise<VisualizationFollowUpResult>
+
+const rejected: VisualizationFollowUp = () => Promise.resolve("rejected")
+
+export type Visualization = {
+  enabled: boolean
+  followUp: VisualizationFollowUp
+}
+
+const context = createSimpleContext({
+  name: "Visualization",
+  init: (props: { enabled?: boolean; followUp?: VisualizationFollowUp }): Visualization => ({
+    enabled: props.enabled ?? false,
+    followUp: props.followUp ?? rejected,
+  }),
+})
+
+export const VisualizationProvider = context.provider
+
+export function useVisualization(): Visualization {
+  try {
+    return context.use()
+  } catch {
+    return { enabled: false, followUp: rejected }
+  }
+}

--- a/packages/session-ui/src/styles/index.css
+++ b/packages/session-ui/src/styles/index.css
@@ -12,3 +12,4 @@
 @import "../components/tool-count-summary.css" layer(components);
 @import "../components/tool-error-card.css" layer(components);
 @import "../components/tool-status-title.css" layer(components);
+@import "../components/visualization.css" layer(components);

--- a/packages/ui/src/context/dialog.test.tsx
+++ b/packages/ui/src/context/dialog.test.tsx
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test"
+import { createDialogStackTransitions } from "./dialog"
+
+function entry(id: string) {
+  let closed = 0
+  let disposed = 0
+  let notified = false
+  return {
+    id,
+    notifyClose: () => {
+      if (notified) return
+      notified = true
+      closed++
+    },
+    dispose: () => {
+      disposed++
+    },
+    get closed() {
+      return closed
+    },
+    get disposed() {
+      return disposed
+    },
+  }
+}
+
+test("show replaces a pushed dialog without closing its replacement", () => {
+  const transitions = createDialogStackTransitions<ReturnType<typeof entry>>()
+  const first = entry("A")
+  const second = entry("B")
+  const firstHandle = transitions.push(() => first)
+  const secondHandle = transitions.show(() => second)
+
+  expect(first.closed).toBe(1)
+  expect(first.disposed).toBe(1)
+  expect(second.closed).toBe(0)
+  firstHandle.close()
+  expect(second.closed).toBe(0)
+  secondHandle.close()
+  expect(second.closed).toBe(1)
+})
+
+test("show settles a pending close only once", () => {
+  const transitions = createDialogStackTransitions<ReturnType<typeof entry>>()
+  const first = entry("A")
+  const second = entry("B")
+  const firstHandle = transitions.push(() => first)
+
+  firstHandle.close()
+  transitions.show(() => second)
+  firstHandle.close()
+
+  expect(first.closed).toBe(1)
+  expect(first.disposed).toBe(1)
+  expect(second.closed).toBe(0)
+})
+
+test("a handle closes only its matching pushed dialog when another dialog is above it", () => {
+  const transitions = createDialogStackTransitions<ReturnType<typeof entry>>()
+  const first = entry("A")
+  const second = entry("B")
+  const firstHandle = transitions.push(() => first)
+  transitions.push(() => second)
+
+  firstHandle.close()
+
+  expect(first.closed).toBe(1)
+  expect(second.closed).toBe(0)
+})

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -18,21 +18,85 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 
 type DialogElement = () => JSX.Element
 
-type Active = {
+type DialogStackEntry = {
   id: string
-  node: JSX.Element
   dispose: () => void
+  notifyClose: () => void
+}
+
+type Active = DialogStackEntry & {
+  node: JSX.Element
   owner: Owner
-  onClose?: () => void
   setClosing: (closing: boolean) => void
+}
+
+export type DialogHandle = {
+  id: string
+  close: () => void
 }
 
 const Context = createContext<ReturnType<typeof init>>()
 
+export function createDialogCloseNotifier(onClose?: () => void) {
+  let notified = false
+
+  return () => {
+    if (notified) return
+    notified = true
+    onClose?.()
+  }
+}
+
+export function createDialogStackTransitions<T extends DialogStackEntry>(onChange?: (items: T[]) => void) {
+  let stack: T[] = []
+  let locked = false
+  const publish = () => onChange?.(stack)
+
+  const close = (id?: string) => {
+    const current = id ? stack.find((item) => item.id === id) : stack.at(-1)
+    if (!current || locked) return
+    locked = true
+    current.notifyClose()
+    return current
+  }
+
+  const handle = (item: T): DialogHandle => ({ id: item.id, close: () => close(item.id) })
+
+  return {
+    stack: () => stack,
+    close,
+    push: (create: (layer: number) => T) => {
+      const item = create(stack.length)
+      stack = [...stack, item]
+      publish()
+      return handle(item)
+    },
+    show: (create: (layer: number) => T) => {
+      for (const item of stack) {
+        item.notifyClose()
+        item.dispose()
+      }
+      locked = false
+      const item = create(0)
+      stack = [item]
+      publish()
+      return handle(item)
+    },
+    remove: (id: string) => {
+      stack = stack.filter((item) => item.id !== id)
+      locked = false
+      publish()
+    },
+    unlock: () => {
+      locked = false
+    },
+  }
+}
+
 function init() {
   const [stack, setStack] = createSignal<Active[]>([])
+  const transitions = createDialogStackTransitions<Active>(setStack)
   const timer = { current: undefined as ReturnType<typeof setTimeout> | undefined }
-  const lock = { value: false }
 
   onCleanup(() => {
     if (timer.current === undefined) return
@@ -41,11 +105,8 @@ function init() {
   })
 
   const close = (id?: string) => {
-    const items = stack()
-    const current = id ? items.find((item) => item.id === id) : items.at(-1)
-    if (!current || lock.value) return
-    lock.value = true
-    current.onClose?.()
+    const current = transitions.close(id)
+    if (!current) return
     current.setClosing(true)
 
     const closed = current.id
@@ -57,8 +118,7 @@ function init() {
     timer.current = setTimeout(() => {
       timer.current = undefined
       current.dispose()
-      setStack((items) => items.filter((item) => item.id !== closed))
-      lock.value = false
+      transitions.remove(closed)
     }, 100)
   }
 
@@ -75,7 +135,7 @@ function init() {
     makeEventListener(window, "keydown", onKeyDown, { capture: true })
   })
 
-  const mount = (element: DialogElement, owner: Owner, onClose: (() => void) | undefined, layer: number) => {
+  const mount = (element: DialogElement, owner: Owner, onClose: (() => void) | undefined, layer: number): Active => {
     const id = Math.random().toString(36).slice(2)
     const zIndex = 50 + layer * 10
     let dispose: (() => void) | undefined
@@ -121,10 +181,9 @@ function init() {
       }),
     )
 
-    if (!dispose || !setClosing) return
+    if (!dispose || !setClosing) throw new Error("Failed to mount dialog")
 
-    const active: Active = { id, node, dispose, owner, onClose, setClosing }
-    setStack((items) => [...items, active])
+    return { id, node, dispose, owner, notifyClose: createDialogCloseNotifier(onClose), setClosing }
   }
 
   const push = (element: DialogElement, owner: Owner, onClose?: () => void) => {
@@ -132,19 +191,16 @@ function init() {
       clearTimeout(timer.current)
       timer.current = undefined
     }
-    lock.value = false
-    mount(element, owner, onClose, stack().length)
+    transitions.unlock()
+    return transitions.push((layer) => mount(element, owner, onClose, layer))
   }
 
   const show = (element: DialogElement, owner: Owner, onClose?: () => void) => {
-    for (const item of stack()) item.dispose()
-    setStack([])
     if (timer.current !== undefined) {
       clearTimeout(timer.current)
       timer.current = undefined
     }
-    lock.value = false
-    mount(element, owner, onClose, 0)
+    return transitions.show((layer) => mount(element, owner, onClose, layer))
   }
 
   return {
@@ -188,7 +244,7 @@ export function useDialog() {
     },
     push(element: DialogElement, onClose?: () => void) {
       const base = ctx.stack().at(-1)?.owner ?? owner
-      return startTransition(() => ctx.push(element, base, onClose))
+      return ctx.push(element, base, onClose)
     },
     close() {
       ctx.close()


### PR DESCRIPTION
### Issue for this PR

Closes #40583

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Desktop-only inline HTML visualizations to assistant conversations.

The model writes a versioned fragment through `visualization_create`; the Desktop host supplies a sandboxed `srcdoc`, transparent/theme-aware canvas, and content-height synchronization. Structured results survive both live V2 projection and history restoration. Web does not enable the renderer and fails closed without executing the HTML.

The iframe uses `sandbox="allow-scripts"`, a network-disabled CSP, bounded/token-checked messages, and Desktop subframe navigation blocking. A visualization can request a follow-up prompt only through a host confirmation dialog. `/visualize` limits its first turn to the visualization tool, with a DeepSeek V4 fallback for models that reject required `tool_choice`.

### How did you verify your code works?

- Core visualization tests: 9 passed
- OpenCode visualization/prompt tests: 59 passed, 1 existing V2-projector test skipped
- Session UI document/schema/frame tests: 37 passed
- App projection/follow-up tests: 48 passed
- Desktop/CLI/UI focused tests: 8 passed
- Web Playwright regression: 1 passed; no iframe or HTML execution
- `bun turbo typecheck`: 30 packages passed in the pre-push hook
- Prettier passed; targeted oxlint reported 0 errors
- Built and signed a macOS arm64 package and manually verified live/history rendering, interaction, and transparent canvas behavior

### Screenshots / recordings

Manually verified with generated clock and interactive control previews in the macOS Desktop conversation. The canvas matches the conversation background while bounded visualization surfaces keep their own background.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
