### PR TITLE
fix(opencode): avoid treating separate clones as sandboxes

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -238,10 +238,19 @@ const layer = Layer.effect(
         vcs: data.vcs?.type ?? fakeVcs,
         time: { ...existing.time, updated: Date.now() },
       }
+      // Only add the directory as a sandbox when it is a genuine linked git
+      // worktree (common .git dir lives outside the working tree). Independent
+      // clones of the same remote share a project ID by design, but each clone
+      // is its own primary worktree and must NOT be treated as a sandbox of the
+      // first one — otherwise the front-end surfaces stale branch info from the
+      // first directory.
+      const isLinkedWorktree =
+        data.vcs?.type === "git" && !FSUtil.contains(data.directory, data.vcs.store)
       if (
         projectID !== ProjectV2.ID.global &&
         data.directory !== result.worktree &&
-        !result.sandboxes.includes(data.directory)
+        !result.sandboxes.includes(data.directory) &&
+        isLinkedWorktree
       )
         result.sandboxes.push(data.directory)
       result.sandboxes = yield* Effect.forEach(

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -362,6 +362,30 @@ describe("Project.fromDirectory with worktrees", () => {
     }),
   )
 
+  it.live("separate clones of the same repo should not add clone as sandbox", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+
+      // Create a bare remote, push, then clone into a second directory
+      const bare = tmp + "-bare"
+      const clone = tmp + "-clone"
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => $`rm -rf ${bare} ${clone}`.quiet().nothrow()).pipe(Effect.ignore),
+      )
+      yield* Effect.promise(() => $`git clone --bare ${tmp} ${bare}`.quiet())
+      yield* Effect.promise(() => $`git clone ${bare} ${clone}`.quiet())
+
+      yield* project.fromDirectory(tmp)
+      const next = yield* project.fromDirectory(clone)
+
+      // The clone is an independent checkout, not a linked git worktree.
+      // It must NOT appear in sandboxes — otherwise the front-end surfaces
+      // stale branch info from the first directory.
+      expect(next.project.sandboxes).not.toContain(clone)
+    }),
+  )
+
   it.live("should accumulate multiple worktrees in sandboxes", () =>
     Effect.gen(function* () {
       const project = yield* Project.Service


### PR DESCRIPTION
### Issue for this PR

Closes #39605

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a case where opening separate clones of the same git repository could make the app treat the second clone as a sandbox/worktree of the first one.

Project IDs can be shared across separate clones when they have the same normalized origin remote. Before this change, any later directory with the same project ID and a different path was added to `sandboxes`. That is correct for linked git worktrees, but not for independent clones. As a result, the UI could reuse workspace/branch state from the first directory when opening the second one.

The fix only adds a directory to `sandboxes` when it is a real linked git worktree, detected by the git common directory living outside the opened worktree. Independent clones keep their shared project ID, but are no longer treated as sandboxes of each other.

### How did you verify your code works?

- Added a regression test for two separate clones of the same repo.
- Ran `bun test test/project/project.test.ts` from `packages/opencode`.
- Ran `bun typecheck`.

### Screenshots / recordings

Not applicable. This is a backend project/worktree classification fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR