### PR TITLE
feat(core): implement V2 manual compaction

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -163,7 +163,9 @@ export interface Interface {
     skill: string
     resume?: boolean
   }) => Effect.Effect<void, OperationUnavailableError>
-  readonly compact: (input: CompactInput) => Effect.Effect<void, NotFoundError | OperationUnavailableError>
+  readonly compact: (
+    input: CompactInput,
+  ) => Effect.Effect<void, NotFoundError | OperationUnavailableError | SessionRunner.RunError>
   readonly wait: (id: SessionSchema.ID) => Effect.Effect<void, NotFoundError | OperationUnavailableError>
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, NotFoundError | SessionRunner.RunError>
@@ -416,7 +418,10 @@ const layer = Layer.effect(
       }),
       compact: Effect.fn("V2Session.compact")(function* (input) {
         yield* result.get(input.sessionID)
-        return yield* new OperationUnavailableError({ operation: "compact" })
+        // A follow-up prompt is a separate durable admission, so it stays unsupported
+        // until callers need it rather than being silently dropped here.
+        if (input.prompt !== undefined) return yield* new OperationUnavailableError({ operation: "compact" })
+        yield* execution.compact(input.sessionID)
       }),
       wait: Effect.fn("V2Session.wait")(function* (sessionID) {
         yield* result.get(sessionID)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -68,6 +68,10 @@ type Input = {
   readonly sessionID: SessionSchema.ID
   readonly entries: readonly Entry[]
   readonly model: Model
+}
+
+/** A compaction evaluated against the budget of an assembled provider turn. */
+type TurnInput = Input & {
   readonly request: LLMRequest
 }
 
@@ -169,25 +173,31 @@ export const buildPrompt = (input: { readonly previousSummary?: string; readonly
 
 export const make = (dependencies: Dependencies) => {
   const config = settings(dependencies.config)
-  const compactAfterOverflow = Effect.fn("SessionCompaction.compactAfterOverflow")(function* (input: Input) {
+  const summarize = Effect.fn("SessionCompaction.summarize")(function* (
+    input: Input & { readonly reason: "auto" | "manual"; readonly output: number },
+  ) {
     const context = input.model.route.defaults.limits?.context
-    if (context === undefined || context <= 0) return false
-    const output = input.request.generation?.maxTokens ?? input.model.route.defaults.limits?.output ?? 0
-    const selected = select(input.entries, config.tokens)
+    // Budget-driven compaction is meaningless without a declared context limit, while an
+    // explicit request should still summarize on models that declare none.
+    const budget = context !== undefined && context > 0 ? context : undefined
+    if (budget === undefined && input.reason !== "manual") return false
+    // Automatic compaction retains a recent verbatim tail because it only needs to free
+    // enough budget to continue. An explicit request means compress everything.
+    const selected = select(input.entries, input.reason === "manual" ? 0 : config.tokens)
     const previousSummary = input.entries.find((entry) => entry.message.type === "compaction")?.message
     if (!selected || (selected.head.length === 0 && previousSummary?.type !== "compaction")) return false
     const summaryPrompt = buildPrompt({
       previousSummary: previousSummary?.type === "compaction" ? previousSummary.summary : undefined,
       context: [previousSummary?.type === "compaction" ? previousSummary.recent : "", selected.head].filter(Boolean),
     })
-    const summaryOutput = Math.min(output || SUMMARY_OUTPUT_TOKENS, SUMMARY_OUTPUT_TOKENS)
-    if (Token.estimate(summaryPrompt) > context - summaryOutput) return false
+    const summaryOutput = Math.min(input.output || SUMMARY_OUTPUT_TOKENS, SUMMARY_OUTPUT_TOKENS)
+    if (budget !== undefined && Token.estimate(summaryPrompt) > budget - summaryOutput) return false
     const messageID = SessionMessage.ID.create()
     yield* dependencies.events.publish(SessionEvent.Compaction.Started, {
       sessionID: input.sessionID,
       messageID,
       timestamp: yield* DateTime.now,
-      reason: "auto",
+      reason: input.reason,
     })
 
     const chunks: string[] = []
@@ -216,26 +226,35 @@ export const make = (dependencies: Dependencies) => {
       sessionID: input.sessionID,
       messageID,
       timestamp: yield* DateTime.now,
-      reason: "auto",
+      reason: input.reason,
       text: summary,
       recent: selected.recent,
     })
     return true
   })
-  const compactIfNeeded = Effect.fn("SessionCompaction.compactIfNeeded")(function* (input: Input) {
+  const turnOutput = (input: TurnInput) =>
+    input.request.generation?.maxTokens ?? input.model.route.defaults.limits?.output ?? 0
+  const compactAfterOverflow = Effect.fn("SessionCompaction.compactAfterOverflow")((input: TurnInput) =>
+    summarize({ ...input, reason: "auto", output: turnOutput(input) }),
+  )
+  const compactIfNeeded = Effect.fn("SessionCompaction.compactIfNeeded")(function* (input: TurnInput) {
     if (!config.auto) return false
     const context = input.model.route.defaults.limits?.context
     if (context === undefined || context <= 0) return false
-    const output = input.request.generation?.maxTokens ?? input.model.route.defaults.limits?.output ?? 0
     if (
       estimate({ system: input.request.system, messages: input.request.messages, tools: input.request.tools }) <=
-      context - Math.max(output, config.buffer)
+      context - Math.max(turnOutput(input), config.buffer)
     )
       return false
     return yield* compactAfterOverflow(input)
   })
+  /** Compacts on explicit request, independent of the request budget. */
+  const compactNow = Effect.fn("SessionCompaction.compactNow")((input: Input) =>
+    summarize({ ...input, reason: "manual", output: input.model.route.defaults.limits?.output ?? 0 }),
+  )
   return {
     compactIfNeeded,
     compactAfterOverflow,
+    compactNow,
   }
 }

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -15,6 +15,8 @@ export interface Interface {
   readonly wake: (sessionID: SessionSchema.ID) => Effect.Effect<void>
   /** Interrupt active work owned by this process. Idle interruption is a no-op. */
   readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  /** Summarizes recorded history, serialized against this Session's other execution. */
+  readonly compact: (sessionID: SessionSchema.ID) => Effect.Effect<void, SessionRunner.RunError>
 }
 
 /** Routes execution from a Session ID to the runner owned by that Session's Location. */
@@ -30,5 +32,6 @@ export const noopLayer = Layer.succeed(
     resume: () => Effect.void,
     wake: () => Effect.void,
     interrupt: () => Effect.void,
+    compact: () => Effect.void,
   }),
 )

--- a/packages/core/src/session/execution/local.ts
+++ b/packages/core/src/session/execution/local.ts
@@ -13,19 +13,27 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const store = yield* SessionStore.Service
     const locations = yield* LocationServiceMap.Service
+    const inLocation = Effect.fnUntraced(function* <A>(
+      sessionID: SessionSchema.ID,
+      failure: string,
+      use: (runner: SessionRunner.Interface) => Effect.Effect<A, SessionRunner.RunError>,
+    ) {
+      const session = yield* store.get(sessionID)
+      if (!session) return yield* Effect.die(`Session not found: ${sessionID}`)
+      return yield* SessionRunner.Service.use(use).pipe(
+        Effect.provide(locations.get(session.location)),
+        Effect.tapCause((cause) =>
+          Cause.hasInterruptsOnly(cause)
+            ? Effect.void
+            : Effect.logError(failure, cause).pipe(Effect.annotateLogs({ sessionID })),
+        ),
+      )
+    })
     const coordinator = yield* SessionRunCoordinator.make<SessionSchema.ID, SessionRunner.RunError>({
-      drain: Effect.fnUntraced(function* (sessionID: SessionSchema.ID, force) {
-        const session = yield* store.get(sessionID)
-        if (!session) return yield* Effect.die(`Session not found: ${sessionID}`)
-        return yield* SessionRunner.Service.use((runner) => runner.run({ sessionID, force })).pipe(
-          Effect.provide(locations.get(session.location)),
-          Effect.tapCause((cause) =>
-            Cause.hasInterruptsOnly(cause)
-              ? Effect.void
-              : Effect.logError("Failed to drain Session", cause).pipe(Effect.annotateLogs({ sessionID })),
-          ),
-        )
-      }),
+      drain: (sessionID, force) =>
+        inLocation(sessionID, "Failed to drain Session", (runner) => runner.run({ sessionID, force })),
+      aside: (sessionID) =>
+        inLocation(sessionID, "Failed to compact Session", (runner) => runner.compact({ sessionID })),
     })
 
     return SessionExecution.Service.of({
@@ -33,6 +41,7 @@ const layer = Layer.effect(
       interrupt: coordinator.interrupt,
       resume: coordinator.run,
       wake: coordinator.wake,
+      compact: coordinator.runAside,
     })
   }),
 )

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -1,6 +1,7 @@
 export * as SessionRunCoordinator from "./run-coordinator"
 
 import { Deferred, Effect, Exit, Fiber, FiberSet, Scope } from "effect"
+import { makeUnsafe, type Semaphore } from "effect/Semaphore"
 
 /** Serializes execution for each key while allowing different keys to run concurrently. */
 export interface Coordinator<Key, E> {
@@ -12,6 +13,8 @@ export interface Coordinator<Key, E> {
   readonly wake: (key: Key) => Effect.Effect<void>
   /** Stops active execution and waits for its cleanup. */
   readonly interrupt: (key: Key) => Effect.Effect<void>
+  /** Runs the aside after any active execution settles. Never joins and never coalesces. */
+  readonly runAside: (key: Key) => Effect.Effect<void, E>
 }
 
 type Entry<E> = {
@@ -23,10 +26,33 @@ type Entry<E> = {
 
 export const make = <Key, E>(options: {
   readonly drain: (key: Key, force: boolean) => Effect.Effect<void, E>
+  readonly aside?: (key: Key) => Effect.Effect<void, E>
 }): Effect.Effect<Coordinator<Key, E>, never, Scope.Scope> =>
   Effect.gen(function* () {
     const active = new Map<Key, Entry<E>>()
     const fork = yield* FiberSet.makeRuntime<never, void, never>()
+
+    // Guards a key against concurrent bodies. Drains and asides both take it, so an aside
+    // never overlaps a provider turn for the same key. Reference counted because keys are
+    // unbounded over a process lifetime; waiters keep the entry alive while queued.
+    const gates = new Map<Key, { readonly semaphore: Semaphore; users: number }>()
+    const withGate = <A>(key: Key, effect: Effect.Effect<A, E>) =>
+      Effect.suspend(() => {
+        const existing = gates.get(key)
+        const entry = existing ?? { semaphore: makeUnsafe(1), users: 0 }
+        if (!existing) gates.set(key, entry)
+        entry.users++
+        return entry.semaphore
+          .withPermits(1)(effect)
+          .pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                entry.users--
+                if (entry.users === 0) gates.delete(key)
+              }),
+            ),
+          )
+      })
 
     const makeEntry = (): Entry<E> => ({
       done: Deferred.makeUnsafe<void, E>(),
@@ -38,7 +64,7 @@ export const make = <Key, E>(options: {
       const ready = Deferred.makeUnsafe<void>()
       const owner = fork(
         (successor ? Effect.yieldNow : Deferred.await(ready)).pipe(
-          Effect.andThen(Effect.suspend(() => options.drain(key, force))),
+          Effect.andThen(Effect.suspend(() => withGate(key, options.drain(key, force)))),
           Effect.onExit((exit) => Effect.sync(() => settle(key, entry, exit))),
           Effect.exit,
           Effect.asVoid,
@@ -100,5 +126,12 @@ export const make = <Key, E>(options: {
         return Fiber.interrupt(entry.owner)
       })
 
-    return { active: Effect.sync(() => new Set(active.keys())), run, wake, interrupt }
+    const runAside = (key: Key): Effect.Effect<void, E> =>
+      Effect.suspend(() => {
+        const aside = options.aside
+        if (aside === undefined) return Effect.void
+        return withGate(key, aside(key))
+      })
+
+    return { active: Effect.sync(() => new Set(active.keys())), run, wake, interrupt, runAside }
   })

--- a/packages/core/src/session/runner/index.ts
+++ b/packages/core/src/session/runner/index.ts
@@ -23,6 +23,8 @@ export interface Interface {
     readonly sessionID: SessionSchema.ID
     readonly force: boolean
   }) => Effect.Effect<void, RunError>
+  /** Summarizes recorded history into a compaction row without running a provider turn. */
+  readonly compact: (input: { readonly sessionID: SessionSchema.ID }) => Effect.Effect<void, RunError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionRunner") {}

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -405,8 +405,27 @@ const layer = Layer.effect(
       }
     })
 
+    /**
+     * Summarizes recorded history on explicit request. This is not a provider turn: no
+     * inbox input is promoted, no tools are materialized, and no assistant reply is
+     * produced. The compaction row it writes becomes the history cutoff for later turns.
+     */
+    const compact = Effect.fn("SessionRunner.compact")(function* (input: { readonly sessionID: SessionSchema.ID }) {
+      const session = yield* getSession(input.sessionID)
+      if (session.location.directory !== location.directory || session.location.workspaceID !== location.workspaceID)
+        return yield* Effect.interrupt
+      const agent = yield* agents.select(session.agent)
+      const initialized = yield* SessionContextEpoch.initialize(db, loadSystemContext(agent), session.id)
+      const system =
+        initialized ?? (yield* SessionContextEpoch.prepare(db, events, loadSystemContext(agent), session.id))
+      const model = yield* models.resolve(session)
+      const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
+      yield* compaction.compactNow({ sessionID: session.id, entries, model })
+    })
+
     return Service.of({
       run,
+      compact,
     })
   }),
 )

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -23,6 +23,7 @@ import { testEffect } from "./lib/effect"
 const executionCalls: SessionV2.ID[] = []
 const interruptCalls: SessionV2.ID[] = []
 const wakeCalls: SessionV2.ID[] = []
+const compactCalls: SessionV2.ID[] = []
 const activeSessions = new Set<SessionV2.ID>()
 const execution = Layer.succeed(
   SessionExecution.Service,
@@ -39,6 +40,10 @@ const execution = Layer.succeed(
     wake: (sessionID) =>
       Effect.sync(() => {
         wakeCalls.push(sessionID)
+      }),
+    compact: (sessionID) =>
+      Effect.sync(() => {
+        compactCalls.push(sessionID)
       }),
   }),
 )

--- a/packages/core/test/session-run-coordinator.test.ts
+++ b/packages/core/test/session-run-coordinator.test.ts
@@ -392,6 +392,116 @@ describe("SessionRunCoordinator", () => {
     ),
   )
 
+  it.effect("runs an aside only after the active drain settles", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        const order: string[] = []
+        const coordinator = yield* SessionRunCoordinator.make<string, never>({
+          drain: () =>
+            Effect.sync(() => order.push("drain:start")).pipe(
+              Effect.andThen(Deferred.succeed(started, undefined)),
+              Effect.andThen(Deferred.await(gate)),
+              Effect.andThen(Effect.sync(() => order.push("drain:end"))),
+            ),
+          aside: () => Effect.sync(() => order.push("aside")),
+        })
+
+        const draining = yield* coordinator.run("session").pipe(Effect.forkChild)
+        yield* Deferred.await(started)
+        const aside = yield* coordinator.runAside("session").pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        expect(order).toEqual(["drain:start"])
+
+        yield* Deferred.succeed(gate, undefined)
+        yield* Effect.all([Fiber.join(draining), Fiber.join(aside)])
+        expect(order).toEqual(["drain:start", "drain:end", "aside"])
+      }),
+    ),
+  )
+
+  it.effect("runs each aside instead of coalescing them", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let asides = 0
+        const coordinator = yield* SessionRunCoordinator.make<string, never>({
+          drain: () => Effect.void,
+          aside: () => Effect.sync(() => asides++),
+        })
+
+        yield* coordinator.runAside("session")
+        yield* coordinator.runAside("session")
+
+        expect(asides).toBe(2)
+      }),
+    ),
+  )
+
+  it.effect("serializes an aside against a concurrent aside for the same key", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        let active = 0
+        let peak = 0
+        const coordinator = yield* SessionRunCoordinator.make<string, never>({
+          drain: () => Effect.void,
+          aside: () =>
+            Effect.sync(() => {
+              active++
+              peak = Math.max(peak, active)
+            }).pipe(
+              Effect.andThen(Deferred.succeed(entered, undefined)),
+              Effect.andThen(Deferred.await(gate)),
+              Effect.andThen(Effect.sync(() => active--)),
+            ),
+        })
+
+        const first = yield* coordinator.runAside("session").pipe(Effect.forkChild)
+        yield* Deferred.await(entered)
+        const second = yield* coordinator.runAside("session").pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Deferred.succeed(gate, undefined)
+        yield* Effect.all([Fiber.join(first), Fiber.join(second)])
+
+        expect(peak).toBe(1)
+      }),
+    ),
+  )
+
+  it.effect("lets asides for different keys run concurrently", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const entered = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        let active = 0
+        let peak = 0
+        const coordinator = yield* SessionRunCoordinator.make<string, never>({
+          drain: () => Effect.void,
+          aside: () =>
+            Effect.sync(() => {
+              active++
+              peak = Math.max(peak, active)
+            }).pipe(
+              Effect.andThen(Deferred.succeed(entered, undefined)),
+              Effect.andThen(Deferred.await(gate)),
+              Effect.andThen(Effect.sync(() => active--)),
+            ),
+        })
+
+        const first = yield* coordinator.runAside("a").pipe(Effect.forkChild)
+        yield* Deferred.await(entered)
+        const second = yield* coordinator.runAside("b").pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Deferred.succeed(gate, undefined)
+        yield* Effect.all([Fiber.join(first), Fiber.join(second)])
+
+        expect(peak).toBe(2)
+      }),
+    ),
+  )
+
   it.effect("trampolines synchronous self-waking execution", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -90,12 +90,14 @@ const execution = Layer.effect(
     const sessionRunner = yield* SessionRunner.Service
     const coordinator = yield* SessionRunCoordinator.make<SessionV2.ID, SessionRunner.RunError>({
       drain: (sessionID, force) => sessionRunner.run({ sessionID, force }),
+      aside: (sessionID) => sessionRunner.compact({ sessionID }),
     })
     return SessionExecution.Service.of({
       active: coordinator.active,
       resume: coordinator.run,
       wake: coordinator.wake,
       interrupt: coordinator.interrupt,
+      compact: coordinator.runAside,
     })
   }),
 ).pipe(Layer.provide(runnerLayer))

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -242,12 +242,14 @@ const execution = Layer.effect(
     const sessionRunner = yield* SessionRunner.Service
     const coordinator = yield* SessionRunCoordinator.make<SessionV2.ID, SessionRunner.RunError>({
       drain: (sessionID, force) => sessionRunner.run({ sessionID, force }),
+      aside: (sessionID) => sessionRunner.compact({ sessionID }),
     })
     return SessionExecution.Service.of({
       active: coordinator.active,
       resume: coordinator.run,
       wake: coordinator.wake,
       interrupt: coordinator.interrupt,
+      compact: coordinator.runAside,
     })
   }),
 ).pipe(Layer.provide(runnerLayer))
@@ -1267,6 +1269,96 @@ describe("SessionRunnerLLM", () => {
       streamGate = undefined
       expect(requests).toHaveLength(2)
       expect((yield* session.context(sessionID)).some((message) => message.type === "compaction")).toBe(false)
+    }),
+  )
+
+  it.effect("compacts on explicit request without running a provider turn", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      response = fragmentFixture("text", "text-first", ["Earlier answer"]).completeEvents
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Earlier question" }), resume: false })
+      yield* session.resume(sessionID)
+
+      requests.length = 0
+      responses = [fragmentFixture("text", "text-summary", ["## Objective\n- Preserve the task"]).completeEvents]
+      yield* session.compact({ sessionID })
+
+      // One summarization request and no follow-up turn.
+      expect(requests).toHaveLength(1)
+      expect(userTexts(requests[0])[0]).toContain("## Objective")
+      expect(requests[0].tools).toEqual([])
+
+      const context = yield* (yield* SessionStore.Service).context(sessionID)
+      expect(context.map((message) => message.type)).toEqual(["compaction"])
+      expect(context[0]).toMatchObject({
+        type: "compaction",
+        reason: "manual",
+        summary: "## Objective\n- Preserve the task",
+      })
+    }),
+  )
+
+  it.effect("compacts on explicit request while the request budget has room", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      response = fragmentFixture("text", "text-first", ["Earlier answer"]).completeEvents
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Short" }), resume: false })
+      yield* session.resume(sessionID)
+
+      // The default model has ample context, so automatic compaction would decline here.
+      requests.length = 0
+      responses = [fragmentFixture("text", "text-summary", ["## Objective\n- Still compacted"]).completeEvents]
+      yield* session.compact({ sessionID })
+
+      expect(requests).toHaveLength(1)
+      expect((yield* (yield* SessionStore.Service).context(sessionID))[0]).toMatchObject({
+        type: "compaction",
+        reason: "manual",
+      })
+    }),
+  )
+
+  it.effect("leaves history unchanged when explicit compaction has nothing to summarize", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      requests.length = 0
+      yield* session.compact({ sessionID })
+
+      expect(requests).toHaveLength(0)
+      expect(yield* (yield* SessionStore.Service).context(sessionID)).toEqual([])
+    }),
+  )
+
+  it.effect("keeps explicit compaction out of an active provider turn", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const gate = yield* Deferred.make<void>()
+      const started = yield* Deferred.make<void>()
+      streamGate = gate
+      streamStarted = started
+      response = fragmentFixture("text", "text-first", ["Answer"]).completeEvents
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Question" }), resume: false })
+      const draining = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* Deferred.await(started)
+
+      // Compaction must wait for the in-flight turn rather than interleaving with it.
+      const compacting = yield* session.compact({ sessionID }).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      expect(requests).toHaveLength(1)
+
+      responses = [fragmentFixture("text", "text-summary", ["## Objective\n- Serialized"]).completeEvents]
+      streamGate = undefined
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.join(draining)
+      yield* Fiber.join(compacting)
+
+      expect(requests).toHaveLength(2)
+      const context = yield* (yield* SessionStore.Service).context(sessionID)
+      expect(context.map((message) => message.type)).toEqual(["compaction"])
     }),
   )
 

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -189,6 +189,9 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                 }),
               ),
             ),
+            // Summarization failures are infrastructure faults with no actionable
+            // client response, matching how other runner-backed routes treat them.
+            Effect.orDie,
           )
           return HttpApiSchema.NoContent.make()
         }),

--- a/specs/v2/session.md
+++ b/specs/v2/session.md
@@ -102,7 +102,6 @@ Current Context Epoch follow-ups:
 
 - Add configured, remote, and nested instruction sources with explicit precedence and removal semantics.
 - Add durable post-crash continuation recovery for promoted or provider-dispatched work.
-- Add explicit manual compaction on top of automatic request-budget compaction.
 - Add operational metrics for observation latency, unavailable sources, contention, baseline size, and chronological-update growth.
 - Consider watcher-backed per-file caching only if measurements show direct safe-boundary observation is too expensive.
 - Expose plugin-defined Context Sources only after plugin reload and scoped cleanup semantics are designed.
@@ -119,6 +118,14 @@ Compaction keeps the full transcript durable while replacing its active model re
 Repeated compactions update the previous structured summary with newly compacted messages. The runner then reloads projected history and executes the original pending turn.
 
 When a provider rejects a request as context overflow before durable assistant output or tool execution, the runner attempts one overflow-triggered compaction even when the local estimate did not predict pressure. A completed checkpoint rebuilds the same logical provider turn with one remaining physical attempt. A second overflow, unavailable compaction, or overflow after durable output becomes the ordinary terminal failure; recovery never loops or replays partial side effects. Deterministic old tool-result pruning remains a separate follow-up.
+
+## Manual Compaction
+
+An explicit compaction request summarizes recorded history without running a provider turn: it promotes no durable input, materializes no tools, and produces no assistant reply. It shares the checkpoint machinery with automatic compaction and durably records `reason: "manual"`, so the next provider attempt rebuilds the baseline from the completed checkpoint exactly as it does after automatic compaction.
+
+Two budget conditions do not apply, because the request is explicit rather than a response to context pressure. The request-budget estimate is skipped entirely, and a model that declares no context window still compacts. Manual compaction also retains no verbatim recent tail: automatic compaction keeps `compaction.keep.tokens` of recent context because it only needs to free enough budget to continue, while an explicit request summarizes the whole active history.
+
+Manual compaction is serialized against that Session's provider turns, so a request issued while a turn is streaming runs once that turn settles. Requests never coalesce with each other or with a pending wakeup. Summarization that produces no usable summary leaves the previous history boundary active, exactly as a failed automatic attempt does.
 
 ## V1 Runtime Context Parity
 
@@ -143,6 +150,7 @@ Status: `complete` is usable in the native V2 path, `partial` covers only part o
 | Per-turn request assembly  | Model variants and request settings                                      | partial  | Apply effective agent options and future plugin-mutated request settings.                                                              |
 | Per-turn request assembly  | Structured-output policy                                                 | missing  | Add prompt format, generated tool, tool choice, and model-visible policy together.                                                     |
 | Per-turn request assembly  | Automatic/context-pressure compaction                                    | complete | V2 initiates automatic and overflow-triggered compaction, then rebuilds the baseline from the completed checkpoint.                    |
+| Per-turn request assembly  | Explicit manual compaction                                               | complete | V2 summarizes on request outside the budget path, serialized against that Session's provider turns.                                    |
 | Prompt/reference expansion | Durable typed prompt attachments                                         | complete | None.                                                                                                                                  |
 | Prompt/reference expansion | Native template and `@` mention expansion                                | missing  | Parse and resolve native V2 prompt input before durable admission.                                                                     |
 | Prompt/reference expansion | File, directory, media, and MCP-resource materialization                 | partial  | Materialize and normalize sources instead of lowering unresolved attachment metadata.                                                  |


### PR DESCRIPTION
### Issue for this PR

Closes #40614

Implements the follow-up recorded in `specs/v2/session.md`: "Add explicit manual compaction on top of automatic request-budget compaction."

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionV2.compact` was a stub that failed with `OperationUnavailableError`, which the server mapped to a 503. So on V2, `/compact` did nothing — in the app it only appeared to work because the compat shim rewrites it to the legacy V1 `session.summarize`. This implements it for real.

Manual compaction is deliberately **not** a provider turn: it promotes no durable inbox input, materializes no tools, and writes no assistant reply. It reuses the existing checkpoint machinery, so once the `Compaction.Ended` event lands, everything downstream already works — `latestCompaction` moves the history cutoff and `SessionContextEpoch.prepare` sees `compaction.seq > baseline_seq` and rebuilds the baseline.

No schema or SDK change was needed. Both `SessionEvent.Compaction.{Started,Ended}` and `SessionMessage.Compaction` already declared `reason: "auto" | "manual"`, and `"manual"` simply had no producer outside tests. `packages/client` `check:generated` is clean.

**Two budget conditions deliberately do not apply.** Automatic compaction exists to relieve context pressure, so it declines when the request still fits, and it declines outright on a model that declares no `limits.context`. Neither makes sense for an explicit request. I found the second one the hard way: my first test failed with zero summarization requests because the default test model declares no context window, which would mean `/compact` silently doing nothing on any such model.

**Manual compaction keeps no verbatim recent tail.** Automatic compaction retains `compaction.keep.tokens` of recent context because it only needs to free enough budget to continue. An explicit request should compress the whole active history, so `select` is called with `0`.

**Placement.** Execution has to live on the Location-scoped runner: `SessionV2` holds neither an LLM client nor model resolution, so it can only schedule. That mirrors how `resume` already works, and `compact` picks up `SessionRunner.RunError` for the same reason `resume` does.

**Scheduling is the one piece of new shared machinery.** Compaction must be mutually exclusive with that Session's provider turns, but must not join an active drain (unlike `run`) and must not coalesce with another request (unlike `wake`). So rather than bending either, I added `runAside` to the coordinator, guarded by a per-key refcounted semaphore that drains also take. Different Sessions still compact concurrently — I verified a global semaphore instead of a per-key one breaks two pre-existing concurrency tests.

A follow-up prompt after compaction (`CompactInput.prompt`) stays unsupported and still fails. It is a separate durable admission, and failing beats silently dropping it. No current caller passes it.

### How did you verify your code works?

`bun typecheck` clean in `packages/core` and `packages/server` (plus all 30 turbo tasks via the pre-push hook). Full `packages/core` suite: 1087 pass, 1 fail — that one is `ProjectCopy > requires force to remove a dirty git worktree`, which fails identically on a clean checkout of the base commit and is unrelated to this change. `check:generated` clean. Prettier and oxlint clean on changed files (the 2 remaining oxlint warnings are pre-existing on lines I didn't author — verified by stashing).

Seven new tests: four in `session-runner.test.ts` for behavior, three in `session-run-coordinator.test.ts` for `runAside`.

I checked each one fails when the behavior breaks rather than trusting green:

| Mutation | Result |
| --- | --- |
| `reason: "manual"` → `"auto"` | all 3 behavior tests fail |
| Drop the mutual-exclusion gate from asides | "runs an aside only after the active drain settles" fails; the runner-level test sees 2 concurrent requests instead of 1 |
| Break refcounting so each call gets a fresh semaphore | both serialization tests fail |
| Make the gate global instead of per-key | "lets asides for different keys run concurrently" fails, plus 2 pre-existing concurrency tests |

The httpapi exerciser passes 209/209 with 0 missing/extra; the existing `v2.session.compact` scenario only asserts the 404 path, so it remains valid.

### Screenshots / recordings

No new UI. `/compact` already exists in both clients and is already bound to `<leader>c` in the TUI — this makes the V2 path actually do something instead of returning 503.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

