### PR TITLE
fix(app): scope manual model override to the selected agent

### DIFF
--- a/packages/app/src/context/prompt-state.ts
+++ b/packages/app/src/context/prompt-state.ts
@@ -49,6 +49,13 @@ export type PromptModel = {
   providerID: string
   modelID: string
   variant?: string | null
+  /**
+   * Agent the selection was made under. A manual model choice is an override
+   * scoped to that agent; it must not outlive switching to a different agent.
+   * Undefined means the value predates this field or was inherited from another
+   * tab, in which case a configured agent model takes precedence over it.
+   */
+  agent?: string
 }
 
 export type FileContextItem = {

--- a/packages/app/src/pages/session/composer/prompt-model-selection.ts
+++ b/packages/app/src/pages/session/composer/prompt-model-selection.ts
@@ -7,7 +7,9 @@ import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { useProviders } from "@/hooks/use-providers"
 
-export function createPromptModelSelection(input: { agent: () => { model?: ModelKey; variant?: string } | undefined }) {
+export function createPromptModelSelection(input: {
+  agent: () => { name?: string; model?: ModelKey; variant?: string } | undefined
+}) {
   const sdk = useSDK()
   const sync = useSync()
   const models = useModels()
@@ -37,8 +39,21 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
     })[0]
   }
 
+  const agentName = () => input.agent()?.name
+
+  // A manual model pick is an override scoped to the agent it was made under.
+  // Unscoped values either predate this field or were inherited from another tab
+  // (see openNewTab in components/titlebar.tsx); those must not shadow an agent
+  // that has a model configured.
+  const override = () => {
+    const value = prompt.model.current()
+    if (!value) return
+    if (value.agent === undefined) return input.agent()?.model ? undefined : value
+    return value.agent === agentName() ? value : undefined
+  }
+
   const current = () => {
-    const key = [prompt.model.current(), input.agent()?.model, configured(), recent(), fallback()].find(
+    const key = [override(), input.agent()?.model, configured(), recent(), fallback()].find(
       (item): item is ModelKey => !!item && valid(item),
     )
     if (!key) return
@@ -68,7 +83,7 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
     set(item: ModelKey | undefined, options?: { recent?: boolean }) {
       startTransition(() =>
         batch(() => {
-          prompt.model.set(item ? { ...item, variant: prompt.model.current()?.variant } : undefined)
+          prompt.model.set(item ? { ...item, variant: override()?.variant, agent: agentName() } : undefined)
           if (!item) return
           models.setVisibility(item, true)
           if (options?.recent) models.recent.push(item)
@@ -88,7 +103,7 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
         })
       },
       selected() {
-        return prompt.model.current()?.variant
+        return override()?.variant
       },
       current() {
         const resolved = resolveModelVariant({
@@ -110,7 +125,12 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
           batch(() => {
             const model = current()
             if (!model) return
-            prompt.model.set({ providerID: model.provider.id, modelID: model.id, variant: value ?? null })
+            prompt.model.set({
+              providerID: model.provider.id,
+              modelID: model.id,
+              variant: value ?? null,
+              agent: agentName(),
+            })
             models.variant.set({ providerID: model.provider.id, modelID: model.id }, value)
           }),
         )


### PR DESCRIPTION
### Issue for this PR

Closes #38333

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the v2 composer the persisted draft model is checked before the agent's configured model:

```ts
const key = [prompt.model.current(), input.agent()?.model, configured(), recent(), fallback()].find(...)
```

Nothing clears it on an agent switch, and `openNewTab` seeds a new draft with the previous tab's model — so the stale value is already in place before the agent is ever consulted.

Instead of reordering that list, this tags the persisted selection with the agent it was made under and only honours it while that agent is active. `PromptModel` gains an optional `agent` field; `override()` returns the persisted model only when the tag matches. Untagged values (pre-existing drafts, models inherited from another tab) lose to a configured agent model, but are still used for agents that have no model configured — so the `openNewTab` inheritance stays intact where it is unambiguous. `set` and `variant.set` write the tag, and `variant.selected` reads through `override` so a stale variant can't leak across a switch.

Result: new sessions and agent switches land on the agent's model, while a deliberate pick sticks for as long as you stay on that agent.

The field is optional and the undefined case is handled explicitly, so no migration is needed.

Note on the neighbouring PRs: #38372 fixes this from the agent select callback, which a new tab never fires. #39319 is the same code path from the other side, where the agent model overwriting a manual pick is the bug — scoping rather than reordering is what lets both hold at once. Happy to rework this if you would rather land one of those first.

### How did you verify your code works?

Applied the equivalent transformation to the shipped 1.18.13 renderer bundle and ran the desktop app against agents with different configured models. Checked: new session, agent switch, manual pick surviving across turns on the same agent, switching away and back, and variant selection. Not yet exercised as a source build.

### Screenshots / recordings

No visual change — the model picker shows a different value. Happy to add a recording if useful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR