### PR TITLE
fix(core): classify git worktree errors independent of locale

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -860,7 +860,9 @@ const layer = Layer.effect(
       cwd = repository.worktree,
     ) {
       const result = yield* proc
-        .run(ChildProcess.make("git", args, { cwd, extendEnv: true, stdin: "ignore" }))
+        // git localizes diagnostics, and `git worktree` has no machine-readable output,
+        // so pin messages to C to keep the classification below locale-independent.
+        .run(ChildProcess.make("git", args, { cwd, env: { LC_ALL: "C" }, extendEnv: true, stdin: "ignore" }))
         .pipe(
           Effect.mapError(
             (cause) => new WorktreeError({ operation, directory: worktreeDirectory, message: cause.message, cause }),

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -108,6 +108,47 @@ describe("Git worktrees", () => {
       expect((yield* git.worktree.list(repo)).some((entry) => entry.directory.endsWith("-git-worktree"))).toBe(false)
     }),
   )
+
+  it.live("reports that force is required under a non-English git locale", () =>
+    Effect.gen(function* () {
+      // git localizes its diagnostics, so classifying them has to survive whatever
+      // locale the user's shell happens to set.
+      const previous = process.env.LC_ALL
+      process.env.LC_ALL = "zh_CN.UTF-8"
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (previous === undefined) delete process.env.LC_ALL
+          else process.env.LC_ALL = previous
+        }),
+      )
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(() => initRepo(root.path))
+      const directory = AbsolutePath.make(yield* Effect.promise(() => fs.realpath(root.path)))
+      const worktree = AbsolutePath.make(`${root.path}-git-worktree-dirty`)
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => fs.rm(worktree, { recursive: true, force: true })).pipe(Effect.ignore),
+      )
+      const git = yield* Git.Service
+      const repo = yield* git.repo.discover(directory)
+      if (!repo) throw new Error("Repository not found")
+      yield* git.worktree.create({ repository: repo, directory: worktree })
+      yield* Effect.promise(() => fs.writeFile(path.join(worktree, "dirty.txt"), "dirty\n"))
+
+      const error = yield* git.worktree
+        .remove({ repository: repo, directory: worktree, force: false })
+        .pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(Git.WorktreeError)
+      if (!(error instanceof Git.WorktreeError)) throw new Error("Expected a worktree error")
+      expect(error.operation).toBe("remove")
+      expect(error.forceRequired).toBe(true)
+
+      yield* git.worktree.remove({ repository: repo, directory: worktree, force: true })
+    }),
+  )
 })
 
 describe("Git trees", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #40613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Git.worktree.remove` decides whether `--force` is required by matching git's stderr against English text:

```ts
forceRequired: operation === "remove" && /contains modified or untracked files|is dirty/i.test(message),
```

git localizes its diagnostics, so this only works on an English system. On mine (`LANG=zh_CN.UTF-8`) the same failure reads:

```
致命错误：'../wt' 包含修改或未跟踪的文件，使用 --force 删除
```

The regex misses, `forceRequired` becomes `false`, and the caller loses the signal that retrying with `--force` would succeed. The user just sees a bare failure.

`git worktree` has no `--porcelain` or other machine-readable output — I checked, `--porcelain` is rejected as an unknown option for `remove` — so there is nothing structured to parse. The fix is to pin the subprocess message locale with `LC_ALL=C` and keep matching the stable English text. `extendEnv: true` is already set, so `env` merges over the inherited environment and only overrides the locale.

I checked the blast radius: `worktreeRun` is the only place in `git.ts` that classifies git's human-readable output. No other call site matches on stderr text, so this is the complete scope.

**Why this hasn't been noticed.** `ProjectCopy > requires force to remove a dirty git worktree` in `packages/core/test/project-copy.test.ts` asserts `forceRequired === true`, so it fails on any non-English machine and passes on CI, where runners default to an English locale. I had been treating that failure as unrelated background noise across several unrelated PRs before actually looking into it.

### How did you verify your code works?

Reproduced the root cause directly before touching anything — same repo state, `LC_ALL=C git worktree remove` gives the English message the regex expects, the ambient `zh_CN.UTF-8` gives the localized one.

`bun typecheck` clean in `packages/core`. Prettier clean. `oxlint` reports the same 6 pre-existing warnings on these two files before and after (verified by stashing).

The full `packages/core` suite is now **1089 pass / 0 fail**. It was 1088/1 before this change, with the one failure being exactly this bug.

`test/git.test.ts` and `test/project-copy.test.ts` pass 18/18 under `LC_ALL=C`, the ambient `zh_CN.UTF-8`, and `ja_JP.UTF-8`.

Reverting just the `LC_ALL` change makes both the new test and the existing `ProjectCopy` test fail, so the fix is causal rather than coincidental.

The new test sets `LC_ALL` to a non-English locale itself instead of relying on the ambient one. That matters: it fails without the fix even when run under `LANG=C LC_ALL=C`, so it will actually protect this on CI rather than passing vacuously there.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

