### PR TITLE
feat: respect disable-model-invocation in SKILL.md frontmatter

### DIFF
--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -2533,6 +2533,7 @@ export type SkillsListOutput = {
     readonly name: string
     readonly description?: string
     readonly slash?: boolean
+    readonly disableModelInvocation?: boolean
     readonly location: string
     readonly content: string
   }>

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -27,13 +27,19 @@ export type Source = typeof Source.Type
 export const Info = Skill.Info
 export type Info = Skill.Info
 
+// Skills with `disable-model-invocation` stay in `list()` so they remain
+// reachable as slash commands, but never reach the model.
 export const available = (skills: ReadonlyArray<Info>, agent: AgentV2.Info) =>
-  skills.filter((skill) => PermissionV2.evaluate("skill", skill.name, agent.permissions).effect !== "deny")
+  skills.filter(
+    (skill) =>
+      !skill.disableModelInvocation && PermissionV2.evaluate("skill", skill.name, agent.permissions).effect !== "deny",
+  )
 
 const Frontmatter = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
   description: Schema.String.pipe(Schema.optional),
   slash: Schema.Boolean.pipe(Schema.optional),
+  "disable-model-invocation": Schema.Boolean.pipe(Schema.optional),
 })
 const decodeFrontmatter = Schema.decodeUnknownOption(Frontmatter)
 
@@ -96,6 +102,7 @@ const layer = Layer.effect(
             name,
             description: frontmatter.description,
             slash: frontmatter.slash,
+            disableModelInvocation: frontmatter["disable-model-invocation"],
             location: AbsolutePath.make(filepath),
             content: markdown.content,
           })

--- a/packages/core/src/tool/skill.ts
+++ b/packages/core/src/tool/skill.ts
@@ -71,7 +71,7 @@ const layer = Layer.effectDiscard(
             Effect.gen(function* () {
               const current = yield* skills.list()
               const skill = current.find((skill) => skill.name === input.name)
-              if (!skill) return yield* unableToLoad(input.name)
+              if (!skill || skill.disableModelInvocation) return yield* unableToLoad(input.name)
               return yield* Effect.gen(function* () {
                 yield* permission.assert({
                   action: name,

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -122,4 +122,39 @@ describe("SkillV2", () => {
       ),
     ),
   )
+
+  it.live("hides skills with disable-model-invocation from agents", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(async () => {
+            await fs.mkdir(path.join(tmp.path, "internal"), { recursive: true })
+            await fs.writeFile(
+              path.join(tmp.path, "internal", "SKILL.md"),
+              `---
+name: internal
+description: Only run this when invoked manually
+disable-model-invocation: true
+---
+# internal`,
+            )
+          })
+
+          const agents = yield* AgentV2.Service
+          yield* agents.transform((editor) => editor.update(AgentV2.ID.make("build"), () => {}))
+
+          const skill = yield* SkillV2.Service
+          yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(tmp.path) }))
+
+          const list = yield* skill.list()
+          expect(list.map((item) => item.name)).toEqual(["internal"])
+          expect(list[0].disableModelInvocation).toBe(true)
+          expect(SkillV2.available(list, (yield* agents.get(AgentV2.ID.make("build")))!)).toEqual([])
+        }),
+      ),
+    ),
+  )
 })

--- a/packages/core/test/skill/guidance.test.ts
+++ b/packages/core/test/skill/guidance.test.ts
@@ -27,6 +27,13 @@ const denied = SkillV2.Info.make({
   location: AbsolutePath.make(path.resolve("/skills/denied/SKILL.md")),
   content: "Denied guidance",
 })
+const manual = SkillV2.Info.make({
+  name: "manual",
+  description: "Only invoked by the user",
+  disableModelInvocation: true,
+  location: AbsolutePath.make(path.resolve("/skills/manual/SKILL.md")),
+  content: "Manual guidance",
+})
 
 const layer = (list: () => SkillV2.Info[]) =>
   AppNodeBuilder.build(SkillGuidance.node, [
@@ -69,6 +76,19 @@ describe("SkillGuidance", () => {
         text: expect.stringContaining("No skills are currently available."),
       })
     }).pipe(Effect.provide(layer(() => skills)))
+  })
+
+  it.effect("omits skills that disable model invocation", () => {
+    const agent = AgentV2.Info.make(AgentV2.Info.empty(build))
+    return Effect.gen(function* () {
+      const guidance = yield* SkillGuidance.Service
+      const baseline = (yield* guidance
+        .load({ id: agent.id, info: agent })
+        .pipe(Effect.flatMap(SystemContext.initialize))).baseline
+
+      expect(baseline).toContain("<name>effect</name>")
+      expect(baseline).not.toContain("<name>manual</name>")
+    }).pipe(Effect.provide(layer(() => [manual, effect])))
   })
 
   it.effect("omits guidance when the selected agent denies all skills", () => {

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -141,6 +141,14 @@ describe("SkillTool", () => {
                 call: { type: "tool-call", id: "call-flat-skill", name: "skill", input: { name: "public" } },
               }),
             ).toEqual({ type: "text", value: SkillTool.toModelOutput(flat, []) })
+            current = [{ ...info, disableModelInvocation: true }]
+            expect(
+              yield* executeTool(registry, {
+                sessionID,
+                ...toolIdentity,
+                call: { type: "tool-call", id: "call-manual-skill", name: "skill", input: { name: "effect" } },
+              }),
+            ).toEqual({ type: "error", value: "Unable to load skill effect" })
           }).pipe(Effect.provide(skillToolLayer))
         }),
       ),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -37,6 +37,7 @@ const CUSTOMIZE_OPENCODE_SKILL_BODY = SkillPlugin.CustomizeOpencodeContent
 export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
+  disableModelInvocation: Schema.optional(Schema.Boolean),
   location: Schema.String,
   content: Schema.String,
 })
@@ -50,11 +51,14 @@ const Issue = Schema.StructWithRest(
   [Schema.Record(Schema.String, Schema.Unknown)],
 )
 
-function isSkillFrontmatter(data: unknown): data is { name: string; description?: string } {
+function isSkillFrontmatter(
+  data: unknown,
+): data is { name: string; description?: string; "disable-model-invocation"?: boolean } {
   return (
     isRecord(data) &&
     typeof data.name === "string" &&
-    (data.description === undefined || typeof data.description === "string")
+    (data.description === undefined || typeof data.description === "string") &&
+    (data["disable-model-invocation"] === undefined || typeof data["disable-model-invocation"] === "boolean")
   )
 }
 
@@ -134,6 +138,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, events: Ev
   state.skills[md.data.name] = {
     name: md.data.name,
     description: md.data.description,
+    disableModelInvocation: md.data["disable-model-invocation"],
     location: match,
     content: md.content,
   }
@@ -307,9 +312,13 @@ const layer = Layer.effect(
       return (yield* InstanceState.get(discovered)).dirs
     })
 
+    // Skills with `disable-model-invocation` stay in `all()` so they remain
+    // reachable as slash commands, but never reach the model.
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
       const s = yield* InstanceState.get(state)
-      const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
+      const list = Object.values(s.skills)
+        .filter((skill) => !skill.disableModelInvocation)
+        .toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
       return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
     })

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -24,6 +24,11 @@ export const SkillTool = Tool.define(
             .require(params.name)
             .pipe(Effect.catchTag("Skill.NotFoundError", (error) => Effect.die(new Error(error.message))))
 
+          if (info.disableModelInvocation)
+            return yield* Effect.die(
+              new Error(`Skill "${info.name}" can only be invoked by the user and cannot be loaded with this tool.`),
+            )
+
           yield* ctx.ask({
             permission: "skill",
             patterns: [params.name],

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -242,6 +242,34 @@ Instructions here.
     ),
   )
 
+  it.live("hides skills with disable-model-invocation from agents", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".opencode", "skill", "internal-skill", "SKILL.md"),
+              `---
+name: internal-skill
+description: Only run this when invoked manually.
+disable-model-invocation: true
+---
+
+# Internal Skill
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          const all = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
+          expect(all.map((s) => s.name)).toEqual(["internal-skill"])
+          expect(all[0].disableModelInvocation).toBe(true)
+          expect((yield* skill.available()).map((s) => s.name)).not.toContain("internal-skill")
+        }),
+      { git: true },
+    ),
+  )
+
   it.live("discovers skills from .claude/skills/ directory", () =>
     provideTmpdirInstance(
       (dir) =>

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -93,6 +93,59 @@ Use this skill.
     }),
   )
 
+  it.instance("execute rejects skills with disable-model-invocation", () =>
+    Effect.gen(function* () {
+      const dir = (yield* TestInstance).directory
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(dir, ".opencode", "skill", "manual-skill", "SKILL.md"),
+          `---
+name: manual-skill
+description: Only run this when invoked manually.
+disable-model-invocation: true
+---
+
+# Manual Skill
+`,
+        ),
+      )
+
+      const home = process.env.OPENCODE_TEST_HOME
+      process.env.OPENCODE_TEST_HOME = dir
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          process.env.OPENCODE_TEST_HOME = home
+        }),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
+      const tool = (yield* registry.tools({
+        providerID: "opencode" as any,
+        modelID: "gpt-5" as any,
+        agent,
+      })).find((tool) => tool.id === SkillTool.id)
+      if (!tool) throw new Error("Skill tool not found")
+
+      const exit = yield* tool
+        .execute(
+          { name: "manual-skill" },
+          {
+            ...baseCtx,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const error = Cause.squash(exit.cause)
+        expect(error).toBeInstanceOf(Error)
+        if (error instanceof Error) expect(error.message).toContain('Skill "manual-skill" can only be invoked')
+      }
+    }),
+  )
+
   it.instance("execute preserves not found message", () =>
     Effect.gen(function* () {
       const dir = (yield* TestInstance).directory

--- a/packages/schema/src/skill.ts
+++ b/packages/schema/src/skill.ts
@@ -21,6 +21,7 @@ export const Info = Schema.Struct({
   name: Schema.String,
   description: Schema.String.pipe(optional),
   slash: Schema.Boolean.pipe(optional),
+  disableModelInvocation: Schema.Boolean.pipe(optional),
   location: AbsolutePath,
   content: Schema.String,
 }).annotate({ identifier: "SkillV2.Info" })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -5017,6 +5017,7 @@ export type SkillV2Info = {
   name: string
   description?: string
   slash?: boolean
+  disableModelInvocation?: boolean
   location: string
   content: string
 }
@@ -8365,6 +8366,7 @@ export type AppSkillsResponses = {
   200: Array<{
     name: string
     description?: string
+    disableModelInvocation?: boolean
     location: string
     content: string
   }>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2813,6 +2813,9 @@
                       "description": {
                         "type": "string"
                       },
+                      "disableModelInvocation": {
+                        "type": "boolean"
+                      },
                       "location": {
                         "type": "string"
                       },
@@ -30684,6 +30687,9 @@
             "type": "string"
           },
           "slash": {
+            "type": "boolean"
+          },
+          "disableModelInvocation": {
             "type": "boolean"
           },
           "location": {

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -38,6 +38,7 @@ Only these fields are recognized:
 
 - `name` (required)
 - `description` (required)
+- `disable-model-invocation` (optional, boolean)
 - `license` (optional)
 - `compatibility` (optional)
 - `metadata` (optional, string-to-string map)
@@ -119,6 +120,23 @@ The agent loads a skill by calling the tool:
 ```
 skill({ name: "git-release" })
 ```
+
+---
+
+## Keep a skill manual-only
+
+Set `disable-model-invocation: true` to keep a skill installed without paying its context cost:
+
+```markdown
+---
+name: internal-debug-helper
+description: Heavy internal workflow that should only run when manually invoked.
+disable-model-invocation: true
+---
+```
+
+The skill is left out of `<available_skills>` and the agent cannot load it with the `skill` tool.
+It stays available as a `/internal-debug-helper` command, which injects the skill content into your next message.
 
 ---
 

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -1,5 +1,11 @@
 # V2 Schema Changelog
 
+## 2026-08-05: Respect Skill Model Invocation Opt-Out
+
+- Add optional `disableModelInvocation` to the `SkillV2.Info` HTTP payload and generated SDK skill list, parsed from `disable-model-invocation` in `SKILL.md` frontmatter.
+- Omit flagged skills from agent skill guidance and reject them from the model-facing `skill` tool; they stay listed so users can still invoke them manually.
+- No durable data or migration is affected; the field is optional and unset for existing skills.
+
 ## 2026-06-26: Add Finite Session History
 
 - Add `GET /api/session/:sessionID/history` and generated Promise, Effect, and legacy JavaScript client methods.


### PR DESCRIPTION
### Issue for this PR

Closes #34498

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skills are always advertised to the model today, so a big manual-only skill costs context on every request even if you only ever run it yourself.
This adds support for `disable-model-invocation: true` in `SKILL.md` frontmatter, which Claude Code and Cursor already use for the same purpose.

A skill with the flag is still discovered and still runs as `/skill-name`, but it is left out of `<available_skills>` and the `skill` tool refuses to load it.
That is the whole behavior change: discovery is untouched, only the two model-facing paths filter on the flag.

There are two skill implementations in the tree right now, so the flag is handled in both:

- v1: parsed in `packages/opencode/src/skill/index.ts`, filtered out of `Skill.available()` (which feeds the system prompt), rejected in `packages/opencode/src/tool/skill.ts`.
- v2: parsed in `packages/core/src/skill.ts`, filtered out of `SkillV2.available()` (which feeds skill guidance), rejected in `packages/core/src/tool/skill.ts`.

Manual invocation keeps working because commands are built from `skill.all()` / `skill.list()`, which still contain the flagged skills.

The flag is surfaced as an optional `disableModelInvocation` field on the skill payload, so the generated SDK files and `packages/sdk/openapi.json` are regenerated (`bun run generate` in `packages/client`, then `./script/generate.ts`), and I added an entry to `specs/v2/schema-changelog.md` since that file asks for generated SDK schema changes to be recorded.
Docs for the new field are in `packages/web/src/content/docs/skills.mdx`.

### How did you verify your code works?

Tests added:

- `packages/opencode/test/skill/skill.test.ts`: a flagged skill shows up in `all()` but not in `available()`.
- `packages/opencode/test/tool/skill.test.ts`: the v1 `skill` tool fails on a flagged skill.
- `packages/core/test/skill.test.ts` and `test/skill/guidance.test.ts`: flagged skill is listed but excluded from `available()` and from rendered guidance.
- `packages/core/test/tool-skill.test.ts`: the v2 `skill` tool returns "Unable to load skill".

`bun test` passes in `packages/core` (the two failing `Snapshot` / `Git trees` tests also fail on a clean `dev` checkout) and for the skill tests in `packages/opencode`.
`bun typecheck` is clean.

To reproduce by hand, create `.opencode/skill/manual-only/SKILL.md`:

```markdown
---
name: manual-only
description: Manual only skill.
disable-model-invocation: true
---

# Manual Only
```

`opencode debug skill` lists it with `"disableModelInvocation": true`, it is gone from the skills section of the system prompt, and `/manual-only` still inserts the skill content.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
