### PR TITLE
fix(opencode): preserve task id on failure

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -325,8 +325,26 @@ export const TaskTool = Tool.define(
               background.waitForPromotion(nextSession.id),
             )
             if (result?.metadata?.background === true) return backgroundResult()
-            if (result?.status === "error") return yield* Effect.fail(new Error(result.error ?? "Task failed"))
-            if (result?.status === "cancelled") return yield* Effect.fail(new Error("Task cancelled"))
+            if (result?.status === "error")
+              return yield* Effect.fail(
+                new Error(
+                  renderOutput({
+                    sessionID: nextSession.id,
+                    state: "error",
+                    text: result.error ?? "Task failed",
+                  }),
+                ),
+              )
+            if (result?.status === "cancelled")
+              return yield* Effect.fail(
+                new Error(
+                  renderOutput({
+                    sessionID: nextSession.id,
+                    state: "error",
+                    text: "Task cancelled",
+                  }),
+                ),
+              )
             return {
               title: params.description,
               metadata,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -3,7 +3,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
-import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -564,6 +564,90 @@ describe("tool.task", () => {
         .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.instance("includes the task id when a foreground task fails", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const exit = yield* def
+        .execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: {
+              promptOps: {
+                ...stubOps(),
+                prompt: () => Effect.die(new Error("provider unavailable")),
+              } satisfies TaskPromptOps,
+            },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      const children = yield* sessions.children(chat.id)
+      expect(children).toHaveLength(1)
+      if (Exit.isSuccess(exit)) throw new Error("expected task failure")
+      const error = Cause.squash(exit.cause)
+      expect(error).toBeInstanceOf(Error)
+      expect(String(error)).toContain(`<task id="${children[0]?.id}" state="error">`)
+      expect(String(error)).toContain("<task_error>\nprovider unavailable\n</task_error>")
+    }),
+  )
+
+  it.instance("includes the task id when a foreground task is cancelled", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const exit = yield* def
+        .execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: {
+              promptOps: {
+                ...stubOps(),
+                prompt: () => Effect.interrupt,
+              } satisfies TaskPromptOps,
+            },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      const children = yield* sessions.children(chat.id)
+      expect(children).toHaveLength(1)
+      if (Exit.isSuccess(exit)) throw new Error("expected task cancellation")
+      const error = Cause.squash(exit.cause)
+      expect(error).toBeInstanceOf(Error)
+      expect(String(error)).toContain(`<task id="${children[0]?.id}" state="error">`)
+      expect(String(error)).toContain("<task_error>\nTask cancelled\n</task_error>")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #39196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Foreground task failures and cancellations currently throw bare error strings, so the parent model loses the child session id and cannot resume the task.

This uses the existing structured task envelope for those two failure paths. The tool call still fails, but its error now includes `<task id="..." state="error">`, matching the identity carried by foreground successes and background failures.

### How did you verify your code works?

- `bun test test/tool/task.test.ts` from `packages/opencode` (22 pass)
- `bun typecheck` from `packages/opencode`
- repository pre-push typecheck (30 packages)
- Prettier check for both changed files

### Screenshots / recordings

Not applicable; this changes the model-facing task failure payload.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR