### PR TITLE
docs: add OutageDeck MCP example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,27 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### OutageDeck
+
+Add the [OutageDeck MCP server](https://github.com/outagedeck/mcp) to check cloud and SaaS provider status and incidents before changing code for an external failure. Public read-only tools require no account or API key.
+
+```json title="opencode.json" {4-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "outagedeck": {
+      "type": "remote",
+      "url": "https://outagedeck.com/api/mcp"
+    }
+  }
+}
+```
+
+Use OutageDeck as supporting evidence when a deployment, API, or integration fails. Provider status does not replace local diagnostics.
+
+```txt "use outagedeck"
+Check AWS, GitHub, and Cloudflare for active incidents before changing deployment code. use outagedeck
+```


### PR DESCRIPTION
### Issue for this PR

Related to #39394. This documents an existing provider-status tool and does not close the request for a first-party OpenCode Go status page.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a copy-ready remote MCP configuration for OutageDeck, an example provider-incident prompt, and a reminder that status evidence does not replace local diagnostics. Public read-only tools require no account or API key.

### How did you verify your code works?

- OpenCode v1.18.13 `mcp list` reported OutageDeck connected.
- `mcp debug outagedeck` returned HTTP 200, no authentication requirement, and server metadata.
- The `packages/web` Astro production build passed and rendered the new section.

### Screenshots / recordings

Not applicable; this is documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR