### PR TITLE
fix(llm): finish usage-only chat streams

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -409,7 +409,9 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     const events: LLMEvent[] = []
     const usage = mapUsage(event.usage) ?? state.usage
     const choice = event.choices[0]
-    const finishReason = choice?.finish_reason ? mapFinishReason(choice.finish_reason) : state.finishReason
+    const finishReason = choice?.finish_reason
+      ? mapFinishReason(choice.finish_reason)
+      : state.finishReason ?? (event.choices.length === 0 && event.usage ? "stop" : undefined)
     const delta = choice?.delta
     const toolDeltas = delta?.tool_calls ?? []
     let tools = state.tools

--- a/packages/llm/test/provider/openai-compatible-chat.test.ts
+++ b/packages/llm/test/provider/openai-compatible-chat.test.ts
@@ -235,4 +235,29 @@ describe("OpenAI-compatible Chat route", () => {
       expect(response.events.at(-1)).toMatchObject({ type: "finish", reason: "stop" })
     }),
   )
+
+  it.effect("treats usage-only stream tails as completed when finish_reason is missing", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          dynamicResponse((input) =>
+            Effect.succeed(
+              input.respond(
+                [
+                  `data: ${JSON.stringify(deltaChunk({ role: "assistant", content: "OK" }))}`,
+                  `data: ${JSON.stringify(usageChunk({ prompt_tokens: 11, completion_tokens: 5, total_tokens: 16 }))}`,
+                  `data: ${JSON.stringify({ choices: [], cost: "0" })}`,
+                ].join("\n\n") + "\n\n",
+                { headers: { "content-type": "text/event-stream" } },
+              ),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.text).toBe("OK")
+      expect(response.usage).toMatchObject({ inputTokens: 11, outputTokens: 5, totalTokens: 16 })
+      expect(response.events.at(-1)).toMatchObject({ type: "finish", reason: "stop" })
+    }),
+  )
 })


### PR DESCRIPTION
## Summary
- Treat usage-only OpenAI Chat stream tail frames as a terminal `stop` when no explicit `finish_reason` arrives
- Preserve usage accounting from the tail frame and continue ignoring following empty provider bookkeeping frames
- Add OpenAI-compatible regression coverage for streams that close after content + usage without `[DONE]`

Refs #40420

## Test Plan
- `bun test test/provider/openai-compatible-chat.test.ts --test-name-pattern "treats usage-only stream tails"`
- `bun test test/provider/openai-compatible-chat.test.ts`
- `bun test test/provider/openai-compatible-chat.test.ts test/provider/openai-chat.test.ts`
- `bun run typecheck`
- `bun run lint packages/llm/src/protocols/openai-chat.ts packages/llm/test/provider/openai-compatible-chat.test.ts`
- `git diff --check`