### PR TITLE
fix(skill): ignore root skill files

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -94,6 +94,11 @@ type ScanState = {
   dirs: Set<string>
 }
 
+function isRootSkillFile(root: string, match: string) {
+  const parts = path.relative(root, match).split(path.sep)
+  return parts.length === 2 && (parts[0] === "skill" || parts[0] === "skills") && parts[1] === "SKILL.md"
+}
+
 export interface Interface {
   readonly get: (name: string) => Effect.Effect<Info | undefined>
   readonly require: (name: string) => Effect.Effect<Info, NotFoundError>
@@ -143,7 +148,7 @@ const scan = Effect.fnUntraced(function* (
   state: ScanState,
   root: string,
   pattern: string,
-  opts?: { dot?: boolean; scope?: string },
+  opts?: { dot?: boolean; scope?: string; skipRootSkillFiles?: boolean },
 ) {
   const matches = yield* Effect.tryPromise({
     try: () =>
@@ -165,6 +170,7 @@ const scan = Effect.fnUntraced(function* (
   )
 
   for (const match of matches) {
+    if (opts?.skipRootSkillFiles && isRootSkillFile(root, match)) continue
     state.matches.add(match)
     state.dirs.add(path.dirname(match))
   }
@@ -190,7 +196,7 @@ const discoverSkills = Effect.fnUntraced(function* (
     for (const dir of externalDirs) {
       const root = path.join(global.home, dir)
       if (!(yield* fsys.isDir(root))) continue
-      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
+      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global", skipRootSkillFiles: true })
     }
 
     const upDirs = yield* fsys
@@ -198,13 +204,13 @@ const discoverSkills = Effect.fnUntraced(function* (
       .pipe(Effect.catch(() => Effect.succeed([] as string[])))
 
     for (const root of upDirs) {
-      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
+      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project", skipRootSkillFiles: true })
     }
   }
 
   const configDirs = yield* config.directories()
   for (const dir of configDirs) {
-    yield* scan(state, dir, OPENCODE_SKILL_PATTERN)
+    yield* scan(state, dir, OPENCODE_SKILL_PATTERN, { skipRootSkillFiles: true })
   }
 
   const cfg = yield* config.get()

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -2,13 +2,8 @@ import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Effect, Layer } from "effect"
 import { Skill } from "../../src/skill"
-import { Discovery } from "../../src/skill/discovery"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
-import { EventV2Bridge } from "../../src/event-v2-bridge"
-import { Config } from "../../src/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Global } from "@opencode-ai/core/global"
 import { provideInstance, provideTmpdirInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
@@ -117,6 +112,31 @@ Instructions here.
           expect(item).toBeDefined()
           expect(item!.description).toBe("A test skill for verification.")
           expect(item!.location).toContain(path.join("skill", "test-skill", "SKILL.md"))
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("ignores root skill files without a named skill directory", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, ".opencode", "skills", "SKILL.md"),
+              `---
+name: root-skill
+description: Root skill should not load.
+---
+
+# Root Skill
+`,
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          expect((yield* skill.all()).filter((s) => s.location !== "<built-in>")).toEqual([])
+          expect(yield* skill.dirs()).toEqual([])
         }),
       { git: true },
     ),


### PR DESCRIPTION
### Issue for this PR

Closes #31616
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Ignore root-level `SKILL.md` files directly under `skill/` or `skills/` discovery roots. A project-level `.opencode/skills/SKILL.md` should not become a callable skill because valid skills live under their own named directory, e.g. `.opencode/skills/my-skill/SKILL.md`.

The scanner still accepts named skill directories, including nested skills below the discovery root.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts --test-name-pattern "ignores root skill files" --timeout 30000`
- `bun test test/skill/skill.test.ts --test-name-pattern "discovers skills from .opencode/skill/ directory|ignores root skill files|returns skill directories" --timeout 30000`
- `bun test test/skill/skill.test.ts --timeout 30000`
- `bun run typecheck`
- `bun run lint packages/opencode/src/skill/index.ts packages/opencode/test/skill/skill.test.ts`
- `git diff --check`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR