### PR TITLE
fix: retry malformed LiteLLM stream errors on Anthropic models

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -105,6 +105,16 @@ export function parseStreamError(input: unknown): ParsedStreamError | undefined 
   if (!body) return
 
   const responseBody = JSON.stringify(body)
+  // TODO: Remove when https://github.com/BerriAI/litellm/pull/33352 is fixed.
+  // LiteLLM can emit its OpenAI-shaped error envelope inside an Anthropic SSE stream.
+  if (body.type !== "error" && /^5\d\d$/.test(String(body?.error?.code))) {
+    return {
+      type: "api_error",
+      message: typeof body?.error?.message === "string" ? body.error.message : "Server error.",
+      isRetryable: true,
+      responseBody,
+    }
+  }
   if (body.type !== "error") return
 
   switch (body?.error?.code) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -17,6 +17,7 @@ import {
 } from "@opencode-ai/core/v1/session"
 
 import { NamedError } from "@opencode-ai/core/util/error"
+import { TypeValidationError } from "@ai-sdk/provider"
 import { APICallError, convertToModelMessages, LoadAPIKeyError, type ModelMessage, type UIMessage } from "ai"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -699,6 +700,8 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case TypeValidationError.isInstance(e):
+      return fromError(e.value, ctx)
     case e instanceof Error:
       return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import type { NamedError } from "@opencode-ai/core/util/error"
+import { TypeValidationError } from "@ai-sdk/provider"
 import { APICallError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Effect, Schedule, Schema } from "effect"
@@ -436,5 +437,28 @@ describe("session.message-v2.fromError", () => {
     expect(SessionRetry.retryable(result, retryProvider)).toEqual({
       message: "An error occurred while processing your request.",
     })
+  })
+
+  test("retries malformed LiteLLM Anthropic stream errors", () => {
+    const body = {
+      error: {
+        message: "Connection closed.",
+        type: "None",
+        param: "None",
+        code: "500",
+      },
+    }
+    const result = MessageV2.fromError(new TypeValidationError({ value: body, cause: new Error("Invalid input") }), {
+      providerID,
+    })
+
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data).toMatchObject({
+      message: "Connection closed.",
+      isRetryable: true,
+      responseBody: JSON.stringify(body),
+    })
+    expect(SessionRetry.retryable(result, retryProvider)).toEqual({ message: "Connection closed." })
   })
 })


### PR DESCRIPTION
## Summary

Retry LiteLLM 5xx errors that leak into Anthropic SSE streams as malformed OpenAI-shaped envelopes.

The AI SDK validation error now unwraps its rejected payload, allowing OpenCode to classify the embedded 5xx as a retryable API error. Includes a TODO to remove the compatibility path after https://github.com/BerriAI/litellm/pull/33352 lands.

## Validation

- `bun test test/session/retry.test.ts`
- `bun typecheck`
- Local source run against the LiteLLM Anthropic proxy (`claude-sonnet-4-6`): returned `OK.`

🤖 Generated with [OpenCode](https://opencode.ai) (GPT-5)