### PR TITLE
fix(snapshot): preserve unicode paths on revert

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -428,7 +428,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                   cwd: state.worktree,
                 })
                 if (result.code === 0) return
-                const tree = yield* git([...core, ...args(["ls-tree", op.hash, "--", op.rel])], {
+                const tree = yield* git([...quote, ...args(["ls-tree", op.hash, "--", op.rel])], {
                   cwd: state.worktree,
                 })
                 if (tree.code === 0 && tree.text.trim()) {
@@ -464,7 +464,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
                 }
 
                 const tree = yield* git(
-                  [...core, ...args(["ls-tree", "--name-only", first.hash, "--", ...run.map((item) => item.rel)])],
+                  [...quote, ...args(["ls-tree", "--name-only", first.hash, "--", ...run.map((item) => item.rel)])],
                   {
                     cwd: state.worktree,
                   },

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -852,6 +852,36 @@ it.instance(
 )
 
 it.instance(
+  "revert preserves unicode files that existed in snapshot",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    const files = ["Doc/设计/初始设置.md", "Doc/设计/执行手册/规则与流程.md"]
+    for (const file of files) {
+      yield* write(`${tmp.path}/${file}`, `original ${file}`)
+    }
+    const hash = yield* snapshot.track()
+    expect(hash).toBeTruthy()
+    for (const file of files) {
+      yield* rm(`${tmp.path}/${file}`)
+      yield* write(`${tmp.path}/${file}`, `recreated ${file}`)
+    }
+    const patch = yield* snapshot.patch(hash!)
+    for (const file of files) {
+      expect(patch.files).toContain(fwd(tmp.path, file))
+    }
+
+    yield* snapshot.revert([patch])
+
+    for (const file of files) {
+      expect(yield* exists(`${tmp.path}/${file}`)).toBe(true)
+      expect(yield* readText(`${tmp.path}/${file}`)).toBe(`original ${file}`)
+    }
+  }),
+  { git: true },
+)
+
+it.instance(
   "diffFull sets status based on git change type",
   Effect.gen(function* () {
     const tmp = yield* bootstrap()


### PR DESCRIPTION
### Issue for this PR

Closes #19357
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the Unicode-path branch of the snapshot revert issue. Revert checks whether a changed file exists in the target snapshot before deciding to delete it. Those `ls-tree` checks were using Git's default quoted path output, so non-ASCII paths could be compared against raw UTF-8 relative paths and treated as absent.

This switches the single-file and batched `ls-tree` existence checks to the existing quote-safe Git config (`core.quotepath=false`) while leaving checkout behavior unchanged. The regression covers two CJK-named files in the same patch batch to exercise the batched `ls-tree` path that previously deleted them.

### How did you verify your code works?

- `bun test test/snapshot/snapshot.test.ts --test-name-pattern "revert preserves unicode files" --timeout 90000`
- `bun test test/snapshot/snapshot.test.ts --test-name-pattern "revert preserves file that existed|revert preserves unicode files|revert should not delete files" --timeout 90000`
- `bun run typecheck`
- `bun run lint packages/opencode/src/snapshot/index.ts packages/opencode/test/snapshot/snapshot.test.ts`
- `git diff --check`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR