### PR TITLE
docs(ecosystem): add qwen-audio-agent to projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)                                  | Full-duplex voice interface for OpenCode; conversations continue while background tasks run, with macOS orb, TUI, and web UI |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

No issue; the ecosystem page itself says: "Want to add your OpenCode related project to this list? Submit a PR."

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row for qwen-audio-agent to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`. It is a full-duplex voice interface that connects to OpenCode natively over ACP (one-click install). Disclosure: I maintain the project.

### How did you verify your code works?

Docs-only change: the new row follows the exact markdown table format of the existing rows (two columns, name link + description), so it renders the same way as its neighbors.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
