### PR TITLE
fix(shell): stop aborted commands after output

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -446,6 +446,7 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      let aborting = false
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -522,11 +523,15 @@ export const ShellTool = Tool.define(
                 }
               }
 
-              return ctx.metadata({
+              const update = ctx.metadata({
                 metadata: {
                   output: last,
                 },
               })
+              if (!ctx.abort.aborted || aborting) return update
+              aborting = true
+              aborted = true
+              return update.pipe(Effect.andThen(handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.ignore)))
             }),
           )
 


### PR DESCRIPTION
### Issue for this PR

Closes #39565
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tightens the shell tool's abort path so an abort triggered while output is streaming terminates the child command immediately and still returns the partial output that was already collected.

The shell tool already races the process exit against the abort signal, but output callbacks can observe the abort first while streaming metadata. This change lets the output stream notice that state, mark the command as aborted, and kill the process once, instead of waiting for the long-running command to finish naturally. The final result keeps the existing `User aborted the command` metadata and partial output behavior.

### How did you verify your code works?

- Before the fix, `bun test test/tool/shell.test.ts --test-name-pattern "preserves output when aborted" --timeout 30000` timed out.
- `bun test test/tool/shell.test.ts --test-name-pattern "preserves output when aborted|streams metadata updates progressively|terminates command on timeout" --timeout 30000`
- `bun run typecheck`
- `bun run lint packages/opencode/src/tool/shell.ts packages/opencode/test/tool/shell.test.ts`
- `git diff --check`

Note: the full `test/tool/shell.test.ts` suite still has an existing Windows-only path-normalization failure in `normalizes external_directory workdir variants on Windows`; I reproduced that same single failure on the unmodified `dev` baseline before restoring this patch.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR