### PR TITLE
fix(tui): wait for diff request in tests

### DIFF
--- a/packages/tui/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer.test.tsx
@@ -147,12 +147,12 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
   const config = createTuiResolvedConfig()
   const transport = createFetch((url) => {
     if (url.pathname !== "/api/vcs/diff") return
-    if (fail) return json({ message: "boom" }, { status: 500 })
     vcsDiffInput = {
       location: { directory: url.searchParams.get("location[directory]") },
       mode: url.searchParams.get("mode"),
       context: url.searchParams.get("context"),
     }
+    if (fail) return json({ message: "boom" }, { status: 500 })
     return json({
       location: { directory: "/repo/session", project: { id: "project-1", directory: "/repo/session" } },
       data: vcsDiff,
@@ -238,6 +238,7 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
 
   const app = await testRender(() => <Harness />, { width: 80, height })
   await waitForCommand(app, commands, "diff.close")
+  await app.waitFor(() => vcsDiffInput !== undefined)
   return {
     app,
     commands,


### PR DESCRIPTION
## What

Stabilize the V2 TUI diff-viewer tests by waiting for the mocked VCS diff request before returning the mounted harness.

## Before / After

**Before:** The harness waited for `diff.close` to be registered synchronously, then returned. Solid's `createResource` could schedule `/api/vcs/diff` afterward, so assertions occasionally observed `vcsDiffInput` as `undefined` on Linux CI.

**After:** The harness does not return until the request handler has captured the VCS diff input. Assertions now run after the asynchronous resource request while retaining the existing timeout behavior.

## How

- `packages/tui/test/cli/tui/diff-viewer.test.tsx` captures request input before producing either a success or failure response.
- The shared render helper waits for that captured input after mounting the viewer.

## Scope

This is a test-harness synchronization fix only. It does not change diff-viewer runtime behavior or address the pre-existing TreeSitter teardown and session-tabs persistence warnings seen during stress runs.

## Testing

- `bun run test test/cli/tui/diff-viewer.test.tsx --rerun-each 100` from `packages/tui`: 500 passed
- `bun run test` from `packages/tui`: 593 passed, 5 skipped
- `bun typecheck` from `packages/tui`
- Repository pre-push typecheck hook: 33 tasks passed
- `git diff --check`
