### PR TITLE
fix(opencode): expand transient retry matching

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -29,9 +29,9 @@ export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
 const RETRYABLE_MESSAGE = [
-  /server[_\s-]?error|internal[_\s-]?error|service[_\s-]?unavailable|overloaded|provider returned error|too many requests|rate increased too quickly|rate[_\s-]?limit/i,
-  /fetch failed|network error|upstream connect|connection (?:error|refused|lost)|socket connection was closed|socket hang up|reset before headers|getaddrinfo|ENOTFOUND|EAI_AGAIN|timeout|timed? out|terminated/i,
-  /resource[_\s-]?exhausted|please retry your request|you can retry your request|try your request again/i,
+  /\b(?:server[_\s-]?error|internal[_\s-]?error|service[_\s-]?unavailable|overloaded|too many requests|rate increased too quickly|rate[_\s-]?limit)\b|\bprovider returned error\b/i,
+  /\b(?:fetch failed|network error|upstream connect|connection (?:error|refused|lost)|socket connection was closed|socket hang up|reset before headers|getaddrinfo|ENOTFOUND|EAI_AGAIN)\b|^timeout$|\b(?:request|response|connection|network|stream|read) (?:timeout|timed? out)\b/i,
+  /\b(?:resource[_\s-]?exhausted|please retry your request|you can retry your request|try your request again)\b/i,
 ]
 
 function cap(ms: number) {
@@ -74,11 +74,13 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
 export function retryable(error: Err, provider: string) {
   // context overflow errors should not be retried
   if (SessionV1.ContextOverflowError.isInstance(error)) return undefined
+  const msg = isRecord(error.data) ? error.data.message : undefined
+  const retryableMessage = isRetryableMessage(msg)
   if (SessionV1.APIError.isInstance(error)) {
     const status = error.data.statusCode
     // 5xx errors are transient server failures and should always be retried,
     // even when the provider SDK doesn't explicitly mark them as retryable.
-    if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
+    if (!error.data.isRetryable && !(status !== undefined && status >= 500) && !retryableMessage) return undefined
     if (error.data.responseBody?.includes("FreeUsageLimitError")) {
       return {
         message: GO_UPSELL_MESSAGE,
@@ -128,7 +130,6 @@ export function retryable(error: Err, provider: string) {
     return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
   }
 
-  const msg = isRecord(error.data) ? error.data.message : undefined
   const json = parseJSON(msg)
   if (json && typeof json === "object") {
     const code = typeof json.code === "string" ? json.code : ""
@@ -142,8 +143,20 @@ export function retryable(error: Err, provider: string) {
       return { message: "Rate Limited" }
     }
   }
-  if (typeof msg === "string" && RETRYABLE_MESSAGE.some((pattern) => pattern.test(msg))) return { message: msg }
+  if (retryableMessage && typeof msg === "string") return { message: msg }
   return undefined
+}
+
+function isRetryableMessage(input: unknown) {
+  if (typeof input !== "string") return false
+  const json = parseJSON(input)
+  const messages =
+    json && typeof json === "object"
+      ? [json.message, json.code, json.error?.message, json.error?.code, json.error?.type]
+      : [input]
+  return messages.some(
+    (message) => typeof message === "string" && RETRYABLE_MESSAGE.some((pattern) => pattern.test(message)),
+  )
 }
 
 function str(value: unknown) {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -149,14 +149,7 @@ export function retryable(error: Err, provider: string) {
 
 function isRetryableMessage(input: unknown) {
   if (typeof input !== "string") return false
-  const json = parseJSON(input)
-  const messages =
-    json && typeof json === "object"
-      ? [json.message, json.code, json.error?.message, json.error?.code, json.error?.type]
-      : [input]
-  return messages.some(
-    (message) => typeof message === "string" && RETRYABLE_MESSAGE.some((pattern) => pattern.test(message)),
-  )
+  return RETRYABLE_MESSAGE.some((pattern) => pattern.test(input))
 }
 
 function str(value: unknown) {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,6 +28,12 @@ export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
+const RETRYABLE_MESSAGE = [
+  /server[_\s-]?error|internal[_\s-]?error|service[_\s-]?unavailable|overloaded|provider returned error|too many requests|rate increased too quickly|rate[_\s-]?limit/i,
+  /fetch failed|network error|upstream connect|connection (?:error|refused|lost)|socket connection was closed|socket hang up|reset before headers|getaddrinfo|ENOTFOUND|EAI_AGAIN|timeout|timed? out|terminated/i,
+  /resource[_\s-]?exhausted|please retry your request|you can retry your request|try your request again/i,
+]
+
 function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
@@ -122,32 +128,21 @@ export function retryable(error: Err, provider: string) {
     return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
   }
 
-  // Check for rate limit patterns in plain text error messages
   const msg = isRecord(error.data) ? error.data.message : undefined
-  if (typeof msg === "string") {
-    const lower = msg.toLowerCase()
-    if (
-      lower.includes("rate increased too quickly") ||
-      lower.includes("rate limit") ||
-      lower.includes("too many requests")
-    ) {
-      return { message: msg }
+  const json = parseJSON(msg)
+  if (json && typeof json === "object") {
+    const code = typeof json.code === "string" ? json.code : ""
+    if (json.type === "error" && json.error?.type === "too_many_requests") {
+      return { message: "Too Many Requests" }
+    }
+    if (code.includes("exhausted") || code.includes("unavailable")) {
+      return { message: "Provider is overloaded" }
+    }
+    if (json.type === "error" && typeof json.error?.code === "string" && json.error.code.includes("rate_limit")) {
+      return { message: "Rate Limited" }
     }
   }
-
-  const json = parseJSON(msg)
-  if (!json || typeof json !== "object") return undefined
-  const code = typeof json.code === "string" ? json.code : ""
-
-  if (json.type === "error" && json.error?.type === "too_many_requests") {
-    return { message: "Too Many Requests" }
-  }
-  if (code.includes("exhausted") || code.includes("unavailable")) {
-    return { message: "Provider is overloaded" }
-  }
-  if (json.type === "error" && typeof json.error?.code === "string" && json.error.code.includes("rate_limit")) {
-    return { message: "Rate Limited" }
-  }
+  if (typeof msg === "string" && RETRYABLE_MESSAGE.some((pattern) => pattern.test(msg))) return { message: msg }
   return undefined
 }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -179,6 +179,28 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(wrap(msg), retryProvider)).toEqual({ message: msg })
   })
 
+  test("retries transient messages nested in json", () => {
+    const msg = JSON.stringify({ type: "error", error: { code: "server_error", message: "xxx" } })
+    expect(SessionRetry.retryable(wrap(msg), retryProvider)).toEqual({ message: msg })
+  })
+
+  test("retries transient API errors even when the SDK does not", () => {
+    const error = new SessionV1.APIError({ message: "server_error", isRetryable: false }).toObject()
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "server_error" })
+  })
+
+  test.each(["Observer error", "Unterminated string in JSON", "Invalid timeout option"])(
+    "does not retry near-miss errors: %s",
+    (msg) => {
+      expect(SessionRetry.retryable(wrap(msg), retryProvider)).toBeUndefined()
+    },
+  )
+
+  test("does not match unrelated json fields", () => {
+    const msg = JSON.stringify({ error: { message: "Invalid request" }, metadata: "server_error" })
+    expect(SessionRetry.retryable(wrap(msg), retryProvider)).toBeUndefined()
+  })
+
   test("retries transport timeout errors", () => {
     const request = MessageV2.fromError(new ProviderError.HeaderTimeoutError(10000), { providerID })
     expect(SessionV1.APIError.isInstance(request)).toBe(true)

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -196,9 +196,9 @@ describe("session.retry.retryable", () => {
     },
   )
 
-  test("does not match unrelated json fields", () => {
-    const msg = JSON.stringify({ error: { message: "Invalid request" }, metadata: "server_error" })
-    expect(SessionRetry.retryable(wrap(msg), retryProvider)).toBeUndefined()
+  test("retries transient messages in arbitrary json fields", () => {
+    const msg = JSON.stringify({ detail: "rate limit exceeded" })
+    expect(SessionRetry.retryable(wrap(msg), retryProvider)).toEqual({ message: msg })
   })
 
   test("retries transport timeout errors", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -163,6 +163,22 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: msg })
   })
 
+  test.each([
+    "server_error",
+    "Internal server error",
+    "Service Unavailable",
+    "Provider is overloaded",
+    "Provider returned error",
+    "fetch failed",
+    "connection timed out",
+    "socket hang up",
+    "getaddrinfo ENOTFOUND api.example.com",
+    "ResourceExhausted",
+    "You can retry your request",
+  ])("retries transient plain text errors: %s", (msg) => {
+    expect(SessionRetry.retryable(wrap(msg), retryProvider)).toEqual({ message: msg })
+  })
+
   test("retries transport timeout errors", () => {
     const request = MessageV2.fromError(new ProviderError.HeaderTimeoutError(10000), { providerID })
     expect(SessionV1.APIError.isInstance(request)).toBe(true)


### PR DESCRIPTION
## Summary
- retry transient provider messages when SDKs discard structured error metadata
- cover server/load, fetch/socket, DNS, timeout, resource exhaustion, and explicit retry guidance wording
- preserve structured JSON classification before plain-text fallback matching

## Tests
- `bun test test/session/retry.test.ts`
- `bun typecheck`
- `bunx prettier --check packages/opencode/src/session/retry.ts packages/opencode/test/session/retry.test.ts`