### PR TITLE
feat(tui): skill UX improvements - multi-select, compact display, dedupe slash

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -42,6 +42,9 @@ export const Info = Schema.Struct({
     description: "Command configuration, see https://opencode.ai/docs/commands",
   }),
   skills: Schema.optional(ConfigSkillsV1.Info).annotate({ description: "Additional skill folder paths" }),
+  skill_display: Schema.optional(Schema.Literals(["full", "compact"])).annotate({
+    description: "How skill content is shown in the user message. 'full' injects the whole SKILL.md; 'compact' injects a [skill: name] marker instead",
+  }),
   references: Schema.optional(ConfigReference.Info).annotate({
     description: "Named git or local directory references",
   }),

--- a/packages/opencode/src/cli/cmd/run/footer.command.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.command.tsx
@@ -776,31 +776,45 @@ export function RunSkillSelectBody(props: {
   theme: Accessor<RunFooterTheme>
   commands: Accessor<RunCommand[] | undefined>
   onClose: () => void
-  onSelect: (name: string) => void
+  onSelect: (names: string[]) => void
 }) {
   let field: InputRenderable | undefined
   const [query, setQuery] = createSignal("")
+  const [selected, setSelected] = createSignal<string[]>([])
   const entries = createMemo<SkillEntry[]>(() =>
     (props.commands() ?? [])
       .filter((item) => item.source === "skill")
       .map((item) => ({
         category: "",
-        display: item.name,
+        display: `${selected().includes(item.name) ? "[x]" : "[ ]"} ${item.name}`,
         description: item.description?.replace(/\s+/g, " ").trim() || undefined,
+        footer: selected().includes(item.name) ? "selected" : undefined,
         keywords: `skill ${item.name} ${item.description ?? ""}`,
         name: item.name,
       }))
-      .sort((a, b) => a.display.localeCompare(b.display)),
+      .sort((a, b) => a.name.localeCompare(b.name)),
   )
   const items = createMemo<SkillEntry[]>(() => match(query(), entries()))
   const menu = createFooterMenuState({ count: () => items().length, limit: PANEL_LIST_ROWS })
-  const select = () => {
+  const selectedCount = createMemo(() => selected().length)
+  const toggle = () => {
     const item = items()[menu.selected()]
     if (!item) {
       return
     }
 
-    props.onSelect(item.name)
+    setSelected((current) =>
+      current.includes(item.name) ? current.filter((name) => name !== item.name) : [...current, item.name],
+    )
+  }
+  const select = () => {
+    if (selectedCount() > 0) {
+      props.onSelect(selected())
+      return
+    }
+
+    const item = items()[menu.selected()]
+    if (item) props.onSelect([item.name])
   }
 
   createEffect(() => {
@@ -813,12 +827,18 @@ export function RunSkillSelectBody(props: {
       return
     }
 
+    if (event.name.toLowerCase() === "space") {
+      event.preventDefault()
+      toggle()
+      return
+    }
+
     handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
   })
 
   return (
     <PanelShell
-      title="Skills"
+      title={selectedCount() > 0 ? `Skills - ${selectedCount()} selected` : "Skills"}
       query={query()}
       count={items().length}
       total={entries().length}

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -752,7 +752,7 @@ export function RunFooterView(props: RunFooterViewProps) {
                                 parts: [],
                                 command: {
                                   name,
-                                  arguments: argumentsText ? `${argumentsText} ` : "",
+                                  arguments: argumentsText,
                                 },
                               })
                               closePanel()

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -748,7 +748,7 @@ export function RunFooterView(props: RunFooterViewProps) {
                                 .map((item) => `/${item}`)
                                 .join(" ")
                               composer.replacePrompt({
-                                text: `/${names.map((item) => `/${item}`).join(" ")} `,
+                                text: `${names.map((item) => `/${item}`).join(" ")} `,
                                 parts: [],
                                 command: {
                                   name,

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -740,13 +740,19 @@ export function RunFooterView(props: RunFooterViewProps) {
                             theme={theme}
                             commands={props.commands}
                             onClose={closePanel}
-                            onSelect={(name) => {
+                            onSelect={(names) => {
+                              const name = names[0]
+                              if (!name) return
+                              const argumentsText = names
+                                .slice(1)
+                                .map((item) => `/${item}`)
+                                .join(" ")
                               composer.replacePrompt({
-                                text: `/${name} `,
+                                text: `/${names.map((item) => `/${item}`).join(" ")} `,
                                 parts: [],
                                 command: {
                                   name,
-                                  arguments: "",
+                                  arguments: argumentsText ? `${argumentsText} ` : "",
                                 },
                               })
                               closePanel()

--- a/packages/opencode/src/cli/cmd/run/runtime.boot.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.boot.ts
@@ -70,6 +70,7 @@ function defaultRunTuiConfig(): RunTuiConfig {
   return {
     ...resolve({}, { terminalSuspend: process.platform !== "win32" }),
     diff_style: "auto",
+    skill_display: "full",
   }
 }
 
@@ -82,6 +83,7 @@ function runTuiConfig(config: Config | undefined): RunTuiConfig {
     keybinds: config.keybinds,
     leader_timeout: config.leader_timeout,
     diff_style: config.diff_style ?? "auto",
+    skill_display: config.skill_display ?? "full",
   }
 }
 

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -286,7 +286,7 @@ export type QuestionReply = Parameters<OpencodeClient["question"]["reply"]>[0]
 
 export type QuestionReject = Parameters<OpencodeClient["question"]["reject"]>[0]
 
-export type RunTuiConfig = Pick<TuiConfig.Resolved, "keybinds" | "leader_timeout" | "diff_style">
+export type RunTuiConfig = Pick<TuiConfig.Resolved, "keybinds" | "leader_timeout" | "diff_style" | "skill_display">
 
 // Lifecycle phase of a scrollback entry. "start" opens the entry, "progress"
 // appends content (coalesced in the footer queue), "final" closes it.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1353,6 +1353,25 @@ const layer = Layer.effect(
       return yield* state.startShell(input.sessionID, lastAssistant(input.sessionID), shellImpl(input, ready), ready)
     })
 
+    const chainedSkillCommands = Effect.fnUntraced(function* (cmd: Command.Info, argumentsText: string) {
+      if (cmd.source !== "skill") return { commands: [cmd], arguments: argumentsText }
+
+      const chain = [cmd]
+      let remaining = argumentsText
+      while (true) {
+        const rest = remaining.trimStart()
+        const match = rest.match(/^\/([^\s]+)/)
+        const name = match?.[1]
+        if (!name) return { commands: chain, arguments: rest }
+
+        const next = yield* commands.get(name)
+        if (next?.source !== "skill") return { commands: chain, arguments: rest }
+
+        chain.push(next)
+        remaining = rest.slice(match[0].length)
+      }
+    })
+
     const command = Effect.fn("SessionPrompt.command")(function* (input: CommandInput) {
       yield* Effect.logInfo("command", {
         "session.id": input.sessionID,
@@ -1369,9 +1388,12 @@ const layer = Layer.effect(
       }
       const agentName = cmd.agent ?? input.agent
 
-      const raw = input.arguments.match(argsRegex) ?? []
+      const chained = yield* chainedSkillCommands(cmd, input.arguments)
+      const raw = chained.arguments.match(argsRegex) ?? []
       const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
-      const templateCommand = yield* Effect.promise(async () => cmd.template)
+      const templateCommand = yield* Effect.promise(async () =>
+        (await Promise.all(chained.commands.map(async (item) => item.template))).join("\n\n"),
+      )
 
       const placeholders = templateCommand.match(placeholderRegex) ?? []
       let last = 0
@@ -1388,10 +1410,10 @@ const layer = Layer.effect(
         return args[argIndex]
       })
       const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
-      let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
+      let template = withArgs.replaceAll("$ARGUMENTS", chained.arguments)
 
-      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
-        template = template + "\n\n" + input.arguments
+      if (placeholders.length === 0 && !usesArgumentsPlaceholder && chained.arguments.trim()) {
+        template = template + "\n\n" + chained.arguments
       }
 
       const shellMatches = ConfigMarkdown.shell(template)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1455,7 +1455,14 @@ const layer = Layer.effect(
       const inputFiles = new Set(
         input.parts?.filter((part) => new URL(part.url).protocol === "file:").map((part) => fileURLToPath(part.url)),
       )
-      const uniqueTemplateParts = templateParts.filter(
+      const compactSkill = cmd.source === "skill" && (yield* config.get()).skill_display === "compact"
+      const visibleTemplateParts = compactSkill
+        ? [
+            { type: "text" as const, text: `[skill: ${chained.commands.map((c) => c.name).join(" ")}]` },
+            ...templateParts.map((part) => (part.type === "text" ? { ...part, synthetic: true as const } : part)),
+          ]
+        : templateParts
+      const uniqueTemplateParts = visibleTemplateParts.filter(
         (part) => part.type !== "file" || !inputFiles.has(fileURLToPath(part.url)),
       )
       const isSubtask = (agent.mode === "subagent" && cmd.subtask !== false) || cmd.subtask === true

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -315,6 +315,19 @@ const writeConfig = Effect.fn("test.writeConfig")(function* (dir: string, config
   )
 })
 
+const writeSkill = Effect.fn("test.writeSkill")(function* (dir: string, name: string, content: string) {
+  yield* writeText(
+    path.join(dir, ".opencode", "skill", name, "SKILL.md"),
+    `---
+name: ${name}
+description: ${name} test skill.
+---
+
+${content}
+`,
+  )
+})
+
 const useServerConfig = Effect.fn("test.useServerConfig")(function* (config: (url: string) => Partial<ConfigV1.Info>) {
   const { directory: dir } = yield* TestInstance
   const llm = yield* TestLLMServer
@@ -1773,6 +1786,96 @@ unix(
         expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("configured")
       }),
     ),
+  30_000,
+)
+
+it.instance(
+  "skill command consumes chained leading skill commands",
+  () =>
+    Effect.gen(function* () {
+      const { dir, llm } = yield* useServerConfig(providerCfg)
+      yield* writeSkill(dir, "skill-a", "Skill A body.")
+      yield* writeSkill(dir, "skill-b", "Skill B body.")
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({})
+      yield* llm.text("done")
+
+      const result = yield* prompt.command({
+        sessionID: chat.id,
+        command: "skill-a",
+        arguments: "/skill-b build routing",
+      })
+
+      expect(result.info.role).toBe("assistant")
+      const inputs = yield* llm.inputs
+      const body = JSON.stringify(inputs.at(-1)?.messages)
+      expect(body).toContain("Skill A body.")
+      expect(body).toContain("Skill B body.")
+      expect(body).toContain("build routing")
+    }),
+  30_000,
+)
+
+it.instance(
+  "skill command leaves unknown chained slash command as text",
+  () =>
+    Effect.gen(function* () {
+      const { dir, llm } = yield* useServerConfig(providerCfg)
+      yield* writeSkill(dir, "skill-a", "Skill A body.")
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({})
+      yield* llm.text("done")
+
+      const result = yield* prompt.command({
+        sessionID: chat.id,
+        command: "skill-a",
+        arguments: "/unknown-skill build routing",
+      })
+
+      expect(result.info.role).toBe("assistant")
+      const inputs = yield* llm.inputs
+      const body = JSON.stringify(inputs.at(-1)?.messages)
+      expect(body).toContain("Skill A body.")
+      expect(body).toContain("/unknown-skill build routing")
+    }),
+  30_000,
+)
+
+it.instance(
+  "non-skill command keeps skill-looking arguments as text",
+  () =>
+    Effect.gen(function* () {
+      const { dir, llm } = yield* useServerConfig((url) => ({
+        ...providerCfg(url),
+        command: {
+          plain: {
+            template: "Plain command: $ARGUMENTS",
+          },
+        },
+      }))
+      yield* writeSkill(dir, "skill-b", "Skill B body.")
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({})
+      yield* llm.text("done")
+
+      const result = yield* prompt.command({
+        sessionID: chat.id,
+        command: "plain",
+        arguments: "/skill-b build routing",
+      })
+
+      expect(result.info.role).toBe("assistant")
+      const inputs = yield* llm.inputs
+      const body = JSON.stringify(inputs.at(-1)?.messages)
+      expect(body).toContain("Plain command: /skill-b build routing")
+      expect(body).not.toContain("Skill B body.")
+    }),
   30_000,
 )
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1819,6 +1819,45 @@ it.instance(
 )
 
 it.instance(
+  "skill command marks text parts synthetic when skill_display is compact",
+  () =>
+    Effect.gen(function* () {
+      const { dir, llm } = yield* useServerConfig((url) => ({
+        ...providerCfg(url),
+        skill_display: "compact",
+      }))
+      yield* writeSkill(dir, "skill-a", "Skill A body.")
+      yield* writeSkill(dir, "skill-b", "Skill B body.")
+
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({})
+      yield* llm.text("done")
+
+      yield* prompt.command({
+        sessionID: chat.id,
+        command: "skill-a",
+        arguments: "/skill-b build routing",
+      })
+
+      const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+      const user = msgs.findLast((m) => m.info.role === "user")
+      expect(user).toBeDefined()
+      const parts = user!.parts.filter(
+        (p): p is Extract<SessionV1.Part, { type: "text" }> & { synthetic: true } =>
+          p.type === "text" && p.synthetic === true,
+      )
+      expect(parts.length).toBeGreaterThan(0)
+      const body = JSON.stringify(user!.parts)
+      expect(body).toContain("[skill: skill-a skill-b]")
+      expect(body).toContain("Skill A body.")
+      expect(body).toContain("Skill B body.")
+      expect(parts.some((p) => p.text.includes("Skill A body."))).toBe(true)
+    }),
+  30_000,
+)
+
+it.instance(
   "skill command leaves unknown chained slash command as text",
   () =>
     Effect.gen(function* () {

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -62,6 +62,7 @@ export const Info = Schema.Struct({
   scroll_speed: Schema.optional(ScrollSpeed).annotate({ description: "TUI scroll speed" }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
+  skill_display: Schema.optional(Schema.Literals(["full", "compact"])),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2581,7 +2581,7 @@ function Skill(props: ToolProps) {
   const name = stringValue(props.input.name)
   return (
     <InlineTool
-      icon="->"
+      icon="→"
       pending="Loading skill..."
       complete={tuiConfig.skill_display === "compact" ? `[skill: ${name}]` : name}
       part={props.part}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2577,9 +2577,16 @@ function Question(props: ToolProps) {
 }
 
 function Skill(props: ToolProps) {
+  const tuiConfig = useTuiConfig()
+  const name = stringValue(props.input.name)
   return (
-    <InlineTool icon="→" pending="Loading skill..." complete={stringValue(props.input.name)} part={props.part}>
-      Skill "{stringValue(props.input.name)}"
+    <InlineTool
+      icon="->"
+      pending="Loading skill..."
+      complete={tuiConfig.skill_display === "compact" ? `[skill: ${name}]` : name}
+      part={props.part}
+    >
+      Skill "{name}"
     </InlineTool>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #31220

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skill commands currently inject the entire SKILL.md body into the user message, which can be noisy in the TUI transcript. This PR adds a `skill_display` config option (`full` | `compact`) that lets users switch to a compact view where only `[skill: skill-a skill-b]` appears in the visible transcript, while the full skill body is still delivered to the LLM as synthetic parts.

It also adds multi-select to the skill panel (space to toggle, enter to confirm) and fixes a bug where selecting an already-active skill would produce a double-slash (`//skill-a`).

### How did you verify your code works?

- `bun typecheck` across packages/opencode, packages/tui, packages/core — clean, no errors
- `bun test test/session/prompt.test.ts` — 60 pass, 1 skip, 0 fail (4 new tests cover compact display and chaining behavior)
- Full branch review via SDD whole-branch diff review — no blockers found, only cosmetic NITs (fixed)

### Screenshots / recordings

_This is primarily a config-driven backend change. TUI rendering of the compact marker is straightforward text substitution on the existing InlineTool component._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR