### PR TITLE
refactor(core): remove dead fork pending copy

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -1,6 +1,6 @@
 export * as SessionProjector from "./projector"
 
-import { and, asc, desc, eq, gt, gte, inArray, lt, lte, sql } from "drizzle-orm"
+import { and, asc, desc, eq, gt, gte, lt, lte, sql } from "drizzle-orm"
 import { DateTime, Effect, Layer, Schema, Stream } from "effect"
 import { Database } from "../database/database"
 import { Bus } from "../bus"
@@ -255,65 +255,21 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
       .pipe(Effect.orDie)
     if (rows.length === 0) break
 
-    const idMap = new Map(rows.map((row) => [row.id, SessionMessage.ID.create()]))
     yield* db
       .insert(SessionMessageTable)
       .values(
-        rows.map((row) => {
-          const id = idMap.get(row.id)
-          if (!id) throw new Error(`Fork message ID mapping missing: ${row.id}`)
-          return {
-            id,
-            session_id: event.data.sessionID,
-            type: row.type,
-            seq: row.seq,
-            time_created: row.time_created,
-            time_updated: row.time_updated,
-            data: row.data,
-          }
-        }),
+        rows.map((row) => ({
+          id: SessionMessage.ID.create(),
+          session_id: event.data.sessionID,
+          type: row.type,
+          seq: row.seq,
+          time_created: row.time_created,
+          time_updated: row.time_updated,
+          data: row.data,
+        })),
       )
       .run()
       .pipe(Effect.orDie)
-
-    const pendingRows = yield* db
-      .select()
-      .from(SessionPendingTable)
-      .where(
-        and(
-          eq(SessionPendingTable.session_id, event.data.parentID),
-          inArray(
-            SessionPendingTable.id,
-            rows.map((row) => row.id),
-          ),
-        ),
-      )
-      .all()
-      .pipe(Effect.orDie)
-    if (pendingRows.length > 0) {
-      yield* db
-        .insert(SessionPendingTable)
-        .values(
-          pendingRows.flatMap((row) => {
-            const id = idMap.get(row.id)
-            return id && row.type !== "compaction"
-              ? [
-                  {
-                    id,
-                    session_id: event.data.sessionID,
-                    type: row.type,
-                    data: row.data,
-                    delivery: row.delivery,
-                    admitted_seq: row.admitted_seq,
-                    time_created: row.time_created,
-                  },
-                ]
-              : []
-          }),
-        )
-        .run()
-        .pipe(Effect.orDie)
-    }
 
     cursor = rows.at(-1)!.seq
   }


### PR DESCRIPTION
## What

Remove the session fork projector's unreachable pending-row copy path.

Forks copy visible projected history from `session_message`. Under the pending-only inbox model, a visible message cannot have a matching row in `session_pending`, so the follow-up pending query and copy always operate on an empty intersection.

This removes 44 net lines and makes the fork invariant explicit: forks copy projected history, not unconsumed work.

## How

Prompt promotion deletes its `session_pending` row and inserts the corresponding `session_message` within the same immediate durable-event transaction. Admission also rejects an ID already present in `session_message`. A concurrent fork therefore observes either the pending row or the projected message, never both for the same ID.

The old block originated when `session_input` retained consumed rows. The pending-only migration dropped that ledger rather than preserving consumed rows, but the fork-copy logic was carried forward mechanically.

`packages/core/src/session/projector.ts` now:

- Generates copied message IDs directly while mapping projected rows.
- Removes the impossible pending lookup and insertion.
- Removes the ID map that existed only to correlate messages with those pending rows.

Running compactions remain excluded by the existing fork query. Settled compactions remove their pending barrier in the same event transaction.

## Scope

This does not change prompt admission, promotion, queueing, replay, compaction, fork boundaries, or sequence reservation. It does not attempt to recover from manually corrupted databases containing both rows for the same message ID.

## Testing

- `bun run test test/session-create.test.ts` from `packages/core` (31 passed)
- `bun typecheck` from `packages/core`
- Push-hook workspace typecheck (33/33 packages)
- `git diff --check`

The existing fork suite verifies copied content, regenerated message IDs, absent pending rows, boundary behavior, and sequence reservation without constructing an unsupported storage state.
