### PR TITLE
refactor(server): remove obsolete auth header helpers

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -2,10 +2,6 @@ export * as ServerAuth from "./auth"
 
 import { Context, Layer, Option, Redacted } from "effect"
 
-export type Credentials = {
-  password?: string
-}
-
 export type DecodedCredentials = {
   readonly username: string
   readonly password: Redacted.Redacted
@@ -36,17 +32,4 @@ export function authorized(credentials: DecodedCredentials, config: Info) {
     credentials.username === config.username &&
     Redacted.value(credentials.password) === config.password.value
   )
-}
-
-export function header(credentials?: Credentials) {
-  const password = credentials?.password
-  if (!password) return undefined
-
-  return `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
-}
-
-export function headers(credentials?: Credentials) {
-  const authorization = header(credentials)
-  if (!authorization) return undefined
-  return { Authorization: authorization }
 }

--- a/packages/server/test/auth.test.ts
+++ b/packages/server/test/auth.test.ts
@@ -7,7 +7,3 @@ test("accepts only the fixed opencode username", () => {
   expect(ServerAuth.authorized({ username: "opencode", password: Redacted.make("secret") }, config)).toBe(true)
   expect(ServerAuth.authorized({ username: "custom", password: Redacted.make("secret") }, config)).toBe(false)
 })
-
-test("encodes the fixed opencode username", () => {
-  expect(ServerAuth.header({ password: "secret" })).toBe(`Basic ${Buffer.from("opencode:secret").toString("base64")}`)
-})


### PR DESCRIPTION
**What**
Remove the obsolete server-side `Credentials`, `header`, and `headers` client encoding helpers and their encoding test. Production clients have migrated to client endpoint authentication and derive request headers through `Service.headers(endpoint)`.

**How**
- Remove the unused outbound Basic-auth encoding surface from `packages/server/src/auth.ts`.
- Remove only the obsolete encoding assertion from `packages/server/test/auth.test.ts`.
- Retain the inbound authorization boundary exactly: `DecodedCredentials`, `Info`, `Config`, `required`, and `authorized` continue to back authorization middleware, including the fixed `opencode` username and configured password check.

**Scope**
This does not change credential decoding, server configuration, authorization middleware behavior, or client endpoint authentication.

**Testing**
- `bun typecheck` in `packages/server`
- `bun run test` in `packages/server` (15 passed)
- `git diff --check`
- Push hook workspace typecheck (33 tasks passed)