### PR TITLE
refactor(session-ui): remove unused exported components

### DIFF
--- a/packages/session-ui/src/components/line-comment-styles.ts
+++ b/packages/session-ui/src/components/line-comment-styles.ts
@@ -36,10 +36,6 @@ export const lineCommentStyles = `
   border: none;
 }
 
-[data-component="line-comment"][data-variant="add"] [data-slot="line-comment-button"] {
-  background: var(--syntax-diff-add);
-}
-
 [data-component="line-comment"] [data-component="icon"] {
   color: var(--white);
 }

--- a/packages/session-ui/src/components/line-comment.tsx
+++ b/packages/session-ui/src/components/line-comment.tsx
@@ -9,7 +9,7 @@ import { useI18n } from "@opencode-ai/ui/context/i18n"
 
 installLineCommentStyles()
 
-export type LineCommentVariant = "default" | "editor" | "add"
+export type LineCommentVariant = "default" | "editor"
 
 function InlineGlyph(props: { icon: "comment" | "plus" }) {
   return (
@@ -153,25 +153,6 @@ export const LineComment = (props: LineCommentProps) => {
         </div>
       </div>
     </LineCommentAnchor>
-  )
-}
-
-export type LineCommentAddProps = Omit<LineCommentAnchorProps, "children" | "variant" | "open" | "icon"> & {
-  label?: string
-}
-
-export const LineCommentAdd = (props: LineCommentAddProps) => {
-  const [split, rest] = splitProps(props, ["label"])
-  const i18n = useI18n()
-
-  return (
-    <LineCommentAnchor
-      {...rest}
-      open={false}
-      variant="add"
-      icon="plus"
-      buttonLabel={split.label ?? i18n.t("ui.lineComment.submit")}
-    />
   )
 }
 

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -948,10 +948,6 @@ function ExaOutput(props: { output?: string }) {
   )
 }
 
-export function registerPartComponent(type: string, component: PartComponent) {
-  PART_MAPPING[type] = component
-}
-
 export function Message(props: MessageProps) {
   return (
     <Switch>


### PR DESCRIPTION
## What

Remove confirmed-unused exported APIs from the private `@opencode-ai/session-ui` package:

- `LineCommentAdd` and `LineCommentAddProps`
- the associated `"add"` line-comment variant and its exclusive button style
- `registerPartComponent`

This is an explicit TypeScript API-surface reduction even though the package is private and unpublished. Repository-wide `rg` searches and GitHub code searches across `anomalyco` found no consumers beyond the definitions being removed. Because the package is private, no changeset is needed.

## How

- Narrow `LineCommentVariant` to the two live variants, `"default"` and `"editor"`.
- Remove the wrapper component and CSS selector used only by its `"add"` variant.
- Remove the unused part-registration function while retaining the exported `PART_MAPPING` and direct built-in registrations.

The existing plus icon support on `LineCommentAnchor`, all live `LineComment` components, `PART_MAPPING`, built-in `tool`/`compaction`/`text`/`reasoning` registrations, and `ToolRegistry`/`registerTool`/`getTool` remain unchanged.

## Scope

This PR deliberately removes only the confirmed-unused exports. It does not redesign line comments, change rendering behavior, or alter the live tool and part registries.

## Testing

- `bun typecheck` in `packages/session-ui`
- `bun run test` in `packages/session-ui` (76 passed)
- pre-push workspace typecheck (33 tasks passed)
- `git diff --check`
- `bun run build` in `packages/storybook` attempted; Storybook fails before story compilation because `storybook-solidjs-vite` cannot detect `solid-js` from the `.storybook` config directory, despite the dependency being installed at `packages/storybook/node_modules/solid-js`
