### PR TITLE
refactor(app): remove unused UI helpers

### DIFF
--- a/packages/app/src/context/command.tsx
+++ b/packages/app/src/context/command.tsx
@@ -248,11 +248,6 @@ export function formatKeybind(config: string, t?: (key: KeyLabel) => string): st
   return IS_MAC ? parts.join("") : parts.join("+")
 }
 
-// KeybindV2 takes an array instead of a string
-export function formatKeybindKeys(config: string, t?: (key: KeyLabel) => string): string[] {
-  return formatKeybindParts(config, t)
-}
-
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false
   if (target.isContentEditable) return true

--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -286,13 +286,6 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
         children: tree.children,
         expand: tree.expandDir,
         collapse: tree.collapseDir,
-        toggle(input: string) {
-          if (tree.dirState(input)?.expanded) {
-            tree.collapseDir(input)
-            return
-          }
-          tree.expandDir(input)
-        },
       },
       get,
       load,

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -153,18 +153,6 @@ export function normalizeProviderList(
   }
 }
 
-export function sanitizeProject(project: Project) {
-  if (!project.icon?.url && !project.icon?.override) return project
-  return {
-    ...project,
-    icon: {
-      ...project.icon,
-      url: undefined,
-      override: undefined,
-    },
-  }
-}
-
 export function normalizeProjectInfo(project: Project | CurrentProject): Project {
   return {
     ...project,

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -753,9 +753,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       },
       mobileSidebar: {
         opened: createMemo(() => store.mobileSidebar?.opened ?? false),
-        show() {
-          setStore("mobileSidebar", "opened", true)
-        },
         hide() {
           setStore("mobileSidebar", "opened", false)
         },
@@ -960,33 +957,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
               if (current.reviewOpen.includes(path)) return
               setStore("sessionView", session, "reviewOpen", current.reviewOpen.length, path)
-            },
-            closePath(path: string) {
-              const session = key()
-              const current = store.sessionView[session]?.reviewOpen
-              if (!current) return
-
-              const index = current.indexOf(path)
-              if (index === -1) return
-              setStore(
-                "sessionView",
-                session,
-                "reviewOpen",
-                produce((draft) => {
-                  if (!draft) return
-                  draft.splice(index, 1)
-                }),
-              )
-            },
-            togglePath(path: string) {
-              const session = key()
-              const current = store.sessionView[session]?.reviewOpen
-              if (!current || !current.includes(path)) {
-                this.openPath(path)
-                return
-              }
-
-              this.closePath(path)
             },
           },
         }

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -22,8 +22,6 @@ type TabsInput = {
   fileBrowser?: Accessor<boolean>
 }
 
-export const getSessionKey = (dir: string | undefined, id: string | undefined) => `${dir ?? ""}${id ? `/${id}` : ""}`
-
 export function shouldShowFileTree(input: { visible: boolean; opened: boolean }) {
   return input.opened && input.visible
 }


### PR DESCRIPTION
**What**
Remove confirmed-unused private app helper and controller surface. This is a callerless cleanup with no reachable UI behavior change.

**How**
- Remove `layout.review.closePath` and `layout.review.togglePath`, introduced with the session helper cleanup in `dce7eceb28`; retain the actively used `review.openPath` and `review.setOpen` APIs.
- Remove `file.tree.toggle`, introduced with the file tree in `d9eed4c6ca`; retain active explicit `tree.expand` and `tree.collapse` behavior.
- Remove `mobileSidebar.show` from the controller introduced in `b8872d9d20`; retain active `mobileSidebar.hide` and `mobileSidebar.toggle` behavior.
- Remove `sanitizeProject`, added during the global sync refactor in `2c58dd6203`; retain `normalizeProjectInfo`, including current-project canonical worktree and VCS normalization.
- Remove `formatKeybindKeys`, added with app UI improvements in `1bcb9d7cb9`; retain active `formatKeybindParts` formatting for `KeybindV2` consumers.
- Remove `getSessionKey`, introduced in `dce7eceb28`; retain `SessionStateKey.from(scope, route)` construction so session identities remain server-scoped.

**Scope**
- No changes to the unrelated Canvas/path `closePath` mock in `packages/app/happydom.ts`.
- No session or timeline behavior changes, so no behavioral benchmark was run.
- No demo: the removed APIs had no callers and produce no reachable UI change.

**Testing**
- `bun typecheck` from `packages/app` (pass)
- repository pre-push typecheck across 33 packages (pass)
- `bun run build` from `packages/app` (pass; existing Vite chunk/dynamic-import warnings)
- `bun run test:unit` from `packages/app` (688 pass, 1 unrelated existing failure: Arabic i18n parity is missing five English keys)
- `git diff --check` (pass)