### PR TITLE
fix(server): allow blob attachments in web UI

### DIFF
--- a/packages/opencode/src/server/shared/ui.ts
+++ b/packages/opencode/src/server/shared/ui.ts
@@ -9,7 +9,7 @@ let embeddedUIPromise: Promise<Record<string, string> | null> | undefined
 export const UI_UPSTREAM = new URL("https://app.opencode.ai")
 
 export const csp = (hash = "") =>
-  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src * data:`
+  `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${hash ? ` 'sha256-${hash}'` : ""}; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; media-src 'self' data:; connect-src * data: blob:`
 export const DEFAULT_CSP = csp()
 
 export function themePreloadHash(body: string) {

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -326,7 +326,7 @@ describe("HttpApi UI fallback", () => {
     }),
   )
 
-  it.live("allows embedded UI terminal wasm and theme preload CSP", () =>
+  it.live("allows embedded UI terminal wasm, blob attachments, and theme preload CSP", () =>
     Effect.gen(function* () {
       const script = 'document.documentElement.dataset.theme = "dark"'
 
@@ -351,7 +351,8 @@ describe("HttpApi UI fallback", () => {
       const csp = response.headers.get("content-security-policy") ?? ""
       expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval'")
       expect(csp).toContain(`'sha256-${createHash("sha256").update(script).digest("base64")}'`)
-      expect(csp).toContain("connect-src * data:")
+      expect(csp).toContain("img-src 'self' data: https: blob:")
+      expect(csp).toContain("connect-src * data: blob:")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #40691

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows `blob:` URLs in the web UI's `img-src` and `connect-src` Content Security Policy directives.

OpenCode 1.18.13 changed attachments to use blob-backed draft storage in #40207. Attachment previews load the object URL as an image, while submission fetches the object URL before converting it into a data URL.

The server CSP allowed `data:` URLs but not `blob:` URLs, so browsers blocked both operations with `blocked:csp`.

This keeps the change limited to the two directives used by the attachment flow and adds regression assertions for both allowances.

### How did you verify your code works?

- `cd packages/opencode && bun test test/server/httpapi-ui.test.ts`
- `cd packages/opencode && bun typecheck`
- `cd packages/opencode && OPENCODE_CHANNEL=latest OPENCODE_VERSION=1.18.13 bun run build --single --skip-install`
- Built a production-channel binary and verified the affected attachment flow through the web UI.
- `git diff --check`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
