### PR TITLE
refactor(core): remove unreachable repository validation

### DIFF
--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -31,14 +31,6 @@ export type EnsureInput = {
   readonly branch?: string
 }
 
-export class InvalidRepositoryError extends Schema.TaggedErrorClass<InvalidRepositoryError>()(
-  "RepositoryCacheInvalidRepositoryError",
-  {
-    repository: Schema.String,
-    message: Schema.String,
-  },
-) {}
-
 export class InvalidBranchError extends Schema.TaggedErrorClass<InvalidBranchError>()(
   "RepositoryCacheInvalidBranchError",
   {
@@ -86,7 +78,6 @@ export class CacheOperationError extends Schema.TaggedErrorClass<CacheOperationE
 ) {}
 
 export type Error =
-  | InvalidRepositoryError
   | InvalidBranchError
   | CloneFailedError
   | FetchFailedError
@@ -103,7 +94,6 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Re
 
 export function isError(error: unknown): error is Error {
   return (
-    error instanceof InvalidRepositoryError ||
     error instanceof InvalidBranchError ||
     error instanceof CloneFailedError ||
     error instanceof FetchFailedError ||
@@ -113,13 +103,6 @@ export function isError(error: unknown): error is Error {
     error instanceof CacheOperationError
   )
 }
-
-export const parseRemote = Effect.fn("RepositoryCache.parseRemote")(function* (repository: string) {
-  return yield* Effect.try({
-    try: () => Repository.parseRemote(repository),
-    catch: (error) => new InvalidRepositoryError({ repository, message: errorMessage(error) }),
-  })
-})
 
 export const validateBranch = Effect.fn("RepositoryCache.validateBranch")(function* (branch: string) {
   return yield* Effect.try({

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -44,16 +44,6 @@ export class InvalidBranchError extends Schema.TaggedErrorClass<InvalidBranchErr
   message: Schema.String,
 }) {}
 
-export type Error = InvalidReferenceError | UnsupportedLocalRepositoryError | InvalidBranchError
-
-export function isError(error: unknown): error is Error {
-  return (
-    error instanceof InvalidReferenceError ||
-    error instanceof UnsupportedLocalRepositoryError ||
-    error instanceof InvalidBranchError
-  )
-}
-
 export function parse(input: string): Reference | undefined {
   const cleaned = normalizeInput(input)
   if (!cleaned) return

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -101,13 +101,10 @@ describe("RepositoryCache", () => {
     ),
   )
 
-  it.live("returns typed validation and clone failures", () =>
+  it.live("returns typed branch validation and clone failures", () =>
     withRemote((fixture) =>
       Effect.gen(function* () {
         const cache = yield* RepositoryCache.Service
-        const invalidRepository = yield* Effect.flip(RepositoryCache.parseRemote("not-a-repo"))
-        expect(invalidRepository).toBeInstanceOf(RepositoryCache.InvalidRepositoryError)
-
         const invalidBranch = yield* Effect.flip(cache.ensure({ reference: fixture.reference, branch: "../unsafe" }))
         expect(invalidBranch).toBeInstanceOf(RepositoryCache.InvalidBranchError)
 


### PR DESCRIPTION
## What

Remove the unreachable raw-string validation surface from `RepositoryCache`. Cache callers already provide a parsed `Repository.RemoteReference`, and `Repository.parseRemote` remains the single owner of raw repository parsing and typed parse failures.

Also remove the unused `Repository.Error` union and `Repository.isError` guard after a repo-wide search confirmed zero consumers. The individual `InvalidReferenceError`, `UnsupportedLocalRepositoryError`, and `InvalidBranchError` classes remain intact.

## How

- remove `RepositoryCache.parseRemote` and `RepositoryCache.InvalidRepositoryError`
- remove the invalid-repository member and check from the cache error union/guard
- remove the unused aggregate `Repository.Error` type and `Repository.isError` guard
- remove the dedicated cache parser assertion while retaining repository parser validation coverage

## Scope

- no changes to repository parsing or validation behavior
- no changes to cache materialization, clone, fetch, checkout, or reset behavior
- no schema, protocol, or generated client changes
- no changeset because `@opencode-ai/core` is private and this is internal dead-code cleanup

## Testing

- `bun run test test/repository.test.ts test/repository-cache.test.ts` in `packages/core` (11 passed)
- `bun run test test/reference.test.ts` in `packages/core` (3 passed)
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/server`
- push hook: `bun turbo typecheck --concurrency=3` (33 packages passed)
- `git diff --check`