### PR TITLE
refactor(core): remove obsolete project commit bridge

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -59,16 +59,6 @@ export interface Interface {
   readonly list: () => Effect.Effect<ReadonlyArray<Info>>
   readonly directories: (input: DirectoriesInput) => Effect.Effect<Directories>
   readonly resolve: (input: AbsolutePath) => Effect.Effect<Resolved>
-  /**
-   * Temporary bridge method for writing the resolved project ID to the repo-local cache.
-   *
-   * This exists while the old opencode project service and this core project
-   * service work together: core resolves the ID, while the old service still owns
-   * database migration and persistence. The old service should call this after it
-   * finishes migrating from `resolve().previous` to `resolve().id`; once project
-   * persistence moves into core, this separate bridge method can go away.
-   */
-  readonly commit: (input: { store: AbsolutePath; id: ID }) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Project") {}
@@ -268,11 +258,7 @@ const layer = Layer.effect(
       return yield* persist({ id: ID.global, directory, canonical: directory, vcs: undefined })
     })
 
-    const commit = Effect.fn("Project.commit")(function* (input: { store: AbsolutePath; id: ID }) {
-      yield* fs.writeFileString(path.join(input.store, "opencode"), input.id).pipe(Effect.ignore)
-    })
-
-    return Service.of({ list, directories, resolve, commit })
+    return Service.of({ list, directories, resolve })
   }),
 )
 

--- a/packages/core/test/effect/layer-node/node-build.test.ts
+++ b/packages/core/test/effect/layer-node/node-build.test.ts
@@ -80,7 +80,6 @@ describe("node build", () => {
           list: () => Effect.succeed([]),
           directories: () => Effect.succeed([]),
           resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
-          commit: () => Effect.void,
         })
       }),
     )

--- a/packages/core/test/location.test.ts
+++ b/packages/core/test/location.test.ts
@@ -21,7 +21,6 @@ const projectLayer = Layer.succeed(
         canonical: AbsolutePath.make("/main/repo"),
         vcs: { type: "git", store: AbsolutePath.make("/repo/.git") },
       }),
-    commit: () => Effect.void,
   }),
 )
 const it = testEffect(AppNodeBuilder.build(Location.boundNode(ref), [[Project.node, projectLayer]]))

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -36,7 +36,6 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
     directories: () => Effect.succeed([]),
-    commit: () => Effect.void,
   }),
 )
 let requests: LLMRequest[] = []

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -34,7 +34,6 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
     directories: () => Effect.succeed([]),
-    commit: () => Effect.void,
   }),
 )
 const it = testEffect(

--- a/packages/core/test/session-instructions.test.ts
+++ b/packages/core/test/session-instructions.test.ts
@@ -56,7 +56,6 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
     directories: () => Effect.succeed([]),
-    commit: () => Effect.void,
   }),
 )
 const permission = Layer.succeed(

--- a/packages/core/test/session-log.test.ts
+++ b/packages/core/test/session-log.test.ts
@@ -23,7 +23,6 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
     directories: () => Effect.succeed([]),
-    commit: () => Effect.void,
   }),
 )
 const it = testEffect(

--- a/packages/core/test/session-remove.test.ts
+++ b/packages/core/test/session-remove.test.ts
@@ -19,7 +19,6 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
     directories: () => Effect.succeed([]),
-    commit: () => Effect.void,
   }),
 )
 const it = testEffect(


### PR DESCRIPTION
## What

Remove the obsolete `Project.Interface.commit` bridge and its implementation.

The bridge was introduced as a temporary handoff to let the V1 project service write Core's resolved project ID after V1 completed its own migration and persistence. There are no remaining production callers, and Core's `Project.resolve` now persists its resolved project directly through the existing private `persist` path.

## How

- Remove `commit` from `Project.Interface` and the Core service implementation.
- Remove the now-dead `commit` fields from structural `Project.Service` test doubles.
- Leave `persist` and every `resolve` branch unchanged.

## Scope

- No changes to project identity resolution, migration, or persistence behavior.
- No changes to the V1 package.
- No changeset: `@opencode-ai/core` is private.

## Testing

- `bun run test test/project*.test.ts test/location*.test.ts` from `packages/core` (61 passed, 1 skipped)
- `bun run test test/effect/layer-node/node-build.test.ts test/session-compact.test.ts test/session-create.test.ts test/session-instructions.test.ts test/session-log.test.ts test/session-remove.test.ts` from `packages/core` (49 passed)
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/server`
- Push hook workspace typecheck (33 packages successful)
- `git diff --check`
