### PR TITLE
refactor(core): remove unused small model selection

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -52,7 +52,6 @@ export interface Interface extends State.Transformable<Draft> {
     readonly all: () => Effect.Effect<Model.Info[]>
     readonly available: () => Effect.Effect<Model.Info[]>
     readonly default: () => Effect.Effect<Model.Info | undefined>
-    readonly small: (providerID: Provider.ID) => Effect.Effect<Model.Info | undefined>
   }
 }
 
@@ -206,66 +205,11 @@ const layer = Layer.effect(
 
           return (yield* result.model.available())[0]
         }),
-
-        small: Effect.fn("Catalog.model.small")(function* (providerID) {
-          const record = state.get().providers.get(providerID)
-          if (!record) return
-          const provider = record.provider
-
-          // TODO: Remove these provider-specific assumptions once model syncing reliably reports available deployments.
-          if (providerID === Provider.ID.azure || providerID === Provider.ID.make("azure-cognitive-services")) {
-            return
-          }
-
-          if (providerID === Provider.ID.opencode) {
-            const gpt5Nano = record.models.get(Model.ID.make("gpt-5-nano"))
-            if (gpt5Nano?.enabled && gpt5Nano.status === "active") return projectModel(gpt5Nano, provider)
-          }
-
-          const candidates = pipe(
-            Array.fromIterable(record.models.values()),
-            Array.filter(
-              (model) =>
-                model.providerID === providerID &&
-                model.enabled &&
-                model.status === "active" &&
-                model.capabilities.input.some((item) => item.startsWith("text")) &&
-                model.capabilities.output.some((item) => item.startsWith("text")),
-            ),
-            Array.map((model) => ({
-              model,
-              cost: model.cost[0] ? model.cost[0].input + model.cost[0].output : 999,
-              age: (Date.now() - model.time.released) / (1000 * 60 * 60 * 24 * 30),
-              small: SMALL_MODEL_RE.test(`${model.id} ${model.family ?? ""} ${model.name}`.toLowerCase()),
-            })),
-            Array.filter((item) => item.cost > 0 && item.age <= 18),
-          )
-
-          const pick = (items: typeof candidates) => {
-            if (!Array.isReadonlyArrayNonEmpty(items)) return
-            const maxCost = Math.max(...items.map((item) => item.cost), 0.01)
-            const maxAge = Math.max(...items.map((item) => item.age), 0.01)
-            const selected = Array.min(
-              items,
-              Order.mapInput(
-                Order.Number,
-                (item: (typeof candidates)[number]) =>
-                  (item.cost / maxCost) * 0.8 + (item.age / maxAge) * 0.2,
-              ),
-            )
-            return projectModel(selected.model, provider)
-          }
-
-          const small = candidates.filter((item) => item.small)
-          return pick(small.length > 0 ? small : candidates)
-        }),
       },
     }
 
     return Service.of(result)
   }),
 )
-
-const SMALL_MODEL_RE = /\b(nano|flash|lite|mini|haiku|small|fast)\b/
 
 export const node = makeLocationNode({ service: Service, layer, deps: [Bus.node, Integration.node] })

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect } from "bun:test"
-import { Money } from "@opencode-ai/schema/money"
 import { Effect, Fiber, Layer, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { Catalog } from "@opencode-ai/core/catalog"
@@ -290,48 +289,6 @@ describe("Catalog", () => {
         providerID: enabledProvider,
         id: fallbackModel,
       })
-    }),
-  )
-
-  it.effect("small model prefers small keyword candidates before cost scoring", () =>
-    Effect.gen(function* () {
-      const catalog = yield* Catalog.Service
-      const providerID = Provider.ID.make("test")
-      yield* catalog.transform((catalog) => {
-        catalog.provider.update(providerID, () => {})
-        catalog.model.update(providerID, Model.ID.make("cheap-large"), (model) => {
-          model.capabilities.input = ["text"]
-          model.capabilities.output = ["text"]
-          model.cost = [
-            {
-              input: Money.USDPerMillionTokens.make(1),
-              output: Money.USDPerMillionTokens.make(1),
-              cache: {
-                read: Money.USDPerMillionTokens.zero,
-                write: Money.USDPerMillionTokens.zero,
-              },
-            },
-          ]
-          model.time.released = Date.now()
-        })
-        catalog.model.update(providerID, Model.ID.make("expensive-mini"), (model) => {
-          model.capabilities.input = ["text"]
-          model.capabilities.output = ["text"]
-          model.cost = [
-            {
-              input: Money.USDPerMillionTokens.make(10),
-              output: Money.USDPerMillionTokens.make(10),
-              cache: {
-                read: Money.USDPerMillionTokens.zero,
-                write: Money.USDPerMillionTokens.zero,
-              },
-            },
-          ]
-          model.time.released = Date.now()
-        })
-      })
-
-      expect((yield* catalog.model.small(providerID))?.id).toMatch("expensive-mini")
     }),
   )
 })

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -30,7 +30,6 @@ const catalog = Layer.mock(Catalog.Service, {
     all: () => Effect.die("unused"),
     available: () => Effect.die("unused"),
     default: () => Effect.die("unused"),
-    small: () => Effect.die("unused"),
   },
 })
 const integrations = Layer.mock(Integration.Service, {

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -484,31 +484,4 @@ describe("OpencodePlugin", () => {
       }),
     ),
   )
-
-  it.effect("prefers gpt-5-nano as the opencode small model", () =>
-    Effect.gen(function* () {
-      const catalog = yield* Catalog.Service
-      const providerID = Provider.ID.opencode
-
-      yield* catalog.transform((catalog) => {
-        catalog.provider.update(providerID, () => {})
-        catalog.model.update(providerID, Model.ID.make("cheap-mini"), (model) => {
-          model.capabilities.input = ["text"]
-          model.capabilities.output = ["text"]
-          model.cost = [...cost(1, 1)]
-          model.time.released = Date.now()
-        })
-        catalog.model.update(providerID, Model.ID.make("gpt-5-nano"), (model) => {
-          model.capabilities.input = ["text"]
-          model.capabilities.output = ["text"]
-          model.cost = [...cost(10, 10)]
-          model.time.released = Date.now()
-        })
-      })
-
-      const selected = yield* catalog.model.small(providerID)
-
-      expect(selected?.id).toBe(Model.ID.make("gpt-5-nano"))
-    }),
-  )
 })

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -102,7 +102,6 @@ const promptCatalog = Layer.mock(Catalog.Service, {
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
     default: () => Effect.succeed(undefined),
-    small: () => Effect.succeed(undefined),
   },
 })
 const runnerLayer = (llmClient: Layer.Layer<typeof LLMClient.Service>) =>

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -362,7 +362,6 @@ const promptCatalog = Layer.mock(Catalog.Service, {
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
     default: () => Effect.succeed(undefined),
-    small: () => Effect.succeed(undefined),
   },
 })
 const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [


### PR DESCRIPTION
## What

Remove the unused `Catalog.Interface.model.small` selection surface from private Core.

The scorer was introduced with the V2 catalog model-listing API and was briefly exposed through the old Effect plugin host. The later namespaced plugin API removed that host method, leaving `catalog.model.small` with no production, server, CLI, SDK, documentation, or current plugin-host consumers.

A separate side branch experimented with using this scorer for session titles, but those commits are not ancestors of current `v2`. Current title generation resolves the title agent's configured model when present and otherwise resolves the session model; this PR leaves that behavior unchanged.

## How

- Remove `Catalog.Interface.model.small` and its provider-specific Azure/OpenCode branches, keyword matching, age/cost scoring, and constants.
- Remove the catalog and OpenCode-provider tests dedicated solely to that selection behavior.
- Remove obsolete `small` entries from Core catalog mocks.

## Scope

- Preserve catalog model `all`, `available`, `default`, and `get` behavior.
- Preserve session model resolution and title-agent selection behavior.
- Preserve the current plugin host catalog surface, which exposes model `list` and `default` and does not expose small-model selection.
- No changeset: `@opencode-ai/core` is private.

## Testing

- `bun run test test/catalog.test.ts test/session-title.test.ts test/plugin/provider-opencode.test.ts` (30 passed)
- `bun typecheck` from `packages/core`
- Push hook: full workspace `bun turbo typecheck --concurrency=3` (33 tasks passed; existing Blume duplicate-label warning only)
- `git diff --check`