### PR TITLE
docs: add claude-codex-windows-notify to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,6 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                       |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
+| [claude-codex-windows-notify](https://github.com/Tomauskasz/claude-codex-windows-notify)          | Native Windows popup notifications for OpenCode, Claude Code, and Codex with click-to-focus       |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |


### PR DESCRIPTION
### Issue for this PR

Closes #40709

### Type of change

- [X] Documentation

### What does this PR do?

Adds claude-codex-windows-notify to the Plugins table on the ecosystem docs page. It is a native Windows notification plugin: desktop popups for OpenCode, Claude Code, and Codex CLI on completion, approval-request, and failure events, with sound, a response preview, and click-to-focus on the originating terminal or WezTerm pane. It has no npm or runtime dependencies, so it installs from local files rather than npm.

### How did you verify this code works?

Docs table edit only; no code change. The check-standards, check-compliance, and check-duplicates workflows pass.

### Screenshots / recordings

Not a UI change; text-only edit to the ecosystem plugins table.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
