### PR TITLE
refactor(core): remove unused agent default method

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -44,7 +44,6 @@ export type Draft = {
 
 export interface Interface extends State.Transformable<Draft> {
   readonly get: (id: ID) => Effect.Effect<Info | undefined>
-  readonly default: () => Effect.Effect<Info | undefined>
   readonly resolve: (id?: ID | string) => Effect.Effect<Info | undefined>
   readonly select: (id?: ID | string) => Effect.Effect<Selection>
   readonly list: () => Effect.Effect<Info[]>
@@ -109,9 +108,6 @@ const layer = Layer.effect(
       reload: state.reload,
       get: Effect.fn("Agent.get")(function* (id) {
         return state.get().agents.get(id)
-      }),
-      default: Effect.fn("Agent.default")(function* () {
-        return selectedDefault()
       }),
       resolve: Effect.fn("Agent.resolve")(function* (id) {
         if (id !== undefined) return state.get().agents.get(ID.make(id))


### PR DESCRIPTION
## What

Remove the unused `Agent.Service.default()` method from the private Core agent interface.

Default-agent selection remains available through the two live operations:

- `resolve()` returns the configured or fallback default agent info.
- `select()` returns the selected ID together with its optional agent info.

## How

- Remove `default()` from `Agent.Interface`.
- Remove its service implementation, leaving the shared `selectedDefault()` selection logic used by `resolve()` and `select()` unchanged.

Repository-wide caller searches found no use of `Agent.Service.default()`. Other `.default()` calls belong to unrelated model and provider interfaces.

## Scope

- `Draft.default(id)` still configures the selected default agent.
- `Agent.defaultID` remains the fallback ID used by `select()`.
- Agent selection order and filtering behavior are unchanged.
- No Protocol, Server `HttpApi`, or generated client surface changes.
- No changeset: `@opencode-ai/core` is private.

## Testing

- `bun run test test/agent.test.ts` in `packages/core` (9 passed)
- `bun typecheck` in `packages/core`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (33 packages passed)
- `git diff --check`
