### PR TITLE
refactor(core): remove discarded MCP connection details

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -12,7 +12,6 @@ import { Credential } from "../credential"
 import { Bus } from "../bus"
 import { Form } from "../form"
 import { Integration } from "../integration"
-import { IntegrationConnection } from "../integration/connection"
 import { KeyedMutex } from "../effect/keyed-mutex"
 import { Location } from "../location"
 import { waitForAbort } from "@opencode-ai/util/process"
@@ -31,7 +30,6 @@ export class ServerInfo extends Schema.Class<ServerInfo>("MCP.ServerInfo")({
   name: ServerName,
   status: Status,
   integrationID: Integration.ID.pipe(Schema.optional),
-  connection: IntegrationConnection.Info.pipe(Schema.optional),
 }) {}
 
 export class ServerInstructions extends Schema.Class<ServerInstructions>("MCP.ServerInstructions")({
@@ -246,14 +244,6 @@ export const layer = (options?: Options) => Layer.effect(
       if (!entry) return yield* new NotFoundError({ server: name })
       return { name, entry }
     })
-
-    const info = (name: ServerName, entry: ServerEntry, connection: IntegrationConnection.Info | undefined) =>
-      new ServerInfo({
-        name,
-        status: entry.status,
-        integrationID: entry.integrationID,
-        connection,
-      })
 
     // Builds the connect-time auth provider for a remote OAuth-integration server. The SDK presents and
     // refreshes stored tokens, persisting refreshes back to the same credential row. The provider never
@@ -603,15 +593,12 @@ export const layer = (options?: Options) => Layer.effect(
     )
     return Service.of({
       servers: Effect.fn("MCP.servers")(function* () {
-        const entries = Array.from(runtime).toSorted(([a], [b]) => a.localeCompare(b))
-        return yield* Effect.forEach(entries, ([name, entry]) =>
-          Effect.gen(function* () {
-            const connection = entry.integrationID
-              ? yield* integration.connection.active(entry.integrationID)
-              : undefined
-            return info(name, entry, connection)
-          }),
-        )
+        return Array.from(runtime)
+          .toSorted(([a], [b]) => a.localeCompare(b))
+          .map(
+            ([name, entry]) =>
+              new ServerInfo({ name, status: entry.status, integrationID: entry.integrationID }),
+          )
       }),
       add: Effect.fn("MCP.add")(function* (server, config) {
         const name = ServerName.make(server)


### PR DESCRIPTION
## What

Stop deriving MCP integration connection details that no caller receives.

`MCP.servers()` previously looked up the active integration connection for every registered server and attached it to the private Core `ServerInfo`. The HTTP list handler deliberately projects only `name`, `status`, and `integrationID`, and no in-repository Core caller reads `connection`.

## How

- Remove `connection` from `MCP.ServerInfo`.
- Remove the per-server `integration.connection.active()` lookup.
- Project sorted runtime entries directly into `ServerInfo` values.
- Inline the now-trivial single-use projection helper.

## Scope

- The public MCP HTTP response is unchanged.
- MCP connection, authentication, reconnect, and credential behavior are unchanged.
- `integrationID` remains available on Core and HTTP server summaries.
- No Protocol or Server `HttpApi` contract changed, so generated clients are unchanged.
- No changeset: `@opencode-ai/core` is private.

## Testing

- `bun run test test/mcp.test.ts test/mcp-instructions.test.ts` in `packages/core` (27 passed)
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/server`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (33 packages passed)
- `git diff --check`
