### PR TITLE
fix(tui): add plain text paste

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -68,9 +68,13 @@ export async function read() {
     if (x11.length) return { data: x11.toString("base64"), mime: "image/png" }
   }
 
-  const { default: clipboardy } = await import("clipboardy")
-  const text = await clipboardy.read().catch(() => undefined)
+  const text = await readText()
   if (text) return { data: text, mime: "text/plain" }
+}
+
+export async function readText() {
+  const { default: clipboardy } = await import("clipboardy")
+  return clipboardy.read().catch(() => undefined)
 }
 
 export function copyCommand(

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -389,6 +389,18 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Paste as text",
+        name: "prompt.paste_plain",
+        category: "Prompt",
+        hidden: true,
+        run: async (ctx: CommandContext<Renderable, KeyEvent>) => {
+          ctx.event.preventDefault()
+          ctx.event.stopPropagation()
+          const text = await clipboard.readText?.()
+          if (text) insertInputText(text)
+        },
+      },
+      {
         title: "Interrupt session",
         name: "session.interrupt",
         category: "Session",
@@ -807,6 +819,14 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
+      enabled: inputTarget() !== undefined && !props.disabled,
+      bindings: tuiConfig.keybinds.get("prompt.paste_plain"),
+    }
+  })
+
+  useBindings(() => {
+    return {
+      target: inputTarget,
       enabled: inputTarget() !== undefined && !props.disabled && store.prompt.input !== "",
       bindings: tuiConfig.keybinds.get("prompt.clear"),
     }
@@ -1211,8 +1231,11 @@ export function Prompt(props: PromptProps) {
       return
     }
 
-    input.insertText(normalizedText)
+    insertInputText(normalizedText)
+  }
 
+  function insertInputText(text: string) {
+    input.insertText(text.replace(/\r\n/g, "\n").replace(/\r/g, "\n"))
     setTimeout(() => {
       if (!input || input.isDestroyed) return
       input.getLayoutNode().markDirty()

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -160,6 +160,7 @@ export const Definitions = {
 
   input_clear: keybind("ctrl+c", "Clear input field"),
   input_paste: keybind({ key: "ctrl+v", preventDefault: false }, "Paste from clipboard"),
+  input_paste_plain: keybind("ctrl+alt+v", "Paste clipboard text without attachments"),
   input_submit: keybind("return", "Submit input"),
   input_newline: keybind("shift+return,ctrl+return,alt+return,ctrl+j", "Insert newline in input"),
   input_move_left: keybind("left,ctrl+b", "Move cursor left in input"),
@@ -363,6 +364,7 @@ export const CommandMap = {
   workspace_set: "workspace.set",
   input_clear: "prompt.clear",
   input_paste: "prompt.paste",
+  input_paste_plain: "prompt.paste_plain",
   input_submit: "input.submit",
   input_newline: "input.newline",
   input_move_left: "input.move.left",

--- a/packages/tui/src/context/clipboard.tsx
+++ b/packages/tui/src/context/clipboard.tsx
@@ -1,12 +1,13 @@
 import { createContext, type JSX, useContext } from "solid-js"
-import { read, write } from "../clipboard"
+import { read, readText, write } from "../clipboard"
 
 export type ClipboardContent = Readonly<{ data: string; mime: string }>
 export type ClipboardService = Readonly<{
   read?(): Promise<ClipboardContent | undefined>
+  readText?(): Promise<string | undefined>
   write?(text: string): Promise<void>
 }>
-const clipboard = { read, write }
+const clipboard = { read, readText, write }
 const ClipboardContext = createContext<ClipboardService>(clipboard)
 
 export function ClipboardProvider(props: { value?: ClipboardService; children: JSX.Element }) {

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -86,6 +86,15 @@ test("resolves a session move keybind", () => {
   expect(config.keybinds.get("session.move")).toMatchObject([{ key: "ctrl+o" }])
 })
 
+test("resolves plain paste separately from attachment paste", () => {
+  const defaults = resolve({}, { terminalSuspend: true })
+  const config = resolve({ keybinds: { input_paste_plain: "alt+v" } }, { terminalSuspend: true })
+
+  expect(config.keybinds.get("prompt.paste")).toMatchObject([{ key: "ctrl+v" }])
+  expect(defaults.keybinds.get("prompt.paste_plain")).toMatchObject([{ key: "ctrl+alt+v" }])
+  expect(config.keybinds.get("prompt.paste_plain")).toMatchObject([{ key: "alt+v" }])
+})
+
 test("disables suspend and assigns ctrl+z to undo when unsupported", () => {
   const config = resolve({}, { terminalSuspend: false })
 


### PR DESCRIPTION
### Issue for this PR

Closes #34006

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `prompt.paste_plain`, bound to `Ctrl+Alt+V`, so clipboard text can be inserted without converting local image or PDF paths into attachments. Existing `Ctrl+V` behavior is unchanged.

This follows the approach from #34123 by @ametel01, which was closed by automated cleanup.

### How did you verify your code works?

- `bun test` in `packages/tui` (192 pass, 1 skip)
- `bun typecheck` in `packages/tui`
- Repository pre-push typecheck (30 packages)

### Screenshots / recordings

Not applicable; this changes TUI clipboard input behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR