### PR TITLE
refactor(codemode): remove unused spread helper

### DIFF
--- a/packages/codemode/src/stdlib/collections.ts
+++ b/packages/codemode/src/stdlib/collections.ts
@@ -58,13 +58,3 @@ export const setMethods = new Set([
   "isSupersetOf",
   "isDisjointFrom",
 ])
-
-export const spreadItems = (value: unknown): Array<unknown> | undefined => {
-  if (Array.isArray(value)) return value
-  if (typeof value === "string") return Array.from(value)
-  if (value instanceof CodeModeMap) return Array.from(value.map.entries(), ([key, item]) => [key, item])
-  if (value instanceof CodeModeSet) return Array.from(value.set.values())
-  if (value instanceof CodeModeURLSearchParams) return Array.from(value.params.entries(), ([key, item]) => [key, item])
-  return undefined
-}
-import { CodeModeMap, CodeModeSet, CodeModeURLSearchParams } from "../values.js"


### PR DESCRIPTION
## What

Remove the dead internal `spreadItems` helper from CodeMode's collection standard-library metadata.

## How

- Delete `spreadItems` from `packages/codemode/src/stdlib/collections.ts`.
- Remove the `CodeModeMap`, `CodeModeSet`, and `CodeModeURLSearchParams` imports used only by that helper.
- Verify repository-wide that the symbol has no direct consumers or indirect re-exports.

## Scope

This is limited to the V2 `packages/codemode` implementation. It does not modify the V1 `packages/opencode` package or runtime behavior.

## Testing

- `bun typecheck` from `packages/codemode`: passed (exit 0).
- `bun run test` from `packages/codemode`: 1,089 passed, 0 failed, 2,002 assertions across 24 files.
- `git diff --check`: passed.
- Pre-push repository typecheck: 33/33 tasks successful.
- Repository-wide `git grep` for `spreadItems` and collection-module re-exports: no remaining symbol references or indirect exports.