### PR TITLE
refactor(core): remove unused session exports

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -52,9 +52,6 @@ import { Shell as ShellSchema } from "@opencode-ai/schema/shell"
 import { KeyedMutex } from "./effect/keyed-mutex"
 import { fileURLToPath } from "url"
 
-export const RevertState = Session.Revert
-export type RevertState = Session.Revert
-
 // get project -> project.locations
 //
 // get all sessions
@@ -110,13 +107,6 @@ type ForkInput = {
   boundary: Session.ForkRequestBoundary
 }
 
-export class OperationUnavailableError extends Schema.TaggedErrorClass<OperationUnavailableError>()(
-  "Session.OperationUnavailableError",
-  {
-    operation: Schema.Literals(["move", "skill", "switchAgent", "compact"]),
-  },
-) {}
-
 export { MessageDecodeError, NotFoundError }
 
 export class PromptConflictError extends Schema.TaggedErrorClass<PromptConflictError>()("Session.PromptConflictError", {
@@ -159,23 +149,6 @@ export class DestinationNotDirectoryError extends Schema.TaggedErrorClass<Destin
 ) {}
 export const MessageNotFoundError = SessionRevert.MessageNotFoundError
 export type MessageNotFoundError = SessionRevert.MessageNotFoundError
-
-export type Error =
-  | NotFoundError
-  | MessageDecodeError
-  | OperationUnavailableError
-  | PromptConflictError
-  | SyntheticConflictError
-  | AttachmentError
-  | CompactionConflictError
-  | BusyError
-  | SkillNotFoundError
-  | DestinationNotFoundError
-  | DestinationNotDirectoryError
-  | Command.NotFoundError
-  | Command.EvaluationError
-  | MessageNotFoundError
-  | SessionGenerate.Error
 
 export interface Interface {
   readonly list: (input?: ListInput) => Effect.Effect<{


### PR DESCRIPTION
## What

Remove three dead exports from the V2 core session module.

## How

- delete `OperationUnavailableError`, which has no producer, consumer, schema composition, or decode path
- delete the unused aggregate `Session.Error` type export
- delete the unused `RevertState` value and type aliases; persisted revert decoding continues to use the canonical shared session revert schemas

## Scope

Deletion-only change in `packages/core/src/session.ts`. No protocol, generated client, persisted schema, runtime behavior, or V1 implementation changes.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/shared-schema.test.ts test/session-create.test.ts test/session-projector.test.ts` (44 passed)
- `bun turbo typecheck --concurrency=3` via the push hook (33 tasks passed)
- `git diff --check`