### PR TITLE
refactor(core): remove duplicate directory query

### DIFF
--- a/packages/core/src/project/copy.ts
+++ b/packages/core/src/project/copy.ts
@@ -158,7 +158,7 @@ const layer = Layer.effect(
 
     const source = Effect.fnUntraced(function* (input: AbsolutePath, projectID: Project.ID) {
       const sourceDirectory = yield* canonical(input)
-      if (!(yield* directories.contains({ projectID, directory: sourceDirectory })))
+      if ((yield* directories.get({ projectID, directory: sourceDirectory })) === undefined)
         return yield* new SourceDirectoryNotFoundError({ directory: sourceDirectory })
       return sourceDirectory
     })

--- a/packages/core/src/project/directories.ts
+++ b/packages/core/src/project/directories.ts
@@ -41,7 +41,6 @@ export interface Interface {
     projectID: ProjectSchema.ID
     directory: AbsolutePath
   }) => Effect.Effect<Directory | undefined>
-  readonly contains: (input: { projectID: ProjectSchema.ID; directory: AbsolutePath }) => Effect.Effect<boolean>
   readonly create: (input: CreateInput, tx?: Transaction) => Effect.Effect<boolean>
   readonly remove: (input: RemoveInput, tx?: Transaction) => Effect.Effect<boolean>
 }
@@ -99,25 +98,6 @@ const layer = Layer.effect(
       return rows.map((row) => ({ directory: row.directory, strategy: row.strategy ?? undefined }))
     })
 
-    const contains = Effect.fn("ProjectDirectories.contains")(function* (input: {
-      projectID: ProjectSchema.ID
-      directory: AbsolutePath
-    }) {
-      return (
-        (yield* db
-          .select({ directory: ProjectDirectoryTable.directory })
-          .from(ProjectDirectoryTable)
-          .where(
-            and(
-              eq(ProjectDirectoryTable.project_id, input.projectID),
-              eq(ProjectDirectoryTable.directory, input.directory),
-            ),
-          )
-          .get()
-          .pipe(Effect.orDie)) !== undefined
-      )
-    })
-
     const get = Effect.fn("ProjectDirectories.get")(function* (input: {
       projectID: ProjectSchema.ID
       directory: AbsolutePath
@@ -139,7 +119,6 @@ const layer = Layer.effect(
     return Service.of({
       list,
       get,
-      contains,
       create,
       remove,
     })


### PR DESCRIPTION
**What**
Remove the duplicate `ProjectDirectories.contains` query and keep project-copy source validation on the existing directory lookup.

**How**
- Remove `contains` from the `ProjectDirectories` service interface and implementation.
- Use `ProjectDirectories.get` in `ProjectCopy` and reject only when the canonical source directory has no exact stored row.
- Preserve canonicalization before lookup and the existing `SourceDirectoryNotFoundError` path.

**Scope**
- V2 core only.
- No protocol, generated client, or V1 `packages/opencode` changes.

**Testing**
- `bun typecheck` from `packages/core`
- `bun run test test/project-copy.test.ts test/project-directories.test.ts` (17 passed)
- `git diff --check`
- Repository typecheck pre-push hook (33 packages passed)