### PR TITLE
refactor(core): remove test-only ignore helper

### DIFF
--- a/packages/core/src/filesystem/ignore.ts
+++ b/packages/core/src/filesystem/ignore.ts
@@ -1,5 +1,3 @@
-import { Glob } from "@opencode-ai/util/glob"
-
 const FOLDERS = new Set([
   "node_modules",
   "bower_components",
@@ -46,22 +44,5 @@ const FILES = [
 ]
 
 export const PATTERNS = [...FILES, ...FOLDERS, `**/{${Array.from(FOLDERS).join(",")}}/**`]
-
-export function match(filepath: string, opts?: { extra?: string[]; whitelist?: string[] }) {
-  for (const pattern of opts?.whitelist || []) {
-    if (Glob.match(pattern, filepath)) return false
-  }
-
-  const parts = filepath.split(/[/\\]/)
-  for (const part of parts) {
-    if (FOLDERS.has(part)) return true
-  }
-
-  for (const pattern of [...FILES, ...(opts?.extra || [])]) {
-    if (Glob.match(pattern, filepath)) return true
-  }
-
-  return false
-}
 
 export * as Ignore from "./ignore"

--- a/packages/core/test/filesystem/ignore.test.ts
+++ b/packages/core/test/filesystem/ignore.test.ts
@@ -3,14 +3,6 @@ import { Ignore } from "@opencode-ai/core/filesystem/ignore"
 // @ts-ignore
 import { createWrapper } from "@parcel/watcher/wrapper"
 
-test("match nested and non-nested", () => {
-  expect(Ignore.match("node_modules/index.js")).toBe(true)
-  expect(Ignore.match("node_modules")).toBe(true)
-  expect(Ignore.match("node_modules/")).toBe(true)
-  expect(Ignore.match("node_modules/bar")).toBe(true)
-  expect(Ignore.match("node_modules/bar/")).toBe(true)
-})
-
 test("parcel patterns ignore built-in folders at any depth", async () => {
   let ignoreGlobs: string[] = []
   const watcher = createWrapper({


### PR DESCRIPTION
## What

Remove the unused `Ignore.match` helper from V2 core. `Ignore.PATTERNS` remains the runtime contract used by `LocationWatcher`.

## How

- Remove the test-only `match` export and its `Glob` import from `packages/core/src/filesystem/ignore.ts`.
- Remove only the unit test that directly exercised the dead helper.
- Retain the Parcel pattern translation regression test and the live `LocationWatcher` test covering nested dependency, VCS, and build directories.

## Scope

- No changes to `Ignore.PATTERNS` or `LocationWatcher`.
- No changes to protected-home behavior, VCS watches, or watcher lifecycle behavior.
- No V1 changes.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/filesystem/ignore.test.ts test/filesystem/watcher.test.ts` from `packages/core` (14 passed)
- Push hook repository typecheck (33 packages successful)
- `git diff --check`