### PR TITLE
refactor(core): remove unused shell posix metadata

### DIFF
--- a/packages/core/src/shell/select.ts
+++ b/packages/core/src/shell/select.ts
@@ -7,16 +7,16 @@ import { Schema } from "effect"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { which } from "../util/which"
 
-const META: Record<string, { deny?: boolean; login?: boolean; posix?: boolean; ps?: boolean }> = {
-  bash: { login: true, posix: true },
-  dash: { login: true, posix: true },
+const META: Record<string, { deny?: boolean; login?: boolean; ps?: boolean }> = {
+  bash: { login: true },
+  dash: { login: true },
   fish: { deny: true, login: true },
-  ksh: { login: true, posix: true },
+  ksh: { login: true },
   nu: { deny: true },
   powershell: { ps: true },
   pwsh: { ps: true },
-  sh: { login: true, posix: true },
-  zsh: { login: true, posix: true },
+  sh: { login: true },
+  zsh: { login: true },
 }
 
 export type Item = {
@@ -114,10 +114,6 @@ export function name(file: string) {
 
 export function login(file: string) {
   return meta(file)?.login === true
-}
-
-export function posix(file: string) {
-  return meta(file)?.posix === true
 }
 
 export function ps(file: string) {

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -34,12 +34,6 @@ describe("shell", () => {
     expect(ShellSelect.login("C:/tools/pwsh.exe")).toBe(false)
   })
 
-  test("detects posix shells", () => {
-    expect(ShellSelect.posix("/bin/bash")).toBe(true)
-    expect(ShellSelect.posix("/bin/fish")).toBe(false)
-    expect(ShellSelect.posix("C:/tools/pwsh.exe")).toBe(false)
-  })
-
   test("falls back when configured shell cannot be resolved", async () => {
     await withShell(undefined, async () => {
       const preferred = ShellSelect.preferred()


### PR DESCRIPTION
## What

Remove the unused `ShellSelect.posix` API and the shell metadata maintained only to support it.

## How

- delete the `posix` flag from `packages/core/src/shell/select.ts` metadata
- delete the unreferenced `ShellSelect.posix` export
- remove the focused tests that exercised only that export

## Scope

This does not change shell listing, PowerShell detection, login-shell detection, command argument construction, preferred or acceptable selection, Windows or Unix selection behavior, or live shell execution semantics. V1 under `packages/opencode` is intentionally excluded.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/shell.test.ts test/shell-parse.test.ts test/tool-shell.test.ts test/pty/pty-session.test.ts` from `packages/core` (35 passed)
- push hook: repository-wide `bun turbo typecheck --concurrency=3` (33 tasks passed)
- `git diff --check`
