### PR TITLE
refactor(core): narrow session message updates

### DIFF
--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -19,7 +19,35 @@ export interface Adapter {
   readonly appendMessage: (message: SessionMessage.Info) => Effect.Effect<void, never, never>
 }
 
-export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
+export type Event =
+  | SessionEvent.AgentSelected
+  | SessionEvent.ModelSelected
+  | SessionEvent.Execution.Succeeded
+  | SessionEvent.Execution.Failed
+  | SessionEvent.Execution.Interrupted
+  | SessionEvent.InstructionsUpdated
+  | SessionEvent.Synthetic
+  | SessionEvent.Skill.Activated
+  | SessionEvent.Shell.Started
+  | SessionEvent.Shell.Ended
+  | SessionEvent.Step.Started
+  | SessionEvent.Step.Ended
+  | SessionEvent.Step.Failed
+  | SessionEvent.Text.Started
+  | SessionEvent.Text.Ended
+  | SessionEvent.Tool.Input.Started
+  | SessionEvent.Tool.Input.Ended
+  | SessionEvent.Tool.Called
+  | SessionEvent.Tool.Success
+  | SessionEvent.Tool.Failed
+  | SessionEvent.Reasoning.Started
+  | SessionEvent.Reasoning.Ended
+  | SessionEvent.RetryScheduled
+  | SessionEvent.Compaction.Started
+  | SessionEvent.Compaction.Ended
+  | SessionEvent.Compaction.Failed
+
+export function update(adapter: Adapter, event: Event) {
   type DraftAssistant = WritableDraft<SessionMessage.Assistant>
   type DraftTool = WritableDraft<SessionMessage.AssistantTool>
   type DraftText = WritableDraft<SessionMessage.AssistantText>
@@ -54,9 +82,8 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
   })
 
   const project = pipe(
-    Match.type<SessionEvent.DurableEvent>(),
+    Match.type<Event>(),
     Match.discriminatorsExhaustive("type")({
-      "session.usage.recorded": () => Effect.void,
       "session.agent.selected": (event) => {
         return adapter.appendMessage(
           SessionMessage.AgentSelected.make({
@@ -83,13 +110,6 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           )
         })
       },
-      "session.moved": () => Effect.void,
-      "session.renamed": () => Effect.void,
-      "session.deleted": () => Effect.void,
-      "session.forked": () => Effect.void,
-      "session.input.promoted": () => Effect.void,
-      "session.input.admitted": () => Effect.void,
-      "session.execution.started": () => Effect.void,
       "session.execution.succeeded": () => clearCurrentRetry,
       "session.execution.failed": () => clearCurrentRetry,
       "session.execution.interrupted": () => clearCurrentRetry,
@@ -354,7 +374,6 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           }
         })
       },
-      "session.compaction.admitted": () => Effect.void,
       "session.compaction.started": (event) =>
         adapter.appendMessage(
           SessionMessage.CompactionRunning.make({
@@ -410,9 +429,6 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           if (current?.status === "running") return yield* adapter.updateCompaction(failed)
           yield* adapter.appendMessage(failed)
         }),
-      "session.revert.staged": () => Effect.void,
-      "session.revert.cleared": () => Effect.void,
-      "session.revert.committed": () => Effect.void,
     }),
   )
   return project(event)

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -20,8 +20,6 @@ import { Slug } from "../util/slug"
 import { Money } from "@opencode-ai/schema/money"
 
 type DatabaseService = Database.Interface["db"]
-type CurrentDurableEvent = Extract<SessionEvent.Event, { readonly durable: object }>
-type MessageEvent = Exclude<CurrentDurableEvent, typeof SessionEvent.Forked.Type | typeof SessionEvent.Deleted.Type>
 
 const decodeMessage = Schema.decodeUnknownSync(SessionMessage.Info)
 const encodeMessage = Schema.encodeSync(SessionMessage.Info)
@@ -275,7 +273,7 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
     yield* InstructionState.initialize(db, event.data.sessionID, event.durable.seq, event.data.instructions)
 })
 
-function run(db: DatabaseService, event: MessageEvent) {
+function run(db: DatabaseService, event: SessionMessageUpdater.Event) {
   return Effect.gen(function* () {
     const decodeRow = (row: typeof SessionMessageTable.$inferSelect) =>
       decodeMessage({ ...row.data, id: row.id, type: row.type })


### PR DESCRIPTION
## What

Narrow `SessionMessageUpdater.update` to the 26 durable event variants that `SessionProjector` actually routes into message projection. This follows up `0af6c82563`, whose durable-union boundary retained unreachable no-op match arms.

## How

- Define an explicit `SessionMessageUpdater.Event` union from the projector's 26 behavior-bearing registrations.
- Type the projector's private `run` helper with that same union, so newly routed variants must be added to the updater explicitly.
- Keep `Match.discriminatorsExhaustive("type")` over the narrowed union.
- Remove 12 no-op arms for events handled by other projector paths: usage recording, movement, rename, deletion, fork, input promotion/admission, execution start, compaction admission, and revert staged/cleared/committed.

## Scope

No event schemas, projector registrations, message behavior, admission/execution ordering, compaction settlement, revert handling, replay behavior, or lifecycle behavior change. V1 is untouched.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/session-projector.test.ts test/session-runner-message.test.ts` from `packages/core` (26 passed)
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (33 tasks passed)
- `git diff --check`