### PR TITLE
refactor(console): remove unused mail helpers

### DIFF
--- a/packages/console/mail/emails/components.tsx
+++ b/packages/console/mail/emails/components.tsx
@@ -19,10 +19,6 @@ export function Span({ children, ...props }: SpanProps) {
   return React.createElement("span", props, children)
 }
 
-export function Wbr({ children, ...props }: WbrProps) {
-  return React.createElement("wbr", props, children)
-}
-
 export function Fonts({ assetsUrl }: { assetsUrl: string }) {
   return (
     <>
@@ -58,15 +54,4 @@ export function Fonts({ assetsUrl }: { assetsUrl: string }) {
       />
     </>
   )
-}
-
-export function SplitString({ text, split }: { text: string; split: number }) {
-  const segments: JSX.Element[] = []
-  for (let i = 0; i < text.length; i += split) {
-    segments.push(<>{text.slice(i, i + split)}</>)
-    if (i + split < text.length) {
-      segments.push(<Wbr key={`${i}wbr`} />)
-    }
-  }
-  return <>{segments}</>
 }


### PR DESCRIPTION
## What

Remove the unused `Wbr` and `SplitString` helpers from the V2 console mail components.

## How

- Delete the unreferenced helper exports from `packages/console/mail/emails/components.tsx`.
- Preserve the shared components used by `InviteEmail`.

## Scope

- No email template content or styling changes.
- No changes to the V1 `packages/opencode` implementation.

## Testing

- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks passed).
- Rendered `InviteEmail` from `origin/v2` and this branch with locked dependencies; normalized only its intentional random `<body id>` and verified identical 6,288-byte HTML.
- `git diff --check`.
- Confirmed no V2 console source references to `Wbr` or `SplitString` remain.
