### PR TITLE
refactor(session-ui): remove unused panel title

### DIFF
--- a/packages/session-ui/src/v2/components/session-file-panel-v2.tsx
+++ b/packages/session-ui/src/v2/components/session-file-panel-v2.tsx
@@ -34,10 +34,6 @@ export function SessionFilePanelV2(props: {
   )
 }
 
-export function SessionFilePanelV2Title(props: ParentProps) {
-  return <div data-slot="session-review-v2-toolbar-title">{props.children}</div>
-}
-
 export function SessionFilePanelV2Empty(props: ParentProps) {
   return <div data-slot="session-review-v2-empty">{props.children}</div>
 }


### PR DESCRIPTION
## What

Remove the unused private `SessionFilePanelV2Title` export from the V2 session file panel.

## How

- Deleted the unreferenced component from `packages/session-ui/src/v2/components/session-file-panel-v2.tsx`.
- Verified app call sites, session-ui stories and registries, dynamic references, CSS selectors, and git history before removal.
- Kept the `session-review-v2-toolbar-title` CSS because `SessionReviewV2` renders that data slot directly.

## Scope

- V2 `session-ui` only.
- No V1 changes and no behavior or styling changes.

## Testing

- `bun typecheck` in `packages/session-ui`
- `bun run test` in `packages/session-ui` (76 tests passed)
- `git diff --check`
- Push hook full-workspace typecheck (33 tasks passed)
