### PR TITLE
refactor(web): remove unused share anchor

### DIFF
--- a/packages/web/src/components/share/common.tsx
+++ b/packages/web/src/components/share/common.tsx
@@ -1,7 +1,6 @@
-import { createContext, createSignal, splitProps, useContext } from "solid-js"
+import { createContext, createSignal, useContext } from "solid-js"
 import type { JSX } from "solid-js/jsx-runtime"
 import { makeResizeObserver } from "@solid-primitives/resize-observer"
-import { IconCheckCircle, IconHashtag } from "../icons"
 
 export type ShareMessages = { locale: string } & Record<string, string>
 
@@ -39,42 +38,6 @@ export function formatCurrency(value: number, locale: string) {
 export function formatCount(value: number, locale: string, singular: string, plural: string) {
   const unit = value === 1 ? singular : plural
   return `${formatNumber(value, locale)} ${unit}`
-}
-
-interface AnchorProps extends JSX.HTMLAttributes<HTMLDivElement> {
-  id: string
-}
-export function AnchorIcon(props: AnchorProps) {
-  const [local, rest] = splitProps(props, ["id", "children"])
-  const [copied, setCopied] = createSignal(false)
-  const messages = useShareMessages()
-
-  return (
-    <div {...rest} data-element-anchor title={messages.link_to_message} data-status={copied() ? "copied" : ""}>
-      <a
-        href={`#${local.id}`}
-        onClick={(e) => {
-          e.preventDefault()
-
-          const anchor = e.currentTarget
-          const hash = anchor.getAttribute("href") || ""
-          const { origin, pathname, search } = window.location
-
-          navigator.clipboard
-            .writeText(`${origin}${pathname}${search}${hash}`)
-            .catch((err) => console.error("Copy failed", err))
-
-          setCopied(true)
-          setTimeout(() => setCopied(false), 3000)
-        }}
-      >
-        {local.children}
-        <IconHashtag width={18} height={18} />
-        <IconCheckCircle width={18} height={18} />
-      </a>
-      <span data-element-tooltip>{messages.copied}</span>
-    </div>
-  )
 }
 
 export function createOverflow() {


### PR DESCRIPTION
## What

Remove the orphaned share-page `AnchorIcon` component and its private props type.

## How

- Delete `AnchorIcon` and `AnchorProps` from `packages/web/src/components/share/common.tsx`.
- Remove `splitProps`, `IconHashtag`, and `IconCheckCircle` imports that were only used by that component.
- Preserve the active anchor implementation, icons, localization, and styling in `packages/web/src/components/share/part.tsx` and `part.module.css`.

## Scope

- V2 web package only.
- No changes to the V1 `packages/opencode` implementation.
- No behavior or styling changes to the active share anchor.

## Testing

- `bun run build` from `packages/web` (passes)
- Repository pre-push typecheck hook (33 configured package checks pass)
- `git diff --check` (passes)
- Repository-wide web search confirms no remaining `AnchorIcon` or `AnchorProps` references
- `bun run astro check` from `packages/web` (blocked by 12 existing diagnostics in untouched files, including unresolved legacy `opencode/session/*` imports; no diagnostics in `common.tsx`)
- No web test script is configured
