### PR TITLE
feat(acp): emit session plan from todo updates

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -102,6 +102,8 @@ export class Subscription {
         return this.handlePartUpdated(event)
       case "message.part.delta":
         return this.handlePartDelta(event)
+      case "todo.updated":
+        return this.handleTodoUpdated(event)
     }
   }
 
@@ -256,6 +258,22 @@ export class Subscription {
         },
       })
     }
+  }
+
+  private async handleTodoUpdated(event: Extract<Event, { type: "todo.updated" }>) {
+    const session = await Effect.runPromise(this.input.session.tryGet(event.properties.sessionID))
+    if (!session) return
+    await this.input.connection.sessionUpdate({
+      sessionId: session.id,
+      update: {
+        sessionUpdate: "plan",
+        entries: event.properties.todos.map((todo) => ({
+          content: todo.content,
+          priority: planPriority(todo.priority),
+          status: planStatus(todo.status),
+        })),
+      },
+    })
   }
 
   private async fetchPartMetadata(sessionId: string, cwd: string, messageId: string, partId: string) {
@@ -416,6 +434,17 @@ function signal() {
     resolve: () => state.resolve(),
     reject: (reason?: unknown) => state.reject(reason),
   }
+}
+
+function planStatus(status: string): "pending" | "in_progress" | "completed" {
+  if (status === "in_progress") return "in_progress"
+  if (status === "pending") return "pending"
+  return "completed"
+}
+
+function planPriority(priority: string): "high" | "medium" | "low" {
+  if (priority === "high" || priority === "medium" || priority === "low") return priority
+  return "medium"
 }
 
 export * as ACPEvent from "./event"

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -167,6 +167,17 @@ function toolUpdated(part: ToolPart): Event {
   }
 }
 
+function todoUpdated(
+  sessionID: string,
+  todos: Array<{ content: string; status: string; priority: string }>,
+): Event {
+  return {
+    id: `evt_todo_${sessionID}`,
+    type: "todo.updated",
+    properties: { sessionID, todos },
+  }
+}
+
 function assistantMessage(sessionID: string, messageID: string, partID: string, type: DeltaPartType) {
   return {
     info: {
@@ -712,6 +723,37 @@ describe("acp event routing", () => {
       content: [{ type: "content", content: { type: "text", text: "failed hard" } }],
       rawOutput: { error: "failed hard", metadata: { exit: 1 } },
     })
+  })
+
+  it("emits an ACP plan from todo.updated events", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_todo", cwd: "/workspace" }))
+
+    await harness.subscription.handle(
+      todoUpdated("ses_todo", [
+        { content: "Analyze", status: "completed", priority: "high" },
+        { content: "Implement", status: "in_progress", priority: "high" },
+        { content: "Ship", status: "pending", priority: "medium" },
+        { content: "Dropped", status: "cancelled", priority: "low" },
+      ]),
+    )
+
+    const plan = harness.updates.find((update) => update.update.sessionUpdate === "plan")
+    expect(plan?.sessionId).toBe("ses_todo")
+    expect((plan!.update as { entries: unknown[] }).entries).toEqual([
+      { content: "Analyze", status: "completed", priority: "high" },
+      { content: "Implement", status: "in_progress", priority: "high" },
+      { content: "Ship", status: "pending", priority: "medium" },
+      { content: "Dropped", status: "completed", priority: "low" },
+    ])
+  })
+
+  it("ignores todo.updated for unknown sessions", async () => {
+    const harness = createHarness()
+    await harness.subscription.handle(
+      todoUpdated("ses_missing", [{ content: "x", status: "pending", priority: "low" }]),
+    )
+    expect(harness.updates).toHaveLength(0)
   })
 
   it("emits image attachments as ACP image content for live and replayed completed tool updates", async () => {


### PR DESCRIPTION
ACP clients never show the session plan: the adapter doesn't emit `sessionUpdate: "plan"`. `todo.updated` already carries the data on the stream the adapter consumes, so this maps it through (Todo.Info → PlanEntry is 1:1). Statuses outside the ACP set (e.g. `cancelled`) collapse to `completed`.

Fixes #40745

Verified: `bun test packages/opencode/test/acp/event.test.ts`. Also confirmed a standalone ACP agent emitting the same `plan` updates renders a live plan panel in Zed.
