### PR TITLE
refactor(app): remove unused drawer wrappers

### DIFF
--- a/packages/app/src/components/ui/drawer.tsx
+++ b/packages/app/src/components/ui/drawer.tsx
@@ -3,14 +3,12 @@
  * Only used in one place hence not a v2 component yet... can be promoted to ui/v2 later
  */
 
-import type { Component, ComponentProps, JSX, ValidComponent } from "solid-js"
+import type { JSX, ValidComponent } from "solid-js"
 import { splitProps } from "solid-js"
-import type { ContentProps, DescriptionProps, DynamicProps, LabelProps, OverlayProps } from "@corvu/drawer"
+import type { ContentProps, DynamicProps, OverlayProps } from "@corvu/drawer"
 import DrawerPrimitive from "@corvu/drawer"
 
 const Drawer = DrawerPrimitive
-
-const DrawerTrigger = DrawerPrimitive.Trigger
 
 const DrawerPortal = DrawerPrimitive.Portal
 
@@ -65,55 +63,10 @@ const DrawerContent = <T extends ValidComponent = "div">(props: DynamicProps<T, 
   )
 }
 
-const DrawerHeader: Component<ComponentProps<"div">> = (props) => {
-  const [, rest] = splitProps(props, ["class"])
-  return <div class={props.class} classList={{ "grid gap-1.5 p-4 text-center sm:text-left": true }} {...rest} />
-}
-
-const DrawerFooter: Component<ComponentProps<"div">> = (props) => {
-  const [, rest] = splitProps(props, ["class"])
-  return <div class={props.class} classList={{ "mt-auto flex flex-col gap-2 p-4": true }} {...rest} />
-}
-
-type DrawerTitleProps<T extends ValidComponent = "div"> = LabelProps<T> & { class?: string }
-
-const DrawerTitle = <T extends ValidComponent = "div">(props: DynamicProps<T, DrawerTitleProps<T>>) => {
-  const [, rest] = splitProps(props as DrawerTitleProps, ["class"])
-  return (
-    <DrawerPrimitive.Label
-      class={props.class}
-      classList={{ "text-base font-[530] leading-none tracking-[-0.04px] text-v2-text-text-base": true }}
-      {...rest}
-    />
-  )
-}
-
-type DrawerDescriptionProps<T extends ValidComponent = "div"> = DescriptionProps<T> & {
-  class?: string
-}
-
-const DrawerDescription = <T extends ValidComponent = "div">(props: DynamicProps<T, DrawerDescriptionProps<T>>) => {
-  const [, rest] = splitProps(props as DrawerDescriptionProps, ["class"])
-  return (
-    <DrawerPrimitive.Description
-      class={props.class}
-      classList={{
-        "text-[13px] font-[440] leading-[140%] tracking-[-0.04px] text-v2-text-text-muted": true,
-      }}
-      {...rest}
-    />
-  )
-}
-
 export {
   Drawer,
   DrawerPortal,
   DrawerOverlay,
-  DrawerTrigger,
   DrawerClose,
   DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
-  DrawerDescription,
 }


### PR DESCRIPTION
## What

Remove five unused local drawer wrappers from the V2 app UI module, reducing dead component surface without changing the help drawer behavior.

## How

- Remove `DrawerTrigger`, `DrawerHeader`, `DrawerFooter`, `DrawerTitle`, and `DrawerDescription` from `packages/app/src/components/ui/drawer.tsx`.
- Remove their private `DrawerTitleProps` and `DrawerDescriptionProps` types.
- Remove the now-unused Solid `Component`/`ComponentProps` and Corvu `DescriptionProps`/`LabelProps` imports.
- Preserve `Drawer`, `DrawerPortal`, `DrawerOverlay`, `DrawerClose`, and `DrawerContent`; `TabsInfoPopup` continues to consume the same retained primitives.

## Scope

- V2 app only; `packages/opencode` V1 is excluded.
- No drawer behavior, styling, package exports, or help-button markup changed.
- Repository searches found no V2 consumers, re-exports, tests, or stories for the deleted wrappers.

## Testing

- `bun typecheck` in `packages/app` (pass)
- `bun run build` in `packages/app` (pass, existing Vite warnings only)
- push hook: `bun turbo typecheck --concurrency=3` (33 tasks pass)
- `bun run test:unit` in `packages/app` (688 pass, 1 unrelated existing failure: Arabic i18n parity is missing five English keys)
- `git diff --check` (pass)