### PR TITLE
fix(tui): keep model search order stable

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -7,12 +7,14 @@ import { DialogVariant } from "./dialog-variant"
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { useData } from "../context/data"
+import { modelPreferenceKey } from "../model-preference"
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
   const data = useData()
   const dialog = useDialog()
   const [query, setQuery] = createSignal("")
+  const favoritePriority = new Set(local.model.favorite().map(modelPreferenceKey))
 
   const connected = useConnected()
   const providers = createMemo(() => new Map((data.location.provider.list() ?? []).map((item) => [item.id, item])))
@@ -63,14 +65,14 @@ export function DialogModel(props: { providerID?: string }) {
         .filter((model) => (props.providerID ? model.providerID === props.providerID : true))
         .map((model) => {
           const provider = providers().get(model.providerID)
-          const favorite = favorites.some((item) => item.providerID === model.providerID && item.modelID === model.id)
+          const key = modelPreferenceKey({ providerID: model.providerID, modelID: model.id })
+          const favorite = favorites.some((item) => modelPreferenceKey(item) === key)
           return {
             value: { providerID: model.providerID, modelID: model.id },
             providerID: model.providerID,
             providerName: provider?.name ?? model.providerID,
             title: model.name,
             releaseDate: model.time.released,
-            favorite,
             description: favorite ? "(Favorite)" : undefined,
             category: connected() ? (provider?.name ?? model.providerID) : undefined,
             footer: free(model) ? "Free" : undefined,
@@ -98,6 +100,7 @@ export function DialogModel(props: { providerID?: string }) {
     if (needle) {
       return prioritizeFavorites(
         fuzzysort.go(needle, modelOptions, { keys: ["title", "category"] }).map((item) => item.obj),
+        favoritePriority,
       )
     }
 
@@ -162,8 +165,13 @@ export function DialogModel(props: { providerID?: string }) {
   )
 }
 
-export function prioritizeFavorites<T extends { favorite: boolean }>(options: T[]) {
-  return options.toSorted((a, b) => Number(b.favorite) - Number(a.favorite))
+export function prioritizeFavorites<T extends { value: { providerID: string; modelID: string } }>(
+  options: T[],
+  favorites: Set<string>,
+) {
+  return options.toSorted(
+    (a, b) => Number(favorites.has(modelPreferenceKey(b.value))) - Number(favorites.has(modelPreferenceKey(a.value))),
+  )
 }
 
 export function sortModelOptions<

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, test } from "bun:test"
 import { prioritizeFavorites, sortModelOptions } from "../../../../src/component/dialog-model"
 
 describe("prioritizeFavorites", () => {
-  test("moves favorites first while preserving fuzzy result order", () => {
-    const prioritized = prioritizeFavorites([
-      { title: "Best match", favorite: false },
-      { title: "Favorite match", favorite: true },
-      { title: "Second best match", favorite: false },
-      { title: "Second favorite match", favorite: true },
-    ])
+  test("uses the favorite order captured when the dialog opened", () => {
+    const prioritized = prioritizeFavorites(
+      [
+        { title: "Best match", value: { providerID: "test", modelID: "best" } },
+        { title: "Favorite match", value: { providerID: "test", modelID: "favorite" } },
+        { title: "Second best match", value: { providerID: "test", modelID: "second-best" } },
+        { title: "Second favorite match", value: { providerID: "test", modelID: "second-favorite" } },
+      ],
+      new Set(["test/favorite", "test/second-favorite"]),
+    )
 
     expect(prioritized.map((model) => model.title)).toEqual([
       "Favorite match",


### PR DESCRIPTION
## What

Keep filtered model picker rows in place when their favorite status changes. The favorite marker updates immediately, while favorite-first ordering is refreshed the next time the picker opens.

## Before / After

**Before:** Favoriting a filtered model moved it to the first result immediately. The highlight remained at the old row, which now referred to a different model.

**After:** Favoriting a filtered model updates its `(Favorite)` marker in place. The result order and highlighted model remain stable for the lifetime of the open picker.

## How

- Capture favorite priority when `DialogModel` opens.
- Keep the live favorites list responsible for the visible favorite marker.
- Sort fuzzy results against the captured priority rather than the live marker.
- Cover the captured-priority behavior in `model-options.test.ts`.

## Scope

This only stabilizes favorite-prioritized search results. The existing unfiltered Favorites and Recent sections remain reactive.

## Testing

- `bun run test test/cli/cmd/tui/model-options.test.ts`
- `bun typecheck` in `packages/tui`
- Repository push hook: 33 workspace typecheck tasks passed
- `bunx oxlint packages/tui/src/component/dialog-model.tsx packages/tui/test/cli/cmd/tui/model-options.test.ts`
- OpenCode Drive before/after interaction using the same simulated model catalog

## Demo

Both sides favorite `Model Charlie` with `ctrl+f`. The left side moves Charlie to the top and leaves the highlight on Bravo; the right side keeps Charlie highlighted in place. Recorded against isolated OpenCode Drive simulations.

https://github.com/user-attachments/assets/567597c4-32c8-4de5-94e6-79db58c87afe
