### PR TITLE
fix(desktop): embed version in server sidecar

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -322,6 +322,7 @@ jobs:
         working-directory: packages/desktop
         env:
           NODE_OPTIONS: --max-old-space-size=4096
+          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
           OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -21,6 +21,7 @@ await Bun.build({
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
     OPENCODE_MODELS_DEV: generated.modelsData,
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },
   files: {


### PR DESCRIPTION
### Summary
- pass the computed release version into the desktop build
- embed that version in the Node server sidecar alongside the release channel
- prevent packaged beta sidecars from falling back to local and requesting @opencode-ai/plugin@local

### Verification
- built the Node sidecar with OPENCODE_VERSION=1.18.14 and OPENCODE_CHANNEL=beta
- verified the generated bundle contains InstallationVersion 1.18.14 and InstallationChannel beta
- bun typecheck passed in packages/opencode