### PR TITLE
fix(opencode): report a missing auth method instead of crashing

### DIFF
--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -164,7 +164,8 @@ const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> = Layer.
       input: { providerID: ProviderV2.ID } & AuthorizeInput,
     ) {
       const { hooks, pending } = yield* InstanceState.get(state)
-      const method = hooks[input.providerID].methods[input.method]
+      const method = hooks[input.providerID]?.methods[input.method]
+      if (!method) return yield* new OauthMissing({ providerID: input.providerID })
       if (method.type !== "oauth") return
 
       if (method.prompts && input.inputs) {

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -311,6 +311,32 @@ describe("provider HttpApi", () => {
   )
 
   it.instance(
+    "reports a missing auth method instead of crashing",
+    Effect.gen(function* () {
+      const directory = (yield* TestInstance).directory
+      const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
+
+      // The parity plugin registers two methods, so index 2 is past the end.
+      const outOfRange = yield* requestAuthorize({ providerID, method: 2, headers })
+      expect(outOfRange.status).toBe(400)
+      expect(JSON.parse(outOfRange.body)).toEqual({
+        name: "ProviderAuthOauthMissing",
+        data: { providerID },
+      })
+
+      // A provider with no registered auth hook at all.
+      const unknown = yield* requestAuthorize({ providerID: "test-oauth-absent", method: 0, headers })
+      expect(unknown.status).toBe(400)
+      expect(JSON.parse(unknown.body)).toEqual({
+        name: "ProviderAuthOauthMissing",
+        data: { providerID: "test-oauth-absent" },
+      })
+    }),
+    { ...projectOptions, init: writeProviderAuthPlugin },
+    30000,
+  )
+
+  it.instance(
     "returns declared provider auth validation errors",
     Effect.gen(function* () {
       const directory = (yield* TestInstance).directory


### PR DESCRIPTION
### Issue for this PR

Closes #40774

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ProviderAuth.authorize` indexes straight into the hook table with no guard on either lookup (`packages/opencode/src/provider/auth.ts:166`):

```ts
const method = hooks[input.providerID].methods[input.method]
if (method.type !== "oauth") return
```

`AuthorizeInput.method` is `Schema.Finite` (`auth.ts:57`), so any finite number decodes successfully, and the handler passes it through without validation (`server/routes/instance/httpapi/handlers/provider.ts:70-74`). Two inputs make `method` undefined and the `.type` read throw: an index past the end of `methods`, and a `providerID` with no registered auth hook at all. A `TypeError` isn't one of the typed `ProviderAuth.Error`s the endpoint declares, so `mapProviderAuthError` never converts it and the request returns 500 rather than a structured error.

The fix mirrors what `callback` already does 25 lines below for the same class of "the thing you asked for isn't there":

```ts
const match = pending.get(input.providerID)
if (!match) return yield* new OauthMissing({ providerID: input.providerID })
```

Two lines. I picked `OauthMissing` over `ValidationFailed` for that parity, and because `mapProviderAuthError` already handles it. Happy to switch to `ValidationFailed` if you'd rather an out-of-range index got a more specific reason.

I left `Schema.Finite` alone deliberately — tightening it to a non-negative integer would catch the index case at the schema boundary but not the missing-provider-hook case, and it changes the public API shape, so that seemed like your call rather than something to bundle in here.

### How did you verify your code works?

Both new cases return 500 on `main`:

```
320 |       const outOfRange = yield* requestAuthorize({ providerID, method: 2, headers })
321 |       expect(outOfRange.status).toBe(400)
      ^
error: expect(received).toBe(expected)

Expected: 400
Received: 500
```

After:

```
$ bun test test/server/httpapi-provider.test.ts
 6 pass
 1 skip
 0 fail
 21 expect() calls

$ bun typecheck
exit 0
```

The skip is pre-existing. The test uses the existing `requestAuthorize` helper and the `provider-oauth-parity` plugin fixture already in that file, which registers two methods — so index `2` is the first one past the end. It drives the real HTTP API rather than mocking, per `AGENTS.md`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
