### PR TITLE
test(core): align event persistence expectations

### DIFF
--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -1018,7 +1018,10 @@ describe("DatabaseMigration", () => {
           }),
         ).pipe(
           Effect.provide(
-            AppNodeBuilder.build(LayerNode.group([Bus.node, SessionProjector.node]), [[Database.node, database]]),
+            AppNodeBuilder.build(LayerNode.group([Bus.node, SessionProjector.node]), [
+              [Database.node, database],
+              [Bus.node, Bus.configured({ persist: true })],
+            ]),
           ),
         )
 

--- a/packages/core/test/session-log.test.ts
+++ b/packages/core/test/session-log.test.ts
@@ -46,7 +46,9 @@ describe("Session.log", () => {
 
       const items = Array.from(yield* Stream.runCollect(session.log({ sessionID: created.id })))
 
-      expect(items.map((item) => item.type)).toEqual(["session.created", "session.renamed", "log.synced"])
+      // Session creation commits a non-public durable event, so the marker's
+      // seq covers more of the aggregate than the public events emitted.
+      expect(items.map((item) => item.type)).toEqual(["session.renamed", "log.synced"])
       expect(items.at(-1)).toEqual({ type: "log.synced", aggregateID: created.id, seq: Event.Seq.make(1) })
     }),
   )


### PR DESCRIPTION
## What

Restore the Core test suite after event payload persistence became opt-in.

## Before / After

**Before:** `Session.log` expected the internal `session.created` event on the public stream, causing a typecheck and runtime failure. The V1 migration test expected a retained event payload while using the default non-persistent Bus.

**After:** the log test verifies only public events while retaining the aggregate watermark assertion, and the migration test explicitly opts into persistence for its event-row assertion.

## How

- Restore the documented `session.created` public-stream boundary in `session-log.test.ts`.
- Configure the migration test Bus with `persist: true`.
- Leave production event visibility and persistence defaults unchanged.

## Testing

- `bun run test test/session-log.test.ts`
- `bun run test test/database-migration.test.ts`
- `bun typecheck` from `packages/core`
- Push hook workspace typecheck: 32/32 tasks passed