### PR TITLE
fix(session): warn on cache busts

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -440,6 +440,14 @@ const layer = Layer.effect(
               usage: value.usage ?? new Usage({}),
               metadata: value.providerMetadata,
             })
+            const cacheWarning = Session.cacheBustWarning({
+              providerID: ctx.model.providerID,
+              modelID: ctx.model.id,
+              sessionID: ctx.sessionID,
+              finish: value.reason,
+              usage,
+            })
+            if (cacheWarning) yield* Effect.logWarning("possible Anthropic prompt cache bust", cacheWarning)
             ctx.assistantMessage.finish = value.reason
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -406,6 +406,33 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   }
 }
 
+export function cacheBustWarning(input: {
+  providerID: string
+  modelID: string
+  sessionID: string
+  finish: string
+  usage: ReturnType<typeof getUsage>
+}) {
+  const cacheWriteTokens = input.usage.tokens.cache.write
+  const cacheReadTokens = input.usage.tokens.cache.read
+  if (cacheWriteTokens < 50_000) return undefined
+  if (cacheReadTokens !== 0) return undefined
+
+  const provider = input.providerID.toLowerCase()
+  const model = input.modelID.toLowerCase()
+  if (!provider.includes("anthropic") && !model.includes("claude")) return undefined
+
+  return {
+    providerID: input.providerID,
+    modelID: input.modelID,
+    sessionID: input.sessionID,
+    finish: input.finish,
+    cost: input.usage.cost,
+    cacheWriteTokens,
+    cacheReadTokens,
+  }
+}
+
 export class BusyError extends Schema.TaggedErrorClass<BusyError>()("SessionBusyError", {
   sessionID: SessionID,
 }) {}

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1579,6 +1579,44 @@ describe("SessionNs.getUsage", () => {
     expect(result.tokens.cache.write).toBe(300)
   })
 
+  test("flags likely Anthropic cache busts when a step rewrites cache without reads", () => {
+    const warning = SessionNs.cacheBustWarning({
+      providerID: "anthropic",
+      modelID: "claude-opus-5",
+      sessionID: "ses_test",
+      finish: "tool-calls",
+      usage: {
+        cost: 1.63,
+        tokens: { input: 3, output: 39, reasoning: 0, cache: { read: 0, write: 259_313 }, total: 259_355 },
+      },
+    })
+
+    expect(warning).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-opus-5",
+      sessionID: "ses_test",
+      finish: "tool-calls",
+      cost: 1.63,
+      cacheWriteTokens: 259_313,
+      cacheReadTokens: 0,
+    })
+  })
+
+  test("does not flag ordinary cache hits", () => {
+    const warning = SessionNs.cacheBustWarning({
+      providerID: "anthropic",
+      modelID: "claude-opus-5",
+      sessionID: "ses_test",
+      finish: "stop",
+      usage: {
+        cost: 0.03,
+        tokens: { input: 3, output: 39, reasoning: 0, cache: { read: 200_000, write: 0 }, total: 200_042 },
+      },
+    })
+
+    expect(warning).toBeUndefined()
+  })
+
   test("subtracts cached tokens for anthropic provider", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     // AI SDK v6 normalizes inputTokens to include cached tokens for all providers


### PR DESCRIPTION
### Issue for this PR

Closes #40790
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a small diagnostic for likely Anthropic prompt-cache busts. When a completed step reports a large cache write with zero cache reads for an Anthropic/Claude model, the session processor now emits a warning with the session, model, finish reason, cache-write tokens, cache-read tokens, and cost.

This does not revive the previously rejected object-identity caching approach from #36852. It only makes the high-cost pattern reported in #40790 visible in logs so users and maintainers can confirm when it happens.

### How did you verify your code works?

- RED: `bun test test/session/compaction.test.ts --test-name-pattern "flags likely Anthropic cache busts|does not flag ordinary cache hits" --timeout 30000` failed because `SessionNs.cacheBustWarning` did not exist.
- GREEN: `bun test test/session/compaction.test.ts --test-name-pattern "SessionNs.getUsage" --timeout 45000` — 17 pass.
- `bun run typecheck`
- `bun run lint packages/opencode/src/session/session.ts packages/opencode/src/session/processor.ts packages/opencode/test/session/compaction.test.ts`
- `git diff --check`

Notes: two broader session tests fail the same way on a clean `dev` baseline in this Windows checkout:
- `stops quickly when aborted during retry backoff`
- `retry OpenAI-compatible midstream server errors`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR