### PR TITLE
fix(ai): harden compatible chat parsing

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -239,6 +239,7 @@ export interface ParserState {
   readonly reasoningDetails: Array<unknown>
   readonly reasoningDetailsObserved: boolean
   readonly reasoningEmitted: boolean
+  readonly latestToolIndex?: number
   readonly nextToolIndex: number
 }
 
@@ -696,6 +697,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     const toolDeltas = delta?.tool_calls ?? []
     let tools = state.tools
     let pendingTools = state.pendingTools
+    let latestToolIndex = state.latestToolIndex
     let nextToolIndex = state.nextToolIndex
 
     let lifecycle = state.lifecycle
@@ -740,15 +742,11 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
     }
 
-    // Compatible providers may omit indexes. Prefer durable identity, use batch
-    // position for parallel deltas, and only infer a singleton continuation
-    // when exactly one call is active.
+    // Compatible providers may omit indexes. Prefer durable identity, then use
+    // batch position for parallel deltas or the latest call for sparse chunks.
     for (const [position, tool] of toolDeltas.entries()) {
       const matched = toolIndexByID(tools, pendingTools, tool.id || undefined)
-      const active = Object.keys({ ...pendingTools, ...tools }).map(Number)
-      if ((tool.index === undefined || tool.index === null) && matched === undefined && !tool.id && active.length > 1)
-        return yield* ProviderShared.eventError(ADAPTER, "OpenAI Chat tool call delta has an ambiguous index")
-      const fallback = toolDeltas.length > 1 ? position : (active[0] ?? position)
+      const fallback = toolDeltas.length > 1 ? position : (latestToolIndex ?? position)
       const fallbackTool = tools[fallback] ?? pendingTools[fallback]
       const index =
         tool.index ?? matched ??
@@ -758,6 +756,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       const id = current?.id ?? pending?.id ?? (tool.id || undefined)
       const name = current?.name ?? pending?.name ?? (tool.function?.name || undefined)
       const text = `${pending?.input ?? ""}${tool.function?.arguments ?? ""}`
+      latestToolIndex = index
       nextToolIndex = Math.max(nextToolIndex, index + 1)
       if (!current && (!id || !name)) {
         pendingTools = {
@@ -805,6 +804,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningDetails: state.reasoningDetails,
         reasoningDetailsObserved,
         reasoningEmitted,
+        latestToolIndex,
         nextToolIndex,
       },
       events,

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -239,7 +239,6 @@ export interface ParserState {
   readonly reasoningDetails: Array<unknown>
   readonly reasoningDetailsObserved: boolean
   readonly reasoningEmitted: boolean
-  readonly latestToolIndex?: number
   readonly nextToolIndex: number
 }
 
@@ -697,7 +696,6 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     const toolDeltas = delta?.tool_calls ?? []
     let tools = state.tools
     let pendingTools = state.pendingTools
-    let latestToolIndex = state.latestToolIndex
     let nextToolIndex = state.nextToolIndex
 
     let lifecycle = state.lifecycle
@@ -742,11 +740,15 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
     }
 
-    // Compatible providers may omit indexes. Prefer durable identity, then use
-    // batch position for parallel deltas or the latest call for sparse chunks.
+    // Compatible providers may omit indexes. Prefer durable identity, use batch
+    // position for parallel deltas, and only infer a singleton continuation
+    // when exactly one call is active.
     for (const [position, tool] of toolDeltas.entries()) {
       const matched = toolIndexByID(tools, pendingTools, tool.id || undefined)
-      const fallback = toolDeltas.length > 1 ? position : (latestToolIndex ?? position)
+      const active = Object.keys({ ...pendingTools, ...tools }).map(Number)
+      if ((tool.index === undefined || tool.index === null) && matched === undefined && !tool.id && active.length > 1)
+        return yield* ProviderShared.eventError(ADAPTER, "OpenAI Chat tool call delta has an ambiguous index")
+      const fallback = toolDeltas.length > 1 ? position : (active[0] ?? position)
       const fallbackTool = tools[fallback] ?? pendingTools[fallback]
       const index =
         tool.index ?? matched ??
@@ -756,7 +758,6 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       const id = current?.id ?? pending?.id ?? (tool.id || undefined)
       const name = current?.name ?? pending?.name ?? (tool.function?.name || undefined)
       const text = `${pending?.input ?? ""}${tool.function?.arguments ?? ""}`
-      latestToolIndex = index
       nextToolIndex = Math.max(nextToolIndex, index + 1)
       if (!current && (!id || !name)) {
         pendingTools = {
@@ -804,7 +805,6 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningDetails: state.reasoningDetails,
         reasoningDetailsObserved,
         reasoningEmitted,
-        latestToolIndex,
         nextToolIndex,
       },
       events,

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -15,6 +15,7 @@ import {
   type JsonSchema,
   type LLMRequest,
   type MediaPart,
+  type ProviderMetadata,
   type ReasoningPart,
   type TextPart,
   type ToolCallPart,
@@ -64,6 +65,9 @@ const OpenAIChatAssistantToolCall = Schema.Struct({
     name: Schema.String,
     arguments: Schema.String,
   }),
+  extra_content: Schema.optional(
+    Schema.Struct({ google: Schema.Struct({ thought_signature: Schema.String }) }),
+  ),
 })
 type OpenAIChatAssistantToolCall = Schema.Schema.Type<typeof OpenAIChatAssistantToolCall>
 
@@ -145,22 +149,33 @@ export type OpenAIChatBody = Schema.Schema.Type<typeof OpenAIChatBody>
 // The event schema is one decoded SSE `data:` payload. `Framing.sse` splits the
 // byte stream into strings, then `Protocol.jsonEvent` decodes each string into
 // this provider-native event shape.
-const OpenAIChatUsage = Schema.Struct({
-  prompt_tokens: Schema.optional(Schema.Number),
-  completion_tokens: Schema.optional(Schema.Number),
-  total_tokens: Schema.optional(Schema.Number),
-  prompt_tokens_details: optionalNull(
-    Schema.Struct({
-      cached_tokens: Schema.optional(Schema.Number),
-      cache_write_tokens: Schema.optional(Schema.Number),
-    }),
-  ),
-  completion_tokens_details: optionalNull(
-    Schema.Struct({
-      reasoning_tokens: Schema.optional(Schema.Number),
-    }),
-  ),
-})
+const OpenAIChatUsage = Schema.StructWithRest(
+  Schema.Struct({
+    prompt_tokens: optionalNull(Schema.Number),
+    completion_tokens: optionalNull(Schema.Number),
+    total_tokens: optionalNull(Schema.Number),
+    prompt_tokens_details: optionalNull(
+      Schema.StructWithRest(
+        Schema.Struct({
+          cached_tokens: optionalNull(Schema.Number),
+          cache_write_tokens: optionalNull(Schema.Number),
+        }),
+        [Schema.Record(Schema.String, Schema.Unknown)],
+      ),
+    ),
+    completion_tokens_details: optionalNull(
+      Schema.StructWithRest(
+        Schema.Struct({
+          reasoning_tokens: optionalNull(Schema.Number),
+          accepted_prediction_tokens: optionalNull(Schema.Number),
+          rejected_prediction_tokens: optionalNull(Schema.Number),
+        }),
+        [Schema.Record(Schema.String, Schema.Unknown)],
+      ),
+    ),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+)
 
 const OpenAIChatToolCallDeltaFunction = Schema.Struct({
   name: optionalNull(Schema.String),
@@ -168,9 +183,14 @@ const OpenAIChatToolCallDeltaFunction = Schema.Struct({
 })
 
 const OpenAIChatToolCallDelta = Schema.Struct({
-  index: Schema.Number,
+  index: optionalNull(Schema.Number),
   id: optionalNull(Schema.String),
   function: optionalNull(OpenAIChatToolCallDeltaFunction),
+  extra_content: optionalNull(
+    Schema.Struct({
+      google: optionalNull(Schema.Struct({ thought_signature: optionalNull(Schema.String) })),
+    }),
+  ),
 })
 type OpenAIChatToolCallDelta = Schema.Schema.Type<typeof OpenAIChatToolCallDelta>
 
@@ -209,6 +229,7 @@ interface PendingToolDelta {
   readonly id?: string
   readonly name?: string
   readonly input: string
+  readonly providerMetadata?: ProviderMetadata
 }
 
 export interface ParserState {
@@ -222,6 +243,8 @@ export interface ParserState {
   readonly reasoningDetails: Array<unknown>
   readonly reasoningDetailsObserved: boolean
   readonly reasoningEmitted: boolean
+  readonly latestToolIndex?: number
+  readonly nextToolIndex: number
 }
 
 // =============================================================================
@@ -254,14 +277,19 @@ const lowerToolChoice = (toolChoice: NonNullable<LLMRequest["toolChoice"]>) =>
     tool: (name) => ({ type: "function" as const, function: { name } }),
   })
 
-const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => ({
-  id: part.id,
-  type: "function",
-  function: {
-    name: part.name,
-    arguments: ProviderShared.encodeJson(part.input),
-  },
-})
+const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => {
+  const signature = part.providerMetadata?.openai?.thoughtSignature
+  return {
+    id: part.id,
+    type: "function",
+    function: {
+      name: part.name,
+      arguments: ProviderShared.encodeJson(part.input),
+    },
+    extra_content:
+      typeof signature === "string" ? { google: { thought_signature: signature } } : undefined,
+  }
+}
 
 const lowerMedia = Effect.fn("OpenAIChat.lowerMedia")(function* (part: MediaPart) {
   const media = yield* ProviderShared.validateMedia("OpenAI Chat", part, IMAGE_MIMES)
@@ -559,20 +587,37 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
 // satisfied on both sides.
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
-  const cached = usage.prompt_tokens_details?.cached_tokens
-  const cacheWrite = usage.prompt_tokens_details?.cache_write_tokens
-  const reasoning = usage.completion_tokens_details?.reasoning_tokens
-  const nonCached = ProviderShared.subtractTokens(usage.prompt_tokens, ProviderShared.sumTokens(cached, cacheWrite))
+  const input = usage.prompt_tokens ?? undefined
+  const output = usage.completion_tokens ?? undefined
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? undefined
+  const cacheWrite = usage.prompt_tokens_details?.cache_write_tokens ?? undefined
+  const reasoning = usage.completion_tokens_details?.reasoning_tokens ?? undefined
+  const nonCached = ProviderShared.subtractTokens(input, ProviderShared.sumTokens(cached, cacheWrite))
   return new Usage({
-    inputTokens: usage.prompt_tokens,
-    outputTokens: usage.completion_tokens,
+    inputTokens: input,
+    outputTokens: output,
     nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
     cacheWriteInputTokens: cacheWrite,
     reasoningTokens: reasoning,
-    totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
+    totalTokens: ProviderShared.totalTokens(input, output, usage.total_tokens ?? undefined),
     providerMetadata: { openai: usage },
   })
+}
+
+const toolIndexByID = (
+  tools: ParserState["tools"],
+  pendingTools: ParserState["pendingTools"],
+  id: string | undefined,
+) => {
+  if (!id) return undefined
+  const entry = Object.entries({ ...pendingTools, ...tools }).find(([, tool]) => tool?.id === id)
+  return entry ? Number(entry[0]) : undefined
+}
+
+const toolMetadata = (tool: OpenAIChatToolCallDelta): ProviderMetadata | undefined => {
+  const signature = tool.extra_content?.google?.thought_signature
+  return signature ? { openai: { thoughtSignature: signature } } : undefined
 }
 
 const reasoningDelta = (
@@ -657,17 +702,38 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     const events: LLMEvent[] = []
     const usage = mapUsage(event.usage) ?? state.usage
     const choice = event.choices?.[0]
-    const finishReason = choice?.finish_reason
-      ? { normalized: mapFinishReason(choice.finish_reason), raw: choice.native_finish_reason ?? choice.finish_reason }
-      : state.finishReason
+    const rawFinishReason = choice?.finish_reason
+    const finishReason =
+      rawFinishReason !== undefined && rawFinishReason !== null
+        ? { normalized: mapFinishReason(rawFinishReason), raw: choice?.native_finish_reason ?? rawFinishReason }
+        : state.finishReason
     const delta = choice?.delta
     const toolDeltas = delta?.tool_calls ?? []
     let tools = state.tools
     let pendingTools = state.pendingTools
+    let latestToolIndex = state.latestToolIndex
+    let nextToolIndex = state.nextToolIndex
 
     let lifecycle = state.lifecycle
 
     const reasoning = reasoningDelta(delta, state.reasoningField)
+    const hasLateContent =
+      Boolean(delta?.content) ||
+      reasoning !== undefined ||
+      (Array.isArray(delta?.reasoning_details) && delta.reasoning_details.length > 0) ||
+      toolDeltas.some(
+        (tool) =>
+          Boolean(tool.id) ||
+          Boolean(tool.function?.name) ||
+          Boolean(tool.function?.arguments) ||
+          Boolean(tool.extra_content?.google?.thought_signature),
+      )
+    if (state.finishReason !== undefined) {
+      if (hasLateContent)
+        return yield* ProviderShared.eventError(ADAPTER, "OpenAI Chat received content after the finish reason")
+      return [{ ...state, usage }, events] as const
+    }
+
     const reasoningField = state.reasoningField ?? (!state.lifecycle.text.has("text-0") ? reasoning?.field : undefined)
     const detailDelta = Array.isArray(delta?.reasoning_details) ? delta.reasoning_details : undefined
     if (detailDelta !== undefined) appendReasoningDetails(state.reasoningDetails, detailDelta)
@@ -694,25 +760,39 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
     }
 
-    for (const tool of toolDeltas) {
-      const current = tools[tool.index]
-      const pending = pendingTools[tool.index]
+    // Compatible providers may omit indexes. Prefer durable identity, then use
+    // batch position for parallel deltas or the latest call for sparse chunks.
+    for (const [position, tool] of toolDeltas.entries()) {
+      const matched = toolIndexByID(tools, pendingTools, tool.id || undefined)
+      const fallback = toolDeltas.length > 1 ? position : (latestToolIndex ?? position)
+      const fallbackTool = tools[fallback] ?? pendingTools[fallback]
+      const index =
+        tool.index ?? matched ??
+        (tool.id && fallbackTool?.id && fallbackTool.id !== tool.id ? nextToolIndex : fallback)
+      const current = tools[index]
+      const pending = pendingTools[index]
       const id = current?.id ?? pending?.id ?? (tool.id || undefined)
       const name = current?.name ?? pending?.name ?? (tool.function?.name || undefined)
       const text = `${pending?.input ?? ""}${tool.function?.arguments ?? ""}`
+      const providerMetadata = toolMetadata(tool) ?? pending?.providerMetadata
+      latestToolIndex = index
+      nextToolIndex = Math.max(nextToolIndex, index + 1)
       if (!current && (!id || !name)) {
-        pendingTools = { ...pendingTools, [tool.index]: { id: id || undefined, name: name || undefined, input: text } }
+        pendingTools = {
+          ...pendingTools,
+          [index]: { id: id || undefined, name: name || undefined, input: text, providerMetadata },
+        }
         continue
       }
       if (pending) {
         pendingTools = { ...pendingTools }
-        delete pendingTools[tool.index]
+        delete pendingTools[index]
       }
       const result = ToolStream.appendOrStart(
         ADAPTER,
         tools,
-        tool.index,
-        { id: id || undefined, name: name || undefined, text },
+        index,
+        { id: id || undefined, name: name || undefined, text, providerMetadata },
         "OpenAI Chat tool call delta is missing id or name",
       )
       if (ToolStream.isError(result)) return yield* result
@@ -743,6 +823,8 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningDetails: state.reasoningDetails,
         reasoningDetailsObserved,
         reasoningEmitted,
+        latestToolIndex,
+        nextToolIndex,
       },
       events,
     ] as const
@@ -799,6 +881,7 @@ export const protocol = Protocol.make({
       reasoningDetails: [],
       reasoningDetailsObserved: false,
       reasoningEmitted: false,
+      nextToolIndex: 0,
     }),
     step,
     onHalt: finishEvents,

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -15,7 +15,6 @@ import {
   type JsonSchema,
   type LLMRequest,
   type MediaPart,
-  type ProviderMetadata,
   type ReasoningPart,
   type TextPart,
   type ToolCallPart,
@@ -65,11 +64,14 @@ const OpenAIChatAssistantToolCall = Schema.Struct({
     name: Schema.String,
     arguments: Schema.String,
   }),
-  extra_content: Schema.optional(
-    Schema.Struct({ google: Schema.Struct({ thought_signature: Schema.String }) }),
-  ),
 })
 type OpenAIChatAssistantToolCall = Schema.Schema.Type<typeof OpenAIChatAssistantToolCall>
+
+// Intentionally omit Gemini's provider-specific `extra_content.google.thought_signature`
+// extension until direct Google OpenAI-compatible routing is supported here:
+// https://github.com/vercel/ai/issues/11590
+// https://github.com/vercel/ai/pull/11745
+// https://ai.google.dev/gemini-api/docs/thought-signatures#openai
 
 const OpenAIChatUserContent = Schema.Union([
   Schema.Struct({
@@ -186,11 +188,6 @@ const OpenAIChatToolCallDelta = Schema.Struct({
   index: optionalNull(Schema.Number),
   id: optionalNull(Schema.String),
   function: optionalNull(OpenAIChatToolCallDeltaFunction),
-  extra_content: optionalNull(
-    Schema.Struct({
-      google: optionalNull(Schema.Struct({ thought_signature: optionalNull(Schema.String) })),
-    }),
-  ),
 })
 type OpenAIChatToolCallDelta = Schema.Schema.Type<typeof OpenAIChatToolCallDelta>
 
@@ -229,7 +226,6 @@ interface PendingToolDelta {
   readonly id?: string
   readonly name?: string
   readonly input: string
-  readonly providerMetadata?: ProviderMetadata
 }
 
 export interface ParserState {
@@ -277,19 +273,14 @@ const lowerToolChoice = (toolChoice: NonNullable<LLMRequest["toolChoice"]>) =>
     tool: (name) => ({ type: "function" as const, function: { name } }),
   })
 
-const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => {
-  const signature = part.providerMetadata?.openai?.thoughtSignature
-  return {
-    id: part.id,
-    type: "function",
-    function: {
-      name: part.name,
-      arguments: ProviderShared.encodeJson(part.input),
-    },
-    extra_content:
-      typeof signature === "string" ? { google: { thought_signature: signature } } : undefined,
-  }
-}
+const lowerToolCall = (part: ToolCallPart): OpenAIChatAssistantToolCall => ({
+  id: part.id,
+  type: "function",
+  function: {
+    name: part.name,
+    arguments: ProviderShared.encodeJson(part.input),
+  },
+})
 
 const lowerMedia = Effect.fn("OpenAIChat.lowerMedia")(function* (part: MediaPart) {
   const media = yield* ProviderShared.validateMedia("OpenAI Chat", part, IMAGE_MIMES)
@@ -615,11 +606,6 @@ const toolIndexByID = (
   return entry ? Number(entry[0]) : undefined
 }
 
-const toolMetadata = (tool: OpenAIChatToolCallDelta): ProviderMetadata | undefined => {
-  const signature = tool.extra_content?.google?.thought_signature
-  return signature ? { openai: { thoughtSignature: signature } } : undefined
-}
-
 const reasoningDelta = (
   delta: Schema.Schema.Type<typeof OpenAIChatDelta> | null | undefined,
   configuredField?: string,
@@ -722,11 +708,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       reasoning !== undefined ||
       (Array.isArray(delta?.reasoning_details) && delta.reasoning_details.length > 0) ||
       toolDeltas.some(
-        (tool) =>
-          Boolean(tool.id) ||
-          Boolean(tool.function?.name) ||
-          Boolean(tool.function?.arguments) ||
-          Boolean(tool.extra_content?.google?.thought_signature),
+        (tool) => Boolean(tool.id) || Boolean(tool.function?.name) || Boolean(tool.function?.arguments),
       )
     if (state.finishReason !== undefined) {
       if (hasLateContent)
@@ -774,13 +756,12 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       const id = current?.id ?? pending?.id ?? (tool.id || undefined)
       const name = current?.name ?? pending?.name ?? (tool.function?.name || undefined)
       const text = `${pending?.input ?? ""}${tool.function?.arguments ?? ""}`
-      const providerMetadata = toolMetadata(tool) ?? pending?.providerMetadata
       latestToolIndex = index
       nextToolIndex = Math.max(nextToolIndex, index + 1)
       if (!current && (!id || !name)) {
         pendingTools = {
           ...pendingTools,
-          [index]: { id: id || undefined, name: name || undefined, input: text, providerMetadata },
+          [index]: { id: id || undefined, name: name || undefined, input: text },
         }
         continue
       }
@@ -792,7 +773,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         ADAPTER,
         tools,
         index,
-        { id: id || undefined, name: name || undefined, text, providerMetadata },
+        { id: id || undefined, name: name || undefined, text },
         "OpenAI Chat tool call delta is missing id or name",
       )
       if (ToolStream.isError(result)) return yield* result

--- a/packages/ai/src/protocols/utils/tool-stream.ts
+++ b/packages/ai/src/protocols/utils/tool-stream.ts
@@ -136,12 +136,7 @@ export const appendOrStart = <K extends StreamKey>(
   route: string,
   tools: State<K>,
   key: K,
-  delta: {
-    readonly id?: string
-    readonly name?: string
-    readonly text: string
-    readonly providerMetadata?: ProviderMetadata
-  },
+  delta: { readonly id?: string; readonly name?: string; readonly text: string },
   missingToolMessage: string,
 ): AppendOutcome<K> | AIError => {
   const current = tools[key]
@@ -154,15 +149,9 @@ export const appendOrStart = <K extends StreamKey>(
     name,
     input: `${current?.input ?? ""}${delta.text}`,
     providerExecuted: current?.providerExecuted,
-    providerMetadata: delta.providerMetadata ?? current?.providerMetadata,
+    providerMetadata: current?.providerMetadata,
   }
-  if (
-    current &&
-    delta.text.length === 0 &&
-    delta.providerMetadata === undefined &&
-    current.id === id &&
-    current.name === name
-  )
+  if (current && delta.text.length === 0 && current.id === id && current.name === name)
     return { tools, tool: current, events: [] }
   return appendTool(tools, key, tool, delta.text)
 }

--- a/packages/ai/src/protocols/utils/tool-stream.ts
+++ b/packages/ai/src/protocols/utils/tool-stream.ts
@@ -136,7 +136,12 @@ export const appendOrStart = <K extends StreamKey>(
   route: string,
   tools: State<K>,
   key: K,
-  delta: { readonly id?: string; readonly name?: string; readonly text: string },
+  delta: {
+    readonly id?: string
+    readonly name?: string
+    readonly text: string
+    readonly providerMetadata?: ProviderMetadata
+  },
   missingToolMessage: string,
 ): AppendOutcome<K> | AIError => {
   const current = tools[key]
@@ -149,9 +154,15 @@ export const appendOrStart = <K extends StreamKey>(
     name,
     input: `${current?.input ?? ""}${delta.text}`,
     providerExecuted: current?.providerExecuted,
-    providerMetadata: current?.providerMetadata,
+    providerMetadata: delta.providerMetadata ?? current?.providerMetadata,
   }
-  if (current && delta.text.length === 0 && current.id === id && current.name === name)
+  if (
+    current &&
+    delta.text.length === 0 &&
+    delta.providerMetadata === undefined &&
+    current.id === id &&
+    current.name === name
+  )
     return { tools, tool: current, events: [] }
   return appendTool(tools, key, tool, delta.text)
 }

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -312,7 +312,7 @@ describe("OpenAI-compatible Chat route", () => {
                   { index: null, id: "call_london", function: { name: "weather", arguments: '{"city":"' } },
                 ],
               }),
-              deltaChunk({ tool_calls: [{ function: { arguments: 'London"}' } }] }),
+              deltaChunk({ tool_calls: [{ id: "call_london", function: { arguments: 'London"}' } }] }),
               deltaChunk({ tool_calls: [{ id: "call_paris", function: { arguments: 'Paris"}' } }] }),
               deltaChunk({}, "tool_calls"),
             ),
@@ -324,6 +324,59 @@ describe("OpenAI-compatible Chat route", () => {
         { id: "call_paris", name: "weather", input: { city: "Paris" } },
         { id: "call_london", name: "weather", input: { city: "London" } },
       ])
+    }),
+  )
+
+  it.effect("assembles one indexless tool call across chunks", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "weather", description: "Get weather", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({
+                tool_calls: [{ id: "call_paris", function: { name: "weather", arguments: '{"city":"' } }],
+              }),
+              deltaChunk({ tool_calls: [{ function: { arguments: 'Paris"}' } }] }),
+              deltaChunk({}, "tool_calls"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.toolCalls).toMatchObject([
+        { id: "call_paris", name: "weather", input: { city: "Paris" } },
+      ])
+    }),
+  )
+
+  it.effect("rejects ambiguous indexless parallel tool deltas", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "weather", description: "Get weather", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({
+                tool_calls: [
+                  { id: "call_paris", function: { name: "weather", arguments: '{"city":"' } },
+                  { id: "call_london", function: { name: "weather", arguments: '{"city":"' } },
+                ],
+              }),
+              deltaChunk({ tool_calls: [{ function: { arguments: 'Paris"}' } }] }),
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.message).toContain("OpenAI Chat tool call delta has an ambiguous index")
     }),
   )
 

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -312,7 +312,7 @@ describe("OpenAI-compatible Chat route", () => {
                   { index: null, id: "call_london", function: { name: "weather", arguments: '{"city":"' } },
                 ],
               }),
-              deltaChunk({ tool_calls: [{ id: "call_london", function: { arguments: 'London"}' } }] }),
+              deltaChunk({ tool_calls: [{ function: { arguments: 'London"}' } }] }),
               deltaChunk({ tool_calls: [{ id: "call_paris", function: { arguments: 'Paris"}' } }] }),
               deltaChunk({}, "tool_calls"),
             ),
@@ -324,59 +324,6 @@ describe("OpenAI-compatible Chat route", () => {
         { id: "call_paris", name: "weather", input: { city: "Paris" } },
         { id: "call_london", name: "weather", input: { city: "London" } },
       ])
-    }),
-  )
-
-  it.effect("assembles one indexless tool call across chunks", () =>
-    Effect.gen(function* () {
-      const response = yield* LLMClient.generate(
-        LLMRequest.update(request, {
-          tools: [ToolDefinition.make({ name: "weather", description: "Get weather", inputSchema: { type: "object" } })],
-        }),
-      ).pipe(
-        Effect.provide(
-          fixedResponse(
-            sseEvents(
-              deltaChunk({
-                tool_calls: [{ id: "call_paris", function: { name: "weather", arguments: '{"city":"' } }],
-              }),
-              deltaChunk({ tool_calls: [{ function: { arguments: 'Paris"}' } }] }),
-              deltaChunk({}, "tool_calls"),
-            ),
-          ),
-        ),
-      )
-
-      expect(response.toolCalls).toMatchObject([
-        { id: "call_paris", name: "weather", input: { city: "Paris" } },
-      ])
-    }),
-  )
-
-  it.effect("rejects ambiguous indexless parallel tool deltas", () =>
-    Effect.gen(function* () {
-      const error = yield* LLMClient.generate(
-        LLMRequest.update(request, {
-          tools: [ToolDefinition.make({ name: "weather", description: "Get weather", inputSchema: { type: "object" } })],
-        }),
-      ).pipe(
-        Effect.provide(
-          fixedResponse(
-            sseEvents(
-              deltaChunk({
-                tool_calls: [
-                  { id: "call_paris", function: { name: "weather", arguments: '{"city":"' } },
-                  { id: "call_london", function: { name: "weather", arguments: '{"city":"' } },
-                ],
-              }),
-              deltaChunk({ tool_calls: [{ function: { arguments: 'Paris"}' } }] }),
-            ),
-          ),
-        ),
-        Effect.flip,
-      )
-
-      expect(error.message).toContain("OpenAI Chat tool call delta has an ambiguous index")
     }),
   )
 

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -7,7 +7,7 @@ import { compileRequest } from "../../src/route/client"
 import * as OpenAICompatible from "../../src/providers/openai-compatible"
 import * as OpenAICompatibleChat from "../../src/protocols/openai-compatible-chat"
 import { it } from "../lib/effect"
-import { dynamicResponse } from "../lib/http"
+import { dynamicResponse, fixedResponse } from "../lib/http"
 import { sseEvents } from "../lib/sse"
 
 const Json = Schema.fromJsonString(Schema.Unknown)
@@ -251,6 +251,150 @@ describe("OpenAI-compatible Chat route", () => {
         type: "finish",
         reason: { normalized: "stop", raw: "stop" },
       })
+    }),
+  )
+
+  it.effect("accepts nullable usage and preserves provider fields", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({ content: "Hello" }),
+              deltaChunk({}, "stop"),
+              usageChunk({
+                prompt_tokens: null,
+                completion_tokens: null,
+                total_tokens: null,
+                prompt_tokens_details: { cached_tokens: null, vendor_cache_tokens: 3 },
+                completion_tokens_details: {
+                  reasoning_tokens: null,
+                  accepted_prediction_tokens: null,
+                  rejected_prediction_tokens: null,
+                },
+                cost: "0.001",
+              }),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.usage).toMatchObject({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+        providerMetadata: {
+          openai: {
+            prompt_tokens: null,
+            completion_tokens: null,
+            total_tokens: null,
+            prompt_tokens_details: { cached_tokens: null, vendor_cache_tokens: 3 },
+            cost: "0.001",
+          },
+        },
+      })
+    }),
+  )
+
+  it.effect("assembles indexless parallel tool calls across sparse chunks", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "weather", description: "Get weather", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({
+                tool_calls: [
+                  { id: "call_paris", function: { name: "weather", arguments: '{"city":"' } },
+                  { index: null, id: "call_london", function: { name: "weather", arguments: '{"city":"' } },
+                ],
+              }),
+              deltaChunk({ tool_calls: [{ function: { arguments: 'London"}' } }] }),
+              deltaChunk({ tool_calls: [{ id: "call_paris", function: { arguments: 'Paris"}' } }] }),
+              deltaChunk({}, "tool_calls"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.toolCalls).toMatchObject([
+        { id: "call_paris", name: "weather", input: { city: "Paris" } },
+        { id: "call_london", name: "weather", input: { city: "London" } },
+      ])
+    }),
+  )
+
+  it.effect("preserves compatible tool thought signatures for continuation", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({
+                tool_calls: [
+                  {
+                    id: "call_1",
+                    function: { name: "lookup", arguments: "{}" },
+                    extra_content: { google: { thought_signature: "signed" } },
+                  },
+                ],
+              }),
+              deltaChunk({}, "tool_calls"),
+            ),
+          ),
+        ),
+      )
+      const replay = yield* compileRequest(LLMRequest.update(request, { messages: [response.message] }))
+
+      expect(response.toolCalls[0]?.providerMetadata).toEqual({ openai: { thoughtSignature: "signed" } })
+      expect(replay.body.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "lookup", arguments: "{}" },
+            extra_content: { google: { thought_signature: "signed" } },
+          },
+        ],
+      })
+    }),
+  )
+
+  it.effect("treats an empty finish reason as terminal", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(fixedResponse(sseEvents(deltaChunk({ content: "Hello" }), deltaChunk({}, "")))),
+      )
+
+      expect(response.finishReason).toEqual({ normalized: "unknown", raw: "" })
+    }),
+  )
+
+  it.effect("rejects content after a terminal chunk", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({ content: "Hello" }),
+              deltaChunk({}, "stop"),
+              deltaChunk({ tool_calls: [{ index: 0, id: "call_1", function: { name: "lookup", arguments: "{}" } }] }),
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.message).toContain("OpenAI Chat received content after the finish reason")
     }),
   )
 })

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -327,48 +327,6 @@ describe("OpenAI-compatible Chat route", () => {
     }),
   )
 
-  it.effect("preserves compatible tool thought signatures for continuation", () =>
-    Effect.gen(function* () {
-      const response = yield* LLMClient.generate(
-        LLMRequest.update(request, {
-          tools: [ToolDefinition.make({ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } })],
-        }),
-      ).pipe(
-        Effect.provide(
-          fixedResponse(
-            sseEvents(
-              deltaChunk({
-                tool_calls: [
-                  {
-                    id: "call_1",
-                    function: { name: "lookup", arguments: "{}" },
-                    extra_content: { google: { thought_signature: "signed" } },
-                  },
-                ],
-              }),
-              deltaChunk({}, "tool_calls"),
-            ),
-          ),
-        ),
-      )
-      const replay = yield* compileRequest(LLMRequest.update(request, { messages: [response.message] }))
-
-      expect(response.toolCalls[0]?.providerMetadata).toEqual({ openai: { thoughtSignature: "signed" } })
-      expect(replay.body.messages.at(-1)).toMatchObject({
-        role: "assistant",
-        content: null,
-        tool_calls: [
-          {
-            id: "call_1",
-            type: "function",
-            function: { name: "lookup", arguments: "{}" },
-            extra_content: { google: { thought_signature: "signed" } },
-          },
-        ],
-      })
-    }),
-  )
-
   it.effect("treats an empty finish reason as terminal", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(


### PR DESCRIPTION
Fixes #40690.

## Summary

- align OpenAI-compatible Chat stream schemas with the AI SDK's nullish usage and indexless tool-call tolerances
- preserve provider-specific usage fields and prediction-token details in raw provider metadata
- resolve indexless tool deltas using persistent call IDs, parallel positions, and sparse-stream state instead of per-chunk position alone
- treat empty finish reasons as terminal unknown values and reject meaningful content after termination
- intentionally omit Gemini's provider-specific OpenAI-compatible thought-signature extension pending dedicated Google routing support

## Source comparison

Compared against `~/development/ai/packages/openai-compatible/src/chat/openai-compatible-chat-language-model.ts` and `convert-openai-compatible-chat-usage.ts`. The native implementation retains its stricter incomplete-stream detection, undefined-vs-zero usage semantics, malformed tool-input isolation, and broader reasoning support where those are safer than AI SDK behavior.

Gemini's `extra_content.google.thought_signature` extension is intentionally excluded because it is specific to Google's OpenAI-compatible endpoint. Source links and follow-up context are documented next to the tool-call schema.

## Validation

- `bun typecheck` in `packages/ai`
- 64 focused OpenAI Chat, OpenAI-compatible Chat, and ToolStream tests
- full `packages/ai` run: 476 passed, 28 skipped; 2 existing OpenRouter recorded fixtures fail because their stored bodies omit the current `usage.include` request field
