### PR TITLE
docs: add model scorecard plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-model-scorecard](https://github.com/bnc4vk/opencode-model-scorecard)                     | Show model task scores, token prices, and token efficiency on the TUI home screen                  |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #35436

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the `opencode-model-scorecard` community plugin to the ecosystem plugin list. The plugin surfaces model task scores, token prices, and token-efficiency details on the TUI home screen, matching the requested ecosystem docs entry.

This is a fresh small docs-only re-file after #35437 was closed by automated age/reaction cleanup, not for a technical objection.

### How did you verify your code works?

- Confirmed the entry was absent from `packages/web/src/content/docs/ecosystem.mdx` before the change.
- Confirmed `bnc4vk/opencode-model-scorecard` exists and is not archived.
- `bun install --frozen-lockfile` to restore the missing local `astro` binary without changing the lockfile.
- `bun run build` from `packages/web`.
- `git diff --check`.

Note: the pre-push hook runs the repo-wide `bun turbo typecheck`, which still fails in this Windows checkout on the existing `custom-elements.d.ts` placeholder issue in app-dependent packages. This docs-only PR does not touch those files; the web build succeeds.

### Screenshots / recordings

Not a UI runtime change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR