### PR TITLE
feat(pr): improve pr checkout command robustness and UX

### DIFF
--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -1,19 +1,36 @@
-import { Effect } from "effect"
+import { Effect, Exit } from "effect"
 import { UI } from "../ui"
 import { effectCmd, fail } from "../effect-cmd"
 import { Git } from "@/git"
 import { InstanceRef } from "@/effect/instance-ref"
 import { Process } from "@/util/process"
 
+type PrInfo = {
+  headRepository?: { name: string }
+  headRepositoryOwner?: { login: string }
+  isCrossRepository?: boolean
+  headRefName?: string
+  body?: string
+}
+
 export const PrCommand = effectCmd({
   command: "pr <number>",
   describe: "fetch and checkout a GitHub PR branch, then run opencode",
   builder: (yargs) =>
-    yargs.positional("number", {
-      type: "number",
-      describe: "PR number to checkout",
-      demandOption: true,
-    }),
+    yargs
+      .positional("number", {
+        type: "number",
+        describe: "PR number to checkout",
+        demandOption: true,
+      })
+      .option("no-force", {
+        type: "boolean",
+        describe: "refuse to discard local changes when checking out",
+      })
+      .option("no-run", {
+        type: "boolean",
+        describe: "checkout the PR without launching opencode",
+      }),
   handler: Effect.fn("Cli.pr")(function* (args) {
     const ctx = yield* InstanceRef
     if (!ctx) return yield* fail("Could not load instance context")
@@ -26,14 +43,13 @@ export const PrCommand = effectCmd({
 
     const prNumber = args.number
     const localBranchName = `pr/${prNumber}`
-    UI.println(`Fetching and checking out PR #${prNumber}...`)
 
-    const checkout = yield* Effect.promise(() =>
-      Process.run(["gh", "pr", "checkout", `${prNumber}`, "--branch", localBranchName, "--force"], { nothrow: true }),
-    )
-    if (checkout.code !== 0) {
-      return yield* fail(`Failed to checkout PR #${prNumber}. Make sure you have gh CLI installed and authenticated.`)
+    const auth = yield* Effect.promise(() => Process.run(["gh", "auth", "status"], { nothrow: true }))
+    if (auth.code !== 0) {
+      return yield* fail("gh CLI is not installed or authenticated. Run `gh auth login` first.")
     }
+
+    UI.println(`Fetching and checking out PR #${prNumber}...`)
 
     const prInfoResult = yield* Effect.promise(() =>
       Process.text(
@@ -48,28 +64,61 @@ export const PrCommand = effectCmd({
         { nothrow: true },
       ),
     )
+    if (prInfoResult.code !== 0) {
+      return yield* fail(`PR #${prNumber} not found or not accessible in this repository.`)
+    }
+
+    const checkoutArgs = ["gh", "pr", "checkout", `${prNumber}`, "--branch", localBranchName]
+    if (!args["no-force"]) checkoutArgs.push("--force")
+    const checkout = yield* Effect.promise(() => Process.run(checkoutArgs, { nothrow: true }))
+    if (checkout.code !== 0) {
+      return yield* fail(
+        `Failed to checkout PR #${prNumber}. Make sure you have gh CLI installed and authenticated.`,
+      )
+    }
 
     let sessionId: string | undefined
 
-    if (prInfoResult.code === 0 && prInfoResult.text.trim()) {
-      const prInfo = JSON.parse(prInfoResult.text)
+    if (prInfoResult.text.trim()) {
+      let prInfo: PrInfo | undefined
+      try {
+        prInfo = JSON.parse(prInfoResult.text)
+      } catch {
+        prInfo = undefined
+      }
 
       if (prInfo?.isCrossRepository && prInfo.headRepository && prInfo.headRepositoryOwner) {
         const forkOwner = prInfo.headRepositoryOwner.login
         const forkName = prInfo.headRepository.name
         const remoteName = forkOwner
 
+        const protocol = yield* Effect.promise(() =>
+          Process.text(["gh", "config", "get", "git_protocol"], { nothrow: true }),
+        )
+        const remoteUrl =
+          protocol.code === 0 && protocol.text.trim() === "ssh"
+            ? `git@github.com:${forkOwner}/${forkName}.git`
+            : `https://github.com/${forkOwner}/${forkName}.git`
+
         const remotes = (yield* git.run(["remote"], { cwd: worktree })).text().trim()
-        if (!remotes.split("\n").includes(remoteName)) {
-          yield* git.run(["remote", "add", remoteName, `https://github.com/${forkOwner}/${forkName}.git`], {
-            cwd: worktree,
-          })
+        const remoteExists = remotes.split("\n").includes(remoteName)
+        if (!remoteExists) {
+          yield* git.run(["remote", "add", remoteName, remoteUrl], { cwd: worktree })
           UI.println(`Added fork remote: ${remoteName}`)
         }
 
-        yield* git.run(["branch", `--set-upstream-to=${remoteName}/${prInfo.headRefName}`, localBranchName], {
-          cwd: worktree,
-        })
+        const setUpstream = yield* Effect.exit(
+          git.run(["branch", `--set-upstream-to=${remoteName}/${prInfo.headRefName}`, localBranchName], {
+            cwd: worktree,
+          }),
+        )
+        if (Exit.isFailure(setUpstream)) {
+          UI.println(`Warning: could not set upstream for '${localBranchName}'.`)
+          if (!remoteExists) {
+            yield* git.run(["remote", "remove", remoteName], { cwd: worktree })
+            UI.println(`Removed fork remote: ${remoteName}`)
+          }
+        }
       }
 
       if (prInfo?.body) {
@@ -88,12 +137,20 @@ export const PrCommand = effectCmd({
               sessionId = sessionIdMatch[1]
               UI.println(`Session imported: ${sessionId}`)
             }
+          } else {
+            UI.println("Warning: failed to import opencode session from PR body.")
           }
         }
       }
     }
 
     UI.println(`Successfully checked out PR #${prNumber} as branch '${localBranchName}'`)
+
+    if (args["no-run"]) {
+      UI.println("Skipping opencode launch (--no-run).")
+      return
+    }
+
     UI.println()
     UI.println("Starting opencode...")
     UI.println()
@@ -105,7 +162,7 @@ export const PrCommand = effectCmd({
           stdin: "inherit",
           stdout: "inherit",
           stderr: "inherit",
-          cwd: process.cwd(),
+          cwd: worktree,
         }).exited,
     )
     // Match legacy throw semantics — propagate as a defect so the top-level

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -344,7 +344,9 @@ Options:
   -v, --version     show version number                                                    [boolean]
       --print-logs  print logs to stderr                                                   [boolean]
       --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
-      --pure        run without external plugins                                           [boolean]"
+      --pure        run without external plugins                                           [boolean]
+      --no-force    refuse to discard local changes when checking out                      [boolean]
+      --no-run      checkout the PR without launching opencode                             [boolean]"
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode session --help 1`] = `


### PR DESCRIPTION
Improves the `pr` command's checkout flow with better error handling, protocol-aware fork remotes, and two new flags.

## Changes

- **`--no-force` flag**: refuse to discard local changes when checking out (skips `--force`)
- **`--no-run` flag**: checkout the PR without launching opencode
- **gh auth guard**: fail with a clear message if `gh` is not installed/authenticated, before doing any work
- **PR-not-found guard**: fail cleanly when the PR doesn't exist or isn't accessible in this repository
- **Hardened JSON parsing**: `prInfo` JSON.parse wrapped in try/catch
- **Protocol-aware fork remote**: detect `git_protocol` (ssh/https) via `gh config get` and build the correct fork remote URL instead of always using https
- **Remote cleanup**: if `--set-upstream-to` fails, remove the fork remote that was just added (avoids leaving stray remotes)
- **Session import warning**: log a warning when importing an opencode session from the PR body fails
- **cwd fix**: spawn opencode from the checked-out `worktree` instead of `process.cwd()`
- **Typecheck fix**: `Effect.either` → `Effect.exit` + `Exit.isFailure` (matches codebase pattern; `Effect.either` no longer exists in effect@4.0.0-beta.83)

Snapshot test updated for the two new flags (`--no-force`/`--no-run`), 1 pass / 40 expects.