### PR TITLE
docs(ecosystem): add qwen-audio-agent voice frontend to Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)                           | Realtime full-duplex voice frontend — talk hands-free to OpenCode with barge-in and a local wake word |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs-only ecosystem listing, no prior issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row for [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`, matching the existing table format. It is a realtime full-duplex voice frontend for OpenCode sessions (native ACP, one-click install via `qwenaudio install opencode`): hands-free voice with barge-in, background task results read back into the conversation, and a local wake word.

Note: this supersedes #40659, which I closed as a duplicate of this one (submitted twice from my fork by mistake).

Disclosure: I'm one of the qwen-audio-agent maintainers.

### How did you verify your code works?

Docs table row only — verified the markdown renders correctly and matches the surrounding rows' column format. All listed claims (native ACP backend, one-click install command) are shipped behavior in qwen-audio-agent; I'm a maintainer of that project.

### Screenshots / recordings

N/A — documentation change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
