### PR TITLE
fix(session): handle AI SDK type validation errors

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -262,6 +262,13 @@ export function toLLMEvents(
       })
 
     case "error":
+      if (event.error instanceof Error && event.error.name === "AI_TypeValidationError") {
+        return Effect.succeed([
+          LLMEvent.providerError({
+            message: `Provider returned an invalid response format: ${errorMessage(event.error)}`,
+          }),
+        ])
+      }
       return Effect.fail(event.error)
 
     case "abort":

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -184,6 +184,20 @@ describe("session.llm.ai-sdk adapter", () => {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- tests defensive adapter branches outside AI SDK's current typed surface
   const uncheckedAdapterEvent = (input: unknown) => input as AISDKAdapterEvent
 
+  test("maps AI SDK type validation errors to provider errors", async () => {
+    const error = new Error('Value: {"tool":"skill_view","status":"running"}. Invalid input')
+    error.name = "AI_TypeValidationError"
+
+    const events = await adapt([uncheckedAdapterEvent({ type: "error", error })])
+
+    expect(events).toEqual([
+      {
+        type: "provider-error",
+        message: expect.stringContaining("Provider returned an invalid response format"),
+      },
+    ])
+  })
+
   test("maps AI SDK stream chunks without losing session-visible fields", async () => {
     const metadata = { openai: { itemID: "item-1" } }
     const events = await adapt([


### PR DESCRIPTION
### Issue for this PR

Closes #31324

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Handles AI SDK `AI_TypeValidationError` stream events as terminal provider errors instead of failing the adapter stream directly. This keeps malformed provider chunks from surfacing as broken session message structure while preserving ordinary error handling for other AI SDK errors.

### How did you verify your code works?

- `bun test test/session/llm.test.ts --test-name-pattern "maps AI SDK type validation errors to provider errors" --timeout 30000`
- `bun test test/session/llm.test.ts --timeout 90000`
- `bun test test/session/processor-effect.test.ts --test-name-pattern "retain partial legacy parts without v2 events|fail provider-executed error results" --timeout 90000`
- `bun run typecheck` from `packages/opencode`
- `bun run lint packages/opencode/src/session/llm/ai-sdk.ts packages/opencode/test/session/llm.test.ts`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR