### PR TITLE
fix(app): keep Add server dialog fields editable

### DIFF
--- a/packages/app/e2e/regression/add-server-dialog-input.spec.ts
+++ b/packages/app/e2e/regression/add-server-dialog-input.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/OpenCode/AddServerDialog"
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+
+test("Add server dialog fields accept and retain input", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: "proj_add_server",
+      worktree: directory,
+      vcs: "git",
+      name: "add-server-dialog",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: [],
+    pageMessages: () => ({ items: [] }),
+  })
+  // The legacy layout hosts the Add server form that uses the shared TextField.
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: false } }))
+  })
+
+  await page.goto("/")
+  await page.keyboard.press("Control+,")
+
+  await page.getByRole("tab", { name: "サーバー" }).click()
+  await page.getByRole("button", { name: "サーバーを追加" }).click()
+
+  const fields = page.locator('input[data-slot="input-input"]')
+  await expect(fields).toHaveCount(4)
+  const [url, name, username, password] = [0, 1, 2, 3].map((index) => fields.nth(index))
+
+  // All four fields must accept input.
+  await url.fill(server)
+  await name.fill("opencode-server")
+  await username.fill("opencode")
+  await password.fill("test-password")
+
+  // Values must survive focus moving away and back.
+  await url.focus()
+  await password.focus()
+  await password.press("End")
+  await password.type("-updated")
+
+  await expect(url).toHaveValue(server)
+  await expect(name).toHaveValue("opencode-server")
+  await expect(username).toHaveValue("opencode")
+  await expect(password).toHaveValue("test-password-updated")
+})

--- a/packages/app/e2e/tsconfig.json
+++ b/packages/app/e2e/tsconfig.json
@@ -15,6 +15,7 @@
     "../src/pages/session/timeline/observe-element-offset.ts",
     "./regression/new-session-panel-corner.spec.ts",
     "./regression/session-timeline-context-resize.spec.ts",
+    "./regression/add-server-dialog-input.spec.ts",
     "./utils/**/*.ts"
   ]
 }

--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -1,5 +1,5 @@
 import { TextField as Kobalte } from "@kobalte/core/text-field"
-import { createSignal, Show, splitProps } from "solid-js"
+import { createEffect, createSignal, Show, splitProps } from "solid-js"
 import type { ComponentProps } from "solid-js"
 import { useI18n } from "../context/i18n"
 import { IconButton } from "./icon-button"
@@ -54,6 +54,18 @@ export function TextField(props: TextFieldProps) {
     "multiline",
   ])
   const [copied, setCopied] = createSignal(false)
+  let inputRef: HTMLInputElement | HTMLTextAreaElement | undefined
+
+  // Kobalte treats a `value` prop as controlled and writes the current value back
+  // into the input synchronously during `onInput`. When the reactive update from
+  // `onChange` hasn't propagated yet (observed on Windows/Electron) this discards
+  // the keystroke. We keep the field uncontrolled inside Kobalte and sync the
+  // external controlled value here so typed text is never lost.
+  createEffect(() => {
+    if (local.value === undefined) return
+    const el = inputRef
+    if (el && el.value !== local.value) el.value = local.value
+  })
 
   const label = () => {
     if (copied()) return i18n.t("ui.textField.copied")
@@ -83,8 +95,7 @@ export function TextField(props: TextFieldProps) {
       data-component="input"
       data-variant={local.variant || "normal"}
       name={local.name}
-      defaultValue={local.defaultValue}
-      value={local.value}
+      defaultValue={local.value ?? local.defaultValue}
       onChange={local.onChange}
       onKeyDown={local.onKeyDown}
       onClick={handleClick}
@@ -101,9 +112,26 @@ export function TextField(props: TextFieldProps) {
       <div data-slot="input-wrapper">
         <Show
           when={local.multiline}
-          fallback={<Kobalte.Input {...others} data-slot="input-input" class={local.class} />}
+          fallback={
+            <Kobalte.Input
+              {...others}
+              data-slot="input-input"
+              class={local.class}
+              ref={(el: HTMLInputElement) => {
+                inputRef = el
+              }}
+            />
+          }
         >
-          <Kobalte.TextArea {...others} autoResize data-slot="input-input" class={local.class} />
+          <Kobalte.TextArea
+            {...others}
+            autoResize
+            data-slot="input-input"
+            class={local.class}
+            ref={(el: HTMLTextAreaElement) => {
+              inputRef = el
+            }}
+          />
         </Show>
         <Show when={local.copyable}>
           <Tooltip value={label()} placement="top" gutter={4} forceOpen={copied()} skipDelayDuration={0}>


### PR DESCRIPTION
### Issue for this PR

Closes #38193

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, only the Server URL field was editable in the Desktop "Add server" dialog; the Server name, Username, and Password fields discarded keystrokes and could not regain focus. This prevented adding remote servers protected with HTTP Basic Auth.

Kobalte's controlled `TextField` writes `value()` back into the input synchronously during `onInput`. When the reactive update from `onChange` has not propagated yet (observed on Windows/Electron), the keystroke is lost and the field stays stuck on its placeholder.

The fix keeps the field uncontrolled inside Kobalte and syncs the external controlled value in an effect so typed text is never lost. A regression test covers focus transitions and value entry.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/ui` and `packages/app`.
- Verified in the browser (Linux) that all four fields accept input, retain values across focus changes, and existing behavior is unchanged.

### Screenshots / recordings

N/A (behavioral fix; verified in browser).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
