### PR TITLE
fix(tui): stream running bash output

### DIFF
--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -670,6 +670,34 @@ function bashCommand(part: ToolPart): string | undefined {
   return typeof command === "string" ? command : undefined
 }
 
+function bashMetadataOutput(part: ToolPart): string | undefined {
+  if (part.tool !== "bash" || part.state.status !== "running") return undefined
+  const metadata = "metadata" in part.state ? part.state.metadata : undefined
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return undefined
+  const output = Reflect.get(metadata, "output")
+  return typeof output === "string" && output.trim() ? output : undefined
+}
+
+function flushToolOutput(
+  data: SessionData,
+  commits: SessionCommit[],
+  part: ToolPart,
+  output: string,
+  toolState: NonNullable<SessionCommit["toolState"]>,
+) {
+  const previous = data.visible.get(part.id) ?? ""
+  const text = output.startsWith(previous) ? output.slice(previous.length) : output
+  data.visible.set(part.id, output)
+  if (!text.trim()) return
+  commits.push(
+    toolCommit(part, {
+      text,
+      phase: "progress",
+      toolState,
+    }),
+  )
+}
+
 function shellCommit(
   input: {
     callID: string
@@ -939,6 +967,9 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
           commits.push(startTool(part))
         }
 
+        const output = bashMetadataOutput(part)
+        if (output) flushToolOutput(data, commits, part, output, "running")
+
         return out(data, commits, view ?? patch({ status: toolStatus(part) }))
       }
 
@@ -959,17 +990,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
 
         const output = part.state.output
         if (mode.output && typeof output === "string" && output.trim()) {
-          commits.push({
-            kind: "tool",
-            text: output,
-            phase: "progress",
-            source: "tool",
-            messageID: part.messageID,
-            partID: part.id,
-            tool: part.tool,
-            part,
-            toolState: "completed",
-          })
+          flushToolOutput(data, commits, part, output, "completed")
         }
 
         if (mode.final) {

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -443,6 +443,63 @@ describe("run session data", () => {
     ).toEqual([])
   })
 
+  test("streams running bash metadata output into scrollback", () => {
+    let data = createSessionData()
+    const first = reduce(
+      data,
+      tool({
+        id: "tool-1",
+        messageID: "msg-1",
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "running",
+          input: { command: "pytest -v" },
+          metadata: { output: "collected 1 item\n" },
+          time: { start: 1 },
+        },
+      }),
+    )
+
+    expect(first.commits).toEqual([
+      expect.objectContaining({ kind: "tool", tool: "bash", phase: "start", text: "running bash" }),
+      expect.objectContaining({
+        kind: "tool",
+        tool: "bash",
+        phase: "progress",
+        text: "collected 1 item\n",
+        toolState: "running",
+      }),
+    ])
+
+    data = first.data
+    const second = reduce(
+      data,
+      tool({
+        id: "tool-1",
+        messageID: "msg-1",
+        callID: "call-1",
+        tool: "bash",
+        state: {
+          status: "running",
+          input: { command: "pytest -v" },
+          metadata: { output: "collected 1 item\ntest_demo.py::test_demo PASSED\n" },
+          time: { start: 1 },
+        },
+      }),
+    )
+
+    expect(second.commits).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        tool: "bash",
+        phase: "progress",
+        text: "test_demo.py::test_demo PASSED\n",
+        toolState: "running",
+      }),
+    ])
+  })
+
   test("suppresses shell events when the legacy bash part claimed the call first", () => {
     let data = reduce(
       createSessionData(),


### PR DESCRIPTION
### Issue for this PR

Fixes #34966

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Streams incremental bash `metadata.output` updates into the standalone TUI scrollback while the tool is still running. The reducer now appends only the newly observed output slice, so long-running commands can surface available stdout/stderr progress before the final completed tool update arrives.

This keeps the existing first-class shell-event path unchanged and does not change subprocess PTY/PIPE semantics.

### How did you verify your code works?

- `bun test test/cli/run/session-data.test.ts --test-name-pattern "streams running bash metadata output into scrollback" --timeout 30000`
- `bun test test/cli/run/session-data.test.ts --test-name-pattern "direct shell|legacy bash|shell events|running bash metadata" --timeout 45000`
- `bun test test/cli/run/session-data.test.ts --timeout 90000`
- `bun test test/cli/run/scrollback.surface.test.ts --timeout 90000`
- `bun run typecheck` from `packages/opencode`
- `bun run lint packages/opencode/src/cli/cmd/run/session-data.ts packages/opencode/test/cli/run/session-data.test.ts`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR