### PR TITLE
docs(ecosystem): add opencode-analyze-image

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-analyze-image](https://github.com/cipherTing/opencode-analyze-image)                     | Analyze image attachments, URLs, local files, and directories in OpenCode through a configurable vision model |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #40858

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one entry for [opencode-analyze-image](https://github.com/cipherTing/opencode-analyze-image) to the Plugins table in the ecosystem documentation.

### How did you verify your code works?

Ran `git diff --check` and verified the change is limited to the ecosystem documentation table.

### Screenshots / recordings

Not applicable; documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR