### PR TITLE
fix(tui): reject unavailable project moves

### DIFF
--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -25,7 +25,7 @@ type ProjectDirectory = ProjectDirectories[number]
 type DialogMoveSessionProps = {
   projectID: string
   current?: MoveSessionSelection
-  onSelect: (selection: MoveSessionSelection) => void
+  onSelect: (selection: MoveSessionSelection) => Promise<void> | void
   onCurrentChange?: (selection: MoveSessionSelection) => void
   initialDirectories?: ProjectDirectory[]
   initialRemoving?: string
@@ -312,7 +312,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
         locked={showError() || directories.loading || loadedProject.loading || Boolean(removing())}
         current={current()}
         onSelect={(option) => {
-          if (option.value) props.onSelect(option.value)
+          if (option.value) void props.onSelect(option.value)
         }}
         onMove={() => setToDelete(undefined)}
         actions={

--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -15,6 +15,23 @@ function moveReminderText(directory: string) {
   return `<system-reminder>The user has changed the current working directory to "${directory}". This is still the same project but at a possibly new location; take this into account when working with any files from now on.</system-reminder>`
 }
 
+export async function resolvePromptMoveDirectory(input: {
+  selection: MoveSessionSelection
+  create: () => Promise<string | undefined>
+  validate: (directory: string) => Promise<void>
+  onUnavailable: (error: unknown) => void
+}) {
+  const directory = input.selection.type === "new" ? await input.create() : input.selection.directory
+  if (!directory) return undefined
+  try {
+    await input.validate(directory)
+    return directory
+  } catch (error) {
+    input.onUnavailable(error)
+    return undefined
+  }
+}
+
 export function usePromptMove(input: { projectID: () => string | undefined; sessionID: () => string | undefined }) {
   const dialog = useDialog()
   const sdk = useSDK()
@@ -29,7 +46,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
 
   async function create(context?: string) {
     const projectID = input.projectID()
-    if (!projectID) return
+    if (!projectID) return undefined
     setCreating(true)
     setProgress("Creating copy")
     try {
@@ -61,8 +78,16 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
       setProgress(undefined)
       setCreating(false)
       toast.show({ title: "Creating workspace failed", message: errorMessage(err), variant: "error" })
-      return
+      return undefined
     }
+  }
+
+  async function validateDirectory(directory: string) {
+    await sdk.client.path.get({ directory }, { throwOnError: true })
+  }
+
+  function showUnavailableDirectory(error: unknown) {
+    toast.show({ title: "Project unavailable", message: errorMessage(error), variant: "error" })
   }
 
   function open() {
@@ -91,8 +116,21 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
         onSelect={(selection) => {
           const sessionID = input.sessionID()
           if (!sessionID) {
-            homeDestination?.setDestination(selection)
-            dialog.clear()
+            if (selection.type === "new") {
+              homeDestination?.setDestination(selection)
+              dialog.clear()
+              return
+            }
+            void resolvePromptMoveDirectory({
+              selection,
+              create: async () => undefined,
+              validate: validateDirectory,
+              onUnavailable: showUnavailableDirectory,
+            }).then((directory) => {
+              if (!directory) return
+              homeDestination?.setDestination({ ...selection, directory })
+              dialog.clear()
+            })
             return
           }
           void moveExistingSession(sessionID, selection)
@@ -119,13 +157,17 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     const status = await sdk.client.vcs.status({ directory: session?.directory }).catch(() => undefined)
     const choice = status?.data?.length ? await DialogWorkspaceFileChanges.show(dialog, status.data) : "no"
     if (!choice) return
-    dialog.clear()
-    const directory = selection.type === "new" ? await create(sessionContext(sessionID)) : selection.directory
+    const directory = await resolvePromptMoveDirectory({
+      selection,
+      create: () => create(sessionContext(sessionID)),
+      validate: validateDirectory,
+      onUnavailable: showUnavailableDirectory,
+    })
     if (!directory) {
       setProgress(undefined)
-      dialog.clear()
       return
     }
+    dialog.clear()
     setProgress("Moving session")
     try {
       await sdk.client.experimental.controlPlane.moveSession(
@@ -165,11 +207,13 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
 
   async function getDirectory(context?: string) {
     const value = homeDestination?.destination()
-    if (!value) return
-    if (value.type === "directory") {
-      return value.directory
-    }
-    return await create(context)
+    if (!value) return undefined
+    return await resolvePromptMoveDirectory({
+      selection: value,
+      create: () => create(context),
+      validate: validateDirectory,
+      onUnavailable: showUnavailableDirectory,
+    })
   }
 
   function startSubmit() {

--- a/packages/tui/test/component/prompt-move.test.ts
+++ b/packages/tui/test/component/prompt-move.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { resolvePromptMoveDirectory } from "../../src/component/prompt/move"
+
+describe("prompt move directory resolution", () => {
+  test("rejects unavailable existing directories before selecting them", async () => {
+    const errors: unknown[] = []
+    const resolved = await resolvePromptMoveDirectory({
+      selection: { type: "directory", directory: "/missing/project", subdirectory: false },
+      create: async () => {
+        throw new Error("should not create")
+      },
+      validate: async () => {
+        throw new Error("directory missing")
+      },
+      onUnavailable: (error) => errors.push(error),
+    })
+
+    expect(resolved).toBeUndefined()
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(Error)
+    if (errors[0] instanceof Error) expect(errors[0].message).toBe("directory missing")
+  })
+
+  test("returns available existing directories", async () => {
+    const resolved = await resolvePromptMoveDirectory({
+      selection: { type: "directory", directory: "/workspace/project", subdirectory: false },
+      create: async () => undefined,
+      validate: async (directory) => {
+        expect(directory).toBe("/workspace/project")
+      },
+      onUnavailable: () => {
+        throw new Error("should not report available directory")
+      },
+    })
+
+    expect(resolved).toBe("/workspace/project")
+  })
+
+  test("keeps generated project copy destinations", async () => {
+    const resolved = await resolvePromptMoveDirectory({
+      selection: { type: "new" },
+      create: async () => "/workspace/copy",
+      validate: async (directory) => {
+        expect(directory).toBe("/workspace/copy")
+      },
+      onUnavailable: () => {
+        throw new Error("should not report generated directory")
+      },
+    })
+
+    expect(resolved).toBe("/workspace/copy")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39903

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Project directories that were deleted outside opencode could still be selected from the TUI move/project picker, leaving the prompt pointed at an unavailable location.

This validates an existing destination with the location path endpoint before storing it as the home destination, before submitting a new session, and before moving an existing session. If validation fails, the current destination is preserved and an error toast is shown. New project-copy destinations still use the existing creation path.

### How did you verify your code works?

- `bun test test/component/prompt-move.test.ts --timeout 30000`
- `bun test test/component/prompt-move.test.ts test/component/dialog-session-list.test.ts --timeout 60000`
- `bun run typecheck` from `packages/tui`
- `bun run lint packages/tui/src/component/prompt/move.tsx packages/tui/src/component/dialog-move-session.tsx packages/tui/test/component/prompt-move.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A; validation behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR