### PR TITLE
refactor(drizzle): declare query variance

### DIFF
--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
@@ -44,11 +44,12 @@ export type SQLiteEffectSelectPrepare<
   TEffectHKT
 >
 
+// Explicit variance prevents comparisons from recursively scanning Drizzle's conditional select types.
 export class SQLiteEffectSelectBuilder<
-  TSelection extends SelectedFields | undefined,
-  TRunResult,
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
-  TBuilderMode extends "db" | "qb" = "db",
+  out TSelection extends SelectedFields | undefined,
+  out TRunResult,
+  out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  out TBuilderMode extends "db" | "qb" = "db",
 > {
   static readonly [entityKind]: string = "SQLiteEffectSelectBuilder"
 

--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
@@ -303,10 +303,11 @@ export class SQLiteEffectPreparedQuery<
   }
 }
 
+// Explicit variance prevents comparisons from recursively scanning the full Drizzle query-builder graph.
 export abstract class SQLiteEffectSession<
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
-  TRunResult = unknown,
-  TRelations extends AnyRelations = EmptyRelations,
+  out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  out TRunResult = unknown,
+  out TRelations extends AnyRelations = EmptyRelations,
 > {
   static readonly [entityKind]: string = "SQLiteEffectSession"
 
@@ -404,9 +405,9 @@ export abstract class SQLiteEffectSession<
 }
 
 export abstract class SQLiteEffectTransaction<
-  TEffectHKT extends QueryEffectHKTBase,
-  TRunResult,
-  TRelations extends AnyRelations = EmptyRelations,
+  out TEffectHKT extends QueryEffectHKTBase,
+  out TRunResult,
+  out TRelations extends AnyRelations = EmptyRelations,
 > extends SQLiteEffectDatabase<TEffectHKT, TRunResult, TRelations> {
   static override readonly [entityKind]: string = "SQLiteEffectTransaction"
 


### PR DESCRIPTION
## Summary
- declare covariance TypeScript already infers for Effect SQLite sessions, transactions, and select builders
- avoid recursively scanning the full Drizzle query-builder graph whenever those generic types are compared
- preserve runtime behavior and type information; no casts, `any`, or erased constraints are introduced

## Benchmarks
Compiler counters and traces were measured by typechecking `packages/core` before and after the change.

| Metric | Before | After | Difference |
| --- | ---: | ---: | ---: |
| `tsgo` symbols | 3,537,965 | 3,471,588 | -66,377 (-1.9%) |
| `tsgo` types | 1,445,957 | 1,400,059 | -45,898 (-3.2%) |
| `tsgo` instantiations | 6,560,025 | 6,296,125 | -263,900 (-4.0%) |
| `tsgo` memory | 1,994 MB | 1,960 MB | -34 MB |
| traced variance work | 3,029.5ms | 1,739.4ms | -1,290.1ms (-42.6%) |

### Normal typecheck A/B

Ran the exact `bun run typecheck` command from `packages/core` in 20 alternating before/after pairs, after one warmup per state. Alternating the order limits cache and machine-drift bias.

| Wall time | Before | After | Difference |
| --- | ---: | ---: | ---: |
| median | 3.080s | 2.945s | -0.135s (-4.4%) |
| mean | 3.121s | 3.076s | -0.046s (-1.5%) |
| range | 2.58-4.56s | 2.64-4.96s | |

The changed version was faster in 12 of 20 pairs. The median paired difference was -0.095s (-2.9%). Wall time is visibly noisy, including one large outlier in each state, so the deterministic type/instantiation counts are the stronger comparison.

In the TypeScript trace, the `SQLiteEffectSession` variance scan (~431ms) and `SQLiteEffectSelectBuilder` scan (~253ms) disappear. The expression that first triggered the recursive scan drops from roughly 430ms to 10ms.

The improvement comes from telling TypeScript the variance relationships it was already deriving structurally. This lets generic comparisons use type arguments directly instead of traversing session, transaction, database, and conditional select-builder members. The declarations are compiler-checked; the builder-mode annotation is stricter than its previously inferred bivariant relationship, not weaker.

## Testing
- full workspace `bun typecheck` pre-push hook
- `bun test --timeout 30000 --only-failures` in `packages/effect-drizzle-sqlite` (7 passed)

Fixes #40890

### 2-core remote benchmark

Repeated the exact `bun run typecheck` command from `packages/core` on a fresh checkout of `v2` at `0f27ee7b4`, using a Linux VM with 2 AMD EPYC 9554P cores, 7.7GB RAM, and no swap. After one warmup per state, eight before/after runs were alternated.

| Wall time | Before | After | Difference |
| --- | ---: | ---: | ---: |
| median | 8.690s | 8.350s | -0.340s (-3.9%) |
| mean | 8.739s | 8.416s | -0.323s (-3.7%) |
| range | 8.33-9.26s | 8.07-8.83s | |