### PR TITLE
fix(core): load well-known config first

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -233,13 +233,13 @@ export const layer = (options?: Options) => Layer.effect(
 
       const supplementary = yield* Effect.forEach(directories, loadDirectory).pipe(Effect.orDie)
       return [
+        ...(yield* loadWellknown().pipe(Effect.orDie)),
         ...claude,
         ...agents,
         ...(supplementary[0] ?? []),
         ...explicit,
         ...direct,
         ...supplementary.slice(1).flat(),
-        ...(yield* loadWellknown().pipe(Effect.orDie)),
         ...content,
       ]
     })


### PR DESCRIPTION
## Summary
- load authenticated `.well-known` configuration before local configuration sources
- let global, project, and inline user rules override remote organizational defaults

## Testing
- `git diff --check`