### PR TITLE
fix(core): align ChatGPT context limits

### DIFF
--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -220,8 +220,7 @@ export const OpenAIPlugin = define({
             return
           }
           draft.cost = []
-          // Match Codex CLI so context consumption and subscription usage stay consistent between clients.
-          draft.limit = { ...draft.limit, context: 272_000, input: 272_000 }
+          draft.limit = { ...draft.limit, context: 400_000, input: 272_000 }
         })
       }
     })

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -220,6 +220,7 @@ export const OpenAIPlugin = define({
             return
           }
           draft.cost = []
+          // Match Codex CLI so context consumption and subscription usage stay consistent between clients.
           draft.limit = { ...draft.limit, context: 400_000, input: 272_000 }
         })
       }

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -151,6 +151,9 @@ describe("ModelResolver", () => {
           http: { body: { custom_extension: { enabled: true } } },
         },
       })
+      const prepared = yield* compileRequest(LLM.request({ model: resolved, prompt: "Hello" }))
+      expect(prepared.body.max_output_tokens).toBeUndefined()
+      expect(JSON.stringify(prepared.body)).not.toContain("max_output_tokens")
     }),
   )
 

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -140,7 +140,7 @@ describe("OpenAIPlugin", () => {
       const eligible = required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))
       expect(eligible.package).toBe("@opencode-ai/ai/providers/openai")
       expect(eligible.cost).toEqual([])
-      expect(eligible.limit).toEqual({ context: 272_000, input: 272_000, output: 128_000 })
+      expect(eligible.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
       expect(eligible.enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5-pro"))).enabled).toBe(
         false,
@@ -149,14 +149,14 @@ describe("OpenAIPlugin", () => {
         false,
       )
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.4"))).limit).toEqual({
-        context: 272_000,
+        context: 400_000,
         input: 272_000,
         output: 64_000,
       })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6"))).enabled).toBe(false)
       const gpt56 = required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.6-sol")))
       expect(gpt56.enabled).toBe(true)
-      expect(gpt56.limit).toEqual({ context: 272_000, input: 272_000, output: 128_000 })
+      expect(gpt56.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.1"))).enabled).toBe(false)
     }),
   )


### PR DESCRIPTION
## Summary
- expose the ChatGPT-plan context window as 400k while retaining the 272k input ceiling
- preserve each model's advertised output limit
- verify native OpenAI requests omit `max_output_tokens` unless explicitly configured

## Compaction impact
With the default 20k compaction buffer, the prompt ceiling moves from 240k to 252k tokens.

## Testing
- `bun test test/plugin/provider-openai.test.ts test/model-resolver.test.ts test/session-compaction.test.ts`
- `bun typecheck`