### PR TITLE
feat(core): add Cloudflare connection prompts

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -561,7 +561,13 @@ function ProviderConnection(props: {
           if (!alive.value) return
           dispatch({ type: "auth.error", error: formatError(e, language.t("common.requestFailed")) })
         })
+      return
     }
+    if (method.prompts?.length && !inputs) {
+      dispatch({ type: "auth.prompt" })
+      return
+    }
+    dispatch({ type: "auth.inputs", inputs: inputs ?? {} })
   }
 
   function AuthPromptsView() {
@@ -572,7 +578,7 @@ function ProviderConnection(props: {
 
     const prompts = createMemo(() => {
       const value = method()
-      return value?.type === "oauth" ? (value.prompts ?? []) : []
+      return value?.prompts ?? []
     })
     const matches = (prompt: NonNullable<ReturnType<typeof prompts>[number]>, value: Record<string, string>) => {
       if (!prompt.when) return true
@@ -820,6 +826,7 @@ function ProviderConnection(props: {
         integrationID: props.provider,
         location: location(),
         key: apiKey,
+        inputs: store.promptInputs ?? {},
       })
       await complete()
     }

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -992,6 +992,7 @@ export type Endpoint10_3Input = {
   readonly integrationID: Integration.ID
   readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
   readonly key: string
+  readonly inputs?: { readonly [x: string]: string } | undefined
   readonly label?: string | undefined
 }
 export type Endpoint10_3Output = void

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -664,7 +664,7 @@ const Endpoint10_3 = (raw: RawClient["server.integration"]) => (input: Endpoint1
     raw["integration.connect.key"]({
       params: { integrationID: input["integrationID"] },
       query: { location: input["location"] },
-      payload: { key: input["key"], label: input["label"] },
+      payload: { key: input["key"], inputs: input["inputs"], label: input["label"] },
     }).pipe(Effect.mapError(mapClientError)),
   )
 

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -963,7 +963,7 @@ export function make(options: ClientOptions) {
               method: "POST",
               path: `/api/integration/${encodeURIComponent(input.integrationID)}/connect/key`,
               query: { location: input["location"] },
-              body: { key: input["key"], label: input["label"] },
+              body: { key: input["key"], inputs: input["inputs"], label: input["label"] },
               successStatus: 204,
               declaredStatuses: [400, 401],
               empty: true,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -197,8 +197,6 @@ export type IntegrationWhen = { key: string; op: "eq" | "neq"; value: string }
 
 export type IntegrationCommandMethod = { id: string; type: "command"; label: string; command: Array<string> }
 
-export type IntegrationKeyMethod = { type: "key"; label?: string }
-
 export type IntegrationEnvMethod = { type: "env"; names: Array<string> }
 
 export type ConnectionCredentialInfo = { type: "credential"; id: string; label: string }
@@ -1635,6 +1633,12 @@ export type IntegrationOAuthMethod = {
   id: string
   type: "oauth"
   label: string
+  prompts?: Array<IntegrationTextPrompt | IntegrationSelectPrompt>
+}
+
+export type IntegrationKeyMethod = {
+  type: "key"
+  label?: string
   prompts?: Array<IntegrationTextPrompt | IntegrationSelectPrompt>
 }
 
@@ -3119,8 +3123,21 @@ export type IntegrationConnectKeyInput = {
   readonly location?: {
     readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
   }["location"]
-  readonly key: { readonly key: string; readonly label?: string | undefined }["key"]
-  readonly label?: { readonly key: string; readonly label?: string | undefined }["label"]
+  readonly key: {
+    readonly key: string
+    readonly inputs?: { readonly [x: string]: string } | undefined
+    readonly label?: string | undefined
+  }["key"]
+  readonly inputs?: {
+    readonly key: string
+    readonly inputs?: { readonly [x: string]: string } | undefined
+    readonly label?: string | undefined
+  }["inputs"]
+  readonly label?: {
+    readonly key: string
+    readonly inputs?: { readonly [x: string]: string } | undefined
+    readonly label?: string | undefined
+  }["label"]
 }
 
 export type IntegrationConnectKeyOutput = void

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -175,6 +175,8 @@ export interface Interface extends State.Transformable<Draft> {
       readonly integrationID: ID
       /** Secret entered by the user. */
       readonly key: string
+      /** Provider-specific values collected before the secret. */
+      readonly inputs?: Inputs
       /** User-facing label for the stored credential. */
       readonly label?: string
     }) => Effect.Effect<void, AuthorizationError>
@@ -704,7 +706,11 @@ const layer = Layer.effect(
           yield* credentials.create({
             integrationID: input.integrationID,
             label: input.label,
-            value: Credential.Key.make({ type: "key", key: input.key }),
+            value: Credential.Key.make({
+              type: "key",
+              key: input.key,
+              metadata: input.inputs && Object.keys(input.inputs).length > 0 ? input.inputs : undefined,
+            }),
           })
           yield* bus.publish(Integration.Event.ConnectionUpdated, { integrationID: input.integrationID })
           yield* bus.publish(Integration.Event.Updated, {})

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -192,6 +192,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
           integration.connection.key({
             integrationID: Integration.ID.make(input.integrationID),
             key: input.key,
+            inputs: input.inputs,
             label: input.label,
           }),
       },
@@ -398,7 +399,7 @@ function methodImplementation(input: IntegrationMethodRegistration): Integration
   }
   return {
     integrationID: Integration.ID.make(input.integrationID),
-    method: { type: "key", label: input.method.label },
+    method: { type: "key", label: input.method.label, prompts: input.method.prompts },
   }
 }
 

--- a/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
+++ b/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
@@ -6,6 +6,37 @@ import { define } from "@opencode-ai/plugin/effect/plugin"
 export const CloudflareAIGatewayPlugin = define({
   id: "opencode.provider.cloudflare-ai-gateway",
   effect: Effect.fn(function* (ctx) {
+    yield* ctx.integration.transform((draft) => {
+      draft.method.update({
+        integrationID: "cloudflare-ai-gateway",
+        method: {
+          type: "key",
+          label: "Gateway API token",
+          prompts: [
+            ...(process.env.CLOUDFLARE_ACCOUNT_ID
+              ? []
+              : [
+                  {
+                    type: "text" as const,
+                    key: "accountId",
+                    message: "Enter your Cloudflare Account ID",
+                    placeholder: "e.g. 1234567890abcdef1234567890abcdef",
+                  },
+                ]),
+            ...(process.env.CLOUDFLARE_GATEWAY_ID
+              ? []
+              : [
+                  {
+                    type: "text" as const,
+                    key: "gatewayId",
+                    message: "Enter your Cloudflare AI Gateway ID",
+                    placeholder: "e.g. my-gateway",
+                  },
+                ]),
+          ],
+        },
+      })
+    })
     yield* ctx.aisdk.hook(
       "sdk",
       Effect.fn(function* (evt) {

--- a/packages/core/src/plugin/provider/cloudflare-workers-ai.ts
+++ b/packages/core/src/plugin/provider/cloudflare-workers-ai.ts
@@ -9,6 +9,25 @@ const providerID = Provider.ID.make("cloudflare-workers-ai")
 export const CloudflareWorkersAIPlugin = define({
   id: "opencode.provider.cloudflare-workers-ai",
   effect: Effect.fn(function* (ctx) {
+    yield* ctx.integration.transform((draft) => {
+      draft.method.update({
+        integrationID: providerID,
+        method: {
+          type: "key",
+          label: "API key",
+          prompts: process.env.CLOUDFLARE_ACCOUNT_ID
+            ? undefined
+            : [
+                {
+                  type: "text",
+                  key: "accountId",
+                  message: "Enter your Cloudflare Account ID",
+                  placeholder: "e.g. 1234567890abcdef1234567890abcdef",
+                },
+              ],
+        },
+      })
+    })
     yield* ctx.catalog.transform((evt) => {
       const item = evt.provider.get(providerID)
       if (!item) return

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -151,6 +151,7 @@ describe("Integration", () => {
       yield* integrations.connection.key({
         integrationID,
         key: "secret",
+        inputs: { accountId: "account" },
         label: "Work",
       })
 
@@ -158,7 +159,7 @@ describe("Integration", () => {
         expect.objectContaining({
           integrationID,
           label: "Work",
-          value: Credential.Key.make({ type: "key", key: "secret" }),
+          value: Credential.Key.make({ type: "key", key: "secret", metadata: { accountId: "account" } }),
         }),
       ])
       expect((yield* Fiber.join(updated)).length).toBe(1)

--- a/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
+++ b/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
@@ -6,6 +6,7 @@ import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { CloudflareAIGatewayPlugin } from "@opencode-ai/core/plugin/provider/cloudflare-ai-gateway"
 import { Provider } from "@opencode-ai/core/provider"
+import { Integration } from "@opencode-ai/core/integration"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 
@@ -102,6 +103,39 @@ mock.module("ai-gateway-provider/providers/unified", () => ({
 }))
 
 describe("CloudflareAIGatewayPlugin", () => {
+  it.effect("prompts for account and gateway IDs when the environment does not provide them", () =>
+    withEnv(
+      cloudflareEnv({
+        CLOUDFLARE_ACCOUNT_ID: undefined,
+        CLOUDFLARE_GATEWAY_ID: undefined,
+      }),
+      () =>
+        Effect.gen(function* () {
+          yield* addPlugin()
+          expect(
+            (yield* (yield* Integration.Service).get(Integration.ID.make("cloudflare-ai-gateway")))?.methods,
+          ).toContainEqual({
+            type: "key",
+            label: "Gateway API token",
+            prompts: [
+              {
+                type: "text",
+                key: "accountId",
+                message: "Enter your Cloudflare Account ID",
+                placeholder: "e.g. 1234567890abcdef1234567890abcdef",
+              },
+              {
+                type: "text",
+                key: "gatewayId",
+                message: "Enter your Cloudflare AI Gateway ID",
+                placeholder: "e.g. my-gateway",
+              },
+            ],
+          })
+        }),
+    ),
+  )
+
   it.effect("requires account, gateway, and token before creating the unified SDK", () =>
     withEnv(
       {

--- a/packages/core/test/plugin/provider-cloudflare-workers-ai.test.ts
+++ b/packages/core/test/plugin/provider-cloudflare-workers-ai.test.ts
@@ -7,6 +7,7 @@ import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { CloudflareWorkersAIPlugin } from "@opencode-ai/core/plugin/provider/cloudflare-workers-ai"
 import { Provider } from "@opencode-ai/core/provider"
+import { Integration } from "@opencode-ai/core/integration"
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
@@ -79,6 +80,28 @@ function cloudflareHeaders(sdk: unknown, modelID = "@cf/model") {
 }
 
 describe("CloudflareWorkersAIPlugin", () => {
+  it.effect("prompts for the account ID when the environment does not provide it", () =>
+    withEnv({ CLOUDFLARE_ACCOUNT_ID: undefined }, () =>
+      Effect.gen(function* () {
+        yield* addPlugin()
+        expect(
+          (yield* (yield* Integration.Service).get(Integration.ID.make("cloudflare-workers-ai")))?.methods,
+        ).toContainEqual({
+          type: "key",
+          label: "API key",
+          prompts: [
+            {
+              type: "text",
+              key: "accountId",
+              message: "Enter your Cloudflare Account ID",
+              placeholder: "e.g. 1234567890abcdef1234567890abcdef",
+            },
+          ],
+        })
+      }),
+    ),
+  )
+
   it.effect("maps account ID to endpoint URL and creates an OpenAI-compatible SDK", () =>
     withEnv({ CLOUDFLARE_ACCOUNT_ID: "acct", CLOUDFLARE_API_KEY: "key" }, () =>
       Effect.gen(function* () {

--- a/packages/protocol/src/groups/integration.ts
+++ b/packages/protocol/src/groups/integration.ts
@@ -59,6 +59,7 @@ export const IntegrationGroup = HttpApiGroup.make("server.integration")
       query: LocationQuery,
       payload: Schema.Struct({
         key: Schema.String,
+        inputs: Schema.optional(Inputs),
         label: Schema.optional(Schema.String),
       }),
       success: HttpApiSchema.NoContent,

--- a/packages/schema/src/integration.ts
+++ b/packages/schema/src/integration.ts
@@ -68,6 +68,7 @@ export interface KeyMethod extends Schema.Schema.Type<typeof KeyMethod> {}
 export const KeyMethod = Schema.Struct({
   type: Schema.Literal("key"),
   label: optional(Schema.String),
+  prompts: optional(Schema.Array(Prompt)),
 }).annotate({ identifier: "Integration.KeyMethod" })
 
 export interface EnvMethod extends Schema.Schema.Type<typeof EnvMethod> {}

--- a/packages/server/src/handlers/integration.ts
+++ b/packages/server/src/handlers/integration.ts
@@ -58,6 +58,7 @@ export const IntegrationHandler = HttpApiBuilder.group(Api, "server.integration"
             service.connection.key({
               integrationID: ctx.params.integrationID,
               key: ctx.payload.key,
+              inputs: ctx.payload.inputs,
               label: ctx.payload.label,
             }),
           )

--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -180,7 +180,7 @@ function openMethod(
   onConnected?: OnIntegrationConnected,
 ) {
   if (method.type === "key") {
-    dialog.replace(() => <KeyMethod integration={integration} method={method} onConnected={onConnected} />)
+    void beginKey(integration, method, dialog, onConnected)
     return
   }
   if (method.type === "command") {
@@ -188,6 +188,19 @@ function openMethod(
     return
   }
   void beginOAuth(integration, method, dialog, onConnected)
+}
+
+async function beginKey(
+  integration: IntegrationInfo,
+  method: Extract<ConnectMethod, { type: "key" }>,
+  dialog: ReturnType<typeof useDialog>,
+  onConnected?: OnIntegrationConnected,
+) {
+  const inputs = method.prompts?.length ? await promptInputs(dialog, method.prompts) : {}
+  if (inputs === null) return
+  dialog.replace(() => (
+    <KeyMethod integration={integration} method={method} inputs={inputs} onConnected={onConnected} />
+  ))
 }
 
 function CommandStarting(props: {
@@ -335,6 +348,7 @@ function CommandView(props: { title: string; output: string; message: string }) 
 function KeyMethod(props: {
   integration: IntegrationInfo
   method: Extract<ConnectMethod, { type: "key" }>
+  inputs: Record<string, string>
   onConnected?: OnIntegrationConnected
 }) {
   const data = useData()
@@ -355,6 +369,7 @@ function KeyMethod(props: {
             integrationID: props.integration.id,
             location: location(data),
             key,
+            inputs: props.inputs,
           })
           .then(() => connected(props.integration, data, dialog, toast, props.onConnected))
           .catch((cause) => setError(message(cause)))


### PR DESCRIPTION
## Summary
- allow key authentication methods to collect provider-specific prompt inputs
- persist prompt values as credential metadata and expose the flow in the App and TUI
- prompt for Cloudflare Workers AI account IDs and AI Gateway account/gateway IDs when environment variables are absent
- regenerate the public clients for the integration API change

## Provider routing
- Workers AI continues to use `@ai-sdk/openai-compatible`
- AI Gateway continues to use `ai-gateway-provider` with its unified adapter

## Testing
- targeted integration and Cloudflare provider tests
- full Core suite: 1,522 passed, 7 skipped
- full TUI suite: 593 passed, 5 skipped
- typechecks: Core, Schema, Protocol, Server, Client, TUI, App