### PR TITLE
refactor(mcp): remove unused registration status

### DIFF
--- a/packages/app/src/components/dialog-select-mcp.tsx
+++ b/packages/app/src/components/dialog-select-mcp.tsx
@@ -10,7 +10,6 @@ const statusLabels = {
   connected: "mcp.status.connected",
   failed: "mcp.status.failed",
   needs_auth: "mcp.status.needs_auth",
-  needs_client_registration: "mcp.status.needs_client_registration",
   disabled: "mcp.status.disabled",
 } as const
 
@@ -57,7 +56,7 @@ export const DialogSelectMcp: Component = () => {
           }
           const error = () => {
             const s = mcpStatus()
-            if (s?.status === "failed" || s?.status === "needs_client_registration") return s.error
+            if (s?.status === "failed") return s.error
           }
           const enabled = () => status() === "connected"
           return (

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -426,8 +426,7 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                             "bg-icon-success-base": status() === "connected",
                             "bg-icon-critical-base": status() === "failed",
                             "bg-border-weak-base": status() === "disabled",
-                            "bg-icon-warning-base":
-                              status() === "needs_auth" || status() === "needs_client_registration",
+                            "bg-icon-warning-base": status() === "needs_auth",
                           }}
                         />
                         <span class="flex flex-col min-w-0 flex-1">

--- a/packages/app/src/components/status-popover-indicator.test.ts
+++ b/packages/app/src/components/status-popover-indicator.test.ts
@@ -35,7 +35,6 @@ describe("hasNonBlockingServiceIssue", () => {
   test("detects MCP failures that do not block chatting", () => {
     expect(hasNonBlockingServiceIssue({ mcp: ["failed"], lsp: [] })).toBe(true)
     expect(hasNonBlockingServiceIssue({ mcp: ["needs_auth"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: ["needs_client_registration"], lsp: [] })).toBe(true)
     expect(hasNonBlockingServiceIssue({ mcp: ["connected", "pending", "disabled"], lsp: [] })).toBe(false)
   })
 
@@ -48,7 +47,6 @@ describe("hasNonBlockingServiceIssue", () => {
 describe("hasServiceNeedingAttention", () => {
   test("detects MCP states that need user attention", () => {
     expect(hasServiceNeedingAttention({ mcp: ["needs_auth"] })).toBe(true)
-    expect(hasServiceNeedingAttention({ mcp: ["needs_client_registration"] })).toBe(true)
   })
 
   test("ignores states that do not need user attention", () => {

--- a/packages/app/src/components/status-popover-indicator.ts
+++ b/packages/app/src/components/status-popover-indicator.ts
@@ -2,7 +2,7 @@ import type { LspStatus } from "@/types"
 import type { McpServer } from "@opencode-ai/client/promise"
 
 export function hasServiceNeedingAttention(input: { mcp: Array<McpServer["status"]["status"]> }) {
-  return input.mcp.some((status) => status === "needs_auth" || status === "needs_client_registration")
+  return input.mcp.some((status) => status === "needs_auth")
 }
 
 export function hasNonBlockingServiceIssue(input: {

--- a/packages/app/src/context/global-sync/mcp.ts
+++ b/packages/app/src/context/global-sync/mcp.ts
@@ -13,7 +13,6 @@ export async function toggleMcp(input: {
     needs_auth: input.authenticate,
     disabled: input.connect,
     failed: input.connect,
-    needs_client_registration: input.connect,
   }[input.status]()
   await input.refresh()
 }

--- a/packages/cli/src/commands/handlers/mcp/list.ts
+++ b/packages/cli/src/commands/handlers/mcp/list.ts
@@ -34,7 +34,6 @@ function icon(status: McpServer["status"]) {
     case "needs_auth":
       return "⚠"
     case "failed":
-    case "needs_client_registration":
       return "✗"
     default:
       return "○"
@@ -45,8 +44,6 @@ function describe(status: McpServer["status"]) {
   switch (status.status) {
     case "needs_auth":
       return "needs authentication"
-    case "needs_client_registration":
-      return `needs client registration: ${status.error}`
     case "failed":
       return `failed: ${status.error}`
     default:

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -259,8 +259,6 @@ export type McpStatusFailed = { status: "failed"; error: string }
 
 export type McpStatusNeedsAuth = { status: "needs_auth" }
 
-export type McpStatusNeedsClientRegistration = { status: "needs_client_registration"; error: string }
-
 export type McpResource = { server: string; name: string; uri: string; description?: string; mimeType?: string }
 
 export type McpResourceTemplate = {
@@ -1261,13 +1259,7 @@ export type ConnectionInfo = ConnectionCredentialInfo | ConnectionEnvInfo
 
 export type McpServer = {
   name: string
-  status:
-    | McpStatusConnected
-    | McpStatusPending
-    | McpStatusDisabled
-    | McpStatusFailed
-    | McpStatusNeedsAuth
-    | McpStatusNeedsClientRegistration
+  status: McpStatusConnected | McpStatusPending | McpStatusDisabled | McpStatusFailed | McpStatusNeedsAuth
   integrationID?: string
 }
 

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -20687,25 +20687,6 @@
         ],
         "additionalProperties": false
       },
-      "Mcp.Status.NeedsClientRegistration": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "needs_client_registration"
-            ]
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "error"
-        ],
-        "additionalProperties": false
-      },
       "Mcp.Server": {
         "type": "object",
         "properties": {
@@ -20728,9 +20709,6 @@
               },
               {
                 "$ref": "#/components/schemas/Mcp.Status.NeedsAuth"
-              },
-              {
-                "$ref": "#/components/schemas/Mcp.Status.NeedsClientRegistration"
               }
             ]
           },

--- a/packages/schema/src/mcp.ts
+++ b/packages/schema/src/mcp.ts
@@ -68,13 +68,9 @@ const Failed = Schema.Struct({ status: Schema.Literal("failed"), error: Schema.S
 const NeedsAuth = Schema.Struct({ status: Schema.Literal("needs_auth") }).annotate({
   identifier: "Mcp.Status.NeedsAuth",
 })
-const NeedsClientRegistration = Schema.Struct({
-  status: Schema.Literal("needs_client_registration"),
-  error: Schema.String,
-}).annotate({ identifier: "Mcp.Status.NeedsClientRegistration" })
 
 export type Status = typeof Status.Type
-export const Status = Schema.Union([Connected, Pending, Disabled, Failed, NeedsAuth, NeedsClientRegistration]).pipe(
+export const Status = Schema.Union([Connected, Pending, Disabled, Failed, NeedsAuth]).pipe(
   Schema.toTaggedUnion("status"),
 )
 

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -15,7 +15,7 @@ import { useConfig } from "../config"
 import { getScrollAcceleration } from "../util/scroll"
 
 function statusError(status: McpServer["status"]) {
-  if (status.status === "failed" || status.status === "needs_client_registration") return status.error
+  if (status.status === "failed") return status.error
   return undefined
 }
 

--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -14,7 +14,6 @@ export function DialogStatus() {
     if (status === "connected") return theme.text.feedback.success.default
     if (status === "failed") return theme.text.feedback.error.default
     if (status === "needs_auth") return theme.text.feedback.warning.default
-    if (status === "needs_client_registration") return theme.text.feedback.error.default
     return theme.text.subdued
   }
   return (
@@ -46,9 +45,6 @@ export function DialogStatus() {
                       <Match when={item.status.status === "failed" && item.status}>{(val) => val().error}</Match>
                       <Match when={item.status.status === "disabled"}>Disabled in configuration</Match>
                       <Match when={item.status.status === "needs_auth"}>Needs authentication</Match>
-                      <Match when={item.status.status === "needs_client_registration" && item.status}>
-                        {(val) => (val() as { error: string }).error}
-                      </Match>
                     </Switch>
                   </span>
                 </text>

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -8,13 +8,7 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
   const list = createMemo(() => props.context.data.location.mcp.server.list(session()?.location) ?? [])
   const on = createMemo(() => list().filter((item) => item.status.status === "connected").length)
   const bad = createMemo(
-    () =>
-      list().filter(
-        (item) =>
-          item.status.status === "failed" ||
-          item.status.status === "needs_auth" ||
-          item.status.status === "needs_client_registration",
-      ).length,
+    () => list().filter((item) => item.status.status === "failed" || item.status.status === "needs_auth").length,
   )
 
   const dot = (status: string) => {
@@ -22,7 +16,6 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
     if (status === "failed") return theme.text.feedback.error.default
     if (status === "disabled") return theme.text.subdued
     if (status === "needs_auth") return theme.text.feedback.warning.default
-    if (status === "needs_client_registration") return theme.text.feedback.error.default
     return theme.text.subdued
   }
 
@@ -65,7 +58,6 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
                       </Match>
                       <Match when={item.status.status === "disabled"}>Disabled</Match>
                       <Match when={item.status.status === "needs_auth"}>Needs auth</Match>
-                      <Match when={item.status.status === "needs_client_registration"}>Needs client ID</Match>
                     </Switch>
                   </span>
                 </text>

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -20687,25 +20687,6 @@
         ],
         "additionalProperties": false
       },
-      "Mcp.Status.NeedsClientRegistration": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "needs_client_registration"
-            ]
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "error"
-        ],
-        "additionalProperties": false
-      },
       "Mcp.Server": {
         "type": "object",
         "properties": {
@@ -20728,9 +20709,6 @@
               },
               {
                 "$ref": "#/components/schemas/Mcp.Status.NeedsAuth"
-              },
-              {
-                "$ref": "#/components/schemas/Mcp.Status.NeedsClientRegistration"
               }
             ]
           },

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -20687,25 +20687,6 @@
         ],
         "additionalProperties": false
       },
-      "Mcp.Status.NeedsClientRegistration": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "needs_client_registration"
-            ]
-          },
-          "error": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "status",
-          "error"
-        ],
-        "additionalProperties": false
-      },
       "Mcp.Server": {
         "type": "object",
         "properties": {
@@ -20728,9 +20709,6 @@
               },
               {
                 "$ref": "#/components/schemas/Mcp.Status.NeedsAuth"
-              },
-              {
-                "$ref": "#/components/schemas/Mcp.Status.NeedsClientRegistration"
               }
             ]
           },


### PR DESCRIPTION
### What does this PR do?

Removes the `needs_client_registration` MCP status from the V2 public contract and deletes the unreachable CLI, TUI, and App branches that handled it. Core never produced this status; OAuth registration failures are surfaced by the separate integration login attempt instead.

This intentionally does not add new OAuth error classification. Actionable handling for authorization servers that require a pre-registered client can be designed separately without preserving a dead connection status or matching SDK error strings.

Regenerates the TypeScript client and OpenAPI documents after the schema change.

### Verification

- `bun typecheck` in `packages/schema`, `packages/protocol`, `packages/client`, `packages/cli`, `packages/tui`, `packages/app`, `packages/core`, and `packages/server`
- `bun test test/mcp.test.ts` in `packages/schema`
- `bun test src/components/status-popover-indicator.test.ts src/context/global-sync/mcp.test.ts` in `packages/app`
- generated artifact checks in `packages/protocol`, `packages/client`, and `packages/www`