### PR TITLE
feat(core): increase retained compaction context

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -20,7 +20,7 @@ import type { Info } from "../model"
 import { SessionUsage } from "./usage"
 
 const DEFAULT_BUFFER = 20_000
-const DEFAULT_KEEP_TOKENS = 8_000
+const DEFAULT_KEEP_TOKENS = 15_000
 const OUTPUT_TOKEN_MAX = 32_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.

--- a/packages/www/content/docs/(Configure)/compaction.mdx
+++ b/packages/www/content/docs/(Configure)/compaction.mdx
@@ -83,7 +83,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
     "auto": true,
     "prune": false,
     "keep": {
-      "tokens": 8000
+      "tokens": 15000
     },
     "buffer": 20000
   }
@@ -94,7 +94,7 @@ Add `compaction` to any [OpenCode configuration file](/config):
 | --- | ---: | --- |
 | `auto` | `true` | Runs the preflight context-size check. It does not disable manual compaction or one-shot provider-overflow recovery. |
 | `prune` | None | Accepted by the V2 schema, but currently has no runtime effect. V2 does not prune old tool outputs in place. |
-| `keep.tokens` | `8000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
+| `keep.tokens` | `15000` | Approximate number of tokens from the newest serialized conversation context to retain beside the summary. |
 | `buffer` | `20000` | Safety reserve below an explicit input limit. Without one, it is the minimum context reserve and the model output allowance wins when larger. |
 
 `keep.tokens` and `buffer` accept non-negative integers. Larger `keep.tokens`

--- a/packages/www/content/docs/config.mdx
+++ b/packages/www/content/docs/config.mdx
@@ -329,7 +329,7 @@ Control automatic context compaction and how much recent context it preserves.
   "compaction": {
     "auto": true,
     "keep": {
-      "tokens": 8000
+      "tokens": 15000
     },
     "buffer": 20000
   }


### PR DESCRIPTION
## Summary
- increase the default retained compaction context from 8,000 to 15,000 tokens
- update the documented default

## Testing
- `bun typecheck` in `packages/core`
- `bun validate` in `packages/www`