### PR TITLE
fix(tui): open authorization links

### DIFF
--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -605,16 +605,18 @@ function OAuthView(props: {
         )}
       </Show>
       <text fg={theme.text.subdued}>{props.message}</text>
-      <Show when={props.open}>
-        <text fg={theme.text.default}>
-          o <span style={{ fg: theme.text.subdued }}>open</span>
-        </text>
-      </Show>
-      <Show when={props.copy}>
-        <text fg={theme.text.default}>
-          c <span style={{ fg: theme.text.subdued }}>copy</span>
-        </text>
-      </Show>
+      <box flexDirection="row" gap={2}>
+        <Show when={props.open}>
+          <text fg={theme.text.default}>
+            o <span style={{ fg: theme.text.subdued }}>open</span>
+          </text>
+        </Show>
+        <Show when={props.copy}>
+          <text fg={theme.text.default}>
+            c <span style={{ fg: theme.text.subdued }}>copy</span>
+          </text>
+        </Show>
+      </box>
     </box>
   )
 }

--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -6,6 +6,7 @@ import type {
   IntegrationOauthConnectOutput,
   IntegrationOAuthMethod,
 } from "@opencode-ai/client"
+import open from "open"
 import { createMemo, createSignal, onCleanup, onMount, Show } from "solid-js"
 import { useClipboard } from "../context/clipboard"
 import { useData } from "../context/data"
@@ -446,6 +447,19 @@ function OAuthAuto(props: {
     mode: "modal",
     commands: [
       {
+        bind: "o",
+        title: "Open authorization URL",
+        group: "Dialog",
+        run: () => {
+          open(props.attempt.url).catch(() =>
+            toast.show({
+              message: "Could not open the browser. Copy the URL and continue manually.",
+              variant: "error",
+            }),
+          )
+        },
+      },
+      {
         bind: "c",
         title: "Copy authorization details",
         group: "Dialog",
@@ -502,6 +516,7 @@ function OAuthAuto(props: {
       instructions={props.attempt.instructions}
       message="Waiting for authorization..."
       copy
+      open
     />
   )
 }
@@ -559,7 +574,14 @@ function OAuthCode(props: {
   )
 }
 
-function OAuthView(props: { title: string; url?: string; instructions?: string; message: string; copy?: boolean }) {
+function OAuthView(props: {
+  title: string
+  url?: string
+  instructions?: string
+  message: string
+  copy?: boolean
+  open?: boolean
+}) {
   const dialog = useDialog()
   const theme = useTheme("elevated")
   return (
@@ -583,6 +605,11 @@ function OAuthView(props: { title: string; url?: string; instructions?: string; 
         )}
       </Show>
       <text fg={theme.text.subdued}>{props.message}</text>
+      <Show when={props.open}>
+        <text fg={theme.text.default}>
+          o <span style={{ fg: theme.text.subdued }}>open</span>
+        </text>
+      </Show>
       <Show when={props.copy}>
         <text fg={theme.text.default}>
           c <span style={{ fg: theme.text.subdued }}>copy</span>

--- a/packages/tui/src/ui/link.tsx
+++ b/packages/tui/src/ui/link.tsx
@@ -28,7 +28,7 @@ export function Link(props: LinkProps) {
         open(props.href).catch(() => {})
       }}
     >
-      {displayText}
+      <a href={props.href}>{displayText}</a>
     </text>
   )
 }


### PR DESCRIPTION
## What

Make OAuth device authorization links keyboard-accessible in the TUI. The waiting dialog now advertises `o open`, while `c copy` remains available as the manual fallback.

## Before / After

**Before:** The authorization URL was visible and mouse-clickable, but keyboard users could only copy the device code or URL and open it manually.

**After:** Pressing `o` opens the authorization URL in the default browser. If browser launch fails, the dialog shows an error directing the user to copy the URL. Rendered links also use OpenTUI's native `<a href>` element so supported terminals receive hyperlink metadata.

## How

- `packages/tui/src/component/dialog-integration.tsx` registers the modal `o` command and renders its key hint.
- `packages/tui/src/ui/link.tsx` renders the shared link through OpenTUI's native anchor element while preserving mouse opening.

## Scope

This only changes automatic OAuth/device authorization dialogs. Manual code-entry dialogs are unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/cmd/tui/integration-options.test.ts` from `packages/tui`
- Full repository typecheck via the pre-push hook
- Real isolated PTY walkthrough with `termctrl`, from `/connect` through the OpenCode Console authorization dialog

## Demo

Fresh isolated TUI showing `o open` and `c copy` in one action row. The displayed authorization attempt was canceled immediately after capture.

![OAuth authorization dialog with horizontally aligned o open and c copy actions](https://github.com/user-attachments/assets/35921378-529c-46d1-a6fd-3a6ed3b20e7f)
