### PR TITLE
fix(tui): simplify MCP status rows

### DIFF
--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -6,7 +6,7 @@ import { pipe, sortBy } from "remeda"
 import { DialogSelect } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
 import { useTheme } from "../context/theme"
-import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
+import { TextAttributes, type RGBA, type ScrollBoxRenderable } from "@opentui/core"
 import type { McpServer } from "@opencode-ai/client"
 import { useClipboard } from "../context/clipboard"
 import { useToast } from "../ui/toast"
@@ -19,21 +19,26 @@ function statusError(status: McpServer["status"]) {
   return undefined
 }
 
-function Status(props: { status: McpServer["status"]; loading: boolean }) {
+function Status(props: { status: McpServer["status"]; loading: boolean; active: boolean }) {
   const theme = useTheme("elevated")
+  const color = (fallback: RGBA) => (props.active ? theme.text.action.primary.focused : fallback)
   if (props.loading || props.status.status === "pending") {
-    return <span style={{ fg: theme.text.subdued }}>Connecting …</span>
+    return <span style={{ fg: color(theme.text.subdued) }}>Connecting …</span>
   }
   if (props.status.status === "connected") {
-    return <span style={{ fg: theme.text.feedback.success.default, attributes: TextAttributes.BOLD }}>Connected ✓</span>
+    return (
+      <span style={{ fg: color(theme.text.feedback.success.default), attributes: TextAttributes.BOLD }}>
+        Connected ✓
+      </span>
+    )
   }
   if (props.status.status === "failed") {
-    return <span style={{ fg: theme.text.feedback.error.default }}>Failed !</span>
+    return <span style={{ fg: color(theme.text.feedback.error.default) }}>Failed !</span>
   }
   if (props.status.status === "needs_auth") {
-    return <span style={{ fg: theme.text.feedback.warning.default }}>Sign in required →</span>
+    return <span style={{ fg: color(theme.text.feedback.warning.default) }}>Sign in required →</span>
   }
-  return <span style={{ fg: theme.text.subdued }}>Disabled ○</span>
+  return <span style={{ fg: color(theme.text.subdued) }}>Disabled ○</span>
 }
 
 export function DialogMcp() {
@@ -64,7 +69,7 @@ export function DialogMcp() {
     return servers().map((server) => ({
       value: server.name,
       title: server.name,
-      footer: <Status status={server.status} loading={loadingMcp === server.name} />,
+      footer: <Status status={server.status} loading={loadingMcp === server.name} active={focused() === server.name} />,
     }))
   })
 

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -19,13 +19,21 @@ function statusError(status: McpServer["status"]) {
   return undefined
 }
 
-function Status(props: { enabled: boolean; loading: boolean }) {
+function Status(props: { status: McpServer["status"]; loading: boolean }) {
   const theme = useTheme("elevated")
-  if (props.loading) return <span style={{ fg: theme.text.subdued }}>⋯ Loading</span>
-  if (props.enabled) {
-    return <span style={{ fg: theme.text.feedback.success.default, attributes: TextAttributes.BOLD }}>✓ Enabled</span>
+  if (props.loading || props.status.status === "pending") {
+    return <span style={{ fg: theme.text.subdued }}>Connecting …</span>
   }
-  return <span style={{ fg: theme.text.subdued }}>○ Disabled</span>
+  if (props.status.status === "connected") {
+    return <span style={{ fg: theme.text.feedback.success.default, attributes: TextAttributes.BOLD }}>Connected ✓</span>
+  }
+  if (props.status.status === "failed") {
+    return <span style={{ fg: theme.text.feedback.error.default }}>Failed !</span>
+  }
+  if (props.status.status === "needs_auth") {
+    return <span style={{ fg: theme.text.feedback.warning.default }}>Sign in required →</span>
+  }
+  return <span style={{ fg: theme.text.subdued }}>Disabled ○</span>
 }
 
 export function DialogMcp() {
@@ -56,14 +64,22 @@ export function DialogMcp() {
     return servers().map((server) => ({
       value: server.name,
       title: server.name,
-      description: server.status.status,
-      footer: <Status enabled={server.status.status === "connected"} loading={loadingMcp === server.name} />,
+      footer: <Status status={server.status} loading={loadingMcp === server.name} />,
     }))
   })
 
+  const focusedServer = createMemo(() => servers().find((server) => server.name === focused()))
+
+  const toggleTitle = createMemo(() => {
+    const status = focusedServer()?.status.status
+    if (status === "connected") return "disconnect"
+    if (status === "failed") return "retry"
+    if (status === "needs_auth") return "sign in"
+    return "connect"
+  })
+
   const focusedError = createMemo(() => {
-    const name = focused()
-    const server = servers().find((entry) => entry.name === name)
+    const server = focusedServer()
     return server ? statusError(server.status) : undefined
   })
 
@@ -100,7 +116,7 @@ export function DialogMcp() {
             onSelect={(option) => open(option.value as string)}
             actions={[
               {
-                title: "toggle",
+                title: toggleTitle(),
                 command: "dialog.mcp.toggle",
                 onTrigger: (option) => {
                   setFocused(option.value as string)

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -6,7 +6,7 @@ import { pipe, sortBy } from "remeda"
 import { DialogSelect } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
 import { useTheme } from "../context/theme"
-import { TextAttributes, type RGBA, type ScrollBoxRenderable } from "@opentui/core"
+import { TextAttributes, type ScrollBoxRenderable } from "@opentui/core"
 import type { McpServer } from "@opencode-ai/client"
 import { useClipboard } from "../context/clipboard"
 import { useToast } from "../ui/toast"
@@ -19,26 +19,20 @@ function statusError(status: McpServer["status"]) {
   return undefined
 }
 
-function Status(props: { status: McpServer["status"]; loading: boolean; active: boolean }) {
-  const theme = useTheme("elevated")
-  const color = (fallback: RGBA) => (props.active ? theme.text.action.primary.focused : fallback)
+function Status(props: { status: McpServer["status"]; loading: boolean }) {
   if (props.loading || props.status.status === "pending") {
-    return <span style={{ fg: color(theme.text.subdued) }}>Connecting …</span>
+    return <>Connecting …</>
   }
   if (props.status.status === "connected") {
-    return (
-      <span style={{ fg: color(theme.text.feedback.success.default), attributes: TextAttributes.BOLD }}>
-        Connected ✓
-      </span>
-    )
+    return <span style={{ attributes: TextAttributes.BOLD }}>Connected ✓</span>
   }
   if (props.status.status === "failed") {
-    return <span style={{ fg: color(theme.text.feedback.error.default) }}>Failed !</span>
+    return <>Failed !</>
   }
   if (props.status.status === "needs_auth") {
-    return <span style={{ fg: color(theme.text.feedback.warning.default) }}>Sign in required →</span>
+    return <>Sign in required →</>
   }
-  return <span style={{ fg: color(theme.text.subdued) }}>Disabled ○</span>
+  return <>Disabled ○</>
 }
 
 export function DialogMcp() {
@@ -50,6 +44,13 @@ export function DialogMcp() {
   const [focused, setFocused] = createSignal<string>()
   const [detail, setDetail] = createSignal<McpServer>()
   const [loading, setLoading] = createSignal<string | null>(null)
+
+  const statusColor = (status: McpServer["status"]) => {
+    if (status.status === "connected") return theme.text.feedback.success.default
+    if (status.status === "failed") return theme.text.feedback.error.default
+    if (status.status === "needs_auth") return theme.text.feedback.warning.default
+    return theme.text.subdued
+  }
 
   const servers = createMemo(() =>
     pipe(
@@ -66,11 +67,15 @@ export function DialogMcp() {
 
   const options = createMemo(() => {
     const loadingMcp = loading()
-    return servers().map((server) => ({
-      value: server.name,
-      title: server.name,
-      footer: <Status status={server.status} loading={loadingMcp === server.name} active={focused() === server.name} />,
-    }))
+    return servers().map((server) => {
+      const pending = loadingMcp === server.name || server.status.status === "pending"
+      return {
+        value: server.name,
+        title: server.name,
+        footer: <Status status={server.status} loading={pending} />,
+        footerColor: pending ? theme.text.subdued : statusColor(server.status),
+      }
+    })
   })
 
   const focusedServer = createMemo(() => servers().find((server) => server.name === focused()))

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -71,6 +71,7 @@ export interface DialogSelectOption<T = any> {
   detailsColor?: RGBA
   detailsWrap?: boolean
   footer?: JSX.Element | string
+  footerColor?: RGBA
   titleWidth?: number
   truncateTitle?: boolean | "left"
   category?: string
@@ -727,6 +728,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                               footer={
                                 flatten() ? (option.searchFooter ?? option.category ?? option.footer) : option.footer
                               }
+                              footerColor={option.footerColor}
                               titleWidth={option.titleWidth}
                               truncateTitle={option.truncateTitle}
                               description={option.description !== category ? option.description : undefined}
@@ -784,6 +786,7 @@ function Option(props: {
   current?: boolean
   muted?: boolean
   footer?: JSX.Element | string
+  footerColor?: RGBA
   titleWidth?: number
   truncateTitle?: boolean | "left"
   gutter?: () => JSX.Element
@@ -832,7 +835,17 @@ function Option(props: {
       </text>
       <Show when={props.footer}>
         <box flexShrink={0}>
-          <text fg={props.active && !props.muted ? text() : theme.text.subdued}>{props.footer}</text>
+          <text
+            fg={
+              props.active && !props.muted
+                ? text()
+                : props.muted && (props.active || props.current)
+                  ? theme.text.subdued
+                  : (props.footerColor ?? theme.text.subdued)
+            }
+          >
+            {props.footer}
+          </text>
         </box>
       </Show>
     </>


### PR DESCRIPTION
## What

Simplify MCP server rows so each server shows one clear status instead of repeating raw connection state beside the name and enabled state on the right.

## Before / After

**Before:** A connected row read `workout connected` on the left and `✓ Enabled` on the right. Disabled and enabled labels also ended at different columns.

**After:** Names stand alone on the left. Human-readable statuses are right-aligned with one space before a trailing icon, so every icon shares a clean right edge.

```text
  behold                              Connected ✓
● paper                                Disabled ○
  workout                             Connected ✓
```

The selected row keeps the standard list focus dot. Its Space action now names the result directly: connect, disconnect, retry, or sign in.

## How

- Render status directly from the MCP server state.
- Remove the duplicate raw status description.
- Move status icons after their labels.
- Derive the Space action label from the focused server.

## Scope

This only changes the V2 TUI MCP server dialog. Connection behavior and MCP state are unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- Full repository typecheck via the pre-push hook
- Live V2 PTY walkthrough with terminal-control, including connected and disabled row selection

## Demo

**Disabled selected:** the status inherits the row's high-contrast focused foreground.

![MCP server dialog with aligned statuses and high-contrast focused Disabled state](https://github.com/user-attachments/assets/d99908a9-2d20-477b-b4a2-37b8b09f4ae1)

**Disabled unselected:** the status returns to the subdued foreground.

![MCP server dialog with an unselected subdued Disabled state](https://github.com/user-attachments/assets/028a5f13-428c-4234-be3e-90dd4d3f0e1c)
