### PR TITLE
fix(core): broadcast connection updates to every location

### DIFF
--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -416,11 +416,14 @@ export function configured(options?: Options) {
       function publish<D extends Event.Definition>(definition: D, data: Event.Data<D>, options?: PublishOptions) {
         return Effect.gen(function* () {
           const serviceLocation = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
-          const location =
-            options?.location ??
-            (serviceLocation
-              ? { directory: serviceLocation.directory, workspaceID: serviceLocation.workspaceID }
-              : undefined)
+          // Global definitions describe location-independent facts. Never tag
+          // them, so location-filtered subscribers in every location observe them.
+          const location = definition.global
+            ? undefined
+            : (options?.location ??
+              (serviceLocation
+                ? { directory: serviceLocation.directory, workspaceID: serviceLocation.workspaceID }
+                : undefined))
           return yield* publishEvent(
             definition,
             {

--- a/packages/core/test/bus.test.ts
+++ b/packages/core/test/bus.test.ts
@@ -75,6 +75,13 @@ const CountMessage = Bus.ephemeral({
     count: Schema.Number,
   },
 })
+const GlobalFact = Bus.ephemeral({
+  type: "test.global.fact",
+  global: true,
+  schema: {
+    text: Schema.String,
+  },
+})
 
 const VersionedMessage = Bus.durable({
   type: "test.versioned",
@@ -150,6 +157,31 @@ describe("Bus", () => {
         directory: AbsolutePath.make("project"),
         workspaceID: Workspace.ID.make("wrk_test"),
       })
+    }),
+  )
+
+  it.effect("publishes global definitions untagged so subscribers in other locations observe them", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const elsewhere = Location.Service.of(
+        location({ directory: AbsolutePath.make("elsewhere"), workspaceID: Workspace.ID.make("wrk_other") }),
+      )
+      const fiber = yield* bus
+        .subscribe([Message, GlobalFact])
+        .pipe(
+          Stream.take(1),
+          Stream.runCollect,
+          Effect.provideService(Location.Service, elsewhere),
+          Effect.forkScoped,
+        )
+      yield* Effect.yieldNow
+
+      // Location-tagged events stay invisible to other locations; the global fact reaches them.
+      yield* bus.publish(Message, { text: "tagged" })
+      const event = yield* bus.publish(GlobalFact, { text: "everywhere" })
+
+      expect(event).not.toHaveProperty("location")
+      expect(Array.from(yield* Fiber.join(fiber))).toEqual([event])
     }),
   )
 

--- a/packages/schema/src/event.ts
+++ b/packages/schema/src/event.ts
@@ -37,6 +37,7 @@ export type DurableDefinition<
     readonly version: number
     readonly aggregate: string
   }
+  readonly global?: never
   readonly data: DataSchema
 }
 
@@ -47,6 +48,8 @@ export type EphemeralDefinition<
   readonly type: Type
   readonly durability: "ephemeral"
   readonly durable?: never
+  /** Global events describe location-independent facts: they are published untagged and reach every location. */
+  readonly global?: boolean
   readonly data: DataSchema
 }
 
@@ -77,13 +80,14 @@ type Input<Type extends string, Fields extends Readonly<Record<PropertyKey, Sche
     readonly version: number
     readonly aggregate: string
   }
+  readonly global?: boolean
   readonly schema: Fields
 }
 
 export function durable<
   const Type extends string,
   const Fields extends Readonly<Record<PropertyKey, Schema.Codec<unknown, unknown>>>,
->(input: Input<Type, Fields> & { readonly durable: NonNullable<Input<Type, Fields>["durable"]> }) {
+>(input: Omit<Input<Type, Fields>, "global"> & { readonly durable: NonNullable<Input<Type, Fields>["durable"]> }) {
   const data = Schema.Struct(input.schema)
   const durable = Schema.Struct({
     aggregateID: DurableEnvelope.fields.aggregateID,
@@ -137,6 +141,7 @@ export function ephemeral<
         type: input.type,
         durability: "ephemeral" as const,
         durable: undefined,
+        global: input.global === true,
         data,
       })),
     ) satisfies EphemeralDefinition<Type, typeof data>

--- a/packages/schema/src/integration.ts
+++ b/packages/schema/src/integration.ts
@@ -88,8 +88,12 @@ const Updated = ephemeral({
   type: "integration.updated",
   schema: {},
 })
+// Credentials live in one global store shared by every location, so a
+// connection change is a location-independent fact: publish it globally so
+// every active location refreshes its provider catalog.
 const ConnectionUpdated = ephemeral({
   type: "integration.connection.updated",
+  global: true,
   schema: { integrationID: ID },
 })
 export const Event = { Updated, ConnectionUpdated, Definitions: inventory(Updated, ConnectionUpdated) }


### PR DESCRIPTION
## What

Connecting or disconnecting an integration only refreshed the provider catalog of the location that served the request. Every other active location kept serving a stale catalog until its location graph idled out (60 minutes of no use) — effectively never for a location with an active session.

Credentials live in one global store shared by all locations, but `integration.connection.updated` was published tagged with the request's location, and bus subscriptions filter out events tagged with a foreign location. The per-location provider plugins (OpenCode Zen, GitHub Copilot, OpenAI), config wellknown reloads, and MCP reconnects never observed the change.

## Before / After

**Before**

1. Two locations are active: `/a` and `/b`.
2. Connect OpenCode Zen from a session in `/a`.
3. `/a`'s catalog reloads; paid Zen models appear.
4. `/b`'s catalog still treats Zen as unauthenticated: paid models stay disabled, selecting one fails with `ModelUnavailableError`, and `GET /api/model?directory=/b` keeps returning the free-only list until the service restarts.

**After**

The connect publishes `integration.connection.updated` untagged. Provider plugins in every active location observe it, re-resolve the credential from the global store, and reload their catalogs; each location publishes its own location-tagged `catalog.updated`, so clients everywhere refresh their model lists.

```mermaid
sequenceDiagram
    participant CA as Client (/a)
    participant IA as Integration service (/a)
    participant Store as Credential store (global)
    participant Bus as Bus
    participant PA as Zen plugin (/a)
    participant PB as Zen plugin (/b)
    CA->>IA: connect key
    IA->>Store: create credential
    IA->>Bus: integration.connection.updated (untagged)
    Bus->>PA: observe, reload catalog
    Bus->>PB: observe, reload catalog (previously filtered out)
    PA->>Bus: catalog.updated (location /a)
    PB->>Bus: catalog.updated (location /b)
```

## How

- `packages/schema/src/event.ts` — ephemeral event definitions accept `global: true`, carried as a static on the definition. Global events describe location-independent facts. Durable definitions cannot set it (they are aggregate-scoped by design). The event wire shape is unchanged — `location` was already optional — so no client regeneration is needed.
- `packages/schema/src/integration.ts` — `Integration.Event.ConnectionUpdated` is marked global.
- `packages/core/src/bus.ts` — `publish` never tags global definitions with a location. Untagged events already pass every location's subscription filter (the same mechanism `models.dev` refreshes rely on), so all subscriber code is unchanged.

## Scope

- `Integration.Event.Updated` stays location-tagged; it drives the requesting client's integration dialog. The web app already refreshes providers on `integration.connection.updated` and now receives it for connects made from any location.
- No other event definitions are marked global in this PR.

## Testing

- `cd packages/core && bun test ./test/bus.test.ts` — new test: a subscriber in another location receives a global-definition event while still never seeing location-tagged events (52 pass).
- `cd packages/core && bun typecheck`, `cd packages/schema && bun typecheck`
- Full `bun test` in `packages/core`: 1524 pass; the single failure (`Config > loads authenticated wellknown config at highest priority`) also fails on clean `origin/v2`.

Observed in production today: after reconnecting Zen from one location, another location's `GET /api/model` kept returning the 27 free-only `opencode/*` models while the connecting location returned the full list, until a service restart.