### PR TITLE
fix(tui): compact single-line prompts

### DIFF
--- a/packages/tui/src/ui/dialog-prompt.tsx
+++ b/packages/tui/src/ui/dialog-prompt.tsx
@@ -85,6 +85,7 @@ export function DialogPrompt(props: DialogPromptProps) {
         {props.description?.()}
         <textarea
           height={1}
+          wrapMode="none"
           ref={(val: TextareaRenderable) => {
             textarea = val
             setTextareaTarget(val)

--- a/packages/tui/src/ui/dialog-prompt.tsx
+++ b/packages/tui/src/ui/dialog-prompt.tsx
@@ -84,7 +84,7 @@ export function DialogPrompt(props: DialogPromptProps) {
       <box gap={1}>
         {props.description?.()}
         <textarea
-          height={3}
+          height={1}
           ref={(val: TextareaRenderable) => {
             textarea = val
             setTextareaTarget(val)


### PR DESCRIPTION
## What

Make TUI text prompts visually match their single-line behavior.

## Before / After

**Before:** Rename, API-key, authorization-code, integration, and plugin prompts reserved three input rows even though Return immediately submits the value.

![Full TUI with the three-row API key prompt before the change](https://github.com/user-attachments/assets/e1dd5741-a855-4b9a-948b-d366414b0354)

**After:** The same prompt uses one input row, removing two empty lines while preserving the existing title, description, busy state, and submit hint.

![Full TUI with the compact single-row API key prompt after the change](https://github.com/user-attachments/assets/bd77f7c6-3e11-42a1-a70f-2c5fbaacb8d3)

## How

Set the shared `DialogPrompt` textarea height to one row and disable wrapping. All current callers already use Return-to-submit semantics and do not support multiline input. Long values remain on one visual line and scroll horizontally with the cursor.

## Scope

This changes only prompt height. Submission, focus, validation, and busy-state behavior are unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/tui/dialog-prompt.test.tsx` from `packages/tui`
- Full repository typecheck via the pre-push hook
- Matched hermetic before/after `/connect` walkthroughs with terminal-control
