### PR TITLE
feat(tools): add standalone MoA (mixture of agents) runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ UPCOMING_CHANGELOG.md
 logs/
 *.bun-build
 tsconfig.tsbuildinfo
+
+# moa-run (tools/moa) — traces are untrusted model output, never commit
+tools/moa/traces/
+tools/moa/audit/
+tools/moa/.venv/
+**/__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,10 @@ const table = sqliteTable("session", {
 - Keep delivery vocabulary explicit. Prompts steer by default and promote at the next safe provider-turn boundary while the current drain requires continuation. An explicit `queue` input remains pending until the Session would otherwise become idle; promote one queued input at that boundary, then reevaluate continuation before promoting another. Promoting any new user input resets the selected agent's provider-turn allowance; a batch of steers resets it once.
 - Keep EventV2 replay owner claims separate from clustered Session execution ownership.
 - Keep the System Context algebra, registry, and built-ins in `src/system-context`; keep Context Source producers with their observed domains, and keep Session History selection plus Context Epoch persistence Session-owned.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ If you're interested in contributing to OpenCode, please read our [contributing 
 
 If you are working on a project that's related to OpenCode and is using "opencode" as part of its name, for example "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in any way.
 
+### Tools
+
+- [`tools/moa`](./tools/moa) — local Mixture-of-Agents (MoA) runner: fans a task prompt to advisor models in parallel (`ollama-cloud/glm-5.2`, `ollama-cloud/minimax-m3`), then aggregates their analyses into a final verdict (`ollama-cloud/deepseek-v4-flash:0731`). Route via `MOA_BASE_URL` / `MOA_API_KEY` (fallbacks `OLLAMA_API_BASE` / `OLLAMA_API_KEY`); no hardcoded keys. See [`tools/moa/README.md`](./tools/moa/README.md).
+
 ---
 
 **Join our community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)

--- a/tools/moa/README.md
+++ b/tools/moa/README.md
@@ -1,0 +1,68 @@
+# MoA — Mixture of Agents runner
+
+Standalone opencode tooling: a local Mixture-of-Agents wrapper. `bin/moa-run`
+fans a task prompt out to multiple advisor models in parallel (thread pool,
+stdlib `urllib` only), collects their analyses, then sends them plus the
+original task to an aggregator model that produces the final verdict — the
+Hermes `captain-test` MOA preset, runnable from the command line via Aperture
+(the captain's Ollama Cloud route).
+
+Self-contained: no opencode core imports, no security-lab imports. The same
+wrapper ships in the security-lab lane in parallel; this copy is kept in sync
+manually.
+
+## Default roles (captain-test preset)
+
+- advisors: `ollama-cloud/glm-5.2`, `ollama-cloud/minimax-m3`
+- aggregator: `ollama-cloud/deepseek-v4-flash:0731` (`reasoning_effort=max`)
+
+## Usage
+
+```bash
+tools/moa/bin/moa-run "Is this exploit chain plausible? ..." --out verdict.json
+# or from a file, with context + audit traces:
+tools/moa/bin/moa-run --file task.md --context "$(cat context.md)" \
+    --out verdict.json --traces traces/
+# override roles:
+tools/moa/bin/moa-run "analyze this" \
+    --advisors ollama-cloud/glm-5.2,ollama-cloud/minimax-m3 \
+    --aggregator ollama-cloud/deepseek-v4-flash:0731
+```
+
+Exit codes: `0` verdict produced, `2` usage error, `3` pipeline failure
+(all advisors failed or aggregator failed). Run `tools/moa/bin/moa-run --help`
+for the full option list.
+
+## Route & keys
+
+`MOA_BASE_URL` (default `http://ai.tail492ce8.ts.net/v1`, fallback
+`OLLAMA_API_BASE`) + `MOA_API_KEY` (fallback `OLLAMA_API_KEY`; default
+`not-required` — Aperture requires no client auth). Keys come from the
+environment only, never from code or committed config. Config: `moa.yaml` or
+`MOA_CONFIG` (`tools/moa/moa.yaml` documents every field).
+
+## Traces & audit
+
+- Advisor analyses + aggregator transcripts are written as JSON into `traces/`
+  (default; `--traces <dir>` or `MOA_TRACES_DIR`) — one dir per run, one file
+  per advisor, one for the aggregator call, plus a `run.json` manifest.
+- One best-effort JSONL audit entry per run is appended to `tools/moa/audit/moa-run.jsonl` (override with `MOA_AUDIT_LOG`); audit failures never break the run.
+
+Both are untrusted model output — never commit them.
+
+## Library
+
+`lib/moa.py` is the whole pipeline (`MoaConfig`, `load_config`,
+`chat_completions`, `run_moa`); `chat_completions` is the single network
+seam. `bin/moa-run` is a thin CLI over it.
+
+## Setup & tests
+
+Requires Python 3.10+ and `pyyaml` (stdlib otherwise). Tests mock
+`chat_completions` — no live quota is consumed.
+
+```bash
+python3 -m venv .venv            # inside tools/moa (gitignored)
+.venv/bin/pip install -r tools/moa/requirements.txt
+.venv/bin/pytest tools/moa/tests
+```

--- a/tools/moa/bin/moa-run
+++ b/tools/moa/bin/moa-run
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""moa-run — local Mixture-of-Agents runner (captain-test preset).
+
+Fans a task prompt out to multiple advisor models in parallel (Aperture /
+Ollama Cloud via the captain's route), collects their analyses, then sends
+them plus the original task to an aggregator model for the final verdict.
+
+Defaults (Hermes captain-test preset):
+  advisors   = ollama-cloud/glm-5.2, ollama-cloud/minimax-m3
+  aggregator = ollama-cloud/deepseek-v4-flash:0731 (reasoning_effort=max)
+
+Route: MOA_BASE_URL (default http://ai.tail492ce8.ts.net/v1, fallback
+OLLAMA_API_BASE) + MOA_API_KEY (fallback OLLAMA_API_KEY; default
+"not-required" — Aperture requires no client auth). Never hardcoded.
+
+Usage:
+    moa-run "task prompt" [--context <text>] [--file <path>]
+            [--out <verdict.json>] [--traces <dir>] [--config <moa.yaml>]
+            [--advisors m1,m2] [--aggregator <model>] [--reasoning <effort>]
+            [--timeout <seconds>] [--max-tokens <n>]
+
+    moa-run --file task.md --out verdict.json --traces traces/
+
+Exit codes:
+    0 = verdict produced (stdout and/or --out file)
+    2 = usage error (unknown flag, bad args, missing prompt)
+    3 = pipeline failure (all advisors failed or aggregator failed)
+
+Audit: one audit-log entry (action=moa-run) appended to the audit JSONL log
+carrying the verdict model, advisor count, and outcome.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+import moa  # noqa: E402
+
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_PIPELINE = 3
+
+
+def _audit(exit_code: int, detail: str) -> None:
+    """Append one best-effort JSONL audit entry (never raises)."""
+    entry = {
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "agent": os.environ.get("USER", os.environ.get("LOGNAME", "agent")),
+        "action": "moa-run",
+        "exit": exit_code,
+        "detail": detail,
+    }
+    try:
+        default_log = Path(__file__).resolve().parent.parent / "audit" / "moa-run.jsonl"
+        log_path = Path(os.environ.get("MOA_AUDIT_LOG", str(default_log)))
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except Exception as exc:  # noqa: BLE001 - audit must never break the run
+        print(f"[!] audit log write failed: {exc}", file=sys.stderr)
+
+
+def _print_usage() -> None:
+    print(__doc__.strip("\n"))
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        _print_usage()
+        return 0 if args else EXIT_USAGE
+
+    prompt = ""
+    context = ""
+    file_path: str | None = None
+    out_path: str | None = None
+    traces_dir: str | None = None
+    config_path: str | None = None
+    advisors_override: list[str] | None = None
+    aggregator_override: str | None = None
+    reasoning_override: str | None = None
+    timeout_override: float | None = None
+    max_tokens_override: int | None = None
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("--context", "--file", "--out", "--traces", "--config",
+                   "--advisors", "--aggregator", "--reasoning", "--timeout",
+                   "--max-tokens"):
+            if i + 1 >= len(args):
+                print(f"moa-run: {arg} requires a value", file=sys.stderr)
+                return EXIT_USAGE
+            value = args[i + 1]
+            i += 2
+            if arg == "--context":
+                context = value
+            elif arg == "--file":
+                file_path = value
+            elif arg == "--out":
+                out_path = value
+            elif arg == "--traces":
+                traces_dir = value
+            elif arg == "--config":
+                config_path = value
+            elif arg == "--advisors":
+                advisors_override = [m.strip() for m in value.split(",") if m.strip()]
+                if not advisors_override:
+                    print("moa-run: --advisors must not be empty", file=sys.stderr)
+                    return EXIT_USAGE
+            elif arg == "--aggregator":
+                aggregator_override = value
+            elif arg == "--reasoning":
+                reasoning_override = value
+            elif arg == "--timeout":
+                try:
+                    timeout_override = float(value)
+                except ValueError:
+                    print("moa-run: --timeout must be a number", file=sys.stderr)
+                    return EXIT_USAGE
+            elif arg == "--max-tokens":
+                try:
+                    max_tokens_override = int(value)
+                except ValueError:
+                    print("moa-run: --max-tokens must be an integer", file=sys.stderr)
+                    return EXIT_USAGE
+            continue
+        if arg.startswith("--") and arg != "--":
+            print(f"moa-run: unknown flag: {arg}", file=sys.stderr)
+            return EXIT_USAGE
+        if arg == "--":
+            rest = args[i + 1:]
+            prompt = " ".join(rest)
+            break
+        prompt = arg
+        i += 1
+
+    if file_path:
+        path = Path(file_path)
+        if not path.is_file():
+            print(f"moa-run: --file not found: {path}", file=sys.stderr)
+            return EXIT_USAGE
+        prompt = path.read_text(encoding="utf-8")
+    prompt = prompt.strip()
+    if not prompt:
+        print("moa-run: no prompt (pass text or --file)", file=sys.stderr)
+        return EXIT_USAGE
+
+    config_path = config_path or os.environ.get("MOA_CONFIG") or None
+    try:
+        config = moa.load_config(config_path)
+    except FileNotFoundError as exc:
+        print(f"moa-run: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+    except Exception as exc:
+        print(f"moa-run: config error: {exc}", file=sys.stderr)
+        return EXIT_USAGE
+
+    if advisors_override:
+        config.advisors = [moa.RoleConfig(model=m, label=m) for m in advisors_override]
+    if aggregator_override:
+        config.aggregator.model = aggregator_override
+        config.aggregator.label = aggregator_override
+    if reasoning_override:
+        config.aggregator.reasoning_effort = reasoning_override
+    if timeout_override is not None:
+        config.timeout = timeout_override
+    if max_tokens_override is not None:
+        config.aggregator.max_tokens = max_tokens_override
+
+    trace_dir = traces_dir or os.environ.get("MOA_TRACES_DIR") or "traces"
+
+    try:
+        result = moa.run_moa(
+            prompt,
+            context=context,
+            config=config,
+            trace_dir=trace_dir,
+        )
+    except moa.MoaError as exc:
+        print(f"moa-run: {exc}", file=sys.stderr)
+        _audit(EXIT_PIPELINE, f"aggregator={config.aggregator.model}; error={exc}")
+        return EXIT_PIPELINE
+
+    if out_path:
+        payload = {
+            "verdict": result["verdict"],
+            "model": result["model"],
+            "reasoning_effort": result.get("reasoning_effort"),
+            "advisors": result["advisors"],
+            "trace_dir": result.get("trace_dir"),
+        }
+        Path(out_path).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(result["verdict"])
+
+    ok_analyses = [a for a in result["advisors"] if a.get("analysis")]
+    _audit(
+        EXIT_OK,
+        (
+            f"aggregator={result['model']}; advisors={len(result['advisors'])}; "
+            f"analyses={len(ok_analyses)}"
+        ),
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/moa/lib/__init__.py
+++ b/tools/moa/lib/__init__.py
@@ -1,0 +1,1 @@
+"""lib — moa-run helpers. See moa.py."""

--- a/tools/moa/lib/moa.py
+++ b/tools/moa/lib/moa.py
@@ -1,0 +1,450 @@
+"""moa — local Mixture-of-Agents runner (captain-test preset).
+
+Fans a task prompt out to several advisor models in parallel, collects their
+analyses, then hands the combined analyses plus the original prompt to an
+aggregator model that produces the final verdict. The same pattern as the
+Hermes `captain-test` MOA preset, but runnable locally from opencode via
+Aperture (the captain's Ollama Cloud route).
+
+Route: OpenAI-compatible ``/v1/chat/completions`` at MOA_BASE_URL (default
+``http://ai.tail492ce8.ts.net/v1``) with MOA_API_KEY (default "not-required" —
+the Aperture route requires no client auth). Keys come from the environment,
+never from code or committed config. OLLAMA_API_BASE / OLLAMA_API_KEY are
+honored as fallbacks, matching the rest of the lab.
+
+Default roles (captain-test preset):
+  advisors   = ollama-cloud/glm-5.2, ollama-cloud/minimax-m3
+  aggregator = ollama-cloud/deepseek-v4-flash:0731 (reasoning_effort=max)
+
+Design notes:
+  - Advisors run concurrently on a thread pool (stdlib urllib only — the lab
+    venv does not ship requests/httpx).
+  - ``chat_completions`` is the only network seam; tests mock it, so the test
+    suite never touches live quota.
+  - Advisor failures are collected per-advisor and never abort siblings; the
+    aggregator runs whenever at least one analysis exists.
+  - Traces (save_traces equivalent) are written as JSON files into a traces
+    dir: one file per advisor (request + raw response + extracted analysis),
+    one for the aggregator call, and one run manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - config parsing only needs yaml
+    yaml = None  # type: ignore[assignment]
+
+DEFAULT_BASE_URL = "http://ai.tail492ce8.ts.net/v1"
+DEFAULT_API_KEY = "not-required"
+DEFAULT_TIMEOUT = 300.0
+
+DEFAULT_ADVISORS: list[dict[str, Any]] = [
+    {
+        "model": "ollama-cloud/glm-5.2",
+        "label": "glm-5.2",
+        "max_tokens": 2048,
+        "extra": {},
+    },
+    {
+        "model": "ollama-cloud/minimax-m3",
+        "label": "minimax-m3",
+        "max_tokens": 2048,
+        "extra": {},
+    },
+]
+
+DEFAULT_AGGREGATOR: dict[str, Any] = {
+    "model": "ollama-cloud/deepseek-v4-flash:0731",
+    "label": "deepseek-v4-flash:0731",
+    "reasoning_effort": "max",
+    "max_tokens": 8192,
+    "extra": {},
+}
+
+DEFAULT_ADVISOR_SYSTEM = (
+    "You are an expert advisor in a mixture-of-agents ensemble. "
+    "Analyze the user's task thoroughly and independently. Be concrete, "
+    "rigorous, and specific. Do not mention the ensemble; produce the best "
+    "analysis you can on your own."
+)
+
+DEFAULT_AGGREGATOR_SYSTEM = (
+    "You are the final aggregator in a mixture-of-agents ensemble. "
+    "Below are independent analyses from several expert advisors, followed by "
+    "the original task. Synthesize them into one final, coherent answer: "
+    "resolve contradictions, keep the strongest evidence and reasoning, and "
+    "produce the definitive verdict. Output only the final answer."
+)
+
+
+@dataclass
+class RoleConfig:
+    """A model role (advisor or aggregator) in the ensemble."""
+
+    model: str
+    label: str = ""
+    max_tokens: int = 2048
+    reasoning_effort: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MoaConfig:
+    """Resolved MOA configuration (env + yaml + CLI overrides)."""
+
+    base_url: str = DEFAULT_BASE_URL
+    api_key: str = DEFAULT_API_KEY
+    advisors: list[RoleConfig] = field(default_factory=list)
+    aggregator: RoleConfig = field(default_factory=lambda: RoleConfig(**DEFAULT_AGGREGATOR))
+    system_prompt_advisor: str = DEFAULT_ADVISOR_SYSTEM
+    system_prompt_aggregator: str = DEFAULT_AGGREGATOR_SYSTEM
+    timeout: float = DEFAULT_TIMEOUT
+
+    def __post_init__(self) -> None:
+        if not self.advisors:
+            self.advisors = [RoleConfig(**a) for a in DEFAULT_ADVISORS]
+        for role in self.advisors + [self.aggregator]:
+            if not role.label:
+                role.label = role.model
+
+
+def _env_or(env_names: tuple[str, ...], default: str) -> str:
+    for name in env_names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return default
+
+
+def load_config(config_path: str | os.PathLike[str] | None = None) -> MoaConfig:
+    """Load MOA config from an optional yaml file + environment, with defaults.
+
+    Precedence (lowest to highest): built-in defaults -> yaml file -> env.
+    ``base_url``/``api_key`` env names: MOA_BASE_URL/MOA_API_KEY, falling back
+    to OLLAMA_API_BASE/OLLAMA_API_KEY (the lab's existing route vars).
+    """
+    raw: dict[str, Any] = {}
+    if config_path is not None:
+        path = Path(config_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"config file not found: {path}")
+        if yaml is None:  # pragma: no cover - yaml is a lab dependency
+            raise RuntimeError("pyyaml is required to read a yaml config")
+        with path.open(encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh) or {}
+
+    base_url = _env_or(("MOA_BASE_URL", "OLLAMA_API_BASE"), raw.get("base_url", DEFAULT_BASE_URL))
+    key_env = raw.get("api_key_env", "MOA_API_KEY")
+    # Keys come from the environment only — never from the yaml file.
+    api_key = _env_or((key_env, "MOA_API_KEY", "OLLAMA_API_KEY"), DEFAULT_API_KEY)
+
+    advisors_raw = raw.get("advisors") or DEFAULT_ADVISORS
+    advisors = [RoleConfig(**dict(a)) for a in advisors_raw]
+    aggregator_raw = raw.get("aggregator") or DEFAULT_AGGREGATOR
+    aggregator = RoleConfig(**dict(aggregator_raw))
+
+    return MoaConfig(
+        base_url=base_url,
+        api_key=api_key,
+        advisors=advisors,
+        aggregator=aggregator,
+        system_prompt_advisor=raw.get("system_prompt_advisor", DEFAULT_ADVISOR_SYSTEM),
+        system_prompt_aggregator=raw.get("system_prompt_aggregator", DEFAULT_AGGREGATOR_SYSTEM),
+        timeout=float(raw.get("timeout", DEFAULT_TIMEOUT)),
+    )
+
+
+def chat_completions(
+    base_url: str,
+    api_key: str,
+    model: str,
+    messages: list[dict[str, str]],
+    *,
+    max_tokens: int | None = None,
+    reasoning_effort: str | None = None,
+    extra_body: dict[str, Any] | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """POST /v1/chat/completions and return the parsed JSON response.
+
+    The single network seam of the library; tests replace this function.
+    Raises urllib.error.URLError / HTTPError / ValueError on transport or
+    JSON errors — callers decide what to do with the failure.
+    """
+    url = base_url.rstrip("/") + "/chat/completions"
+    body: dict[str, Any] = {"model": model, "messages": messages}
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+    if reasoning_effort:
+        body["reasoning_effort"] = reasoning_effort
+    if extra_body:
+        body.update(extra_body)
+
+    # S310 is suppressed: the URL is constructed from lab-owned config/env
+    # (MOA_BASE_URL / OLLAMA_API_BASE), never from target-influenced input.
+    req = urllib.request.Request(  # noqa: S310
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def extract_message_text(message: dict[str, Any]) -> str:
+    """Extract the assistant text from a chat-completion message.
+
+    Aperture's proxy returns ``message.content`` for plain answers but puts
+    the text in ``message.reasoning`` for reasoning-capable models when
+    thinking kicks in — so fall back to reasoning when content is empty.
+    """
+    content = message.get("content") or ""
+    if content.strip():
+        return content
+    return message.get("reasoning") or ""
+
+
+def advisor_analysis(
+    prompt: str,
+    context: str,
+    role: RoleConfig,
+    config: MoaConfig,
+) -> tuple[str, str, dict[str, Any]]:
+    """Run one advisor against the task; returns (label, analysis, trace_meta).
+
+    trace_meta carries the raw response and request body so the caller can
+    persist an auditable trace. Raises on network/parse errors; the fan-out
+    loop is responsible for catching and recording the failure.
+    """
+    user_parts: list[str] = []
+    if context.strip():
+        user_parts.append(f"## Context\n{context.strip()}")
+    user_parts.append(f"## Task\n{prompt}")
+    messages = [
+        {"role": "system", "content": config.system_prompt_advisor},
+        {"role": "user", "content": "\n\n".join(user_parts)},
+    ]
+    started = time.monotonic()
+    response = chat_completions(
+        config.base_url,
+        config.api_key,
+        role.model,
+        messages,
+        max_tokens=role.max_tokens,
+        reasoning_effort=role.reasoning_effort,
+        extra_body=role.extra,
+        timeout=config.timeout,
+    )
+    duration_ms = int((time.monotonic() - started) * 1000)
+    message = (response.get("choices") or [{}])[0].get("message", {})
+    analysis = extract_message_text(message)
+    meta = {
+        "label": role.label,
+        "model": role.model,
+        "request": messages,
+        "response": response,
+        "extracted": analysis,
+        "duration_ms": duration_ms,
+    }
+    return role.label, analysis, meta
+
+
+def build_aggregator_messages(
+    prompt: str,
+    context: str,
+    analyses: list[tuple[str, str, str]],  # (label, model, analysis)
+    system_prompt: str,
+) -> list[dict[str, str]]:
+    """Combine the original task + context + all advisor analyses."""
+    blocks: list[str] = []
+    for label, model, analysis in analyses:
+        blocks.append(f"### Advisor: {label} ({model})\n{analysis}")
+    body = "\n\n".join(blocks)
+    user_parts: list[str] = []
+    if context.strip():
+        user_parts.append(f"## Context\n{context.strip()}")
+    user_parts.append(f"## Original task\n{prompt}")
+    user_parts.append(f"## Advisor analyses\n\n{body}")
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": "\n\n".join(user_parts)},
+    ]
+
+
+def run_moa(
+    prompt: str,
+    context: str = "",
+    config: MoaConfig | None = None,
+    trace_dir: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
+    """Run the full MOA pipeline: parallel advisors -> aggregator -> verdict.
+
+    Returns the run envelope:
+      {
+        "verdict": <aggregator answer text>,
+        "model": <aggregator model>,
+        "reasoning_effort": ...,
+        "advisors": [ {"label","model","analysis","error"} ... ],
+        "trace_dir": <str|None>,
+      }
+    Raises MoaAllAdvisorsFailed when every advisor errors, MoaAggregatorFailed
+    when no verdict could be produced. Traces are written best-effort before
+    raising so partial runs are still auditable.
+    """
+    config = config or load_config()
+    trace_dir_path: Path | None = None
+    if trace_dir:
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        prompt_slug = _slugify(prompt[:40]).strip("_") or "run"
+        trace_dir_path = Path(trace_dir) / f"{stamp}-{prompt_slug}"
+        trace_dir_path.mkdir(parents=True, exist_ok=True)
+        _write_json(trace_dir_path / "run.json", {
+            "prompt": prompt,
+            "context": context,
+            "config": _config_snapshot(config),
+        })
+
+    advisor_results: list[tuple[str, str, str, dict[str, Any] | None]] = []
+    # ^ (label, model, analysis, trace_meta) — trace_meta carries the raw
+    #   response for audit, or {"error": ...} when the advisor call failed.
+    with ThreadPoolExecutor(max_workers=len(config.advisors)) as pool:
+        futures = {
+            pool.submit(advisor_analysis, prompt, context, role, config): role
+            for role in config.advisors
+        }
+        for future in as_completed(futures):
+            role = futures[future]
+            try:
+                label, analysis, meta = future.result()
+                advisor_results.append((label, role.model, analysis, meta))
+            except Exception as exc:  # noqa: BLE001 - per-advisor isolation
+                meta: dict[str, Any] = {"error": repr(exc)}
+                advisor_results.append((role.label, role.model, "", meta))
+                if trace_dir_path is not None:
+                    _write_json(advisor_trace_path(trace_dir_path, role.label), meta)
+
+    ok = [(label, model, analysis) for label, model, analysis, meta in advisor_results if analysis]
+    failed = [a for a in advisor_results if not a[2]]
+    if not ok:
+        raise MoaAllAdvisorsFailed(
+            "every advisor failed: "
+            + "; ".join(
+                f"{label}: {meta.get('error', 'unknown')}"
+                for label, _model, _analysis, meta in failed
+            )
+        )
+
+    for label, _model, _analysis, meta in advisor_results:
+        if meta is not None and trace_dir_path is not None:
+            _write_json(advisor_trace_path(trace_dir_path, label), meta)
+
+    messages = build_aggregator_messages(
+        prompt, context, ok, config.system_prompt_aggregator
+    )
+    started = time.monotonic()
+    try:
+        response = chat_completions(
+            config.base_url,
+            config.api_key,
+            config.aggregator.model,
+            messages,
+            max_tokens=config.aggregator.max_tokens,
+            reasoning_effort=config.aggregator.reasoning_effort,
+            extra_body=config.aggregator.extra,
+            timeout=config.timeout,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced as MoaAggregatorFailed
+        if trace_dir_path is not None:
+            _write_json(trace_dir_path / "aggregator.json", {"error": repr(exc)})
+        raise MoaAggregatorFailed(f"aggregator call failed: {exc}") from exc
+    duration_ms = int((time.monotonic() - started) * 1000)
+    message = (response.get("choices") or [{}])[0].get("message", {})
+    verdict = extract_message_text(message)
+    if not verdict.strip():
+        verdict = "[aggregator returned an empty answer]"
+    if trace_dir_path is not None:
+        _write_json(trace_dir_path / "aggregator.json", {
+            "request": messages,
+            "response": response,
+            "extracted": verdict,
+            "duration_ms": duration_ms,
+        })
+
+    return {
+        "verdict": verdict,
+        "model": config.aggregator.model,
+        "reasoning_effort": config.aggregator.reasoning_effort,
+        "advisors": [
+            {
+                "label": label,
+                "model": model,
+                "analysis": analysis,
+                "error": meta.get("error") if meta else None,
+            }
+            for label, model, analysis, meta in advisor_results
+        ],
+        "trace_dir": str(trace_dir_path) if trace_dir_path else None,
+    }
+
+
+class MoaError(Exception):
+    """Base class for MOA pipeline failures."""
+
+
+class MoaAllAdvisorsFailed(MoaError):
+    """Every advisor call failed; there is nothing to aggregate."""
+
+
+class MoaAggregatorFailed(MoaError):
+    """Advisors produced analyses but the aggregator call failed."""
+
+
+def _config_snapshot(config: MoaConfig) -> dict[str, Any]:
+    return {
+        "base_url": config.base_url,
+        "api_key_env": "set" if config.api_key else "unset",
+        "advisors": [
+            {"label": a.label, "model": a.model, "max_tokens": a.max_tokens}
+            for a in config.advisors
+        ],
+        "aggregator": {
+            "label": config.aggregator.label,
+            "model": config.aggregator.model,
+            "reasoning_effort": config.aggregator.reasoning_effort,
+            "max_tokens": config.aggregator.max_tokens,
+        },
+        "timeout": config.timeout,
+    }
+
+
+def _write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+
+
+def _slugify(value: str) -> str:
+    """Safe filename fragment: keep word chars and -_. only."""
+    return "".join(c if c.isalnum() or c in "-_." else "_" for c in value) or "role"
+
+
+def advisor_trace_path(trace_dir_path: Path | None, label: str) -> Path | None:
+    """Trace file path for an advisor (label-safe filename)."""
+    if trace_dir_path is None:
+        return None
+    return trace_dir_path / f"advisor-{_slugify(label)}.json"

--- a/tools/moa/moa.yaml
+++ b/tools/moa/moa.yaml
@@ -1,0 +1,29 @@
+# moa-run — MoA (Mixture of Agents) wrapper config.
+# Optional: bin/moa-run picks it up via --config <path> or MOA_CONFIG.
+# Everything below has a working default (Hermes captain-test preset), so
+# this file is only needed for customization.
+
+# Aperture base URL (Ollama Cloud route). Env: MOA_BASE_URL / OLLAMA_API_BASE.
+base_url: http://ai.tail492ce8.ts.net/v1
+# API key env var to read. Default "not-required" (Aperture needs no client
+# auth). Env: MOA_API_KEY / OLLAMA_API_KEY.
+api_key_env: MOA_API_KEY
+
+# Advisor roles — fan out in parallel. Keep at least two for real diversity.
+advisors:
+  - model: ollama-cloud/glm-5.2
+    label: glm-5.2
+    max_tokens: 2048
+  - model: ollama-cloud/minimax-m3
+    label: minimax-m3
+    max_tokens: 2048
+
+# Aggregator role — combines all analyses + the original task into the verdict.
+aggregator:
+  model: ollama-cloud/deepseek-v4-flash:0731
+  label: deepseek-v4-flash:0731
+  reasoning_effort: max
+  max_tokens: 8192
+
+# Per-call network timeout in seconds.
+timeout: 300

--- a/tools/moa/requirements.txt
+++ b/tools/moa/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml>=6.0
+pytest>=8.0

--- a/tools/moa/tests/test_moa.py
+++ b/tools/moa/tests/test_moa.py
@@ -1,0 +1,221 @@
+"""Tests for lib/moa.py — the local MoA (Mixture of Agents) runner.
+
+All model calls are mocked (moa.chat_completions is the single network seam);
+these tests never touch live quota or the Aperture route.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+import moa  # noqa: E402
+
+FAKE_ADVISORS = [
+    {"model": "mock/advisor-a", "label": "a"},
+    {"model": "mock/advisor-b", "label": "b"},
+]
+FAKE_AGGREGATOR = {"model": "mock/aggregator", "label": "agg", "reasoning_effort": "max"}
+
+
+def _fake_config() -> moa.MoaConfig:
+    return moa.MoaConfig(
+        base_url="http://mock/v1",
+        api_key="test-key",
+        advisors=[moa.RoleConfig(**a) for a in FAKE_ADVISORS],
+        aggregator=moa.RoleConfig(**FAKE_AGGREGATOR),
+    )
+
+
+def _reply(content: str, reasoning: str = "") -> dict:
+    message = {"role": "assistant", "content": content}
+    if reasoning:
+        message["reasoning"] = reasoning
+    return {"choices": [{"message": message}]}
+
+
+class TestConfig:
+    def test_defaults_match_captain_test_preset(self, monkeypatch):
+        monkeypatch.delenv("MOA_BASE_URL", raising=False)
+        monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+        monkeypatch.delenv("MOA_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        cfg = moa.load_config(None)
+        assert cfg.base_url == "http://ai.tail492ce8.ts.net/v1"
+        assert cfg.api_key == "not-required"
+        assert [a.model for a in cfg.advisors] == [
+            "ollama-cloud/glm-5.2",
+            "ollama-cloud/minimax-m3",
+        ]
+        assert cfg.aggregator.model == "ollama-cloud/deepseek-v4-flash:0731"
+        assert cfg.aggregator.reasoning_effort == "max"
+
+    def test_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("MOA_BASE_URL", "http://env/v1")
+        monkeypatch.setenv("MOA_API_KEY", "env-key")
+        cfg = moa.load_config(None)
+        assert cfg.base_url == "http://env/v1"
+        assert cfg.api_key == "env-key"
+
+    def test_ollama_env_fallback(self, monkeypatch):
+        monkeypatch.delenv("MOA_BASE_URL", raising=False)
+        monkeypatch.delenv("MOA_API_KEY", raising=False)
+        monkeypatch.setenv("OLLAMA_API_BASE", "http://ollama/v1")
+        monkeypatch.setenv("OLLAMA_API_KEY", "ollama-key")
+        cfg = moa.load_config(None)
+        assert cfg.base_url == "http://ollama/v1"
+        assert cfg.api_key == "ollama-key"
+
+    def test_yaml_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MOA_BASE_URL", raising=False)
+        monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
+        (tmp_path / "moa.yaml").write_text(
+            "base_url: http://yaml/v1\n"
+            "advisors:\n"
+            "  - model: mock/one\n"
+            "  - model: mock/two\n"
+            "aggregator:\n"
+            "  model: mock/agg\n"
+            "timeout: 42\n",
+            encoding="utf-8",
+        )
+        cfg = moa.load_config(tmp_path / "moa.yaml")
+        assert cfg.base_url == "http://yaml/v1"
+        assert [a.model for a in cfg.advisors] == ["mock/one", "mock/two"]
+        assert cfg.aggregator.model == "mock/agg"
+        assert cfg.timeout == 42
+
+    def test_missing_config_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            moa.load_config(tmp_path / "nope.yaml")
+
+    def test_yaml_never_supplies_api_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("MOA_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        (tmp_path / "moa.yaml").write_text(
+            "api_key: super-secret\n", encoding="utf-8"
+        )
+        cfg = moa.load_config(tmp_path / "moa.yaml")
+        assert cfg.api_key == "not-required"
+
+
+class TestExtraction:
+    def test_content_used(self):
+        assert moa.extract_message_text({"content": "answer", "reasoning": "thinking"}) == "answer"
+
+    def test_reasoning_fallback(self):
+        assert moa.extract_message_text({"content": "", "reasoning": "thinking"}) == "thinking"
+
+    def test_empty_message(self):
+        assert moa.extract_message_text({}) == ""
+
+
+class TestAggregatorMessages:
+    def test_combines_task_context_and_analyses(self):
+        messages = moa.build_aggregator_messages(
+            "the task",
+            "the ctx",
+            [("a", "mock/a", "analysis-a"), ("b", "mock/b", "analysis-b")],
+            "sys",
+        )
+        assert messages[0]["content"] == "sys"
+        user = messages[1]["content"]
+        assert "the task" in user
+        assert "the ctx" in user
+        assert "analysis-a" in user
+        assert "analysis-b" in user
+        assert "mock/a" in user
+
+
+class TestRunMoa:
+    def test_full_pipeline_fanout_and_verdict(self, tmp_path, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            calls.append({"model": model, "messages": messages, **kwargs})
+            if model == "mock/aggregator":
+                return _reply("FINAL VERDICT")
+            return _reply(f"analysis from {model}")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        result = moa.run_moa(
+            "solve this",
+            context="some context",
+            config=_fake_config(),
+            trace_dir=str(tmp_path / "traces"),
+        )
+        assert result["verdict"] == "FINAL VERDICT"
+        assert result["model"] == "mock/aggregator"
+        assert len(result["advisors"]) == 2
+        assert {a["label"] for a in result["advisors"]} == {"a", "b"}
+        assert all(a["error"] is None for a in result["advisors"])
+        assert result["trace_dir"] is not None
+
+        # Fan-out is parallel: both advisor calls must be submitted before the
+        # aggregator is called.
+        assert len(calls) == 3
+        agg_index = next(i for i, c in enumerate(calls) if c["model"] == "mock/aggregator")
+        assert agg_index == 2
+        # Aggregator receives both analyses.
+        agg_user = calls[agg_index]["messages"][1]["content"]
+        assert "analysis from mock/advisor-a" in agg_user
+        assert "analysis from mock/advisor-b" in agg_user
+
+    def test_traces_written_for_audit(self, tmp_path, monkeypatch):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            return _reply(f"analysis from {model}")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        result = moa.run_moa("trace me", config=_fake_config(), trace_dir=str(tmp_path / "traces"))
+        trace_dir = Path(result["trace_dir"])
+        assert trace_dir.is_dir()
+        assert (trace_dir / "run.json").is_file()
+        assert (trace_dir / "advisor-a.json").is_file()
+        assert (trace_dir / "advisor-b.json").is_file()
+        assert (trace_dir / "aggregator.json").is_file()
+        for name in ("advisor-a.json", "advisor-b.json", "aggregator.json"):
+            payload = json.loads((trace_dir / name).read_text(encoding="utf-8"))
+            assert payload["response"]["choices"]
+            assert "extracted" in payload
+
+    def test_advisor_failure_isolated_and_aggregator_still_runs(self, tmp_path, monkeypatch):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            if model == "mock/advisor-a":
+                raise RuntimeError("boom-a")
+            if model == "mock/aggregator":
+                return _reply("verdict from surviving advisor")
+            return _reply("analysis from b")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        result = moa.run_moa("partial", config=_fake_config(), trace_dir=str(tmp_path / "traces"))
+        assert result["verdict"] == "verdict from surviving advisor"
+        by_label = {a["label"]: a for a in result["advisors"]}
+        assert by_label["a"]["error"] is not None
+        assert by_label["b"]["error"] is None
+        # Failed advisor's trace still records the error.
+        err_trace = json.loads(
+            (Path(result["trace_dir"]) / "advisor-a.json").read_text(encoding="utf-8")
+        )
+        assert "error" in err_trace
+
+    def test_all_advisors_failed_raises(self, tmp_path, monkeypatch):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        with pytest.raises(moa.MoaAllAdvisorsFailed):
+            moa.run_moa("doomed", config=_fake_config(), trace_dir=str(tmp_path / "traces"))
+
+    def test_aggregator_failure_raises(self, tmp_path, monkeypatch):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            if model == "mock/aggregator":
+                raise RuntimeError("agg down")
+            return _reply(f"analysis from {model}")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        with pytest.raises(moa.MoaAggregatorFailed):
+            moa.run_moa("agg fail", config=_fake_config(), trace_dir=str(tmp_path / "traces"))

--- a/tools/moa/tests/test_moa_run_cli.py
+++ b/tools/moa/tests/test_moa_run_cli.py
@@ -1,0 +1,149 @@
+"""Tests for bin/moa-run — the MoA CLI.
+
+Model calls are mocked via lib/moa.chat_completions (the single network seam);
+no live quota is consumed.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+BIN_DIR = HERE.parent / "bin"
+
+sys.path.insert(0, str(HERE.parent / "lib"))
+import moa  # noqa: E402
+
+
+def _import_moa_run():
+    loader = importlib.machinery.SourceFileLoader("moa_run", str(BIN_DIR / "moa-run"))
+    spec = importlib.util.spec_from_loader("moa_run", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+moa_run = _import_moa_run()
+
+
+def _reply(content: str) -> dict:
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+@pytest.fixture
+def fake_route(monkeypatch):
+    """Stub chat_completions so runs are deterministic and quota-free."""
+    calls: list[dict] = []
+
+    def fake_chat(base_url, api_key, model, messages, **kwargs):
+        calls.append({"model": model, "messages": messages})
+        if model == "mock/aggregator":
+            return _reply("VERDICT TEXT")
+        return _reply(f"analysis from {model}")
+
+    monkeypatch.setattr(moa, "chat_completions", fake_chat)
+    monkeypatch.setenv("MOA_BASE_URL", "http://mock/v1")
+    monkeypatch.setenv("MOA_API_KEY", "test-key")
+    return calls
+
+
+MOCK_ROLES = ("--advisors", "mock/advisor-a,mock/advisor-b", "--aggregator", "mock/aggregator")
+
+
+@pytest.fixture
+def cli_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MOA_TRACES_DIR", str(tmp_path / "traces"))
+    return tmp_path
+
+
+def _run(monkeypatch, *args):
+    monkeypatch.setattr(sys, "argv", ["moa-run", *args])
+    return moa_run.main()
+
+
+class TestMoaRunCli:
+    def test_no_args_prints_usage_exit_2(self, capsys, monkeypatch):
+        rc = _run(monkeypatch)
+        out = capsys.readouterr().out
+        assert rc == moa_run.EXIT_USAGE
+        assert "moa-run" in out
+
+    def test_help_exits_0(self, capsys, monkeypatch):
+        rc = _run(monkeypatch, "--help")
+        assert rc == 0
+        assert "advisors" in capsys.readouterr().out
+
+    def test_unknown_flag_errors(self, capsys, monkeypatch):
+        rc = _run(monkeypatch, "--bogus", "x")
+        assert rc == moa_run.EXIT_USAGE
+        assert "unknown flag" in capsys.readouterr().err
+
+    def test_missing_prompt_errors(self, capsys, monkeypatch):
+        rc = _run(monkeypatch, "--out", "/tmp/x.json")
+        assert rc == moa_run.EXIT_USAGE
+
+    def test_missing_file_errors(self, capsys, monkeypatch):
+        rc = _run(monkeypatch, "--file", "/nonexistent/task.md")
+        assert rc == moa_run.EXIT_USAGE
+
+    def test_verdict_to_stdout(self, capsys, monkeypatch, fake_route, cli_env):
+        rc = _run(monkeypatch, "check the config", *MOCK_ROLES)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert out.strip() == "VERDICT TEXT"
+        assert [c["model"] for c in fake_route] == [
+            "mock/advisor-a",
+            "mock/advisor-b",
+            "mock/aggregator",
+        ]
+
+    def test_out_file_written_with_verdict_shape(self, tmp_path, monkeypatch, fake_route, cli_env):
+        out_path = tmp_path / "verdict.json"
+        rc = _run(monkeypatch, "task", "--out", str(out_path), *MOCK_ROLES)
+        assert rc == 0
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        assert payload["verdict"] == "VERDICT TEXT"
+        assert payload["model"] == "mock/aggregator"
+        assert len(payload["advisors"]) == 2
+
+    def test_file_prompt_and_context(self, tmp_path, monkeypatch, fake_route, cli_env):
+        task = tmp_path / "task.md"
+        task.write_text("prompt from file", encoding="utf-8")
+        rc = _run(monkeypatch, "--file", str(task), "--context", "ctx data", *MOCK_ROLES)
+        assert rc == 0
+        all_messages = [m for c in fake_route for m in c["messages"]]
+        assert any("prompt from file" in m["content"] for m in all_messages)
+        assert any("ctx data" in m["content"] for m in all_messages)
+
+    def test_traces_dir_written(self, tmp_path, monkeypatch, fake_route, cli_env):
+        rc = _run(monkeypatch, "trace me", *MOCK_ROLES)
+        assert rc == 0
+        trace_root = cli_env  # MOA_TRACES_DIR = <tmp>/traces
+        run_dirs = [p for p in Path(trace_root).glob("traces/*/run.json")]
+        assert run_dirs, "expected a run.json under the traces dir"
+        assert list(Path(trace_root).glob("traces/*/advisor-*.json")), "expected advisor traces"
+
+    def test_all_advisors_failed_exit_3(self, capsys, monkeypatch, cli_env):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            raise RuntimeError("down")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        rc = _run(monkeypatch, "doomed", *MOCK_ROLES)
+        assert rc == moa_run.EXIT_PIPELINE
+        assert "failed" in capsys.readouterr().err
+
+    def test_aggregator_failure_exit_3(self, capsys, monkeypatch, cli_env):
+        def fake_chat(base_url, api_key, model, messages, **kwargs):
+            if model == "mock/aggregator":
+                raise RuntimeError("agg down")
+            return _reply("analysis")
+
+        monkeypatch.setattr(moa, "chat_completions", fake_chat)
+        rc = _run(monkeypatch, "agg fail", *MOCK_ROLES)
+        assert rc == moa_run.EXIT_PIPELINE


### PR DESCRIPTION
Port of the verified MOA (Mixture of Agents) wrapper into opencode as standalone tooling under `tools/moa/` (source: security-lab-workflow `fm/oc-moa-wrapper-v1`, 26 passing tests). The security-lab lane ships the same wrapper in parallel — both repos carry it for now, to be revisited later.

## What's included

- `tools/moa/bin/moa-run` — CLI entry (Python3 shebang)
- `tools/moa/lib/moa.py` — config + stdlib-urllib OpenAI-compatible client + thread-pool fan-out + aggregator synthesis + traces
- `tools/moa/moa.yaml` — captain-test preset defaults
- `tools/moa/tests/` — 26 tests (mocked network, no live quota)
- `tools/moa/README.md` + `requirements.txt`
- Root README section + .gitignore entries for traces/audit/venv

## Behavior

Fans a task prompt to advisor models in parallel (`ollama-cloud/glm-5.2`, `ollama-cloud/minimax-m3`), then aggregates their analyses plus the original task into a final verdict (`ollama-cloud/deepseek-v4-flash:0731`, reasoning_effort=max). Route: `MOA_BASE_URL` (default `http://ai.tail492ce8.ts.net/v1`, fallback `OLLAMA_API_BASE`) + `MOA_API_KEY` (fallback `OLLAMA_API_KEY`; default `not-required`). No hardcoded keys.

## Design constraints honored

- Additive only: no changes to opencode core (`src/`, `packages/`)
- Self-contained: no security-lab imports — the CLI's audit hook (previously `labutil.audit()`) is now a local best-effort JSONL append (`tools/moa/audit/moa-run.jsonl`, `MOA_AUDIT_LOG` override)
- Ported faithfully, no redesign

## Verification

`python3 -m pytest tools/moa/tests` → 26 passed.