### PR TITLE
docs: add BitFun to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [BitFun](https://github.com/GCWing/BitFun)                                                 | Rust-native agent using OpenCode commands, tools, and MCP config |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs-only ecosystem entry.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds BitFun to the Projects table. I maintain BitFun; its current OpenCode adapter registers command, standalone-tool, and MCP providers.

### How did you verify your code works?

Ran Prettier 3.6.2 and git diff --check. Re-checked the repository link and those provider registrations on BitFun main.

### Screenshots / recordings

N/A — one-line docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR