### PR TITLE
fix(tui): hide empty integration output

### DIFF
--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -317,15 +317,19 @@ function CommandView(props: { title: string; output: string; message: string }) 
           esc close
         </text>
       </box>
-      <box
-        backgroundColor={overlayTheme.background.default}
-        paddingLeft={2}
-        paddingRight={2}
-        paddingTop={1}
-        paddingBottom={1}
-      >
-        <text fg={overlayTheme.text.default}>{props.output.trim()}</text>
-      </box>
+      <Show when={props.output.trim()}>
+        {(output) => (
+          <box
+            backgroundColor={overlayTheme.background.default}
+            paddingLeft={2}
+            paddingRight={2}
+            paddingTop={1}
+            paddingBottom={1}
+          >
+            <text fg={overlayTheme.text.default}>{output()}</text>
+          </box>
+        )}
+      </Show>
       <box paddingLeft={2} paddingRight={2}>
         <text fg={theme.text.subdued}>{props.message}</text>
       </box>


### PR DESCRIPTION
## What

Hide the command-output panel in integration dialogs when the command produced only whitespace.

## Before / After

**Before:** A successful command with no visible output left an empty elevated panel between the dialog header and status message.

**After:** Whitespace-only output skips the panel while non-empty output keeps the existing presentation.

## How

- Trim command output once in `dialog-integration.tsx`.
- Render the output container only when trimmed content exists.

## Scope

Only integration command-result rendering changes.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/cmd/tui/integration-options.test.ts`
- Repository pre-push typecheck
- `git diff --check`