### PR TITLE
fix(tui): clarify working copy actions

### DIFF
--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -258,6 +258,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
         const choice = await DialogWorkspaceFileChanges.show(dialog, status?.data ?? [], {
           title: "Delete working copy?",
           message: "This working copy has file changes. Do you want to delete it anyway?",
+          labels: { no: "cancel", yes: "delete" },
         })
         if (choice !== "yes") {
           reopen()

--- a/packages/tui/src/component/dialog-workspace-file-changes.tsx
+++ b/packages/tui/src/component/dialog-workspace-file-changes.tsx
@@ -29,6 +29,7 @@ export function DialogWorkspaceFileChanges(props: {
   onSelect: (choice: WorkspaceFileChangesChoice) => void
   title?: string
   message?: string
+  labels?: Partial<Record<WorkspaceFileChangesChoice, string>>
 }) {
   const dialog = useDialog()
   const theme = useTheme("elevated")
@@ -125,7 +126,9 @@ export function DialogWorkspaceFileChanges(props: {
                 dialog.clear()
               }}
             >
-              <text fg={item === store.active ? theme.text.action.primary.focused : theme.text.subdued}>{item}</text>
+              <text fg={item === store.active ? theme.text.action.primary.focused : theme.text.subdued}>
+                {props.labels?.[item] ?? (item === "no" ? "cancel" : "move")}
+              </text>
             </box>
           )}
         </For>
@@ -137,7 +140,11 @@ export function DialogWorkspaceFileChanges(props: {
 DialogWorkspaceFileChanges.show = (
   dialog: DialogContext,
   files: VcsFileStatus[],
-  options?: { title?: string; message?: string },
+  options?: {
+    title?: string
+    message?: string
+    labels?: Partial<Record<WorkspaceFileChangesChoice, string>>
+  },
 ) => {
   return new Promise<WorkspaceFileChangesChoice | undefined>((resolve) => {
     dialog.replace(


### PR DESCRIPTION
## What

Replace ambiguous `no` / `yes` working-copy confirmation labels with actions that describe the result.

## Before / After

**Before:** Move and forced-delete confirmations displayed `no` / `yes`, requiring users to infer what each choice would do.

**After:** Move uses `cancel` / `move`; forced deletion uses `cancel` / `delete`.

## How

- Add optional choice labels to `DialogWorkspaceFileChanges`.
- Keep move labels as the defaults.
- Supply deletion-specific labels from `DialogMoveSession`.

## Scope

No confirmation behavior or default selection changes.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/tui/dialog-select.test.tsx`
- Repository pre-push typecheck
- `git diff --check`