### PR TITLE
fix(tui): distinguish disconnect actions

### DIFF
--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -123,6 +123,7 @@ function manageConnections(
   onConnected?: OnIntegrationConnected,
 ) {
   dialog.replace(() => {
+    const theme = useTheme("elevated")
     const data = useData()
     const client = useClient()
     const toast = useToast()
@@ -142,6 +143,9 @@ function manageConnections(
           ...credentialConnections(integration).map((connection) => ({
             title: `Disconnect ${connection.label}`,
             value: connection.id,
+            category: "Connected accounts",
+            bg: theme.background.action.destructive.focused,
+            fg: theme.text.action.destructive.focused,
             onSelect: () => {
               void client.api.credential
                 .remove({ credentialID: connection.id, location: location(data) })


### PR DESCRIPTION
## What

Separate connected accounts from connection methods and visibly mark Disconnect as destructive.

## Before / After

**Before:** Disconnect entries appeared alongside connection methods with the same primary focus styling.

**After:** Existing accounts appear under `Connected accounts`, and focused Disconnect actions use destructive colors.

## How

- Categorize credential-backed disconnect options.
- Supply destructive focused foreground and background colors to the select option.

## Scope

Connection, credential removal, and environment-discovered integrations behave as before.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/cmd/tui/integration-options.test.ts`
- Repository pre-push typecheck
- `git diff --check`