### PR TITLE
fix(console): distinct error message for blocked workspaces

### DIFF
--- a/packages/console/app/src/i18n/en.ts
+++ b/packages/console/app/src/i18n/en.ts
@@ -374,6 +374,7 @@ export const dict = {
   "zen.api.error.missingApiKey": "Missing API key.",
   "zen.api.error.invalidApiKey": "Invalid API key.",
   "zen.api.error.requestBlockedByUpstreamProvider": "Request blocked by upstream provider.",
+  "zen.api.error.workspaceBlocked": "This workspace has been blocked. Contact support: https://opencode.ai/discord",
   "zen.api.error.subscriptionQuotaExceeded": "Subscription quota exceeded. Retry in {{retryIn}}.",
   "zen.api.error.goSubscriptionRollingLimitExceeded":
     "5-hour usage limit reached. Resets in {{retryIn}}. To continue using this model now, enable usage from your available balance: {{consoleGoUrl}}",

--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -780,8 +780,8 @@ export async function handler(
     )
 
     if (!data) throw new AuthError(t("zen.api.error.invalidApiKey"))
+    if (data.workspace.isBlocked) throw new AuthError(t("zen.api.error.workspaceBlocked"))
     if (
-      data.workspace.isBlocked ||
       (data.workspace.isFlaggedByAnthropic && modelInfo.id.startsWith("claude-")) ||
       (data.workspace.isFlaggedByOpenAI && modelInfo.id.startsWith("gpt-"))
     )


### PR DESCRIPTION
### Issue for this PR

Closes #38218

Same error reported in #38195, #38216, #38257, #38323, #38473, #39215, #39827, #40055. Root-cause analysis: https://github.com/anomalyco/opencode/issues/38218#issuecomment-5209769210

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`authenticate()` in `packages/console/app/src/routes/zen/util/handler.ts` throws the same message for three different workspace flags:

```ts
if (
  data.workspace.isBlocked ||
  (data.workspace.isFlaggedByAnthropic && modelInfo.id.startsWith("claude-")) ||
  (data.workspace.isFlaggedByOpenAI && modelInfo.id.startsWith("gpt-"))
)
  throw new AuthError(t("zen.api.error.requestBlockedByUpstreamProvider"))
```

For the two vendor flags the wording is accurate. For `is_blocked` it is not: the request is rejected before any relay and no upstream provider is involved. Users then debug the wrong things (rotate keys, clear auth caches, check vendor status) and file duplicate issues — the 9 linked above all show the error on `minimax-*`, `kimi-*`, `glm-*`, `deepseek-*` or `*-free` ids, which the vendor flags cannot match, so every one of them is the `is_blocked` branch.

The fix gives `is_blocked` its own branch and message:

```ts
if (data.workspace.isBlocked) throw new AuthError(t("zen.api.error.workspaceBlocked"))
```

with `"zen.api.error.workspaceBlocked": "This workspace has been blocked. Contact support: https://opencode.ai/discord"` added to `en.ts`.

Enforcement is unchanged: a blocked workspace is refused at the same point, with the same `AuthError` class and the same 401. Only the message differs. Locale dicts spread `...en` before their overrides, so the new key falls back to English in all locales without touching the other dictionaries (happy to add translations if wanted).

### How did you verify your code works?

- Imported `en.ts` and `zh.ts` with bun: all 730 keys load, the new key resolves, and `zh` falls back to the English string through the spread.
- The changed condition only moves the first disjunct one line up, so behavior for non-blocked workspaces is identical.
- Reproduced the bug live against opencode.ai with a blocked workspace key: `POST /zen/v1/chat/completions` returns this 401 in ~115 ms (same latency as the local invalid-key path), while the identical anonymous request to a free model returns 200 — confirming no upstream call is involved and the current message is wrong for this branch.

### Screenshots / recordings

Not a UI change (API error message only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
