### PR TITLE
fix(tui): style destructive dialog actions

### DIFF
--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -128,6 +128,7 @@ export function DialogMcp() {
               {
                 title: toggleTitle(),
                 command: "dialog.mcp.toggle",
+                variant: toggleTitle() === "disconnect" ? "destructive" : "primary",
                 onTrigger: (option) => {
                   setFocused(option.value as string)
                   toggle(option.value as string)

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -372,6 +372,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
                 {
                   command: "dialog.move_session.delete",
                   title: "delete",
+                  variant: "destructive",
                   disabled: (option) => {
                     const value = option?.value
                     if (!value || value.type !== "directory" || value.subdirectory) return true

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -236,6 +236,7 @@ export function DialogSessionList() {
         {
           command: "session.delete",
           title: "delete",
+          variant: "destructive",
           onTrigger: (option: { value: string }) => {
             if (toDelete() !== option.value) {
               setToDelete(option.value)

--- a/packages/tui/src/component/dialog-stash.tsx
+++ b/packages/tui/src/component/dialog-stash.tsx
@@ -75,6 +75,7 @@ export function DialogStash(props: { onSelect: (entry: StashEntry) => void }) {
         {
           command: "stash.delete",
           title: "delete",
+          variant: "destructive",
           onTrigger: (option) => {
             if (toDelete() === option.value) {
               stash.remove(option.value)

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -45,6 +45,7 @@ export interface DialogSelectProps<T> {
 type DialogSelectActionBase<T> = {
   command: string
   title: string
+  variant?: "primary" | "destructive"
   side?: "left" | "right"
   hidden?: boolean
   disabled?: boolean | ((option: DialogSelectOption<T> | undefined) => boolean)
@@ -551,19 +552,22 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     const item = action.item
     const active = createMemo(() => isActionFocused(item))
     const disabled = createMemo(() => isActionDisabled(item))
+    const variant = () => item.variant ?? "primary"
     return (
       <box
         flexDirection="row"
-        backgroundColor={active() ? theme.background.action.primary.focused : RGBA.fromInts(0, 0, 0, 0)}
+        backgroundColor={active() ? theme.background.action[variant()].focused : RGBA.fromInts(0, 0, 0, 0)}
         onMouseUp={() => trigger(item)}
       >
         <text
           fg={
             disabled()
-              ? theme.text.action.primary.disabled
+              ? theme.text.action[variant()].disabled
               : active()
-                ? theme.text.action.primary.focused
-                : theme.text.default
+                ? theme.text.action[variant()].focused
+                : variant() === "destructive"
+                  ? theme.text.action.destructive.default
+                  : theme.text.default
           }
           attributes={active() ? TextAttributes.BOLD : undefined}
         >
@@ -572,9 +576,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         <text
           fg={
             disabled()
-              ? theme.text.action.primary.disabled
+              ? theme.text.action[variant()].disabled
               : active()
-                ? theme.text.action.primary.focused
+                ? theme.text.action[variant()].focused
                 : theme.text.subdued
           }
         >

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -565,9 +565,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
               ? theme.text.action[variant()].disabled
               : active()
                 ? theme.text.action[variant()].focused
-                : variant() === "destructive"
-                  ? theme.text.feedback.error.default
-                  : theme.text.default
+                : theme.text.default
           }
           attributes={active() ? TextAttributes.BOLD : undefined}
         >

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -566,7 +566,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
               : active()
                 ? theme.text.action[variant()].focused
                 : variant() === "destructive"
-                  ? theme.text.action.destructive.default
+                  ? theme.text.feedback.error.default
                   : theme.text.default
           }
           attributes={active() ? TextAttributes.BOLD : undefined}


### PR DESCRIPTION
## What

Give destructive `DialogSelect` footer actions a distinct keyboard-focus state while preserving the ordinary idle presentation.

## Before / After

**Before:** Focused Delete and Disconnect actions used the same primary styling as benign actions such as Rename, New, and Refresh.

**After:** All actions look neutral at rest. Focused session Delete, stash Delete, project-copy Delete, and connected MCP Disconnect use destructive action colors; benign actions keep primary focus colors.

## How

- Add a `primary | destructive` variant to shared `DialogSelect` actions.
- Resolve focused and disabled colors from the selected variant.
- Keep the existing neutral foreground when no footer action is focused.
- Mark the four existing destructive consumers without changing their behavior.

## Scope

This PR changes focused action styling only. It does not change confirmation, default selection, deletion, or disconnect behavior. Safe-default confirmation remains tracked in #36302.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/tui/dialog-select.test.tsx test/cli/cmd/tui/integration-options.test.ts`
- Repository pre-push typecheck
- Inspected deterministic idle, Delete-focused, and Rename-focused PNG frames at 80x20
- `git diff --check`

## Demo

The comparison moves from neutral idle state to destructive Delete focus, then ordinary Rename focus.

https://github.com/user-attachments/assets/a58b29d7-b0f7-480b-8e53-f814cd21a06d