### PR TITLE
fix(tui): dismiss stale permission prompts

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -15,6 +15,7 @@ import type {
   ModelInfo,
   PermissionSavedInfo,
   PermissionRequest,
+  PermissionReplyInput,
   Project,
   ProviderInfo,
   ReferenceInfo,
@@ -31,6 +32,7 @@ import type {
   OpenCodeEvent,
   WebSearchProvider,
 } from "@opencode-ai/client"
+import { isPermissionNotFoundError } from "@opencode-ai/client"
 import type { Plugin } from "@opencode-ai/plugin/tui"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { createSimpleContext } from "./helper"
@@ -1035,6 +1037,17 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           },
           invalidate(sessionID: string) {
             sync.invalidate(`session.permission:${sessionID}`)
+          },
+          async reply(input: PermissionReplyInput) {
+            await client.api.permission.reply(input).catch((error: unknown) => {
+              if (!isPermissionNotFoundError(error)) throw error
+            })
+            setStore(
+              "session",
+              "permission",
+              input.sessionID,
+              (requests = []) => requests.filter((request) => request.id !== input.requestID),
+            )
           },
         },
         form: {

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -178,6 +178,17 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       )
     }
 
+    function removePermission(sessionID: string, requestID: string) {
+      const requests = store.session.permission[sessionID]
+      if (!requests?.some((request) => request.id === requestID)) return
+      setStore(
+        "session",
+        "permission",
+        sessionID,
+        requests.filter((request) => request.id !== requestID),
+      )
+    }
+
     const message = {
       update(sessionID: string, fn: (messages: SessionMessageInfo[], index: Map<string, number>) => void) {
         setStore(
@@ -842,14 +853,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           ])
           break
         case "permission.replied":
-          setStore(
-            "session",
-            "permission",
-            event.data.sessionID,
-            (store.session.permission[event.data.sessionID] ?? []).filter(
-              (request) => request.id !== event.data.requestID,
-            ),
-          )
+          removePermission(event.data.sessionID, event.data.requestID)
           break
         case "form.created":
           if (store.session.form[event.data.form.sessionID]?.some((form) => form.id === event.data.form.id)) break
@@ -1042,12 +1046,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             await client.api.permission.reply(input).catch((error: unknown) => {
               if (!isPermissionNotFoundError(error)) throw error
             })
-            setStore(
-              "session",
-              "permission",
-              input.sessionID,
-              (requests = []) => requests.filter((request) => request.id !== input.requestID),
-            )
+            removePermission(input.sessionID, input.requestID)
           },
         },
         form: {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -227,7 +227,7 @@ export function Session() {
     permissions().forEach((request) => {
       if (autoApproved.has(request.id)) return
       autoApproved.add(request.id)
-      void client.api.permission
+      void data.session.permission
         .reply({
           sessionID: request.sessionID,
           reply: "once",

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -3,8 +3,7 @@ import { createMemo, For, Match, Show, Switch } from "solid-js"
 import { Portal, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useTheme, useThemes } from "../../context/theme"
-import type { PermissionRequest } from "@opencode-ai/client"
-import { useClient } from "../../context/client"
+import type { PermissionReplyInput, PermissionRequest } from "@opencode-ai/client"
 import { SplitBorder } from "../../ui/border"
 import { useData } from "../../context/data"
 import { filetype } from "../../util/filetype"
@@ -15,6 +14,7 @@ import { Keymap } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { SimulationSemantics } from "../../simulation/semantics"
 import { PatchDiff } from "../../component/patch-diff"
+import { useToast } from "../../ui/toast"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -110,8 +110,8 @@ function EditBody(props: { file?: string; diff?: string; patch?: string }) {
 }
 
 export function PermissionPrompt(props: { request: PermissionRequest; directory?: string }) {
-  const client = useClient()
   const data = useData()
+  const toast = useToast()
   const [store, setStore] = createStore({
     stage: "permission" as PermissionStage,
   })
@@ -132,6 +132,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
   const theme = useTheme()
 
+  function reply(input: PermissionReplyInput) {
+    void data.session.permission.reply(input).catch((error: unknown) => toast.error(error))
+  }
+
   return (
     <Switch>
       <Match when={store.stage === "always"}>
@@ -151,7 +155,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
           onSelect={(option) => {
             setStore("stage", "permission")
             if (option === "cancel") return
-            void client.api.permission.reply({
+            reply({
               sessionID: props.request.sessionID,
               reply: "always",
               requestID: props.request.id,
@@ -164,7 +168,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
           action={props.request.action}
           instance={props.request.id}
           onConfirm={(message) => {
-            void client.api.permission.reply({
+            reply({
               sessionID: props.request.sessionID,
               reply: "reject",
               requestID: props.request.id,
@@ -265,14 +269,14 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                     setStore("stage", "reject")
                     return
                   }
-                  void client.api.permission.reply({
+                  reply({
                     sessionID: props.request.sessionID,
                     reply: "reject",
                     requestID: props.request.id,
                   })
                   return
                 }
-                void client.api.permission.reply({
+                reply({
                   sessionID: props.request.sessionID,
                   reply: "once",
                   requestID: props.request.id,

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -3,7 +3,7 @@ import { createMemo, For, Match, Show, Switch } from "solid-js"
 import { Portal, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useTheme, useThemes } from "../../context/theme"
-import type { PermissionReplyInput, PermissionRequest } from "@opencode-ai/client"
+import type { PermissionReply, PermissionRequest } from "@opencode-ai/client"
 import { SplitBorder } from "../../ui/border"
 import { useData } from "../../context/data"
 import { filetype } from "../../util/filetype"
@@ -132,8 +132,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
   const theme = useTheme()
 
-  function reply(input: PermissionReplyInput) {
-    void data.session.permission.reply(input).catch((error: unknown) => toast.error(error))
+  function reply(value: PermissionReply, message?: string) {
+    void data.session.permission
+      .reply({ sessionID: props.request.sessionID, requestID: props.request.id, reply: value, message })
+      .catch((error: unknown) => toast.error(error))
   }
 
   return (
@@ -155,11 +157,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
           onSelect={(option) => {
             setStore("stage", "permission")
             if (option === "cancel") return
-            reply({
-              sessionID: props.request.sessionID,
-              reply: "always",
-              requestID: props.request.id,
-            })
+            reply("always")
           }}
         />
       </Match>
@@ -168,12 +166,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
           action={props.request.action}
           instance={props.request.id}
           onConfirm={(message) => {
-            reply({
-              sessionID: props.request.sessionID,
-              reply: "reject",
-              requestID: props.request.id,
-              message: message || undefined,
-            })
+            reply("reject", message || undefined)
           }}
           onCancel={() => {
             setStore("stage", "permission")
@@ -269,18 +262,10 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                     setStore("stage", "reject")
                     return
                   }
-                  reply({
-                    sessionID: props.request.sessionID,
-                    reply: "reject",
-                    requestID: props.request.id,
-                  })
+                  reply("reject")
                   return
                 }
-                reply({
-                  sessionID: props.request.sessionID,
-                  reply: "once",
-                  requestID: props.request.id,
-                })
+                reply("once")
               }}
             />
           )

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -2070,13 +2070,8 @@ test("reconciles active session permissions when the event stream reconnects", a
 test("dismisses a permission that expired before its reply", async () => {
   const events = createEventStream()
   const request = { id: "per_stale", sessionID: "ses_active", action: "read", resources: ["old.txt"] }
-  let lists = 0
   let replies = 0
   const calls = createFetch((url, init) => {
-    if (url.pathname === "/api/session/ses_active/permission" && init.method === "GET") {
-      lists++
-      return json({ data: [request] })
-    }
     if (url.pathname === "/api/session/ses_active/permission/per_stale/reply" && init.method === "POST") {
       replies++
       return json(
@@ -2109,8 +2104,13 @@ test("dismisses a permission that expired before its reply", async () => {
   ))
 
   try {
-    await data.session.permission.sync(request.sessionID)
-    expect(data.session.permission.list(request.sessionID)).toEqual([request])
+    emitEvent(events, {
+      id: "evt_permission_asked_stale",
+      created: 0,
+      type: "permission.asked",
+      data: request,
+    })
+    await wait(() => data.session.permission.list(request.sessionID)?.length === 1)
 
     await data.session.permission.reply({
       sessionID: request.sessionID,
@@ -2119,7 +2119,6 @@ test("dismisses a permission that expired before its reply", async () => {
     })
 
     expect(replies).toBe(1)
-    expect(lists).toBe(1)
     expect(data.session.permission.list(request.sessionID)).toEqual([])
   } finally {
     app.renderer.destroy()

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -2067,6 +2067,65 @@ test("reconciles active session permissions when the event stream reconnects", a
   }
 })
 
+test("dismisses a permission that expired before its reply", async () => {
+  const events = createEventStream()
+  const request = { id: "per_stale", sessionID: "ses_active", action: "read", resources: ["old.txt"] }
+  let lists = 0
+  let replies = 0
+  const calls = createFetch((url, init) => {
+    if (url.pathname === "/api/session/ses_active/permission" && init.method === "GET") {
+      lists++
+      return json({ data: [request] })
+    }
+    if (url.pathname === "/api/session/ses_active/permission/per_stale/reply" && init.method === "POST") {
+      replies++
+      return json(
+        {
+          _tag: "PermissionNotFoundError",
+          requestID: request.id,
+          message: `Permission request not found: ${request.id}`,
+        },
+        { status: 404 },
+      )
+    }
+  }, events)
+  let data!: ReturnType<typeof useData>
+
+  function Probe() {
+    data = useData()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ClientProvider api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </ClientProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await data.session.permission.sync(request.sessionID)
+    expect(data.session.permission.list(request.sessionID)).toEqual([request])
+
+    await data.session.permission.reply({
+      sessionID: request.sessionID,
+      requestID: request.id,
+      reply: "once",
+    })
+
+    expect(replies).toBe(1)
+    expect(lists).toBe(1)
+    expect(data.session.permission.list(request.sessionID)).toEqual([])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("adds, dismisses, and refreshes form requests", async () => {
   const events = createEventStream()
   const calls = createFetch((url) => {


### PR DESCRIPTION
## What

Dismiss stale TUI permission prompts when the server reports that the request no longer exists.

The full TUI now routes manual and automatic permission replies through its data layer. Once a reply succeeds, or returns `PermissionNotFoundError`, that exact request is removed from local state. Other failures remain visible and surface through the existing toast.

## Before / After

**Before**

1. The TUI received `permission.asked` and displayed the approval dialog.
2. The server-side request disappeared before the user replied, for example when the waiting execution was interrupted.
3. Selecting Allow posted the stale request ID and received `404 PermissionNotFoundError`.
4. The rejected promise was ignored, so the same dialog remained and every Enter retried the same expired request forever.

**After**

1. The reply endpoint succeeds or authoritatively reports that the request is already absent.
2. The data layer removes that exact request ID from the owning session's local permission list.
3. The dialog closes while any unrelated pending permissions remain intact.
4. Transport and unexpected server errors still retain the prompt and show an error.

## How

- `packages/tui/src/context/data.tsx` owns reply settlement and reuses one idempotent removal path for API outcomes and `permission.replied` events.
- `packages/tui/src/routes/session/permission.tsx` closes over the active request and passes only the varying reply and optional message.
- `packages/tui/src/routes/session/index.tsx` uses the same path for automatic approval.
- `packages/tui/test/cli/tui/data.test.tsx` reproduces a cached request whose reply returns the tagged 404 and verifies that it is dismissed without another list request.

## Scope

This PR does not change the server's ephemeral permission lifecycle or add a new cancellation event. It makes the full TUI robust when a reply races with server-side cleanup or a terminal permission event is missed. The Mini TUI has a separate transport projection and remains out of scope.

## Testing

- `bun run test test/cli/tui/data.test.tsx test/cli/tui/permission.test.ts` from `packages/tui`: 41 passed
- `bun typecheck` from `packages/tui`: passed
- Push hook workspace typecheck: 32 packages passed
- `bun run lint -- <changed files>`: 0 errors; existing warnings remain in the touched large files
- Live reproduction on `0.0.0-next-16927`: repeated replies for one expired permission returned 404; delivering its missing terminal event dismissed the prompt without restarting the shared service

## Demo

No recording is attached because the live reproduction contained a private session transcript and temporary filesystem paths. The regression test covers the exact visible transition: cached permission dialog to no pending permission after the tagged 404.

## Flow

```mermaid
sequenceDiagram
    participant User
    participant TUI
    participant Server

    User->>TUI: Allow permission
    TUI->>Server: Reply with request ID
    alt Request is pending
        Server-->>TUI: Success
    else Request already disappeared
        Server-->>TUI: PermissionNotFoundError
    else Unexpected failure
        Server-->>TUI: Error
        TUI-->>User: Keep dialog and show toast
    end
    TUI->>TUI: Remove settled request ID
    TUI-->>User: Dismiss dialog
```
