### PR TITLE
fix(llm): treat empty tool call identity in stream deltas as absent

### DIFF
--- a/packages/llm/src/protocols/utils/tool-stream.ts
+++ b/packages/llm/src/protocols/utils/tool-stream.ts
@@ -112,7 +112,9 @@ export const start = <K extends StreamKey>(
  * Append a streamed argument delta, starting the tool if this provider encodes
  * identity on the first delta instead of a separate start event. OpenAI Chat has
  * this shape: `tool_calls[].index` is the stream key, and `id` / `name` may only
- * appear on the first delta for that index.
+ * appear on the first delta for that index. Some OpenAI-compatible providers
+ * (Alibaba DashScope) send them as empty strings on continuation deltas, so
+ * empty identity falls back to the accumulated tool the same as an absent one.
  */
 export const appendOrStart = <K extends StreamKey>(
   route: string,
@@ -122,8 +124,8 @@ export const appendOrStart = <K extends StreamKey>(
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
   const current = tools[key]
-  const id = delta.id ?? current?.id
-  const name = delta.name ?? current?.name
+  const id = delta.id || current?.id
+  const name = delta.name || current?.name
   if (!id || !name) return eventError(route, missingToolMessage)
 
   const tool = {

--- a/packages/llm/test/tool-stream.test.ts
+++ b/packages/llm/test/tool-stream.test.ts
@@ -36,6 +36,39 @@ describe("ToolStream", () => {
     }),
   )
 
+  it.effect("treats empty-string identity on continuation deltas as absent", () =>
+    Effect.gen(function* () {
+      const first = ToolStream.appendOrStart(
+        ADAPTER,
+        ToolStream.empty<number>(),
+        0,
+        { id: "call_1", name: "lookup", text: "" },
+        "missing tool",
+      )
+      if (ToolStream.isError(first)) return yield* first
+      const second = ToolStream.appendOrStart(
+        ADAPTER,
+        first.tools,
+        0,
+        { id: "", text: '{"query":"weather"}' },
+        "missing tool",
+      )
+      if (ToolStream.isError(second)) return yield* second
+      const finished = yield* ToolStream.finish(ADAPTER, second.tools, 0)
+
+      expect(second.events).toEqual([
+        { type: "tool-input-delta", id: "call_1", name: "lookup", text: '{"query":"weather"}' },
+      ])
+      expect(finished).toEqual({
+        tools: {},
+        events: [
+          { type: "tool-input-end", id: "call_1", name: "lookup" },
+          { type: "tool-call", id: "call_1", name: "lookup", input: { query: "weather" } },
+        ],
+      })
+    }),
+  )
+
   it.effect("fails appendExisting when the provider skipped the tool start", () =>
     Effect.gen(function* () {
       const error = ToolStream.appendExisting(ADAPTER, ToolStream.empty<number>(), 0, "{}", "missing tool")


### PR DESCRIPTION
## Problem

Streaming tool calls through an OpenAI-compatible endpoint fails with `OpenAI Chat tool call delta is missing id or name` on providers that send `id` as an **empty string** (instead of omitting it) on continuation deltas. Alibaba DashScope (`*.maas.aliyuncs.com/compatible-mode/v1`, also serving qwen3-max / deepseek models) does this. The session errors out mid-turn and the pending tool call is never resolved.

Actual chunks captured from DashScope (`qwen3.8-max`):

```
data: {"choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_a1ad8367bde7444f82142e8e","type":"function","index":0,"function":{"name":"bash","arguments":""}}]}}]}
data: {"choices":[{"index":0,"delta":{"tool_calls":[{"id":"","type":"function","index":0,"function":{"arguments":"{\"command\": "}}]}}]}
```

The first delta carries the real identity. Continuation deltas carry `id: ""` with no `function.name`. In `ToolStream.appendOrStart`, `delta.id ?? current?.id` keeps the empty string (it is not nullish), so the fallback to the accumulated tool never happens and the truthiness guard reports the identity as missing.

## Fix

Fall back on empty-string identity the same as on absent identity (`||` instead of `??`). A genuinely missing identity on the first delta for an index still errors as before.

## Tests

Added a `ToolStream` regression test replicating the DashScope shape: identity on the first delta, `id: ""` on the continuation delta. `bun test` in `packages/llm`: 299 pass, 0 fail.