### PR TITLE
fix(provider): forward agent temperature for config-defined custom models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1453,7 +1453,9 @@ const layer = Layer.effect(
               name,
               providerID: ProviderV2.ID.make(providerID),
               capabilities: {
-                temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
+                // Config-defined custom models should forward agent-level temperature
+                // unless the user explicitly disables it for that model.
+                temperature: model.temperature ?? existingModel?.capabilities.temperature ?? true,
                 reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2057,3 +2057,34 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
     expect(keyedCount).toBeGreaterThan(0)
   }).pipe(provideMultiInstance),
 )
+
+it.instance(
+  "config-defined custom models allow temperature by default",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("brand-new-provider")].models["new-model"]
+    expect(model.capabilities.temperature).toBe(true)
+  }),
+  {
+    config: {
+      provider: {
+        "brand-new-provider": {
+          name: "Brand New",
+          npm: "@ai-sdk/openai-compatible",
+          env: [],
+          api: "https://new-api.com/v1",
+          models: {
+            "new-model": {
+              name: "New Model",
+              tool_call: true,
+              limit: { context: 32000, output: 8000 },
+            },
+          },
+          options: {
+            apiKey: "new-key",
+          },
+        },
+      },
+    },
+  },
+)

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -843,6 +843,7 @@ describe("session.llm.stream", () => {
           new Response(createChatStream("Hello"), {
             status: 200,
             headers: { "Content-Type": "text/event-stream" },
+
           }),
         )
 
@@ -900,6 +901,77 @@ describe("session.llm.stream", () => {
         provider: {
           [cerebrasFixture.providerID]: {
             options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "sends agent temperature for config-defined custom openai-compatible models by default",
+    () =>
+      Effect.gen(function* () {
+        const request = waitRequest(
+          "/chat/completions",
+          new Response(createChatStream("Hello"), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+        )
+        const providerID = ProviderV2.ID.make("custom-openai")
+        const resolved = yield* Provider.use.getModel(providerID, ModelV2.ID.make("custom-model"))
+        const sessionID = SessionID.make("session-test-custom-temp")
+        const agent = {
+          name: "build",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 1,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-custom-temp"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id, variant: "high" },
+        } satisfies SessionV1.User
+
+        yield* drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = yield* Effect.promise(() => request)
+        expect(capture.body.model).toBe(resolved.api.id)
+        expect(capture.body.temperature).toBe(1)
+      }),
+    {
+      config: () => ({
+        enabled_providers: ["custom-openai"],
+        provider: {
+          "custom-openai": {
+            name: "Custom OpenAI",
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            api: `${state.server!.url.origin}/v1`,
+            options: {
+              apiKey: "test-key",
+              baseURL: `${state.server!.url.origin}/v1`,
+            },
+            models: {
+              "custom-model": {
+                name: "Custom Model",
+                limit: { context: 32000, output: 8000 },
+                tool_call: true,
+              },
+            },
           },
         },
       }),


### PR DESCRIPTION
## Summary

Config-defined custom models (e.g. `provider.<id>.models` in `opencode.json`) currently default to `temperature: false`, so an agent-level `temperature` setting is silently dropped for these models. This makes custom openai-compatible/other providers behave inconsistently with built-in models.

This PR defaults the temperature capability to **enabled** for config-defined custom models, unless the user explicitly sets `temperature: false` for that model. The agent's temperature is then forwarded to the provider request as expected.

## Changes

- `packages/opencode/src/provider/provider.ts`: default `capabilities.temperature` to `true` for config-defined custom models (explicit `model.temperature` still wins).
- `packages/opencode/test/provider/provider.test.ts`: assert config-defined custom models report `temperature: true` by default.
- `packages/opencode/test/session/llm.test.ts`: assert the provider request body actually carries the agent temperature for a custom openai-compatible model.

## Notes

This replaces the previously auto-closed #34555 (opencode's automated PR cleanup closed it despite the fix being confirmed by a user on 1.18.4). The branch is rebased on the latest `dev` and conflicts are resolved.