### PR TITLE
fix(session): dedupe idle status events

### DIFF
--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -38,12 +38,15 @@ const layer = Layer.effect(
 
     const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
       const data = yield* InstanceState.get(state)
-      yield* events.publish(Event.Status, { sessionID, status })
+      const previous = data.get(sessionID)
       if (status.type === "idle") {
+        if (!previous) return
+        yield* events.publish(Event.Status, { sessionID, status })
         yield* events.publish(Event.Idle, { sessionID })
         data.delete(sessionID)
         return
       }
+      yield* events.publish(Event.Status, { sessionID, status })
       data.set(sessionID, status)
     })
 

--- a/packages/opencode/test/session/status.test.ts
+++ b/packages/opencode/test/session/status.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect } from "bun:test"
+import { Effect, Schema } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { SessionID } from "../../src/session/schema"
+import { SessionStatus } from "../../src/session/status"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(LayerNode.group([SessionStatus.node, EventV2Bridge.node, CrossSpawnSpawner.node])))
+
+describe("SessionStatus", () => {
+  it.instance("does not republish idle when a session is already idle", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2Bridge.Service
+      const status = yield* SessionStatus.Service
+      const sessionID = SessionID.make("session-status-idle-dedupe")
+      const statuses: string[] = []
+      const idleEvents: string[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        Effect.sync(() => {
+          if (event.type === SessionStatus.Event.Status.type) {
+            const data = Schema.decodeUnknownSync(SessionStatus.Event.Status.data)(event.data)
+            if (data.sessionID === sessionID) statuses.push(data.status.type)
+          }
+          if (event.type === SessionStatus.Event.Idle.type) {
+            const data = Schema.decodeUnknownSync(SessionStatus.Event.Idle.data)(event.data)
+            if (data.sessionID === sessionID) idleEvents.push(data.sessionID)
+          }
+        }),
+      )
+
+      yield* status.set(sessionID, { type: "busy" })
+      yield* status.set(sessionID, { type: "idle" })
+      yield* status.set(sessionID, { type: "idle" })
+      yield* unsubscribe
+
+      expect(statuses).toEqual(["busy", "idle"])
+      expect(idleEvents).toEqual([sessionID])
+      expect(yield* status.get(sessionID)).toEqual({ type: "idle" })
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #40882

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionStatus.set(idle)` now only publishes `session.status` / `session.idle` when the session was previously in a non-idle state. Repeated idle writes are no-ops, so clients do not receive duplicate idle/done events while a session is already idle.

The regression test covers a busy -> idle -> idle sequence and asserts that only one idle transition is published.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/status.test.ts --timeout 30000`
- `cd packages/opencode && bun test test/session/retry.test.ts --timeout 60000`
- `cd packages/opencode && bun test test/session/processor-effect.test.ts --test-name-pattern 'status|idle|busy' --timeout 90000`
- `cd packages/opencode && bun run typecheck`
- `cd packages/tui && bun test test/cli/cmd/tui/notifications.test.ts --timeout 60000`
- `bunx oxlint packages/opencode/src/session/status.ts packages/opencode/test/session/status.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A; this is an event emission fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
