### PR TITLE
fix(app): reconnect stale event streams

### DIFF
--- a/packages/app/src/context/server-sdk.test.ts
+++ b/packages/app/src/context/server-sdk.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { adaptServerEvent, coalesceServerEvents, enqueueServerEvent, resumeStreamAfterPageShow } from "./server-sdk"
+import {
+  adaptServerEvent,
+  coalesceServerEvents,
+  createEventStreamWatchdog,
+  enqueueServerEvent,
+  resumeStreamAfterPageShow,
+} from "./server-sdk"
 import type { OpenCodeEvent } from "@opencode-ai/client/promise"
 import type { Event } from "@opencode-ai/sdk/v2/client"
 
@@ -12,6 +18,44 @@ describe("resumeStreamAfterPageShow", () => {
     resumeStreamAfterPageShow({ persisted: true } as PageTransitionEvent, start)
 
     expect(starts).toBe(1)
+  })
+})
+
+describe("createEventStreamWatchdog", () => {
+  test("fires only when no newer stream activity resets the timer", () => {
+    const timers = new Map<number, () => void>()
+    const cleared: number[] = []
+    let timeout = 0
+    let stale = 0
+    const watchdog = createEventStreamWatchdog({
+      timeout: 10,
+      onStale: () => stale++,
+      setTimer: (callback, ms) => {
+        expect(ms).toBe(10)
+        timeout++
+        timers.set(timeout, callback)
+        return timeout as unknown as ReturnType<typeof setTimeout>
+      },
+      clearTimer: (timer) => cleared.push(timer as unknown as number),
+    })
+
+    watchdog.reset()
+    const first = timeout
+    watchdog.reset()
+    const second = timeout
+    timers.get(first)?.()
+    expect(stale).toBe(0)
+
+    timers.get(second)?.()
+    expect(stale).toBe(1)
+
+    watchdog.reset()
+    const third = timeout
+    watchdog.stop()
+    timers.get(third)?.()
+
+    expect(stale).toBe(1)
+    expect(cleared).toEqual([first, third])
   })
 })
 

--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -18,6 +18,44 @@ const isAbortError = (error: unknown) =>
   error !== null && typeof error === "object" && "name" in error && error.name === "AbortError"
 
 const isStreamClosed = (error: unknown, signal?: AbortSignal) => isAbortError(error) || signal?.aborted === true
+
+const EVENT_STREAM_STALE_MS = 45_000
+
+type EventStreamWatchdogOptions = {
+  timeout: number
+  onStale: () => void
+  setTimer?: (callback: () => void, timeout: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void
+}
+
+export function createEventStreamWatchdog(options: EventStreamWatchdogOptions) {
+  const setTimer = options.setTimer ?? setTimeout
+  const clearTimer = options.clearTimer ?? clearTimeout
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let generation = 0
+
+  const stop = () => {
+    generation++
+    if (!timer) return
+    clearTimer(timer)
+    timer = undefined
+  }
+
+  const reset = () => {
+    generation++
+    const current = generation
+    if (timer) clearTimer(timer)
+    timer = setTimer(() => {
+      if (current !== generation) return
+      timer = undefined
+      options.onStale()
+    }, options.timeout)
+  }
+
+  return { reset, stop }
+}
+
 export type ServerEvent = Event & { current?: OpenCodeEvent }
 type QueuedServerEvent = { directory: string; payload: ServerEvent }
 type CurrentDelta = Extract<
@@ -267,8 +305,13 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
       // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
       while (!abort.signal.aborted && started && generation === active) {
         attempt = new AbortController()
+        const streamAttempt = attempt
+        const watchdog = createEventStreamWatchdog({
+          timeout: EVENT_STREAM_STALE_MS,
+          onStale: () => streamAttempt.abort(),
+        })
         const onAbort = () => {
-          attempt?.abort()
+          streamAttempt.abort()
         }
         abort.signal.addEventListener("abort", onAbort)
         try {
@@ -277,8 +320,10 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
             kind === "v1"
               ? (await eventSdk.global.event({ signal: attempt.signal })).stream
               : eventApi.event.subscribe({ signal: attempt.signal })
+          watchdog.reset()
           let yielded = Date.now()
           for await (const event of events) {
+            watchdog.reset()
             streamErrorLogged = false
             const legacy = "payload" in event
             if (legacy && event.payload.type === "sync") continue
@@ -300,6 +345,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
             })
           }
         } finally {
+          watchdog.stop()
           abort.signal.removeEventListener("abort", onAbort)
           attempt = undefined
         }


### PR DESCRIPTION
### Issue for this PR

Closes #40910

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a client-side watchdog for the global web event stream. After a stream connects, the watchdog is reset whenever an SSE event arrives. If no event or heartbeat arrives for 45 seconds, it aborts the current stream attempt so the existing reconnect loop can establish a fresh subscription.

This helps the web UI recover when a reverse proxy silently drops or stalls the `/global/event` SSE stream while the session continues running server-side.

### How did you verify your code works?

- `cd packages/app && bun test --conditions=solid --preload ./happydom.ts src/context/server-sdk.test.ts --timeout 30000`
- `bunx oxlint packages/app/src/context/server-sdk.tsx packages/app/src/context/server-sdk.test.ts`
- `git diff --check`

`cd packages/app && bun run typecheck` is currently blocked by the existing, unmodified `src/custom-elements.d.ts` file (`../../ui/src/custom-elements.d.ts`), which matches `upstream/dev` and fails before this change is typechecked.

### Screenshots / recordings

N/A; this is an event-stream recovery fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
