### PR TITLE
fix(effect-drizzle): declare query type variance

### DIFF
--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
@@ -46,9 +46,9 @@ export type SQLiteEffectSelectPrepare<
 
 export class SQLiteEffectSelectBuilder<
   TSelection extends SelectedFields | undefined,
-  TRunResult,
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
-  TBuilderMode extends "db" | "qb" = "db",
+  out TRunResult,
+  in out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  in out TBuilderMode extends "db" | "qb" = "db",
 > {
   static readonly [entityKind]: string = "SQLiteEffectSelectBuilder"
 

--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
@@ -304,9 +304,9 @@ export class SQLiteEffectPreparedQuery<
 }
 
 export abstract class SQLiteEffectSession<
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
-  TRunResult = unknown,
-  TRelations extends AnyRelations = EmptyRelations,
+  in out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  out TRunResult = unknown,
+  out TRelations extends AnyRelations = EmptyRelations,
 > {
   static readonly [entityKind]: string = "SQLiteEffectSession"
 


### PR DESCRIPTION
### Issue for this PR

Closes #40890
### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds explicit TypeScript variance annotations to the safe generic parameters on the Effect Drizzle session/select-builder types that showed up in the compiler variance trace.

`SQLiteEffectSession` now declares covariance for `TRunResult` and `TRelations` while preserving invariance for `TEffectHKT`. `SQLiteEffectSelectBuilder` now declares covariance for `TRunResult` and invariance for `TEffectHKT` / `TBuilderMode`.

I intentionally left `TSelection` inferred because explicit annotations for it break the existing select overload relationships during typecheck.

### How did you verify your code works?

- `cd packages/effect-drizzle-sqlite && bun run typecheck`
- `cd packages/effect-drizzle-sqlite && bun test --timeout 30000`
- `bunx oxlint packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts`
- `git diff --check`

### Screenshots / recordings

N/A; this is a type-level performance cleanup.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
