### PR TITLE
fix(console): terminate oa-compatible cost streams

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -173,7 +173,7 @@ export function buildCostChunk(format: ZenData.Format, cost: string): string {
     case "openai":
       return `event: ping\ndata: ${JSON.stringify({ type: "ping", cost })}\n\n`
     case "oa-compat":
-      return `data: ${JSON.stringify({ choices: [], cost })}\n\n`
+      return `data: ${JSON.stringify({ choices: [], cost })}\n\ndata: [DONE]\n\n`
     default:
       return `data: ${JSON.stringify({ type: "ping", cost })}\n\n`
   }

--- a/packages/console/app/test/providerUsage.test.ts
+++ b/packages/console/app/test/providerUsage.test.ts
@@ -5,6 +5,7 @@ import { anthropicHelper } from "../src/routes/zen/util/provider/anthropic"
 import { googleHelper } from "../src/routes/zen/util/provider/google"
 import { oaCompatHelper } from "../src/routes/zen/util/provider/openai-compatible"
 import { openaiHelper } from "../src/routes/zen/util/provider/openai"
+import { buildCostChunk } from "../src/routes/zen/util/provider/provider"
 
 const providers = {
   anthropic: anthropicHelper({ reqModel: "claude-haiku-4-5", providerModel: "claude-haiku-4-5" }),
@@ -14,6 +15,14 @@ const providers = {
 } satisfies Record<ZenData.Format, ReturnType<ProviderHelper>>
 
 describe("provider usage extraction", () => {
+  test("terminates OpenAI-compatible cost tails with DONE", () => {
+    expect(buildCostChunk("oa-compat", "0").split("\n\n")).toEqual([
+      'data: {"choices":[],"cost":"0"}',
+      "data: [DONE]",
+      "",
+    ])
+  })
+
   test("extracts Google non-stream usage metadata", () => {
     const usage = providers.google.extractUsage({
       usageMetadata: {


### PR DESCRIPTION
### Issue for this PR

Closes #40420
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a terminal `data: [DONE]` marker after the OpenAI-compatible hosted gateway cost tail chunk.

Some upstream OpenAI-compatible streams can end with a usage/cost tail frame (`data: {"choices":[],"cost":"0"}`) without a terminal marker. Emitting `[DONE]` at the gateway boundary lets strict OpenAI-compatible consumers observe a complete stream instead of treating the response as truncated.

This is complementary to the earlier client-side tolerance work and fixes the hosted gateway stream shape directly.

### How did you verify your code works?

- `cd packages/console/app && bun test test/providerUsage.test.ts --test-name-pattern 'terminates OpenAI-compatible cost tails with DONE' --timeout 30000`
- `cd packages/console/app && bun run typecheck`
- `bunx oxlint packages/console/app/src/routes/zen/util/provider/provider.ts packages/console/app/test/providerUsage.test.ts`
- `git diff --check`

Note: the full `providerUsage.test.ts` file has existing Google usage expectation failures unrelated to this change; those were present before the production code change in this branch.

### Screenshots / recordings

N/A; this is an API stream-format fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
