### PR TITLE
docs: add opencode-skill-forge to ecosystem list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -38,6 +38,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                       |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
+| [opencode-skill-forge](https://github.com/ugur-murat-alt/opencode-skill-forge) | Self-improving skill library - agents learn from their work and forge reusable skills via a background review loop |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |


### PR DESCRIPTION
Adds [opencode-skill-forge](https://github.com/ugur-murat-alt/opencode-skill-forge) to the plugins section of the ecosystem docs.

A self-improving skill library for OpenCode: a background review loop inspects completed conversations and creates/patches/maintains SKILL.md skills (skill_manage/skill_list/skill_view tools, ownership guards, audit journal, isolated reviewer subagent). Source + docs: https://github.com/ugur-murat-alt/opencode-skill-forge (MIT).