### PR TITLE
fix(provider): forward agent temperature for config-defined custom models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1514,7 +1514,9 @@ const layer = Layer.effect(
               name,
               providerID: ProviderV2.ID.make(providerID),
               capabilities: {
-                temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
+                // Config-defined custom models should forward agent-level temperature
+                // unless the user explicitly disables it for that model.
+                temperature: model.temperature ?? existingModel?.capabilities.temperature ?? true,
                 reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2116,3 +2116,34 @@ it.effect("opencode loader keeps paid models when auth exists", () =>
     expect(keyedCount).toBeGreaterThan(0)
   }).pipe(provideMultiInstance),
 )
+
+it.instance(
+  "config-defined custom models allow temperature by default",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("brand-new-provider")].models["new-model"]
+    expect(model.capabilities.temperature).toBe(true)
+  }),
+  {
+    config: {
+      provider: {
+        "brand-new-provider": {
+          name: "Brand New",
+          npm: "@ai-sdk/openai-compatible",
+          env: [],
+          api: "https://new-api.com/v1",
+          models: {
+            "new-model": {
+              name: "New Model",
+              tool_call: true,
+              limit: { context: 32000, output: 8000 },
+            },
+          },
+          options: {
+            apiKey: "new-key",
+          },
+        },
+      },
+    },
+  },
+)

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -977,6 +977,7 @@ describe("session.llm.stream", () => {
           new Response(createChatStream("Hello"), {
             status: 200,
             headers: { "Content-Type": "text/event-stream" },
+
           }),
         )
 
@@ -1034,6 +1035,77 @@ describe("session.llm.stream", () => {
         provider: {
           [cerebrasFixture.providerID]: {
             options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "sends agent temperature for config-defined custom openai-compatible models by default",
+    () =>
+      Effect.gen(function* () {
+        const request = waitRequest(
+          "/chat/completions",
+          new Response(createChatStream("Hello"), {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+        )
+        const providerID = ProviderV2.ID.make("custom-openai")
+        const resolved = yield* Provider.use.getModel(providerID, ModelV2.ID.make("custom-model"))
+        const sessionID = SessionID.make("session-test-custom-temp")
+        const agent = {
+          name: "build",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 1,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("msg_user-custom-temp"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id, variant: "high" },
+        } satisfies SessionV1.User
+
+        yield* drain({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        const capture = yield* Effect.promise(() => request)
+        expect(capture.body.model).toBe(resolved.api.id)
+        expect(capture.body.temperature).toBe(1)
+      }),
+    {
+      config: () => ({
+        enabled_providers: ["custom-openai"],
+        provider: {
+          "custom-openai": {
+            name: "Custom OpenAI",
+            npm: "@ai-sdk/openai-compatible",
+            env: [],
+            api: `${state.server!.url.origin}/v1`,
+            options: {
+              apiKey: "test-key",
+              baseURL: `${state.server!.url.origin}/v1`,
+            },
+            models: {
+              "custom-model": {
+                name: "Custom Model",
+                limit: { context: 32000, output: 8000 },
+                tool_call: true,
+              },
+            },
           },
         },
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #34554

### Type of change

- [x] Bug fix

### What does this PR do?

Config-defined custom models (`provider.<id>.models` in `opencode.json`) default their temperature capability to `false`, so an agent-level `temperature` is silently dropped for those models (issue #34554). Built-in models do not have this problem.

The fix defaults the temperature capability to **enabled** for config-defined custom models. Explicit `temperature: false` in the model config still wins, so users can opt out per model. With this change the agent's temperature is forwarded in the provider request body, matching the behavior of built-in models.

Changes:
- `packages/opencode/src/provider/provider.ts`: default `capabilities.temperature` to `true` for config-defined custom models (explicit `model.temperature` still takes precedence).
- `packages/opencode/test/provider/provider.test.ts`: assert config-defined custom models report `temperature: true` by default.
- `packages/opencode/test/session/llm.test.ts`: assert the provider request body carries the agent temperature for a custom openai-compatible model.

### How did you verify your code works?

- Ran the targeted suites with `bun test test/provider/provider.test.ts test/session/llm.test.ts`: 129 pass, 0 fail.
- Manually confirmed the failing behavior on 1.18.4 (agent temperature dropped for custom providers) and verified this branch fixes it.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR