### PR TITLE
fix(app): register new home projects

### DIFF
--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -90,7 +90,20 @@ export function createHomeController() {
         const directory = directories[0]
         if (!directory) return
         const ctx = global.ensureServerCtx(conn)
-        directories.forEach((item) => ctx.projects.open(item))
+        directories.forEach((item) => {
+          if (ctx.projects.list().some((project) => project.worktree === item)) return
+          const location = { directory: item }
+          void ctx.sdk.api.file
+            .list({ path: ".", location })
+            .then(async (files) => {
+              if (files.data.length > 0) return ctx.sdk.api.project.current({ location })
+              const result = await ctx.sdk.client.project.initGit({ directory: item })
+              return result.data ?? ctx.sdk.api.project.current({ location })
+            })
+            .then((project) => ctx.sync.child(item, { bootstrap: false })[1]("project", project.id))
+            .catch(() => undefined)
+          ctx.projects.open(item)
+        })
         ctx.projects.touch(directory)
         setSelection({ server: ServerConnection.key(conn), directory })
       },

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -161,6 +161,21 @@ describe("HttpApi instance context middleware", () => {
     }),
   )
 
+  it.live("persists the routed project while loading instance context", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const project = yield* Project.Service
+      yield* serveProbe()
+
+      const response = yield* HttpClient.get(`/probe?directory=${encodeURIComponent(dir)}`)
+
+      expect(response.status).toBe(200)
+      const saved = (yield* project.list()).find((item) => item.worktree === dir)
+      expect(saved).toBeDefined()
+      expect(saved?.id).not.toBe("global")
+    }),
+  )
+
   it.live("falls back to the raw directory when URI decoding fails", () =>
     Effect.gen(function* () {
       yield* serveProbe()


### PR DESCRIPTION
## Summary
- register newly added Home projects through a directory-scoped backend request
- initialize Git automatically when the selected folder is empty
- seed the resolved project ID in client state and avoid redundant registration requests
- verify instance routing persists committed Git projects with non-global IDs

## Tests
- `bun typecheck` (`packages/app`)
- `bun test --timeout 30000 test/server/project-init-git.test.ts test/server/httpapi-instance-context.test.ts test/project/project.test.ts` (`packages/opencode`)
- `git diff --check`