### PR TITLE
fix(tui): restore worktree session labels

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -141,7 +141,11 @@ export function DialogSessionList() {
     const option = (session: SessionInfo, category: string) => {
       const directory = session.location.directory
       const project = data.project.get(session.projectID)
-      const footer = allProjects() ? Locale.truncate(projectName(project, directory) ?? "", 20) : undefined
+      const footer = allProjects()
+        ? Locale.truncate(projectName(project, directory) ?? "", 20)
+        : directory === data.location.info()?.project.directory
+          ? undefined
+          : Locale.truncate(path.basename(directory), 20)
       const slot = sessionTabs.enabled() ? undefined : slotByID.get(session.id)
       const deleting = toDelete() === session.id
       return {


### PR DESCRIPTION
### Issue for this PR

Closes #41025

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In OpenCode v2, current-project `/session` currently hides every row footer. This keeps project-root sessions unlabeled and restores the directory basename for worktree sessions. All-projects mode is unchanged.

### How did you verify your code works?

- `bun typecheck` in `packages/tui`
- Full pre-push typecheck: 32 tasks passed

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
