### PR TITLE
fix(core): retry failed ripgrep resolution and sanitize PowerShell 5.1 module path on Windows

### DIFF
--- a/packages/core/src/ripgrep/binary.ts
+++ b/packages/core/src/ripgrep/binary.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { Context, Effect, Layer, Stream } from "effect"
+import { Context, Effect, Layer, Option, Ref, Semaphore, Stream } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
@@ -28,6 +28,30 @@ export namespace RipgrepBinary {
 
   export class Service extends Context.Service<Service, Interface>()("@opencode/RipgrepBinary") {}
 
+  // Unlike Effect.cached, only successful results are memoized: a failed resolution
+  // must be retried on the next call in the same process.
+  export const memoizeSuccess = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const resolved = yield* Ref.make(Option.none<A>())
+      const singleFlight = Semaphore.makeUnsafe(1).withPermit
+      return singleFlight(
+        Effect.gen(function* () {
+          const hit = yield* Ref.get(resolved)
+          if (Option.isSome(hit)) return hit.value
+          const value = yield* effect
+          yield* Ref.set(resolved, Option.some(value))
+          return value
+        }),
+      )
+    })
+
+  // Windows PowerShell 5.1 inherits PSModulePath from the launching process. When opencode
+  // is started from the MSIX (Microsoft Store) build of PowerShell 7, that variable points at
+  // the Core-edition modules first, so Expand-Archive autoload fails inside the 5.1 child.
+  // Pinning the child to the inbox 5.1 module directory avoids the polluted lookup.
+  export const windowsPowerShell5ModulePath = (systemRoot: string | undefined = process.env.SystemRoot) =>
+    path.join(systemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "Modules")
+
   const layer = Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -35,8 +59,10 @@ export namespace RipgrepBinary {
       const http = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
       const spawner = yield* ChildProcessSpawner
 
-      const run = Effect.fnUntraced(function* (command: string, args: string[]) {
-        const handle = yield* spawner.spawn(ChildProcess.make(command, args, { extendEnv: true, stdin: "ignore" }))
+      const run = Effect.fnUntraced(function* (command: string, args: string[], env?: Record<string, string>) {
+        const handle = yield* spawner.spawn(
+          ChildProcess.make(command, args, { extendEnv: true, stdin: "ignore", env }),
+        )
         const [stdout, stderr, code] = yield* Effect.all(
           [
             Stream.mkString(Stream.decodeText(handle.stdout)),
@@ -57,12 +83,20 @@ export namespace RipgrepBinary {
 
         if (config.extension === "zip") {
           const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
-          const result = yield* run(shell, [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
-          ])
+          const env =
+            path.basename(shell).toLowerCase() === "powershell.exe"
+              ? { PSModulePath: windowsPowerShell5ModulePath() }
+              : undefined
+          const result = yield* run(
+            shell,
+            [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
+            ],
+            env,
+          )
           if (result.code !== 0)
             throw new Error(
               result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
@@ -88,39 +122,39 @@ export namespace RipgrepBinary {
         if (process.platform !== "win32") yield* fs.chmod(target, 0o755)
       }, Effect.scoped)
 
-      return Service.of({
-        filepath: yield* Effect.cached(
-          Effect.gen(function* () {
-            const system = yield* Effect.sync(() => which(process.platform === "win32" ? "rg.exe" : "rg"))
-            if (system && (yield* fs.isFile(system).pipe(Effect.orDie))) return system
+      const resolve = Effect.gen(function* () {
+        const system = yield* Effect.sync(() => which(process.platform === "win32" ? "rg.exe" : "rg"))
+        if (system && (yield* fs.isFile(system).pipe(Effect.orDie))) return system
 
-            const target = path.join(Global.Path.bin, `rg${process.platform === "win32" ? ".exe" : ""}`)
-            if (yield* fs.isFile(target).pipe(Effect.orDie)) return target
+        const target = path.join(Global.Path.bin, `rg${process.platform === "win32" ? ".exe" : ""}`)
+        if (yield* fs.isFile(target).pipe(Effect.orDie)) return target
 
-            const platformKey = `${process.arch}-${process.platform}` as keyof typeof PLATFORM
-            const config = PLATFORM[platformKey]
-            if (!config) throw new Error(`unsupported platform for ripgrep: ${platformKey}`)
+        const platformKey = `${process.arch}-${process.platform}` as keyof typeof PLATFORM
+        const config = PLATFORM[platformKey]
+        if (!config) throw new Error(`unsupported platform for ripgrep: ${platformKey}`)
 
-            const filename = `ripgrep-${VERSION}-${config.platform}.${config.extension}`
-            const url = `https://github.com/BurntSushi/ripgrep/releases/download/${VERSION}/${filename}`
-            const archive = path.join(Global.Path.bin, filename)
+        const filename = `ripgrep-${VERSION}-${config.platform}.${config.extension}`
+        const url = `https://github.com/BurntSushi/ripgrep/releases/download/${VERSION}/${filename}`
+        const archive = path.join(Global.Path.bin, filename)
 
-            yield* Effect.logInfo("downloading ripgrep", { url })
-            yield* fs.ensureDir(Global.Path.bin).pipe(Effect.orDie)
-            const bytes = yield* HttpClientRequest.get(url).pipe(
-              http.execute,
-              Effect.flatMap((response) => response.arrayBuffer),
-              Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause)))),
-            )
-            if (bytes.byteLength === 0) throw new Error(`failed to download ripgrep from ${url}`)
+        yield* Effect.logInfo("downloading ripgrep", { url })
+        yield* fs.ensureDir(Global.Path.bin).pipe(Effect.orDie)
+        const bytes = yield* HttpClientRequest.get(url).pipe(
+          http.execute,
+          Effect.flatMap((response) => response.arrayBuffer),
+          Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause)))),
+        )
+        if (bytes.byteLength === 0) throw new Error(`failed to download ripgrep from ${url}`)
 
-            yield* fs.writeWithDirs(archive, new Uint8Array(bytes))
-            yield* extract(archive, config, target)
-            yield* fs.remove(archive, { force: true }).pipe(Effect.ignore)
-            return target
-          }),
-        ),
+        yield* fs.writeWithDirs(archive, new Uint8Array(bytes))
+        yield* extract(archive, config, target)
+        yield* fs.remove(archive, { force: true }).pipe(Effect.ignore)
+        return target
       })
+
+      const filepath = yield* memoizeSuccess(resolve)
+
+      return Service.of({ filepath })
     }),
   )
 

--- a/packages/core/test/ripgrep-binary.test.ts
+++ b/packages/core/test/ripgrep-binary.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Effect, Exit } from "effect"
+import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+
+describe("RipgrepBinary.memoizeSuccess", () => {
+  test("memoizes a successful resolution", async () => {
+    let attempts = 0
+    const program = Effect.gen(function* () {
+      const memoized = yield* RipgrepBinary.memoizeSuccess(
+        Effect.sync(() => {
+          attempts++
+          return "rg"
+        }),
+      )
+      const first = yield* memoized
+      const second = yield* memoized
+      return [first, second]
+    })
+
+    expect(await Effect.runPromise(program)).toEqual(["rg", "rg"])
+    expect(attempts).toBe(1)
+  })
+
+  test("retries a failed resolution instead of caching the failure", async () => {
+    let attempts = 0
+    const program = Effect.gen(function* () {
+      const memoized = yield* RipgrepBinary.memoizeSuccess(
+        Effect.sync(() => {
+          attempts++
+          if (attempts === 1) throw new Error("extraction failed")
+          return "rg"
+        }),
+      )
+      const first = yield* Effect.exit(memoized)
+      const second = yield* memoized
+      const third = yield* memoized
+      return { first, second, third }
+    })
+
+    const { first, second, third } = await Effect.runPromise(program)
+    expect(Exit.isFailure(first)).toBe(true)
+    expect(second).toBe("rg")
+    expect(third).toBe("rg")
+    expect(attempts).toBe(2)
+  })
+})
+
+describe("RipgrepBinary.windowsPowerShell5ModulePath", () => {
+  test("points at the inbox Windows PowerShell 5.1 module directory", () => {
+    expect(RipgrepBinary.windowsPowerShell5ModulePath("D:\\WinRoot")).toBe(
+      path.join("D:\\WinRoot", "System32", "WindowsPowerShell", "v1.0", "Modules"),
+    )
+  })
+
+  test("falls back to C:\\Windows when SystemRoot is unset", () => {
+    expect(RipgrepBinary.windowsPowerShell5ModulePath(undefined)).toBe(
+      path.join("C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "Modules"),
+    )
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #40623

### Type of change

- [x] Bug fix

### What does this PR do?

grep/glob fail on Windows for two independent reasons, both fixed here.

1. **Failed ripgrep resolution was cached forever.** `RipgrepBinary.filepath` wrapped the locate/download/extract effect in `Effect.cached`, which memoizes failures as well as successes. One failed download or extraction poisoned every `grep`/`glob` call in that process until opencode was restarted — even after the user fixed the environment. Replaced with a single-flight memo that caches only successful resolutions, so the next call retries.
2. **Zip extraction breaks when launched from MSIX PowerShell 7.** Extraction spawns `powershell.exe` (Windows PowerShell 5.1) with `Expand-Archive`, and the child inherits `PSModulePath` from the launching shell. When opencode is started from the Microsoft Store (MSIX) build of PowerShell 7, that variable lists the Core-edition module directory first; the 5.1 module autoloader deems it incompatible and stops searching, so `Expand-Archive` fails with `CouldNotAutoloadMatchingModule` and the downloaded zip is never extracted. The child now gets a pinned `PSModulePath` pointing at the inbox 5.1 module directory (`%SystemRoot%\System32\WindowsPowerShell\v1.0\Modules`) when the resolved shell is `powershell.exe`. `pwsh.exe` spawns are untouched.

### How did you verify your code works?

- Added `packages/core/test/ripgrep-binary.test.ts`:
  - `memoizeSuccess` memoizes a successful resolution (runs once)
  - `memoizeSuccess` retries a failed resolution instead of caching the failure, then caches the eventual success
  - `windowsPowerShell5ModulePath` honors `SystemRoot` and falls back to `C:\Windows`
- `bun test test/ripgrep.test.ts test/ripgrep-binary.test.ts test/filesystem/search.test.ts` — 8 pass / 0 fail (re-run after rebasing onto latest `dev`)
- `bun run typecheck` (tsgo) — clean

### Screenshots / recordings

N/A — core fix, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
