### PR TITLE
fix(prompt): route MiniMax models to the Kimi agentic prompt

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -37,7 +37,8 @@ export function provider(model: Provider.Model) {
   if (model.api.id.includes("gemini-")) return [PROMPT_GEMINI]
   if (model.api.id.includes("claude")) return [PROMPT_ANTHROPIC]
   if (model.api.id.toLowerCase().includes("trinity")) return [PROMPT_TRINITY]
-  if (model.api.id.toLowerCase().includes("kimi")) return [PROMPT_KIMI]
+  if (model.api.id.toLowerCase().includes("kimi") || model.api.id.toLowerCase().includes("minimax"))
+    return [PROMPT_KIMI]
   return [PROMPT_DEFAULT]
 }
 

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -90,6 +90,13 @@ describe("session.system", () => {
     )
   })
 
+  test("MiniMax model IDs share the Kimi prompt for open-weight agentic models", () => {
+    const kimi = SystemPrompt.provider({ api: { id: "kimi-k2-thinking" } } as Provider.Model)[0]
+    for (const id of ["MiniMax/MiniMax-M3", "minimax/minimax-m2.5", "MiniMax-M1"]) {
+      expect(SystemPrompt.provider({ api: { id } } as Provider.Model)[0]).toBe(kimi)
+    }
+  })
+
   it.effect("skills output is sorted by name and stable across calls", () =>
     Effect.gen(function* () {
       const prompt = yield* SystemPrompt.Service


### PR DESCRIPTION
### Issue for this PR

Closes #41031

### Type of change

- [x] Bug fix

### What does this PR do?

`provider()` in `session/system.ts` selects a prompt by substring-matching the model id and has no MiniMax branch, so every MiniMax model falls through to `PROMPT_DEFAULT` (written for Claude). This adds `minimax` to the existing `kimi` branch so both share `kimi.txt`.

`kimi.txt` has no Kimi/Moonshot-specific content (grep is clean) — it is the open-weight agentic prompt: it makes tool use explicit ("Code that only appears in your text response is NOT saved"), gives `<system-reminder>` authority, encourages parallel tool calls, and matches the user's language. That profile fits MiniMax; `default.txt` does not.

I reused the branch rather than adding a `minimax.txt` on purpose: it would duplicate ~95 lines with no upstream counterpart to keep in sync. `transform.ts` already groups `minimax` with `kimi`/`deepseek`/`qwen` as open-weight, so this just aligns prompt selection with a grouping already made there. Match is `.toLowerCase()` like the neighbouring `kimi`/`trinity` branches, since ids vary in case (`MiniMax-M1`, `minimax/minimax-m2.5`).

### How did you verify your code works?

Added a case to `test/session/system.test.ts`: `MiniMax/MiniMax-M3`, `minimax/minimax-m2.5`, and `MiniMax-M1` all resolve to the same prompt as `kimi-k2-thinking`. `bun test test/session/system.test.ts` (5 pass) and `bun typecheck` in `packages/opencode` are green.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
