### PR TITLE
docs: fix TUI path in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
 - Core pieces:
   - `packages/opencode`: OpenCode core business logic & server.
-  - `packages/opencode/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)
+  - `packages/tui`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)
   - `packages/app`: The shared web UI components, written in SolidJS
   - `packages/desktop`: The native desktop app, built with Electron (wraps `packages/app`)
   - `packages/plugin`: Source for `@opencode-ai/plugin`


### PR DESCRIPTION
### Issue for this PR

Closes #41050

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

CONTRIBUTING.md line 74 lists `packages/opencode/src/cli/cmd/tui/` as where the TUI lives. That directory doesn't exist anymore — the TUI is in `packages/tui`, which `specs/tui-package.md` also says. This just updates the path in the "Core pieces" list.

### How did you verify your code works?

```
$ ls packages/opencode/src/cli/cmd/tui
ls: cannot access 'packages/opencode/src/cli/cmd/tui': No such file or directory
$ ls -d packages/tui
packages/tui
```

### Screenshots / recordings

n/a, docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
