### PR TITLE
fix(sdk): match text/html when the header has parameters

### DIFF
--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -83,7 +83,7 @@ export function createOpencodeClient(config?: Config & { directory?: string; exp
   )
   client.interceptors.response.use((response) => {
     const contentType = response.headers.get("content-type")
-    if (contentType === "text/html")
+    if (contentType?.startsWith("text/html"))
       throw new Error("Request is not supported by this version of OpenCode Server (Server responded with text/html)")
 
     return response


### PR DESCRIPTION
### Issue for this PR

Closes #41052

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The response interceptor in `packages/sdk/js/src/v2/client.ts:86` compared the content-type header with `===`:

```ts
if (contentType === "text/html")
  throw new Error("Request is not supported by this version of OpenCode Server (Server responded with text/html)")
```

Servers normally send `text/html; charset=utf-8`, so the comparison is false and the guard never fires. The response then falls through and fails later during JSON parsing, so instead of the message telling you the server version doesn't support the request, you get a parse error that says nothing useful.

Changed to `contentType?.startsWith("text/html")`. The optional chaining also covers a missing header, where `.get()` returns null.

### How did you verify your code works?

Checked the comparison directly against the header values servers actually send:

```
"text/html"                 === "text/html"  -> true   (worked before too)
"text/html; charset=utf-8"  === "text/html"  -> false  <- the bug
"text/html; charset=utf-8".startsWith("text/html") -> true
```

Also grepped for other `content-type` equality checks in the SDK to see if the same pattern appears elsewhere. It doesn't — this is the only one.

### Screenshots / recordings

n/a.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
