### PR TITLE
fix(sdk): stop handing out "asdasd" as a message id

### DIFF
--- a/packages/sdk/js/src/v2/data.ts
+++ b/packages/sdk/js/src/v2/data.ts
@@ -1,5 +1,30 @@
 import type { Part, UserMessage } from "./client.js"
 
+const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+let lastTimestamp = 0
+let counter = 0
+
+// Mirrors the monotonic, time-ordered ID scheme the server uses so builder output sorts
+// alongside server-generated records. The SDK cannot import @opencode-ai/schema (it must stay
+// dependency-free), so the generator is inlined here.
+function identifier(prefix: string) {
+  const timestamp = Date.now()
+  if (timestamp !== lastTimestamp) {
+    lastTimestamp = timestamp
+    counter = 0
+  }
+  counter++
+
+  const current = BigInt(timestamp) * 0x1000n + BigInt(counter)
+  const time = Array.from({ length: 6 }, (_, index) =>
+    Number((current >> BigInt(40 - 8 * index)) & 0xffn)
+      .toString(16)
+      .padStart(2, "0"),
+  ).join("")
+  const bytes = crypto.getRandomValues(new Uint8Array(14))
+  return prefix + "_" + time + Array.from(bytes, (byte) => chars[byte % 62]).join("")
+}
+
 export const message = {
   user(input: Omit<UserMessage, "role" | "time" | "id"> & { parts: Omit<Part, "id" | "sessionID" | "messageID">[] }): {
     info: UserMessage
@@ -9,7 +34,7 @@ export const message = {
 
     const info: UserMessage = {
       ...rest,
-      id: "asdasd",
+      id: identifier("msg"),
       time: {
         created: Date.now(),
       },
@@ -22,7 +47,7 @@ export const message = {
         (part) =>
           ({
             ...part,
-            id: "asdasd",
+            id: identifier("prt"),
             messageID: info.id,
             sessionID: info.sessionID,
           }) as Part,


### PR DESCRIPTION
### Issue for this PR

Closes #41051

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`data.message.user()` in `packages/sdk/js/src/v2/data.ts` set the id to the literal string `"asdasd"` on the message and again on every part it built. So every message and every part produced by that builder came out with the same id.

It's exported (`export * as data from "./data.js"` in `src/v2/index.ts`, and `./v2` is in the package exports), so this is public API. `grep -rn "asdasd" packages/` finds only those two lines and nothing that reads the value, so it looks like scaffolding that never got replaced rather than a sentinel anyone depends on.

The fix generates `msg_`/`prt_` ids in the same monotonic, time-ordered format the server uses, so builder output still sorts next to server records instead of clustering at one point in the ordering.

I inlined the generator rather than importing it. The SDK's only runtime dependency is `cross-spawn`, and pulling in `@opencode-ai/schema` for one function felt like the wrong trade. If you'd rather share the implementation, say so and I'll rework it — it's the part of this PR I'm least sure about.

### How did you verify your code works?

Ran the generator 5000 times:

```
sample: msg_fdc1cbb3a001QMCBv23rr5vLdS   (30 chars, matching msg_ + 26)
unique: 5000 of 5000
sorting the ids lexicographically matches creation order: true
prt sample: prt_fdc1cbba0001HNWs63e1JAbUhm
```

The counter resets per millisecond and increments within one, so ids stay ordered even when several are created in the same tick.

### Screenshots / recordings

n/a.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
