### PR TITLE
fix(core): don't put the split message in head twice

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -125,7 +125,7 @@ const settings = (documents: readonly Config.Entry[]) => {
   )
 }
 
-const select = (
+export const select = (
   entries: readonly Entry[],
   tokens: number,
 ): { readonly head: string; readonly recent: string } | undefined => {
@@ -136,6 +136,10 @@ const select = (
   if (conversation.length === 0) return
   let total = 0
   let split = conversation.length
+  // `head` and `recent` need different boundaries: when a message straddles the token budget it
+  // is cut in two, so `recent` starts after it (`split`) while `head` stops before it (`headEnd`)
+  // and receives only `splitPrefix`.
+  let headEnd = conversation.length
   let splitPrefix = ""
   let splitSuffix = ""
   for (let index = conversation.length - 1; index >= 0; index--) {
@@ -146,14 +150,16 @@ const select = (
         splitPrefix = conversation[index].slice(0, -remaining)
         splitSuffix = conversation[index].slice(-remaining)
         split = index + 1
+        headEnd = index
       }
       break
     }
     total = next
     split = index
+    headEnd = index
   }
   return {
-    head: [...conversation.slice(0, split), splitPrefix].filter(Boolean).join("\n\n"),
+    head: [...conversation.slice(0, headEnd), splitPrefix].filter(Boolean).join("\n\n"),
     recent: [splitSuffix, ...conversation.slice(split)].filter(Boolean).join("\n\n"),
   }
 }

--- a/packages/core/test/session-compaction-select.test.ts
+++ b/packages/core/test/session-compaction-select.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { SessionCompaction } from "@opencode-ai/core/session/compaction"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { DateTime } from "effect"
+
+const created = DateTime.makeUnsafe(0)
+
+const entry = (seq: number, text: string) => ({
+  seq,
+  message: SessionMessage.User.make({
+    id: SessionMessage.ID.make(`msg_${seq}`),
+    type: "user",
+    text,
+    time: { created },
+  }),
+})
+
+test("compaction split does not duplicate the straddling message into the head", () => {
+  // "c" is far larger than the token budget, so it is cut: its prefix belongs to `head`
+  // and its suffix stays verbatim in `recent`. The full message must appear exactly once.
+  const large = "c".repeat(80_000)
+  const selected = SessionCompaction.select([entry(0, "a".repeat(400)), entry(1, "b".repeat(400)), entry(2, large)], 8000)
+
+  expect(selected).toBeDefined()
+  expect(selected!.head).not.toContain(large)
+  expect(selected!.head.length).toBeLessThan(large.length)
+  expect(selected!.recent).toContain(large.slice(-1000))
+})
+
+test("compaction split keeps everything in recent when the conversation fits the budget", () => {
+  const selected = SessionCompaction.select([entry(0, "hello"), entry(1, "world")], 100_000)
+
+  expect(selected).toBeDefined()
+  expect(selected!.head).toBe("")
+  expect(selected!.recent).toContain("hello")
+  expect(selected!.recent).toContain("world")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33329

(I opened #41053 before finding #33329, which describes the same bug from June. Closing mine as a duplicate — this PR targets the original.)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`select()` in `packages/core/src/session/compaction.ts` uses one boundary variable for two slices that need different boundaries.

When a message straddles the token budget it gets cut into `splitPrefix` and `splitSuffix`, and `split` becomes `index + 1`. That's correct for `recent`: `conversation.slice(split)` skips the straddling message because `splitSuffix` already carries its tail. But `head` reuses `split`, so `conversation.slice(0, split)` includes that message in full, and then `splitPrefix` — a prefix of the same text — gets appended after it.

So the boundary message lands in `head` twice: once whole, once as a prefix.

The fix tracks the head boundary in its own variable (`headEnd`), which stops one short of the straddling message. Both branches of the loop update it alongside `split`, so the non-straddling paths behave exactly as before.

The wasted tokens aren't really the problem. `compactAfterOverflow` bails out when `Token.estimate(summaryPrompt) > context - summaryOutput`, so a head at roughly double its intended size makes compaction refuse to run on exactly the large sessions that need it, and the session keeps hitting the provider context limit instead.

### How did you verify your code works?

Messages of 400 / 400 / 80000 chars with `tokens = 8000` (input is 80800 chars):

| | before | after |
|---|---|---|
| head | 128806 | 48804 |
| recent | 32000 | 32000 |
| head + recent | 160806 | 80804 |

After the fix the sum is the input plus separators, and `head` no longer contains the straddling message.

I confirmed the test actually catches the bug rather than just passing: reverting only the `conversation.slice(0, headEnd)` line makes it fail with the full 80000-char message present in the head, and restoring it passes.

```
$ bun test test/session-compaction-select.test.ts test/session-compaction.test.ts
 4 pass
 0 fail
$ bun typecheck   # in packages/core
$ tsgo --noEmit   # clean
```

Also checked the edge cases: everything fitting inside the budget (head empty, all in recent), a zero budget (everything in head), and a single straddling message with nothing before it.

`select` is module-private, so I exported it to test it. `buildPrompt` and `serializeToolContent` are already exported and tested the same way in `session-compaction.test.ts`, so this follows the file's existing convention — but if you'd rather I drive it through `compactAfterOverflow` instead, I'm happy to redo it.

### Screenshots / recordings

n/a.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
