### PR TITLE
fix(tui): truncate helpers can return a longer string than they got

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -65,17 +65,19 @@ export function truncate(str: string, len: number): string {
 
 export function truncateLeft(str: string, len: number): string {
   if (str.length <= len) return str
+  // slice(-0) returns the whole string, so budgets below 2 must short-circuit
+  if (len <= 1) return "…"
   return "…" + str.slice(-(len - 1))
 }
 
 export function truncateMiddle(str: string, maxLength: number = 35): string {
   if (str.length <= maxLength) return str
+  if (maxLength <= 1) return "…"
 
-  const ellipsis = "…"
-  const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
-  const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
+  const available = maxLength - 1
+  const keepEnd = Math.floor(available / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  return str.slice(0, Math.ceil(available / 2)) + "…" + (keepEnd ? str.slice(-keepEnd) : "")
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {

--- a/packages/tui/test/util-locale.test.ts
+++ b/packages/tui/test/util-locale.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { truncate, truncateLeft, truncateMiddle } from "@opencode-ai/tui/util/locale"
+
+const input = "abcdefghij"
+
+test("truncate returns the input when it fits", () => {
+  expect(truncate(input, 10)).toBe(input)
+  expect(truncateLeft(input, 10)).toBe(input)
+  expect(truncateMiddle(input, 10)).toBe(input)
+})
+
+test("truncateLeft never returns more than the requested budget", () => {
+  for (const len of [0, 1, 2, 3, 5, 9]) {
+    expect(truncateLeft(input, len).length).toBeLessThanOrEqual(Math.max(1, len))
+  }
+  expect(truncateLeft(input, 1)).toBe("…")
+  expect(truncateLeft(input, 2)).toBe("…j")
+})
+
+test("truncateMiddle never returns more than the requested budget", () => {
+  for (const len of [0, 1, 2, 3, 5, 9]) {
+    expect(truncateMiddle(input, len).length).toBeLessThanOrEqual(Math.max(1, len))
+  }
+  expect(truncateMiddle(input, 1)).toBe("…")
+  expect(truncateMiddle(input, 3)).toBe("a…j")
+})
+
+test("truncateMiddle keeps both ends of the input", () => {
+  expect(truncateMiddle(input, 5)).toBe("ab…ij")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #37458

(I opened #41054 before finding #37458. Closing mine as a duplicate — this PR targets the existing one. Same bug was also reported in #20880 and #34395, and a fix in #34482 was closed by the automated PR cleanup in July rather than reviewed.)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`truncateLeft` and `truncateMiddle` in `packages/tui/src/util/locale.ts` compute a slice length that reaches zero or goes negative on small budgets. `String.prototype.slice(-0)` is `slice(0)`, which returns the whole string, so both helpers hand back something longer than the input:

```
truncateMiddle("abcdefghij", 0) -> "…bcdefghij"
truncateMiddle("abcdefghij", 1) -> "…abcdefghij"
truncateLeft("abcdefghij", 1)   -> "…abcdefghij"
```

They grow the text exactly when the terminal has the least room for it.

Clamped inside both helpers so callers don't each need their own guard. `truncateMiddle` also got restructured slightly: `keepEnd` is now checked before slicing, which is what removes the `slice(-0)` path.

Worth noting for review: the `Math.max(1, ...)` at `dialog-select.tsx:702` and `dialog-move-session.tsx:151` looks like a guard against this, but 1 is inside the broken range, so it clamps straight into it. `files.tsx:35` uses `Math.max(2, ...)` and happens to land just outside. After this change those clamps are redundant but harmless, so I left them alone to keep the diff focused.

### How did you verify your code works?

Ran the actual call site expressions from the TUI against the real module, on `dev` and on this branch:

```
term | callsite                     | budget | before | after
  10 | dialog-select.tsx:702        |      1 |     40 |     1
  10 | dialog-move-session.tsx:151  |      1 |     40 |     1
  12 | dialog-select.tsx:702        |      1 |     40 |     1
  14 | dialog-select.tsx:702        |      2 |     41 |     2
  16 | dialog-move-session.tsx:151  |      2 |     41 |     2
```

9 call sites returned more than their budget before, 0 after. Output stays correct for normal widths (`truncateMiddle("...", 5)` gives `"ab…ij"`).

```
$ bun test test/util-locale.test.ts
 4 pass
 0 fail
 20 expect() calls
```

`util/locale.ts` had no tests, which is presumably how this survived three reports. The tests assert the budget is never exceeded across the whole small range rather than checking specific strings.

Two things I deliberately left out:

- `packages/core/src/util/path.ts:31` has a byte-identical copy of the same bug. Different package, seemed like it should be its own PR — happy to include it here if you'd prefer.
- These helpers budget in `str.length` (UTF-16 code units) while callers are budgeting terminal columns, so CJK and emoji still under-truncate. `packages/tui/src/prompt/display.ts:7` shows the house approach with `Bun.stringWidth` + `Intl.Segmenter`. That's a behavior change and needs its own discussion.

### Screenshots / recordings

This only shows up below roughly 16 columns, where the layout is already degraded. The table above is the measurable version.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
