### PR TITLE
feat(tui): type into custom form answers

### DIFF
--- a/packages/tui/src/mini/footer.form.tsx
+++ b/packages/tui/src/mini/footer.form.tsx
@@ -71,6 +71,7 @@ export function RunFormBody(props: {
     return typeof value === "string" ? value : undefined
   })
   let area: TextareaRenderable | undefined
+  let editingReady = false
 
   createEffect(() => {
     setState((previous) => formSync(previous, props.request))
@@ -93,6 +94,7 @@ export function RunFormBody(props: {
       if (!area || area.isDestroyed || !state().editing) return
       area.focus()
       area.cursorOffset = area.plainText.length
+      editingReady = true
     })
   })
 
@@ -209,7 +211,6 @@ export function RunFormBody(props: {
       return
     }
     if (unsupported()) return
-    if (state().editing) return
     const character =
       !event.ctrl &&
       !event.meta &&
@@ -219,12 +220,14 @@ export function RunFormBody(props: {
       /^[^\p{C}\p{Zl}\p{Zp}]$/u.test(event.sequence)
         ? event.sequence
         : undefined
-    if (custom() && state().selected === rows().length && character) {
-      const next = formPick(state(), props.request)
+    if (custom() && state().selected === rows().length && character && !editingReady) {
+      const next = state().editing ? state() : formPick(state(), props.request)
+      if (!state().editing) editingReady = false
       setState(formSetDraft(next, current(), formInput(next, current()) + character))
       event.preventDefault()
       return
     }
+    if (state().editing) return
     if (
       event.name === "tab" ||
       event.name === "left" ||

--- a/packages/tui/src/mini/footer.form.tsx
+++ b/packages/tui/src/mini/footer.form.tsx
@@ -210,6 +210,21 @@ export function RunFormBody(props: {
     }
     if (unsupported()) return
     if (state().editing) return
+    const character =
+      !event.ctrl &&
+      !event.meta &&
+      !event.option &&
+      !event.super &&
+      !event.hyper &&
+      /^[^\p{C}\p{Zl}\p{Zp}]$/u.test(event.sequence)
+        ? event.sequence
+        : undefined
+    if (custom() && state().selected === rows().length && character) {
+      const next = formPick(state(), props.request)
+      setState(formSetDraft(next, current(), formInput(next, current()) + character))
+      event.preventDefault()
+      return
+    }
     if (
       event.name === "tab" ||
       event.name === "left" ||

--- a/packages/tui/src/routes/session/form.tsx
+++ b/packages/tui/src/routes/session/form.tsx
@@ -67,6 +67,7 @@ export function FormPrompt(props: { form: FormWithLocation }) {
   })
 
   let textarea: TextareaRenderable | undefined
+  let editingReady = false
   let review: ScrollBoxRenderable | undefined
 
   const message = createMemo(() => {
@@ -178,13 +179,16 @@ export function FormPrompt(props: { form: FormWithLocation }) {
   onCleanup(
     keymap.intercept("key", ({ event, consume }) => {
       if (keymap.mode.current() !== FORM_MODE) return
-      if (store.editing || textual() || !other()) return
+      if (textual() || !other() || (store.editing && editingReady)) return
       if (event.ctrl || event.meta || event.option || event.super || event.hyper) return
       if (!/^[^\p{C}\p{Zl}\p{Zp}]$/u.test(event.sequence)) return
       const current = answerField()
       if (!current) return
       setStore("custom", { ...store.custom, [current.key]: input() + event.sequence })
-      setStore("editing", true)
+      if (!store.editing) {
+        editingReady = false
+        setStore("editing", true)
+      }
       consume()
     }),
   )
@@ -884,8 +888,10 @@ export function FormPrompt(props: { form: FormWithLocation }) {
                             textarea = val
                             val.traits = { status: "ANSWER" }
                             queueMicrotask(() => {
+                              val.setText(input())
                               val.focus()
                               val.gotoLineEnd()
+                              editingReady = true
                             })
                           }}
                           initialValue={input()}

--- a/packages/tui/src/routes/session/form.tsx
+++ b/packages/tui/src/routes/session/form.tsx
@@ -175,6 +175,20 @@ export function FormPrompt(props: { form: FormWithLocation }) {
     return answer === value
   })
 
+  onCleanup(
+    keymap.intercept("key", ({ event, consume }) => {
+      if (keymap.mode.current() !== FORM_MODE) return
+      if (store.editing || textual() || !other()) return
+      if (event.ctrl || event.meta || event.option || event.super || event.hyper) return
+      if (!/^[^\p{C}\p{Zl}\p{Zp}]$/u.test(event.sequence)) return
+      const current = answerField()
+      if (!current) return
+      setStore("custom", { ...store.custom, [current.key]: input() + event.sequence })
+      setStore("editing", true)
+      consume()
+    }),
+  )
+
   function answer(key: string, value: FormValue | undefined) {
     setStore("answers", { ...store.answers, [key]: value })
     setStore("error", "")

--- a/packages/tui/test/cli/tui/form.test.tsx
+++ b/packages/tui/test/cli/tui/form.test.tsx
@@ -15,7 +15,7 @@ import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { createApi, createEventStream, createFetch } from "../../fixture/tui-client"
 
-async function mountForm(root: string, width = 80) {
+async function mountForm(root: string, width = 80, input?: FormWithLocation) {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
 
@@ -33,7 +33,7 @@ async function mountForm(root: string, width = 80) {
     events,
   )
   const config = createTuiResolvedConfig()
-  const form = {
+  const form = input ?? ({
     id: "frm_test",
     sessionID: "ses_test",
     title: "Authorization required",
@@ -45,7 +45,7 @@ async function mountForm(root: string, width = 80) {
         title: "Authorize access",
       },
     ],
-  } satisfies FormWithLocation
+  } satisfies FormWithLocation)
   const { FormPrompt } = await import("../../../src/routes/session/form")
 
   function Harness() {
@@ -84,7 +84,7 @@ async function mountForm(root: string, width = 80) {
 
   const app = await testRender(() => <Harness />, { width, height: 20, kittyKeyboard: true })
   app.renderer.start()
-  await app.waitForFrame((frame) => frame.includes("Authorization required"))
+  await app.waitForFrame((frame) => frame.includes(form.title))
   return { app, copied, replies }
 }
 
@@ -122,6 +122,35 @@ test("includes external acknowledgements in progress", async () => {
   try {
     expect(prompt.app.captureCharFrame()).toContain("0/1")
     expect(prompt.replies).toEqual([])
+  } finally {
+    prompt.app.renderer.destroy()
+  }
+})
+
+test("typing starts a highlighted custom answer without losing the first character", async () => {
+  await using tmp = await tmpdir()
+  const prompt = await mountForm(tmp.path, 80, {
+    id: "frm_test",
+    sessionID: "ses_test",
+    title: "Choose a target",
+    fields: [
+      {
+        key: "target",
+        type: "string",
+        options: [{ value: "production", label: "Production" }],
+        custom: true,
+      },
+    ],
+  })
+  try {
+    prompt.app.mockInput.pressKey("x")
+    await prompt.app.renderOnce()
+    expect(prompt.app.renderer.currentFocusedEditor).toBeNull()
+
+    prompt.app.mockInput.pressKey("j")
+    prompt.app.mockInput.pressKey("1")
+    await prompt.app.waitFor(() => prompt.app.renderer.currentFocusedEditor?.plainText === "1")
+    expect(prompt.app.renderer.currentFocusedEditor?.plainText).toBe("1")
   } finally {
     prompt.app.renderer.destroy()
   }

--- a/packages/tui/test/cli/tui/form.test.tsx
+++ b/packages/tui/test/cli/tui/form.test.tsx
@@ -148,9 +148,9 @@ test("typing starts a highlighted custom answer without losing the first charact
     expect(prompt.app.renderer.currentFocusedEditor).toBeNull()
 
     prompt.app.mockInput.pressKey("j")
-    prompt.app.mockInput.pressKey("1")
-    await prompt.app.waitFor(() => prompt.app.renderer.currentFocusedEditor?.plainText === "1")
-    expect(prompt.app.renderer.currentFocusedEditor?.plainText).toBe("1")
+    await prompt.app.mockInput.typeText("123")
+    await prompt.app.waitFor(() => prompt.app.renderer.currentFocusedEditor?.plainText === "123")
+    expect(prompt.app.renderer.currentFocusedEditor?.plainText).toBe("123")
   } finally {
     prompt.app.renderer.destroy()
   }

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -277,6 +277,37 @@ test("direct footer preserves a partial multi-field form draft across permission
   }
 })
 
+test("direct footer typing starts a highlighted custom answer without losing the first character", async () => {
+  const request: FormInfo = {
+    id: "frm_custom",
+    sessionID: "ses_child",
+    title: "Choose a target",
+    fields: [
+      {
+        key: "target",
+        type: "string",
+        options: [{ value: "production", label: "Production" }],
+        custom: true,
+      },
+    ],
+  }
+  const app = await renderFooter({ height: 12, view: { type: "form", request } })
+
+  try {
+    await app.renderOnce()
+    app.mockInput.pressKey("x")
+    await app.renderOnce()
+    expect(app.renderer.currentFocusedEditor).toBeNull()
+
+    app.mockInput.pressKey("j")
+    app.mockInput.pressKey("h")
+    await app.waitFor(() => app.renderer.currentFocusedEditor?.plainText === "h")
+    expect(app.renderer.currentFocusedEditor?.plainText).toBe("h")
+  } finally {
+    app.cleanup()
+  }
+})
+
 function expectPaletteList(list: BoxRenderable, selectedIndex: number) {
   expect(list.backgroundColor.toInts()).toEqual((RUN_THEME_FALLBACK.footer.shade as RGBA).toInts())
   expect((list.getChildren()[selectedIndex] as BoxRenderable).backgroundColor.toInts()).toEqual(

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -300,9 +300,9 @@ test("direct footer typing starts a highlighted custom answer without losing the
     expect(app.renderer.currentFocusedEditor).toBeNull()
 
     app.mockInput.pressKey("j")
-    app.mockInput.pressKey("h")
-    await app.waitFor(() => app.renderer.currentFocusedEditor?.plainText === "h")
-    expect(app.renderer.currentFocusedEditor?.plainText).toBe("h")
+    await app.mockInput.typeText("hello")
+    await app.waitFor(() => app.renderer.currentFocusedEditor?.plainText === "hello")
+    expect(app.renderer.currentFocusedEditor?.plainText).toBe("hello")
   } finally {
     app.cleanup()
   }


### PR DESCRIPTION
## What

Typing while **Type your own answer** is highlighted now opens the custom-answer editor and preserves the complete typed input. This removes the extra Enter press before entering a custom form answer.

Closes #34476.

## How

- `packages/tui/src/routes/session/form.tsx` intercepts unmodified printable input while the custom row is active, then buffers characters until the textarea is focused.
- `packages/tui/src/mini/footer.form.tsx` applies the same behavior to the direct-run form footer.
- Navigation and shortcuts keep their existing behavior unless the custom row is highlighted.
- Focus handoff preserves burst input, including digits and navigation-letter characters typed as answer text.

## Scope

This PR covers printable typing only. Pasting from any selected option into the custom answer is handled separately in #41080.

## Testing

- `bun run test test/cli/tui/form.test.tsx test/mini/footer.view.test.tsx` from `packages/tui`: 44 passed, 4 skipped
- `bun typecheck` from `packages/tui`
- Pre-push `bun turbo typecheck --concurrency=3`: 32 tasks passed
- OpenCode Drive end-to-end recording against this worktree

## Demo

The recording uses an isolated OpenCode Drive TUI with a simulated question response. It highlights **Type your own answer**, then types a complete custom value without pressing Enter first.

https://github.com/user-attachments/assets/25aeef82-c4c9-4491-9489-8b3e691ac662
