### PR TITLE
refactor(core): move read tool onto environment

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -395,6 +395,7 @@
         "ignore": "7.0.5",
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
+        "mime-types": "3.0.2",
         "tree-sitter-bash": "0.25.0",
         "tree-sitter-powershell": "0.25.10",
         "turndown": "7.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -118,6 +118,7 @@
     "immer": "11.1.4",
     "ignore": "7.0.5",
     "jsonc-parser": "3.3.1",
+    "mime-types": "3.0.2",
     "turndown": "7.2.0",
     "tree-sitter-bash": "0.25.0",
     "tree-sitter-powershell": "0.25.10",

--- a/packages/core/src/environment/environment.ts
+++ b/packages/core/src/environment/environment.ts
@@ -1,0 +1,26 @@
+import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Context, Effect, Layer } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import type { Files } from "./files"
+import { makeFiles } from "./index"
+import { makeLocalDriver } from "./local"
+
+export interface Interface {
+  readonly files: Files
+  readonly spawner: ChildProcessSpawner["Service"]
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Environment") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner
+    return Service.of({ files: makeFiles(makeLocalDriver(spawner)), spawner })
+  }),
+)
+
+export const node = makeLocationNode({ service: Service, layer, deps: [CrossSpawnSpawner.node] })
+
+export * as EnvironmentService from "./environment"

--- a/packages/core/src/environment/exec-defaults.ts
+++ b/packages/core/src/environment/exec-defaults.ts
@@ -50,13 +50,13 @@ fi
 `
 
 const listScript = `
-${loadMetadata()}
+${loadMetadata("-L")}
 kind=\${metadata%%${TAB}*}
 if [ "$kind" != directory ]; then
   printf '%s' "$kind" >&2
   exit ${WRONG_KIND}
 fi
-find "$1" -mindepth 1 -maxdepth 1 -printf '%y\\0%f\\0'
+find -H "$1" -mindepth 1 -maxdepth 1 -printf '%y\\0%f\\0'
 `
 
 const moveScript = `

--- a/packages/core/src/environment/files.ts
+++ b/packages/core/src/environment/files.ts
@@ -30,7 +30,8 @@ export class Failed extends Schema.TaggedErrorClass<Failed>()("Environment.Faile
 
 export interface FilesImpl {
   /**
-   * Reads a file, following a final symlink so `info` describes the target whose bytes are returned.
+   * Content operations (`read`, `list`) follow final symlinks; metadata operations (`stat` and entry
+   * tags returned by `list`) do not. `info` describes the target file whose bytes are returned.
    * The process-backed default caps collected output at 64 MiB; larger whole-file reads fail with
    * `Failed`, so callers must use ranges for larger files.
    */
@@ -41,7 +42,7 @@ export interface FilesImpl {
   readonly write: (path: string, bytes: Uint8Array) => Effect.Effect<void, Failed>
   /** Describes the path entry itself, so a final symlink is reported as `symlink` rather than followed. */
   readonly stat: (path: string) => Effect.Effect<FileInfo, NotFound | Failed>
-  /** Lists a directory entry without following a final symlink; intermediate symlinks are traversed. */
+  /** Follows a final symlink to the listed directory while preserving each returned entry's own type. */
   readonly list: (path: string) => Effect.Effect<ReadonlyArray<DirEntry>, NotFound | WrongKind | Failed>
   readonly remove: (path: string) => Effect.Effect<void, Failed>
   readonly move: (from: string, to: string) => Effect.Effect<void, NotFound | Failed>

--- a/packages/core/src/environment/index.ts
+++ b/packages/core/src/environment/index.ts
@@ -14,6 +14,7 @@ export {
 export { execDefaults } from "./exec-defaults"
 export { makeLocalDriver } from "./local"
 export { makeMemoryDriver, type MemoryDriver } from "./memory"
+export { type Interface, node, Service } from "./environment"
 
 import type { Driver } from "./driver"
 import { execDefaults } from "./exec-defaults"

--- a/packages/core/src/environment/local.ts
+++ b/packages/core/src/environment/local.ts
@@ -43,7 +43,7 @@ export const makeLocalDriver = (spawner: ChildProcessSpawner["Service"]): Driver
     stat: (value) => stat(value, false),
     list: (value) =>
       Effect.gen(function* () {
-        const info = yield* stat(value, false)
+        const info = yield* stat(value, true)
         if (info.type !== "directory") return yield* new WrongKind({ path: value, actual: info.type })
         const entries = yield* attempt(value, () => fs.readdir(value, { withFileTypes: true }), true)
         return entries.map((entry) => ({ name: entry.name, type: fileType(entry) }))

--- a/packages/core/src/environment/memory.ts
+++ b/packages/core/src/environment/memory.ts
@@ -90,7 +90,7 @@ export const makeMemoryDriver = (): MemoryDriver => {
         catch: (cause) => failed(value, cause),
       }),
     list: (value) => {
-      const target = resolveKey(value, false) ?? key(value)
+      const target = resolveKey(value, true) ?? key(value)
       const node = nodes.get(target)
       if (!node) return Effect.fail(new NotFound({ path: value }))
       if (node.type !== "directory") return Effect.fail(new WrongKind({ path: value, actual: node.type }))

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -8,6 +8,7 @@ import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Node } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "./bus"
 import { FileMutation } from "./file-mutation"
+import { Environment } from "./environment"
 import { Formatter } from "./formatter"
 import { FileSystem } from "./filesystem"
 import { FileSystemSearch } from "./filesystem/search"
@@ -53,6 +54,7 @@ export { LocationServiceMap } from "./location-service-map"
 
 const locationServiceNodes = [
   Location.node,
+  Environment.node,
   Config.node,
   Agent.node,
   Command.node,

--- a/packages/core/src/tool/plugin/read.ts
+++ b/packages/core/src/tool/plugin/read.ts
@@ -11,6 +11,7 @@ import { Permission } from "../../permission"
 import { SessionInstructions } from "../../session/instructions"
 import { AbsolutePath } from "../../schema"
 import { ReadToolFileSystem } from "../read-filesystem"
+import { Environment } from "../../environment"
 
 export const name = "read"
 const FILENAME = "AGENTS.md"
@@ -72,16 +73,12 @@ export const Plugin = {
                 agent: context.agent,
                 source,
               })
-              const type = yield* reader
-                .inspect(absolute)
-                .pipe(Effect.catchReason("PlatformError", "NotFound", () => missing(input.path, target.absolute)))
-              const content =
-                type === "directory"
-                  ? yield* reader.list(absolute, { offset: input.offset, limit: input.limit })
-                  : yield* reader.read(absolute, resource, {
-                      offset: input.offset,
-                      limit: input.limit,
-                    })
+              const content = yield* reader.read(absolute, resource, { offset: input.offset, limit: input.limit }).pipe(
+                Effect.catchIf(
+                  (error) => error instanceof Environment.NotFound,
+                  () => missing(input.path, target.absolute),
+                ),
+              )
               // After a successful read, discover nearby AGENTS.md walking up to the Location
               // root exclusive and inject them as durable synthetic instructions. For a
               // directory listing the walk starts at the directory itself (so its own AGENTS.md
@@ -95,7 +92,7 @@ export const Plugin = {
                 // supplied by core initial instructions) is dropped by the dirname filter.
                 const discovered = yield* fs.up({
                   targets: [FILENAME],
-                  start: type === "directory" ? resolved : dirname(resolved),
+                  start: content.type === "list-page" ? resolved : dirname(resolved),
                   stop: root,
                 })
                 const candidates = (yield* Effect.forEach(discovered, fs.resolve)).filter(

--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -2,17 +2,22 @@ export * as ReadToolFileSystem from "./read-filesystem"
 
 import path from "path"
 import { pathToFileURL } from "url"
-import { Context, Effect, Layer, Option, Schema } from "effect"
-import { FileSystem } from "../filesystem"
-import { FSUtil } from "@opencode-ai/util/fs-util"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Context, Effect, Layer, Schema } from "effect"
+import { lookup } from "mime-types"
+import { Environment } from "../environment"
+import type { Files } from "../environment"
+import { FileSystem } from "../filesystem"
+import { Mime } from "../mime"
 import { AbsolutePath, NonNegativeInt, PositiveInt, RelativePath } from "../schema"
 
 export const MAX_READ_LINES = 2_000
 export const MAX_READ_BYTES = 50 * 1024
 export const MAX_MEDIA_INGEST_BYTES = 20 * 1024 * 1024
+const FIRST_CHUNK = 256 * 1024
 const MAX_LINE_LENGTH = 2_000
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
+const MEDIA_MIMES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"])
 
 export class BinaryFileError extends Schema.TaggedErrorClass<BinaryFileError>()("ReadTool.BinaryFileError", {
   resource: Schema.String,
@@ -52,8 +57,13 @@ export class PathKindError extends Schema.TaggedErrorClass<PathKindError>()("Rea
   }
 }
 
-export type InspectError = FSUtil.Error | PathKindError
-export type ReadError = FSUtil.Error | BinaryFileError | MediaIngestLimitError | OffsetOutOfRangeError | PathKindError
+export type ReadError =
+  | Environment.NotFound
+  | Environment.Failed
+  | BinaryFileError
+  | MediaIngestLimitError
+  | OffsetOutOfRangeError
+  | PathKindError
 
 export const PageInput = Schema.Struct({
   offset: Schema.optionalKey(NonNegativeInt),
@@ -90,202 +100,120 @@ export class ListPage extends Schema.Class<ListPage>("ReadTool.ListPage")({
 }) {}
 
 export interface Interface {
-  readonly inspect: (path: AbsolutePath) => Effect.Effect<"file" | "directory", InspectError>
   readonly read: (
     path: AbsolutePath,
     resource: string,
     page?: PageInput,
-  ) => Effect.Effect<FileContent | TextPage, ReadError>
-  readonly list: (path: AbsolutePath, page?: PageInput) => Effect.Effect<ListPage, FSUtil.Error>
+  ) => Effect.Effect<FileContent | TextPage | ListPage, ReadError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ReadToolFileSystem") {}
 
-const startsWith = (bytes: Uint8Array, prefix: number[]) => prefix.every((value, index) => bytes[index] === value)
-const mediaMime = (bytes: Uint8Array) => {
-  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png"
-  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg"
-  if (startsWith(bytes, [0x47, 0x49, 0x46, 0x38])) return "image/gif"
-  if (startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) && startsWith(bytes.subarray(8), [0x57, 0x45, 0x42, 0x50]))
-    return "image/webp"
-  if (startsWith(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf"
-}
-const binary = (bytes: Uint8Array) => {
-  if (bytes.length === 0) return false
-  let nonPrintable = 0
-  for (const byte of bytes) {
-    if (byte === 0) return true
-    if (byte < 9 || (byte > 13 && byte < 32)) nonPrintable++
-  }
-  return nonPrintable / bytes.length > 0.3
-}
-const decodeUtf8 = (decoder: TextDecoder, bytes?: Uint8Array) => decoder.decode(bytes, { stream: bytes !== undefined })
-const decodeChunk = (resource: string, decoder: TextDecoder, bytes: Uint8Array) =>
-  bytes.includes(0) ? Effect.fail(new BinaryFileError({ resource })) : Effect.succeed(decodeUtf8(decoder, bytes))
-
-export const inspect = Effect.fn("ReadTool.inspect")(function* (fs: FSUtil.Interface, input: string) {
-  const info = yield* fs.stat(input)
-  const type = info.type === "File" ? "file" : info.type === "Directory" ? "directory" : undefined
-  if (!type) return yield* Effect.fail(new PathKindError({ resource: input, expected: "a file or directory" }))
-  return type
-})
+const mimeType = (value: string) => lookup(value) || "application/octet-stream"
 
 export const read = Effect.fn("ReadTool.read")(function* (
-  fs: FSUtil.Interface,
-  input: string,
+  files: Files,
+  input: AbsolutePath,
   resource: string,
   page: PageInput = {},
 ) {
-  const real = yield* fs.realPath(input)
-  return yield* Effect.scoped(
-    Effect.gen(function* () {
-      const file = yield* fs.open(real, { flag: "r" })
-      const info = yield* file.stat
-      if (info.type !== "File") return yield* Effect.fail(new PathKindError({ resource, expected: "a file" }))
-      const first = Option.getOrElse(
-        yield* file.readAlloc(Math.min(64 * 1024, Number(info.size) || 4 * 1024)),
-        () => new Uint8Array(),
+  const first = yield* files.read(input, { offset: 0, length: FIRST_CHUNK }).pipe(
+    Effect.catchTag("Environment.WrongKind", (error) => {
+      if (error.actual !== "directory")
+        return Effect.fail(new PathKindError({ resource, expected: "a file or directory" }))
+      return files.list(input).pipe(
+        Effect.map((entries) => list(entries, page)),
+        Effect.catchTag("Environment.WrongKind", () =>
+          Effect.fail(new PathKindError({ resource, expected: "a file or directory" })),
+        ),
       )
-      const mime = mediaMime(first)
-      if (mime) {
-        if (info.size > MAX_MEDIA_INGEST_BYTES)
-          return yield* Effect.fail(new MediaIngestLimitError({ resource, maximumBytes: MAX_MEDIA_INGEST_BYTES }))
-        const chunks = [first]
-        let total = first.length
-        while (total <= MAX_MEDIA_INGEST_BYTES) {
-          const chunk = yield* file.readAlloc(Math.min(64 * 1024, MAX_MEDIA_INGEST_BYTES + 1 - total))
-          if (Option.isNone(chunk)) break
-          chunks.push(chunk.value)
-          total += chunk.value.length
-        }
-        if (total > MAX_MEDIA_INGEST_BYTES)
-          return yield* Effect.fail(new MediaIngestLimitError({ resource, maximumBytes: MAX_MEDIA_INGEST_BYTES }))
-        return {
-          type: "file" as const,
-          uri: pathToFileURL(real).href,
-          name: path.basename(real),
-          content: Buffer.concat(
-            chunks.map((chunk) => Buffer.from(chunk)),
-            total,
-          ).toString("base64"),
-          encoding: "base64" as const,
-          mime,
-        }
-      }
-      const paged = info.size > MAX_READ_BYTES || page.offset !== undefined || page.limit !== undefined
-      if (!paged) {
-        if (binary(first)) return yield* Effect.fail(new BinaryFileError({ resource }))
-        const decoder = new TextDecoder()
-        const text = [decodeUtf8(decoder, first)]
-        while (true) {
-          const chunk = yield* file.readAlloc(64 * 1024)
-          if (Option.isNone(chunk)) break
-          text.push(yield* decodeChunk(resource, decoder, chunk.value))
-        }
-        text.push(decodeUtf8(decoder))
-        return {
-          type: "file" as const,
-          uri: pathToFileURL(real).href,
-          name: path.basename(real),
-          content: text.join(""),
-          encoding: "utf8" as const,
-          mime: FSUtil.mimeType(real),
-        }
-      }
-      const offset = page.offset || 1
-      const limit = Math.min(page.limit || MAX_READ_LINES, MAX_READ_LINES)
-      const lines: string[] = []
-      const decoder = new TextDecoder()
-      let pending = ""
-      let discard = false
-      let line = 1
-      let bytes = 0
-      let next: number | undefined
-      const append = (input: string) => {
-        if (line < offset) {
-          line++
-          return true
-        }
-        if (lines.length >= limit || bytes >= MAX_READ_BYTES) {
-          next = line
-          return false
-        }
-        const text = input.length > MAX_LINE_LENGTH ? input.slice(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : input
-        const size = Buffer.byteLength(text, "utf-8") + (lines.length > 0 ? 1 : 0)
-        if (bytes + size > MAX_READ_BYTES) {
-          next = line
-          return false
-        }
-        lines.push(text)
-        bytes += size
-        line++
-        return true
-      }
-      const consume = (input: string) => {
-        let text = input
-        while (true) {
-          const index = text.indexOf("\n")
-          if (index === -1) {
-            if (!discard) {
-              pending += text
-              if (pending.length > MAX_LINE_LENGTH) {
-                pending = pending.slice(0, MAX_LINE_LENGTH + 1)
-                discard = true
-              }
-            }
-            break
-          }
-          const current = pending + (discard ? "" : text.slice(0, index))
-          pending = ""
-          discard = false
-          text = text.slice(index + 1)
-          if (!append(current.endsWith("\r") ? current.slice(0, -1) : current)) return false
-        }
-        return true
-      }
-      const consumeChunk = Effect.fnUntraced(function* (chunk: Uint8Array) {
-        let start = 0
-        while (start < chunk.length) {
-          if (lines.length >= limit || bytes >= MAX_READ_BYTES) {
-            next = line
-            return false
-          }
-          const newline = chunk.indexOf(10, start)
-          const end = newline === -1 ? chunk.length : newline + 1
-          const segment = chunk.subarray(start, end)
-          if (binary(segment)) return yield* Effect.fail(new BinaryFileError({ resource }))
-          if (!consume(decodeUtf8(decoder, segment))) return false
-          start = end
-        }
-        return true
-      })
-      let done = !(yield* consumeChunk(first))
-      while (!done) {
-        const chunk = yield* file.readAlloc(64 * 1024)
-        if (Option.isNone(chunk)) break
-        done = !(yield* consumeChunk(chunk.value))
-      }
-      if (!done) {
-        const tail = decodeUtf8(decoder)
-        if (!discard) pending += tail
-        if (pending) append(pending.endsWith("\r") ? pending.slice(0, -1) : pending)
-      }
-      if (lines.length === 0 && offset !== 1) return yield* Effect.fail(new OffsetOutOfRangeError({ offset }))
-      return new TextPage({
-        type: "text-page",
-        content: lines.join("\n"),
-        mime: FSUtil.mimeType(real),
-        offset,
-        truncated: next !== undefined,
-        ...(next === undefined ? {} : { next }),
-      })
     }),
   )
+  if (first instanceof ListPage) return first
+
+  const media = Mime.detect(first.bytes)
+  if (MEDIA_MIMES.has(media)) {
+    if (first.info.size > MAX_MEDIA_INGEST_BYTES)
+      return yield* new MediaIngestLimitError({ resource, maximumBytes: MAX_MEDIA_INGEST_BYTES })
+    const whole = yield* readFile(files, input, resource)
+    return {
+      type: "file" as const,
+      uri: pathToFileURL(input).href,
+      name: path.basename(input),
+      content: Buffer.from(whole.bytes).toString("base64"),
+      encoding: "base64" as const,
+      mime: media,
+    }
+  }
+
+  const paged = first.info.size > MAX_READ_BYTES || page.offset !== undefined || page.limit !== undefined
+  if (!paged) {
+    if (first.bytes.includes(0)) return yield* new BinaryFileError({ resource })
+    const bytes =
+      first.bytes.length < first.info.size
+        ? Buffer.concat([
+            first.bytes,
+            (yield* readFile(files, input, resource, { offset: first.bytes.length, length: first.info.size })).bytes,
+          ])
+        : first.bytes
+    return {
+      type: "file" as const,
+      uri: pathToFileURL(input).href,
+      name: path.basename(input),
+      content: new TextDecoder().decode(bytes),
+      encoding: "utf8" as const,
+      mime: mimeType(input),
+    }
+  }
+
+  const chunks = [first.bytes]
+  while (true) {
+    const bytes = Buffer.concat(chunks)
+    const eof = bytes.length >= first.info.size
+    const result = textPage(bytes, eof, page)
+    if (result !== undefined) return yield* makeTextPage(bytes, input, resource, result)
+    const next = yield* readFile(files, input, resource, { offset: bytes.length, length: FIRST_CHUNK })
+    if (next.bytes.length === 0) {
+      const result = textPage(bytes, true, page)
+      if (result === undefined) return yield* Effect.die("Read page did not settle at EOF")
+      return yield* makeTextPage(bytes, input, resource, result)
+    }
+    chunks.push(next.bytes)
+  }
 })
 
-export const list = Effect.fn("ReadTool.list")(function* (fs: FSUtil.Interface, input: string, page: PageInput = {}) {
-  const real = yield* fs.realPath(input)
-  const items = yield* fs.readDirectoryEntries(real)
+const readFile = (
+  files: Files,
+  input: AbsolutePath,
+  resource: string,
+  range?: { readonly offset: number; readonly length: number },
+) =>
+  files
+    .read(input, range)
+    .pipe(
+      Effect.catchTag("Environment.WrongKind", () => Effect.fail(new PathKindError({ resource, expected: "a file" }))),
+    )
+
+const makeTextPage = Effect.fnUntraced(function* (
+  bytes: Uint8Array,
+  input: AbsolutePath,
+  resource: string,
+  result: NonNullable<ReturnType<typeof textPage>>,
+) {
+  if (bytes.subarray(0, result.consumed).includes(0)) return yield* new BinaryFileError({ resource })
+  if (result.entries.length === 0 && result.offset !== 1)
+    return yield* new OffsetOutOfRangeError({ offset: result.offset })
+  return new TextPage({
+    type: "text-page",
+    content: result.entries.join("\n"),
+    mime: mimeType(input),
+    offset: result.offset,
+    truncated: result.next !== undefined,
+    ...(result.next === undefined ? {} : { next: result.next }),
+  })
+})
+
+const list = (items: ReadonlyArray<Environment.DirEntry>, page: PageInput) => {
   const offset = page.offset || 1
   const limit = Math.min(page.limit || MAX_READ_LINES, MAX_READ_LINES)
   const visible = items
@@ -316,18 +244,58 @@ export const list = Effect.fn("ReadTool.list")(function* (fs: FSUtil.Interface, 
     truncated,
     ...(truncated ? { next: offset + selected.length } : {}),
   })
-})
+}
+
+const textPage = (bytes: Uint8Array, eof: boolean, page: PageInput) => {
+  const offset = page.offset || 1
+  const limit = Math.min(page.limit || MAX_READ_LINES, MAX_READ_LINES)
+  const decoded = new TextDecoder().decode(bytes)
+  const split = decoded.split("\n")
+  const complete = eof ? (split.at(-1) === "" ? split.slice(0, -1) : split) : split.slice(0, -1)
+  const available = complete.map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line))
+
+  const entries: string[] = []
+  let size = 0
+  let next: number | undefined
+  for (const [index, value] of available.slice(offset - 1).entries()) {
+    const line = offset + index
+    if (entries.length >= limit || size >= MAX_READ_BYTES) {
+      next = line
+      break
+    }
+    const text = value.length > MAX_LINE_LENGTH ? value.slice(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : value
+    const lineSize = Buffer.byteLength(text, "utf-8") + (entries.length > 0 ? 1 : 0)
+    if (size + lineSize > MAX_READ_BYTES) {
+      next = line
+      break
+    }
+    entries.push(text)
+    size += lineSize
+  }
+  if (next === undefined && entries.length >= limit && (!eof || offset - 1 + entries.length < available.length))
+    next = offset + entries.length
+  if (!eof && next === undefined) return
+
+  const consumedLines = next === undefined ? available.length : next - 1
+  const consumed = consumedLines === 0 ? 0 : (nthNewline(bytes, consumedLines) ?? bytes.length)
+  return { entries, offset, next, consumed }
+}
+
+const nthNewline = (bytes: Uint8Array, count: number) => {
+  let found = 0
+  for (const [index, byte] of bytes.entries()) {
+    if (byte !== 10) continue
+    found++
+    if (found === count) return index + 1
+  }
+}
 
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const fs = yield* FSUtil.Service
-    return Service.of({
-      inspect: (path) => inspect(fs, path),
-      read: (path, resource, page) => read(fs, path, resource, page),
-      list: (path, page) => list(fs, path, page),
-    })
+    const environment = yield* Environment.Service
+    return Service.of({ read: (path, resource, page) => read(environment.files, path, resource, page) })
   }),
 )
 
-export const node = makeLocationNode({ service: Service, layer, deps: [FSUtil.node] })
+export const node = makeLocationNode({ service: Service, layer, deps: [Environment.node] })

--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -149,18 +149,11 @@ export const read = Effect.fn("ReadTool.read")(function* (
   const paged = first.info.size > MAX_READ_BYTES || page.offset !== undefined || page.limit !== undefined
   if (!paged) {
     if (first.bytes.includes(0)) return yield* new BinaryFileError({ resource })
-    const bytes =
-      first.bytes.length < first.info.size
-        ? Buffer.concat([
-            first.bytes,
-            (yield* readFile(files, input, resource, { offset: first.bytes.length, length: first.info.size })).bytes,
-          ])
-        : first.bytes
     return {
       type: "file" as const,
       uri: pathToFileURL(input).href,
       name: path.basename(input),
-      content: new TextDecoder().decode(bytes),
+      content: new TextDecoder().decode(first.bytes),
       encoding: "utf8" as const,
       mime: mimeType(input),
     }

--- a/packages/core/test/lib/environment-conformance.ts
+++ b/packages/core/test/lib/environment-conformance.ts
@@ -105,19 +105,29 @@ export const environmentConformance = <E>(
       }),
     )
 
-    check("reports symlinks without resolving them", (harness) =>
+    check("preserves symlink metadata while following symlinks for content", (harness) =>
       Effect.gen(function* () {
         if (!harness.symlink) return
         yield* harness.files.write(`${harness.root}/target`, bytes("target"))
         yield* harness.files.write(`${harness.root}/target-dir/file`, bytes("through link"))
+        yield* harness.symlink("../target", `${harness.root}/target-dir/entry-link`)
         yield* harness.symlink("target", `${harness.root}/link`)
         yield* harness.symlink("target-dir", `${harness.root}/link-dir`)
+        yield* harness.symlink("missing", `${harness.root}/dangling-link`)
         expect((yield* harness.files.stat(`${harness.root}/link`)).type).toBe("symlink")
         expect(yield* harness.files.list(harness.root)).toContainEqual({ name: "link", type: "symlink" })
         expect(text((yield* harness.files.read(`${harness.root}/link-dir/file`)).bytes)).toBe("through link")
-        const listError = yield* Effect.flip(harness.files.list(`${harness.root}/link-dir`))
-        expect(listError).toBeInstanceOf(WrongKind)
-        expect((listError as WrongKind).actual).toBe("symlink")
+        expect(
+          (yield* harness.files.list(`${harness.root}/link-dir`)).toSorted((a, b) => a.name.localeCompare(b.name)),
+        ).toEqual([
+          { name: "entry-link", type: "symlink" },
+          { name: "file", type: "file" },
+        ])
+
+        const fileError = yield* Effect.flip(harness.files.list(`${harness.root}/link`))
+        expect(fileError).toBeInstanceOf(WrongKind)
+        expect((fileError as WrongKind).actual).toBe("file")
+        expect(yield* Effect.flip(harness.files.list(`${harness.root}/dangling-link`))).toBeInstanceOf(NotFound)
       }),
     )
 

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -102,6 +102,25 @@ describe("ReadToolFileSystem", () => {
     }),
   )
 
+  it.effect("reads a symlinked directory as a listing", () =>
+    Effect.gen(function* () {
+      if (process.platform === "win32") return
+      const { environment, files, directory } = yield* fixture
+      const target = path.join(directory, "target")
+      const link = path.join(directory, "link")
+      yield* files.makeDirectory(target)
+      yield* files.writeFileString(path.join(target, "file.txt"), "hello")
+      yield* Effect.promise(() => fs.symlink(target, link))
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(link), "link")
+
+      expect(result).toMatchObject({
+        type: "list-page",
+        entries: [{ path: "file.txt", type: "file" }],
+      })
+    }),
+  )
+
   it.effect("reports out-of-range pagination as a typed error", () =>
     Effect.gen(function* () {
       const { environment, files, directory } = yield* fixture

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -1,66 +1,65 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, FileSystem } from "effect"
+import { Environment } from "@opencode-ai/core/environment"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { ReadToolFileSystem } from "@opencode-ai/core/tool/read-filesystem"
+import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
 import { LayerNodePlatform } from "@opencode-ai/util/effect/app-node-platform"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { FSUtil } from "@opencode-ai/util/fs-util"
-import { ReadToolFileSystem } from "@opencode-ai/core/tool/read-filesystem"
+import { Effect, FileSystem } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(LayerNode.compile(LayerNode.group([FSUtil.node, LayerNodePlatform.filesystem])))
+const it = testEffect(LayerNode.compile(LayerNode.group([CrossSpawnSpawner.node, LayerNodePlatform.filesystem])))
 const fixture = Effect.gen(function* () {
-  const fs = yield* FSUtil.Service
   const files = yield* FileSystem.FileSystem
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
   const directory = yield* files.makeTempDirectoryScoped()
-  return { fs, files, directory }
+  return { environment: Environment.makeFiles(Environment.makeLocalDriver(spawner)), files, directory }
 })
+const absolute = (value: string) => AbsolutePath.make(value)
 
 describe("ReadToolFileSystem", () => {
-  it.effect("fails with a typed filesystem error when a resolved file disappears", () =>
+  it.effect("preserves the environment not-found error", () =>
     Effect.gen(function* () {
-      const { fs, directory } = yield* fixture
+      const { environment, directory } = yield* fixture
       const file = path.join(directory, "missing.txt")
 
-      const error = yield* ReadToolFileSystem.read(fs, file, "missing.txt").pipe(Effect.flip)
+      const error = yield* ReadToolFileSystem.read(environment, absolute(file), "missing.txt").pipe(Effect.flip)
 
-      expect(error).toMatchObject({ _tag: "PlatformError" })
+      expect(error).toBeInstanceOf(Environment.NotFound)
     }),
   )
 
-  it.effect("fails when a file becomes the wrong path kind", () =>
+  it.effect("returns a listing when read reports a directory", () =>
     Effect.gen(function* () {
-      const { fs, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
+      yield* files.makeDirectory(path.join(directory, "folder"))
+      yield* files.writeFileString(path.join(directory, "file.txt"), "hello")
 
-      const error = yield* ReadToolFileSystem.read(fs, directory, "folder").pipe(Effect.flip)
+      const result = yield* ReadToolFileSystem.read(environment, absolute(directory), "folder")
 
-      expect(error).toBeInstanceOf(ReadToolFileSystem.PathKindError)
-    }),
-  )
-
-  it.effect("fails with a typed filesystem error when directory listing fails", () =>
-    Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
-      const file = path.join(directory, "file.txt")
-      yield* files.writeFileString(file, "hello")
-
-      const error = yield* ReadToolFileSystem.list(fs, file).pipe(Effect.flip)
-
-      expect(error).toBeInstanceOf(FSUtil.FileSystemError)
-      if (error instanceof FSUtil.FileSystemError) expect(error.method).toBe("readDirectoryEntries")
+      expect(result).toMatchObject({
+        type: "list-page",
+        entries: [
+          { path: `folder${path.sep}`, type: "directory" },
+          { path: "file.txt", type: "file" },
+        ],
+      })
     }),
   )
 
   it.effect("reads malformed UTF-8 lossily and still rejects null-byte binary content", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const binary = path.join(directory, "archive.dat")
       const malformed = path.join(directory, "malformed.txt")
       yield* files.writeFile(binary, Uint8Array.of(0, 1, 2, 3))
       yield* files.writeFile(malformed, Uint8Array.of(0x68, 0x69, 0x80))
 
-      const binaryError = yield* ReadToolFileSystem.read(fs, binary, "archive.dat").pipe(Effect.flip)
-      const malformedResult = yield* ReadToolFileSystem.read(fs, malformed, "malformed.txt")
+      const binaryError = yield* ReadToolFileSystem.read(environment, absolute(binary), "archive.dat").pipe(Effect.flip)
+      const malformedResult = yield* ReadToolFileSystem.read(environment, absolute(malformed), "malformed.txt")
 
       expect(binaryError).toBeInstanceOf(ReadToolFileSystem.BinaryFileError)
       expect(binaryError.message).toBe("Cannot read binary file: archive.dat")
@@ -70,11 +69,11 @@ describe("ReadToolFileSystem", () => {
 
   it.effect("reads text despite a binary-associated extension", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const file = path.join(directory, "notes.docx")
       yield* files.writeFileString(file, "plain text")
 
-      const result = yield* ReadToolFileSystem.read(fs, file, "notes.docx")
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "notes.docx")
 
       expect(result).toMatchObject({ type: "file", content: "plain text", encoding: "utf8" })
     }),
@@ -83,15 +82,17 @@ describe("ReadToolFileSystem", () => {
   it.effect("lists unresolved symlinks, including broken and escaping links", () =>
     Effect.gen(function* () {
       if (process.platform === "win32") return
-      const { fs: service, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const outside = yield* files.makeTempDirectoryScoped()
       yield* files.makeDirectory(path.join(directory, "folder"))
       yield* files.writeFileString(path.join(directory, "file.txt"), "hello")
       yield* Effect.promise(() => fs.symlink(path.join(outside, "target.txt"), path.join(directory, "escape")))
       yield* Effect.promise(() => fs.symlink(path.join(directory, "missing.txt"), path.join(directory, "broken")))
 
-      const result = yield* ReadToolFileSystem.list(service, directory)
+      const result = yield* ReadToolFileSystem.read(environment, absolute(directory), "folder")
 
+      expect(result.type).toBe("list-page")
+      if (result.type !== "list-page") return
       expect(result.entries.map((entry) => ({ ...entry, path: String(entry.path) }))).toEqual([
         { path: `folder${path.sep}`, type: "directory" },
         { path: "broken", type: "symlink" },
@@ -103,43 +104,133 @@ describe("ReadToolFileSystem", () => {
 
   it.effect("reports out-of-range pagination as a typed error", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const file = path.join(directory, "short.txt")
       yield* files.writeFileString(file, "one\n")
 
-      const error = yield* ReadToolFileSystem.read(fs, file, "short.txt", { offset: 2 }).pipe(Effect.flip)
+      const error = yield* ReadToolFileSystem.read(environment, absolute(file), "short.txt", { offset: 2 }).pipe(
+        Effect.flip,
+      )
 
       expect(error).toBeInstanceOf(ReadToolFileSystem.OffsetOutOfRangeError)
       expect(error.message).toBe("Offset 2 is out of range")
     }),
   )
 
-  it.effect("stops reading after the requested page is complete", () =>
+  it.effect("pages text with one-based offsets", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
-      const prefix = new TextEncoder().encode("one\n")
-      for (const [name, trailing] of [
-        ["malformed.txt", 0x80],
-        ["nul.txt", 0],
-      ] as const) {
-        const file = path.join(directory, name)
-        yield* files.writeFile(file, Uint8Array.from([...prefix, trailing]))
+      const { environment, files, directory } = yield* fixture
+      const file = path.join(directory, "lines.txt")
+      yield* files.writeFileString(file, "one\r\ntwo\nthree")
 
-        const result = yield* ReadToolFileSystem.read(fs, file, name, { limit: 1 })
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "lines.txt", {
+        offset: 2,
+        limit: 1,
+      })
 
-        expect(result).toMatchObject({ type: "text-page", content: "one", truncated: true, next: 2 })
+      expect(result).toMatchObject({ type: "text-page", content: "two", offset: 2, truncated: true, next: 3 })
+    }),
+  )
+
+  it.effect("truncates long lines", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      const file = path.join(directory, "long.txt")
+      yield* files.writeFileString(file, "a".repeat(2_001))
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "long.txt", { limit: 1 })
+
+      expect(result).toMatchObject({
+        type: "text-page",
+        content: `${"a".repeat(2_000)}... (line truncated to 2000 chars)`,
+        truncated: false,
+      })
+    }),
+  )
+
+  it.effect("enforces line and byte budgets with continuation offsets", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      const linesFile = path.join(directory, "many-lines.txt")
+      const bytesFile = path.join(directory, "many-bytes.txt")
+      yield* files.writeFileString(linesFile, Array.from({ length: 2_001 }, (_, index) => String(index)).join("\n"))
+      yield* files.writeFileString(bytesFile, Array.from({ length: 200 }, () => "a".repeat(2_000)).join("\n"))
+      const ranges: Array<{ readonly offset: number; readonly length: number } | undefined> = []
+      const tracked = {
+        ...environment,
+        read: (path: string, range?: { readonly offset: number; readonly length: number }) =>
+          Effect.sync(() => ranges.push(range)).pipe(Effect.andThen(environment.read(path, range))),
       }
+
+      const lines = yield* ReadToolFileSystem.read(environment, absolute(linesFile), "many-lines.txt", { limit: 2_000 })
+      const bytes = yield* ReadToolFileSystem.read(tracked, absolute(bytesFile), "many-bytes.txt", {})
+
+      expect(lines).toMatchObject({ type: "text-page", truncated: true, next: 2_001 })
+      expect(lines.type === "text-page" ? lines.content.split("\n") : []).toHaveLength(2_000)
+      expect(bytes).toMatchObject({ type: "text-page", truncated: true, next: 26 })
+      expect(bytes.type === "text-page" ? Buffer.byteLength(bytes.content) : Infinity).toBeLessThanOrEqual(
+        ReadToolFileSystem.MAX_READ_BYTES,
+      )
+      expect(ranges).toEqual([{ offset: 0, length: 256 * 1024 }])
+    }),
+  )
+
+  it.effect("sorts and pages directory entries", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      yield* files.makeDirectory(path.join(directory, "z"))
+      yield* files.makeDirectory(path.join(directory, "a"))
+      yield* files.writeFileString(path.join(directory, "b.txt"), "")
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(directory), "folder", {
+        offset: 2,
+        limit: 1,
+      })
+
+      expect(result).toMatchObject({
+        type: "list-page",
+        entries: [{ path: `z${path.sep}`, type: "directory" }],
+        truncated: true,
+        next: 3,
+      })
+    }),
+  )
+
+  it.effect("stops checking for null bytes after the requested page", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      const file = path.join(directory, "nul.txt")
+      yield* files.writeFile(file, Uint8Array.from([...new TextEncoder().encode("one\n"), 0]))
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "nul.txt", { limit: 1 })
+
+      expect(result).toMatchObject({ type: "text-page", content: "one", truncated: true, next: 2 })
+    }),
+  )
+
+  it.effect("reads page two after fetching more than the first 256KB range", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      const file = path.join(directory, "large.txt")
+      yield* files.writeFileString(file, `${"a".repeat(300 * 1024)}\nsecond\n`)
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "large.txt", {
+        offset: 2,
+        limit: 1,
+      })
+
+      expect(result).toMatchObject({ type: "text-page", content: "second", offset: 2, truncated: false })
     }),
   )
 
   it.effect("preserves the media ingestion limit message", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const file = path.join(directory, "oversized.png")
       yield* files.writeFile(file, Uint8Array.of(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a))
       yield* files.truncate(file, ReadToolFileSystem.MAX_MEDIA_INGEST_BYTES + 1)
 
-      const error = yield* ReadToolFileSystem.read(fs, file, "oversized.png").pipe(Effect.flip)
+      const error = yield* ReadToolFileSystem.read(environment, absolute(file), "oversized.png").pipe(Effect.flip)
 
       expect(error).toBeInstanceOf(ReadToolFileSystem.MediaIngestLimitError)
       expect(error.message).toBe(
@@ -150,11 +241,11 @@ describe("ReadToolFileSystem", () => {
 
   it.effect("reads PDFs as bounded media", () =>
     Effect.gen(function* () {
-      const { fs, files, directory } = yield* fixture
+      const { environment, files, directory } = yield* fixture
       const file = path.join(directory, "document.pdf")
       yield* files.writeFileString(file, "%PDF-1.7\ncontent")
 
-      const result = yield* ReadToolFileSystem.read(fs, file, "document.pdf")
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "document.pdf")
 
       expect(result).toMatchObject({
         type: "file",

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect } from "bun:test"
 import path from "path"
-import { Effect, Exit, Layer, PlatformError, Stream } from "effect"
+import { Effect, Exit, Layer, Stream } from "effect"
 import { Config } from "@opencode-ai/core/config"
 import { Document, Info } from "@opencode-ai/schema/config"
 import { ConfigMedia } from "@opencode-ai/schema/config/media"
@@ -21,6 +21,7 @@ import { ReadTool } from "@opencode-ai/core/tool/plugin/read"
 import { ReadToolFileSystem } from "@opencode-ai/core/tool/read-filesystem"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { SessionInstructions } from "@opencode-ai/core/session/instructions"
+import { Environment } from "@opencode-ai/core/environment"
 import { testEffect } from "./lib/effect"
 import { toolIdentity, executeTool, registerToolPlugin, toolDefinitions } from "./lib/tool"
 
@@ -42,24 +43,13 @@ const readToolNode = makeLocationNode({
 const assertions: Permission.AssertInput[] = []
 const missingPath = "__missing_read_target__.txt"
 const missingAbsolutePath = path.join(process.cwd(), missingPath)
-const notFound = (target: string) =>
-  PlatformError.systemError({
-    _tag: "NotFound",
-    module: "FileSystem",
-    method: "stat",
-    pathOrDescriptor: target,
-  })
 const readCalls: {
   input: AbsolutePath
   page: ReadToolFileSystem.PageInput
 }[] = []
-const listCalls: ReadToolFileSystem.PageInput[] = []
-let listResult = new ReadToolFileSystem.ListPage({ type: "list-page", entries: [], truncated: false })
-let resolvedType: "file" | "directory" = "file"
 let resolveFailure: unknown
-let inspectFailure: ReadToolFileSystem.InspectError | undefined
 let directoryEntries: string[] = []
-let readResult: ReadToolFileSystem.FileContent | ReadToolFileSystem.TextPage = {
+let readResult: ReadToolFileSystem.FileContent | ReadToolFileSystem.TextPage | ReadToolFileSystem.ListPage = {
   type: "file",
   uri: "file:///README.md",
   name: "README.md",
@@ -71,22 +61,12 @@ let readFailure: ReadToolFileSystem.ReadError | undefined
 const reader = Layer.succeed(
   ReadToolFileSystem.Service,
   ReadToolFileSystem.Service.of({
-    inspect: () =>
-      resolveFailure !== undefined
-        ? Effect.die(resolveFailure)
-        : inspectFailure !== undefined
-          ? Effect.fail(inspectFailure)
-          : Effect.succeed(resolvedType),
     read: (input, _resource, page = {}) => {
       readCalls.push({ input, page })
+      if (resolveFailure !== undefined) return Effect.die(resolveFailure)
       if (readFailure !== undefined) return Effect.fail(readFailure)
       return Effect.succeed(readResult)
     },
-    list: (_path, input = {}) =>
-      Effect.sync(() => {
-        listCalls.push(input)
-        return listResult
-      }),
   }),
 )
 let allow = true
@@ -125,17 +105,6 @@ const testFileSystem = Layer.effect(
       FSUtil.Service.of({
         ...fs,
         readDirectory: () => Effect.succeed(directoryEntries),
-        realPath: (path) =>
-          path === missingAbsolutePath
-            ? Effect.fail(
-                PlatformError.systemError({
-                  _tag: "NotFound",
-                  module: "FileSystem",
-                  method: "realPath",
-                  pathOrDescriptor: path,
-                }),
-              )
-            : Effect.succeed(path),
       }),
     ),
   ),
@@ -195,11 +164,8 @@ describe("ReadTool", () => {
   beforeEach(() => {
     assertions.length = 0
     readCalls.length = 0
-    listCalls.length = 0
     allow = true
-    resolvedType = "file"
     resolveFailure = undefined
-    inspectFailure = undefined
     directoryEntries = []
     readResult = {
       type: "file",
@@ -210,7 +176,6 @@ describe("ReadTool", () => {
       mime: "text/plain",
     }
     readFailure = undefined
-    listResult = new ReadToolFileSystem.ListPage({ type: "list-page", entries: [], truncated: false })
   })
 
   it.effect("registers, authorizes, and reads through the location filesystem", () =>
@@ -672,7 +637,7 @@ describe("ReadTool", () => {
 
   it.effect("returns missing paths as model-visible tool failures", () =>
     Effect.gen(function* () {
-      inspectFailure = notFound(missingAbsolutePath)
+      readFailure = new Environment.NotFound({ path: missingAbsolutePath })
       directoryEntries = [
         "__missing_read_target__.txt.bak",
         "copy___missing_read_target__.txt",
@@ -696,14 +661,18 @@ describe("ReadTool", () => {
         },
       })
       expect(assertions).toMatchObject([{ sessionID, action: "read", resources: [missingPath], save: ["*"] }])
-      expect(readCalls).toEqual([])
+      expect(readCalls).toEqual([
+        {
+          input: AbsolutePath.make(missingAbsolutePath),
+          page: { offset: undefined, limit: undefined },
+        },
+      ])
     }),
   )
 
   it.effect("lists a bounded directory page through read", () =>
     Effect.gen(function* () {
-      resolvedType = "directory"
-      listResult = new ReadToolFileSystem.ListPage({
+      readResult = new ReadToolFileSystem.ListPage({
         type: "list-page",
         entries: [
           FileSystem.Entry.make({ path: RelativePath.make("components/"), type: "directory" }),
@@ -726,7 +695,7 @@ describe("ReadTool", () => {
       })
       expect(result).toMatchObject({
         status: "completed",
-        output: { entries: listResult.entries, truncated: true, next: 4 },
+        output: { entries: readResult.entries, truncated: true, next: 4 },
       })
       if (result.status !== "completed") return
       expect(result.metadata).toEqual({ truncated: true })
@@ -737,14 +706,15 @@ describe("ReadTool", () => {
         },
       ])
       expect(assertions).toMatchObject([{ sessionID, action: "read", resources: ["src"], save: ["*"] }])
-      expect(listCalls).toEqual([{ offset: 2, limit: 10 }])
+      expect(readCalls).toEqual([
+        { input: AbsolutePath.make(path.join(process.cwd(), "src")), page: { offset: 2, limit: 10 } },
+      ])
     }),
   )
 
   it.effect("does not list a directory when permission is denied", () =>
     Effect.gen(function* () {
       allow = false
-      resolvedType = "directory"
       const registry = yield* Tool.Service
 
       expect(
@@ -754,7 +724,7 @@ describe("ReadTool", () => {
           call: { type: "tool-call", id: "call-read-directory-denied", name: "read", input: { path: "src" } },
         }),
       ).toEqual({ status: "error", error: { type: "permission.rejected", message: "Permission denied: read" } })
-      expect(listCalls).toEqual([])
+      expect(readCalls).toEqual([])
     }),
   )
 
@@ -773,7 +743,12 @@ describe("ReadTool", () => {
         ),
       ).toBe(true)
 
-      expect(readCalls).toEqual([])
+      expect(readCalls).toEqual([
+        {
+          input: AbsolutePath.make(path.join(process.cwd(), "missing.txt")),
+          page: { offset: undefined, limit: undefined },
+        },
+      ])
     }),
   )
 


### PR DESCRIPTION
## What

Move the read tool's filesystem access onto the new Location-scoped `Environment` service while preserving text paging, directory listing, media, binary, permission, and `AGENTS.md` discovery behavior.

The tool now makes one read-service call. `Environment.Files.read` carries file metadata on success and carries the directory branch in `Environment.WrongKind`, so the separate `inspect` round trip is gone.

## How

- Add `@opencode/Environment` with `files` and `spawner`, backed locally by `makeFiles(makeLocalDriver(spawner))` and wired into the Location service graph.
- Collapse `ReadToolFileSystem` to one `read(path, resource, page)` operation backed by `Environment.Files`.
- Convert `WrongKind(actual: "directory")` into `files.list`, retaining directory-first sorting, symlink tags, and entry paging.
- Define content operations (`read`, `list`) to follow final symlinks while metadata (`stat`, listing entry tags) remains lstat-based, preserving reads of symlinked directories.
- Read the first 256 KiB for metadata and media/binary sniffing, then fetch additional ranges only until a text page is satisfied.
- Decode text lossily and split/slice lines directly, preserving line, byte, and line-length budgets.
- Catch `Environment.NotFound` in the plugin for the existing missing-file suggestion flow.
- Delete the incremental streaming decoder/parser state machine and the `inspect` and separate `list` service methods.
- Drop the old non-printable-ratio binary heuristic and retain only null-byte detection. This accepted behavior change matches Codex, pi-mono, and flue; UTF-16 remains detected through its null bytes.

## Scope

- Read tool only. Edit, write, patch, shell, grep, glob, watch, paths, and hosted environment work remain unchanged.
- The locked `Environment.Files` contract and its drivers/conformance suite are unchanged.

## Testing

- `cd packages/core && bun typecheck`
- `cd packages/core && bun run test test/environment.test.ts test/tool-read.test.ts test/tool-read-filesystem.test.ts` (54 pass, 9 skipped)
- `cd packages/core && bun run test` (1,587 pass, 16 skipped; known environment-dependent `config/plugin.test.ts` failure plus unrelated `location-layer.test.ts` timeout, which reproduces in isolation)
- `cd packages/server && bun typecheck`
- `cd packages/cli && bun typecheck`
- Prettier on all changed source, test, and package files
