### PR TITLE
fix(core): bound project filesystem watches

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -688,6 +688,8 @@ export default function Page() {
     return {
       queryKey: [...vcsKey(), mode] as const,
       enabled,
+      refetchOnMount: "always" as const,
+      refetchOnWindowFocus: true,
       queryFn: mode
         ? () =>
             sdk()
@@ -701,6 +703,16 @@ export default function Page() {
     }
   })
   const refreshVcs = debounce(() => void queryClient.invalidateQueries({ queryKey: vcsKey() }), 100)
+  createEffect(
+    on(
+      () => desktopReviewOpen() || mobileChanges(),
+      (open, previous) => {
+        if (!open || previous || !desktopFileTreeOpen()) return
+        refreshVcs()
+      },
+      { defer: true },
+    ),
+  )
   const reviewDiffs = () => {
     if (reviewMode() === "git" || reviewMode() === "branch")
       // avoids suspense
@@ -946,19 +958,6 @@ export default function Page() {
       { defer: true },
     ),
   )
-
-  const stopVcs = sdk().event.listen((evt) => {
-    const details = evt.details as { type: string; properties?: unknown }
-    if (details.type !== "file.watcher.updated" && details.type !== "filesystem.changed") return
-    const props =
-      typeof details.properties === "object" && details.properties
-        ? (details.properties as Record<string, unknown>)
-        : undefined
-    const file = typeof props?.file === "string" ? props.file : undefined
-    if (!file || file.startsWith(".git/")) return
-    refreshVcs()
-  })
-  onCleanup(stopVcs)
 
   createEffect(
     on(

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -707,7 +707,7 @@ export default function Page() {
     on(
       () => desktopReviewOpen() || mobileChanges(),
       (open, previous) => {
-        if (!open || previous || !desktopFileTreeOpen()) return
+        if (!open || previous || !desktopFileTreeOpen() || vcsQuery.isFetching) return
         refreshVcs()
       },
       { defer: true },

--- a/packages/core/src/filesystem/location-watcher.ts
+++ b/packages/core/src/filesystem/location-watcher.ts
@@ -11,15 +11,6 @@ import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "../git"
 import { Location } from "../location"
 import { Watcher } from "./watcher"
-import { Ignore } from "./ignore"
-import { Protected } from "./protected"
-
-function protecteds(dir: string) {
-  return Protected.paths().filter((item) => {
-    const relative = path.relative(dir, item)
-    return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative)
-  })
-}
 
 export interface Interface {}
 
@@ -44,19 +35,6 @@ const layer = Layer.effect(
       const config = (yield* configService.entries())
         .filter((entry): entry is Document => entry.type === "document")
         .flatMap((item) => item.info.watcher?.ignore ?? [])
-      const home = Protected.isHome(location.directory)
-
-      if (!home && location.vcs) {
-        const updates = yield* watcher.subscribe({
-          path: location.directory,
-          type: "directory",
-          ignore: [...Ignore.PATTERNS, ...config, ...protecteds(location.directory)],
-        })
-        yield* updates.pipe(Stream.runForEach(publish), Effect.forkScoped)
-      }
-      if (home) {
-        yield* Effect.logInfo("location watcher skipped home directory", { directory: location.directory })
-      }
 
       if (location.vcs?.type === "git") {
         const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory
@@ -64,10 +42,7 @@ const layer = Layer.effect(
           ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
           : undefined
         if (vcs && !config.includes(".git") && !config.includes(vcs) && (!resolved || !config.includes(resolved))) {
-          const ignore = (yield* fs.readDirectoryEntries(vcs).pipe(Effect.catch(() => Effect.succeed([])))).flatMap(
-            (entry) => (entry.name === "HEAD" ? [] : [entry.name]),
-          )
-          const updates = yield* watcher.subscribe({ path: vcs, type: "directory", ignore })
+          const updates = yield* watcher.subscribe({ path: path.join(vcs, "HEAD"), type: "file" })
           yield* updates.pipe(Stream.runForEach(publish), Effect.forkScoped)
         }
       }

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -74,8 +74,6 @@ export interface TestInterface extends Interface {
   readonly emit: (update: Update) => Effect.Effect<void>
   /** Returns every subscribe call observed so far, in order. */
   readonly subscriptions: () => Effect.Effect<readonly WatchInput[]>
-  /** Returns subscriptions whose streams are still active. */
-  readonly activeSubscriptions: () => Effect.Effect<readonly WatchInput[]>
 }
 
 export class Test extends Context.Service<Test, TestInterface>()("@opencode/Watcher/Test") {}
@@ -94,7 +92,9 @@ export const layer = (options?: Options) =>
       const watchers = yield* RcMap.make({
         lookup: (key: Key) =>
           Effect.gen(function* () {
-            const pubsub = yield* Effect.acquireRelease(PubSub.unbounded<Update>(), (pubsub) => PubSub.shutdown(pubsub))
+            const pubsub = yield* Effect.acquireRelease(PubSub.unbounded<Update>(), (pubsub) =>
+              PubSub.shutdown(pubsub),
+            )
             const subscription = yield* Effect.acquireRelease(
               native.subscribe({
                 type: key.type,
@@ -157,18 +157,18 @@ export const layer = (options?: Options) =>
 export const testLayer = Layer.effectContext(
   Effect.gen(function* () {
     const subscriptions: WatchInput[] = []
-    const active = new Map<(update: Update) => void, WatchInput>()
+    const active = new Set<(update: Update) => void>()
     const native = Native.of({
       subscribe: (input) =>
         Effect.sync(() => {
-          const subscription: WatchInput =
+          subscriptions.push(
             input.type === "file"
               ? { path: input.target, type: "file" }
               : input.ignore.length > 0
                 ? { path: input.target, type: "directory", ignore: input.ignore }
-                : { path: input.target, type: "directory" }
-          subscriptions.push(subscription)
-          active.set(input.publish, subscription)
+                : { path: input.target, type: "directory" },
+          )
+          active.add(input.publish)
           return {
             unsubscribe: () => {
               active.delete(input.publish)
@@ -180,9 +180,8 @@ export const testLayer = Layer.effectContext(
     const context = yield* Layer.build(layer().pipe(Layer.provide(Layer.succeed(Native, native))))
     const test = Test.of({
       subscribe: Context.get(context, Service).subscribe,
-      emit: (update) => Effect.sync(() => active.forEach((_, publish) => publish(update))),
+      emit: (update) => Effect.sync(() => active.forEach((publish) => publish(update))),
       subscriptions: () => Effect.sync(() => [...subscriptions]),
-      activeSubscriptions: () => Effect.sync(() => Array.from(active.values())),
     })
     return Context.empty().pipe(Context.add(Service, test), Context.add(Test, test))
   }),

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -74,6 +74,8 @@ export interface TestInterface extends Interface {
   readonly emit: (update: Update) => Effect.Effect<void>
   /** Returns every subscribe call observed so far, in order. */
   readonly subscriptions: () => Effect.Effect<readonly WatchInput[]>
+  /** Returns subscriptions whose streams are still active. */
+  readonly activeSubscriptions: () => Effect.Effect<readonly WatchInput[]>
 }
 
 export class Test extends Context.Service<Test, TestInterface>()("@opencode/Watcher/Test") {}
@@ -92,9 +94,7 @@ export const layer = (options?: Options) =>
       const watchers = yield* RcMap.make({
         lookup: (key: Key) =>
           Effect.gen(function* () {
-            const pubsub = yield* Effect.acquireRelease(PubSub.unbounded<Update>(), (pubsub) =>
-              PubSub.shutdown(pubsub),
-            )
+            const pubsub = yield* Effect.acquireRelease(PubSub.unbounded<Update>(), (pubsub) => PubSub.shutdown(pubsub))
             const subscription = yield* Effect.acquireRelease(
               native.subscribe({
                 type: key.type,
@@ -157,18 +157,18 @@ export const layer = (options?: Options) =>
 export const testLayer = Layer.effectContext(
   Effect.gen(function* () {
     const subscriptions: WatchInput[] = []
-    const active = new Set<(update: Update) => void>()
+    const active = new Map<(update: Update) => void, WatchInput>()
     const native = Native.of({
       subscribe: (input) =>
         Effect.sync(() => {
-          subscriptions.push(
+          const subscription: WatchInput =
             input.type === "file"
               ? { path: input.target, type: "file" }
               : input.ignore.length > 0
                 ? { path: input.target, type: "directory", ignore: input.ignore }
-                : { path: input.target, type: "directory" },
-          )
-          active.add(input.publish)
+                : { path: input.target, type: "directory" }
+          subscriptions.push(subscription)
+          active.set(input.publish, subscription)
           return {
             unsubscribe: () => {
               active.delete(input.publish)
@@ -180,8 +180,9 @@ export const testLayer = Layer.effectContext(
     const context = yield* Layer.build(layer().pipe(Layer.provide(Layer.succeed(Native, native))))
     const test = Test.of({
       subscribe: Context.get(context, Service).subscribe,
-      emit: (update) => Effect.sync(() => active.forEach((publish) => publish(update))),
+      emit: (update) => Effect.sync(() => active.forEach((_, publish) => publish(update))),
       subscriptions: () => Effect.sync(() => [...subscriptions]),
+      activeSubscriptions: () => Effect.sync(() => Array.from(active.values())),
     })
     return Context.empty().pipe(Context.add(Service, test), Context.add(Test, test))
   }),

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -2,7 +2,7 @@ export * as Skill from "./skill"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Context, Effect, Exit, Layer, Schema, Scope, Stream, Types } from "effect"
+import { Context, Effect, FiberMap, Layer, Schema, Semaphore, Stream, Types } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
 import { Agent } from "./agent"
 import { ConfigMarkdown } from "./config/markdown"
@@ -82,35 +82,41 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
     const bus = yield* Bus.Service
     const watcher = yield* Watcher.Service
-    const scope = yield* Scope.Scope
     const cache = new Map<string, { skills: Info[]; paths: readonly string[] }>()
-    const watched = { file: new Set<string>(), directory: new Set<string>() }
-    let watchScope = Scope.forkUnsafe(scope)
+    const watches = yield* FiberMap.make<string>()
+    const lock = Semaphore.makeUnsafe(1)
 
     const invalidate = Effect.fn("Skill.invalidateFromWatcher")(function* (file: string) {
-      const invalidated = Array.from(cache.entries()).filter(([, loaded]) =>
-        loaded.paths.some((item) => FSUtil.overlaps(item, file)),
+      yield* lock.withPermit(
+        Effect.gen(function* () {
+          const invalidated = Array.from(cache.entries()).filter(([, loaded]) =>
+            loaded.paths.some((item) => FSUtil.overlaps(item, file)),
+          )
+          if (invalidated.length === 0) return
+          for (const [key] of invalidated) cache.delete(key)
+          yield* Effect.logInfo("skill cache invalidated", {
+            file,
+            sources: invalidated.map(([key]) => key),
+            skills: invalidated.flatMap(([, loaded]) => loaded.skills.map((skill) => skill.id)),
+          })
+          yield* bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid)
+        }),
       )
-      if (invalidated.length === 0) return
-      for (const [key] of invalidated) cache.delete(key)
-      yield* Effect.logInfo("skill cache invalidated", {
-        file,
-        sources: invalidated.map(([key]) => key),
-        skills: invalidated.flatMap(([, loaded]) => loaded.skills.map((skill) => skill.id)),
-      })
-      yield* bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid)
     })
 
     const watch = Effect.fn("Skill.watch")(function* (directory: string, type: Watcher.WatchInput["type"]) {
       const target = path.resolve(directory)
-      if (watched[type].has(target)) return
-      watched[type].add(target)
       const updates = yield* watcher.subscribe(
         type === "file" ? { path: target, type: "file" } : { path: target, type: "directory" },
       )
-      yield* updates.pipe(
-        Stream.runForEach((update) => invalidate(update.path)),
-        Effect.forkIn(watchScope, { startImmediately: true }),
+      yield* FiberMap.run(
+        watches,
+        `${type}:${target}`,
+        updates.pipe(Stream.runForEach((update) => invalidate(update.path))),
+        {
+          onlyIfMissing: true,
+          startImmediately: true,
+        },
       )
     })
 
@@ -146,17 +152,12 @@ const layer = Layer.effect(
         list: () => draft.sources as Source[],
       }),
       finalize: () =>
-        Scope.close(watchScope, Exit.void).pipe(
-          Effect.andThen(
-            Effect.sync(() => {
-              cache.clear()
-              watched.file.clear()
-              watched.directory.clear()
-              watchScope = Scope.forkUnsafe(scope)
-            }),
+        lock.withPermit(
+          FiberMap.clear(watches).pipe(
+            Effect.andThen(Effect.sync(() => cache.clear())),
+            Effect.andThen(bus.publish(Skill.Event.Updated, {})),
+            Effect.asVoid,
           ),
-          Effect.andThen(bus.publish(Skill.Event.Updated, {})),
-          Effect.asVoid,
         ),
     })
 
@@ -216,14 +217,18 @@ const layer = Layer.effect(
     })
 
     const list = Effect.fn("Skill.list")(function* () {
-      const skills = new Map<ID, Info>()
-      for (const source of state.get().sources) {
-        const key = Source.key(source)
-        const loaded = cache.get(key) ?? (yield* load(source))
-        cache.set(key, loaded)
-        for (const skill of loaded.skills) skills.set(skill.id, skill)
-      }
-      return Array.from(skills.values())
+      return yield* lock.withPermit(
+        Effect.gen(function* () {
+          const skills = new Map<ID, Info>()
+          for (const source of state.get().sources) {
+            const key = Source.key(source)
+            const loaded = cache.get(key) ?? (yield* load(source))
+            cache.set(key, loaded)
+            for (const skill of loaded.skills) skills.set(skill.id, skill)
+          }
+          return Array.from(skills.values())
+        }),
+      )
     })
 
     return Service.of({

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -2,7 +2,7 @@ export * as Skill from "./skill"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Context, Effect, FiberMap, Layer, Schema, Semaphore, Stream, Types } from "effect"
+import { Context, Effect, FiberMap, Layer, PubSub, Schema, Semaphore, Stream, Types } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
 import { Agent } from "./agent"
 import { ConfigMarkdown } from "./config/markdown"
@@ -85,24 +85,30 @@ const layer = Layer.effect(
     const cache = new Map<string, { skills: Info[]; paths: readonly string[] }>()
     const watches = yield* FiberMap.make<string>()
     const lock = Semaphore.makeUnsafe(1)
+    const changes = yield* PubSub.unbounded<string>()
 
     const invalidate = Effect.fn("Skill.invalidateFromWatcher")(function* (file: string) {
-      yield* lock.withPermit(
+      const changed = yield* lock.withPermit(
         Effect.gen(function* () {
           const invalidated = Array.from(cache.entries()).filter(([, loaded]) =>
             loaded.paths.some((item) => FSUtil.overlaps(item, file)),
           )
-          if (invalidated.length === 0) return
+          if (invalidated.length === 0) return false
           for (const [key] of invalidated) cache.delete(key)
+          yield* FiberMap.clear(watches)
           yield* Effect.logInfo("skill cache invalidated", {
             file,
             sources: invalidated.map(([key]) => key),
             skills: invalidated.flatMap(([, loaded]) => loaded.skills.map((skill) => skill.id)),
           })
-          yield* bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid)
+          return true
         }),
       )
+      if (!changed) return
+      yield* bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid)
     })
+
+    yield* Stream.fromPubSub(changes).pipe(Stream.runForEach(invalidate), Effect.forkScoped({ startImmediately: true }))
 
     const watch = Effect.fn("Skill.watch")(function* (directory: string, type: Watcher.WatchInput["type"]) {
       const target = path.resolve(directory)
@@ -112,7 +118,7 @@ const layer = Layer.effect(
       yield* FiberMap.run(
         watches,
         `${type}:${target}`,
-        updates.pipe(Stream.runForEach((update) => invalidate(update.path))),
+        updates.pipe(Stream.runForEach((update) => PubSub.publish(changes, update.path).pipe(Effect.asVoid))),
         {
           onlyIfMissing: true,
           startImmediately: true,
@@ -126,18 +132,29 @@ const layer = Layer.effect(
       return fs.isDir(parent).pipe(Effect.flatMap((exists) => (exists ? Effect.succeed(target) : firstMissing(parent))))
     }
 
-    const watchDirectory = Effect.fn("Skill.watchDirectory")(function* (directory: string) {
+    const watchDirectory: (directory: string) => Effect.Effect<string[]> = Effect.fn("Skill.watchDirectory")(function* (
+      directory: string,
+    ) {
       const target = path.resolve(directory)
       const resolved = yield* fs.realPath(directory).pipe(Effect.catch(() => Effect.succeed(undefined)))
       if (resolved) {
         yield* watch(resolved, "directory")
         if (resolved !== target) {
-          yield* watch(path.dirname(target), "directory")
+          yield* watch(target, "file")
         }
         return resolved === target ? [target] : [target, resolved]
       }
       const missing = yield* firstMissing(target)
       if (missing) yield* watch(missing, "file")
+      if (
+        yield* fs.realPath(directory).pipe(
+          Effect.as(true),
+          Effect.catch(() => Effect.succeed(false)),
+        )
+      ) {
+        if (missing) yield* FiberMap.remove(watches, `file:${path.resolve(missing)}`)
+        return yield* watchDirectory(directory)
+      }
       return [target]
     })
 
@@ -152,13 +169,9 @@ const layer = Layer.effect(
         list: () => draft.sources as Source[],
       }),
       finalize: () =>
-        lock.withPermit(
-          FiberMap.clear(watches).pipe(
-            Effect.andThen(Effect.sync(() => cache.clear())),
-            Effect.andThen(bus.publish(Skill.Event.Updated, {})),
-            Effect.asVoid,
-          ),
-        ),
+        lock
+          .withPermit(FiberMap.clear(watches).pipe(Effect.andThen(Effect.sync(() => cache.clear())), Effect.asVoid))
+          .pipe(Effect.andThen(bus.publish(Skill.Event.Updated, {})), Effect.asVoid),
     })
 
     const load = Effect.fn("Skill.load")(function* (source: Source) {

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -94,7 +94,7 @@ const layer = Layer.effect(
             loaded.paths.some((item) => FSUtil.overlaps(item, file)),
           )
           if (invalidated.length === 0) return false
-          for (const [key] of invalidated) cache.delete(key)
+          cache.clear()
           yield* FiberMap.clear(watches)
           yield* Effect.logInfo("skill cache invalidated", {
             file,

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -2,8 +2,7 @@ export * as Skill from "./skill"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Context, Effect, Layer, Schema, Scope, Stream, Types } from "effect"
-import { FileSystem } from "@opencode-ai/schema/filesystem"
+import { Context, Effect, Exit, Layer, Schema, Scope, Stream, Types } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
 import { Agent } from "./agent"
 import { ConfigMarkdown } from "./config/markdown"
@@ -85,7 +84,8 @@ const layer = Layer.effect(
     const watcher = yield* Watcher.Service
     const scope = yield* Scope.Scope
     const cache = new Map<string, { skills: Info[]; paths: readonly string[] }>()
-    const watched = new Set<string>()
+    const watched = { file: new Set<string>(), directory: new Set<string>() }
+    let watchScope = Scope.forkUnsafe(scope)
 
     const invalidate = Effect.fn("Skill.invalidateFromWatcher")(function* (file: string) {
       const invalidated = Array.from(cache.entries()).filter(([, loaded]) =>
@@ -101,30 +101,37 @@ const layer = Layer.effect(
       yield* bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid)
     })
 
-    const watch = Effect.fn("Skill.watch")(function* (directory: string) {
+    const watch = Effect.fn("Skill.watch")(function* (directory: string, type: Watcher.WatchInput["type"]) {
       const target = path.resolve(directory)
-      if (watched.has(target)) return
-      watched.add(target)
-      const updates = yield* watcher.subscribe({ path: target, type: "directory" })
+      if (watched[type].has(target)) return
+      watched[type].add(target)
+      const updates = yield* watcher.subscribe(
+        type === "file" ? { path: target, type: "file" } : { path: target, type: "directory" },
+      )
       yield* updates.pipe(
         Stream.runForEach((update) => invalidate(update.path)),
-        Effect.forkIn(scope, { startImmediately: true }),
+        Effect.forkIn(watchScope, { startImmediately: true }),
       )
     })
+
+    function firstMissing(target: string): Effect.Effect<string | undefined> {
+      const parent = path.dirname(target)
+      if (parent === target) return Effect.succeed(undefined)
+      return fs.isDir(parent).pipe(Effect.flatMap((exists) => (exists ? Effect.succeed(target) : firstMissing(parent))))
+    }
 
     const watchDirectory = Effect.fn("Skill.watchDirectory")(function* (directory: string) {
       const target = path.resolve(directory)
       const resolved = yield* fs.realPath(directory).pipe(Effect.catch(() => Effect.succeed(undefined)))
       if (resolved) {
-        yield* watch(resolved)
+        yield* watch(resolved, "directory")
         if (resolved !== target) {
-          yield* watch(path.dirname(target))
+          yield* watch(path.dirname(target), "directory")
         }
         return resolved === target ? [target] : [target, resolved]
       }
-      if (yield* fs.isDir(path.dirname(target))) {
-        yield* watch(path.dirname(target))
-      }
+      const missing = yield* firstMissing(target)
+      if (missing) yield* watch(missing, "file")
       return [target]
     })
 
@@ -139,7 +146,18 @@ const layer = Layer.effect(
         list: () => draft.sources as Source[],
       }),
       finalize: () =>
-        Effect.sync(() => cache.clear()).pipe(Effect.andThen(bus.publish(Skill.Event.Updated, {})), Effect.asVoid),
+        Scope.close(watchScope, Exit.void).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              cache.clear()
+              watched.file.clear()
+              watched.directory.clear()
+              watchScope = Scope.forkUnsafe(scope)
+            }),
+          ),
+          Effect.andThen(bus.publish(Skill.Event.Updated, {})),
+          Effect.asVoid,
+        ),
     })
 
     const load = Effect.fn("Skill.load")(function* (source: Source) {
@@ -165,7 +183,7 @@ const layer = Layer.effect(
           if (!roots.some((root) => FSUtil.contains(root, resolved))) {
             const external = path.dirname(resolved)
             paths.push(external)
-            yield* watch(external)
+            yield* watch(external, "directory")
           }
           const content = yield* fs.readFileStringSafe(filepath).pipe(Effect.catch(() => Effect.succeed(undefined)))
           if (!content) continue
@@ -196,11 +214,6 @@ const layer = Layer.effect(
       })
       return { skills, paths }
     })
-
-    yield* bus.subscribe(FileSystem.Event.Changed).pipe(
-      Stream.runForEach((event) => invalidate(event.data.file)),
-      Effect.forkScoped({ startImmediately: true }),
-    )
 
     const list = Effect.fn("Skill.list")(function* () {
       const skills = new Map<ID, Info>()

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -17,8 +17,6 @@ import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
-const describeWatcher = Watcher.hasNativeBinding() && !process.env.CI ? describe : describe.skip
-
 type WatcherEvent = { file: string; event: "add" | "change" | "unlink" }
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([FSUtil.node, Bus.node])))
@@ -75,10 +73,9 @@ describe("Watcher lifecycle", () => {
       const interrupted = yield* Deferred.make<void>()
       yield* Effect.gen(function* () {
         const watcher = yield* Watcher.Service
-        const consumer = yield* watcher.subscribe({ path: "/pending", type: "directory" }).pipe(
-          Effect.flatMap(Stream.runDrain),
-          Effect.forkScoped({ startImmediately: true }),
-        )
+        const consumer = yield* watcher
+          .subscribe({ path: "/pending", type: "directory" })
+          .pipe(Effect.flatMap(Stream.runDrain), Effect.forkScoped({ startImmediately: true }))
         yield* Deferred.await(started)
         yield* Fiber.interrupt(consumer)
         expect(yield* Deferred.isDone(interrupted)).toBe(true)
@@ -99,10 +96,9 @@ describe("Watcher lifecycle", () => {
     return Effect.gen(function* () {
       const watcher = yield* Watcher.Service
       const consume = () =>
-        watcher.subscribe({ path: "/shared", type: "directory" }).pipe(
-          Effect.flatMap(Stream.runDrain),
-          Effect.forkScoped({ startImmediately: true }),
-        )
+        watcher
+          .subscribe({ path: "/shared", type: "directory" })
+          .pipe(Effect.flatMap(Stream.runDrain), Effect.forkScoped({ startImmediately: true }))
       const first = yield* consume()
       const second = yield* consume()
       yield* Effect.yieldNow
@@ -138,22 +134,68 @@ describe("Watcher lifecycle", () => {
   })
 })
 
-function provide(directory: string, vcs?: Location.Interface["vcs"]) {
+describe("Watcher native file subscriptions", () => {
+  it.live("detects atomic replacement of an existing target", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const native = yield* Watcher.Native
+          const updates: Watcher.Update[] = []
+          const target = path.join(tmp.path, "HEAD")
+          yield* Effect.promise(() => fs.writeFile(target, "ref: refs/heads/old\n"))
+          const subscription = yield* Effect.acquireRelease(
+            native.subscribe({
+              type: "file",
+              target,
+              ignore: [],
+              publish: (update) => updates.push(update),
+            }),
+            (subscription) => (subscription ? Effect.promise(() => subscription.unsubscribe()) : Effect.void),
+          )
+          if (!subscription) return yield* Effect.fail(new Error("native file watcher unavailable"))
+          yield* Effect.sleep("100 millis")
+
+          yield* Effect.promise(async () => {
+            const replacement = `${target}.replacement`
+            await fs.writeFile(replacement, "ref: refs/heads/main\n")
+            await fs.rename(replacement, target)
+          })
+          const update = yield* Effect.sync(() => updates[0]).pipe(
+            Effect.filterOrFail((update) => update !== undefined),
+            Effect.retry(Schedule.spaced("10 millis")),
+            Effect.timeout("3 seconds"),
+          )
+          expect(update).toEqual({
+            path: target,
+            type: "update",
+          })
+        }).pipe(Effect.provide(Watcher.nativeLayer)),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+})
+
+function provide(directory: string, vcs?: Location.Interface["vcs"], watcher?: Layer.Layer<Watcher.Service>) {
   const locationLayer = Layer.succeed(
     Location.Service,
     Location.Service.of(location({ directory: AbsolutePath.make(directory) }, { vcs })),
   )
-  return Effect.provide(
-    AppNodeBuilder.build(LocationWatcher.node, [
-      [Config.node, configLayer],
-      [Location.node, locationLayer],
-    ]),
-  )
+  const built = AppNodeBuilder.build(LocationWatcher.node, [
+    [Config.node, configLayer],
+    [Location.node, locationLayer],
+    ...(watcher ? ([[Watcher.node, watcher]] as const) : []),
+  ])
+  return Effect.provide(built)
 }
 
 function withTmp<A, E, R>(
   f: (directory: string, vcs?: Location.Interface["vcs"]) => Effect.Effect<A, E, R>,
-  options?: { vcs?: "git" | "hg"; init?: (directory: string) => Promise<void> },
+  options?: {
+    vcs?: "git" | "hg"
+    init?: (directory: string) => Promise<void>
+    watcher?: Layer.Layer<Watcher.Service>
+  },
 ) {
   return Effect.acquireRelease(
     Effect.promise(async () => {
@@ -173,8 +215,32 @@ function withTmp<A, E, R>(
       return { tmp, vcs: { type: "git" as const, store: AbsolutePath.make(path.join(tmp.path, ".git")) } }
     }),
     ({ tmp }) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ).pipe(Effect.flatMap(({ tmp, vcs }) => f(tmp.path, vcs).pipe(provide(tmp.path, vcs))))
+  ).pipe(Effect.flatMap(({ tmp, vcs }) => f(tmp.path, vcs).pipe(provide(tmp.path, vcs, options?.watcher))))
 }
+
+describe("LocationWatcher subscriptions", () => {
+  it.live("watches only exact Git branch metadata", () => {
+    const subscriptions: Watcher.WatchInput[] = []
+    const watcher = Layer.succeed(
+      Watcher.Service,
+      Watcher.Service.of({
+        subscribe: (input) => Effect.sync(() => subscriptions.push(input)).pipe(Effect.as(Stream.empty)),
+      }),
+    )
+    return withTmp(
+      (directory) =>
+        Effect.gen(function* () {
+          yield* LocationWatcher.Service
+          const requested = yield* Effect.sync(() => [...subscriptions]).pipe(
+            Effect.filterOrFail((items) => items.length > 0),
+            Effect.retry(Schedule.spaced("10 millis")),
+          )
+          expect(requested).toEqual([{ path: path.join(directory, ".git", "HEAD"), type: "file" }])
+        }),
+      { vcs: "git", watcher },
+    )
+  })
+})
 
 function wait(check: (event: WatcherEvent) => boolean) {
   return Effect.gen(function* () {
@@ -239,18 +305,18 @@ function noUpdate<E>(check: (event: WatcherEvent) => boolean, trigger: Effect.Ef
   )
 }
 
-function ready(directory: string) {
-  const file = path.join(directory, `.watcher-${Math.random().toString(36).slice(2)}`)
+function ready(file: string, eventFile = file) {
   return Effect.gen(function* () {
     const fs = yield* FSUtil.Service
+    const content = (yield* fs.readFileStringSafe(file)) ?? `ready-${Math.random()}`
     yield* eventuallyUpdate(
-      (event) => event.file === file,
-      () => fs.writeFileString(file, `ready-${Math.random()}`),
-    ).pipe(Effect.ensuring(fs.remove(file, { force: true }).pipe(Effect.ignore)), Effect.asVoid)
+      (event) => event.file === eventFile,
+      () => fs.writeFileString(file, content),
+    ).pipe(Effect.asVoid)
   })
 }
 
-describeWatcher("LocationWatcher", () => {
+describe("LocationWatcher", () => {
   it.live("limits file watches to the exact target", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
@@ -276,77 +342,26 @@ describeWatcher("LocationWatcher", () => {
     ),
   )
 
-  it.live("publishes root create, update, and delete events", () =>
-    withTmp(
-      (directory) =>
-        Effect.gen(function* () {
-          const fs = yield* FSUtil.Service
-          const file = path.join(directory, "watch.txt")
-          yield* ready(directory)
-          for (const item of [
-            { event: "add" as const, trigger: fs.writeFileString(file, "a") },
-            { event: "change" as const, trigger: fs.writeFileString(file, "b") },
-            { event: "unlink" as const, trigger: fs.remove(file) },
-          ]) {
-            expect(
-              yield* nextUpdate((event) => event.file === file && event.event === item.event, item.trigger),
-            ).toEqual({
-              file,
-              event: item.event,
-            })
-          }
-        }),
-      { vcs: "git" },
-    ),
-  )
-
-  it.live("skips non-git roots", () =>
+  it.live("detects creation of a missing directory target", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
         const fs = yield* FSUtil.Service
-        const file = path.join(directory, "plain.txt")
-        yield* noUpdate((event) => event.file === file, fs.writeFileString(file, "plain"))
-      }),
-    ),
-  )
+        const watcher = yield* Watcher.Service
+        const target = path.join(directory, "generated")
+        const updates = yield* watcher.subscribe({ path: target, type: "file" })
+        const update = yield* updates.pipe(
+          Stream.take(1),
+          Stream.runHead,
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        const creates = yield* Effect.suspend(() =>
+          fs.remove(target, { recursive: true, force: true }).pipe(Effect.andThen(fs.ensureDir(target))),
+        ).pipe(Effect.repeat(Schedule.spaced("10 millis")), Effect.forkScoped)
+        const event = yield* Fiber.join(update).pipe(Effect.ensuring(Fiber.interrupt(creates)))
 
-  it.live("ignores dependency, VCS, and build directories at any depth", () =>
-    withTmp(
-      (directory) =>
-        Effect.gen(function* () {
-          const afs = yield* FSUtil.Service
-          yield* ready(directory)
-          const roots = ["node_modules", ".git", "dist"].map((name) => path.join(directory, "nested", name))
-          const files = roots.map((root) => path.join(root, "package", "index.js"))
-          yield* noUpdate(
-            (event) => roots.some((root) => event.file === root || event.file.startsWith(`${root}${path.sep}`)),
-            Effect.forEach(files, (file) => afs.writeWithDirs(file, "ignored"), {
-              concurrency: "unbounded",
-              discard: true,
-            }),
-          )
-        }),
-      { vcs: "git" },
+        expect(event.valueOrUndefined?.path).toBe(target)
+      }).pipe(Effect.provide(AppNodeBuilder.build(Watcher.node))),
     ),
-  )
-
-  it.live("cleanup stops publishing events", () =>
-    Effect.gen(function* () {
-      const bus = yield* Bus.Service
-      const fs = yield* FSUtil.Service
-      const tmp = yield* Effect.acquireRelease(
-        Effect.promise(() => tmpdir()),
-        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-      )
-      yield* ready(tmp.path).pipe(
-        provide(tmp.path, { type: "git", store: AbsolutePath.make(path.join(tmp.path, ".git")) }),
-        Effect.scoped,
-      )
-      const file = path.join(tmp.path, "after-dispose.txt")
-      yield* noUpdate((event) => event.file === file, fs.writeFileString(file, "gone")).pipe(
-        Effect.provideService(Bus.Service, bus),
-      )
-    }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([FSUtil.node, Bus.node])))),
   )
 
   it.live("ignores .git/index changes", () =>
@@ -355,7 +370,7 @@ describeWatcher("LocationWatcher", () => {
         Effect.gen(function* () {
           const fs = yield* FSUtil.Service
           const index = path.join(directory, ".git", "index")
-          yield* ready(directory)
+          yield* ready(path.join(directory, ".git", "HEAD"))
           yield* noUpdate(
             (event) => event.file === index,
             fs
@@ -374,11 +389,11 @@ describeWatcher("LocationWatcher", () => {
           const fs = yield* FSUtil.Service
           const head = path.join(directory, ".git", "HEAD")
           const branch = `watch-${Math.random().toString(36).slice(2)}`
-          yield* ready(directory)
+          yield* ready(head)
           yield* Effect.promise(() => $`git branch ${branch}`.cwd(directory).quiet())
           expect(
             yield* nextUpdate((event) => event.file === head, fs.writeFileString(head, `ref: refs/heads/${branch}\n`)),
-          ).toMatchObject({ file: head })
+          ).toEqual({ file: head, event: "change" })
         }),
       { vcs: "git" },
     ),
@@ -393,8 +408,8 @@ describeWatcher("LocationWatcher", () => {
             const afs = yield* FSUtil.Service
             const actual = path.join(directory, "..", `actual_${path.basename(directory)}`)
             yield* Effect.addFinalizer(() => Effect.promise(() => fs.rm(actual, { recursive: true, force: true })))
-            yield* ready(directory)
             const head = path.join(directory, ".git", "HEAD")
+            yield* ready(head, path.join(actual, "HEAD"))
             const branch = `watch-${Math.random().toString(36).slice(2)}`
             yield* Effect.promise(() => $`git branch ${branch}`.cwd(directory).quiet())
             expect(
@@ -422,7 +437,7 @@ describeWatcher("LocationWatcher", () => {
         Effect.gen(function* () {
           const fs = yield* FSUtil.Service
           const branch = path.join(directory, ".hg", "branch")
-          yield* ready(directory)
+          yield* ready(branch)
           expect(
             yield* nextUpdate((event) => event.file === branch, fs.writeFileString(branch, "feature\n")),
           ).toMatchObject({ file: branch })

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 type WatcherEvent = { file: string; event: "add" | "change" | "unlink" }
+const describeNative = process.env.CI ? describe.skip : describe
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([FSUtil.node, Bus.node])))
 
@@ -132,48 +133,6 @@ describe("Watcher lifecycle", () => {
       expect(counts.unsubscribes).toBe(1)
     })
   })
-})
-
-describe("Watcher native file subscriptions", () => {
-  it.live("detects atomic replacement of an existing target", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) =>
-        Effect.gen(function* () {
-          const native = yield* Watcher.Native
-          const updates: Watcher.Update[] = []
-          const target = path.join(tmp.path, "HEAD")
-          yield* Effect.promise(() => fs.writeFile(target, "ref: refs/heads/old\n"))
-          const subscription = yield* Effect.acquireRelease(
-            native.subscribe({
-              type: "file",
-              target,
-              ignore: [],
-              publish: (update) => updates.push(update),
-            }),
-            (subscription) => (subscription ? Effect.promise(() => subscription.unsubscribe()) : Effect.void),
-          )
-          if (!subscription) return yield* Effect.fail(new Error("native file watcher unavailable"))
-          yield* Effect.sleep("100 millis")
-
-          yield* Effect.promise(async () => {
-            const replacement = `${target}.replacement`
-            await fs.writeFile(replacement, "ref: refs/heads/main\n")
-            await fs.rename(replacement, target)
-          })
-          const update = yield* Effect.sync(() => updates[0]).pipe(
-            Effect.filterOrFail((update) => update !== undefined),
-            Effect.retry(Schedule.spaced("10 millis")),
-            Effect.timeout("3 seconds"),
-          )
-          expect(update).toEqual({
-            path: target,
-            type: "update",
-          })
-        }).pipe(Effect.provide(Watcher.nativeLayer)),
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
-  )
 })
 
 function provide(directory: string, vcs?: Location.Interface["vcs"], watcher?: Layer.Layer<Watcher.Service>) {
@@ -292,19 +251,6 @@ function eventuallyUpdate<E>(check: (event: WatcherEvent) => boolean, trigger: (
   )
 }
 
-function noUpdate<E>(check: (event: WatcherEvent) => boolean, trigger: Effect.Effect<void, E>, timeout = 500) {
-  return Effect.acquireUseRelease(
-    wait(check),
-    ({ deferred }) =>
-      trigger.pipe(
-        Effect.andThen(Deferred.await(deferred)),
-        Effect.timeoutOption(`${timeout} millis`),
-        Effect.tap((result) => Effect.sync(() => expect(result).toEqual(Option.none()))),
-      ),
-    ({ fiber }) => Fiber.interrupt(fiber),
-  )
-}
-
 function ready(file: string, eventFile = file) {
   return Effect.gen(function* () {
     const fs = yield* FSUtil.Service
@@ -316,7 +262,7 @@ function ready(file: string, eventFile = file) {
   })
 }
 
-describe("LocationWatcher", () => {
+describeNative("LocationWatcher", () => {
   it.live("limits file watches to the exact target", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
@@ -361,24 +307,6 @@ describe("LocationWatcher", () => {
 
         expect(event.valueOrUndefined?.path).toBe(target)
       }).pipe(Effect.provide(AppNodeBuilder.build(Watcher.node))),
-    ),
-  )
-
-  it.live("ignores .git/index changes", () =>
-    withTmp(
-      (directory) =>
-        Effect.gen(function* () {
-          const fs = yield* FSUtil.Service
-          const index = path.join(directory, ".git", "index")
-          yield* ready(path.join(directory, ".git", "HEAD"))
-          yield* noUpdate(
-            (event) => event.file === index,
-            fs
-              .writeFileString(path.join(directory, "tracked.txt"), "a")
-              .pipe(Effect.andThen(Effect.promise(() => $`git add .`.cwd(directory).quiet())), Effect.asVoid),
-          )
-        }),
-      { vcs: "git" },
     ),
   )
 

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -190,13 +190,37 @@ describe("LocationWatcher subscriptions", () => {
       (directory) =>
         Effect.gen(function* () {
           yield* LocationWatcher.Service
-          const requested = yield* Effect.sync(() => [...subscriptions]).pipe(
-            Effect.filterOrFail((items) => items.length > 0),
+          yield* Effect.sync(() => subscriptions.length).pipe(
+            Effect.filterOrFail((count) => count > 0),
             Effect.retry(Schedule.spaced("10 millis")),
           )
-          expect(requested).toEqual([{ path: path.join(directory, ".git", "HEAD"), type: "file" }])
+          yield* Effect.sleep("10 millis")
+          expect(subscriptions).toEqual([{ path: path.join(directory, ".git", "HEAD"), type: "file" }])
         }),
       { vcs: "git", watcher },
+    )
+  })
+
+  it.live("watches only exact Hg branch metadata", () => {
+    const subscriptions: Watcher.WatchInput[] = []
+    const watcher = Layer.succeed(
+      Watcher.Service,
+      Watcher.Service.of({
+        subscribe: (input) => Effect.sync(() => subscriptions.push(input)).pipe(Effect.as(Stream.empty)),
+      }),
+    )
+    return withTmp(
+      (directory) =>
+        Effect.gen(function* () {
+          yield* LocationWatcher.Service
+          yield* Effect.sync(() => subscriptions.length).pipe(
+            Effect.filterOrFail((count) => count > 0),
+            Effect.retry(Schedule.spaced("10 millis")),
+          )
+          yield* Effect.sleep("10 millis")
+          expect(subscriptions).toEqual([{ path: path.join(directory, ".hg", "branch"), type: "file" }])
+        }),
+      { vcs: "hg", watcher },
     )
   })
 })

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -9,7 +9,6 @@ import { Bus } from "@opencode-ai/core/bus"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Skill } from "@opencode-ai/core/skill"
 import { SkillDiscovery } from "@opencode-ai/core/skill/discovery"
-import { FileSystem } from "@opencode-ai/schema/filesystem"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
@@ -236,13 +235,17 @@ metadata:
           })
 
           const skill = yield* Skill.Service
+          const watcher = yield* Watcher.Test
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(tmp.path) }))
           expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Initial deploy")
+          expect(yield* watcher.activeSubscriptions()).toHaveLength(1)
 
           yield* Effect.promise(() => write(tmp.path, "deploy", "Updated deploy"))
           yield* skill.reload()
+          expect(yield* watcher.activeSubscriptions()).toEqual([])
 
           expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Updated deploy")
+          expect(yield* watcher.activeSubscriptions()).toHaveLength(1)
         }),
       ),
     ),
@@ -258,24 +261,18 @@ metadata:
           const source = path.join(tmp.path, "generated", "skills")
           const file = path.join(source, "deploy", "SKILL.md")
           const skill = yield* Skill.Service
-          const bus = yield* Bus.Service
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(source) }))
           expect(yield* skill.list()).toEqual([])
+          yield* expectSubscription((input) => input.type === "file" && input.path === path.join(tmp.path, "generated"))
 
           yield* Effect.promise(async () => {
             await fs.mkdir(path.dirname(file), { recursive: true })
             await write(source, "deploy", "Deploy production")
           })
-          yield* Effect.acquireUseRelease(
-            waitForSkillUpdate(),
-            ({ deferred }) =>
-              bus
-                .publish(FileSystem.Event.Changed, { file, event: "add" })
-                .pipe(Effect.andThen(Deferred.await(deferred)), Effect.timeout("1 second")),
-            ({ fiber }) => Fiber.interrupt(fiber),
-          )
+          yield* emitAndWait({ type: "create", path: path.join(tmp.path, "generated") })
 
           expect((yield* skill.list()).map((item) => item.id)).toEqual([Skill.ID.make("deploy")])
+          yield* expectSubscription((input) => input.type === "directory" && input.path === source)
         }),
       ),
     ),

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -236,15 +236,29 @@ metadata:
 
           const skill = yield* Skill.Service
           const watcher = yield* Watcher.Test
+          const bus = yield* Bus.Service
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(tmp.path) }))
           expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Initial deploy")
-          expect(yield* watcher.subscriptions()).toHaveLength(1)
+          expect(yield* watcher.subscriptions()).toEqual([{ path: tmp.path, type: "directory" }])
+
+          let refreshed: Skill.Info[] = []
+          const unsubscribe = yield* bus.listen((event) => {
+            if (event.type !== Skill.Event.Updated.type) return Effect.void
+            return skill.list().pipe(
+              Effect.tap((items) => Effect.sync(() => (refreshed = items))),
+              Effect.asVoid,
+            )
+          })
 
           yield* Effect.promise(() => write(tmp.path, "deploy", "Updated deploy"))
-          yield* skill.reload()
+          yield* skill.reload().pipe(Effect.timeout("1 second"))
+          yield* unsubscribe
 
-          expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Updated deploy")
-          expect(yield* watcher.subscriptions()).toHaveLength(2)
+          expect(refreshed.find((item) => item.id === "deploy")?.description).toBe("Updated deploy")
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: tmp.path, type: "directory" },
+            { path: tmp.path, type: "directory" },
+          ])
         }),
       ),
     ),
@@ -260,18 +274,31 @@ metadata:
           const source = path.join(tmp.path, "generated", "skills")
           const file = path.join(source, "deploy", "SKILL.md")
           const skill = yield* Skill.Service
+          const watcher = yield* Watcher.Test
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(source) }))
           expect(yield* skill.list()).toEqual([])
-          yield* expectSubscription((input) => input.type === "file" && input.path === path.join(tmp.path, "generated"))
+          expect(yield* watcher.subscriptions()).toEqual([{ path: path.join(tmp.path, "generated"), type: "file" }])
+
+          yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "generated")))
+          yield* emitAndWait({ type: "create", path: path.join(tmp.path, "generated") })
+          expect(yield* skill.list()).toEqual([])
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: path.join(tmp.path, "generated"), type: "file" },
+            { path: source, type: "file" },
+          ])
 
           yield* Effect.promise(async () => {
             await fs.mkdir(path.dirname(file), { recursive: true })
             await write(source, "deploy", "Deploy production")
           })
-          yield* emitAndWait({ type: "create", path: path.join(tmp.path, "generated") })
+          yield* emitAndWait({ type: "create", path: source })
 
           expect((yield* skill.list()).map((item) => item.id)).toEqual([Skill.ID.make("deploy")])
-          yield* expectSubscription((input) => input.type === "directory" && input.path === source)
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: path.join(tmp.path, "generated"), type: "file" },
+            { path: source, type: "file" },
+            { path: source, type: "directory" },
+          ])
         }),
       ),
     ),
@@ -367,10 +394,13 @@ metadata:
           })
 
           const skill = yield* Skill.Service
+          const watcher = yield* Watcher.Test
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(source) }))
           expect((yield* skill.list()).find((item) => item.id === "bro")?.description).toBe("First")
-          yield* expectSubscription((input) => input.type === "directory" && input.path === first)
-          yield* expectSubscription((input) => input.type === "directory" && input.path === tmp.path)
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: first, type: "directory" },
+            { path: source, type: "file" },
+          ])
 
           yield* Effect.promise(async () => {
             await fs.unlink(source)
@@ -379,7 +409,12 @@ metadata:
           yield* emitAndWait({ type: "update", path: source })
 
           expect((yield* skill.list()).find((item) => item.id === "bro")?.description).toBe("Second")
-          yield* expectSubscription((input) => input.type === "directory" && input.path === second)
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: first, type: "directory" },
+            { path: source, type: "file" },
+            { path: second, type: "directory" },
+            { path: source, type: "file" },
+          ])
         }),
       ),
     ),

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -113,6 +113,7 @@ describe("Skill", () => {
           })
 
           const skill = yield* Skill.Service
+          const watcher = yield* Watcher.Test
           yield* skill.transform((editor) => {
             editor.source({ type: "directory", path: AbsolutePath.make(first) })
             editor.source({ type: "directory", path: AbsolutePath.make(first) })
@@ -142,6 +143,21 @@ describe("Skill", () => {
               location: AbsolutePath.make(path.join(second, "review", "SKILL.md")),
               content: "# review",
             },
+          ])
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: first, type: "directory" },
+            { path: second, type: "directory" },
+          ])
+
+          yield* Effect.promise(() => write(second, "review", "Updated Second"))
+          yield* emitAndWait({ type: "update", path: path.join(second, "review", "SKILL.md") })
+
+          expect((yield* skill.list()).find((item) => item.id === "review")?.description).toBe("Updated Second")
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: first, type: "directory" },
+            { path: second, type: "directory" },
+            { path: first, type: "directory" },
+            { path: second, type: "directory" },
           ])
         }),
       ),

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -238,14 +238,13 @@ metadata:
           const watcher = yield* Watcher.Test
           yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(tmp.path) }))
           expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Initial deploy")
-          expect(yield* watcher.activeSubscriptions()).toHaveLength(1)
+          expect(yield* watcher.subscriptions()).toHaveLength(1)
 
           yield* Effect.promise(() => write(tmp.path, "deploy", "Updated deploy"))
           yield* skill.reload()
-          expect(yield* watcher.activeSubscriptions()).toEqual([])
 
           expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Updated deploy")
-          expect(yield* watcher.activeSubscriptions()).toHaveLength(1)
+          expect(yield* watcher.subscriptions()).toHaveLength(2)
         }),
       ),
     ),


### PR DESCRIPTION
## What

Stop recursively watching every directory in an opened VCS project. Large Linux projects currently consume one shared inotify watch per included directory; the investigation repro observed 513 watches for a root containing 513 directories.

The replacement keeps live reload scoped to the sources that need it: exact VCS branch metadata and discovered Skill roots.

## Before / After

**Before**

Opening any non-home Git or Hg location recursively subscribed to the complete working tree through Parcel. On Linux, a repository with many directories could exhaust `fs.inotify.max_user_watches` for every process owned by that user. The resulting broad `filesystem.changed` stream also refreshed Git review for every working-tree event.

**After**

Opening a Git location requests one exact watch for the canonical `HEAD` path. Hg keeps its exact `.hg/branch` watch. Skills recursively watch only loaded Skill directories; deeply missing Skill sources exact-watch the first missing path component until the source exists. An Effect `FiberMap` deduplicates Skill watch consumers by kind and path, and clears them atomically with the Skill cache on state reload.

Git review fetches on mount, refetches on window focus, refreshes when a previously enabled file tree opens review, and still refreshes when a session returns to idle. Arbitrary external edits no longer refresh a continuously open and focused review pane immediately.

## How

- `packages/core/src/filesystem/location-watcher.ts` removes the recursive project-root subscription and replaces the filtered `.git` directory subscription with an exact canonical `HEAD` file watch.
- `packages/core/src/skill.ts` removes the broad filesystem-event fallback, advances missing sources with bounded exact-path watches, and uses `FiberMap` plus a Skill-local semaphore for keyed lifecycle and atomic cache replacement.
- `packages/app/src/pages/session.tsx` replaces broad filesystem-event invalidation with bounded TanStack Query lifecycle refreshes.
- Watcher regressions assert the complete Git subscription topology, missing-directory discovery, symlinked Git metadata, Hg metadata, and Skill watch cleanup. Timing-sensitive native delivery checks remain supplemental and are skipped in CI.

## Scope

- Keeps the public `filesystem.changed` event for VCS metadata; it is no longer a general working-tree event stream.
- Does not change FFF indexing or search.
- Does not raise Linux inotify limits.
- Does not restore the already-disconnected legacy file-tree `file.watcher.updated` path.

Related: #37111, #37740, #16610

## Testing

- `cd packages/core && CI=1 bun run test test/filesystem/watcher.test.ts test/skill.test.ts test/skill-discovery.test.ts test/vcs-hg.test.ts` (22 passed, 11 skipped)
- `cd packages/core && bun run test test/location-layer.test.ts` (18 passed)
- `cd packages/app && bun run test:browser` (33 passed)
- `cd packages/core && bun typecheck`
- `cd packages/app && bun typecheck`
- Repository-wide pre-push typecheck (32 packages passed)
- `git diff --check`

Full Core run: 1,594 passed and 16 skipped. Three unrelated baseline failures remained: the existing `LocationServiceMap` timing flake (passes in isolation), global plugin-config contamination, and process output ordering.

Full app unit run: 638 passed and 13 skipped. The unrelated i18n parity test still reports five Arabic keys missing from the base branch.

## Flow

```mermaid
flowchart TD
  A[Open project] --> B{VCS}
  B -->|Git| C[Watch canonical .git/HEAD]
  B -->|Hg| D[Watch exact .hg/branch]
  A --> E[Load Skill sources]
  E --> F{Source exists?}
  F -->|Yes| G[Watch Skill directory]
  F -->|No| H[Exact-watch first missing path]
  H --> E
  C --> I[Publish branch metadata change]
  D --> I
  I --> J[Refresh VCS branch state]
```
