### PR TITLE
fix(core): normalize tool images once

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -118,13 +118,12 @@ const layer = Layer.effect(
         yield* hooks.trigger("tool", "execute.after", afterEvent)
         return yield* afterEvent.error
       }
-      const content = yield* normalizeImages(execution.value.content)
       const afterEvent: PluginHooks.Domains["tool"]["execute.after"] = {
         ...base,
         status: "completed",
         result: {
           ...(execution.value.output === undefined ? {} : { output: execution.value.output }),
-          content: content.length > 0 ? content : execution.value.content,
+          content: execution.value.content,
           ...(execution.value.metadata === undefined ? {} : { metadata: execution.value.metadata }),
         },
       }

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -3,10 +3,12 @@ import { Agent } from "@opencode-ai/core/agent"
 import type { Permission } from "@opencode-ai/core/permission"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Image } from "@opencode-ai/core/image"
+import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { Session } from "@opencode-ai/core/session"
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { Tool } from "@opencode-ai/core/tool"
 import type { Info } from "@opencode-ai/schema/tool"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { executeTool, toolDefinitions } from "./lib/tool"
 import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Schema, SchemaGetter, SchemaIssue, Scope } from "effect"
 import { testEffect } from "./lib/effect"
@@ -26,10 +28,14 @@ const imageStore = Layer.mock(Image.Service, {
           maxBytes: 5,
         }),
       )
-    return Effect.succeed({ ...content, content: "bm9ybWFsaXplZA==", mime: "image/jpeg" })
+    return Effect.succeed({
+      ...content,
+      content: Buffer.from(`${Buffer.from(content.content, "base64").toString()} normalized`).toString("base64"),
+      mime: "image/jpeg",
+    })
   },
 })
-const registryLayer = AppNodeBuilder.build(Tool.node, [[Image.node, imageStore]])
+const registryLayer = AppNodeBuilder.build(LayerNode.group([Tool.node, PluginHooks.node]), [[Image.node, imageStore]])
 const it = testEffect(registryLayer)
 const identity = {
   agent: Agent.ID.make("build"),
@@ -42,33 +48,25 @@ const call = (name: string, id = `call-${name}`): Parameters<Tool.Snapshot["exec
   call: { type: "tool-call", id, name, input: { text: name } },
 })
 
-const make = (): Info =>
-  ({
-    name: "echo",
-    description: "Echo text",
-    input: Schema.Struct({ text: Schema.String }),
-    output: Schema.Struct({ text: Schema.String }),
-    execute: ({ text }) => Effect.succeed({ output: { text }, content: text }),
-  })
+const make = (): Info => ({
+  name: "echo",
+  description: "Echo text",
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.Struct({ text: Schema.String }),
+  execute: ({ text }) => Effect.succeed({ output: { text }, content: text }),
+})
 
-const constant = (text: string): Info =>
-  ({
-    name: "constant",
-    description: "Return text",
-    input: Schema.Struct({ text: Schema.String }),
-    output: Schema.Struct({ text: Schema.String }),
-    execute: () => Effect.succeed({ output: { text }, content: text }),
-  })
+const constant = (text: string): Info => ({
+  name: "constant",
+  description: "Return text",
+  input: Schema.Struct({ text: Schema.String }),
+  output: Schema.Struct({ text: Schema.String }),
+  execute: () => Effect.succeed({ output: { text }, content: text }),
+})
 
-const transform = (
-  service: Tool.Interface,
-  tools: Readonly<Record<string, Info>>,
-  options?: Tool.Options,
-) =>
+const transform = (service: Tool.Interface, tools: Readonly<Record<string, Info>>, options?: Tool.Options) =>
   service.transform((draft) =>
-    Object.entries(tools).forEach(([name, tool]) =>
-      draft.add({ ...tool, name, options: options ?? tool.options }),
-    ),
+    Object.entries(tools).forEach(([name, tool]) => draft.add({ ...tool, name, options: options ?? tool.options })),
   )
 
 describe("Tool", () => {
@@ -89,8 +87,9 @@ describe("Tool", () => {
       const invalid = yield* transform(service, { "123": make() }, { codemode: false }).pipe(Effect.flip)
       expect(invalid.message).toBe("Invalid tool name: 123")
 
-      const collision = yield* transform(service, { "echo.tool": make(), echo_tool: make() }, { codemode: false })
-        .pipe(Effect.flip)
+      const collision = yield* transform(service, { "echo.tool": make(), echo_tool: make() }, { codemode: false }).pipe(
+        Effect.flip,
+      )
       expect(collision.message).toBe("Duplicate normalized tool name: echo_tool")
       expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
     }),
@@ -196,11 +195,7 @@ describe("Tool", () => {
           { action: "*", resource: "*", effect: "deny" },
         ]),
       ).toEqual([])
-      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual([
-        "bash",
-        "question",
-        "execute",
-      ])
+      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual(["bash", "question", "execute"])
     }),
   )
 
@@ -233,13 +228,12 @@ describe("Tool", () => {
       const service = yield* Tool.Service
       const scope = yield* Scope.make()
       const registered = yield* Deferred.make<void>()
-      const fiber = yield* transform(service, { echo: make() }, { codemode: false })
-        .pipe(
-          Effect.andThen(Deferred.succeed(registered, undefined)),
-          Effect.andThen(Effect.never),
-          Scope.provide(scope),
-          Effect.forkChild,
-        )
+      const fiber = yield* transform(service, { echo: make() }, { codemode: false }).pipe(
+        Effect.andThen(Deferred.succeed(registered, undefined)),
+        Effect.andThen(Effect.never),
+        Scope.provide(scope),
+        Effect.forkChild,
+      )
       yield* Deferred.await(registered)
       yield* Fiber.interrupt(fiber)
 
@@ -252,15 +246,16 @@ describe("Tool", () => {
   it.effect("returns model errors without swallowing interruption or defects", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          failed: ({
+          failed: {
             name: "failed",
             description: "Failed",
             input: Schema.Struct({}),
             output: Schema.Struct({ ok: Schema.Boolean }),
             execute: () => Effect.fail(new Tool.Error({ message: "Denied" })),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -279,15 +274,16 @@ describe("Tool", () => {
         }),
       ).toEqual({ status: "error", error: { type: "tool.execution", message: "Unknown tool: missing" } })
 
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          defect: ({
+          defect: {
             name: "defect",
             description: "Defect",
             input: Schema.Struct({}),
             output: Schema.Struct({}),
             execute: () => Effect.die("unexpected executor defect"),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -320,16 +316,17 @@ describe("Tool", () => {
     Effect.gen(function* () {
       const service = yield* Tool.Service
       const contexts: Tool.Context[] = []
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          context: ({
+          context: {
             name: "context",
             description: "Context",
             input: Schema.Struct({}),
             output: Schema.Struct({ ok: Schema.Boolean }),
             execute: (_, context) =>
               Effect.sync(() => contexts.push(context)).pipe(Effect.as({ output: { ok: true } })),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -344,12 +341,13 @@ describe("Tool", () => {
     }),
   )
 
-  it.effect("normalizes image tool output at execution and drops unresizable images", () =>
+  it.effect("normalizes image tool output once and drops unresizable images", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          snapshot: ({
+          snapshot: {
             name: "snapshot",
             description: "Return images",
             input: Schema.Struct({ text: Schema.String }),
@@ -369,14 +367,19 @@ describe("Tool", () => {
                   { type: "text", text },
                 ],
               }),
-          }),
+          },
         },
         { codemode: false },
       )
 
       const execution = yield* executeTool(service, call("snapshot"))
       expect(execution.content).toEqual([
-        { type: "file", uri: "data:image/jpeg;base64,bm9ybWFsaXplZA==", mime: "image/jpeg", name: "frame.png" },
+        {
+          type: "file",
+          uri: "data:image/jpeg;base64,aW1hZ2Ugbm9ybWFsaXplZA==",
+          mime: "image/jpeg",
+          name: "frame.png",
+        },
         { type: "text", text: "snapshot" },
         { type: "text", text: "[1 image omitted: could not be decoded.]" },
         { type: "text", text: "[1 image omitted: could not be resized below the image size limit.]" },
@@ -384,19 +387,46 @@ describe("Tool", () => {
     }),
   )
 
+  it.effect("normalizes image content added by an after hook", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      const hooks = yield* PluginHooks.Service
+      yield* transform(service, { hooked: constant("original") }, { codemode: false })
+      yield* hooks.register("tool", "execute.after", (event) =>
+        Effect.sync(() => {
+          if (event.status !== "completed") return
+          event.result = {
+            ...event.result,
+            content: [{ type: "file", uri: "data:image/png;base64,aW1hZ2U=", mime: "image/png", name: "hook.png" }],
+          }
+        }),
+      )
+
+      expect((yield* executeTool(service, call("hooked"))).content).toEqual([
+        {
+          type: "file",
+          uri: "data:image/jpeg;base64,aW1hZ2Ugbm9ybWFsaXplZA==",
+          mime: "image/jpeg",
+          name: "hook.png",
+        },
+      ])
+    }),
+  )
+
   it.effect("publishes progress metadata unchanged", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          progressive: ({
+          progressive: {
             name: "progressive",
             description: "Emit image progress",
             input: Schema.Struct({ text: Schema.String }),
             output: Schema.Struct({ text: Schema.String }),
             execute: ({ text }, context) =>
               context.progress({ stage: "capture" }).pipe(Effect.as({ output: { text } })),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -423,16 +453,17 @@ describe("Tool", () => {
           encode: SchemaGetter.transform((value) => value === "yes"),
         }),
       )
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          transformed: ({
+          transformed: {
             name: "transformed",
             description: "Transform values",
             input: Schema.Struct({ value: Transformed }),
             output: Schema.Struct({ value: Transformed }),
             execute: ({ value }) =>
               Effect.sync(() => executed.push(value)).pipe(Effect.as({ output: { value }, content: String(value) })),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -462,9 +493,10 @@ describe("Tool", () => {
       })
       expect(executed).toEqual(["yes"])
 
-      yield* transform(service,
+      yield* transform(
+        service,
         {
-          invalid_output: ({
+          invalid_output: {
             name: "invalid_output",
             description: "Return invalid output",
             input: Schema.Struct({}),
@@ -481,7 +513,7 @@ describe("Tool", () => {
               ),
             }),
             execute: () => Effect.succeed({ output: { value: "invalid" } }),
-          }),
+          },
         },
         { codemode: false },
       )
@@ -531,19 +563,18 @@ describe("Tool", () => {
       const executed: string[] = []
       const scope = yield* Scope.make()
       yield* transform(service, {
-          echo: ({
-            name: "echo",
-            description: "Echo text",
-            input: Schema.Struct({ text: Schema.String }),
-            output: Schema.Struct({ text: Schema.String }),
-            execute: ({ text }, context) =>
-              Effect.sync(() => executed.push(`old:${text}`)).pipe(
-                Effect.andThen(context.progress({ stage: "old" })),
-                Effect.as({ output: { text } }),
-              ),
-          }),
-        })
-        .pipe(Scope.provide(scope))
+        echo: {
+          name: "echo",
+          description: "Echo text",
+          input: Schema.Struct({ text: Schema.String }),
+          output: Schema.Struct({ text: Schema.String }),
+          execute: ({ text }, context) =>
+            Effect.sync(() => executed.push(`old:${text}`)).pipe(
+              Effect.andThen(context.progress({ stage: "old" })),
+              Effect.as({ output: { text } }),
+            ),
+        },
+      }).pipe(Scope.provide(scope))
       const toolSet = yield* service.snapshot()
       const execute = toolSet.definitions.find((tool) => tool.name === "execute")
       expect(toolSet.codeModeCatalog?.[0]?.signature).toContain("tools.echo")
@@ -551,13 +582,13 @@ describe("Tool", () => {
       expect(execute?.description).not.toContain("Echo text")
       yield* Scope.close(scope, Exit.void)
       yield* transform(service, {
-        echo: ({
+        echo: {
           name: "echo",
           description: "Echo text",
           input: Schema.Struct({ text: Schema.String }),
           output: Schema.Struct({ text: Schema.String }),
           execute: ({ text }) => Effect.sync(() => executed.push(`new:${text}`)).pipe(Effect.as({ output: { text } })),
-        }),
+        },
       })
 
       const progress: Tool.Metadata[] = []

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -48,25 +48,33 @@ const call = (name: string, id = `call-${name}`): Parameters<Tool.Snapshot["exec
   call: { type: "tool-call", id, name, input: { text: name } },
 })
 
-const make = (): Info => ({
-  name: "echo",
-  description: "Echo text",
-  input: Schema.Struct({ text: Schema.String }),
-  output: Schema.Struct({ text: Schema.String }),
-  execute: ({ text }) => Effect.succeed({ output: { text }, content: text }),
-})
+const make = (): Info =>
+  ({
+    name: "echo",
+    description: "Echo text",
+    input: Schema.Struct({ text: Schema.String }),
+    output: Schema.Struct({ text: Schema.String }),
+    execute: ({ text }) => Effect.succeed({ output: { text }, content: text }),
+  })
 
-const constant = (text: string): Info => ({
-  name: "constant",
-  description: "Return text",
-  input: Schema.Struct({ text: Schema.String }),
-  output: Schema.Struct({ text: Schema.String }),
-  execute: () => Effect.succeed({ output: { text }, content: text }),
-})
+const constant = (text: string): Info =>
+  ({
+    name: "constant",
+    description: "Return text",
+    input: Schema.Struct({ text: Schema.String }),
+    output: Schema.Struct({ text: Schema.String }),
+    execute: () => Effect.succeed({ output: { text }, content: text }),
+  })
 
-const transform = (service: Tool.Interface, tools: Readonly<Record<string, Info>>, options?: Tool.Options) =>
+const transform = (
+  service: Tool.Interface,
+  tools: Readonly<Record<string, Info>>,
+  options?: Tool.Options,
+) =>
   service.transform((draft) =>
-    Object.entries(tools).forEach(([name, tool]) => draft.add({ ...tool, name, options: options ?? tool.options })),
+    Object.entries(tools).forEach(([name, tool]) =>
+      draft.add({ ...tool, name, options: options ?? tool.options }),
+    ),
   )
 
 describe("Tool", () => {
@@ -87,9 +95,8 @@ describe("Tool", () => {
       const invalid = yield* transform(service, { "123": make() }, { codemode: false }).pipe(Effect.flip)
       expect(invalid.message).toBe("Invalid tool name: 123")
 
-      const collision = yield* transform(service, { "echo.tool": make(), echo_tool: make() }, { codemode: false }).pipe(
-        Effect.flip,
-      )
+      const collision = yield* transform(service, { "echo.tool": make(), echo_tool: make() }, { codemode: false })
+        .pipe(Effect.flip)
       expect(collision.message).toBe("Duplicate normalized tool name: echo_tool")
       expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
     }),
@@ -195,7 +202,11 @@ describe("Tool", () => {
           { action: "*", resource: "*", effect: "deny" },
         ]),
       ).toEqual([])
-      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual(["bash", "question", "execute"])
+      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual([
+        "bash",
+        "question",
+        "execute",
+      ])
     }),
   )
 
@@ -228,12 +239,13 @@ describe("Tool", () => {
       const service = yield* Tool.Service
       const scope = yield* Scope.make()
       const registered = yield* Deferred.make<void>()
-      const fiber = yield* transform(service, { echo: make() }, { codemode: false }).pipe(
-        Effect.andThen(Deferred.succeed(registered, undefined)),
-        Effect.andThen(Effect.never),
-        Scope.provide(scope),
-        Effect.forkChild,
-      )
+      const fiber = yield* transform(service, { echo: make() }, { codemode: false })
+        .pipe(
+          Effect.andThen(Deferred.succeed(registered, undefined)),
+          Effect.andThen(Effect.never),
+          Scope.provide(scope),
+          Effect.forkChild,
+        )
       yield* Deferred.await(registered)
       yield* Fiber.interrupt(fiber)
 
@@ -246,16 +258,15 @@ describe("Tool", () => {
   it.effect("returns model errors without swallowing interruption or defects", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          failed: {
+          failed: ({
             name: "failed",
             description: "Failed",
             input: Schema.Struct({}),
             output: Schema.Struct({ ok: Schema.Boolean }),
             execute: () => Effect.fail(new Tool.Error({ message: "Denied" })),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -274,16 +285,15 @@ describe("Tool", () => {
         }),
       ).toEqual({ status: "error", error: { type: "tool.execution", message: "Unknown tool: missing" } })
 
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          defect: {
+          defect: ({
             name: "defect",
             description: "Defect",
             input: Schema.Struct({}),
             output: Schema.Struct({}),
             execute: () => Effect.die("unexpected executor defect"),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -316,17 +326,16 @@ describe("Tool", () => {
     Effect.gen(function* () {
       const service = yield* Tool.Service
       const contexts: Tool.Context[] = []
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          context: {
+          context: ({
             name: "context",
             description: "Context",
             input: Schema.Struct({}),
             output: Schema.Struct({ ok: Schema.Boolean }),
             execute: (_, context) =>
               Effect.sync(() => contexts.push(context)).pipe(Effect.as({ output: { ok: true } })),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -344,10 +353,9 @@ describe("Tool", () => {
   it.effect("normalizes image tool output once and drops unresizable images", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          snapshot: {
+          snapshot: ({
             name: "snapshot",
             description: "Return images",
             input: Schema.Struct({ text: Schema.String }),
@@ -367,7 +375,7 @@ describe("Tool", () => {
                   { type: "text", text },
                 ],
               }),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -397,7 +405,9 @@ describe("Tool", () => {
           if (event.status !== "completed") return
           event.result = {
             ...event.result,
-            content: [{ type: "file", uri: "data:image/png;base64,aW1hZ2U=", mime: "image/png", name: "hook.png" }],
+            content: [
+              { type: "file", uri: "data:image/png;base64,aW1hZ2U=", mime: "image/png", name: "hook.png" },
+            ],
           }
         }),
       )
@@ -416,17 +426,16 @@ describe("Tool", () => {
   it.effect("publishes progress metadata unchanged", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          progressive: {
+          progressive: ({
             name: "progressive",
             description: "Emit image progress",
             input: Schema.Struct({ text: Schema.String }),
             output: Schema.Struct({ text: Schema.String }),
             execute: ({ text }, context) =>
               context.progress({ stage: "capture" }).pipe(Effect.as({ output: { text } })),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -453,17 +462,16 @@ describe("Tool", () => {
           encode: SchemaGetter.transform((value) => value === "yes"),
         }),
       )
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          transformed: {
+          transformed: ({
             name: "transformed",
             description: "Transform values",
             input: Schema.Struct({ value: Transformed }),
             output: Schema.Struct({ value: Transformed }),
             execute: ({ value }) =>
               Effect.sync(() => executed.push(value)).pipe(Effect.as({ output: { value }, content: String(value) })),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -493,10 +501,9 @@ describe("Tool", () => {
       })
       expect(executed).toEqual(["yes"])
 
-      yield* transform(
-        service,
+      yield* transform(service,
         {
-          invalid_output: {
+          invalid_output: ({
             name: "invalid_output",
             description: "Return invalid output",
             input: Schema.Struct({}),
@@ -513,7 +520,7 @@ describe("Tool", () => {
               ),
             }),
             execute: () => Effect.succeed({ output: { value: "invalid" } }),
-          },
+          }),
         },
         { codemode: false },
       )
@@ -563,18 +570,19 @@ describe("Tool", () => {
       const executed: string[] = []
       const scope = yield* Scope.make()
       yield* transform(service, {
-        echo: {
-          name: "echo",
-          description: "Echo text",
-          input: Schema.Struct({ text: Schema.String }),
-          output: Schema.Struct({ text: Schema.String }),
-          execute: ({ text }, context) =>
-            Effect.sync(() => executed.push(`old:${text}`)).pipe(
-              Effect.andThen(context.progress({ stage: "old" })),
-              Effect.as({ output: { text } }),
-            ),
-        },
-      }).pipe(Scope.provide(scope))
+          echo: ({
+            name: "echo",
+            description: "Echo text",
+            input: Schema.Struct({ text: Schema.String }),
+            output: Schema.Struct({ text: Schema.String }),
+            execute: ({ text }, context) =>
+              Effect.sync(() => executed.push(`old:${text}`)).pipe(
+                Effect.andThen(context.progress({ stage: "old" })),
+                Effect.as({ output: { text } }),
+              ),
+          }),
+        })
+        .pipe(Scope.provide(scope))
       const toolSet = yield* service.snapshot()
       const execute = toolSet.definitions.find((tool) => tool.name === "execute")
       expect(toolSet.codeModeCatalog?.[0]?.signature).toContain("tools.echo")
@@ -582,13 +590,13 @@ describe("Tool", () => {
       expect(execute?.description).not.toContain("Echo text")
       yield* Scope.close(scope, Exit.void)
       yield* transform(service, {
-        echo: {
+        echo: ({
           name: "echo",
           description: "Echo text",
           input: Schema.Struct({ text: Schema.String }),
           output: Schema.Struct({ text: Schema.String }),
           execute: ({ text }) => Effect.sync(() => executed.push(`new:${text}`)).pipe(Effect.as({ output: { text } })),
-        },
+        }),
       })
 
       const progress: Tool.Metadata[] = []


### PR DESCRIPTION
## What

Normalize successful tool image output exactly once, avoiding duplicate decode/resize work on the ordinary unchanged-hook path.

## Before / After

**Before:** Successful image content was normalized before `tool.execute.after`, then the hook result was normalized again. When hooks left content unchanged, each image was decoded and resized twice.

**After:** Successful content reaches `tool.execute.after` unchanged and the final hook result is normalized once before returning. Images introduced or replaced by an after hook are still normalized at that final boundary.

## How

- `packages/core/src/tool.ts` removes the pre-hook normalization pass and retains the existing post-hook normalization pass.
- `packages/core/test/session-runner-tool-registry.test.ts` makes the injected image normalizer non-idempotent so repeated normalization is observable, and covers image content added by an after hook.

## Scope

This only changes successful tool image normalization ordering. Error hooks, tool output shaping, image limits, and public APIs are unchanged.

## Testing

- `cd packages/core && bun run test test/session-runner-tool-registry.test.ts`
- `cd packages/core && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3`