### PR TITLE
fix(opencode): enforce per-target task subagent permissions

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -257,19 +257,30 @@ const layer = Layer.effect(
       return (yield* all()).map((tool) => tool.id)
     })
 
-    const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (agent: Agent.Info) {
-      const items = (yield* agents.list()).filter((item) => item.mode !== "primary")
-      const filtered = items.filter(
-        (item) => Permission.evaluate("task", item.name, agent.permission).action !== "deny",
-      )
+    const describeTask = Effect.fn("ToolRegistry.describeTask")(function* (input: {
+      agent: Agent.Info
+      permission?: PermissionV1.Ruleset
+    }) {
+      // Merge agent + session rules so model-facing guidance matches execute-time
+      // evaluation (session ceilings can deny targets that the agent alone allows).
+      const ruleset = Permission.merge(input.agent.permission, input.permission ?? [])
+      const items = (yield* agents.list()).filter((item) => item.mode !== "primary" && item.hidden !== true)
+      const filtered = items.filter((item) => Permission.evaluate("task", item.name, ruleset).action !== "deny")
       const list = filtered.toSorted((a, b) => a.name.localeCompare(b.name))
+      if (list.length === 0) {
+        return "No subagent types are available under the current permission rules. Do not call the task tool."
+      }
       const description = list
         .map(
           (item) =>
             `- ${item.name}: ${item.description ?? "This subagent should only be called manually by the user."}`,
         )
         .join("\n")
-      return ["Available agent types and the tools they have access to:", description].join("\n")
+      return [
+        "Available agent types and the tools they have access to:",
+        description,
+        "Only use subagent_type values from this list. Other types will be rejected.",
+      ].join("\n")
     })
 
     const describeCodeMode = Effect.fn("ToolRegistry.describeCodeMode")(function* (input: {
@@ -319,7 +330,9 @@ const layer = Layer.effect(
             id: tool.id,
             description: [
               output.description,
-              tool.id === TaskTool.id ? yield* describeTask(input.agent) : undefined,
+              tool.id === TaskTool.id
+                ? yield* describeTask({ agent: input.agent, permission: input.permission })
+                : undefined,
               tool.id === "execute" ? codeModeDescription : undefined,
             ]
               .filter(Boolean)

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
+import { Permission } from "@/permission"
 import { Effect, Exit, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -116,7 +117,31 @@ export const TaskTool = Tool.define(
         )
       }
 
+      const next = yield* agent.get(params.subagent_type)
+      if (!next) {
+        return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
+      }
+      // Primary agents are user-facing modes, not delegatable task targets (#35238).
+      if (next.mode === "primary") {
+        return yield* Effect.fail(
+          new Error(
+            `Agent type "${params.subagent_type}" is a primary agent and cannot be used as a task subagent`,
+          ),
+        )
+      }
+
       if (!ctx.extra?.bypassAgentCheck) {
+        // Hard-deny before ask so per-target deny rules are a runtime boundary even
+        // when the model invents a subagent_type name that is not listed in guidance.
+        const caller = yield* agent.get(ctx.agent)
+        const ruleset = Permission.merge(caller.permission, parent.permission ?? [])
+        if (Permission.evaluate(id, params.subagent_type, ruleset).action === "deny") {
+          return yield* Effect.fail(
+            new Error(
+              `Subagent type "${params.subagent_type}" is denied by permission rules for agent "${ctx.agent}"`,
+            ),
+          )
+        }
         yield* ctx.ask({
           permission: id,
           patterns: [params.subagent_type],
@@ -126,11 +151,6 @@ export const TaskTool = Tool.define(
             subagent_type: params.subagent_type,
           },
         })
-      }
-
-      const next = yield* agent.get(params.subagent_type)
-      if (!next) {
-        return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
       }
 
       const session = params.task_id

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -19,6 +19,7 @@ import { SessionStatus } from "@/session/status"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
+import { Permission } from "../../src/permission"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { disposeAllInstances } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -214,6 +215,141 @@ describe("tool.task", () => {
         },
       },
     },
+  )
+
+  it.instance(
+    "description applies session permission ceilings on top of agent rules",
+    () =>
+      Effect.gen(function* () {
+        const agent = yield* Agent.Service
+        const build = yield* agent.get("build")
+        const registry = yield* ToolRegistry.Service
+        const description =
+          (
+            yield* registry.tools({
+              ...ref,
+              agent: build,
+              permission: Permission.fromConfig({
+                task: {
+                  alpha: "deny",
+                },
+              }),
+            })
+          ).find((tool) => tool.id === TaskTool.id)?.description ?? ""
+
+        expect(description).toContain("- beta: Beta agent")
+        expect(description).not.toContain("- alpha: Alpha agent")
+      }),
+    {
+      config: {
+        permission: {
+          task: {
+            "*": "allow",
+          },
+        },
+        agent: {
+          alpha: {
+            description: "Alpha agent",
+            mode: "subagent",
+          },
+          beta: {
+            description: "Beta agent",
+            mode: "subagent",
+          },
+        },
+      },
+    },
+  )
+
+  it.instance(
+    "execute rejects denied subagent_type without creating a child session",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        const promptOps = stubOps()
+
+        const exit = yield* def
+          .execute(
+            {
+              description: "not allowed",
+              prompt: "do something",
+              subagent_type: "zebra",
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(Effect.exit)
+
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const text = String(exit.cause)
+          expect(text).toContain("denied by permission rules")
+        }
+        expect(yield* sessions.children(chat.id)).toHaveLength(0)
+      }),
+    {
+      config: {
+        permission: {
+          task: {
+            "*": "allow",
+            zebra: "deny",
+          },
+        },
+        agent: {
+          zebra: {
+            description: "Zebra agent",
+            mode: "subagent",
+          },
+        },
+      },
+    },
+  )
+
+  it.instance("execute rejects primary agents as task subagent targets", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps()
+
+      const exit = yield* def
+        .execute(
+          {
+            description: "wrong mode",
+            prompt: "plan something",
+            subagent_type: "build",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(String(exit.cause)).toContain("primary agent")
+      }
+      expect(yield* sessions.children(chat.id)).toHaveLength(0)
+    }),
   )
 
   it.instance("execute resumes an existing task session from task_id", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #35238

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Per-target `task` permission rules (for example allow only `explore`) were not a hard runtime boundary when the model invented a denied `subagent_type`, and model-facing task guidance only considered agent rules, not session permission ceilings.

This change:

1. Filters the task tool description using `Permission.merge(agent.permission, session.permission)` and hides primary/hidden agents.
2. Rejects primary-mode targets at execute time (they are not delegatable subagents).
3. Hard-denies denied `subagent_type` values before `ctx.ask` and before creating a child session, so inventing a name still fails closed.

`bypassAgentCheck` (explicit user `@agent` routing) is unchanged.

### How did you verify your code works?

```text
cd packages/opencode
bun test test/tool/task.test.ts test/permission-task.test.ts
# 44 pass, 0 fail
```

New coverage:

1. description applies session permission ceilings
2. execute rejects denied subagent_type without a child session
3. execute rejects primary agents as task targets

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR