### PR TITLE
fix(tui): align running shell output

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2604,6 +2604,8 @@ function Shell(props: ToolProps) {
     if (expanded() || !collapsed().overflow) return content()
     return collapsed().output
   })
+  const limitedInput = createMemo(() => limited().slice(0, input().length))
+  const limitedOutput = createMemo(() => limited().slice(Math.min(limited().length, input().length + 2)))
   const expandable = createMemo(() => Boolean(shellID()) || collapsed().overflow)
   const toggle = () => {
     const next = !expanded()
@@ -2628,15 +2630,15 @@ function Shell(props: ToolProps) {
             when={isRunning()}
             fallback={
               <text>
-                <span style={{ fg: theme.text.default }}>{limited().slice(0, input().length)}</span>
+                <span style={{ fg: theme.text.default }}>{limitedInput()}</span>
                 <span style={{ fg: theme.text.subdued }}>{limited().slice(input().length)}</span>
               </text>
             }
           >
-            <Spinner color={color()}>
-              <span style={{ fg: theme.text.default }}>{limited().slice(0, input().length)}</span>
-              <span style={{ fg: theme.text.subdued }}>{limited().slice(input().length)}</span>
-            </Spinner>
+            <Spinner color={color()}>{limitedInput()}</Spinner>
+            <Show when={limitedOutput()}>
+              <text fg={theme.text.subdued}>{limitedOutput()}</text>
+            </Show>
           </Show>
         </Show>
         <Show when={background()}>


### PR DESCRIPTION
## What

Align running shell output with the completed shell card. The activity spinner remains beside the command, while streamed output now uses the card's normal content inset.

## Before / After

**Before:** While a shell command was running, its command and output were rendered together inside the spinner's text column. Multiline output inherited the spinner's two-column offset. Once the command completed, the spinner disappeared and the same output jumped two columns left.

| Running | Completed |
| --- | --- |
| ![Running shell output before the fix](https://github.com/user-attachments/assets/5c29395c-1f02-4da9-a8d0-b348258c9be9) | ![Completed shell output before the fix](https://github.com/user-attachments/assets/6a2cde3d-494d-4ef6-858f-278b9b7dad28) |

**After:** The spinner wraps only the command. Running output is rendered as a sibling at the card's normal left edge, so its indentation remains stable when the command completes.

| Running | Completed |
| --- | --- |
| ![Running shell output after the fix](https://github.com/user-attachments/assets/b49882ab-afa2-47da-93e4-6020309c1ceb) | ![Completed shell output after the fix](https://github.com/user-attachments/assets/d4a6f0b9-ff1c-4189-9d4d-0b99daa5de7b) |

## How

- `packages/tui/src/routes/session/index.tsx` separates the limited command and output portions.
- The running command stays inside `Spinner`; the running output renders in its own subdued text node.
- Completed rendering and existing collapse/expand limits remain unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test` from `packages/tui`: 594 passed, 5 skipped, 0 failed
- OpenCode Drive end-to-end simulation with a shell command that emits output, waits, then emits another line; captured both running and completed states before and after the fix
