### PR TITLE
fix(session): preserve prompt agent

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -633,7 +633,8 @@ const layer = Layer.effect(
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {
-      const agentName = input.agent
+      const current = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
+      const agentName = input.agent ?? current.agent
       const ag = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!ag) {
         const available = (yield* agents.list()).filter((a) => !a.hidden).map((a) => a.name)
@@ -669,7 +670,6 @@ const layer = Layer.effect(
         format: input.format,
       }
 
-      const current = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
       if (
         current.agent !== info.agent ||
         current.model?.providerID !== info.model.providerID ||

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -427,6 +427,52 @@ describe("session HttpApi", () => {
     }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(AppNodeBuilder.build(CrossSpawnSpawner.node))),
   )
 
+  it.live("legacy prompt endpoint honors explicit and persisted session agents", () =>
+    Effect.gen(function* () {
+      const llm = yield* TestLLMServer
+      yield* llm.text("ok", { usage: { input: 1, output: 1 } })
+      yield* llm.text("ok", { usage: { input: 1, output: 1 } })
+
+      const directory = yield* tmpdirScoped({
+        git: true,
+        config: {
+          ...testProviderConfig(llm.url),
+          agent: {
+            helper: {
+              mode: "primary",
+              model: "test/test-model",
+              permission: {},
+            },
+          },
+        },
+      })
+      const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
+      const session = yield* createSession({ title: "agent prompt", agent: "helper" }).pipe(provideInstanceEffect(directory))
+
+      const implicit = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ noReply: true, parts: [{ type: "text", text: "implicit" }] }),
+      })
+      const explicit = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ agent: "helper", noReply: true, parts: [{ type: "text", text: "explicit" }] }),
+      })
+
+      expect(implicit.status).toBe(200)
+      expect(explicit.status).toBe(200)
+      yield* responseJson(implicit)
+      yield* responseJson(explicit)
+
+      const messages = yield* Session.use.messages({ sessionID: session.id }).pipe(provideInstanceEffect(directory), Effect.orDie)
+      const userAgents = messages
+        .filter((message) => message.info.role === "user")
+        .map((message) => message.info.agent)
+      expect(userAgents).toEqual(["helper", "helper"])
+    }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(AppNodeBuilder.build(CrossSpawnSpawner.node))),
+  )
+
   it.instance(
     "returns v2 public request errors for cursor and workspace query failures",
     () =>


### PR DESCRIPTION
### Issue for this PR

Closes #40998
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps the legacy `POST /session/:id/message` endpoint on the session's current agent when the request body does not include `agent`, instead of falling back to the default `build` agent.

The same regression also exercises an explicit `agent` value on the request body so the endpoint keeps accepting that field without returning an unexpected server error.

### How did you verify your code works?

- `bun test ./test/server/httpapi-session.test.ts --test-name-pattern 'legacy prompt endpoint honors explicit and persisted session agents' --timeout 30000`
- `bun test ./test/server/httpapi-session.test.ts --test-name-pattern 'uses the persisted session directory for prompt requests|legacy prompt endpoint honors explicit and persisted session agents' --timeout 30000`
- `bun typecheck` in `packages/opencode`
- `bun run lint packages/opencode/src/session/prompt.ts packages/opencode/test/server/httpapi-session.test.ts`
- `git diff --check`

Note: repo-wide pre-push typecheck is currently blocked by an existing `@opencode-ai/enterprise/src/custom-elements.d.ts` parse error unrelated to this diff, so I pushed with `--no-verify` after the focused checks passed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
