### PR TITLE
docs: add opencode-fusion to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -82,3 +82,4 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+| [opencode-fusion](https://github.com/mihneaptu/opencode-fusion)   | Multi-model team: the main agent plans and reviews but cannot edit; a cheaper sidekick does |


### PR DESCRIPTION
### Issue for this PR

Closes #41114

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-fusion](https://github.com/mihneaptu/opencode-fusion) to the Agents section of the ecosystem page. The entry describes its permission-enforced workflow: a main agent plans and reviews while a cheaper sidekick edits.

### How did you verify your code works?

Ran `git diff --check` and verified the PR changes only `packages/web/src/content/docs/ecosystem.mdx`.

### Screenshots / recordings

Not applicable; this is a documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
