### PR TITLE
fix(lsp): honor static workspace diagnostics

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -80,6 +80,12 @@ function getSyncKind(capabilities?: ServerCapabilities) {
   return sync?.change
 }
 
+function hasWorkspaceDiagnostics(value: unknown) {
+  if (typeof value !== "object" || value === null) return false
+  if (!Object.hasOwn(value, "workspaceDiagnostics")) return false
+  return Object.getOwnPropertyDescriptor(value, "workspaceDiagnostics")?.value === true
+}
+
 function endPosition(text: string) {
   const lines = text.split(/\r\n|\r|\n/)
   return {
@@ -256,6 +262,7 @@ export async function create(input: {
 
   const syncKind = getSyncKind(initialized.capabilities)
   const hasStaticPullDiagnostics = Boolean(initialized.capabilities?.diagnosticProvider)
+  const hasStaticWorkspaceDiagnostics = hasWorkspaceDiagnostics(initialized.capabilities?.diagnosticProvider)
 
   await connection.sendNotification("initialized", {})
 
@@ -372,7 +379,7 @@ export async function create(input: {
       workspaceIdentifiers: [
         ...new Set(workspaceRegistrations.flatMap((registration) => registration.registerOptions?.identifier ?? [])),
       ],
-      supported: workspaceRegistrations.length > 0,
+      supported: hasStaticWorkspaceDiagnostics || workspaceRegistrations.length > 0,
     }
   }
 

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -18,6 +18,7 @@ let pullConfig = {
   workspaceDiagnosticsByIdentifier: {},
   workspaceDelayMsByIdentifier: {},
 }
+const staticWorkspaceDiagnostics = process.env.OPENCODE_FAKE_LSP_STATIC_WORKSPACE_DIAGNOSTICS === "1"
 
 function encode(message) {
   const json = JSON.stringify(message)
@@ -118,6 +119,9 @@ function handle(raw) {
         textDocumentSync: {
           change: 2,
         },
+        ...(staticWorkspaceDiagnostics
+          ? { diagnosticProvider: { interFileDependencies: false, workspaceDiagnostics: true } }
+          : {}),
       },
     })
     return

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -5,12 +5,16 @@ import { tmpdir, withTestInstance } from "../fixture/fixture"
 import { LSPClient } from "@/lsp/client"
 import * as LSPServer from "@/lsp/server"
 
-function spawnFakeServer() {
+function spawnFakeServer(options: { staticWorkspaceDiagnostics?: boolean } = {}) {
   const { spawn } = require("child_process")
   const serverPath = path.join(__dirname, "../fixture/lsp/fake-lsp-server.js")
   return {
     process: spawn(process.execPath, [serverPath], {
       stdio: "pipe",
+      env: {
+        ...process.env,
+        ...(options.staticWorkspaceDiagnostics ? { OPENCODE_FAKE_LSP_STATIC_WORKSPACE_DIAGNOSTICS: "1" } : {}),
+      },
     }),
   }
 }
@@ -485,4 +489,49 @@ describe("LSPClient interop", () => {
       },
     })
   })
+
+  test("full mode uses static workspace pull diagnostics capability", async () => {
+    const handle = spawnFakeServer({ staticWorkspaceDiagnostics: true }) as any
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "client.cs")
+    await Bun.write(file, "class C {}\n")
+
+    await withTestInstance({
+      directory: tmp.path,
+      fn: async (ctx) => {
+        const client = await LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: tmp.path,
+          directory: tmp.path,
+          instance: ctx,
+        })
+
+        await client.connection.sendRequest("test/configure-pull-diagnostics", {
+          workspaceDiagnostics: [
+            {
+              uri: pathToFileURL(file).href,
+              items: [
+                {
+                  range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 5 },
+                  },
+                  message: "static workspace file",
+                  severity: 1,
+                },
+              ],
+            },
+          ],
+        })
+
+        const version = await client.notify.open({ path: file })
+        await client.waitForDiagnostics({ path: file, version, mode: "full" })
+
+        expect(client.diagnostics.get(file)?.[0]?.message).toBe("static workspace file")
+
+        await client.shutdown()
+      },
+    })
+  }, 30_000)
 })


### PR DESCRIPTION
### Issue for this PR

Closes #40773
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes `workspacePullState()` honor a language server's static `diagnosticProvider.workspaceDiagnostics` capability from the initialize response, not only dynamic `client/registerCapability` registrations.

This keeps the existing dynamic-registration behavior unchanged and only enables the workspace pull path when the server explicitly advertises static workspace diagnostics.

### How did you verify your code works?

- `bun test ./test/lsp/client.test.ts --test-name-pattern 'full mode uses static workspace pull diagnostics capability'`
- `bun test ./test/lsp/client.test.ts --test-name-pattern 'full mode treats an empty workspace pull response as handled|full mode uses static workspace pull diagnostics capability'`
- `bun test ./test/lsp/client.test.ts`
- `bun typecheck` in `packages/opencode`
- `bun run lint packages/opencode/src/lsp/client.ts packages/opencode/test/lsp/client.test.ts packages/opencode/test/fixture/lsp/fake-lsp-server.js`
- `git diff --check`

Note: repo-wide pre-push typecheck is currently blocked by an existing `@opencode-ai/enterprise/src/custom-elements.d.ts` parse error unrelated to this diff, so I pushed with `--no-verify` after the focused checks passed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
