### PR TITLE
fix(acp): emit plan updates for todos

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -92,6 +92,19 @@ export class Subscription {
 
   async handle(event: Event) {
     switch (event.type) {
+      case "todo.updated":
+        await this.input.connection.sessionUpdate({
+          sessionId: event.properties.sessionID,
+          update: {
+            sessionUpdate: "plan",
+            entries: event.properties.todos.map((todo) => ({
+              content: todo.content,
+              priority: planPriority(todo.priority),
+              status: planStatus(todo.status),
+            })),
+          },
+        })
+        return
       case "session.status":
         if (event.properties.status.type === "idle") this.idle(event.properties.sessionID)
         return
@@ -416,6 +429,19 @@ function signal() {
     resolve: () => state.resolve(),
     reject: (reason?: unknown) => state.reject(reason),
   }
+}
+
+function planPriority(value: string) {
+  if (value === "high") return "high"
+  if (value === "low") return "low"
+  return "medium"
+}
+
+function planStatus(value: string) {
+  if (value === "pending") return "pending"
+  if (value === "in_progress") return "in_progress"
+  if (value === "completed") return "completed"
+  return "pending"
 }
 
 export * as ACPEvent from "./event"

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -319,6 +319,35 @@ async function createKnownSession(
 }
 
 describe("acp event routing", () => {
+  it("routes todo.updated events to ACP plan updates", async () => {
+    const harness = createHarness()
+
+    await harness.subscription.handle({
+      id: "evt_todo_updated",
+      type: "todo.updated",
+      properties: {
+        sessionID: "ses_plan",
+        todos: [
+          { content: "Inspect failing path", priority: "high", status: "completed" },
+          { content: "Patch event adapter", priority: "medium", status: "in_progress" },
+        ],
+      },
+    } as Event)
+
+    expect(harness.updates).toEqual([
+      {
+        sessionId: "ses_plan",
+        update: {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Inspect failing path", priority: "high", status: "completed" },
+            { content: "Patch event adapter", priority: "medium", status: "in_progress" },
+          ],
+        },
+      },
+    ])
+  })
+
   it("routes message.part.delta by sessionID without cross-session pollution", async () => {
     const harness = createHarness()
     await createKnownSession(harness.session, "ses_a", { messageId: "msg_a", partId: "part_a", partType: "text" })


### PR DESCRIPTION
### Issue for this PR

Closes #40745
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Maps OpenCode `todo.updated` events into ACP `session/update` messages with `sessionUpdate: "plan"`.

This lets ACP clients render the current session plan from the same todo events already used by OpenCode. The mapping preserves task content, priority, and the ACP-supported statuses (`pending`, `in_progress`, `completed`).

### How did you verify your code works?

- `bun test ./test/acp/event.test.ts --test-name-pattern 'routes todo.updated events to ACP plan updates'`
- `bun test ./test/acp/event.test.ts`
- `bun typecheck` in `packages/opencode`
- `bun run lint packages/opencode/src/acp/event.ts packages/opencode/test/acp/event.test.ts`
- `git diff --check`

Note: repo-wide pre-push typecheck is currently blocked by an existing `@opencode-ai/enterprise/src/custom-elements.d.ts` parse error unrelated to this diff, so I pushed with `--no-verify` after the focused checks passed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
