### PR TITLE
fix(app): auto-register server working directory as a project

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -110,6 +110,22 @@ function createServerCtx(
   const sdk = createServerSdkContext(conn, scope)
   const sync = createServerSyncContext(sdk)
 
+  // Register the server's working directory as an open project so a fresh
+  // `opencode web`/`serve` in a folder surfaces that folder and its
+  // sessions in the UI without requiring a manual "Add project". Skip the
+  // user's home dir and the filesystem root, which the file finder cannot
+  // index and would otherwise appear empty.
+  createEffect(() => {
+    const directory = sync.data.path.directory
+    const home = sync.data.path.home
+    if (!directory || !home) return
+    const key = pathKey(directory)
+    if (key === pathKey(home) || key === "/") return
+    if (projects.list().some((project) => pathKey(project.worktree) === key)) return
+    projects.open(directory)
+    projects.touch(directory)
+  })
+
   function enrich(project: { worktree: string; expanded: boolean }) {
     const [childStore] = sync.child(project.worktree, { bootstrap: false })
     const projectID = childStore.project


### PR DESCRIPTION
### Issue for this PR

Closes #39655

### Type of change

- [x] Bug fix

### What does this PR do?

A fresh `opencode web`/`serve` started in a folder showed an empty UI — no
projects in the sidebar, "Nothing here yet" — even though the backend returns
projects and sessions. The web sidebar and session list are driven by the
app's local open-projects store (keyed on worktree), not the server `/project`
table, so until the user manually typed the folder path into the (empty)
picker, nothing appeared.

This registers the server's working directory as an open project on connect
(once `sync.data.path.directory` is known), skipping the user's home dir and
the filesystem root, which the file finder cannot index. The project then
appears in the sidebar with its sessions, without a manual "Add project" step.

### How did you verify your code works?

- Ran the app and backend dev servers locally (`bun`), started the server in a
  clean scratch folder, and loaded the UI in a fresh browser context (no
  persisted state): the launch folder appeared as a project with a new session.
- `bun typecheck` in `packages/app` passes.

### Screenshots / recordings

Before: empty sidebar, "Nothing here yet"; after: the server's working
directory (`ocdemo`) shown as a project with a session. (I can attach the PNG
to the issue if needed.)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
