### PR TITLE
feat(app): add server connect links

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -64,6 +64,7 @@ import { ErrorPage } from "./pages/error"
 import { useCheckServerHealth } from "./utils/server-health"
 import { legacySessionHref, legacySessionServer, requireServerKey, sessionHref } from "./utils/session-route"
 import { createSessionLineage } from "@/pages/session/session-lineage"
+import { ConnectIntentHandler } from "@/components/connect-intent-handler"
 
 import { SessionPage, SessionRouteErrorBoundary, TargetSessionRouteContent } from "@/pages/session"
 import { NewHome } from "@/pages/home"
@@ -314,6 +315,7 @@ function SharedProviders(props: ParentProps) {
   return (
     <>
       <BodyDesignClass />
+      <ConnectIntentHandler />
       <CommandProvider>
         <DesktopCommands />
         <HighlightsProvider>{props.children}</HighlightsProvider>

--- a/packages/app/src/components/connect-intent-handler.tsx
+++ b/packages/app/src/components/connect-intent-handler.tsx
@@ -1,0 +1,143 @@
+import { useDirectoryPicker } from "@/components/directory-picker"
+import { useGlobal } from "@/context/global"
+import { useLanguage } from "@/context/language"
+import { ServerConnection, useServer } from "@/context/server"
+import { useSettings } from "@/context/settings"
+import { useTabs } from "@/context/tabs"
+import {
+  collectConnectIntents,
+  deepLinkEvent,
+  parseConnectIntent,
+  takePendingDeepLinks,
+  type ConnectIntent,
+} from "@/pages/layout/deep-links"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useNavigate } from "@solidjs/router"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import { onMount } from "solid-js"
+
+export function ConnectIntentHandler() {
+  const pickDirectory = useDirectoryPicker()
+  const language = useLanguage()
+  const settings = useSettings()
+  const navigate = useNavigate()
+  const dialog = useDialog()
+  const global = useGlobal()
+  const server = useServer()
+  const tabs = useTabs()
+  let activeFlow: AbortController | undefined
+
+  const openProject = (conn: ServerConnection.Any, directory: string) => {
+    const projects = global.ensureServerCtx(conn).projects
+    projects.open(directory)
+    projects.touch(directory)
+    server.setActive(ServerConnection.key(conn))
+    if (settings.general.newLayoutDesigns()) {
+      void tabs.newDraft({ server: ServerConnection.key(conn), directory })
+      return
+    }
+    navigate(`/${base64Encode(directory)}`)
+  }
+
+  const selectDirectory = (conn: ServerConnection.Any, directory?: string) => {
+    if (!directory) {
+      server.setActive(ServerConnection.key(conn))
+      navigate("/")
+      return
+    }
+    pickDirectory({
+      server: conn,
+      title: language.t("command.project.open"),
+      start: directory,
+      onSelect: (result) => {
+        if (typeof result === "string") openProject(conn, result)
+      },
+    })
+  }
+
+  const openExisting = async (
+    conn: ServerConnection.Http,
+    directory?: string,
+    closeAfterOpen = false,
+    signal?: AbortSignal,
+  ) => {
+    if (signal?.aborted) return
+    if (!directory) {
+      selectDirectory(conn)
+      if (closeAfterOpen) dialog.close()
+      return
+    }
+    const ctx = global.ensureServerCtx(conn)
+    const resolved = directory.startsWith("~")
+      ? await ctx.sdk.client.path
+          .get()
+          .then((result) => result.data?.home && directory.replace(/^~(?=\/|$)/, result.data.home))
+          .catch(() => undefined)
+      : directory
+    if (signal?.aborted) return
+    if (!resolved) {
+      selectDirectory(conn, directory)
+      return
+    }
+    const valid = await ctx.sdk.api.file
+      .list({ location: { directory: resolved } })
+      .then(() => true)
+      .catch(() => false)
+    if (signal?.aborted) return
+    if (valid) {
+      openProject(conn, resolved)
+      if (closeAfterOpen) dialog.close()
+      return
+    }
+    selectDirectory(conn, resolved)
+  }
+
+  const openServer = (intent: ConnectIntent) => {
+    activeFlow?.abort()
+    const flow = new AbortController()
+    activeFlow = flow
+    const existing = global.servers
+      .list()
+      .find(
+        (conn): conn is ServerConnection.Http =>
+          conn.type === "http" && ServerConnection.key(conn) === ServerConnection.Key.make(intent.server),
+    )
+    if (existing) {
+      void openExisting(existing, intent.directory, false, flow.signal)
+      return
+    }
+
+    const onAdded = (conn: ServerConnection.Http, signal: AbortSignal) =>
+      openExisting(conn, intent.directory, true, AbortSignal.any([flow.signal, signal]))
+    if (settings.general.newLayoutDesigns()) {
+      void import("@/components/settings-v2/dialog-server-v2").then(({ DialogServerV2 }) => {
+        if (flow.signal.aborted) return
+        dialog.show(() => <DialogServerV2 mode="add" url={intent.server} onAdded={onAdded} />, () => flow.abort())
+      })
+      return
+    }
+    void import("@/components/dialog-select-server").then(({ DialogSelectServer }) => {
+      if (flow.signal.aborted) return
+      dialog.show(() => <DialogSelectServer url={intent.server} onAdded={onAdded} />, () => flow.abort())
+    })
+  }
+
+  const consume = () => {
+    const urls = takePendingDeepLinks(window, (input) => !!parseConnectIntent(input))
+    const intent = collectConnectIntents(urls).at(-1)
+    if (intent) openServer(intent)
+  }
+
+  onMount(() => {
+    const web = parseConnectIntent(window.location.href)
+    if (web) {
+      history.replaceState(history.state, "", location.pathname + location.search)
+      openServer(web)
+    }
+    consume()
+    makeEventListener(window, deepLinkEvent, consume)
+  })
+
+  return null
+}

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -16,6 +16,7 @@ interface DialogSelectDirectoryProps {
   multiple?: boolean
   onSelect: (result: string | string[] | null) => void
   server: ServerConnection.Any
+  start?: string
 }
 
 const RECENT_PROJECT_LIMIT = 5
@@ -56,7 +57,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const dialog = useDialog()
   const language = useLanguage()
 
-  const [filter, setFilter] = createSignal("")
+  const [filter, setFilter] = createSignal(props.start ?? "")
   let list: ListRef | undefined
 
   const missingHome = createMemo(() => !sync.data.path.home)
@@ -133,6 +134,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
       <List
         class="px-3"
         search={{ placeholder: language.t("dialog.directory.search.placeholder"), autofocus: true }}
+        filter={filter()}
         emptyMessage={language.t("dialog.directory.empty")}
         loadingMessage={language.t("common.loading")}
         items={items}

--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -9,7 +9,7 @@ import { TextField } from "@opencode-ai/ui/text-field"
 import { useMutation } from "@tanstack/solid-query"
 import { showToast } from "@/utils/toast"
 import { useNavigate } from "@solidjs/router"
-import { createEffect, createMemo, createResource, Show } from "solid-js"
+import { createEffect, createMemo, createResource, onCleanup, onMount, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { ServerHealthIndicator, ServerRow } from "@/components/server/server-row"
 import { useGlobal } from "@/context/global"
@@ -175,9 +175,19 @@ function ServerForm(props: ServerFormProps) {
   )
 }
 
-export function DialogSelectServer() {
+export function DialogSelectServer(
+  props: { url?: string; onAdded?: (conn: ServerConnection.Http, signal: AbortSignal) => void | Promise<void> } = {},
+) {
   const dialog = useDialog()
-  const controller = useServerManagementController({ onSelect: dialog.close })
+  const controller = useServerManagementController({
+    onSelect: dialog.close,
+    onAdded: props.onAdded,
+    navigateOnAdd: props.onAdded ? false : undefined,
+  })
+
+  onMount(() => {
+    if (props.url) controller.startAdd(props.url)
+  })
 
   return (
     <Dialog title={controller.formTitle()}>
@@ -190,7 +200,13 @@ export function DialogSelectServer() {
   )
 }
 
-export function useServerManagementController(options: { onSelect?: () => void; navigateOnAdd?: boolean } = {}) {
+export function useServerManagementController(
+  options: {
+    onSelect?: () => void
+    onAdded?: (conn: ServerConnection.Http, signal: AbortSignal) => void | Promise<void>
+    navigateOnAdd?: boolean
+  } = {},
+) {
   const navigate = useNavigate()
   const server = useServer()
   const tabs = useTabs()
@@ -200,6 +216,14 @@ export function useServerManagementController(options: { onSelect?: () => void; 
   const { defaultKey, canDefault, setDefault } = useDefaultServer()
   const { previewStatus } = useServerPreview()
   const checkServerHealth = useCheckServerHealth()
+  let addGeneration = 0
+  let editGeneration = 0
+  let addAbort: AbortController | undefined
+  const invalidateAdd = () => {
+    addGeneration++
+    addAbort?.abort()
+    addAbort = undefined
+  }
   const [store, setStore] = createStore({
     addServer: {
       url: "",
@@ -222,6 +246,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
   })
 
   const resetAdd = () => {
+    invalidateAdd()
     setStore("addServer", {
       url: "",
       name: "",
@@ -233,6 +258,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
     })
   }
   const resetEdit = () => {
+    editGeneration++
     setStore("editServer", {
       id: undefined,
       value: "",
@@ -245,10 +271,18 @@ export function useServerManagementController(options: { onSelect?: () => void; 
   }
 
   const addMutation = useMutation(() => ({
-    mutationFn: async (value: string) => {
-      const normalized = normalizeServerUrl(value)
+    mutationFn: async (input: {
+      value: string
+      name: string
+      username: string
+      password: string
+      generation: number
+      signal: AbortSignal
+    }) => {
+      const active = () => input.generation === addGeneration && !input.signal.aborted
+      const normalized = normalizeServerUrl(input.value)
       if (!normalized) {
-        resetAdd()
+        if (active()) resetAdd()
         return
       }
 
@@ -256,10 +290,11 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         type: "http",
         http: { url: normalized },
       }
-      if (store.addServer.name.trim()) conn.displayName = store.addServer.name.trim()
-      if (store.addServer.password) conn.http.password = store.addServer.password
-      if (store.addServer.password && store.addServer.username) conn.http.username = store.addServer.username
+      if (input.name.trim()) conn.displayName = input.name.trim()
+      if (input.password) conn.http.password = input.password
+      if (input.password && input.username) conn.http.username = input.username
       const result = await checkServerHealth(conn.http)
+      if (!active()) return
       if (!result.healthy) {
         setStore("addServer", { error: language.t("dialog.server.add.error") })
         return
@@ -268,22 +303,38 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         !settings.general.newLayoutDesigns() &&
         (await detectServerProtocol(conn.http, platform.fetch ?? globalThis.fetch)) === "v2"
       ) {
+        if (!active()) return
         setStore("addServer", { error: language.t("dialog.server.add.error") })
         return
       }
+      if (!active()) return
 
-      resetAdd()
       if (options.navigateOnAdd === false) {
-        server.add(conn)
+        const added = server.add(conn, { activate: !options.onAdded })
+        if (!added) return
+        if (options.onAdded) {
+          await options.onAdded(added, input.signal)
+          return
+        }
+        resetAdd()
         options.onSelect?.()
         return
       }
+      resetAdd()
       await select(conn, true)
     },
   }))
 
   const editMutation = useMutation(() => ({
-    mutationFn: async (input: { original: ServerConnection.Any; value: string }) => {
+    mutationFn: async (input: {
+      original: ServerConnection.Any
+      value: string
+      name: string
+      username: string
+      password: string
+      generation: number
+    }) => {
+      const active = () => input.generation === editGeneration
       if (input.original.type !== "http") return
       const normalized = normalizeServerUrl(input.value)
       if (!normalized) {
@@ -291,9 +342,9 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         return
       }
 
-      const name = store.editServer.name.trim() || undefined
-      const username = store.editServer.username || undefined
-      const password = store.editServer.password || undefined
+      const name = input.name.trim() || undefined
+      const username = input.username || undefined
+      const password = input.password || undefined
       const existingName = input.original.displayName
       if (
         normalized === input.original.http.url &&
@@ -311,6 +362,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         http: { url: normalized, username, password },
       }
       const result = await checkServerHealth(conn.http)
+      if (!active()) return
       if (!result.healthy) {
         setStore("editServer", { error: language.t("dialog.server.add.error") })
         return
@@ -319,9 +371,11 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         !settings.general.newLayoutDesigns() &&
         (await detectServerProtocol(conn.http, platform.fetch ?? globalThis.fetch)) === "v2"
       ) {
+        if (!active()) return
         setStore("editServer", { error: language.t("dialog.server.add.error") })
         return
       }
+      if (!active()) return
       if (normalized === input.original.http.url) {
         server.add(conn)
       } else {
@@ -395,59 +449,70 @@ export function useServerManagementController(options: { onSelect?: () => void; 
 
   const handleAddChange = (value: string) => {
     if (addMutation.isPending) return
+    invalidateAdd()
+    const generation = addGeneration
     setStore("addServer", { url: value, error: "" })
     void previewStatus(value, store.addServer.username, store.addServer.password, (next) =>
-      setStore("addServer", { status: next }),
+      generation === addGeneration && setStore("addServer", { status: next }),
     )
   }
 
   const handleAddNameChange = (value: string) => {
     if (addMutation.isPending) return
+    invalidateAdd()
     setStore("addServer", { name: value, error: "" })
   }
 
   const handleAddUsernameChange = (value: string) => {
     if (addMutation.isPending) return
+    invalidateAdd()
+    const generation = addGeneration
     setStore("addServer", { username: value, error: "" })
     void previewStatus(store.addServer.url, value, store.addServer.password, (next) =>
-      setStore("addServer", { status: next }),
+      generation === addGeneration && setStore("addServer", { status: next }),
     )
   }
 
   const handleAddPasswordChange = (value: string) => {
     if (addMutation.isPending) return
+    invalidateAdd()
+    const generation = addGeneration
     setStore("addServer", { password: value, error: "" })
     void previewStatus(store.addServer.url, store.addServer.username, value, (next) =>
-      setStore("addServer", { status: next }),
+      generation === addGeneration && setStore("addServer", { status: next }),
     )
   }
 
   const handleEditChange = (value: string) => {
     if (editMutation.isPending) return
+    const generation = ++editGeneration
     setStore("editServer", { value, error: "" })
     void previewStatus(value, store.editServer.username, store.editServer.password, (next) =>
-      setStore("editServer", { status: next }),
+      generation === editGeneration && setStore("editServer", { status: next }),
     )
   }
 
   const handleEditNameChange = (value: string) => {
     if (editMutation.isPending) return
+    editGeneration++
     setStore("editServer", { name: value, error: "" })
   }
 
   const handleEditUsernameChange = (value: string) => {
     if (editMutation.isPending) return
+    const generation = ++editGeneration
     setStore("editServer", { username: value, error: "" })
     void previewStatus(store.editServer.value, value, store.editServer.password, (next) =>
-      setStore("editServer", { status: next }),
+      generation === editGeneration && setStore("editServer", { status: next }),
     )
   }
 
   const handleEditPasswordChange = (value: string) => {
     if (editMutation.isPending) return
+    const generation = ++editGeneration
     setStore("editServer", { password: value, error: "" })
     void previewStatus(store.editServer.value, store.editServer.username, value, (next) =>
-      setStore("editServer", { status: next }),
+      generation === editGeneration && setStore("editServer", { status: next }),
     )
   }
 
@@ -467,11 +532,12 @@ export function useServerManagementController(options: { onSelect?: () => void; 
     resetEdit()
   }
 
-  const startAdd = () => {
+  const startAdd = (url = "") => {
+    invalidateAdd()
     resetEdit()
     setStore("addServer", {
       showForm: true,
-      url: "",
+      url,
       name: "",
       username: DEFAULT_USERNAME,
       password: "",
@@ -481,6 +547,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
   }
 
   const startEdit = (conn: ServerConnection.Http) => {
+    editGeneration++
     resetAdd()
     setStore("editServer", {
       id: conn.http.url,
@@ -497,14 +564,31 @@ export function useServerManagementController(options: { onSelect?: () => void; 
     if (mode() === "add") {
       if (addMutation.isPending) return
       setStore("addServer", { error: "" })
-      addMutation.mutate(store.addServer.url)
+      const abort = new AbortController()
+      addAbort?.abort()
+      addAbort = abort
+      addMutation.mutate({
+        value: store.addServer.url,
+        name: store.addServer.name,
+        username: store.addServer.username,
+        password: store.addServer.password,
+        generation: addGeneration,
+        signal: abort.signal,
+      })
       return
     }
     const original = editing()
     if (!original) return
     if (editMutation.isPending) return
     setStore("editServer", { error: "" })
-    editMutation.mutate({ original, value: store.editServer.value })
+    editMutation.mutate({
+      original,
+      value: store.editServer.value,
+      name: store.editServer.name,
+      username: store.editServer.username,
+      password: store.editServer.password,
+      generation: editGeneration,
+    })
   }
 
   const isFormMode = createMemo(() => mode() !== "list")
@@ -525,6 +609,11 @@ export function useServerManagementController(options: { onSelect?: () => void; 
     if (!store.editServer.id) return
     if (editing()) return
     resetEdit()
+  })
+
+  onCleanup(() => {
+    invalidateAdd()
+    editGeneration++
   })
 
   async function handleRemove(key: ServerConnection.Key) {

--- a/packages/app/src/components/directory-picker.tsx
+++ b/packages/app/src/components/directory-picker.tsx
@@ -14,6 +14,7 @@ type DirectoryPickerInput = {
   server: ServerConnection.Any
   title?: string
   multiple?: boolean
+  start?: string
   onSelect: (result: string | string[] | null) => void
 }
 

--- a/packages/app/src/components/settings-v2/dialog-server-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-server-v2.tsx
@@ -2,6 +2,7 @@ import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { Dialog, DialogBody, DialogFooter, DialogHeader, DialogTitle } from "@opencode-ai/ui/v2/dialog-v2"
 import { DividerV2 } from "@opencode-ai/ui/v2/divider-v2"
 import { TextInputV2 } from "@opencode-ai/ui/v2/text-input-v2"
+import { LoaderV2 } from "@opencode-ai/ui/v2/loader-v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { type Component, Show, createEffect, createSignal, onCleanup, onMount } from "solid-js"
 import { useLanguage } from "@/context/language"
@@ -12,17 +13,20 @@ import "./settings-v2.css"
 export const DialogServerV2: Component<{
   mode: "add" | "edit"
   server?: ServerConnection.Http
+  url?: string
+  onAdded?: (conn: ServerConnection.Http, signal: AbortSignal) => void | Promise<void>
 }> = (props) => {
   const dialog = useDialog()
   const language = useLanguage()
   const controller = useServerManagementController({
     onSelect: () => dialog.close(),
+    onAdded: props.onAdded,
     navigateOnAdd: false,
   })
   const [opened, setOpened] = createSignal(false)
 
   onMount(() => {
-    if (props.mode === "add") controller.startAdd()
+    if (props.mode === "add") controller.startAdd(props.url)
     if (props.mode === "edit" && props.server) controller.startEdit(props.server)
     setOpened(true)
   })
@@ -125,7 +129,14 @@ export const DialogServerV2: Component<{
         <ButtonV2 variant="neutral" disabled={controller.formBusy()} onClick={() => dialog.close()}>
           {language.t("common.cancel")}
         </ButtonV2>
-        <ButtonV2 variant="contrast" disabled={controller.formBusy()} onClick={controller.submitForm}>
+        <ButtonV2
+          variant={controller.formBusy() ? "loading" : "contrast"}
+          disabled={controller.formBusy()}
+          onClick={controller.submitForm}
+        >
+          <Show when={controller.formBusy()}>
+            <LoaderV2 />
+          </Show>
           {submitLabel()}
         </ButtonV2>
       </DialogFooter>

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -287,7 +287,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
       if (state.active !== input) setState("active", input)
     }
 
-    function add(input: ServerConnection.Http) {
+    function add(input: ServerConnection.Http, options?: { activate?: boolean }) {
       const url_ = normalizeServerUrl(input.http.url)
       if (!url_) return
       const conn: ServerConnection.Http = { ...input, authToken: undefined, http: { ...input.http, url: url_ } }
@@ -298,7 +298,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
         } else {
           setStore("list", store.list.length, conn)
         }
-        setState("active", ServerConnection.key(conn))
+        if (options?.activate !== false) setState("active", ServerConnection.key(conn))
         return conn
       })
     }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -71,7 +71,9 @@ import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
   deepLinkEvent,
-  drainPendingDeepLinks,
+  parseDeepLink,
+  parseNewSessionDeepLink,
+  takePendingDeepLinks,
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
@@ -1281,15 +1283,14 @@ export default function LegacyLayout(props: ParentProps) {
   }
 
   onMount(() => {
-    const handler = (event: Event) => {
-      const detail = (event as CustomEvent<{ urls: string[] }>).detail
-      const urls = detail?.urls ?? []
+    const consume = () => {
+      const urls = takePendingDeepLinks(window, (input) => !!parseDeepLink(input) || !!parseNewSessionDeepLink(input))
       if (urls.length === 0) return
       handleDeepLinks(urls)
     }
 
-    handleDeepLinks(drainPendingDeepLinks(window))
-    makeEventListener(window, deepLinkEvent, handler as EventListener)
+    consume()
+    makeEventListener(window, deepLinkEvent, consume)
   })
 
   async function renameProject(project: LocalProject, next: string) {

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -1,10 +1,47 @@
 export const deepLinkEvent = "opencode:deep-link"
 
+export type ConnectIntent = {
+  server: string
+  directory?: string
+}
+
 const parseUrl = (input: string) => {
   if (!input.startsWith("opencode://")) return
   if (typeof URL.canParse === "function" && !URL.canParse(input)) return
   try {
     return new URL(input)
+  } catch {
+    return
+  }
+}
+
+const parseConnectParams = (params: URLSearchParams): ConnectIntent | undefined => {
+  const input = params.get("server")?.trim()
+  if (!input) return
+  try {
+    const server = new URL(input)
+    if (server.protocol !== "http:" && server.protocol !== "https:") return
+    if (server.username || server.password || server.search || server.hash) return
+    const directory = params.get("directory")?.trim() || undefined
+    if (directory && !/^(?:~(?:[\\/]|$)|\/|[A-Za-z]:[\\/]|\\\\)/.test(directory)) return
+    return { server: server.toString().replace(/\/+$/, ""), directory }
+  } catch {
+    return
+  }
+}
+
+export const parseConnectIntent = (input: string) => {
+  if (input.startsWith("opencode://")) {
+    const url = parseUrl(input)
+    if (!url || url.hostname !== "connect") return
+    return parseConnectParams(url.searchParams)
+  }
+
+  try {
+    const url = new URL(input)
+    const match = url.hash.match(/^#connect(?:\?(.*))?$/)
+    if (!match) return
+    return parseConnectParams(new URLSearchParams(match[1] ?? ""))
   } catch {
     return
   }
@@ -36,6 +73,9 @@ export const collectOpenProjectDeepLinks = (urls: string[]) =>
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
 
+export const collectConnectIntents = (urls: string[]) =>
+  urls.map(parseConnectIntent).filter((intent): intent is ConnectIntent => !!intent)
+
 type OpenCodeWindow = Window & {
   __OPENCODE__?: {
     deepLinks?: string[]
@@ -43,8 +83,13 @@ type OpenCodeWindow = Window & {
 }
 
 export const drainPendingDeepLinks = (target: OpenCodeWindow) => {
+  return takePendingDeepLinks(target, () => true)
+}
+
+export const takePendingDeepLinks = (target: OpenCodeWindow, matches: (input: string) => boolean) => {
   const pending = target.__OPENCODE__?.deepLinks ?? []
   if (pending.length === 0) return []
-  if (target.__OPENCODE__) target.__OPENCODE__.deepLinks = []
-  return pending
+  const selected = pending.filter(matches)
+  if (target.__OPENCODE__) target.__OPENCODE__.deepLinks = pending.filter((input) => !matches(input))
+  return selected
 }

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import {
+  collectConnectIntents,
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
   drainPendingDeepLinks,
+  parseConnectIntent,
   parseDeepLink,
   parseNewSessionDeepLink,
+  takePendingDeepLinks,
 } from "./deep-links"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import {
@@ -100,6 +103,48 @@ describe("layout deep links", () => {
     expect(result).toEqual([{ directory: "/a" }, { directory: "/c", prompt: "ship it" }])
   })
 
+  test("parses web and desktop connect links", () => {
+    const query = "server=https%3A%2F%2Fdemo.example.com&directory=%2Fworkspace%2Fdemo"
+    const expected = { server: "https://demo.example.com", directory: "/workspace/demo" }
+
+    expect(parseConnectIntent(`https://app.opencode.ai/#connect?${query}`)).toEqual(expected)
+    expect(parseConnectIntent(`opencode://connect?${query}`)).toEqual(expected)
+  })
+
+  test("allows remote home-relative directories", () => {
+    expect(
+      parseConnectIntent(
+        "https://app.opencode.ai/#connect?server=http%3A%2F%2Flocalhost%3A8888&directory=%7E%2Fworkspace%2Fdemo",
+      ),
+    ).toEqual({ server: "http://localhost:8888", directory: "~/workspace/demo" })
+  })
+
+  test("parses connect links without a directory", () => {
+    expect(parseConnectIntent("opencode://connect?server=https%3A%2F%2Fdemo.example.com")).toEqual({
+      server: "https://demo.example.com",
+    })
+  })
+
+  test("rejects unsafe connect server URLs", () => {
+    expect(parseConnectIntent("opencode://connect?server=file%3A%2F%2F%2Ftmp%2Fserver")).toBeUndefined()
+    expect(parseConnectIntent("opencode://connect?server=https%3A%2F%2Fuser%3Apass%40example.com")).toBeUndefined()
+    expect(parseConnectIntent("opencode://connect?server=https%3A%2F%2Fexample.com%3Ftoken%3Dsecret")).toBeUndefined()
+    expect(parseConnectIntent("opencode://connect")).toBeUndefined()
+    expect(
+      parseConnectIntent("opencode://connect?server=https%3A%2F%2Fexample.com&directory=relative%2Fproject"),
+    ).toBeUndefined()
+  })
+
+  test("collects only connect intents", () => {
+    expect(
+      collectConnectIntents([
+        "opencode://open-project?directory=/a",
+        "opencode://connect?server=https%3A%2F%2Fone.example.com",
+        "opencode://connect?server=ssh%3A%2F%2Ftwo.example.com",
+      ]),
+    ).toEqual([{ server: "https://one.example.com" }])
+  })
+
   test("drains global deep links once", () => {
     const target = {
       __OPENCODE__: {
@@ -109,6 +154,22 @@ describe("layout deep links", () => {
 
     expect(drainPendingDeepLinks(target)).toEqual(["opencode://open-project?directory=/a"])
     expect(drainPendingDeepLinks(target)).toEqual([])
+  })
+
+  test("takes matching pending deep links without discarding the rest", () => {
+    const target = {
+      __OPENCODE__: {
+        deepLinks: [
+          "opencode://connect?server=https%3A%2F%2Fdemo.example.com",
+          "opencode://open-project?directory=/a",
+        ],
+      },
+    } as unknown as Window & { __OPENCODE__?: { deepLinks?: string[] } }
+
+    expect(takePendingDeepLinks(target, (input) => !!parseConnectIntent(input))).toEqual([
+      "opencode://connect?server=https%3A%2F%2Fdemo.example.com",
+    ])
+    expect(drainPendingDeepLinks(target)).toEqual(["opencode://open-project?directory=/a"])
   })
 })
 

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -80,9 +80,12 @@ function useEnvProxy() {
 
 function emitDeepLinks(urls: string[]) {
   if (urls.length === 0) return
-  pendingDeepLinks.push(...urls)
   const win = getLastFocusedWindow()
-  if (win) sendDeepLinks(win, urls)
+  if (win) {
+    sendDeepLinks(win, urls)
+    return
+  }
+  pendingDeepLinks.push(...urls)
 }
 
 async function killSidecar() {
@@ -220,6 +223,8 @@ const main = Effect.gen(function* () {
     logger.log("deep link received via open-url", { url })
     emitDeepLinks([url])
   })
+
+  emitDeepLinks(process.argv.filter((arg) => arg.startsWith("opencode://")))
 
   app.on("before-quit", () => {
     setAppQuitting()


### PR DESCRIPTION
### Issue for this PR

- Closes #
- Not applicable.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds `#connect?server=...&directory=...` links for the hosted app and `opencode://connect?...` links for desktop.
- Pre-fills the validated server connection form without putting credentials in the link.
- Opens an existing server and valid project directly; falls back to the remote directory picker when the project cannot be validated.
- Keeps credentials and transient connection work scoped to the dialog, including cancellation handling.

### How did you verify your code works?

- Ran focused app tests for server state, server protocol/health, directory selection, and deep-link parsing.
- Ran `bun typecheck` in `packages/app` and `packages/desktop`.
- Ran the full workspace typecheck through the pre-push hook.
- Tested the hosted-app link flow locally against a remote server.

### Screenshots / recordings

- Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR