### PR TITLE
fix(app): show server projects until the first bookmark (#39655)

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -1,7 +1,13 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createEffect, createMemo, createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
-import { createServerProjects, RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
+import {
+  createServerProjects,
+  RECENTLY_CLOSED_DISPLAY_LIMIT,
+  ServerConnection,
+  useServer,
+  visibleProjectEntries,
+} from "./server"
 import { pathKey } from "@/utils/path-key"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
@@ -127,7 +133,7 @@ function createServerCtx(
     return base
   }
 
-  const projectsList = createMemo(() => projects.list().map(enrich))
+  const projectsList = createMemo(() => visibleProjectEntries(projects.list(), sync.data.project).map(enrich))
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -133,7 +133,9 @@ function createServerCtx(
     return base
   }
 
-  const projectsList = createMemo(() => visibleProjectEntries(projects.list(), sync.data.project).map(enrich))
+  const projectsList = createMemo(() =>
+    visibleProjectEntries(projects.list(), sync.data.project, projects.recentlyClosed()).map(enrich),
+  )
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -7,6 +7,7 @@ import {
   nextServerAfterRemoval,
   resolveServerList,
   ServerConnection,
+  visibleProjectEntries,
 } from "./server"
 import { ServerScope } from "@/utils/server-scope"
 
@@ -241,5 +242,19 @@ describe("migrateCanonicalLocalServerState", () => {
       },
       lastProject: { local: "/local" },
     })
+  })
+})
+
+describe("visibleProjectEntries", () => {
+  test("shows server projects until the first bookmark exists", () => {
+    expect(visibleProjectEntries([], [{ worktree: "/repo/a" }, { worktree: "/repo/b" }])).toEqual([
+      { worktree: "/repo/a", expanded: false },
+      { worktree: "/repo/b", expanded: false },
+    ])
+  })
+
+  test("prefers bookmarks over server projects once any exist", () => {
+    const bookmarked = [{ worktree: "/repo/a", expanded: true }]
+    expect(visibleProjectEntries(bookmarked, [{ worktree: "/repo/b" }])).toEqual(bookmarked)
   })
 })

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -253,8 +253,24 @@ describe("visibleProjectEntries", () => {
     ])
   })
 
-  test("prefers bookmarks over server projects once any exist", () => {
+  test("keeps server projects after the first bookmark appears", () => {
     const bookmarked = [{ worktree: "/repo/a", expanded: true }]
-    expect(visibleProjectEntries(bookmarked, [{ worktree: "/repo/b" }])).toEqual(bookmarked)
+    expect(visibleProjectEntries(bookmarked, [{ worktree: "/repo/a" }, { worktree: "/repo/b" }])).toEqual([
+      { worktree: "/repo/a", expanded: true },
+      { worktree: "/repo/b", expanded: false },
+    ])
+  })
+
+  test("deduplicates server projects already bookmarked by normalized path", () => {
+    const bookmarked = [{ worktree: "/repo/a/", expanded: true }]
+    expect(visibleProjectEntries(bookmarked, [{ worktree: "/repo/a" }])).toEqual([
+      { worktree: "/repo/a/", expanded: true },
+    ])
+  })
+
+  test("hides server projects the user closed", () => {
+    expect(visibleProjectEntries([], [{ worktree: "/repo/a" }, { worktree: "/repo/b" }], ["/repo/a"])).toEqual([
+      { worktree: "/repo/b", expanded: false },
+    ])
   })
 })

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -145,6 +145,14 @@ export function createServerProjects<T extends ServerProjectState>(input: {
   }
 }
 
+export function visibleProjectEntries(
+  bookmarked: ReadonlyArray<StoredProject>,
+  server: ReadonlyArray<{ worktree: string }>,
+) {
+  if (bookmarked.length > 0) return [...bookmarked]
+  return server.map((project) => ({ worktree: project.worktree, expanded: false }))
+}
+
 export function resolveServerList(input: {
   props?: Array<ServerConnection.Any>
   stored: StoredServer[]

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -145,12 +145,24 @@ export function createServerProjects<T extends ServerProjectState>(input: {
   }
 }
 
+// Bookmarks are authoritative and keep their order. Server projects stay discoverable alongside
+// them so a fresh web client (which never seeds bookmarks) still shows the `/project` list, and so
+// bookmarks added later do not evict the remaining server projects. `hidden` is the per-server
+// recently-closed set: server projects the user explicitly closed stay out until reopened.
 export function visibleProjectEntries(
   bookmarked: ReadonlyArray<StoredProject>,
   server: ReadonlyArray<{ worktree: string }>,
-) {
-  if (bookmarked.length > 0) return [...bookmarked]
-  return server.map((project) => ({ worktree: project.worktree, expanded: false }))
+  hidden: ReadonlyArray<string> = [],
+): StoredProject[] {
+  const seen = new Set(bookmarked.map((project) => pathKey(project.worktree)))
+  const hiddenKeys = new Set(hidden.map((project) => pathKey(project)))
+  const discovered = server.flatMap((project) => {
+    const key = pathKey(project.worktree)
+    if (hiddenKeys.has(key) || seen.has(key)) return []
+    seen.add(key)
+    return [{ worktree: project.worktree, expanded: false }]
+  })
+  return [...bookmarked, ...discovered]
 }
 
 export function resolveServerList(input: {


### PR DESCRIPTION
### Issue for this PR

Closes #39655

### Type of change

- [x] Bug fix

### What does this PR do?

The home project list and picker recents only read client-side bookmarks, which `opencode web` never seeds, so a fresh session showed "Nothing here yet". The list now merges the server `/project` list alongside bookmarks (bookmarks first, remaining server projects appended and deduplicated by normalized path), so adding the first bookmark no longer hides the other server projects or their sessions. Server projects the user closes stay hidden until reopened.

### How did you verify your code works?

- Added unit tests for the fallback, bookmark-first transition, path deduplication, and the closed/hidden case.
- App unit suite passes (728 tests); full monorepo typecheck passes.

### Screenshots / recordings

None.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Related: #39732 (New Session flow with no project open) overlaps with the fresh-session case this PR covers.