### PR TITLE
fix(provider): propagate config-level npm override to inherited models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1516,6 +1516,21 @@ const layer = Layer.effect(
             )
             parsed.models[modelID] = parsedModel
           }
+
+          // Propagate config provider-level npm to inherited models (models not
+          // explicitly declared in config). Without this, a config override like
+          // `provider.synthetic.npm = "@ai-sdk/anthropic"` is silently dropped for
+          // models sourced from models.dev, leaving their api.npm stuck at the
+          // snapshot value (e.g. @ai-sdk/openai-compatible) while options.baseURL
+          // is applied — producing mismatched SDK+URL 404s.
+          if (provider.npm) {
+            const declared = new Set(Object.keys(provider.models ?? {}))
+            for (const [mid, m] of Object.entries(parsed.models)) {
+              if (declared.has(mid)) continue
+              if (m.api.npm !== provider.npm) m.api.npm = provider.npm
+            }
+          }
+
           database[providerID] = parsed
         }
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1380,6 +1380,29 @@ it.instance(
   },
 )
 
+it.instance(
+  "config provider npm override propagates to inherited models",
+  Effect.gen(function* () {
+    yield* set("OPENAI_API_KEY", "test-api-key")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.openai]).toBeDefined()
+    // An inherited model (not declared in config) should pick up the
+    // config-level provider npm override, not keep the models.dev default.
+    const model = providers[ProviderV2.ID.openai].models["gpt-4o"]
+    expect(model).toBeDefined()
+    expect(model.api.npm).toBe("@ai-sdk/anthropic")
+  }),
+  {
+    config: {
+      provider: {
+        openai: {
+          npm: "@ai-sdk/anthropic",
+        },
+      },
+    },
+  },
+)
+
 test("mode options and cost are derived from the base model", () => {
   const provider = {
     id: "openai",


### PR DESCRIPTION
### Issue for this PR

Closes #41162

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A config-level `npm` override for an existing provider (e.g. `provider.synthetic.npm = "@ai-sdk/anthropic"`) was silently dropped for models inherited from models.dev. The config-merge `parsed` object in `provider.ts` never carried `npm`, and `apiNpm` was only recomputed for models explicitly declared in config. Inherited models kept their models.dev `api.npm`, so requests used the overridden `options.baseURL` with the *original* SDK — producing mismatched SDK+URL 404s (e.g. POSTing `/chat/completions` to an Anthropic-compatible base URL).

The fix adds a post-loop pass that re-resolves inherited models' `api.npm` when the config provider declares `npm`, skipping models explicitly declared in config (which already resolve correctly).

### How did you verify your code works?

- New test `config provider npm override propagates to inherited models` — overrides `openai`'s npm via config and asserts an inherited model (`gpt-4o`) picks up `@ai-sdk/anthropic` — passes.
- `bun run typecheck` clean.
- End-to-end: `opencode run --model "synthetic/hf:moonshotai/Kimi-K3"` (provider with config npm override) completed successfully through the anthropic endpoint after the fix; before the fix it 404'd.

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR