### PR TITLE
fix(session): extract tool-result media for models without attachment capability

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -145,6 +145,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
   // Only apply this workaround if the model actually supports that media input -
   // otherwise unsupportedParts() will turn it into a user-visible error.
   const supportsMediaInToolResult = (attachment: { mime: string }) => {
+    // If the model has no attachment capability at all (e.g. GLM-5.2 on
+    // Synthetic via @ai-sdk/anthropic), don't keep media in tool results -
+    // route it to a user message so unsupportedParts() can degrade gracefully
+    // instead of the provider rejecting the whole request.
+    if (!model.capabilities.attachment) return false
     if (model.api.npm === "@ai-sdk/anthropic") return true
     if (model.api.npm === "@ai-sdk/openai") return true
     if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -398,17 +398,107 @@ describe("session.message-v2.toModelMessage", () => {
             toolCallId: "call-1",
             toolName: "bash",
             output: {
-              type: "content",
-              value: [
-                { type: "text", text: "ok" },
-                { type: "media", mediaType: "image/png", data: "Zm9v" },
-              ],
+              type: "text",
+              value: "ok",
             },
             providerOptions: { openai: { tool: "meta" } },
           },
         ],
       },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: MessageV2.SYNTHETIC_ATTACHMENT_PROMPT },
+          {
+            type: "file",
+            data: "data:image/png;base64,Zm9v",
+            mediaType: "image/png",
+            filename: "attachment.png",
+          },
+        ],
+      },
     ])
+  })
+
+  test("extracts tool-result media for anthropic models without attachment capability", async () => {
+    const noAttachmentAnthropicModel: Provider.Model = {
+      ...model,
+      id: ModelV2.ID.make("synthetic/hf:zai-org/GLM-5.2"),
+      providerID: ProviderV2.ID.make("synthetic"),
+      api: {
+        id: "hf:zai-org/GLM-5.2",
+        url: "https://api.synthetic.new/anthropic/v1",
+        npm: "@ai-sdk/anthropic",
+      },
+      capabilities: {
+        ...model.capabilities,
+        attachment: false,
+      },
+    }
+
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "text",
+            text: "done",
+          },
+          {
+            ...basePart(assistantID, "a2"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-1"),
+                  type: "file",
+                  mime: "image/png",
+                  filename: "attachment.png",
+                  url: "data:image/png;base64,Zm9v",
+                },
+              ],
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, noAttachmentAnthropicModel)
+    // Media must be extracted out of the tool result and injected as a user
+    // message (so unsupportedParts() can degrade it gracefully), not kept in
+    // the tool result where the provider would reject the whole request.
+    const toolResult = result.find((m) => m.role === "tool")
+    expect(toolResult).toBeDefined()
+    const output = (toolResult!.content as any[])[0] as any
+    expect(output.output.type).toBe("text")
+    expect(JSON.stringify(output.output)).not.toContain("image/png")
+
+    const mediaMsg = result.find(
+      (m) => m.role === "user" && Array.isArray(m.content) && m.content.some((c: any) => c.type === "file"),
+    )
+    expect(mediaMsg).toBeDefined()
   })
 
   test("preserves jpeg tool-result media for anthropic models", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #41162

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`supportsMediaInToolResult` in `message-v2.ts` returned `true` unconditionally for `@ai-sdk/anthropic` and `@ai-sdk/openai` npm packages. For models with `attachment: false` (no vision — e.g. GLM-5.2 served through an Anthropic-compatible endpoint), image/PDF attachments from tool results stayed **inside the tool result** and were re-sent on every subsequent turn as part of history replay. The provider then rejected the entire request with a 400 (e.g. `Model ... does not appear to support image inputs.`), killing the response instead of degrading gracefully.

The fix makes `supportsMediaInToolResult` return `false` when `model.capabilities.attachment` is false. Media then routes to the user-message path where `unsupportedParts()` degrades it to a graceful text note ("ERROR: Cannot read image ... Inform the user.") and the model replies normally — matching the behavior of the openai-compatible path.

### How did you verify your code works?

- Updated the existing tool-result-attachment test to assert extraction for a no-attachment model (`@ai-sdk/openai`, `attachment: false`).
- New test `extracts tool-result media for anthropic models without attachment capability` — anthropic npm + `attachment: false` → media extracted out of tool result into a user message.
- Full `message-v2.test.ts` suite: 40 pass / 0 fail. `bun run typecheck` clean.
- Reproduced the original failure in a real session (tool screenshot in history → 400 on later turn), confirmed the fix routes media to the graceful path.

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR