### PR TITLE
feat(opencode): let web users avoid browser launches

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -30,7 +30,12 @@ function getNetworkIPs() {
 
 export const WebCommand = effectCmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("open", {
+      type: "boolean",
+      describe: "open web interface in browser",
+      default: true,
+    }),
   describe: "start opencode server and open web interface",
   // Server loads instances per-request via x-opencode-directory header — no
   // ambient project InstanceContext needed at startup.
@@ -72,11 +77,11 @@ export const WebCommand = effectCmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      if (args.open) open(localhostUrl).catch(() => {})
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      if (args.open) open(displayUrl).catch(() => {})
     }
 
     yield* Effect.never

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -242,7 +242,8 @@ Options:
                                                                           [boolean] [default: false]
       --mdns-domain  custom domain name for mDNS service (default: opencode.local)
                                                                 [string] [default: "opencode.local"]
-      --cors         additional domains to allow for CORS                      [array] [default: []]"
+      --cors         additional domains to allow for CORS                      [array] [default: []]
+      --open         open web interface in browser                             [boolean] [default: true]"
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode models --help 1`] = `

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -106,6 +106,10 @@ describe("opencode CLI help-text snapshots", () => {
         expect(topLevel.stderr).not.toContain("--variant")
         expect(topLevel.stderr).not.toContain("--demo")
 
+        const webNoOpen = yield* opencode.spawn(["web", "--no-open", "--help"], { env: SNAPSHOT_ENV })
+        expect(webNoOpen.exitCode).toBe(0)
+        expect(webNoOpen.stderr).toContain("--open")
+
         const argvs: Array<readonly string[]> = [...TOP_LEVEL.map((c) => [c] as const), ...SUBCOMMANDS]
 
         // Spawn in parallel, then assert in argv order so snapshot output is


### PR DESCRIPTION
### Issue for this PR

Closes None

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `opencode web --no-open` for users who want the web UI to start without automatically launching a browser tab.

The `web` command now defines an `--open` option that defaults to `true`; yargs supports `--no-open` as its negation. Both browser-launch paths respect this option, while the server URL is still printed so users can open it manually.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/opencode` successfully.
- Added a CLI regression assertion that `opencode web --no-open --help` parses successfully.
- Updated the `opencode web --help` snapshot.

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR