### PR TITLE
fix(lsp): match wildcard root markers like *.cabal

### DIFF
--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -215,6 +215,16 @@ export async function* up(options: { targets: string[]; start: string; stop?: st
   let current = start
   while (true) {
     for (const target of targets) {
+      // Wildcard targets like "*.cabal" name a shape rather than a concrete path, so an
+      // existence probe can never match them. Scan the directory instead. `include: "all"`
+      // is required because some glob markers resolve to directories (e.g. Xcode's
+      // "*.xcodeproj" / "*.xcworkspace" bundles), not just files.
+      if (target.includes("*")) {
+        for (const match of await Glob.scan(target, { cwd: current, absolute: true, include: "all", dot: true })) {
+          yield match
+        }
+        continue
+      }
       const search = join(current, target)
       if (await exists(search)) yield search
     }

--- a/packages/opencode/test/lsp/glob-root.test.ts
+++ b/packages/opencode/test/lsp/glob-root.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import os from "os"
+import * as LSPServer from "@/lsp/server"
+import type { InstanceContext } from "@/project/instance-context"
+
+// Regression tests for Filesystem.up's handling of wildcard ("glob") root markers.
+//
+// Several language servers declare their project root with a glob pattern instead of a
+// concrete filename: Haskell's "*.cabal", Terraform's "*.tf", Julia's "*.jl", and Xcode/
+// Swift's "*.xcodeproj" / "*.xcworkspace" bundles. Filesystem.up previously probed these
+// with a literal exists(join(dir, target)) check, which can never match a wildcard, so the
+// server silently fell back to the workspace root. These tests lock in the scan-based fix.
+
+const tmpBase = path.join(os.tmpdir(), "opencode-glob-root")
+
+function makeCtx(directory: string): InstanceContext {
+  return { directory, worktree: "/", project: {} as any }
+}
+
+async function touch(p: string) {
+  await fs.mkdir(path.dirname(p), { recursive: true })
+  await fs.writeFile(p, "", "utf-8")
+}
+
+async function mkdir(p: string) {
+  await fs.mkdir(p, { recursive: true })
+}
+
+afterAll(async () => {
+  await fs.rm(tmpBase, { recursive: true, force: true }).catch(() => {})
+})
+
+describe("glob root markers", () => {
+  test("HLS: *.cabal resolves to the cabal package directory, not the workspace root", async () => {
+    const root = path.join(tmpBase, "hls")
+    const pkg = path.join(root, "packages", "mylib")
+    await touch(path.join(pkg, "mylib.cabal"))
+    const file = path.join(pkg, "src", "Main.hs")
+    await touch(file)
+
+    const result = await LSPServer.HLS.root(file, makeCtx(root))
+    expect(result).toBe(pkg)
+  })
+
+  test("TerraformLS: *.tf resolves to the module directory", async () => {
+    const root = path.join(tmpBase, "tf")
+    const mod = path.join(root, "modules", "vpc")
+    await touch(path.join(mod, "main.tf"))
+    await touch(path.join(root, ".terraform.lock.hcl"))
+
+    const result = await LSPServer.TerraformLS.root(path.join(mod, "main.tf"), makeCtx(root))
+    expect(result).toBe(mod)
+  })
+
+  test("JuliaLS: *.jl resolves to the directory holding the nearest .jl file", async () => {
+    const root = path.join(tmpBase, "julia")
+    const pkg = path.join(root, "src")
+    const file = path.join(pkg, "Foo.jl")
+    await touch(file)
+
+    const result = await LSPServer.JuliaLS.root(file, makeCtx(root))
+    expect(result).toBe(pkg)
+  })
+
+  test("SourceKit: *.xcodeproj (a directory bundle) resolves to the project directory", async () => {
+    const root = path.join(tmpBase, "swift")
+    const project = path.join(root, "MyApp")
+    await mkdir(path.join(project, "MyApp.xcodeproj"))
+    const file = path.join(project, "Sources", "main.swift")
+    await touch(file)
+
+    const result = await LSPServer.SourceKit.root(file, makeCtx(root))
+    expect(result).toBe(project)
+  })
+
+  test("literal (non-glob) markers keep working — no regression", async () => {
+    const root = path.join(tmpBase, "literal")
+    const pkg = path.join(root, "packages", "other")
+    await touch(path.join(pkg, "hie.yaml"))
+    const file = path.join(pkg, "src", "Lib.hs")
+    await touch(file)
+
+    const result = await LSPServer.HLS.root(file, makeCtx(root))
+    expect(result).toBe(pkg)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41168

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Filesystem.up()` in `packages/opencode/src/util/filesystem.ts` walks up the directory tree and yields any target it finds, but it only ever does a literal `exists(join(current, target))` probe. Four language servers declare their root with glob markers, so that probe can never match them:

- `HLS` -> `*.cabal`
- `TerraformLS` -> `*.tf`
- `JuliaLS` -> `*.jl`
- `SourceKit` -> `*.xcodeproj`, `*.xcworkspace`

`exists("/repo/pkg-a/*.cabal")` is always false, so `NearestRoot` yields nothing and silently falls back to the workspace root. In a multi-package Haskell repo every package ends up with the repo root as its LSP root, and the same happens for Terraform submodules, Julia packages and Xcode projects.

Fix: when a target contains `*`, scan the directory with `Glob.scan` instead of probing an exact path. `include: "all"` is required rather than `"file"`, because `*.xcodeproj` and `*.xcworkspace` are directory bundles, not files.

Literal targets keep the existing `exists` path, so their behaviour is unchanged. `Filesystem.up` is only consumed by `lsp/server.ts`, so the blast radius is limited to root detection.

### How did you verify your code works?

Added `packages/opencode/test/lsp/glob-root.test.ts`. It builds temp workspaces containing `*.cabal`, `*.tf`, `*.jl` and an `*.xcodeproj` directory, and asserts each server resolves the nested package directory instead of the workspace root, plus one literal-marker case as a control.

- With the fix: 5 pass.
- Reverting only the `up()` change: 4 fail, 1 pass (the literal control still passes). So the test genuinely guards this behaviour rather than passing either way.

Run with `bun test test/lsp/glob-root.test.ts` from `packages/opencode`. `oxlint` reports no new errors on the two touched files.

Caveat: I don't have the Haskell/Swift/Julia toolchains installed, so this verifies root resolution only, not a live language server session.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
