### PR TITLE
fix(tui): refine provider failure presentation

### DIFF
--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -1,4 +1,4 @@
-import { Cause, Context, Effect, Layer } from "effect"
+import { Cause, Context, Effect, Layer, Option, Schema } from "effect"
 import {
   FetchHttpClient,
   Headers,
@@ -198,8 +198,20 @@ const responseBody = (body: string | void, request: HttpClientRequest.HttpClient
   return { body: redacted.slice(0, BODY_LIMIT), bodyTruncated: true }
 }
 
+const decodeProviderBody = Schema.decodeUnknownOption(
+  Schema.fromJsonString(
+    Schema.Struct({
+      message: Schema.optionalKey(Schema.String),
+      error: Schema.optionalKey(Schema.Struct({ message: Schema.optionalKey(Schema.String) })),
+    }),
+  ),
+)
+
 const providerMessage = (status: number, body: { readonly body?: string }) => {
-  if (body.body && body.body.length <= 500) return `Provider request failed with HTTP ${status}: ${body.body}`
+  if (body.body && body.body.length <= 500) {
+    const decoded = Option.getOrUndefined(decodeProviderBody(body.body))
+    return `Provider request failed with HTTP ${status}: ${decoded?.error?.message ?? decoded?.message ?? body.body}`
+  }
   return `Provider request failed with HTTP ${status}`
 }
 

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1154,15 +1154,6 @@ function App(props: { pair?: DialogPairCredentials }) {
     }
   })
 
-  event.on("session.execution.failed", (evt, { workspace }) => {
-    if (workspace !== (location.current?.workspaceID ?? data.location.default().workspaceID)) return
-    toast.show({
-      variant: "error",
-      message: evt.data.error.message,
-      duration: 5000,
-    })
-  })
-
   // Suppress the full-screen overlay for transient startup and event-stream retry states.
   // Initial connection gets a longer grace period; retries surface more quickly.
   const [showReconnecting, setShowReconnecting] = createSignal(false)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1631,21 +1631,13 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
   const interrupted = createMemo(() => props.message.error?.message === "Step interrupted")
   return (
     <>
-      <Show when={props.message.error && !interrupted()}>
-        <box
-          border={["left"]}
-          paddingTop={1}
-          paddingBottom={1}
-          paddingLeft={2}
-          backgroundColor={theme.background.default}
-          customBorderChars={SplitBorder.customBorderChars}
-          borderColor={theme.text.feedback.error.default}
-        >
-          <text fg={theme.text.subdued}>{errorMessage(props.message.error)}</text>
+      <Show when={props.message.error && !interrupted() && !props.message.retry}>
+        <box paddingLeft={3}>
+          <text fg={theme.text.feedback.error.default}>Error: {errorMessage(props.message.error)}</text>
         </box>
       </Show>
       <AssistantRetry retry={props.message.retry} />
-      <box paddingLeft={3} marginTop={props.message.error && !interrupted() ? 1 : 0}>
+      <box paddingLeft={3} marginTop={props.message.retry || (props.message.error && !interrupted()) ? 1 : 0}>
         <text>
           <span style={{ fg: props.message.error ? theme.text.subdued : local.agent.color(props.message.agent) }}>
             {Locale.titlecase(props.message.agent)}
@@ -2043,7 +2035,7 @@ function AssistantRetry(props: { retry: SessionMessageAssistant["retry"] }) {
   return (
     <Show when={props.retry}>
       {(retry) => (
-        <box paddingLeft={3} marginTop={1}>
+        <box paddingLeft={3}>
           <text fg={theme.text.subdued}>
             Retry attempt {retry().attempt} scheduled: {retry().error.message} [{retry().error.type}]
           </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2036,8 +2036,8 @@ function AssistantRetry(props: { retry: SessionMessageAssistant["retry"] }) {
     <Show when={props.retry}>
       {(retry) => (
         <box paddingLeft={3}>
-          <text fg={theme.text.subdued}>
-            Retry attempt {retry().attempt} scheduled: {retry().error.message} [{retry().error.type}]
+          <text fg={theme.text.feedback.warning.default}>
+            ⚠ Retry attempt {retry().attempt} scheduled: {retry().error.message} [{retry().error.type}]
           </text>
         </box>
       )}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2037,7 +2037,7 @@ function AssistantRetry(props: { retry: SessionMessageAssistant["retry"] }) {
       {(retry) => (
         <box paddingLeft={3}>
           <text fg={theme.text.feedback.warning.default}>
-            ⚠ Retry attempt {retry().attempt} scheduled: {retry().error.message} [{retry().error.type}]
+            ⚠ Retry attempt {retry().attempt} scheduled: {retry().error.message}
           </text>
         </box>
       )}


### PR DESCRIPTION
## Summary

- render terminal provider failures as concise inline `Error:` rows and remove duplicate execution-failure toasts
- hide terminal error styling while a retry is scheduled and normalize retry/footer spacing
- extract provider messages from small JSON HTTP error bodies while retaining the full redacted body in diagnostics

## Testing

- `bun typecheck` in `packages/ai`
- `bun test test/executor.test.ts` in `packages/ai`
- `bun typecheck` in `packages/tui`
- `bun test test/cli/tui/session-rows.test.ts` in `packages/tui`
- OpenCode Drive reproductions for malformed streams, partial disconnects, content filtering, empty responses, output truncation, late stream content, malformed tool input, retries, clean EOF, and HTTP 401

## Screenshots

All screenshots were captured from the real V2 TUI with OpenCode Drive.

### Malformed stream

![Malformed stream](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/malformed-stream.png)

### Partial output followed by disconnect

![Partial disconnect](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/partial-disconnect.png)

### Content filter after partial output

![Content filter](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/content-filter.png)

### Empty successful response

![Empty successful response](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/empty-success.png)

### Output-limit truncation

![Output-limit truncation](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/truncation.png)

### Content after finish

![Content after finish](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/content-after-finish.png)

### Malformed tool arguments

![Malformed tool arguments](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/9825de026f305da447321e0734cdff563acbef7d/malformed-tool.png)

### Provider retry before output

![Provider retry](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/provider-retry.png)

### Rate-limit retry row updating in place

![Rate-limit retry attempt 2](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/rate-limit-retry-attempt-2.png)

![Rate-limit retry attempt 3](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/rate-limit-retry-attempt-3.png)

### Clean EOF: first retry

![Clean EOF first retry](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/clean-eof-first-retry.png)

### Clean EOF: accumulated retries

![Clean EOF accumulated retries](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/clean-eof-late-retry.png)

### Clean EOF: terminal exhaustion

![Clean EOF terminal exhaustion](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/b87a1522e5ac0518ac22dd7f012242e94a986ad4/clean-eof-terminal.png)

### HTTP 401 with extracted provider message

![HTTP 401](https://gist.githubusercontent.com/jlongster/5174991ceb599527cf6513c99749000f/raw/http-401.png)
