### PR TITLE
fix(merman): derive neutral diagram palette

### DIFF
--- a/packages/merman/src/palette.test.ts
+++ b/packages/merman/src/palette.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { createOpenCodeDiagramPalette } from "./palette.js"
+
+type Rgb = readonly [number, number, number]
+
+const rgb = (value: Rgb) => RGBA.fromInts(...value)
+
+describe("OpenCode diagram palette", () => {
+  test.each(
+    [
+    {
+      name: "dark theme",
+      text: [230, 232, 240],
+      subdued: [114, 120, 138],
+      secondary: [172, 176, 189],
+      muted: [149, 154, 169],
+    },
+    {
+      name: "light theme",
+      text: [32, 35, 43],
+      subdued: [119, 125, 138],
+      secondary: [76, 80, 91],
+      muted: [93, 98, 110],
+    },
+    ] satisfies ReadonlyArray<{
+      name: string
+      text: Rgb
+      subdued: Rgb
+      secondary: Rgb
+      muted: Rgb
+    }>,
+  )("derives a controlled neutral ladder for a $name", ({ text, subdued, secondary, muted }) => {
+    const primary = rgb(text)
+    const info = RGBA.fromInts(40, 120, 220)
+    const background = RGBA.fromInts(10, 20, 30)
+    const palette = createOpenCodeDiagramPalette({
+      text: primary,
+      subdued: rgb(subdued),
+      info,
+      background,
+    })
+
+    expect(palette.text).toBe(primary)
+    expect(palette.primary).toBe(primary)
+    expect(palette.secondary.equals(rgb(secondary))).toBe(true)
+    expect(palette.muted.equals(rgb(muted))).toBe(true)
+    expect(palette.warning).toBe(info)
+    expect(palette.background).toBe(background)
+  })
+})

--- a/packages/merman/src/palette.ts
+++ b/packages/merman/src/palette.ts
@@ -1,0 +1,20 @@
+import type { RGBA } from "@opentui/core"
+import { blendColor } from "./core/color/style.js"
+
+export interface OpenCodeDiagramPaletteInput {
+  readonly text: RGBA
+  readonly subdued: RGBA
+  readonly info: RGBA
+  readonly background: RGBA
+}
+
+export function createOpenCodeDiagramPalette(input: OpenCodeDiagramPaletteInput) {
+  return {
+    text: input.text,
+    primary: input.text,
+    secondary: blendColor(input.text, input.subdued, 0.5),
+    muted: blendColor(input.text, input.subdued, 0.7),
+    warning: input.info,
+    background: input.background,
+  }
+}

--- a/packages/merman/src/plugin.ts
+++ b/packages/merman/src/plugin.ts
@@ -1,5 +1,6 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createMermaidCodeBlockRenderer } from "./markdown.js"
+import { createOpenCodeDiagramPalette } from "./palette.js"
 
 export default Plugin.define({
   id: "opencode.merman",
@@ -7,14 +8,12 @@ export default Plugin.define({
     context.markdown.registerCodeBlockRenderer(
       "mermaid",
       createMermaidCodeBlockRenderer(context.renderer, () => ({
-        colors: {
-          text: context.theme.markdown.text,
-          primary: context.theme.text.default,
-          secondary: context.theme.text.subdued,
-          muted: context.theme.border.default,
-          warning: context.theme.text.feedback.info.default,
+        colors: createOpenCodeDiagramPalette({
+          text: context.theme.text.default,
+          subdued: context.theme.text.subdued,
+          info: context.theme.text.feedback.info.default,
           background: context.theme.background.default,
-        },
+        }),
       })),
     )
   },


### PR DESCRIPTION
## What

Derive Merman's neutral diagram palette from OpenCode's foreground text colors so themes with faint border tokens do not produce harsh or disappearing structural lines.

## Before / After

**Before:** Merman mapped `secondary` directly to `text.subdued` and `muted` to `border.default`. Themes are free to place those independent tokens far apart, so color ramps could jump from bright node frames to nearly invisible routes and containers.

**After:** primary remains `text.default`, while secondary and muted are controlled 50% and 70% blends toward `text.subdued`. Notes remain informationally colored. Adjacent diagram roles now form a predictable tonal ladder in both light and dark themes.

## How

- `palette.ts` owns the OpenCode-specific semantic mapping.
- The existing RGBA `blendColor` helper performs channel interpolation.
- `plugin.ts` supplies the resolved palette to all three diagram renderers.

## Scope

This changes only OpenCode's built-in Merman theme adapter. It does not change standalone renderer defaults or diagram layout.

## Testing

- `bun run typecheck` in `packages/merman`
- `bun run test` in `packages/merman` (214 tests)
- Push-hook monorepo typecheck (33 tasks)
- OpenCode Drive rendering across `opencode`, `tokyonight`, `github`, `rosepine`, and `gruvbox`
- Exact dark- and light-direction palette unit cases

## Demo

The recording holds the same flowchart and sequence diagrams for one second under each of five contrasting themes.

https://github.com/user-attachments/assets/e1b5d0a2-e845-416b-81f5-9434f03e52be
