### PR TITLE
fix(core): reuse shared patch diff

### DIFF
--- a/packages/core/src/tool/plugin/patch.ts
+++ b/packages/core/src/tool/plugin/patch.ts
@@ -3,7 +3,6 @@ export * as PatchTool from "./patch"
 import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
 import { ToolFailure } from "@opencode-ai/ai"
 import { FileDiff } from "@opencode-ai/schema/file-diff"
-import { createTwoFilesPatch, diffLines } from "diff"
 import { Effect, Result, Schema } from "effect"
 import path from "path"
 import { Bom } from "@opencode-ai/util/bom"
@@ -15,6 +14,7 @@ import { Location } from "../../location"
 import { Patch } from "@opencode-ai/util/patch"
 import { Permission } from "../../permission"
 import DESCRIPTION from "../patch.txt"
+import { fileDiff } from "./file-diff"
 
 export const name = "patch"
 
@@ -353,22 +353,16 @@ function errorMessage(error: unknown) {
 
 function patchFile(change: Prepared, after = change.after): typeof FileDiff.Info.Type {
   const target = (change.type === "update" ? change.moveTarget : undefined)?.resource ?? change.target.resource
-  const patch = trimDiff(createTwoFilesPatch(change.target.absolute, change.target.absolute, change.before, after))
-  const counts =
-    change.type === "delete"
-      ? { additions: 0, deletions: change.before.split("\n").length }
-      : diffLines(change.before, after).reduce(
-          (result, item) => ({
-            additions: result.additions + (item.added ? (item.count ?? 0) : 0),
-            deletions: result.deletions + (item.removed ? (item.count ?? 0) : 0),
-          }),
-          { additions: 0, deletions: 0 },
-        )
+  const diff = fileDiff(
+    change.target.absolute,
+    change.before,
+    after,
+    change.type === "add" ? "added" : change.type === "delete" ? "deleted" : "modified",
+  )
   return {
+    ...diff,
     file: target,
-    patch,
-    status: change.type === "add" ? "added" : change.type === "delete" ? "deleted" : "modified",
-    ...counts,
+    patch: trimDiff(diff.patch),
   }
 }
 

--- a/packages/core/test/tool-patch.test.ts
+++ b/packages/core/test/tool-patch.test.ts
@@ -215,7 +215,7 @@ describe("PatchTool", () => {
                       file: "remove.txt",
                       status: "deleted",
                       additions: 0,
-                      deletions: 2,
+                      deletions: 1,
                       patch: expect.stringContaining("-remove"),
                     },
                   ],
@@ -245,6 +245,29 @@ describe("PatchTool", () => {
         )
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("counts deleted lines with and without a trailing newline", () =>
+    withTempTool((directory, registry) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          Promise.all([
+            fs.writeFile(path.join(directory, "trailing.txt"), "remove\n"),
+            fs.writeFile(path.join(directory, "unterminated.txt"), "remove"),
+          ]),
+        )
+        const settled = yield* executeTool(
+          registry,
+          call("*** Begin Patch\n*** Delete File: trailing.txt\n*** Delete File: unterminated.txt\n*** End Patch"),
+        )
+        expect(settled.status).toBe("completed")
+        if (settled.status !== "completed") return
+        expect(settled.output.files).toMatchObject([
+          { file: "trailing.txt", additions: 0, deletions: 1 },
+          { file: "unterminated.txt", additions: 0, deletions: 1 },
+        ])
+      }),
     ),
   )
 
@@ -446,7 +469,7 @@ describe("PatchTool", () => {
             {
               file: "renamed/dir/name.txt",
               status: "modified",
-              patch: expect.stringContaining("-old content\n+new content"),
+              patch: expect.stringContaining(`Index: ${source}`),
             },
           ],
         })


### PR DESCRIPTION
## What

Consolidate Patch file-diff construction on the shared `fileDiff` helper used by edit/write. This corrects the observable deletion count for a one-line file ending in a newline from `2` to `1`.

## Before / After

**Before:** deleting a file containing `remove\n` generated a patch with one removed line but returned `deletions: 2` because Patch counted `before.split("\n").length`. Patch also duplicated patch construction and line-counting logic already owned by `fileDiff`.

**After:** Patch delegates patch construction and additions/deletions counting to `fileDiff`, so both `remove\n` and `remove` report `deletions: 1`. Move results still expose the destination resource in `file`, while generated patch headers still identify the source path.

## How

- `packages/core/src/tool/plugin/patch.ts` calls `fileDiff` with the source absolute path and Patch status, then preserves Patch-specific destination-resource projection and `trimDiff` processing.
- `packages/core/test/tool-patch.test.ts` covers one-line deletions with and without a trailing newline and pins move patch headers to the source path.

## Scope

- No changes to the shared `fileDiff` helper.
- No changes to Patch formatting, mutation, permission, or move behavior beyond consolidating diff construction and correcting the derived deletion count.

## Testing

- `cd packages/core && bun run test test/tool-patch.test.ts` (37 passed)
- `cd packages/core && bun typecheck`
- `bun run lint packages/core/src/tool/plugin/patch.ts packages/core/test/tool-patch.test.ts`
- `bunx prettier --check packages/core/src/tool/plugin/patch.ts packages/core/test/tool-patch.test.ts`
- `bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/tool/plugin/patch.ts`
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks passed)

Also attempted the repository-wide `bun run lint:effect-patterns`; it remains blocked by six pre-existing diagnostics in unrelated files (`filesystem/watcher.ts`, `session.ts`, `aisdk.ts`, `models-dev.ts`, `tool/read-filesystem.ts`, and `tool/runtime.ts`).