### PR TITLE
feat(tui): hierarchical slot tree for plugin UI placement

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -169,6 +169,55 @@ export interface SlotMap {
 export type SlotName = keyof SlotMap
 export type Slot<Name extends SlotName = SlotName> = (props: SlotMap[Name]) => JSX.Element
 
+/**
+ * The host UI's extensible regions. Each region publishes an input (reactive
+ * props passed to every claim render) and a part vocabulary: the stable ids
+ * of host furniture that placements may anchor to. Part ids are documented
+ * API — coarse, few, and kept stable across host refactors.
+ */
+export interface RegionMap {
+  readonly app: { readonly input: Readonly<Record<string, never>>; readonly part: never }
+  readonly "home.footer": { readonly input: Readonly<Record<string, never>>; readonly part: never }
+  readonly "prompt.footer": {
+    readonly input: { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+    readonly part: "status" | "file"
+  }
+  readonly "session.composer.top": { readonly input: { readonly sessionID: string }; readonly part: never }
+  readonly "sidebar.content": { readonly input: { readonly sessionID: string }; readonly part: never }
+  readonly "sidebar.footer": { readonly input: Readonly<Record<string, never>>; readonly part: never }
+}
+export type RegionName = keyof RegionMap
+
+/**
+ * Where a claim lands in a region's structure. Exactly one of:
+ * - `at`: the region's edge — `"end"` is the ceremony-free default position
+ * - `before` / `after`: adjacent to a host part, wherever the host keeps it
+ * - `replace`: take over one part — or the whole region by naming it.
+ *   Replace is takeover: anything anchored inside the replaced subtree is
+ *   suppressed and recorded, never silently dropped. At the same target the
+ *   last-enabled claim wins; an ancestor takeover beats a descendant one
+ *   regardless of order.
+ * A placement aimed at a part the host no longer publishes degrades to the
+ * region's end (after end-edge claims) rather than disappearing.
+ *
+ * The `?: never` fields make the variants mutually exclusive: a claim with
+ * two placement keys is a type error, not a silent priority pick.
+ */
+export type RegionPlacement<Name extends RegionName = RegionName> =
+  | { readonly at: "start" | "end"; readonly before?: never; readonly after?: never; readonly replace?: never }
+  | { readonly before: RegionMap[Name]["part"]; readonly at?: never; readonly after?: never; readonly replace?: never }
+  | { readonly after: RegionMap[Name]["part"]; readonly at?: never; readonly before?: never; readonly replace?: never }
+  | {
+      readonly replace: RegionMap[Name]["part"] | Name
+      readonly at?: never
+      readonly before?: never
+      readonly after?: never
+    }
+
+export type RegionClaim<Name extends RegionName = RegionName> = RegionPlacement<Name> & {
+  readonly render: (input: RegionMap[Name]["input"]) => JSX.Element
+}
+
 export interface App {
   readonly version: string
   readonly channel: string
@@ -394,7 +443,16 @@ export interface UI {
     /** Closes an open tab, or the active tab when omitted, and returns false when no tab matched. */
     close(sessionID?: string): boolean
   }
-  readonly slot: <Name extends SlotName>(name: Name, render: Slot<Name>) => () => void
+  readonly slot: {
+    /**
+     * @deprecated Position-encoded slot names are the legacy surface; use
+     * the region + placement form. `slot("prompt.footer.end", render)` is
+     * `slot("prompt.footer", { at: "end", render })`.
+     */
+    <Name extends SlotName>(name: Name, render: Slot<Name>): () => void
+    /** Claims a place in a region's structure; see RegionPlacement. */
+    <Name extends RegionName>(region: Name, claim: RegionClaim<Name>): () => void
+  }
 }
 
 export interface Context {

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -150,25 +150,6 @@ export interface Page {
   readonly render: (input: { readonly data?: Record<string, any> }) => JSX.Element
 }
 
-export interface SlotMap {
-  readonly app: Readonly<Record<string, never>>
-  readonly "home.footer": Readonly<Record<string, never>>
-  readonly "prompt.footer.end": {
-    readonly sessionID?: string
-    readonly mode: "normal" | "shell"
-  }
-  readonly "session.composer.top": {
-    readonly sessionID: string
-  }
-  readonly "sidebar.content": {
-    readonly sessionID: string
-  }
-  readonly "sidebar.footer": Readonly<Record<string, never>>
-}
-
-export type SlotName = keyof SlotMap
-export type Slot<Name extends SlotName = SlotName> = (props: SlotMap[Name]) => JSX.Element
-
 /**
  * The host UI's extensible regions. Each region publishes an input (reactive
  * props passed to every claim render) and a part vocabulary: the stable ids
@@ -443,16 +424,8 @@ export interface UI {
     /** Closes an open tab, or the active tab when omitted, and returns false when no tab matched. */
     close(sessionID?: string): boolean
   }
-  readonly slot: {
-    /**
-     * @deprecated Position-encoded slot names are the legacy surface; use
-     * the region + placement form. `slot("prompt.footer.end", render)` is
-     * `slot("prompt.footer", { at: "end", render })`.
-     */
-    <Name extends SlotName>(name: Name, render: Slot<Name>): () => void
-    /** Claims a place in a region's structure; see RegionPlacement. */
-    <Name extends RegionName>(region: Name, claim: RegionClaim<Name>): () => void
-  }
+  /** Claims a place in a region's structure; see RegionPlacement. */
+  readonly slot: <Name extends RegionName>(region: Name, claim: RegionClaim<Name>) => () => void
 }
 
 export interface Context {

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -150,6 +150,8 @@ export interface Page {
   readonly render: (input: { readonly data?: Record<string, any> }) => JSX.Element
 }
 
+type PromptFooterInput = { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+
 /**
  * The host UI's slot tree. Every path is one slot: a named boundary a plugin
  * may render around, inside, or take over. Paths are absolute and
@@ -158,16 +160,15 @@ export interface Page {
  *
  * Each slot publishes an input: reactive props passed to every claim render
  * targeting it. Inputs carry only what the SDK cannot answer — instance
- * identity (which composer, which session) and client-local state — never
- * data derivable through the client. Paths and their inputs are documented
+ * identity and client-local state. Paths and their inputs are documented
  * API: coarse, few, and kept stable across host refactors.
  */
 export interface SlotMap {
   readonly app: Readonly<Record<string, never>>
   readonly "home.footer": Readonly<Record<string, never>>
-  readonly "prompt.footer": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
-  readonly "prompt.footer.status": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
-  readonly "prompt.footer.file": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+  readonly "prompt.footer": PromptFooterInput
+  readonly "prompt.footer.status": PromptFooterInput
+  readonly "prompt.footer.file": PromptFooterInput
   readonly "session.composer.top": { readonly sessionID: string }
   readonly "sidebar.content": { readonly sessionID: string }
   readonly "sidebar.footer": Readonly<Record<string, never>>

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -151,53 +151,87 @@ export interface Page {
 }
 
 /**
- * The host UI's extensible regions. Each region publishes an input (reactive
- * props passed to every claim render) and a part vocabulary: the stable ids
- * of host furniture that placements may anchor to. Part ids are documented
- * API — coarse, few, and kept stable across host refactors.
+ * The host UI's slot tree. Every path is one slot: a named boundary a plugin
+ * may render around, inside, or take over. Paths are absolute and
+ * dot-separated, and a path contains every path it prefixes — replacing
+ * `prompt.footer` owns everything under `prompt.footer.*`.
+ *
+ * Each slot publishes an input: reactive props passed to every claim render
+ * targeting it. Inputs carry only what the SDK cannot answer — instance
+ * identity (which composer, which session) and client-local state — never
+ * data derivable through the client. Paths and their inputs are documented
+ * API: coarse, few, and kept stable across host refactors.
  */
-export interface RegionMap {
-  readonly app: { readonly input: Readonly<Record<string, never>>; readonly part: never }
-  readonly "home.footer": { readonly input: Readonly<Record<string, never>>; readonly part: never }
-  readonly "prompt.footer": {
-    readonly input: { readonly sessionID?: string; readonly mode: "normal" | "shell" }
-    readonly part: "status" | "file"
-  }
-  readonly "session.composer.top": { readonly input: { readonly sessionID: string }; readonly part: never }
-  readonly "sidebar.content": { readonly input: { readonly sessionID: string }; readonly part: never }
-  readonly "sidebar.footer": { readonly input: Readonly<Record<string, never>>; readonly part: never }
+export interface SlotMap {
+  readonly app: Readonly<Record<string, never>>
+  readonly "home.footer": Readonly<Record<string, never>>
+  readonly "prompt.footer": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+  readonly "prompt.footer.status": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+  readonly "prompt.footer.file": { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+  readonly "session.composer.top": { readonly sessionID: string }
+  readonly "sidebar.content": { readonly sessionID: string }
+  readonly "sidebar.footer": Readonly<Record<string, never>>
 }
-export type RegionName = keyof RegionMap
+export type SlotPath = keyof SlotMap
 
 /**
- * Where a claim lands in a region's structure. Exactly one of:
- * - `at`: the region's edge — `"end"` is the ceremony-free default position
- * - `before` / `after`: adjacent to a host part, wherever the host keeps it
- * - `replace`: take over one part — or the whole region by naming it.
- *   Replace is takeover: anything anchored inside the replaced subtree is
- *   suppressed and recorded, never silently dropped. At the same target the
- *   last-enabled claim wins; an ancestor takeover beats a descendant one
- *   regardless of order.
- * A placement aimed at a part the host no longer publishes degrades to the
- * region's end (after end-edge claims) rather than disappearing.
+ * One contribution to the slot tree. Exactly one placement key names an
+ * absolute target path:
+ * - `prepend` / `append`: first/last inside the target's boundary
+ * - `before` / `after`: siblings adjacent to the target, outside its boundary
+ * - `replace`: take over the target. The boundary itself survives — siblings
+ *   anchored `before`/`after` it still compose — but the original content and
+ *   every claim inside the boundary are suppressed and recorded, never
+ *   silently dropped. At the same target the last-enabled claim wins; an
+ *   ancestor replacement beats a descendant one regardless of enable order.
  *
- * The `?: never` fields make the variants mutually exclusive: a claim with
- * two placement keys is a type error, not a silent priority pick.
+ * A claim aimed at a path the host no longer publishes degrades: additive
+ * claims append to the nearest surviving ancestor, replacements are
+ * suppressed. Several claims at one anchor coexist in plugin enable order.
+ *
+ * `render` receives the target slot's input, reactively. The `?: never`
+ * fields make the variants mutually exclusive: a claim with two placement
+ * keys is a type error, not a silent priority pick.
  */
-export type RegionPlacement<Name extends RegionName = RegionName> =
-  | { readonly at: "start" | "end"; readonly before?: never; readonly after?: never; readonly replace?: never }
-  | { readonly before: RegionMap[Name]["part"]; readonly at?: never; readonly after?: never; readonly replace?: never }
-  | { readonly after: RegionMap[Name]["part"]; readonly at?: never; readonly before?: never; readonly replace?: never }
-  | {
-      readonly replace: RegionMap[Name]["part"] | Name
-      readonly at?: never
-      readonly before?: never
-      readonly after?: never
-    }
-
-export type RegionClaim<Name extends RegionName = RegionName> = RegionPlacement<Name> & {
-  readonly render: (input: RegionMap[Name]["input"]) => JSX.Element
-}
+export type SlotClaim<Path extends SlotPath = SlotPath> = Path extends SlotPath
+  ? { readonly render: (input: SlotMap[Path]) => JSX.Element } & (
+      | {
+          readonly prepend: Path
+          readonly append?: never
+          readonly before?: never
+          readonly after?: never
+          readonly replace?: never
+        }
+      | {
+          readonly append: Path
+          readonly prepend?: never
+          readonly before?: never
+          readonly after?: never
+          readonly replace?: never
+        }
+      | {
+          readonly before: Path
+          readonly prepend?: never
+          readonly append?: never
+          readonly after?: never
+          readonly replace?: never
+        }
+      | {
+          readonly after: Path
+          readonly prepend?: never
+          readonly append?: never
+          readonly before?: never
+          readonly replace?: never
+        }
+      | {
+          readonly replace: Path
+          readonly prepend?: never
+          readonly append?: never
+          readonly before?: never
+          readonly after?: never
+        }
+    )
+  : never
 
 export interface App {
   readonly version: string
@@ -424,8 +458,8 @@ export interface UI {
     /** Closes an open tab, or the active tab when omitted, and returns false when no tab matched. */
     close(sessionID?: string): boolean
   }
-  /** Claims a place in a region's structure; see RegionPlacement. */
-  readonly slot: <Name extends RegionName>(region: Name, claim: RegionClaim<Name>) => () => void
+  /** Claims a place in the slot tree; see SlotClaim. */
+  readonly slot: (claim: SlotClaim) => () => void
 }
 
 export interface Context {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -87,7 +87,7 @@ import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { Config, ConfigProvider, useConfig } from "./config"
 import { PluginProvider, usePlugin, type PackageResolver } from "./plugin/context"
 import { tuiPluginDirectories } from "./plugin/discovery"
-import { PluginRoute, Region } from "./plugin/render"
+import { PluginRoute, Slot } from "./plugin/render"
 import { CommandPaletteDialog } from "./component/command-palette"
 import { COMMAND_PALETTE_COMMAND, Keymap, type KeymapCommand } from "./context/keymap"
 
@@ -1240,7 +1240,7 @@ function App(props: { pair?: DialogPairCredentials }) {
                 </Match>
               </Switch>
             </box>
-            <Region name="app" input={{}} />
+            <Slot path="app" />
           </Show>
         </box>
       </box>

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -87,7 +87,7 @@ import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { Config, ConfigProvider, useConfig } from "./config"
 import { PluginProvider, usePlugin, type PackageResolver } from "./plugin/context"
 import { tuiPluginDirectories } from "./plugin/discovery"
-import { PluginRoute, PluginSlot } from "./plugin/render"
+import { PluginRoute, Region } from "./plugin/render"
 import { CommandPaletteDialog } from "./component/command-palette"
 import { COMMAND_PALETTE_COMMAND, Keymap, type KeymapCommand } from "./context/keymap"
 
@@ -1240,7 +1240,7 @@ function App(props: { pair?: DialogPairCredentials }) {
                 </Match>
               </Switch>
             </box>
-            <PluginSlot name="app" input={{}} mode="all" />
+            <Region name="app" input={{}} />
           </Show>
         </box>
       </box>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1469,6 +1469,7 @@ export function Prompt(props: PromptProps) {
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
+  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined
@@ -1778,8 +1779,8 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
-          <Slot path="prompt.footer" input={{ sessionID: props.sessionID, mode: store.mode }}>
-            <Slot path="prompt.footer.status" input={{ sessionID: props.sessionID, mode: store.mode }}>
+          <Slot path="prompt.footer" input={footerInput()}>
+            <Slot path="prompt.footer.status" input={footerInput()}>
               <box flexGrow={1} flexShrink={1} minWidth={0}>
                 <Switch>
                   <Match when={status() === "running"}>
@@ -1835,7 +1836,7 @@ export function Prompt(props: PromptProps) {
                 </Switch>
               </box>
             </Slot>
-            <Slot path="prompt.footer.file" input={{ sessionID: props.sessionID, mode: store.mode }}>
+            <Slot path="prompt.footer.file" input={footerInput()}>
               <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
                 {(file) => (
                   <text

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -58,7 +58,7 @@ import { useData } from "../../context/data"
 import { useLocation } from "../../context/location"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
-import { PluginSlot } from "../../plugin/render"
+import { Region } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import {
   deduplicatePromptImages,
@@ -1778,76 +1778,93 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
-          <box flexGrow={1} flexShrink={1} minWidth={0}>
-            <Switch>
-              <Match when={status() === "running"}>
-                <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
-                  <box marginLeft={1}>
-                    <Show when={config.animations ?? true} fallback={<text fg={theme.text.subdued}>[⋯]</text>}>
-                      <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
-                    </Show>
-                  </box>
-                  <text
-                    fg={store.interrupt > 0 ? theme.background.action.primary.default : theme.text.default}
-                    wrapMode="none"
-                    truncate
-                    flexShrink={1}
-                  >
-                    esc{" "}
-                    <span
-                      style={{
-                        fg: store.interrupt > 0 ? theme.background.action.primary.default : theme.text.subdued,
-                      }}
-                    >
-                      {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                    </span>
-                  </text>
-                </box>
-              </Match>
-              <Match when={move.progress()}>
-                {(progress) => (
-                  <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
-                    <Spinner color={theme.hue.accent[500]}>
-                      {progress()}
-                      <span style={{ fg: theme.text.subdued }}>{".".repeat(move.creatingDots())}</span>
-                    </Spinner>
-                  </box>
-                )}
-              </Match>
-              <Match when={move.pendingNew()}>
-                <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
-                  <text fg={theme.hue.accent[500]} wrapMode="none" truncate>
-                    (new working copy)
-                  </text>
-                </box>
-              </Match>
-              <Match when={true}>
-                <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
-                  {(location) => (
-                    <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
-                      {location()}
-                    </text>
-                  )}
-                </Show>
-              </Match>
-            </Switch>
-          </box>
-          <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
-            {(file) => (
-              <text
-                wrapMode="none"
-                truncate
-                flexShrink={1}
-                fg={editorContextLabelState() === "pending" ? theme.hue.accent[500] : theme.text.subdued}
-              >
-                {file()}
-              </text>
-            )}
-          </Show>
-          <PluginSlot
-            name="prompt.footer.end"
+          <Region
+            name="prompt.footer"
             input={{ sessionID: props.sessionID, mode: store.mode }}
-            mode="replace"
+            parts={[
+              {
+                id: "status",
+                render: () => (
+                  <box flexGrow={1} flexShrink={1} minWidth={0}>
+                    <Switch>
+                      <Match when={status() === "running"}>
+                        <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
+                          <box marginLeft={1}>
+                            <Show
+                              when={config.animations ?? true}
+                              fallback={<text fg={theme.text.subdued}>[⋯]</text>}
+                            >
+                              <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
+                            </Show>
+                          </box>
+                          <text
+                            fg={store.interrupt > 0 ? theme.background.action.primary.default : theme.text.default}
+                            wrapMode="none"
+                            truncate
+                            flexShrink={1}
+                          >
+                            esc{" "}
+                            <span
+                              style={{
+                                fg:
+                                  store.interrupt > 0
+                                    ? theme.background.action.primary.default
+                                    : theme.text.subdued,
+                              }}
+                            >
+                              {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                            </span>
+                          </text>
+                        </box>
+                      </Match>
+                      <Match when={move.progress()}>
+                        {(progress) => (
+                          <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                            <Spinner color={theme.hue.accent[500]}>
+                              {progress()}
+                              <span style={{ fg: theme.text.subdued }}>{".".repeat(move.creatingDots())}</span>
+                            </Spinner>
+                          </box>
+                        )}
+                      </Match>
+                      <Match when={move.pendingNew()}>
+                        <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                          <text fg={theme.hue.accent[500]} wrapMode="none" truncate>
+                            (new working copy)
+                          </text>
+                        </box>
+                      </Match>
+                      <Match when={true}>
+                        <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
+                          {(location) => (
+                            <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
+                              {location()}
+                            </text>
+                          )}
+                        </Show>
+                      </Match>
+                    </Switch>
+                  </box>
+                ),
+              },
+              {
+                id: "file",
+                render: () => (
+                  <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
+                    {(file) => (
+                      <text
+                        wrapMode="none"
+                        truncate
+                        flexShrink={1}
+                        fg={editorContextLabelState() === "pending" ? theme.hue.accent[500] : theme.text.subdued}
+                      >
+                        {file()}
+                      </text>
+                    )}
+                  </Show>
+                ),
+              },
+            ]}
           />
         </box>
       </box>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -58,7 +58,7 @@ import { useData } from "../../context/data"
 import { useLocation } from "../../context/location"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
-import { Region } from "../../plugin/render"
+import { Slot } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import {
   deduplicatePromptImages,
@@ -1778,94 +1778,78 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
-          <Region
-            name="prompt.footer"
-            input={{ sessionID: props.sessionID, mode: store.mode }}
-            parts={[
-              {
-                id: "status",
-                render: () => (
-                  <box flexGrow={1} flexShrink={1} minWidth={0}>
-                    <Switch>
-                      <Match when={status() === "running"}>
-                        <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
-                          <box marginLeft={1}>
-                            <Show
-                              when={config.animations ?? true}
-                              fallback={<text fg={theme.text.subdued}>[⋯]</text>}
-                            >
-                              <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
-                            </Show>
-                          </box>
-                          <text
-                            fg={store.interrupt > 0 ? theme.background.action.primary.default : theme.text.default}
-                            wrapMode="none"
-                            truncate
-                            flexShrink={1}
-                          >
-                            esc{" "}
-                            <span
-                              style={{
-                                fg:
-                                  store.interrupt > 0
-                                    ? theme.background.action.primary.default
-                                    : theme.text.subdued,
-                              }}
-                            >
-                              {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                            </span>
-                          </text>
-                        </box>
-                      </Match>
-                      <Match when={move.progress()}>
-                        {(progress) => (
-                          <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
-                            <Spinner color={theme.hue.accent[500]}>
-                              {progress()}
-                              <span style={{ fg: theme.text.subdued }}>{".".repeat(move.creatingDots())}</span>
-                            </Spinner>
-                          </box>
-                        )}
-                      </Match>
-                      <Match when={move.pendingNew()}>
-                        <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
-                          <text fg={theme.hue.accent[500]} wrapMode="none" truncate>
-                            (new working copy)
-                          </text>
-                        </box>
-                      </Match>
-                      <Match when={true}>
-                        <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
-                          {(location) => (
-                            <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
-                              {location()}
-                            </text>
-                          )}
+          <Slot path="prompt.footer" input={{ sessionID: props.sessionID, mode: store.mode }}>
+            <Slot path="prompt.footer.status" input={{ sessionID: props.sessionID, mode: store.mode }}>
+              <box flexGrow={1} flexShrink={1} minWidth={0}>
+                <Switch>
+                  <Match when={status() === "running"}>
+                    <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
+                      <box marginLeft={1}>
+                        <Show when={config.animations ?? true} fallback={<text fg={theme.text.subdued}>[⋯]</text>}>
+                          <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
                         </Show>
-                      </Match>
-                    </Switch>
-                  </box>
-                ),
-              },
-              {
-                id: "file",
-                render: () => (
-                  <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
-                    {(file) => (
+                      </box>
                       <text
+                        fg={store.interrupt > 0 ? theme.background.action.primary.default : theme.text.default}
                         wrapMode="none"
                         truncate
                         flexShrink={1}
-                        fg={editorContextLabelState() === "pending" ? theme.hue.accent[500] : theme.text.subdued}
                       >
-                        {file()}
+                        esc{" "}
+                        <span
+                          style={{
+                            fg: store.interrupt > 0 ? theme.background.action.primary.default : theme.text.subdued,
+                          }}
+                        >
+                          {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                        </span>
                       </text>
+                    </box>
+                  </Match>
+                  <Match when={move.progress()}>
+                    {(progress) => (
+                      <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                        <Spinner color={theme.hue.accent[500]}>
+                          {progress()}
+                          <span style={{ fg: theme.text.subdued }}>{".".repeat(move.creatingDots())}</span>
+                        </Spinner>
+                      </box>
                     )}
-                  </Show>
-                ),
-              },
-            ]}
-          />
+                  </Match>
+                  <Match when={move.pendingNew()}>
+                    <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                      <text fg={theme.hue.accent[500]} wrapMode="none" truncate>
+                        (new working copy)
+                      </text>
+                    </box>
+                  </Match>
+                  <Match when={true}>
+                    <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
+                      {(location) => (
+                        <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
+                          {location()}
+                        </text>
+                      )}
+                    </Show>
+                  </Match>
+                </Switch>
+              </box>
+            </Slot>
+            <Slot path="prompt.footer.file" input={{ sessionID: props.sessionID, mode: store.mode }}>
+              <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
+                {(file) => (
+                  <text
+                    wrapMode="none"
+                    truncate
+                    flexShrink={1}
+                    fg={editorContextLabelState() === "pending" ? theme.hue.accent[500] : theme.text.subdued}
+                  >
+                    {file()}
+                  </text>
+                )}
+              </Show>
+            </Slot>
+          </Slot>
         </box>
       </box>
       <Autocomplete

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -64,6 +64,6 @@ export default Plugin.define({
   setup(context) {
     // Root takeover: an external plugin replacing home.footer wins (last-
     // enabled) and this builtin shows as suppressed, not silently gone.
-    context.ui.slot("home.footer", { replace: "home.footer", render: () => <View context={context} /> })
+    context.ui.slot({ replace: "home.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -62,6 +62,8 @@ function View(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id: "opencode.home-footer",
   setup(context) {
-    context.ui.slot("home.footer", () => <View context={context} />)
+    // Root takeover: an external plugin replacing home.footer wins (last-
+    // enabled) and this builtin shows as suppressed, not silently gone.
+    context.ui.slot("home.footer", { replace: "home.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -64,6 +64,8 @@ export default Plugin.define({
   setup(context) {
     // Root takeover: an external plugin replacing home.footer wins (last-
     // enabled) and this builtin shows as suppressed, not silently gone.
-    context.ui.slot({ replace: "home.footer", render: () => <View context={context} /> })
+    // Append keeps the path open to additive plugin claims; an external
+    // replace still takes the boundary over.
+    context.ui.slot({ append: "home.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -85,8 +85,9 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
 export default Plugin.define({
   id: "opencode.prompt-footer",
   setup(context) {
-    context.ui.slot("prompt.footer.end", (props) => (
-      <PromptFooter context={context} sessionID={props.sessionID} mode={props.mode} />
-    ))
+    context.ui.slot("prompt.footer", {
+      at: "end",
+      render: (props) => <PromptFooter context={context} sessionID={props.sessionID} mode={props.mode} />,
+    })
   },
 })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -85,8 +85,8 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
 export default Plugin.define({
   id: "opencode.prompt-footer",
   setup(context) {
-    context.ui.slot("prompt.footer", {
-      at: "end",
+    context.ui.slot({
+      append: "prompt.footer",
       render: (props) => <PromptFooter context={context} sessionID={props.sessionID} mode={props.mode} />,
     })
   },

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -44,6 +44,9 @@ export function SidebarContext(props: { context: Plugin.Context; sessionID: stri
 export default Plugin.define({
   id: "internal:sidebar-context",
   setup(context) {
-    context.ui.slot("sidebar.content", (props) => <SidebarContext context={context} sessionID={props.sessionID} />)
+    context.ui.slot("sidebar.content", {
+      at: "end",
+      render: (props) => <SidebarContext context={context} sessionID={props.sessionID} />,
+    })
   },
 })

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -44,8 +44,8 @@ export function SidebarContext(props: { context: Plugin.Context; sessionID: stri
 export default Plugin.define({
   id: "internal:sidebar-context",
   setup(context) {
-    context.ui.slot("sidebar.content", {
-      at: "end",
+    context.ui.slot({
+      append: "sidebar.content",
       render: (props) => <SidebarContext context={context} sessionID={props.sessionID} />,
     })
   },

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -19,6 +19,8 @@ function View(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id: "opencode.sidebar-footer",
   setup(context) {
-    context.ui.slot({ replace: "sidebar.footer", render: () => <View context={context} /> })
+    // Append keeps the path open to additive plugin claims; an external
+    // replace still takes the boundary over.
+    context.ui.slot({ append: "sidebar.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -19,6 +19,6 @@ function View(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id: "opencode.sidebar-footer",
   setup(context) {
-    context.ui.slot("sidebar.footer", { replace: "sidebar.footer", render: () => <View context={context} /> })
+    context.ui.slot({ replace: "sidebar.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -19,6 +19,6 @@ function View(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id: "opencode.sidebar-footer",
   setup(context) {
-    context.ui.slot("sidebar.footer", () => <View context={context} />)
+    context.ui.slot("sidebar.footer", { replace: "sidebar.footer", render: () => <View context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -73,6 +73,9 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
 export default Plugin.define({
   id: "internal:sidebar-mcp",
   setup(context) {
-    context.ui.slot("sidebar.content", (props) => <View context={context} sessionID={props.sessionID} />)
+    context.ui.slot("sidebar.content", {
+      at: "end",
+      render: (props) => <View context={context} sessionID={props.sessionID} />,
+    })
   },
 })

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -73,8 +73,8 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
 export default Plugin.define({
   id: "internal:sidebar-mcp",
   setup(context) {
-    context.ui.slot("sidebar.content", {
-      at: "end",
+    context.ui.slot({
+      append: "sidebar.content",
       render: (props) => <View context={context} sessionID={props.sessionID} />,
     })
   },

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -1090,6 +1090,6 @@ export default Plugin.define({
       name: ROUTE,
       render: () => <DiffViewer context={context} />,
     })
-    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
+    context.ui.slot({ append: "app", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -1090,6 +1090,6 @@ export default Plugin.define({
       name: ROUTE,
       render: () => <DiffViewer context={context} />,
     })
-    context.ui.slot("app", () => <Commands context={context} />)
+    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -85,6 +85,6 @@ function Commands(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id,
   setup(context) {
-    context.ui.slot("app", () => <Commands context={context} />)
+    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -85,6 +85,6 @@ function Commands(props: { context: Plugin.Context }) {
 export default Plugin.define({
   id,
   setup(context) {
-    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
+    context.ui.slot({ append: "app", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/system/storybook/index.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/index.tsx
@@ -137,6 +137,6 @@ export default Plugin.define({
         return <StorybookIndex context={context} />
       },
     })
-    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
+    context.ui.slot({ append: "app", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/feature-plugins/system/storybook/index.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/index.tsx
@@ -137,6 +137,6 @@ export default Plugin.define({
         return <StorybookIndex context={context} />
       },
     })
-    context.ui.slot("app", () => <Commands context={context} />)
+    context.ui.slot("app", { at: "end", render: () => <Commands context={context} /> })
   },
 })

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -1,6 +1,24 @@
 import { PluginContextProvider } from "@opencode-ai/plugin/tui"
 import type { JSX } from "solid-js"
-import type { Context, Dialog, Page, Slot, SlotMap, Toast } from "@opencode-ai/plugin/tui/context"
+import type {
+  Context,
+  Dialog,
+  Page,
+  RegionClaim,
+  RegionName,
+  Slot,
+  SlotMap,
+  SlotName,
+  Toast,
+} from "@opencode-ai/plugin/tui/context"
+import type { Placement } from "./structure"
+
+// A registered claim as stored by the plugin provider's registry.
+export type SlotClaim = {
+  readonly region: RegionName
+  readonly placement: Placement
+  readonly render: Slot
+}
 import { infoStringToFiletype, type MarkdownCodeBlockRenderer } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import { useClient } from "../context/client"
@@ -29,10 +47,25 @@ export type Dispose = () => Promise<void>
 export type Registry = {
   has(kind: "routes" | "slots" | "markdown", name: string): boolean
   set(kind: "routes", name: string, page: Page): void
-  set(kind: "slots", name: string, slot: Slot): void
+  set(kind: "slots", name: string, claim: SlotClaim): void
   set(kind: "markdown", name: string, render: MarkdownCodeBlockRenderer): void
   remove(kind: "routes" | "slots" | "markdown", name: string): void
   active(): boolean
+}
+
+// Position-encoded legacy slot names map onto the region model. Append
+// slots become end-edge claims. Host-declared "replace" slots on partless
+// regions become root takeovers, reproducing their old last-registrant-wins
+// semantics exactly. One deliberate change: "prompt.footer.end" was also
+// last-registrant-wins, but maps to an end-edge claim — chips from several
+// plugins now coexist instead of silently shadowing each other.
+const legacySlots: Record<SlotName, { readonly region: RegionName; readonly placement: Placement }> = {
+  app: { region: "app", placement: { at: "end" } },
+  "home.footer": { region: "home.footer", placement: { replace: "home.footer" } },
+  "prompt.footer.end": { region: "prompt.footer", placement: { at: "end" } },
+  "session.composer.top": { region: "session.composer.top", placement: { at: "end" } },
+  "sidebar.content": { region: "sidebar.content", placement: { at: "end" } },
+  "sidebar.footer": { region: "sidebar.footer", placement: { replace: "sidebar.footer" } },
 }
 
 // The host services a plugin context adapts. Collected once by the provider
@@ -70,6 +103,7 @@ export function createPluginContext(input: {
 }): Context {
   const host = input.host
   let context: Context
+  let claims = 0
   // Every dialog and registered render is wrapped so plugin components can
   // reach their own context through usePlugin().
   const provide = (render: () => JSX.Element) => (
@@ -184,12 +218,45 @@ export function createPluginContext(input: {
           return true
         },
       },
-      slot(name, render) {
-        if (input.registry.has("slots", name)) throw new Error(`Slot already registered: ${name}`)
-        // The registration map erases the slot-specific input type.
-        input.registry.set("slots", name, ((slotInput: SlotMap[typeof name]) =>
-          provide(() => render(slotInput))) as Slot)
-        return registration("slots", name)
+      slot(name: SlotName | RegionName, value: Slot | RegionClaim) {
+        // Legacy form: position-encoded name plus a bare render function.
+        if (typeof value === "function") {
+          if (input.registry.has("slots", name)) throw new Error(`Slot already registered: ${name}`)
+          const mapped = legacySlots[name as SlotName]
+          // Reachable only from untyped plugin code; fail with the name
+          // instead of a property access on undefined.
+          if (!mapped) throw new Error(`Unknown slot: ${name}`)
+          input.registry.set("slots", name, {
+            region: mapped.region,
+            placement: mapped.placement,
+            // The registration map erases the slot-specific input type.
+            render: ((slotInput: SlotMap[SlotName]) => provide(() => value(slotInput))) as Slot,
+          })
+          return registration("slots", name)
+        }
+        // Region form: a placement plus render. Keys are counter-suffixed so
+        // one plugin may claim several places in the same region; order
+        // within the plugin is registration order.
+        const key = `${name}#${claims++}`
+        // Rebuilt field-by-field rather than rest-spread so malformed input
+        // from untyped plugins normalizes to exactly one placement key — a
+        // claim carrying two keys would match twice in the resolver.
+        const placement: Placement =
+          value.at !== undefined
+            ? { at: value.at }
+            : value.before !== undefined
+              ? { before: value.before }
+              : value.after !== undefined
+                ? { after: value.after }
+                : { replace: value.replace }
+        input.registry.set("slots", key, {
+          // The overloads correlate the second argument's shape with the
+          // name: an object value implies a region name.
+          region: name as RegionName,
+          placement,
+          render: ((slotInput: SlotMap[SlotName]) => provide(() => value.render(slotInput))) as Slot,
+        })
+        return registration("slots", key)
       },
     },
   }

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -1,25 +1,16 @@
 import { PluginContextProvider } from "@opencode-ai/plugin/tui"
 import type { JSX } from "solid-js"
-import type {
-  Context,
-  Dialog,
-  Page,
-  RegionClaim,
-  RegionMap,
-  RegionName,
-  Toast,
-} from "@opencode-ai/plugin/tui/context"
+import type { Context, Dialog, Page, SlotClaim, SlotMap, SlotPath, Toast } from "@opencode-ai/plugin/tui/context"
 import type { Placement } from "./structure"
 
-// Region inputs erased to their union: the registry stores one render shape
-// regardless of which region a claim targets.
-export type RegionRender = (input: RegionMap[RegionName]["input"]) => JSX.Element
+// Slot inputs erased to their union: the registry stores one render shape
+// regardless of which path a claim targets.
+export type SlotRender = (input: SlotMap[SlotPath]) => JSX.Element
 
 // A registered claim as stored by the plugin provider's registry.
-export type SlotClaim = {
-  readonly region: RegionName
+export type RegisteredSlot = {
   readonly placement: Placement
-  readonly render: RegionRender
+  readonly render: SlotRender
 }
 import { infoStringToFiletype, type MarkdownCodeBlockRenderer } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
@@ -49,13 +40,11 @@ export type Dispose = () => Promise<void>
 export type Registry = {
   has(kind: "routes" | "slots" | "markdown", name: string): boolean
   set(kind: "routes", name: string, page: Page): void
-  set(kind: "slots", name: string, claim: SlotClaim): void
+  set(kind: "slots", name: string, claim: RegisteredSlot): void
   set(kind: "markdown", name: string, render: MarkdownCodeBlockRenderer): void
   remove(kind: "routes" | "slots" | "markdown", name: string): void
   active(): boolean
 }
-
-
 
 // The host services a plugin context adapts. Collected once by the provider
 // (hooks must run during component setup) and shared by every activation.
@@ -207,26 +196,27 @@ export function createPluginContext(input: {
           return true
         },
       },
-      slot(name: RegionName, value: RegionClaim) {
-        // Keys are counter-suffixed so one plugin may claim several places
-        // in the same region; order within the plugin is registration order.
-        const key = `${name}#${claims++}`
+      slot(value: SlotClaim) {
+        // Keys are counter-suffixed so one plugin may claim several places;
+        // order within the plugin is registration order.
+        const key = `slot#${claims++}`
         // Rebuilt field-by-field rather than rest-spread so malformed input
         // from untyped plugins normalizes to exactly one placement key — a
         // claim carrying two keys would match twice in the resolver.
         const placement: Placement =
-          value.at !== undefined
-            ? { at: value.at }
-            : value.before !== undefined
-              ? { before: value.before }
-              : value.after !== undefined
-                ? { after: value.after }
-                : { replace: value.replace }
+          value.prepend !== undefined
+            ? { prepend: value.prepend }
+            : value.append !== undefined
+              ? { append: value.append }
+              : value.before !== undefined
+                ? { before: value.before }
+                : value.after !== undefined
+                  ? { after: value.after }
+                  : { replace: value.replace }
         input.registry.set("slots", key, {
-          region: name,
           placement,
-          // The registration map erases the region-specific input type.
-          render: (slotInput) => provide(() => (value.render as RegionRender)(slotInput)),
+          // The registration map erases the path-specific input type.
+          render: (slotInput) => provide(() => (value.render as SlotRender)(slotInput)),
         })
         return registration("slots", key)
       },

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -5,19 +5,21 @@ import type {
   Dialog,
   Page,
   RegionClaim,
+  RegionMap,
   RegionName,
-  Slot,
-  SlotMap,
-  SlotName,
   Toast,
 } from "@opencode-ai/plugin/tui/context"
 import type { Placement } from "./structure"
+
+// Region inputs erased to their union: the registry stores one render shape
+// regardless of which region a claim targets.
+export type RegionRender = (input: RegionMap[RegionName]["input"]) => JSX.Element
 
 // A registered claim as stored by the plugin provider's registry.
 export type SlotClaim = {
   readonly region: RegionName
   readonly placement: Placement
-  readonly render: Slot
+  readonly render: RegionRender
 }
 import { infoStringToFiletype, type MarkdownCodeBlockRenderer } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
@@ -53,20 +55,7 @@ export type Registry = {
   active(): boolean
 }
 
-// Position-encoded legacy slot names map onto the region model. Append
-// slots become end-edge claims. Host-declared "replace" slots on partless
-// regions become root takeovers, reproducing their old last-registrant-wins
-// semantics exactly. One deliberate change: "prompt.footer.end" was also
-// last-registrant-wins, but maps to an end-edge claim — chips from several
-// plugins now coexist instead of silently shadowing each other.
-const legacySlots: Record<SlotName, { readonly region: RegionName; readonly placement: Placement }> = {
-  app: { region: "app", placement: { at: "end" } },
-  "home.footer": { region: "home.footer", placement: { replace: "home.footer" } },
-  "prompt.footer.end": { region: "prompt.footer", placement: { at: "end" } },
-  "session.composer.top": { region: "session.composer.top", placement: { at: "end" } },
-  "sidebar.content": { region: "sidebar.content", placement: { at: "end" } },
-  "sidebar.footer": { region: "sidebar.footer", placement: { replace: "sidebar.footer" } },
-}
+
 
 // The host services a plugin context adapts. Collected once by the provider
 // (hooks must run during component setup) and shared by every activation.
@@ -218,25 +207,9 @@ export function createPluginContext(input: {
           return true
         },
       },
-      slot(name: SlotName | RegionName, value: Slot | RegionClaim) {
-        // Legacy form: position-encoded name plus a bare render function.
-        if (typeof value === "function") {
-          if (input.registry.has("slots", name)) throw new Error(`Slot already registered: ${name}`)
-          const mapped = legacySlots[name as SlotName]
-          // Reachable only from untyped plugin code; fail with the name
-          // instead of a property access on undefined.
-          if (!mapped) throw new Error(`Unknown slot: ${name}`)
-          input.registry.set("slots", name, {
-            region: mapped.region,
-            placement: mapped.placement,
-            // The registration map erases the slot-specific input type.
-            render: ((slotInput: SlotMap[SlotName]) => provide(() => value(slotInput))) as Slot,
-          })
-          return registration("slots", name)
-        }
-        // Region form: a placement plus render. Keys are counter-suffixed so
-        // one plugin may claim several places in the same region; order
-        // within the plugin is registration order.
+      slot(name: RegionName, value: RegionClaim) {
+        // Keys are counter-suffixed so one plugin may claim several places
+        // in the same region; order within the plugin is registration order.
         const key = `${name}#${claims++}`
         // Rebuilt field-by-field rather than rest-spread so malformed input
         // from untyped plugins normalizes to exactly one placement key — a
@@ -250,11 +223,10 @@ export function createPluginContext(input: {
                 ? { after: value.after }
                 : { replace: value.replace }
         input.registry.set("slots", key, {
-          // The overloads correlate the second argument's shape with the
-          // name: an object value implies a region name.
-          region: name as RegionName,
+          region: name,
           placement,
-          render: ((slotInput: SlotMap[SlotName]) => provide(() => value.render(slotInput))) as Slot,
+          // The registration map erases the region-specific input type.
+          render: (slotInput) => provide(() => (value.render as RegionRender)(slotInput)),
         })
         return registration("slots", key)
       },

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -1,17 +1,7 @@
 import { PluginContextProvider } from "@opencode-ai/plugin/tui"
 import type { JSX } from "solid-js"
 import type { Context, Dialog, Page, SlotClaim, SlotMap, SlotPath, Toast } from "@opencode-ai/plugin/tui/context"
-import type { Placement } from "./structure"
-
-// Slot inputs erased to their union: the registry stores one render shape
-// regardless of which path a claim targets.
-export type SlotRender = (input: SlotMap[SlotPath]) => JSX.Element
-
-// A registered claim as stored by the plugin provider's registry.
-export type RegisteredSlot = {
-  readonly placement: Placement
-  readonly render: SlotRender
-}
+import type { Placement, PlacementKind } from "./structure"
 import { infoStringToFiletype, type MarkdownCodeBlockRenderer } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
 import { useClient } from "../context/client"
@@ -33,6 +23,18 @@ import { useSessionTabs } from "../context/session-tabs"
 import { abbreviateHome } from "../util/path-format"
 
 export type Dispose = () => Promise<void>
+
+// Slot inputs erased to their union: the registry stores one render shape
+// regardless of which path a claim targets.
+export type SlotRender = (input: SlotMap[SlotPath]) => JSX.Element
+
+// A registered claim as stored by the plugin provider's registry.
+export type RegisteredSlot = {
+  readonly placement: Placement
+  readonly render: SlotRender
+}
+
+const placements = ["prepend", "append", "before", "after", "replace"] as const satisfies readonly PlacementKind[]
 
 // The provider's registration store, narrowed to what a plugin context needs:
 // route/slot registration lands there, but ordering and lifecycle stay owned
@@ -200,21 +202,12 @@ export function createPluginContext(input: {
         // Keys are counter-suffixed so one plugin may claim several places;
         // order within the plugin is registration order.
         const key = `slot#${claims++}`
-        // Rebuilt field-by-field rather than rest-spread so malformed input
-        // from untyped plugins normalizes to exactly one placement key — a
-        // claim carrying two keys would match twice in the resolver.
-        const placement: Placement =
-          value.prepend !== undefined
-            ? { prepend: value.prepend }
-            : value.append !== undefined
-              ? { append: value.append }
-              : value.before !== undefined
-                ? { before: value.before }
-                : value.after !== undefined
-                  ? { after: value.after }
-                  : { replace: value.replace }
+        // Exactly one placement kind, enforced at runtime for untyped plugins.
+        const kinds = placements.filter((item) => value[item] !== undefined)
+        if (kinds.length !== 1) throw new Error("Slot claim requires exactly one placement key")
+        const kind = kinds[0]
         input.registry.set("slots", key, {
-          placement,
+          placement: { kind, target: value[kind] as string },
           // The registration map erases the path-specific input type.
           render: (slotInput) => provide(() => (value.render as SlotRender)(slotInput)),
         })

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -15,7 +15,7 @@ import path from "path"
 import { stat } from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
 import type { Page } from "@opencode-ai/plugin/tui/context"
-import type { Claim } from "./structure"
+import { resolveSlots, type Claim } from "./structure"
 import { createStore, produce, reconcile as reconcileStore, unwrap } from "solid-js/store"
 import { isDeepEqual } from "remeda"
 import "#runtime-plugin-support"
@@ -23,7 +23,7 @@ import { useConfig } from "../config"
 import { useTuiLifecycle } from "../context/runtime"
 import { errorMessage } from "../util/error"
 import { builtins } from "./builtins"
-import { createPluginContext, usePluginHost, type Dispose, type RegionRender, type SlotClaim } from "./api"
+import { createPluginContext, usePluginHost, type Dispose, type RegisteredSlot, type SlotRender } from "./api"
 import { createSourceWatcher } from "./watch"
 import { discoverTuiPlugins, freshSpecifier, localSource } from "./discovery"
 
@@ -47,7 +47,11 @@ type Value = {
   readonly list: () => ReadonlyArray<State>
   readonly registered: () => ReadonlyArray<RegisteredPlugin>
   readonly route: (id: string, name: string) => Page["render"] | undefined
-  readonly claims: (region: string) => ReadonlyArray<Claim<RegionRender>>
+  readonly slots: {
+    // A mounted <Slot> instance registers its path; the disposer unregisters.
+    readonly register: (path: string) => () => void
+    readonly resolved: () => ReturnType<typeof resolveSlots<SlotRender>>
+  }
   readonly markdown: () => MarkdownOptions["renderNode"]
   readonly activate: (id: string) => Promise<boolean>
   readonly deactivate: (id: string) => Promise<boolean>
@@ -61,7 +65,7 @@ type Registration = {
   options?: Readonly<Record<string, any>>
   active: boolean
   routes: Record<string, Page>
-  slots: Record<string, SlotClaim>
+  slots: Record<string, RegisteredSlot>
   markdown: Record<string, MarkdownCodeBlockRenderer>
   cleanups: Dispose[]
 }
@@ -118,8 +122,11 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
       owned,
       registry: {
         has: (kind, name) => Boolean(store.registrations[id]?.[kind][name]),
-        set: (kind: "routes" | "slots" | "markdown", name: string, value: Page | SlotClaim | MarkdownCodeBlockRenderer) =>
-          setStore("registrations", id, kind, name, () => value),
+        set: (
+          kind: "routes" | "slots" | "markdown",
+          name: string,
+          value: Page | RegisteredSlot | MarkdownCodeBlockRenderer,
+        ) => setStore("registrations", id, kind, name, () => value),
         remove: (kind, name) =>
           setStore(
             "registrations",
@@ -386,7 +393,43 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
         host.toast.show({ variant: "error", title: "Plugin", message: `${state.target}: ${state.error}` })
     setStore("states", reconcileStore(states))
   }
-  const slotItems = new WeakMap<RegionRender, Claim<RegionRender>>()
+  const slotItems = new WeakMap<SlotRender, Claim<SlotRender>>()
+  // The mounted slot tree: path -> live <Slot> instance count. Reference
+  // counted because the same path can be mounted several times (one composer
+  // footer per session tab); a path exists while any instance is mounted.
+  const [mounted, setMounted] = createStore<Record<string, number>>({})
+  const registerSlot = (slotPath: string) => {
+    setMounted(slotPath, (count) => (count ?? 0) + 1)
+    return () =>
+      setMounted(
+        produce((counts) => {
+          const count = counts[slotPath]
+          if (count && count > 1) counts[slotPath] = count - 1
+          else delete counts[slotPath]
+        }),
+      )
+  }
+  // Claims come back in enable order: registration-store key order across
+  // plugins (generations preserve key positions in place), then registration
+  // order within one plugin. The resolver's last-wins rules depend on it.
+  const claims = createMemo(() =>
+    Object.entries(store.registrations).flatMap(([id, registration]) =>
+      Object.entries(registration.active ? registration.slots : {}).map(([key, slot]) => {
+        // Rows downstream diff by reference; a stable claim per render
+        // function keeps untouched plugins' slot rows (and their state)
+        // alive across other plugins' reloads.
+        const cached = slotItems.get(slot.render)
+        if (cached) return cached
+        // Placements are immutable once registered; unwrap the store proxy
+        // so the resolver's `in` checks hit plain objects instead of
+        // subscribing tracked scopes to every key probe.
+        const item = { key: `${id}/${key}`, plugin: id, placement: unwrap(slot.placement), render: slot.render }
+        slotItems.set(slot.render, item)
+        return item
+      }),
+    ),
+  )
+  const resolved = createMemo(() => resolveSlots({ paths: new Set(Object.keys(mounted)), claims: claims() }))
   createEffect(
     on(
       () => JSON.stringify(config.data.plugins ?? []),
@@ -435,27 +478,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
             active: plugin.active,
           })),
         route: (id, name) => store.registrations[id]?.routes[name]?.render,
-        // Claims come back in enable order: registration-store key order
-        // across plugins (generations preserve key positions in place), then
-        // registration order within one plugin. The resolver's last-wins
-        // rules depend on it.
-        claims: (region) =>
-          Object.entries(store.registrations).flatMap(([id, registration]) =>
-            Object.entries(registration.active ? registration.slots : {}).flatMap(([key, slot]) => {
-              if (slot.region !== region) return []
-              // <For> diffs rows by reference; a stable claim per render
-              // function keeps untouched plugins' slot rows (and their
-              // state) alive across other plugins' reloads.
-              const cached = slotItems.get(slot.render)
-              if (cached) return [cached]
-              // Placements are immutable once registered; unwrap the store
-              // proxy so the resolver's `in` checks hit plain objects
-              // instead of subscribing tracked scopes to every key probe.
-              const item = { key: `${id}/${key}`, plugin: id, placement: unwrap(slot.placement), render: slot.render }
-              slotItems.set(slot.render, item)
-              return [item]
-            }),
-          ),
+        slots: { register: registerSlot, resolved },
         markdown,
         // Manual dialog toggles join the same chain as reconciles so a
         // toggle mid-reload cannot mix registrations across generations.

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -421,14 +421,15 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
         const cached = slotItems.get(slot.render)
         if (cached) return cached
         // Placements are immutable once registered; unwrap the store proxy
-        // so the resolver's `in` checks hit plain objects instead of
-        // subscribing tracked scopes to every key probe.
+        // so resolver reads don't subscribe tracked scopes.
         const item = { key: `${id}/${key}`, plugin: id, placement: unwrap(slot.placement), render: slot.render }
         slotItems.set(slot.render, item)
         return item
       }),
     ),
   )
+  // Object.keys tracks the store's keys node only: refcount changes on an
+  // already-mounted path (a second tab's composer) skip re-resolution.
   const resolved = createMemo(() => resolveSlots({ paths: new Set(Object.keys(mounted)), claims: claims() }))
   createEffect(
     on(

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -14,15 +14,16 @@ import {
 import path from "path"
 import { stat } from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
-import type { Page, Slot, SlotName } from "@opencode-ai/plugin/tui/context"
-import { createStore, produce, reconcile as reconcileStore } from "solid-js/store"
+import type { Page, Slot } from "@opencode-ai/plugin/tui/context"
+import type { Claim } from "./structure"
+import { createStore, produce, reconcile as reconcileStore, unwrap } from "solid-js/store"
 import { isDeepEqual } from "remeda"
 import "#runtime-plugin-support"
 import { useConfig } from "../config"
 import { useTuiLifecycle } from "../context/runtime"
 import { errorMessage } from "../util/error"
 import { builtins } from "./builtins"
-import { createPluginContext, usePluginHost, type Dispose } from "./api"
+import { createPluginContext, usePluginHost, type Dispose, type SlotClaim } from "./api"
 import { createSourceWatcher } from "./watch"
 import { discoverTuiPlugins, freshSpecifier, localSource } from "./discovery"
 
@@ -46,9 +47,7 @@ type Value = {
   readonly list: () => ReadonlyArray<State>
   readonly registered: () => ReadonlyArray<RegisteredPlugin>
   readonly route: (id: string, name: string) => Page["render"] | undefined
-  readonly slot: <Name extends SlotName>(
-    name: Name,
-  ) => ReadonlyArray<{ readonly id: string; readonly render: Slot<Name> }>
+  readonly claims: (region: string) => ReadonlyArray<Claim<Slot>>
   readonly markdown: () => MarkdownOptions["renderNode"]
   readonly activate: (id: string) => Promise<boolean>
   readonly deactivate: (id: string) => Promise<boolean>
@@ -62,7 +61,7 @@ type Registration = {
   options?: Readonly<Record<string, any>>
   active: boolean
   routes: Record<string, Page>
-  slots: Record<string, Slot>
+  slots: Record<string, SlotClaim>
   markdown: Record<string, MarkdownCodeBlockRenderer>
   cleanups: Dispose[]
 }
@@ -119,7 +118,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
       owned,
       registry: {
         has: (kind, name) => Boolean(store.registrations[id]?.[kind][name]),
-        set: (kind: "routes" | "slots" | "markdown", name: string, value: Page | Slot | MarkdownCodeBlockRenderer) =>
+        set: (kind: "routes" | "slots" | "markdown", name: string, value: Page | SlotClaim | MarkdownCodeBlockRenderer) =>
           setStore("registrations", id, kind, name, () => value),
         remove: (kind, name) =>
           setStore(
@@ -387,7 +386,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
         host.toast.show({ variant: "error", title: "Plugin", message: `${state.target}: ${state.error}` })
     setStore("states", reconcileStore(states))
   }
-  const slotItems = new WeakMap<Slot, { readonly id: string; readonly render: Slot }>()
+  const slotItems = new WeakMap<Slot, Claim<Slot>>()
   createEffect(
     on(
       () => JSON.stringify(config.data.plugins ?? []),
@@ -436,19 +435,27 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
             active: plugin.active,
           })),
         route: (id, name) => store.registrations[id]?.routes[name]?.render,
-        slot: (name) =>
-          Object.entries(store.registrations).flatMap(([id, registration]) => {
-            const render = registration.active ? registration.slots[name] : undefined
-            if (!render) return []
-            // <For> diffs rows by reference; a stable wrapper per render
-            // function keeps untouched plugins' slot rows (and their state)
-            // alive across other plugins' reloads.
-            const cached = slotItems.get(render)
-            if (cached) return [cached]
-            const item = { id, render }
-            slotItems.set(render, item)
-            return [item]
-          }),
+        // Claims come back in enable order: registration-store key order
+        // across plugins (generations preserve key positions in place), then
+        // registration order within one plugin. The resolver's last-wins
+        // rules depend on it.
+        claims: (region) =>
+          Object.entries(store.registrations).flatMap(([id, registration]) =>
+            Object.entries(registration.active ? registration.slots : {}).flatMap(([key, slot]) => {
+              if (slot.region !== region) return []
+              // <For> diffs rows by reference; a stable claim per render
+              // function keeps untouched plugins' slot rows (and their
+              // state) alive across other plugins' reloads.
+              const cached = slotItems.get(slot.render)
+              if (cached) return [cached]
+              // Placements are immutable once registered; unwrap the store
+              // proxy so the resolver's `in` checks hit plain objects
+              // instead of subscribing tracked scopes to every key probe.
+              const item = { key: `${id}/${key}`, plugin: id, placement: unwrap(slot.placement), render: slot.render }
+              slotItems.set(slot.render, item)
+              return [item]
+            }),
+          ),
         markdown,
         // Manual dialog toggles join the same chain as reconciles so a
         // toggle mid-reload cannot mix registrations across generations.

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -14,7 +14,7 @@ import {
 import path from "path"
 import { stat } from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
-import type { Page, Slot } from "@opencode-ai/plugin/tui/context"
+import type { Page } from "@opencode-ai/plugin/tui/context"
 import type { Claim } from "./structure"
 import { createStore, produce, reconcile as reconcileStore, unwrap } from "solid-js/store"
 import { isDeepEqual } from "remeda"
@@ -23,7 +23,7 @@ import { useConfig } from "../config"
 import { useTuiLifecycle } from "../context/runtime"
 import { errorMessage } from "../util/error"
 import { builtins } from "./builtins"
-import { createPluginContext, usePluginHost, type Dispose, type SlotClaim } from "./api"
+import { createPluginContext, usePluginHost, type Dispose, type RegionRender, type SlotClaim } from "./api"
 import { createSourceWatcher } from "./watch"
 import { discoverTuiPlugins, freshSpecifier, localSource } from "./discovery"
 
@@ -47,7 +47,7 @@ type Value = {
   readonly list: () => ReadonlyArray<State>
   readonly registered: () => ReadonlyArray<RegisteredPlugin>
   readonly route: (id: string, name: string) => Page["render"] | undefined
-  readonly claims: (region: string) => ReadonlyArray<Claim<Slot>>
+  readonly claims: (region: string) => ReadonlyArray<Claim<RegionRender>>
   readonly markdown: () => MarkdownOptions["renderNode"]
   readonly activate: (id: string) => Promise<boolean>
   readonly deactivate: (id: string) => Promise<boolean>
@@ -386,7 +386,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
         host.toast.show({ variant: "error", title: "Plugin", message: `${state.target}: ${state.error}` })
     setStore("states", reconcileStore(states))
   }
-  const slotItems = new WeakMap<Slot, Claim<Slot>>()
+  const slotItems = new WeakMap<RegionRender, Claim<RegionRender>>()
   createEffect(
     on(
       () => JSON.stringify(config.data.plugins ?? []),

--- a/packages/tui/src/plugin/render.tsx
+++ b/packages/tui/src/plugin/render.tsx
@@ -1,5 +1,6 @@
 import {
   createComponent,
+  createContext,
   createMemo,
   ErrorBoundary,
   For,
@@ -7,6 +8,7 @@ import {
   onCleanup,
   onMount,
   Show,
+  useContext,
   type JSX,
   type ParentProps,
 } from "solid-js"
@@ -73,6 +75,9 @@ export function PluginRoute(props: { readonly fallback: (id: string, name: strin
 // Placement policy — boundary suppression, last-enabled-wins, missing-target
 // degradation — lives in resolveSlots; this component only renders its own
 // path's buckets.
+// The nearest enclosing slot's path. Root slots mount outside any provider.
+const SlotParent = createContext<string>()
+
 export function Slot<Path extends SlotPath>(
   props: ParentProps<{ readonly path: Path; readonly input?: SlotMap[Path] }>,
 ) {
@@ -81,6 +86,14 @@ export function Slot<Path extends SlotPath>(
   // reference-counted so the same path may be mounted several times (one
   // composer footer per session tab).
   const path = props.path
+  // Paths are declared, not inferred: nesting a slot under the wrong parent
+  // would silently publish a mislocated public path, so containment is
+  // asserted at mount. Only host code can trip this — plugins cannot mount
+  // slots — which makes it a programming error worth failing loudly on.
+  const parent = useContext(SlotParent)
+  if (parent !== undefined && !path.startsWith(parent + ".")) {
+    throw new Error(`Slot "${path}" is mounted inside "${parent}" but its path does not extend it`)
+  }
   onCleanup(plugins.slots.register(path))
   const slotted = createMemo(
     () => plugins.slots.resolved().slotted.get(path) ?? emptySlotted<SlotRender>(),
@@ -110,7 +123,7 @@ export function Slot<Path extends SlotPath>(
     </PluginBoundary>
   )
   return (
-    <>
+    <SlotParent.Provider value={path}>
       <For each={slotted().before}>{contribution}</For>
       <Show
         keyed
@@ -126,7 +139,7 @@ export function Slot<Path extends SlotPath>(
         {contribution}
       </Show>
       <For each={slotted().after}>{contribution}</For>
-    </>
+    </SlotParent.Provider>
   )
 }
 

--- a/packages/tui/src/plugin/render.tsx
+++ b/packages/tui/src/plugin/render.tsx
@@ -4,14 +4,15 @@ import {
   ErrorBoundary,
   For,
   mergeProps,
+  onCleanup,
   onMount,
   Show,
   type JSX,
   type ParentProps,
 } from "solid-js"
-import type { RegionMap, RegionName } from "@opencode-ai/plugin/tui/context"
-import type { RegionRender } from "./api"
-import { resolveStructure, type Entry, type Part } from "./structure"
+import type { SlotMap, SlotPath } from "@opencode-ai/plugin/tui/context"
+import type { SlotRender } from "./api"
+import { emptySlotted, type Claim } from "./structure"
 import { useRoute } from "../context/route"
 import { useToast } from "../ui/toast"
 import { errorMessage } from "../util/error"
@@ -66,69 +67,69 @@ export function PluginRoute(props: { readonly fallback: (id: string, name: strin
   )
 }
 
-type HostRender = () => JSX.Element
-
-// One extensible area of the host UI: the host's parts plus every active
-// plugin claim, resolved into one ordered child list. Placement policy —
-// takeover suppression, last-enabled-wins, missing-anchor degradation —
-// lives in resolveStructure; this component only renders the result.
-export function Region<Name extends RegionName>(props: {
-  readonly name: Name
-  readonly input: RegionMap[Name]["input"]
-  readonly parts?: ReadonlyArray<Part<HostRender, RegionMap[Name]["part"]>>
-}) {
+// One named boundary of the host UI's slot tree. The host's own content are
+// the children; every active plugin claim targeting this path resolves into
+// siblings around it, contributions inside it, or one takeover of it.
+// Placement policy — boundary suppression, last-enabled-wins, missing-target
+// degradation — lives in resolveSlots; this component only renders its own
+// path's buckets.
+export function Slot<Path extends SlotPath>(
+  props: ParentProps<{ readonly path: Path; readonly input?: SlotMap[Path] }>,
+) {
   const plugins = usePlugin()
-  // resolveStructure builds fresh entry objects each run, but <For> diffs
-  // rows by reference: cache entries so untouched rows (and the plugin
-  // state inside them) survive unrelated claim changes. Part entries key on
-  // their documented-stable id — render-function identity would break if
-  // the compiled parts prop ever rebuilt its closures. Claim entries key on
-  // the render function (weakly, so hot-reloaded generations collect).
-  const partEntries = new Map<string, Entry<HostRender, RegionRender>>()
-  const claimEntries = new WeakMap<RegionRender, Entry<HostRender, RegionRender>>()
-  const entries = createMemo(
-    () =>
-      resolveStructure<HostRender, RegionRender>({
-        region: props.name,
-        parts: props.parts ?? [],
-        claims: plugins.claims(props.name),
-      }).entries.map((entry) => {
-        if (entry.kind === "part") {
-          const cached = partEntries.get(entry.id)
-          if (cached) return cached
-          partEntries.set(entry.id, entry)
-          return entry
-        }
-        const cached = claimEntries.get(entry.claim.render)
-        if (cached) return cached
-        claimEntries.set(entry.claim.render, entry)
-        return entry
-      }),
-    [] as ReadonlyArray<Entry<HostRender, RegionRender>>,
-    // Rows are reference-stable, so an elementwise comparison makes a claim
-    // change in some other region a complete no-op for this one.
-    { equals: (a, b) => a.length === b.length && a.every((entry, index) => entry === b[index]) },
+  // A slot's path is its identity for the whole mount; instances are
+  // reference-counted so the same path may be mounted several times (one
+  // composer footer per session tab).
+  const path = props.path
+  onCleanup(plugins.slots.register(path))
+  const slotted = createMemo(
+    () => plugins.slots.resolved().slotted.get(path) ?? emptySlotted<SlotRender>(),
+    emptySlotted<SlotRender>(),
+    // Claim objects are reference-stable across resolutions, so a bucketwise
+    // comparison makes a claim change elsewhere in the tree a no-op here.
+    {
+      equals: (a, b) =>
+        same(a.before, b.before) &&
+        same(a.prepend, b.prepend) &&
+        same(a.append, b.append) &&
+        same(a.after, b.after) &&
+        a.replace === b.replace,
+    },
+  )
+  // Component semantics: the render body runs once and untracked, so signals
+  // and intervals created inside are stable, while the slot input stays
+  // reactive through the merged getter. A bare render(props.input) call
+  // would run inside the host's tracked scope and re-execute the whole body
+  // (resetting plugin state) on every tracked read.
+  const contribution = (claim: Claim<SlotRender>) => (
+    <PluginBoundary id={claim.plugin} where={`slot ${path}`}>
+      {createComponent(
+        claim.render,
+        mergeProps(() => props.input ?? ({} as SlotMap[Path])),
+      )}
+    </PluginBoundary>
   )
   return (
-    <For each={entries()}>
-      {(entry) =>
-        // A row's entry object is cached, so its kind never changes within
-        // the row's lifetime — a plain branch is safe here.
-        entry.kind === "part" ? (
-          entry.render()
-        ) : (
-          <PluginBoundary id={entry.claim.plugin} where={`region ${props.name}`}>
-            {
-              // Component semantics: the render body runs once and untracked, so
-              // signals and intervals created inside are stable, while props stay
-              // reactive through the merged getter. A bare render(props.input)
-              // call would run inside the host's tracked scope and re-execute the
-              // whole body (resetting plugin state) on every tracked read.
-              createComponent(entry.claim.render, mergeProps(() => props.input) as RegionMap[RegionName]["input"])
-            }
-          </PluginBoundary>
-        )
-      }
-    </For>
+    <>
+      <For each={slotted().before}>{contribution}</For>
+      <Show
+        keyed
+        when={slotted().replace}
+        fallback={
+          <>
+            <For each={slotted().prepend}>{contribution}</For>
+            {props.children}
+            <For each={slotted().append}>{contribution}</For>
+          </>
+        }
+      >
+        {contribution}
+      </Show>
+      <For each={slotted().after}>{contribution}</For>
+    </>
   )
+}
+
+function same(a: ReadonlyArray<unknown>, b: ReadonlyArray<unknown>) {
+  return a.length === b.length && a.every((item, index) => item === b[index])
 }

--- a/packages/tui/src/plugin/render.tsx
+++ b/packages/tui/src/plugin/render.tsx
@@ -9,7 +9,8 @@ import {
   type JSX,
   type ParentProps,
 } from "solid-js"
-import type { RegionMap, RegionName, Slot, SlotMap, SlotName } from "@opencode-ai/plugin/tui/context"
+import type { RegionMap, RegionName } from "@opencode-ai/plugin/tui/context"
+import type { RegionRender } from "./api"
 import { resolveStructure, type Entry, type Part } from "./structure"
 import { useRoute } from "../context/route"
 import { useToast } from "../ui/toast"
@@ -83,11 +84,11 @@ export function Region<Name extends RegionName>(props: {
   // their documented-stable id — render-function identity would break if
   // the compiled parts prop ever rebuilt its closures. Claim entries key on
   // the render function (weakly, so hot-reloaded generations collect).
-  const partEntries = new Map<string, Entry<HostRender, Slot>>()
-  const claimEntries = new WeakMap<Slot, Entry<HostRender, Slot>>()
+  const partEntries = new Map<string, Entry<HostRender, RegionRender>>()
+  const claimEntries = new WeakMap<RegionRender, Entry<HostRender, RegionRender>>()
   const entries = createMemo(
     () =>
-      resolveStructure<HostRender, Slot>({
+      resolveStructure<HostRender, RegionRender>({
         region: props.name,
         parts: props.parts ?? [],
         claims: plugins.claims(props.name),
@@ -103,7 +104,7 @@ export function Region<Name extends RegionName>(props: {
         claimEntries.set(entry.claim.render, entry)
         return entry
       }),
-    [] as ReadonlyArray<Entry<HostRender, Slot>>,
+    [] as ReadonlyArray<Entry<HostRender, RegionRender>>,
     // Rows are reference-stable, so an elementwise comparison makes a claim
     // change in some other region a complete no-op for this one.
     { equals: (a, b) => a.length === b.length && a.every((entry, index) => entry === b[index]) },
@@ -123,7 +124,7 @@ export function Region<Name extends RegionName>(props: {
               // reactive through the merged getter. A bare render(props.input)
               // call would run inside the host's tracked scope and re-execute the
               // whole body (resetting plugin state) on every tracked read.
-              createComponent(entry.claim.render, mergeProps(() => props.input) as SlotMap[SlotName])
+              createComponent(entry.claim.render, mergeProps(() => props.input) as RegionMap[RegionName]["input"])
             }
           </PluginBoundary>
         )

--- a/packages/tui/src/plugin/render.tsx
+++ b/packages/tui/src/plugin/render.tsx
@@ -12,9 +12,10 @@ import {
   type JSX,
   type ParentProps,
 } from "solid-js"
+import { isShallowEqual } from "remeda"
 import type { SlotMap, SlotPath } from "@opencode-ai/plugin/tui/context"
 import type { SlotRender } from "./api"
-import { emptySlotted, type Claim } from "./structure"
+import { contains, emptySlotted, type Claim } from "./structure"
 import { useRoute } from "../context/route"
 import { useToast } from "../ui/toast"
 import { errorMessage } from "../util/error"
@@ -69,32 +70,33 @@ export function PluginRoute(props: { readonly fallback: (id: string, name: strin
   )
 }
 
-// One named boundary of the host UI's slot tree. The host's own content are
-// the children; every active plugin claim targeting this path resolves into
-// siblings around it, contributions inside it, or one takeover of it.
-// Placement policy — boundary suppression, last-enabled-wins, missing-target
-// degradation — lives in resolveSlots; this component only renders its own
-// path's buckets.
 // The nearest enclosing slot's path. Root slots mount outside any provider.
 const SlotParent = createContext<string>()
 
-export function Slot<Path extends SlotPath>(
-  props: ParentProps<{ readonly path: Path; readonly input?: SlotMap[Path] }>,
-) {
+// `input` is required exactly when the path publishes a non-empty input.
+type SlotProps<Path extends SlotPath> = ParentProps<{ readonly path: Path }> &
+  ({} extends SlotMap[Path] ? { readonly input?: SlotMap[Path] } : { readonly input: SlotMap[Path] })
+
+// One named boundary of the host UI's slot tree. The host's own content are
+// the children; every active plugin claim targeting this path resolves into
+// siblings around it, contributions inside it, or one takeover of it.
+// Placement policy lives in resolveSlots; this component only renders its
+// own path's buckets.
+export function Slot<Path extends SlotPath>(props: SlotProps<Path>) {
   const plugins = usePlugin()
   // A slot's path is its identity for the whole mount; instances are
   // reference-counted so the same path may be mounted several times (one
   // composer footer per session tab).
   const path = props.path
-  // Paths are declared, not inferred: nesting a slot under the wrong parent
-  // would silently publish a mislocated public path, so containment is
-  // asserted at mount. Only host code can trip this — plugins cannot mount
-  // slots — which makes it a programming error worth failing loudly on.
+  // Paths are declared, not inferred: nesting under the wrong parent would
+  // silently publish a mislocated public path, so containment fails loudly
+  // at mount. Only host code can trip this — plugins cannot mount slots.
   const parent = useContext(SlotParent)
-  if (parent !== undefined && !path.startsWith(parent + ".")) {
+  if (parent !== undefined && !contains(parent, path)) {
     throw new Error(`Slot "${path}" is mounted inside "${parent}" but its path does not extend it`)
   }
   onCleanup(plugins.slots.register(path))
+  const input = () => (props as { readonly input?: SlotMap[Path] }).input ?? ({} as SlotMap[Path])
   const slotted = createMemo(
     () => plugins.slots.resolved().slotted.get(path) ?? emptySlotted<SlotRender>(),
     emptySlotted<SlotRender>(),
@@ -102,47 +104,41 @@ export function Slot<Path extends SlotPath>(
     // comparison makes a claim change elsewhere in the tree a no-op here.
     {
       equals: (a, b) =>
-        same(a.before, b.before) &&
-        same(a.prepend, b.prepend) &&
-        same(a.append, b.append) &&
-        same(a.after, b.after) &&
+        isShallowEqual(a.before, b.before) &&
+        isShallowEqual(a.prepend, b.prepend) &&
+        isShallowEqual(a.append, b.append) &&
+        isShallowEqual(a.after, b.after) &&
         a.replace === b.replace,
     },
   )
-  // Component semantics: the render body runs once and untracked, so signals
-  // and intervals created inside are stable, while the slot input stays
-  // reactive through the merged getter. A bare render(props.input) call
-  // would run inside the host's tracked scope and re-execute the whole body
-  // (resetting plugin state) on every tracked read.
+  // Component semantics: the render body runs once and untracked, so state
+  // created inside is stable while the slot input stays reactive through the
+  // merged getter.
   const contribution = (claim: Claim<SlotRender>) => (
     <PluginBoundary id={claim.plugin} where={`slot ${path}`}>
-      {createComponent(
-        claim.render,
-        mergeProps(() => props.input ?? ({} as SlotMap[Path])),
-      )}
+      {createComponent(claim.render, mergeProps(input))}
     </PluginBoundary>
   )
   return (
-    <SlotParent.Provider value={path}>
+    <>
       <For each={slotted().before}>{contribution}</For>
-      <Show
-        keyed
-        when={slotted().replace}
-        fallback={
-          <>
-            <For each={slotted().prepend}>{contribution}</For>
-            {props.children}
-            <For each={slotted().append}>{contribution}</For>
-          </>
-        }
-      >
-        {contribution}
-      </Show>
+      {/* before/after are siblings outside the boundary, so outside the provider. */}
+      <SlotParent.Provider value={path}>
+        <Show
+          keyed
+          when={slotted().replace}
+          fallback={
+            <>
+              <For each={slotted().prepend}>{contribution}</For>
+              {props.children}
+              <For each={slotted().append}>{contribution}</For>
+            </>
+          }
+        >
+          {contribution}
+        </Show>
+      </SlotParent.Provider>
       <For each={slotted().after}>{contribution}</For>
-    </SlotParent.Provider>
+    </>
   )
-}
-
-function same(a: ReadonlyArray<unknown>, b: ReadonlyArray<unknown>) {
-  return a.length === b.length && a.every((item, index) => item === b[index])
 }

--- a/packages/tui/src/plugin/render.tsx
+++ b/packages/tui/src/plugin/render.tsx
@@ -9,7 +9,8 @@ import {
   type JSX,
   type ParentProps,
 } from "solid-js"
-import type { SlotMap, SlotName } from "@opencode-ai/plugin/tui/context"
+import type { RegionMap, RegionName, Slot, SlotMap, SlotName } from "@opencode-ai/plugin/tui/context"
+import { resolveStructure, type Entry, type Part } from "./structure"
 import { useRoute } from "../context/route"
 import { useToast } from "../ui/toast"
 import { errorMessage } from "../util/error"
@@ -64,31 +65,69 @@ export function PluginRoute(props: { readonly fallback: (id: string, name: strin
   )
 }
 
-export function PluginSlot<Name extends SlotName>(props: {
+type HostRender = () => JSX.Element
+
+// One extensible area of the host UI: the host's parts plus every active
+// plugin claim, resolved into one ordered child list. Placement policy —
+// takeover suppression, last-enabled-wins, missing-anchor degradation —
+// lives in resolveStructure; this component only renders the result.
+export function Region<Name extends RegionName>(props: {
   readonly name: Name
-  readonly input: SlotMap[Name]
-  readonly mode: "all" | "replace"
+  readonly input: RegionMap[Name]["input"]
+  readonly parts?: ReadonlyArray<Part<HostRender, RegionMap[Name]["part"]>>
 }) {
   const plugins = usePlugin()
-  const renderers = createMemo(() => {
-    const items = plugins.slot(props.name)
-    if (props.mode === "replace") return items.slice(-1)
-    return items
-  })
+  // resolveStructure builds fresh entry objects each run, but <For> diffs
+  // rows by reference: cache entries so untouched rows (and the plugin
+  // state inside them) survive unrelated claim changes. Part entries key on
+  // their documented-stable id — render-function identity would break if
+  // the compiled parts prop ever rebuilt its closures. Claim entries key on
+  // the render function (weakly, so hot-reloaded generations collect).
+  const partEntries = new Map<string, Entry<HostRender, Slot>>()
+  const claimEntries = new WeakMap<Slot, Entry<HostRender, Slot>>()
+  const entries = createMemo(
+    () =>
+      resolveStructure<HostRender, Slot>({
+        region: props.name,
+        parts: props.parts ?? [],
+        claims: plugins.claims(props.name),
+      }).entries.map((entry) => {
+        if (entry.kind === "part") {
+          const cached = partEntries.get(entry.id)
+          if (cached) return cached
+          partEntries.set(entry.id, entry)
+          return entry
+        }
+        const cached = claimEntries.get(entry.claim.render)
+        if (cached) return cached
+        claimEntries.set(entry.claim.render, entry)
+        return entry
+      }),
+    [] as ReadonlyArray<Entry<HostRender, Slot>>,
+    // Rows are reference-stable, so an elementwise comparison makes a claim
+    // change in some other region a complete no-op for this one.
+    { equals: (a, b) => a.length === b.length && a.every((entry, index) => entry === b[index]) },
+  )
   return (
-    <For each={renderers()}>
-      {(item) => (
-        <PluginBoundary id={item.id} where={`slot ${props.name}`}>
-          {
-            // Component semantics: the render body runs once and untracked, so
-            // signals and intervals created inside are stable, while props stay
-            // reactive through the merged getter. A bare item.render(props.input)
-            // call would run inside the host's tracked scope and re-execute the
-            // whole body (resetting plugin state) on every tracked read.
-            createComponent(item.render, mergeProps(() => props.input) as SlotMap[Name])
-          }
-        </PluginBoundary>
-      )}
+    <For each={entries()}>
+      {(entry) =>
+        // A row's entry object is cached, so its kind never changes within
+        // the row's lifetime — a plain branch is safe here.
+        entry.kind === "part" ? (
+          entry.render()
+        ) : (
+          <PluginBoundary id={entry.claim.plugin} where={`region ${props.name}`}>
+            {
+              // Component semantics: the render body runs once and untracked, so
+              // signals and intervals created inside are stable, while props stay
+              // reactive through the merged getter. A bare render(props.input)
+              // call would run inside the host's tracked scope and re-execute the
+              // whole body (resetting plugin state) on every tracked read.
+              createComponent(entry.claim.render, mergeProps(() => props.input) as SlotMap[SlotName])
+            }
+          </PluginBoundary>
+        )
+      }
     </For>
   )
 }

--- a/packages/tui/src/plugin/structure.ts
+++ b/packages/tui/src/plugin/structure.ts
@@ -1,18 +1,20 @@
-// Pure resolution of a region's structure: the host's part tree plus plugin
-// claims in, an ordered render list plus suppressions out. No solid, no I/O —
-// every policy rule (takeover, hierarchy-beats-timeline, last-enabled-wins,
-// missing-anchor degradation) is testable as a data transform.
+// Pure resolution of the slot tree: the mounted slot paths plus plugin claims
+// in, per-path placement buckets plus diagnostics out. No solid, no I/O —
+// every policy rule (replacement takeover, hierarchy-beats-timeline,
+// last-enabled-wins, missing-target degradation) is testable as a data
+// transform.
 
-// Mirrors the public RegionPlacement type (plugin package) with part ids
-// erased to strings so the resolver stays independent of the region map.
-// Keep the two unions' variants in sync.
+// Mirrors the public SlotClaim type (plugin package) with target paths erased
+// to strings so the resolver stays independent of the slot map. Keep the two
+// unions' variants in sync.
 export type Placement =
-  | { readonly at: "start" | "end" }
+  | { readonly prepend: string }
+  | { readonly append: string }
   | { readonly before: string }
   | { readonly after: string }
   | { readonly replace: string }
 
-// One plugin's registered slot, in enable order within the claims array.
+// One plugin's registered slot claim, in enable order within the claims array.
 export type Claim<Render> = {
   readonly key: string
   readonly plugin: string
@@ -20,106 +22,142 @@ export type Claim<Render> = {
   readonly render: Render
 }
 
-// Host furniture: a leaf renders, a container groups — never both. Part ids
-// are the stable anchor vocabulary and must be unique within a region.
-export type Part<Render, Id extends string = string> =
-  | { readonly id: Id; readonly render: Render; readonly parts?: never }
-  | { readonly id: Id; readonly parts: ReadonlyArray<Part<Render, Id>>; readonly render?: never }
-
-export type Entry<PartRender, ClaimRender> =
-  | { readonly kind: "part"; readonly id: string; readonly render: PartRender }
-  | { readonly kind: "claim"; readonly claim: Claim<ClaimRender> }
-
-export function resolveStructure<PartRender extends {}, ClaimRender>(input: {
-  readonly region: string
-  readonly parts: ReadonlyArray<Part<PartRender>>
-  readonly claims: ReadonlyArray<Claim<ClaimRender>>
-}): {
-  readonly entries: ReadonlyArray<Entry<PartRender, ClaimRender>>
-  readonly suppressed: ReadonlyArray<{ readonly claim: Claim<ClaimRender>; readonly by: Claim<ClaimRender> }>
-  readonly degraded: ReadonlyArray<Claim<ClaimRender>>
-} {
-  // Root takeover: the region's content is the winning claim, full stop.
-  // Every other claim — including edge-anchored ones — is suppressed, so a
-  // theme can never be silently decorated by chips it didn't plan for.
-  const takeover = input.claims
-    .filter((claim) => "replace" in claim.placement && claim.placement.replace === input.region)
-    .at(-1)
-  if (takeover)
-    return {
-      entries: [{ kind: "claim", claim: takeover }],
-      suppressed: input.claims.filter((claim) => claim !== takeover).map((claim) => ({ claim, by: takeover })),
-      degraded: [],
-    }
-
-  const known = new Set<string>()
-  const register = (parts: ReadonlyArray<Part<PartRender>>) => {
-    for (const part of parts) {
-      known.add(part.id)
-      if (part.parts !== undefined) register(part.parts)
-    }
-  }
-  register(input.parts)
-
-  const entries: Entry<PartRender, ClaimRender>[] = []
-  const suppressed: { claim: Claim<ClaimRender>; by: Claim<ClaimRender> }[] = []
-
-  // A container takeover orphans everything anchored to (or replacing) the
-  // parts inside it. Recorded so the host can surface it (plugins dialog,
-  // in a follow-up) — never silently dropped.
-  const suppressSubtree = (parts: ReadonlyArray<Part<PartRender>>, by: Claim<ClaimRender>) => {
-    for (const part of parts) {
-      for (const claim of input.claims) if (anchor(claim.placement) === part.id) suppressed.push({ claim, by })
-      if (part.parts !== undefined) suppressSubtree(part.parts, by)
-    }
-  }
-
-  const walk = (parts: ReadonlyArray<Part<PartRender>>) => {
-    for (const part of parts) {
-      for (const claim of input.claims)
-        if ("before" in claim.placement && claim.placement.before === part.id) entries.push({ kind: "claim", claim })
-      // Replacing keeps the part's position: before/after anchors on the
-      // replaced id stay valid, only the content (and subtree) changes hands.
-      const replacers = input.claims.filter(
-        (claim) => "replace" in claim.placement && claim.placement.replace === part.id,
-      )
-      const winner = replacers.at(-1)
-      if (winner) {
-        for (const loser of replacers.slice(0, -1)) suppressed.push({ claim: loser, by: winner })
-        entries.push({ kind: "claim", claim: winner })
-        // Hierarchy beats timeline: claims into the subtree lose to the
-        // container's winner no matter when they were enabled.
-        if (part.parts !== undefined) suppressSubtree(part.parts, winner)
-      }
-      if (!winner && part.parts !== undefined) walk(part.parts)
-      if (!winner && part.render !== undefined) entries.push({ kind: "part", id: part.id, render: part.render })
-      for (const claim of input.claims)
-        if ("after" in claim.placement && claim.placement.after === part.id) entries.push({ kind: "claim", claim })
-    }
-  }
-
-  for (const claim of input.claims)
-    if ("at" in claim.placement && claim.placement.at === "start") entries.push({ kind: "claim", claim })
-  walk(input.parts)
-  for (const claim of input.claims)
-    if ("at" in claim.placement && claim.placement.at === "end") entries.push({ kind: "claim", claim })
-
-  // A claim aimed at a part the host no longer publishes degrades to the
-  // region's end rather than vanishing: an anchor rename must never silently
-  // cost a plugin its render. Degraded claims land after end-edge claims,
-  // in enable order.
-  const degraded = input.claims.filter((claim) => {
-    const id = anchor(claim.placement)
-    return id !== undefined && !known.has(id)
-  })
-  for (const claim of degraded) entries.push({ kind: "claim", claim })
-
-  return { entries, suppressed, degraded }
+// Everything one mounted slot renders besides its own children: siblings
+// around the boundary, contributions inside it, and at most one takeover.
+export type Slotted<Render> = {
+  readonly before: ReadonlyArray<Claim<Render>>
+  readonly prepend: ReadonlyArray<Claim<Render>>
+  readonly append: ReadonlyArray<Claim<Render>>
+  readonly after: ReadonlyArray<Claim<Render>>
+  readonly replace?: Claim<Render>
 }
 
-function anchor(placement: Placement) {
-  if ("before" in placement) return placement.before
-  if ("after" in placement) return placement.after
-  if ("replace" in placement) return placement.replace
+export type Suppressed<Render> = {
+  readonly claim: Claim<Render>
+  // The winning claim for a conflict or boundary suppression; absent when a
+  // replacement's target no longer exists (missing replacements never degrade).
+  readonly by?: Claim<Render>
+}
+
+export type Degraded<Render> = {
+  readonly claim: Claim<Render>
+  // The surviving ancestor path the claim was appended to.
+  readonly to: string
+}
+
+const EMPTY: Slotted<never> = { before: [], prepend: [], append: [], after: [] }
+
+export function emptySlotted<Render>(): Slotted<Render> {
+  return EMPTY
+}
+
+// `paths` is the set of currently mounted slot paths; `claims` is every
+// active claim in plugin enable order. The result maps each targeted path to
+// its placement buckets — untargeted paths are absent and render as empty.
+export function resolveSlots<Render>(input: {
+  readonly paths: ReadonlySet<string>
+  readonly claims: ReadonlyArray<Claim<Render>>
+}): {
+  readonly slotted: ReadonlyMap<string, Slotted<Render>>
+  readonly suppressed: ReadonlyArray<Suppressed<Render>>
+  readonly degraded: ReadonlyArray<Degraded<Render>>
+} {
+  const suppressed: Suppressed<Render>[] = []
+  const degraded: Degraded<Render>[] = []
+
+  // Pass 1 — replacement boundaries. Per target the last-enabled claim wins;
+  // then an accepted boundary swallows every replacement strictly inside it,
+  // regardless of enable order (hierarchy beats timeline).
+  const winners = new Map<string, Claim<Render>>()
+  for (const claim of input.claims) {
+    if (!("replace" in claim.placement)) continue
+    if (!input.paths.has(claim.placement.replace)) {
+      suppressed.push({ claim })
+      continue
+    }
+    const prior = winners.get(claim.placement.replace)
+    if (prior) suppressed.push({ claim: prior, by: claim })
+    winners.set(claim.placement.replace, claim)
+  }
+  const boundaries = new Map<string, Claim<Render>>()
+  const containing = (path: string) => {
+    for (const [boundary, winner] of boundaries) if (path.startsWith(boundary + ".")) return winner
+    return undefined
+  }
+  // Shallow boundaries first, so a nested replacement meets its container.
+  for (const [path, winner] of [...winners].sort((a, b) => depth(a[0]) - depth(b[0]))) {
+    const outer = containing(path)
+    if (outer) {
+      suppressed.push({ claim: winner, by: outer })
+      continue
+    }
+    boundaries.set(path, winner)
+  }
+
+  // Pass 2 — additive claims, in enable order. A claim whose target sits
+  // inside a replaced boundary is suppressed; a claim whose target is gone
+  // degrades to appending on the nearest surviving ancestor.
+  const buckets = new Map<
+    string,
+    { before: Claim<Render>[]; prepend: Claim<Render>[]; append: Claim<Render>[]; after: Claim<Render>[] }
+  >()
+  const bucket = (path: string) => {
+    const existing = buckets.get(path)
+    if (existing) return existing
+    const fresh = { before: [], prepend: [], append: [], after: [] }
+    buckets.set(path, fresh)
+    return fresh
+  }
+  for (const claim of input.claims) {
+    if ("replace" in claim.placement) continue
+    const [kind, path] =
+      "prepend" in claim.placement
+        ? (["prepend", claim.placement.prepend] as const)
+        : "append" in claim.placement
+          ? (["append", claim.placement.append] as const)
+          : "before" in claim.placement
+            ? (["before", claim.placement.before] as const)
+            : (["after", claim.placement.after] as const)
+    // Inside placements targeting a replaced boundary are part of its
+    // contents; sibling placements on the boundary itself stay outside it.
+    const inside = kind === "prepend" || kind === "append" ? boundaries.get(path) : undefined
+    const outer = inside ?? containing(path)
+    if (outer) {
+      suppressed.push({ claim, by: outer })
+      continue
+    }
+    if (input.paths.has(path)) {
+      bucket(path)[kind].push(claim)
+      continue
+    }
+    const ancestor = survivingAncestor(path, input.paths)
+    if (ancestor === undefined) {
+      suppressed.push({ claim })
+      continue
+    }
+    const boundary = boundaries.get(ancestor)
+    if (boundary) {
+      suppressed.push({ claim, by: boundary })
+      continue
+    }
+    degraded.push({ claim, to: ancestor })
+    bucket(ancestor).append.push(claim)
+  }
+
+  const slotted = new Map<string, Slotted<Render>>()
+  for (const [path, lists] of buckets) slotted.set(path, lists)
+  for (const [path, winner] of boundaries) slotted.set(path, { ...(buckets.get(path) ?? EMPTY), replace: winner })
+  return { slotted, suppressed, degraded }
+}
+
+function depth(path: string) {
+  return path.split(".").length
+}
+
+function survivingAncestor(path: string, paths: ReadonlySet<string>) {
+  for (let index = path.lastIndexOf("."); index !== -1; index = path.lastIndexOf(".", index - 1)) {
+    const ancestor = path.slice(0, index)
+    if (paths.has(ancestor)) return ancestor
+  }
   return undefined
 }

--- a/packages/tui/src/plugin/structure.ts
+++ b/packages/tui/src/plugin/structure.ts
@@ -4,15 +4,12 @@
 // last-enabled-wins, missing-target degradation) is testable as a data
 // transform.
 
-// Mirrors the public SlotClaim type (plugin package) with target paths erased
-// to strings so the resolver stays independent of the slot map. Keep the two
-// unions' variants in sync.
-export type Placement =
-  | { readonly prepend: string }
-  | { readonly append: string }
-  | { readonly before: string }
-  | { readonly after: string }
-  | { readonly replace: string }
+export type PlacementKind = "prepend" | "append" | "before" | "after" | "replace"
+
+// Normalized from the public SlotClaim shape by the plugin API: exactly one
+// placement kind, the target path erased to a string so the resolver stays
+// independent of the slot map.
+export type Placement = { readonly kind: PlacementKind; readonly target: string }
 
 // One plugin's registered slot claim, in enable order within the claims array.
 export type Claim<Render> = {
@@ -51,6 +48,12 @@ export function emptySlotted<Render>(): Slotted<Render> {
   return EMPTY
 }
 
+// The tree's one containment rule: a path contains every path it prefixes.
+// Shared with the <Slot> mount assertion so the spellings cannot drift.
+export function contains(ancestor: string, path: string) {
+  return path.startsWith(ancestor + ".")
+}
+
 // `paths` is the set of currently mounted slot paths; `claims` is every
 // active claim in plugin enable order. The result maps each targeted path to
 // its placement buckets — untargeted paths are absent and render as empty.
@@ -70,18 +73,18 @@ export function resolveSlots<Render>(input: {
   // regardless of enable order (hierarchy beats timeline).
   const winners = new Map<string, Claim<Render>>()
   for (const claim of input.claims) {
-    if (!("replace" in claim.placement)) continue
-    if (!input.paths.has(claim.placement.replace)) {
+    if (claim.placement.kind !== "replace") continue
+    if (!input.paths.has(claim.placement.target)) {
       suppressed.push({ claim })
       continue
     }
-    const prior = winners.get(claim.placement.replace)
+    const prior = winners.get(claim.placement.target)
     if (prior) suppressed.push({ claim: prior, by: claim })
-    winners.set(claim.placement.replace, claim)
+    winners.set(claim.placement.target, claim)
   }
   const boundaries = new Map<string, Claim<Render>>()
   const containing = (path: string) => {
-    for (const [boundary, winner] of boundaries) if (path.startsWith(boundary + ".")) return winner
+    for (const [boundary, winner] of boundaries) if (contains(boundary, path)) return winner
     return undefined
   }
   // Shallow boundaries first, so a nested replacement meets its container.
@@ -109,37 +112,30 @@ export function resolveSlots<Render>(input: {
     return fresh
   }
   for (const claim of input.claims) {
-    if ("replace" in claim.placement) continue
-    const [kind, path] =
-      "prepend" in claim.placement
-        ? (["prepend", claim.placement.prepend] as const)
-        : "append" in claim.placement
-          ? (["append", claim.placement.append] as const)
-          : "before" in claim.placement
-            ? (["before", claim.placement.before] as const)
-            : (["after", claim.placement.after] as const)
+    const kind = claim.placement.kind
+    if (kind === "replace") continue
+    const target = claim.placement.target
     // Inside placements targeting a replaced boundary are part of its
     // contents; sibling placements on the boundary itself stay outside it.
-    const inside = kind === "prepend" || kind === "append" ? boundaries.get(path) : undefined
-    const outer = inside ?? containing(path)
+    const inside = kind === "prepend" || kind === "append" ? boundaries.get(target) : undefined
+    const outer = inside ?? containing(target)
     if (outer) {
       suppressed.push({ claim, by: outer })
       continue
     }
-    if (input.paths.has(path)) {
-      bucket(path)[kind].push(claim)
+    if (input.paths.has(target)) {
+      bucket(target)[kind].push(claim)
       continue
     }
-    const ancestor = survivingAncestor(path, input.paths)
+    const ancestor = survivingAncestor(target, input.paths)
     if (ancestor === undefined) {
       suppressed.push({ claim })
       continue
     }
-    const boundary = boundaries.get(ancestor)
-    if (boundary) {
-      suppressed.push({ claim, by: boundary })
-      continue
-    }
+    // The ancestor is never a replaced boundary (containing() caught that).
+    // Appending is load-bearing: a parent slot registers before its children
+    // and <Slot> renders append after them, so the transient degradation
+    // during a nested mount never instantiates anything.
     degraded.push({ claim, to: ancestor })
     bucket(ancestor).append.push(claim)
   }

--- a/packages/tui/src/plugin/structure.ts
+++ b/packages/tui/src/plugin/structure.ts
@@ -1,0 +1,125 @@
+// Pure resolution of a region's structure: the host's part tree plus plugin
+// claims in, an ordered render list plus suppressions out. No solid, no I/O —
+// every policy rule (takeover, hierarchy-beats-timeline, last-enabled-wins,
+// missing-anchor degradation) is testable as a data transform.
+
+// Mirrors the public RegionPlacement type (plugin package) with part ids
+// erased to strings so the resolver stays independent of the region map.
+// Keep the two unions' variants in sync.
+export type Placement =
+  | { readonly at: "start" | "end" }
+  | { readonly before: string }
+  | { readonly after: string }
+  | { readonly replace: string }
+
+// One plugin's registered slot, in enable order within the claims array.
+export type Claim<Render> = {
+  readonly key: string
+  readonly plugin: string
+  readonly placement: Placement
+  readonly render: Render
+}
+
+// Host furniture: a leaf renders, a container groups — never both. Part ids
+// are the stable anchor vocabulary and must be unique within a region.
+export type Part<Render, Id extends string = string> =
+  | { readonly id: Id; readonly render: Render; readonly parts?: never }
+  | { readonly id: Id; readonly parts: ReadonlyArray<Part<Render, Id>>; readonly render?: never }
+
+export type Entry<PartRender, ClaimRender> =
+  | { readonly kind: "part"; readonly id: string; readonly render: PartRender }
+  | { readonly kind: "claim"; readonly claim: Claim<ClaimRender> }
+
+export function resolveStructure<PartRender extends {}, ClaimRender>(input: {
+  readonly region: string
+  readonly parts: ReadonlyArray<Part<PartRender>>
+  readonly claims: ReadonlyArray<Claim<ClaimRender>>
+}): {
+  readonly entries: ReadonlyArray<Entry<PartRender, ClaimRender>>
+  readonly suppressed: ReadonlyArray<{ readonly claim: Claim<ClaimRender>; readonly by: Claim<ClaimRender> }>
+  readonly degraded: ReadonlyArray<Claim<ClaimRender>>
+} {
+  // Root takeover: the region's content is the winning claim, full stop.
+  // Every other claim — including edge-anchored ones — is suppressed, so a
+  // theme can never be silently decorated by chips it didn't plan for.
+  const takeover = input.claims
+    .filter((claim) => "replace" in claim.placement && claim.placement.replace === input.region)
+    .at(-1)
+  if (takeover)
+    return {
+      entries: [{ kind: "claim", claim: takeover }],
+      suppressed: input.claims.filter((claim) => claim !== takeover).map((claim) => ({ claim, by: takeover })),
+      degraded: [],
+    }
+
+  const known = new Set<string>()
+  const register = (parts: ReadonlyArray<Part<PartRender>>) => {
+    for (const part of parts) {
+      known.add(part.id)
+      if (part.parts !== undefined) register(part.parts)
+    }
+  }
+  register(input.parts)
+
+  const entries: Entry<PartRender, ClaimRender>[] = []
+  const suppressed: { claim: Claim<ClaimRender>; by: Claim<ClaimRender> }[] = []
+
+  // A container takeover orphans everything anchored to (or replacing) the
+  // parts inside it. Recorded so the host can surface it (plugins dialog,
+  // in a follow-up) — never silently dropped.
+  const suppressSubtree = (parts: ReadonlyArray<Part<PartRender>>, by: Claim<ClaimRender>) => {
+    for (const part of parts) {
+      for (const claim of input.claims) if (anchor(claim.placement) === part.id) suppressed.push({ claim, by })
+      if (part.parts !== undefined) suppressSubtree(part.parts, by)
+    }
+  }
+
+  const walk = (parts: ReadonlyArray<Part<PartRender>>) => {
+    for (const part of parts) {
+      for (const claim of input.claims)
+        if ("before" in claim.placement && claim.placement.before === part.id) entries.push({ kind: "claim", claim })
+      // Replacing keeps the part's position: before/after anchors on the
+      // replaced id stay valid, only the content (and subtree) changes hands.
+      const replacers = input.claims.filter(
+        (claim) => "replace" in claim.placement && claim.placement.replace === part.id,
+      )
+      const winner = replacers.at(-1)
+      if (winner) {
+        for (const loser of replacers.slice(0, -1)) suppressed.push({ claim: loser, by: winner })
+        entries.push({ kind: "claim", claim: winner })
+        // Hierarchy beats timeline: claims into the subtree lose to the
+        // container's winner no matter when they were enabled.
+        if (part.parts !== undefined) suppressSubtree(part.parts, winner)
+      }
+      if (!winner && part.parts !== undefined) walk(part.parts)
+      if (!winner && part.render !== undefined) entries.push({ kind: "part", id: part.id, render: part.render })
+      for (const claim of input.claims)
+        if ("after" in claim.placement && claim.placement.after === part.id) entries.push({ kind: "claim", claim })
+    }
+  }
+
+  for (const claim of input.claims)
+    if ("at" in claim.placement && claim.placement.at === "start") entries.push({ kind: "claim", claim })
+  walk(input.parts)
+  for (const claim of input.claims)
+    if ("at" in claim.placement && claim.placement.at === "end") entries.push({ kind: "claim", claim })
+
+  // A claim aimed at a part the host no longer publishes degrades to the
+  // region's end rather than vanishing: an anchor rename must never silently
+  // cost a plugin its render. Degraded claims land after end-edge claims,
+  // in enable order.
+  const degraded = input.claims.filter((claim) => {
+    const id = anchor(claim.placement)
+    return id !== undefined && !known.has(id)
+  })
+  for (const claim of degraded) entries.push({ kind: "claim", claim })
+
+  return { entries, suppressed, degraded }
+}
+
+function anchor(placement: Placement) {
+  if ("before" in placement) return placement.before
+  if ("after" in placement) return placement.after
+  if ("replace" in placement) return placement.replace
+  return undefined
+}

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -9,7 +9,7 @@ import { useEditorContext } from "../context/editor"
 import { useData } from "../context/data"
 import { useLocation } from "../context/location"
 import { FormPrompt } from "./session/form"
-import { PluginSlot } from "../plugin/render"
+import { Region } from "../plugin/render"
 import { useTerminalDimensions } from "@opentui/solid"
 
 let once = false
@@ -91,7 +91,7 @@ export function Home() {
         <box flexGrow={1} minHeight={0} />
       </box>
       <box width="100%" flexShrink={0}>
-        <PluginSlot name="home.footer" input={{}} mode="replace" />
+        <Region name="home.footer" input={{}} />
       </box>
       <Show when={forms()[0]?.id} keyed>
         {(_) => {

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -9,7 +9,7 @@ import { useEditorContext } from "../context/editor"
 import { useData } from "../context/data"
 import { useLocation } from "../context/location"
 import { FormPrompt } from "./session/form"
-import { Region } from "../plugin/render"
+import { Slot } from "../plugin/render"
 import { useTerminalDimensions } from "@opentui/solid"
 
 let once = false
@@ -91,7 +91,7 @@ export function Home() {
         <box flexGrow={1} minHeight={0} />
       </box>
       <box width="100%" flexShrink={0}>
-        <Region name="home.footer" input={{}} />
+        <Slot path="home.footer" />
       </box>
       <Show when={forms()[0]?.id} keyed>
         {(_) => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -86,7 +86,7 @@ import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
-import { PluginSlot } from "../../plugin/render"
+import { Region } from "../../plugin/render"
 import { usePlugin } from "../../plugin/context"
 import {
   cacheReuseDrop,
@@ -1088,7 +1088,7 @@ export function Session() {
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                 <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>
-              <PluginSlot name="session.composer.top" input={{ sessionID: route.sessionID }} mode="all" />
+              <Region name="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Composer
                 sessionID={route.sessionID}
                 open={composer.open || (!!session()?.parentID && forms().length === 0)}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -86,7 +86,7 @@ import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
-import { Region } from "../../plugin/render"
+import { Slot } from "../../plugin/render"
 import { usePlugin } from "../../plugin/context"
 import {
   cacheReuseDrop,
@@ -1088,7 +1088,7 @@ export function Session() {
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                 <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>
-              <Region name="session.composer.top" input={{ sessionID: route.sessionID }} />
+              <Slot path="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Composer
                 sessionID={route.sessionID}
                 open={composer.open || (!!session()?.parentID && forms().length === 0)}

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -2,7 +2,7 @@ import { useData } from "../../context/data"
 import { createMemo, Show } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useConfig } from "../../config"
-import { Region } from "../../plugin/render"
+import { Slot } from "../../plugin/render"
 import { withTimestampedFallback } from "@opencode-ai/util/session-title-fallback"
 
 import { getScrollAcceleration } from "../../util/scroll"
@@ -52,12 +52,12 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 <text fg={theme.text.subdued}>{session()!.location.workspaceID}</text>
               </Show>
             </box>
-            <Region name="sidebar.content" input={{ sessionID: props.sessionID }} />
+            <Slot path="sidebar.content" input={{ sessionID: props.sessionID }} />
           </box>
         </scrollbox>
 
         <box flexShrink={0} gap={1} paddingTop={1}>
-          <Region name="sidebar.footer" input={{}} />
+          <Slot path="sidebar.footer" />
         </box>
       </box>
     </Show>

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -2,7 +2,7 @@ import { useData } from "../../context/data"
 import { createMemo, Show } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useConfig } from "../../config"
-import { PluginSlot } from "../../plugin/render"
+import { Region } from "../../plugin/render"
 import { withTimestampedFallback } from "@opencode-ai/util/session-title-fallback"
 
 import { getScrollAcceleration } from "../../util/scroll"
@@ -52,12 +52,12 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 <text fg={theme.text.subdued}>{session()!.location.workspaceID}</text>
               </Show>
             </box>
-            <PluginSlot name="sidebar.content" input={{ sessionID: props.sessionID }} mode="all" />
+            <Region name="sidebar.content" input={{ sessionID: props.sessionID }} />
           </box>
         </scrollbox>
 
         <box flexShrink={0} gap={1} paddingTop={1}>
-          <PluginSlot name="sidebar.footer" input={{}} mode="replace" />
+          <Region name="sidebar.footer" input={{}} />
         </box>
       </box>
     </Show>

--- a/packages/tui/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer.test.tsx
@@ -8,7 +8,7 @@ import type {
   KeymapCommand,
   KeymapLayer,
   Page,
-  RegionClaim,
+  SlotClaim,
   Route,
 } from "@opencode-ai/plugin/tui/context"
 import { ThemeProvider, useThemes } from "../../../src/context/theme"
@@ -143,7 +143,7 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
   const commands = new Map<string, KeymapCommand>()
   let current = initialRoute ?? startRoute
   let renderDiff: Page["render"] | undefined
-  let renderCommands: RegionClaim<"app">["render"] | undefined
+  let renderCommands: SlotClaim<"app">["render"] | undefined
   let vcsDiffInput: unknown
   const config = createTuiResolvedConfig()
   const transport = createFetch((url) => {
@@ -200,7 +200,7 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
           },
           current: () => current,
         },
-        slot(_name: string, claim: RegionClaim<"app">) {
+        slot(claim: SlotClaim<"app">) {
           renderCommands = claim.render
           return () => {}
         },

--- a/packages/tui/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer.test.tsx
@@ -8,8 +8,8 @@ import type {
   KeymapCommand,
   KeymapLayer,
   Page,
+  RegionClaim,
   Route,
-  Slot,
 } from "@opencode-ai/plugin/tui/context"
 import { ThemeProvider, useThemes } from "../../../src/context/theme"
 import { emptyThemeSource } from "../../fixture/fixture"
@@ -143,7 +143,7 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
   const commands = new Map<string, KeymapCommand>()
   let current = initialRoute ?? startRoute
   let renderDiff: Page["render"] | undefined
-  let renderCommands: Slot | undefined
+  let renderCommands: RegionClaim<"app">["render"] | undefined
   let vcsDiffInput: unknown
   const config = createTuiResolvedConfig()
   const transport = createFetch((url) => {
@@ -200,8 +200,8 @@ async function renderDiffViewer(vcsDiff: unknown[], height = 20, initialRoute?: 
           },
           current: () => current,
         },
-        slot(_name: string, render: Slot) {
-          renderCommands = render
+        slot(_name: string, claim: RegionClaim<"app">) {
+          renderCommands = claim.render
           return () => {}
         },
       },

--- a/packages/tui/test/plugin-hot-reload.test.tsx
+++ b/packages/tui/test/plugin-hot-reload.test.tsx
@@ -140,8 +140,11 @@ import { appendFile } from "node:fs/promises"
 export default {
   id: "test.crash",
   setup: async (context: any) => {
-    context.ui.slot("home.footer", () => {
-      throw new Error("boom")
+    context.ui.slot("home.footer", {
+      replace: "home.footer",
+      render: () => {
+        throw new Error("boom")
+      },
     })
     await appendFile(${JSON.stringify(markerCrash)}, "setup\\n")
   },

--- a/packages/tui/test/plugin-hot-reload.test.tsx
+++ b/packages/tui/test/plugin-hot-reload.test.tsx
@@ -140,7 +140,7 @@ import { appendFile } from "node:fs/promises"
 export default {
   id: "test.crash",
   setup: async (context: any) => {
-    context.ui.slot("home.footer", {
+    context.ui.slot({
       replace: "home.footer",
       render: () => {
         throw new Error("boom")

--- a/packages/tui/test/plugin-structure.test.ts
+++ b/packages/tui/test/plugin-structure.test.ts
@@ -1,148 +1,206 @@
 import { expect, test } from "bun:test"
-import type { RegionClaim } from "@opencode-ai/plugin/tui/context"
-import { resolveStructure, type Claim, type Part, type Placement } from "../src/plugin/structure"
+import type { SlotClaim } from "@opencode-ai/plugin/tui/context"
+import { resolveSlots, type Claim, type Placement } from "../src/plugin/structure"
 
-// Type-level canaries, checked by `bun typecheck`: the placement sum and the
-// part union are exclusive — nonsense shapes must not compile.
+// Type-level canaries, checked by `bun typecheck`: exactly one placement key,
+// absolute paths only, and the render input follows the targeted path.
 export const canaries = () => {
-  const claims: RegionClaim<"prompt.footer">[] = []
-  claims.push({ at: "end", render: () => null })
+  const claims: SlotClaim[] = []
+  claims.push({ append: "prompt.footer", render: (input) => (input.mode === "shell" ? null : null) })
+  claims.push({ after: "prompt.footer.status", render: () => null })
   // @ts-expect-error two placement keys cannot coexist
-  claims.push({ at: "end", before: "status", render: () => null })
+  claims.push({ append: "prompt.footer", before: "prompt.footer.status", render: () => null })
   // @ts-expect-error replace does not combine with an anchor
-  claims.push({ replace: "status", after: "file", render: () => null })
-  // @ts-expect-error a part is a leaf or a container, never both
-  const hybrid: Part<string> = { id: "x", render: "x", parts: [] }
-  return { claims, hybrid }
+  claims.push({ replace: "prompt.footer.status", after: "prompt.footer.file", render: () => null })
+  // @ts-expect-error targets must be absolute published paths
+  claims.push({ after: "status", render: () => null })
+  // @ts-expect-error the render input is the targeted slot's input
+  claims.push({ append: "prompt.footer", render: (input: { mode: number }) => null })
+  return claims
 }
 
-// The resolver is generic over render types; strings make ordering
-// assertions read as layouts.
-function claim(plugin: string, placement: Placement, render?: string): Claim<string> {
-  return { key: `${plugin}/${render ?? JSON.stringify(placement)}`, plugin, placement, render: render ?? plugin }
+// The resolver is generic over render values; strings make layout assertions
+// read as layouts.
+function claim(plugin: string, placement: Placement, render: string): Claim<string> {
+  return { key: `${plugin}/${render}`, plugin, placement, render }
 }
 
-function layout(result: ReturnType<typeof resolveStructure<string, string>>) {
-  return result.entries.map((entry) => (entry.kind === "part" ? entry.id : entry.claim.render))
+// A host slot tree for tests: a node's children are its child slots, a leaf's
+// content is its own name. Mirrors how nested <Slot> components mount.
+type Node = { readonly path: string; readonly children?: ReadonlyArray<Node> }
+
+function paths(nodes: ReadonlyArray<Node>, into = new Set<string>()): Set<string> {
+  for (const node of nodes) {
+    into.add(node.path)
+    paths(node.children ?? [], into)
+  }
+  return into
 }
 
-const footer: Part<string>[] = [
-  { id: "status", render: "status" },
-  { id: "file", render: "file" },
+// Fold the tree with a resolution into the flat render order, mirroring the
+// <Slot> component: before + (replace | prepend + own content + append) + after.
+function layout(nodes: ReadonlyArray<Node>, resolved: ReturnType<typeof resolveSlots<string>>): ReadonlyArray<string> {
+  return nodes.flatMap((node) => {
+    const slotted = resolved.slotted.get(node.path)
+    const own = node.children ? layout(node.children, resolved) : [leafName(node.path)]
+    const inside = slotted?.replace
+      ? [slotted.replace.render]
+      : [
+          ...(slotted?.prepend ?? []).map((item) => item.render),
+          ...own,
+          ...(slotted?.append ?? []).map((item) => item.render),
+        ]
+    return [
+      ...(slotted?.before ?? []).map((item) => item.render),
+      ...inside,
+      ...(slotted?.after ?? []).map((item) => item.render),
+    ]
+  })
+}
+
+function leafName(path: string) {
+  return path.slice(path.lastIndexOf(".") + 1)
+}
+
+function resolve(tree: ReadonlyArray<Node>, claims: ReadonlyArray<Claim<string>>) {
+  return resolveSlots({ paths: paths(tree), claims })
+}
+
+const footer: Node[] = [
+  {
+    path: "prompt.footer",
+    children: [{ path: "prompt.footer.status" }, { path: "prompt.footer.file" }],
+  },
 ]
 
-const tree: Part<string>[] = [
-  { id: "left", parts: [{ id: "mode", render: "mode" }] },
+const tree: Node[] = [
   {
-    id: "right",
-    parts: [
-      { id: "directory", render: "directory" },
-      { id: "model", render: "model" },
-      { id: "tokens", render: "tokens" },
+    path: "prompt.footer",
+    children: [
+      { path: "prompt.footer.left", children: [{ path: "prompt.footer.left.mode" }] },
+      {
+        path: "prompt.footer.right",
+        children: [
+          { path: "prompt.footer.right.directory" },
+          { path: "prompt.footer.right.model" },
+          { path: "prompt.footer.right.tokens" },
+        ],
+      },
     ],
   },
 ]
 
-test("no claims renders the host parts in order", () => {
-  const result = resolveStructure<string, string>({ region: "prompt.footer", parts: footer, claims: [] })
-  expect(layout(result)).toEqual(["status", "file"])
+test("no claims renders the host tree in order", () => {
+  const result = resolve(footer, [])
+  expect(layout(footer, result)).toEqual(["status", "file"])
   expect(result.suppressed).toEqual([])
   expect(result.degraded).toEqual([])
 })
 
-test("edge claims land at the region's edges, several in enable order", () => {
-  const result = resolveStructure({
-    region: "prompt.footer",
-    parts: footer,
-    claims: [
-      claim("a", { at: "end" }, "a1"),
-      claim("b", { at: "start" }, "b1"),
-      claim("a", { at: "end" }, "a2"),
-    ],
-  })
-  expect(layout(result)).toEqual(["b1", "status", "file", "a1", "a2"])
+test("prepend and append land inside a boundary's edges, several in enable order", () => {
+  const result = resolve(footer, [
+    claim("a", { append: "prompt.footer" }, "a1"),
+    claim("b", { prepend: "prompt.footer" }, "b1"),
+    claim("a", { append: "prompt.footer" }, "a2"),
+  ])
+  expect(layout(footer, result)).toEqual(["b1", "status", "file", "a1", "a2"])
 })
 
-test("before and after anchor to a part, wherever the host keeps it", () => {
-  const result = resolveStructure({
-    region: "prompt.footer",
-    parts: footer,
-    claims: [claim("a", { after: "status" }, "chip"), claim("b", { before: "status" }, "vim")],
-  })
-  expect(layout(result)).toEqual(["vim", "status", "chip", "file"])
+test("before and after anchor to a slot, wherever the host keeps it", () => {
+  const result = resolve(footer, [
+    claim("a", { after: "prompt.footer.status" }, "chip"),
+    claim("b", { before: "prompt.footer.status" }, "vim"),
+  ])
+  expect(layout(footer, result)).toEqual(["vim", "status", "chip", "file"])
 })
 
-test("a missing anchor degrades to the end instead of disappearing", () => {
-  const result = resolveStructure({
-    region: "prompt.footer",
-    parts: footer,
-    claims: [claim("a", { after: "tokens" }, "chip")],
-  })
-  expect(layout(result)).toEqual(["status", "file", "chip"])
-  expect(result.degraded.map((item) => item.render)).toEqual(["chip"])
+test("a missing anchor degrades to the nearest surviving ancestor's end", () => {
+  const result = resolve(footer, [claim("a", { after: "prompt.footer.tokens" }, "chip")])
+  expect(layout(footer, result)).toEqual(["status", "file", "chip"])
+  expect(result.degraded).toEqual([
+    { claim: claim("a", { after: "prompt.footer.tokens" }, "chip"), to: "prompt.footer" },
+  ])
 })
 
-test("replacing a part swaps content but keeps the position and its anchors", () => {
-  const result = resolveStructure({
-    region: "prompt.footer",
-    parts: footer,
-    claims: [claim("a", { replace: "status" }, "fancy-status"), claim("b", { after: "status" }, "chip")],
-  })
-  expect(layout(result)).toEqual(["fancy-status", "chip", "file"])
+test("an additive claim with no surviving ancestor is suppressed", () => {
+  const result = resolve(footer, [claim("a", { append: "session.composer.top" }, "chip")])
+  expect(layout(footer, result)).toEqual(["status", "file"])
+  expect(result.suppressed).toEqual([{ claim: claim("a", { append: "session.composer.top" }, "chip") }])
+})
+
+test("a missing replacement is suppressed, never degraded into a widget", () => {
+  const result = resolve(footer, [claim("a", { replace: "prompt.footer.tokens" }, "cost")])
+  expect(layout(footer, result)).toEqual(["status", "file"])
+  expect(result.suppressed).toEqual([{ claim: claim("a", { replace: "prompt.footer.tokens" }, "cost") }])
+  expect(result.degraded).toEqual([])
+})
+
+test("replacing a slot swaps content but keeps the boundary and its outside anchors", () => {
+  const fancy = claim("a", { replace: "prompt.footer.status" }, "fancy-status")
+  const result = resolve(footer, [fancy, claim("b", { after: "prompt.footer.status" }, "chip")])
+  expect(layout(footer, result)).toEqual(["fancy-status", "chip", "file"])
   expect(result.suppressed).toEqual([])
 })
 
-test("same target: the last-enabled claim wins and the loser is recorded", () => {
-  const first = claim("a", { replace: "status" }, "first")
-  const second = claim("b", { replace: "status" }, "second")
-  const result = resolveStructure({ region: "prompt.footer", parts: footer, claims: [first, second] })
-  expect(layout(result)).toEqual(["second", "file"])
+test("inside contributions to a replaced boundary are suppressed", () => {
+  const takeover = claim("a", { replace: "prompt.footer" }, "powerline")
+  const badge = claim("b", { append: "prompt.footer" }, "badge")
+  const result = resolve(footer, [badge, takeover])
+  expect(layout(footer, result)).toEqual(["powerline"])
+  expect(result.suppressed).toEqual([{ claim: badge, by: takeover }])
+})
+
+test("same target: the last-enabled replacement wins and the loser is recorded", () => {
+  const first = claim("a", { replace: "prompt.footer.status" }, "first")
+  const second = claim("b", { replace: "prompt.footer.status" }, "second")
+  const result = resolve(footer, [first, second])
+  expect(layout(footer, result)).toEqual(["second", "file"])
   expect(result.suppressed).toEqual([{ claim: first, by: second }])
 })
 
 test("container takeover suppresses everything anchored in the subtree", () => {
-  const takeover = claim("theme", { replace: "right" }, "my-right")
-  const chip = claim("pr", { after: "model" }, "chip")
-  const inner = claim("x", { replace: "tokens" }, "cost")
-  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [takeover, chip, inner] })
-  expect(layout(result)).toEqual(["mode", "my-right"])
+  const takeover = claim("theme", { replace: "prompt.footer.right" }, "my-right")
+  const chip = claim("pr", { after: "prompt.footer.right.model" }, "chip")
+  const inner = claim("x", { replace: "prompt.footer.right.tokens" }, "cost")
+  const result = resolve(tree, [takeover, chip, inner])
+  expect(layout(tree, result)).toEqual(["mode", "my-right"])
   expect(result.suppressed).toEqual([
-    { claim: chip, by: takeover },
     { claim: inner, by: takeover },
+    { claim: chip, by: takeover },
   ])
 })
 
 test("hierarchy beats timeline: an ancestor takeover wins over a later descendant claim", () => {
   // The descendant replace was enabled after the container takeover; the
-  // container still wins because its target contains the descendant's.
-  const inner = claim("x", { replace: "model" }, "swap-model")
-  const outer = claim("theme", { replace: "right" }, "my-right")
-  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [outer, inner] })
-  expect(layout(result)).toEqual(["mode", "my-right"])
+  // container still wins because its path contains the descendant's.
+  const inner = claim("x", { replace: "prompt.footer.right.model" }, "swap-model")
+  const outer = claim("theme", { replace: "prompt.footer.right" }, "my-right")
+  const result = resolve(tree, [outer, inner])
+  expect(layout(tree, result)).toEqual(["mode", "my-right"])
   expect(result.suppressed).toEqual([{ claim: inner, by: outer }])
 })
 
-test("root takeover: nothing original survives, all other claims suppressed", () => {
+test("root takeover: nothing original survives, all inside claims suppressed", () => {
   const theme = claim("powerline", { replace: "prompt.footer" }, "powerline")
-  const chip = claim("pr", { at: "end" }, "chip")
-  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [chip, theme] })
-  expect(layout(result)).toEqual(["powerline"])
+  const chip = claim("pr", { append: "prompt.footer" }, "chip")
+  const result = resolve(tree, [chip, theme])
+  expect(layout(tree, result)).toEqual(["powerline"])
   expect(result.suppressed).toEqual([{ claim: chip, by: theme }])
 })
 
-test("root takeover at the same node: last enabled wins", () => {
-  const first = claim("a", { replace: "home.footer" }, "first")
-  const second = claim("b", { replace: "home.footer" }, "second")
-  const result = resolveStructure<string, string>({ region: "home.footer", parts: [], claims: [first, second] })
-  expect(layout(result)).toEqual(["second"])
-  expect(result.suppressed).toEqual([{ claim: first, by: second }])
+test("a degraded claim landing inside a replaced boundary is suppressed, not shown", () => {
+  const takeover = claim("theme", { replace: "prompt.footer.right" }, "my-right")
+  const stray = claim("pr", { after: "prompt.footer.right.gone" }, "chip")
+  const result = resolve(tree, [takeover, stray])
+  expect(layout(tree, result)).toEqual(["mode", "my-right"])
+  expect(result.suppressed).toEqual([{ claim: stray, by: takeover }])
+  expect(result.degraded).toEqual([])
 })
 
-test("containers flatten in order and anchors on a container wrap its whole span", () => {
-  const result = resolveStructure({
-    region: "prompt.footer",
-    parts: tree,
-    claims: [claim("a", { before: "right" }, "divider"), claim("b", { after: "right" }, "clock")],
-  })
-  expect(layout(result)).toEqual(["mode", "divider", "directory", "model", "tokens", "clock"])
+test("anchors on a container wrap its whole span", () => {
+  const result = resolve(tree, [
+    claim("a", { before: "prompt.footer.right" }, "divider"),
+    claim("b", { after: "prompt.footer.right" }, "clock"),
+  ])
+  expect(layout(tree, result)).toEqual(["mode", "divider", "directory", "model", "tokens", "clock"])
 })

--- a/packages/tui/test/plugin-structure.test.ts
+++ b/packages/tui/test/plugin-structure.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "bun:test"
+import type { RegionClaim } from "@opencode-ai/plugin/tui/context"
+import { resolveStructure, type Claim, type Part, type Placement } from "../src/plugin/structure"
+
+// Type-level canaries, checked by `bun typecheck`: the placement sum and the
+// part union are exclusive — nonsense shapes must not compile.
+export const canaries = () => {
+  const claims: RegionClaim<"prompt.footer">[] = []
+  claims.push({ at: "end", render: () => null })
+  // @ts-expect-error two placement keys cannot coexist
+  claims.push({ at: "end", before: "status", render: () => null })
+  // @ts-expect-error replace does not combine with an anchor
+  claims.push({ replace: "status", after: "file", render: () => null })
+  // @ts-expect-error a part is a leaf or a container, never both
+  const hybrid: Part<string> = { id: "x", render: "x", parts: [] }
+  return { claims, hybrid }
+}
+
+// The resolver is generic over render types; strings make ordering
+// assertions read as layouts.
+function claim(plugin: string, placement: Placement, render?: string): Claim<string> {
+  return { key: `${plugin}/${render ?? JSON.stringify(placement)}`, plugin, placement, render: render ?? plugin }
+}
+
+function layout(result: ReturnType<typeof resolveStructure<string, string>>) {
+  return result.entries.map((entry) => (entry.kind === "part" ? entry.id : entry.claim.render))
+}
+
+const footer: Part<string>[] = [
+  { id: "status", render: "status" },
+  { id: "file", render: "file" },
+]
+
+const tree: Part<string>[] = [
+  { id: "left", parts: [{ id: "mode", render: "mode" }] },
+  {
+    id: "right",
+    parts: [
+      { id: "directory", render: "directory" },
+      { id: "model", render: "model" },
+      { id: "tokens", render: "tokens" },
+    ],
+  },
+]
+
+test("no claims renders the host parts in order", () => {
+  const result = resolveStructure<string, string>({ region: "prompt.footer", parts: footer, claims: [] })
+  expect(layout(result)).toEqual(["status", "file"])
+  expect(result.suppressed).toEqual([])
+  expect(result.degraded).toEqual([])
+})
+
+test("edge claims land at the region's edges, several in enable order", () => {
+  const result = resolveStructure({
+    region: "prompt.footer",
+    parts: footer,
+    claims: [
+      claim("a", { at: "end" }, "a1"),
+      claim("b", { at: "start" }, "b1"),
+      claim("a", { at: "end" }, "a2"),
+    ],
+  })
+  expect(layout(result)).toEqual(["b1", "status", "file", "a1", "a2"])
+})
+
+test("before and after anchor to a part, wherever the host keeps it", () => {
+  const result = resolveStructure({
+    region: "prompt.footer",
+    parts: footer,
+    claims: [claim("a", { after: "status" }, "chip"), claim("b", { before: "status" }, "vim")],
+  })
+  expect(layout(result)).toEqual(["vim", "status", "chip", "file"])
+})
+
+test("a missing anchor degrades to the end instead of disappearing", () => {
+  const result = resolveStructure({
+    region: "prompt.footer",
+    parts: footer,
+    claims: [claim("a", { after: "tokens" }, "chip")],
+  })
+  expect(layout(result)).toEqual(["status", "file", "chip"])
+  expect(result.degraded.map((item) => item.render)).toEqual(["chip"])
+})
+
+test("replacing a part swaps content but keeps the position and its anchors", () => {
+  const result = resolveStructure({
+    region: "prompt.footer",
+    parts: footer,
+    claims: [claim("a", { replace: "status" }, "fancy-status"), claim("b", { after: "status" }, "chip")],
+  })
+  expect(layout(result)).toEqual(["fancy-status", "chip", "file"])
+  expect(result.suppressed).toEqual([])
+})
+
+test("same target: the last-enabled claim wins and the loser is recorded", () => {
+  const first = claim("a", { replace: "status" }, "first")
+  const second = claim("b", { replace: "status" }, "second")
+  const result = resolveStructure({ region: "prompt.footer", parts: footer, claims: [first, second] })
+  expect(layout(result)).toEqual(["second", "file"])
+  expect(result.suppressed).toEqual([{ claim: first, by: second }])
+})
+
+test("container takeover suppresses everything anchored in the subtree", () => {
+  const takeover = claim("theme", { replace: "right" }, "my-right")
+  const chip = claim("pr", { after: "model" }, "chip")
+  const inner = claim("x", { replace: "tokens" }, "cost")
+  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [takeover, chip, inner] })
+  expect(layout(result)).toEqual(["mode", "my-right"])
+  expect(result.suppressed).toEqual([
+    { claim: chip, by: takeover },
+    { claim: inner, by: takeover },
+  ])
+})
+
+test("hierarchy beats timeline: an ancestor takeover wins over a later descendant claim", () => {
+  // The descendant replace was enabled after the container takeover; the
+  // container still wins because its target contains the descendant's.
+  const inner = claim("x", { replace: "model" }, "swap-model")
+  const outer = claim("theme", { replace: "right" }, "my-right")
+  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [outer, inner] })
+  expect(layout(result)).toEqual(["mode", "my-right"])
+  expect(result.suppressed).toEqual([{ claim: inner, by: outer }])
+})
+
+test("root takeover: nothing original survives, all other claims suppressed", () => {
+  const theme = claim("powerline", { replace: "prompt.footer" }, "powerline")
+  const chip = claim("pr", { at: "end" }, "chip")
+  const result = resolveStructure({ region: "prompt.footer", parts: tree, claims: [chip, theme] })
+  expect(layout(result)).toEqual(["powerline"])
+  expect(result.suppressed).toEqual([{ claim: chip, by: theme }])
+})
+
+test("root takeover at the same node: last enabled wins", () => {
+  const first = claim("a", { replace: "home.footer" }, "first")
+  const second = claim("b", { replace: "home.footer" }, "second")
+  const result = resolveStructure<string, string>({ region: "home.footer", parts: [], claims: [first, second] })
+  expect(layout(result)).toEqual(["second"])
+  expect(result.suppressed).toEqual([{ claim: first, by: second }])
+})
+
+test("containers flatten in order and anchors on a container wrap its whole span", () => {
+  const result = resolveStructure({
+    region: "prompt.footer",
+    parts: tree,
+    claims: [claim("a", { before: "right" }, "divider"), claim("b", { after: "right" }, "clock")],
+  })
+  expect(layout(result)).toEqual(["mode", "divider", "directory", "model", "tokens", "clock"])
+})

--- a/packages/tui/test/plugin-structure.test.ts
+++ b/packages/tui/test/plugin-structure.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import type { SlotClaim } from "@opencode-ai/plugin/tui/context"
-import { resolveSlots, type Claim, type Placement } from "../src/plugin/structure"
+import { resolveSlots, type Claim, type PlacementKind } from "../src/plugin/structure"
 
 // Type-level canaries, checked by `bun typecheck`: exactly one placement key,
 // absolute paths only, and the render input follows the targeted path.
@@ -20,9 +20,11 @@ export const canaries = () => {
 }
 
 // The resolver is generic over render values; strings make layout assertions
-// read as layouts.
-function claim(plugin: string, placement: Placement, render: string): Claim<string> {
-  return { key: `${plugin}/${render}`, plugin, placement, render }
+// read as layouts. Placements are written in the public claim shape and
+// normalized here, like the plugin API does.
+function claim(plugin: string, placement: Partial<Record<PlacementKind, string>>, render: string): Claim<string> {
+  const kind = (["prepend", "append", "before", "after", "replace"] as const).find((item) => placement[item])!
+  return { key: `${plugin}/${render}`, plugin, placement: { kind, target: placement[kind]! }, render }
 }
 
 // A host slot tree for tests: a node's children are its child slots, a leaf's


### PR DESCRIPTION
## What

Plugin UI placement becomes **one recursive slot tree**. There are no separate regions, parts, or structures: every extensible boundary in the host UI is a slot with an absolute dot-separated path, and a path contains every path it prefixes.

```
app
home.footer
prompt.footer
├── prompt.footer.status
└── prompt.footer.file
session.composer.top
sidebar.content
sidebar.footer
```

Plugins claim a place with one verb and one object; the placement is an exclusive sum of five operations that work uniformly at every node:

```tsx
// siblings around a boundary
context.ui.slot({ after: "prompt.footer.status", render: () => <text>#{pr.number}</text> })

// contributions inside a boundary
context.ui.slot({ append: "prompt.footer", render: () => <Clock /> })

// takeover of a boundary
context.ui.slot({ replace: "prompt.footer", render: () => <Powerline /> })
```

`prepend` / `append` land inside the target's boundary; `before` / `after` are siblings outside it; `replace` takes the boundary over. `?: never` fields make a claim with two placement keys a compile error, pinned by type canaries.

Policy, all host-side and recorded (never silently dropped):

- **Replace preserves the named boundary, replaces everything it contains.** Siblings anchored `before`/`after` a replaced slot still compose; the original content and every claim inside the boundary are suppressed.
- **Hierarchy beats timeline**: an ancestor takeover wins over a later descendant claim; at the same target, last-enabled wins. Plugin enable order is the only precedence mechanism — no priorities, weights, or conflict callbacks.
- **Missing targets degrade asymmetrically**: additive claims append to the nearest surviving ancestor (a host path rename can't cost a plugin its render); replacements are suppressed (a whole-boundary takeover must never quietly become an appended widget).

**Slot inputs.** Each path publishes an explicit input — reactive props passed to every claim render targeting it — with a strict admission rule: only instance identity and client-local state the SDK cannot answer (`prompt.footer` publishes `{ sessionID, mode }`; the composer's shell/normal mode is per-instance component state with no other escape hatch). Anything derivable through `ctx.client`/`ctx.data` stays out, so most paths publish `{}`. No inheritance: the absolute path determines both placement and input type.

```tsx
context.ui.slot({
  after: "prompt.footer.status",
  render: (input) => <VoiceControl sessionID={input.sessionID} />,
})
```

## How

- `packages/plugin/src/tui/context.ts` — public `SlotMap` (absolute path → input type), `SlotPath`, and `SlotClaim` as a distributed union so an inline claim literal types its `render` input from the targeted path. `ui.slot(claim)` is the single-object signature; the region/part vocabulary is deleted.
- `packages/tui/src/plugin/structure.ts` — the policy engine as one pure function, `resolveSlots({ paths, claims }) → { slotted, suppressed, degraded }`, over the set of mounted paths plus claims in enable order. Two passes: replacement boundaries (last-enabled per target, then shallow-first ancestor domination), then additive claims (boundary suppression, else bucket, else degrade). No solid, no I/O — every rule is unit-tested as a data transform.
- `packages/tui/src/plugin/render.tsx` — `Region` becomes the recursive `<Slot path input>` primitive. Host content is ordinary JSX children; each mounted instance registers its path (reference-counted, so several composers can mount `prompt.footer` simultaneously under session tabs) and renders only its own buckets: `before + (replace | prepend + children + append) + after`. Per-claim `PluginBoundary` crash containment and component semantics are unchanged; the bucket memo is elementwise-equal so a claim change elsewhere in the tree is a no-op here. Paths are declared, not inferred — so each slot provides its path via context and a nested slot asserts at mount that its path extends its parent's, turning a wrong-parent copy-paste into a loud error instead of a silently mislocated public path.
- `packages/tui/src/plugin/context.tsx` — the provider owns the mounted-path store and one global `resolveSlots` memo; claim objects are cached per render function so rows stay reference-stable across other plugins' reloads.
- Host call sites (`component/prompt/index.tsx`, `routes/home.tsx`, `routes/session/index.tsx`, `routes/session/sidebar.tsx`, `app.tsx`) — declare the tree with nested `<Slot>`s; the prompt footer mounts `prompt.footer` with `status` and `file` children.

All eight builtin feature-plugins are migrated and dogfood the new claims — the prompt footer and sidebar builtins consume per-path inputs, so the input contract is exercised in-tree before any external plugin touches it. The home and sidebar footer builtins contribute via `append` rather than `replace`, keeping those paths open to additive plugin claims while an external `replace` still takes the boundary over.

A post-implementation review pass (reuse, quality, efficiency reviewers + a final correctness audit) tightened the internals: `input` is conditionally required on `<Slot>` (omitting it on `sidebar.content` is now a type error), placements normalize once to `{ kind, target }`, a dead resolver branch was removed, `ui.slot` throws on claims carrying more than one placement key, and the mount-order/refcount subtleties are pinned by comments.

## Scope

Deliberately not in this PR, all layerable without changing the call site:

- Plugins-dialog surfacing of the `suppressed`/`degraded` records (the data is computed and tested)
- User-config slot hiding, width-pressure policy, size variants
- More host furniture as named paths — `prompt.footer.status`/`file` is the starter vocabulary; paths are permanent API, so nothing ships speculatively

## Testing

- `packages/tui`: `bun test` — 641 pass, 0 fail. Resolver suite rewritten against `resolveSlots` with a fold helper mirroring `<Slot>` composition, so assertions still read as whole layouts: placement edges, anchoring, degradation to surviving ancestors, missing-replacement suppression, boundary takeover, same-target last-wins, hierarchy-beats-timeline, container spans.
- `bun typecheck` clean in `packages/tui` and `packages/plugin`; `@ts-expect-error` canaries pin placement exclusivity, absolute-path targets, and per-path input typing.
- Plugin hot-reload e2e suite green on the new `ui.slot` shape.

## Flow

```mermaid
flowchart LR
  C["plugin claims<br/>(enable order)"] --> R["resolveSlots<br/>(pure)"]
  M["mounted slot paths<br/>(ref-counted per &lt;Slot&gt;)"] --> R
  R --> B["per-path buckets<br/>before / prepend / append / after / replace"]
  B --> S["each &lt;Slot&gt; renders its own buckets<br/>PluginBoundary per claim"]
  R -.-> D["suppressed + degraded<br/>(recorded; dialog follow-up)"]
```
