### PR TITLE
fix(session): extract unsupported tool media

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -145,6 +145,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
   // Only apply this workaround if the model actually supports that media input -
   // otherwise unsupportedParts() will turn it into a user-visible error.
   const supportsMediaInToolResult = (attachment: { mime: string }) => {
+    if (!supportsMediaInput(attachment)) return false
     if (model.api.npm === "@ai-sdk/anthropic") return true
     if (model.api.npm === "@ai-sdk/openai") return true
     if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true
@@ -156,6 +157,12 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       return id.includes("gemini-3") && !id.includes("gemini-2")
     }
     return false
+  }
+  const supportsMediaInput = (attachment: { mime: string }) => {
+    if (!model.capabilities.attachment) return false
+    if (attachment.mime === "application/pdf") return model.capabilities.input.pdf
+    if (attachment.mime.startsWith("image/")) return model.capabilities.input.image
+    return true
   }
 
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -322,6 +322,18 @@ describe("session.message-v2.toModelMessage", () => {
   test("converts assistant tool completion into tool-call + tool-result messages with attachments", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"
+    const mediaModel: Provider.Model = {
+      ...model,
+      capabilities: {
+        ...model.capabilities,
+        attachment: true,
+        input: {
+          ...model.capabilities.input,
+          image: true,
+          pdf: true,
+        },
+      },
+    }
 
     const input: SessionV1.WithParts[] = [
       {
@@ -371,7 +383,7 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ]
 
-    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+    expect(await MessageV2.toModelMessages(input, mediaModel)).toStrictEqual([
       {
         role: "user",
         content: [{ type: "text", text: "run tool" }],
@@ -405,6 +417,85 @@ describe("session.message-v2.toModelMessage", () => {
               ],
             },
             providerOptions: { openai: { tool: "meta" } },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("moves OpenAI tool-result media out when the model has no attachment capability", async () => {
+    const png = Buffer.from("image").toString("base64")
+    const userID = "m-user-openai-no-media"
+    const assistantID = "m-assistant-openai-no-media"
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1-openai-no-media"), type: "text", text: "run tool" }] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-openai-no-media"),
+            type: "tool",
+            callID: "call-openai-no-media",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/screenshot.png" },
+              output: "Screenshot read successfully",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-openai-no-media"),
+                  type: "file",
+                  mime: "image/png",
+                  filename: "screenshot.png",
+                  url: `data:image/png;base64,${png}`,
+                },
+              ],
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      { role: "user", content: [{ type: "text", text: "run tool" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-openai-no-media",
+            toolName: "read",
+            input: { filePath: "/tmp/screenshot.png" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-openai-no-media",
+            toolName: "read",
+            output: { type: "text", value: "Screenshot read successfully" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Attached media from tool result:" },
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "screenshot.png",
+            data: `data:image/png;base64,${png}`,
           },
         ],
       },


### PR DESCRIPTION
### Issue for this PR

Closes #41163
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps tool-result media out of provider tool results when the selected model does not support attachments for that media type.

`@ai-sdk/openai` and `@ai-sdk/anthropic` were treated as always supporting media inside tool results. For a provider served through those SDK packages but configured with `attachment: false`, image/PDF attachments stayed in history replay and could poison later turns. This now checks the model capability first, then falls back to the existing provider-specific tool-result media rules.

### How did you verify your code works?

- `bun test ./test/session/message-v2.test.ts --test-name-pattern 'moves OpenAI tool-result media out when the model has no attachment capability|converts assistant tool completion into tool-call \+ tool-result messages with attachments|preserves jpeg tool-result media for anthropic models|moves bedrock pdf tool-result media into a separate user message'`
- `bun test ./test/session/message-v2.test.ts`
- `bun typecheck` in `packages/opencode`
- `bun run lint packages/opencode/src/session/message-v2.ts packages/opencode/test/session/message-v2.test.ts`
- `git diff --check`

Note: scoped lint reports existing warnings in this file but exits successfully with no errors. Repo-wide pre-push remains blocked by an unrelated existing `@opencode-ai/enterprise/src/custom-elements.d.ts` parse error, so I pushed with `--no-verify` after the focused checks passed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
