### PR TITLE
fix(app): fade review panel tab header

### DIFF
--- a/packages/ui/src/components/tabs.css
+++ b/packages/ui/src/components/tabs.css
@@ -779,8 +779,18 @@ body[data-new-layout] #review-panel [data-component="tabs"] .session-review-v2-t
   min-width: 0;
   gap: 8px;
   box-sizing: border-box;
-  border-bottom: 1px solid var(--border-weaker-base, var(--v2-border-border-weak));
   background-color: var(--v2-background-bg-base);
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    inset-inline: 0;
+    z-index: 1;
+    height: 16px;
+    background: linear-gradient(to bottom, var(--v2-background-bg-base), transparent);
+    pointer-events: none;
+  }
 }
 
 body[data-new-layout] #review-panel [data-component="tabs"] .session-review-v2-tabs-bar [data-slot="tabs-list"],


### PR DESCRIPTION
### Issue for this PR

Closes #41192

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the hard bottom border from the new-layout Review/files tab bar and adds a 16px background fade below it. This matches the transition used by the adjacent session title without changing tab sizing, controls, or panel content layout.

### How did you verify your code works?

- `bun typecheck` in `packages/ui`
- `bun test` in `packages/ui` (27 passed)
- `bun run build` in `packages/app`
- Windows Desktop visual check with the Review panel open

### Screenshots / recordings

The right panel tab bar now blends into the content area without the full-width divider.

<img width="1296" height="808" alt="Borderless Review panel tab bar with a soft fade" src="https://github.com/user-attachments/assets/d8fab2c8-31a8-48fd-be68-26cc95f0075a" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
