### PR TITLE
refactor(core): remove dead AISDK hook domain

### DIFF
--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -1,6 +1,5 @@
 export * as PluginHooks from "./hooks"
 
-import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
 import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
@@ -9,7 +8,6 @@ import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
 
 export interface Domains {
-  readonly aisdk: AISDKHooks
   readonly session: SessionHooks
   readonly shell: ShellHooks
   readonly tool: ToolHooks


### PR DESCRIPTION
## What

Remove the unused `aisdk` member from Core's generic `PluginHooks.Domains` type map.

The active AISDK plugin API is a separate path: `PluginHost` maps `ctx.aisdk` hooks directly to `AISDK.Service`. This change removes only generic registry typing that has no registrations or triggers.

## Before / After

**Before:** `PluginHooks.Domains` advertised an `aisdk` domain even though no repository caller registered or triggered an AISDK hook through the generic `PluginHooks` service.

**After:** `PluginHooks.Domains` describes only its used `session`, `shell`, and `tool` domains. Live Promise and Effect AISDK plugin hooks continue through `PluginHost` and `AISDK.Service` unchanged.

## How

- Remove the type-only `AISDKHooks` import from `packages/core/src/plugin/hooks.ts`.
- Remove the `readonly aisdk: AISDKHooks` member from `PluginHooks.Domains`.
- Confirm repository-wide that no generic `register("aisdk", ...)` or `trigger("aisdk", ...)` consumers exist.

## Flow

```mermaid
flowchart LR
  subgraph removed["Removed: dead generic typing"]
    domain["PluginHooks.Domains.aisdk<br/>(type only)"] -. "no register/trigger callers" .-> registry["Generic PluginHooks registry"]
  end

  subgraph live["Unchanged: live AISDK hooks"]
    host["PluginHost<br/>ctx.aisdk adapter"] --> service["AISDK.Service"] --> provider["Provider hook callback"]
  end
```

## Scope

This deliberately does not change `AISDK.Service`, plugin host adapters, Promise or Effect plugin contracts, provider registrations, AISDK documentation, or tests for active AISDK behavior.

## Testing

- `bun run test test/plugin-hooks.test.ts` from `packages/core` (2 passed)
- `bun typecheck` from `packages/core`
- `bunx oxlint packages/core/src/plugin/hooks.ts`
- `bunx prettier --check packages/core/src/plugin/hooks.ts`
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks successful)
- Repository-wide search confirmed no generic `register("aisdk")` or `trigger("aisdk")` consumers
