### PR TITLE
fix(core): preserve admitted tool names

### DIFF
--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -155,7 +155,7 @@ function runtime(
 ) {
   const tools: Record<string, Tool.Tool<never>> = {}
   for (const [name, registration] of registrations) {
-    const child = definition(registration)
+    const child = definition(name, registration)
     const path = qualifiedName(registration)
     tools[path] = Tool.make({
       description: child.description,

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -213,8 +213,8 @@ const layer = Layer.effect(
               definitions: [
                 ...Array.from(direct)
                   .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-                  .map(([, tool]) => definition(tool)),
-                ...(codemodeTool ? [definition(codemodeTool)] : []),
+                  .map(([name, tool]) => definition(name, tool)),
+                ...(codemodeTool ? [definition("execute", codemodeTool)] : []),
               ],
               execute: (input: {
                 readonly sessionID: SessionSchema.ID

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -3,8 +3,8 @@ import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { Effect, JsonSchema, Schema } from "effect"
 
-export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
-  name: effectiveName(tool),
+export const definition = (name: string, tool: Tool.Info<any, any>): ToolDefinition => ({
+  name,
   description: tool.description,
   inputSchema: inputJsonSchema(tool.input),
   ...(tool.output === undefined ? {} : { outputSchema: outputJsonSchema(tool.output) }),
@@ -199,10 +199,3 @@ const stringify = (value: unknown) => {
     return String(value)
   }
 }
-
-const normalizedName = (tool: Tool.Info) => tool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
-
-const effectiveName = (tool: Tool.Info) =>
-  tool.options?.namespace === undefined
-    ? normalizedName(tool)
-    : `${tool.options.namespace.replaceAll(".", "_")}_${normalizedName(tool)}`

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -146,6 +146,25 @@ describe("Tool", () => {
     }),
   )
 
+  it.effect("advertises the admitted direct lookup identity", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      const tool = {
+        ...make(),
+        name: "send.message",
+        options: { namespace: "slack.admin", codemode: false },
+      }
+      yield* service.transform((draft) => draft.add(tool))
+      tool.name = "renamed"
+
+      const snapshot = yield* service.snapshot()
+      expect(snapshot.definitions.map((definition) => definition.name)).toEqual(["slack_admin_send_message", "execute"])
+      expect((yield* snapshot.execute(call("slack_admin_send_message"))).content).toEqual([
+        { type: "text", text: "slack_admin_send_message" },
+      ])
+    }),
+  )
+
   it.effect("snapshots external tools with missing input schemas", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -14,7 +14,7 @@ test("tools are structural values", async () => {
   }
   const tool: Info = config
 
-  expect(definition(tool)).toEqual({
+  expect(definition(tool.name, tool)).toEqual({
     name: "foreign",
     description: "Foreign tool",
     inputSchema: {
@@ -43,7 +43,7 @@ test("Effect tool schemas use exact optional keys and flatten compatible constra
     execute: () => Effect.succeed({ content: "unused" }),
   }
 
-  expect(definition(tool).inputSchema).toEqual({
+  expect(definition(tool.name, tool).inputSchema).toEqual({
     type: "object",
     properties: {
       offset: { type: "integer", minimum: 0 },
@@ -63,7 +63,7 @@ test("Effect tool schemas inline named child schemas", () => {
     execute: () => Effect.succeed({ content: "unused" }),
   }
 
-  expect(definition(tool).inputSchema).toEqual({
+  expect(definition(tool.name, tool).inputSchema).toEqual({
     type: "object",
     properties: {
       child: {
@@ -89,8 +89,8 @@ test("Effect tool schemas resolve escaped definition names", () => {
     execute: () => Effect.succeed({ content: "unused" }),
   }
 
-  expect(JSON.stringify(definition(tool).inputSchema)).not.toContain("$ref")
-  expect(JSON.stringify(definition(tool).inputSchema)).not.toContain("$defs")
+  expect(JSON.stringify(definition(tool.name, tool).inputSchema)).not.toContain("$ref")
+  expect(JSON.stringify(definition(tool.name, tool).inputSchema)).not.toContain("$defs")
 })
 
 test("portable schemas validate and describe typed tools", async () => {
@@ -129,7 +129,7 @@ test("portable schemas validate and describe typed tools", async () => {
     execute: ({ count }) => Effect.succeed({ output: count + 1 }),
   })
 
-  expect(definition(tool)).toEqual({
+  expect(definition(tool.name, tool)).toEqual({
     name: "portable",
     description: "Portable tool",
     inputSchema: { type: "object", properties: { count: { type: "string" } } },
@@ -194,7 +194,7 @@ test("raw JSON schemas are render-only and omitted output means model-only", asy
     execute: (input) => Effect.succeed({ content: JSON.stringify(input) }),
   })
 
-  expect(definition(tool)).toEqual({
+  expect(definition(tool.name, tool)).toEqual({
     name: "raw",
     description: "Raw tool",
     inputSchema: { type: "object", properties: { value: { type: "string" } } },
@@ -213,7 +213,7 @@ test("missing external input schemas fall back to an empty schema", () => {
     execute: () => Effect.succeed({ content: "unused" }),
   } as unknown as Info
 
-  expect(definition(tool)).toEqual({
+  expect(definition(tool.name, tool)).toEqual({
     name: "external",
     description: "External tool",
     inputSchema: {},


### PR DESCRIPTION
## What

Keep provider-advertised direct tool names identical to the canonical names admitted by the tool registry.

## Before / After

**Before:** `src/tool.ts` normalized and validated a registration such as namespace `slack.admin` plus tool name `send.message`, then stored it under `slack_admin_send_message`. `tool/runtime.ts` independently recomputed the provider definition name from the producer object. If that object changed after registration, the provider could receive a name the registry lookup never admitted, so executing the advertised call returned `Unknown tool`.

**After:** provider definitions receive the already-admitted registry key. Advertisement, permission fallback, registration storage, and execution lookup now use the same canonical identity even if the producer object's name changes after registration.

```mermaid
flowchart LR
  subgraph before["Before: duplicated recomputation"]
    B0["Producer tool object"] --> B1["Registry normalizes and admits"]
    B0 --> B2["Runtime recomputes name"]
    B1 --> B3["Execution lookup key"]
    B2 --> B4["Provider definition name"]
    B4 -. "may not match" .-> B3
  end

  subgraph after["After: one admitted identity"]
    A0["Producer tool object"] --> A1["Registry normalizes and admits"]
    A1 --> A2["Admitted registry key"]
    A2 --> A3["Provider definition name"]
    A2 --> A4["Execution lookup key"]
  end
```

## How

- `packages/core/src/tool/runtime.ts` makes `definition` accept its canonical name explicitly and removes its duplicate normalization implementation.
- `packages/core/src/tool.ts` passes direct registration map keys into definition derivation and uses the canonical synthetic name `execute` for CodeMode.
- `packages/core/src/codemode/tool.ts` passes each existing admitted registration key while deriving child schemas; CodeMode still owns its separate catalog path representation.
- `packages/core/test/tool-schema.test.ts` updates direct definition call sites for the explicit identity.
- `packages/core/test/session-runner-tool-registry.test.ts` proves a namespaced, normalized tool advertises and executes through its admitted lookup key after the producer object's name is mutated.

Passing the admitted identity is preferable to sharing a normalization helper because a shared helper would still rederive identity from a producer object after validation. The registration key is already the authoritative result of normalization, collision validation, permission fallback, and map admission, so passing it removes both drift and a second derivation point without reversing the registry/runtime dependency direction.

## Scope

- Does not change normalization or namespace rules.
- Does not change CodeMode catalog paths or tool execution behavior.
- Does not add registration cloning or immutability enforcement.
- Does not change Protocol or Server HTTP APIs.

Production change: 5 insertions, 12 deletions (`-7` net) across `packages/core/src`.

## Testing

- `cd packages/core && bun run test test/tool-schema.test.ts test/session-runner-tool-registry.test.ts test/codemode.test.ts` (31 passed)
- `cd packages/core && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3` (33/33 tasks successful)
- `bun run lint packages/core/src/tool.ts packages/core/src/tool/runtime.ts packages/core/src/codemode/tool.ts packages/core/test/tool-schema.test.ts packages/core/test/session-runner-tool-registry.test.ts` (0 errors; 17 warnings on pre-existing lines)
- `git diff --check`
- Scoped Prettier was run on the five changed files. Its whole-file rewrites on four already-unformatted files were reverted to avoid unrelated churn; `bunx prettier --check ...` continues to report that pre-existing formatting drift.
