### PR TITLE
feat: support configurable cost display currency

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -16,6 +16,7 @@ import { getSessionContext } from "@/components/session/session-context-metrics"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { useSettings } from "@/context/settings"
+import { createSessionContextFormatter } from "@/components/session/session-context-format"
 
 interface SessionContextUsageProps {
   variant?: "button" | "indicator"
@@ -65,17 +66,11 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   const messages = createMemo(() => (params.id ? (sync().data.message[params.id] ?? []) : []))
   const info = createMemo(() => (params.id ? sync().session.get(params.id) : undefined))
 
-  const usd = createMemo(
-    () =>
-      new Intl.NumberFormat(language.intl(), {
-        style: "currency",
-        currency: "USD",
-      }),
-  )
+  const formatter = createMemo(() => createSessionContextFormatter(language.intl()))
 
   const context = createMemo(() => getSessionContext(messages(), [...providers.all().values()]))
   const cost = createMemo(() => {
-    return usd().format(info()?.cost ?? 0)
+    return formatter().cost(info()?.cost ?? 0, context()?.model?.cost?.currency ?? "USD", sync().data.config.display)
   })
   const contextVisible = createMemo(() => view().reviewPanel.opened() && tabState.activeTab() === "context")
   const hasOtherTabs = createMemo(() =>

--- a/packages/app/src/components/session/session-context-format.ts
+++ b/packages/app/src/components/session/session-context-format.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon"
+import { Currency } from "@opencode-ai/core/currency"
 
 export function createSessionContextFormatter(locale: string) {
   return {
@@ -15,6 +16,17 @@ export function createSessionContextFormatter(locale: string) {
     time(value: number | undefined) {
       if (!value) return "—"
       return DateTime.fromMillis(value).setLocale(locale).toLocaleString(DateTime.DATETIME_MED)
+    },
+    cost(
+      amount: number,
+      source: string,
+      display: { currency?: string; exchangeRates?: Record<string, number> } | undefined,
+    ) {
+      const target = display?.currency?.trim()
+      if (!target) return Currency.format(amount, source, locale)
+      const converted = Currency.convert(amount, source, target, display?.exchangeRates)
+      if (converted === undefined) return Currency.format(amount, source, locale)
+      return Currency.format(converted, target, locale)
     },
   }
 }

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -11,6 +11,9 @@ type Model = {
   limit: {
     context: number
   }
+  cost?: {
+    currency?: string
+  }
 }
 
 type Context = {

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -130,19 +130,11 @@ export function SessionContextTab() {
     { equals: same },
   )
 
-  const usd = createMemo(
-    () =>
-      new Intl.NumberFormat(language.intl(), {
-        style: "currency",
-        currency: "USD",
-      }),
-  )
-
   const ctx = createMemo(() => getSessionContext(messages(), [...providers.all().values()]))
   const formatter = createMemo(() => createSessionContextFormatter(language.intl()))
 
   const cost = createMemo(() => {
-    return usd().format(info()?.cost ?? 0)
+    return formatter().cost(info()?.cost ?? 0, ctx()?.model?.cost?.currency ?? "USD", sync().data.config.display)
   })
 
   const counts = createMemo(() => {

--- a/packages/core/src/currency.ts
+++ b/packages/core/src/currency.ts
@@ -1,0 +1,78 @@
+export * as Currency from "./currency"
+
+// Approximate display exchange rates, units per 1 USD. Snapshot: 2026-08.
+// These are display-only approximations and are never billing-authoritative.
+export const ExchangeRates: Readonly<Record<string, number>> = {
+  USD: 1,
+  EUR: 0.86,
+  GBP: 0.74,
+  JPY: 147.5,
+  CNY: 7.15,
+  HKD: 7.8,
+  SGD: 1.34,
+  KRW: 1380,
+  INR: 84,
+  CAD: 1.37,
+  AUD: 1.52,
+  NZD: 1.68,
+  CHF: 0.8,
+  SEK: 10.5,
+  NOK: 10.8,
+  DKK: 6.9,
+  PLN: 3.9,
+  BRL: 5.4,
+  MXN: 18.5,
+  ZAR: 18,
+}
+
+export function normalize(currency: string): string {
+  return currency.trim().toUpperCase()
+}
+
+export function rate(currency: string, overrides?: Readonly<Record<string, number>>): number | undefined {
+  const code = normalize(currency)
+  if (overrides) {
+    const matches = Object.entries(overrides).filter(([key]) => normalize(key) === code)
+    if (matches.length > 0) {
+      for (const [, value] of matches) {
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) return value
+      }
+      return undefined
+    }
+  }
+  const builtin = ExchangeRates[code]
+  if (typeof builtin === "number" && builtin > 0) return builtin
+  return undefined
+}
+
+export function convert(
+  amount: number,
+  from: string,
+  to: string,
+  rates?: Readonly<Record<string, number>>,
+): number | undefined {
+  const source = normalize(from)
+  const target = normalize(to)
+  if (source === target) return amount
+  const fromRate = rate(source, rates)
+  const toRate = rate(target, rates)
+  if (!fromRate || !toRate) return undefined
+  return (amount / fromRate) * toRate
+}
+
+const formatters = new Map<string, Intl.NumberFormat>()
+
+export function format(amount: number, currency: string, locale = "en-US"): string {
+  const code = normalize(currency)
+  const key = `${locale}\u0000${code}`
+  let formatter = formatters.get(key)
+  if (!formatter) {
+    try {
+      formatter = new Intl.NumberFormat(locale, { style: "currency", currency: code })
+    } catch {
+      return `${amount.toFixed(2)} ${code}`
+    }
+    formatters.set(key, formatter)
+  }
+  return formatter.format(amount)
+}

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -125,6 +125,21 @@ export const Info = Schema.Struct({
     description: "Additional instruction files or patterns to include",
   }),
   layout: Schema.optional(ConfigLayoutV1.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
+  display: Schema.optional(
+    Schema.Struct({
+      currency: Schema.optional(Schema.String).annotate({
+        description:
+          'Preferred display currency (ISO 4217 code, e.g. "CNY") for usage costs. When unset, costs are shown in the provider\'s source currency.',
+      }),
+      exchangeRates: Schema.optional(Schema.Record(Schema.String, Schema.Finite)).annotate({
+        description:
+          "Custom exchange rates as units per 1 USD. Take precedence over the built-in approximate display rates. An invalid rate disables conversion for that currency.",
+      }),
+    }),
+  ).annotate({
+    description:
+      "Presentation options. The display currency only affects how usage costs are shown; amounts are never relabeled without conversion.",
+  }),
   permission: Schema.optional(ConfigPermissionV1.Info),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
   attachment: Schema.optional(ConfigAttachmentV1.Info).annotate({

--- a/packages/core/test/currency.test.ts
+++ b/packages/core/test/currency.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import { Currency } from "@opencode-ai/core/currency"
+
+describe("currency", () => {
+  test("identity conversion returns the amount unchanged", () => {
+    expect(Currency.convert(1.5, "USD", "USD")).toBe(1.5)
+  })
+
+  test("identity conversion ignores case and whitespace", () => {
+    expect(Currency.convert(2.25, " usd ", "USD")).toBe(2.25)
+  })
+
+  test("converts between builtin rates", () => {
+    expect(Currency.convert(1.5, "USD", "CNY")).toBeCloseTo(1.5 * 7.15, 10)
+  })
+
+  test("converts via USD cross rate", () => {
+    expect(Currency.convert(10, "EUR", "CNY")).toBeCloseTo((10 / 0.86) * 7.15, 10)
+  })
+
+  test("normalizes currency codes", () => {
+    expect(Currency.convert(1, " cny ", "usd")).toBeCloseTo(1 / 7.15, 10)
+  })
+
+  test("overrides take precedence over builtin rates", () => {
+    expect(Currency.convert(1.5, "USD", "CNY", { CNY: 7.2 })).toBeCloseTo(1.5 * 7.2, 10)
+  })
+
+  test("overrides can introduce currencies missing from the builtin table", () => {
+    expect(Currency.convert(2, "USD", "BTC", { BTC: 0.00001 })).toBeCloseTo(0.00002, 12)
+  })
+
+  test("override lookup ignores key casing", () => {
+    expect(Currency.convert(1.5, "USD", "CNY", { cny: 7.2 })).toBeCloseTo(1.5 * 7.2, 10)
+  })
+
+  test("returns undefined when a rate is unknown", () => {
+    expect(Currency.convert(1, "USD", "XYZ")).toBeUndefined()
+    expect(Currency.convert(1, "XYZ", "USD")).toBeUndefined()
+  })
+
+  test("returns undefined when the source currency is missing or empty", () => {
+    expect(Currency.convert(1, "", "USD")).toBeUndefined()
+    expect(Currency.convert(1, "   ", "CNY")).toBeUndefined()
+  })
+
+  test("an invalid override disables conversion instead of falling back", () => {
+    expect(Currency.convert(1, "USD", "CNY", { CNY: 0 })).toBeUndefined()
+    expect(Currency.convert(1, "USD", "CNY", { CNY: -7 })).toBeUndefined()
+    expect(Currency.convert(1, "USD", "CNY", { CNY: Number.NaN })).toBeUndefined()
+  })
+
+  test("invalid overrides do not introduce unknown currencies", () => {
+    expect(Currency.convert(1, "USD", "XYZ", { XYZ: 0 })).toBeUndefined()
+  })
+
+  test("rate resolves overrides before builtin table", () => {
+    expect(Currency.rate("CNY")).toBe(7.15)
+    expect(Currency.rate("CNY", { CNY: 7.2 })).toBe(7.2)
+    expect(Currency.rate("CNY", { CNY: 0 })).toBeUndefined()
+    expect(Currency.rate("XYZ")).toBeUndefined()
+  })
+
+  test("formats amounts with the currency symbol", () => {
+    expect(Currency.format(10.8, "CNY")).toContain("10.8")
+    expect(Currency.format(10.8, "USD")).toContain("10.8")
+  })
+
+  test("format falls back to a plain label for codes Intl rejects", () => {
+    expect(Currency.format(1.234, "X")).toBe("1.23 X")
+  })
+})

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -602,6 +602,7 @@ function makeDirectoryService(sdk: OpencodeClient) {
 function makeUsageService(sdk: OpencodeClient) {
   const limits = new Map<string, Promise<number | undefined>>()
   const currencies = new Map<string, Promise<string>>()
+  const displays = new Map<string, Promise<Parameters<typeof UsageService.displayCost>[2]>>()
   const contextLimit: UsageService.Interface["contextLimit"] = Effect.fn("ACP.promptUsage.contextLimit")(
     function* (params) {
       const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
@@ -622,25 +623,39 @@ function makeUsageService(sdk: OpencodeClient) {
     },
   )
 
-  const modelCurrency = Effect.fn("ACP.promptUsage.modelCurrency")(
-    function* (params: { readonly directory: string; readonly providerID: ProviderV2.ID; readonly modelID: ModelV2.ID }) {
-      const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
-      const current = currencies.get(key)
-      if (current) return yield* Effect.promise(() => current)
+  const modelCurrency = Effect.fn("ACP.promptUsage.modelCurrency")(function* (params: {
+    readonly directory: string
+    readonly providerID: ProviderV2.ID
+    readonly modelID: ModelV2.ID
+  }) {
+    const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
+    const current = currencies.get(key)
+    if (current) return yield* Effect.promise(() => current)
 
-      const next = sdk.config
-        .providers({ directory: params.directory }, { throwOnError: true })
-        .then((response) => {
-          const providers = Object.fromEntries(
-            (response.data?.providers ?? []).map((provider) => [provider.id, provider]),
-          ) as Record<ProviderV2.ID, Provider.Info>
-          return UsageService.findCurrency(providers, params.providerID, params.modelID)
-        })
-        .catch(() => "USD")
-      currencies.set(key, next)
-      return yield* Effect.promise(() => next)
-    },
-  )
+    const next = sdk.config
+      .providers({ directory: params.directory }, { throwOnError: true })
+      .then((response) => {
+        const providers = Object.fromEntries(
+          (response.data?.providers ?? []).map((provider) => [provider.id, provider]),
+        ) as Record<ProviderV2.ID, Provider.Info>
+        return UsageService.findCurrency(providers, params.providerID, params.modelID)
+      })
+      .catch(() => "USD")
+    currencies.set(key, next)
+    return yield* Effect.promise(() => next)
+  })
+
+  const displayConfig = Effect.fn("ACP.promptUsage.displayConfig")(function* (params: { readonly directory: string }) {
+    const current = displays.get(params.directory)
+    if (current) return yield* Effect.promise(() => current)
+
+    const next = sdk.config
+      .get({ directory: params.directory }, { throwOnError: true })
+      .then((response) => response.data?.display)
+      .catch(() => undefined)
+    displays.set(params.directory, next)
+    return yield* Effect.promise(() => next)
+  })
 
   const sendUpdate: UsageService.Interface["sendUpdate"] = Effect.fn("ACP.promptUsage.sendUpdate")(function* (params) {
     const messages = yield* request(
@@ -677,6 +692,9 @@ function makeUsageService(sdk: OpencodeClient) {
       modelID: ModelV2.ID.make(message.modelID),
     })
 
+    const display = yield* displayConfig({ directory: params.directory })
+    const cost = UsageService.displayCost(UsageService.totalSessionCost(messages), currency, display)
+
     yield* Effect.promise(() =>
       params.connection
         .sessionUpdate({
@@ -685,7 +703,7 @@ function makeUsageService(sdk: OpencodeClient) {
             sessionUpdate: "usage_update",
             used: UsageService.contextTokens(message),
             size,
-            cost: { amount: UsageService.totalSessionCost(messages), currency },
+            cost,
           },
         })
         .catch(() => {}),

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -601,6 +601,7 @@ function makeDirectoryService(sdk: OpencodeClient) {
 
 function makeUsageService(sdk: OpencodeClient) {
   const limits = new Map<string, Promise<number | undefined>>()
+  const currencies = new Map<string, Promise<string>>()
   const contextLimit: UsageService.Interface["contextLimit"] = Effect.fn("ACP.promptUsage.contextLimit")(
     function* (params) {
       const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
@@ -617,6 +618,26 @@ function makeUsageService(sdk: OpencodeClient) {
         })
         .catch(() => undefined)
       limits.set(key, next)
+      return yield* Effect.promise(() => next)
+    },
+  )
+
+  const modelCurrency = Effect.fn("ACP.promptUsage.modelCurrency")(
+    function* (params: { readonly directory: string; readonly providerID: ProviderV2.ID; readonly modelID: ModelV2.ID }) {
+      const key = `${params.directory}\u0000${params.providerID}\u0000${params.modelID}`
+      const current = currencies.get(key)
+      if (current) return yield* Effect.promise(() => current)
+
+      const next = sdk.config
+        .providers({ directory: params.directory }, { throwOnError: true })
+        .then((response) => {
+          const providers = Object.fromEntries(
+            (response.data?.providers ?? []).map((provider) => [provider.id, provider]),
+          ) as Record<ProviderV2.ID, Provider.Info>
+          return UsageService.findCurrency(providers, params.providerID, params.modelID)
+        })
+        .catch(() => "USD")
+      currencies.set(key, next)
       return yield* Effect.promise(() => next)
     },
   )
@@ -650,6 +671,12 @@ function makeUsageService(sdk: OpencodeClient) {
     })
     if (!size) return
 
+    const currency = yield* modelCurrency({
+      directory: params.directory,
+      providerID: ProviderV2.ID.make(message.providerID),
+      modelID: ModelV2.ID.make(message.modelID),
+    })
+
     yield* Effect.promise(() =>
       params.connection
         .sessionUpdate({
@@ -658,7 +685,7 @@ function makeUsageService(sdk: OpencodeClient) {
             sessionUpdate: "usage_update",
             used: UsageService.contextTokens(message),
             size,
-            cost: { amount: UsageService.totalSessionCost(messages), currency: "USD" },
+            cost: { amount: UsageService.totalSessionCost(messages), currency },
           },
         })
         .catch(() => {}),

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -122,6 +122,14 @@ export function findContextLimit(
   return providers[providerID]?.models[modelID]?.limit.context
 }
 
+export function findCurrency(
+  providers: Record<ProviderV2.ID, Provider.Info>,
+  providerID: ProviderV2.ID,
+  modelID: ModelV2.ID,
+): string {
+  return providers[providerID]?.models[modelID]?.cost.currency ?? "USD"
+}
+
 export const contextLimitLoaderLayer = Layer.effect(
   ContextLimitLoader,
   Effect.gen(function* () {
@@ -180,6 +188,38 @@ const layer = Layer.effect(
       return yield* yield* cachedLimit(input)
     })
 
+    const currencies = yield* SynchronizedRef.make(new Map<string, Effect.Effect<string>>())
+
+    const cachedCurrency = Effect.fnUntraced(function* (input: {
+      readonly directory: string
+      readonly providerID: ProviderV2.ID
+      readonly modelID: ModelV2.ID
+    }) {
+      return yield* SynchronizedRef.modifyEffect(
+        currencies,
+        Effect.fnUntraced(function* (items) {
+          const key = `${input.directory}\u0000${input.providerID}\u0000${input.modelID}`
+          const current = items.get(key)
+          if (current) return [current, items] as const
+          const next = yield* Effect.cached(
+            contextLimitLoader.providers(input.directory).pipe(
+              Effect.map((providers) => findCurrency(providers, input.providerID, input.modelID)),
+              Effect.catch(() => Effect.succeed("USD")),
+            ),
+          )
+          return [next, new Map(items).set(key, next)] as const
+        }),
+      )
+    })
+
+    const modelCurrency = Effect.fn("ACPUsage.modelCurrency")(function* (input: {
+      readonly directory: string
+      readonly providerID: ProviderV2.ID
+      readonly modelID: ModelV2.ID
+    }) {
+      return yield* yield* cachedCurrency(input)
+    })
+
     const sendUpdate = Effect.fn("ACPUsage.sendUpdate")(function* (input: {
       readonly connection: UsageConnection
       readonly sessionID: string
@@ -205,6 +245,12 @@ const layer = Layer.effect(
       })
       if (!size) return
 
+      const currency = yield* modelCurrency({
+        directory: input.directory,
+        providerID: ProviderV2.ID.make(message.providerID),
+        modelID: ModelV2.ID.make(message.modelID),
+      })
+
       yield* Effect.promise(() =>
         input.connection
           .sessionUpdate({
@@ -213,7 +259,7 @@ const layer = Layer.effect(
               sessionUpdate: "usage_update",
               used: contextTokens(message),
               size,
-              cost: { amount: totalSessionCost(messages), currency: "USD" },
+              cost: { amount: totalSessionCost(messages), currency },
             },
           })
           .catch(() => {}),

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -5,8 +5,11 @@ import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { makeGlobalNode, Node } from "@opencode-ai/core/effect/app-node"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Currency } from "@opencode-ai/core/currency"
+import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { Config } from "@/config/config"
 import { Provider } from "@/provider/provider"
 import { Context, Effect, Layer, SynchronizedRef } from "effect"
 
@@ -42,6 +45,10 @@ export interface ContextLimitLoaderInterface {
   readonly providers: (directory: string) => Effect.Effect<Record<ProviderV2.ID, Provider.Info>, unknown>
 }
 
+export interface ConfigLoaderInterface {
+  readonly display: (directory: string) => Effect.Effect<ConfigV1.Info["display"], unknown>
+}
+
 export type UsageConnection = Pick<AgentSideConnection, "sessionUpdate">
 
 export interface Interface {
@@ -66,6 +73,10 @@ export class MessageLoader extends Context.Service<MessageLoader, MessageLoaderI
 
 export class ContextLimitLoader extends Context.Service<ContextLimitLoader, ContextLimitLoaderInterface>()(
   "@opencode/ACPUsageContextLimitLoader",
+) {}
+
+export class ConfigLoader extends Context.Service<ConfigLoader, ConfigLoaderInterface>()(
+  "@opencode/ACPUsageConfigLoader",
 ) {}
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ACPUsage") {}
@@ -130,6 +141,18 @@ export function findCurrency(
   return providers[providerID]?.models[modelID]?.cost.currency ?? "USD"
 }
 
+export function displayCost(
+  amount: number,
+  source: string,
+  display: ConfigV1.Info["display"],
+): { amount: number; currency: string } {
+  const target = display?.currency?.trim()
+  if (!target) return { amount, currency: source }
+  const converted = Currency.convert(amount, source, target, display?.exchangeRates)
+  if (converted === undefined) return { amount, currency: source }
+  return { amount: converted, currency: Currency.normalize(target) }
+}
+
 export const contextLimitLoaderLayer = Layer.effect(
   ContextLimitLoader,
   Effect.gen(function* () {
@@ -147,11 +170,30 @@ export const contextLimitLoaderLayer = Layer.effect(
   }),
 )
 
+export const configLoaderLayer = Layer.effect(
+  ConfigLoader,
+  Effect.gen(function* () {
+    const store = yield* InstanceStore.Service
+    const config = yield* Config.Service
+
+    return ConfigLoader.of({
+      display: Effect.fn("ACPUsageConfigLoader.display")(function* (directory) {
+        const ctx = yield* store.load({ directory })
+        return yield* Effect.gen(function* () {
+          const info = yield* config.get()
+          return info.display
+        }).pipe(Effect.provideService(InstanceRef, ctx))
+      }),
+    })
+  }),
+)
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const messageLoader = yield* MessageLoader
     const contextLimitLoader = yield* ContextLimitLoader
+    const configLoader = yield* ConfigLoader
     const limits = yield* SynchronizedRef.make(new Map<string, Effect.Effect<number | undefined>>())
 
     const cachedLimit = Effect.fnUntraced(function* (input: {
@@ -220,6 +262,26 @@ const layer = Layer.effect(
       return yield* yield* cachedCurrency(input)
     })
 
+    const displays = yield* SynchronizedRef.make(new Map<string, Effect.Effect<ConfigV1.Info["display"]>>())
+
+    const cachedDisplay = Effect.fnUntraced(function* (input: { readonly directory: string }) {
+      return yield* SynchronizedRef.modifyEffect(
+        displays,
+        Effect.fnUntraced(function* (items) {
+          const current = items.get(input.directory)
+          if (current) return [current, items] as const
+          const next = yield* Effect.cached(
+            configLoader.display(input.directory).pipe(Effect.catch(() => Effect.succeed(undefined))),
+          )
+          return [next, new Map(items).set(input.directory, next)] as const
+        }),
+      )
+    })
+
+    const displayConfig = Effect.fn("ACPUsage.displayConfig")(function* (input: { readonly directory: string }) {
+      return yield* yield* cachedDisplay(input)
+    })
+
     const sendUpdate = Effect.fn("ACPUsage.sendUpdate")(function* (input: {
       readonly connection: UsageConnection
       readonly sessionID: string
@@ -251,6 +313,9 @@ const layer = Layer.effect(
         modelID: ModelV2.ID.make(message.modelID),
       })
 
+      const display = yield* displayConfig({ directory: input.directory })
+      const cost = displayCost(totalSessionCost(messages), currency, display)
+
       yield* Effect.promise(() =>
         input.connection
           .sessionUpdate({
@@ -259,7 +324,7 @@ const layer = Layer.effect(
               sessionUpdate: "usage_update",
               used: contextTokens(message),
               size,
-              cost: { amount: totalSessionCost(messages), currency },
+              cost,
             },
           })
           .catch(() => {}),
@@ -284,6 +349,16 @@ export const contextLimitLoaderNode = makeGlobalNode({
   deps: [Provider.node, InstanceStore.node],
 })
 
-export const node = makeGlobalNode({ service: Service, layer, deps: [messageLoaderNode, contextLimitLoaderNode] })
+export const configLoaderNode = makeGlobalNode({
+  service: ConfigLoader,
+  layer: configLoaderLayer,
+  deps: [Config.node, InstanceStore.node],
+})
+
+export const node = makeGlobalNode({
+  service: Service,
+  layer,
+  deps: [messageLoaderNode, contextLimitLoaderNode, configLoaderNode],
+})
 
 export * as UsageService from "./usage"

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1017,6 +1017,7 @@ const ProviderCost = Schema.Struct({
   input: Schema.Finite,
   output: Schema.Finite,
   cache: ProviderCacheCost,
+  currency: optional(Schema.String),
   tiers: optional(Schema.Array(ProviderCostTier)),
   experimentalOver200K: optional(
     Schema.Struct({

--- a/packages/opencode/test/acp/usage.test.ts
+++ b/packages/opencode/test/acp/usage.test.ts
@@ -43,7 +43,7 @@ const assistantWithoutProvider = (): UsageService.SessionMessage => ({
   },
 })
 
-const model = (providerID: ProviderV2.ID, modelID: ModelV2.ID, context: number): Provider.Model => ({
+const model = (providerID: ProviderV2.ID, modelID: ModelV2.ID, context: number, currency?: string): Provider.Model => ({
   id: modelID,
   providerID,
   api: {
@@ -66,6 +66,7 @@ const model = (providerID: ProviderV2.ID, modelID: ModelV2.ID, context: number):
     input: 0,
     output: 0,
     cache: { read: 0, write: 0 },
+    ...(currency ? { currency } : {}),
   },
   limit: {
     context,
@@ -77,7 +78,7 @@ const model = (providerID: ProviderV2.ID, modelID: ModelV2.ID, context: number):
   release_date: "2026-01-01",
 })
 
-const providers = (context = 128_000): Record<ProviderV2.ID, Provider.Info> => {
+const providers = (context = 128_000, currency?: string): Record<ProviderV2.ID, Provider.Info> => {
   const providerID = ProviderV2.ID.make("anthropic")
   const modelID = ModelV2.ID.make("claude-sonnet")
   return {
@@ -88,7 +89,7 @@ const providers = (context = 128_000): Record<ProviderV2.ID, Provider.Info> => {
       env: [],
       options: {},
       models: {
-        [modelID]: model(providerID, modelID, context),
+        [modelID]: model(providerID, modelID, context, currency),
       },
     },
   }
@@ -97,6 +98,7 @@ const providers = (context = 128_000): Record<ProviderV2.ID, Provider.Info> => {
 const fakeLayer = (input: {
   readonly messages?: Effect.Effect<readonly UsageService.SessionMessage[], unknown>
   readonly providers?: (directory: string) => Effect.Effect<Record<ProviderV2.ID, Provider.Info>, unknown>
+  readonly display?: (directory: string) => Effect.Effect<Parameters<typeof UsageService.displayCost>[2], unknown>
 }) =>
   LayerNode.compile(UsageService.node, [
     [
@@ -114,6 +116,15 @@ const fakeLayer = (input: {
         UsageService.ContextLimitLoader,
         UsageService.ContextLimitLoader.of({
           providers: input.providers ?? (() => Effect.succeed(providers())),
+        }),
+      ),
+    ],
+    [
+      UsageService.configLoaderNode,
+      Layer.succeed(
+        UsageService.ConfigLoader,
+        UsageService.ConfigLoader.of({
+          display: input.display ?? (() => Effect.succeed(undefined)),
         }),
       ),
     ],
@@ -174,6 +185,31 @@ describe("acp usage", () => {
 
   test("calculates total session cost from assistant messages", () => {
     expect(UsageService.totalSessionCost([assistant({ cost: 1.25 }), user(), assistant({ cost: 2.5 })])).toBe(3.75)
+  })
+
+  test("displayCost keeps the source currency when no display currency is configured", () => {
+    expect(UsageService.displayCost(1.5, "EUR", undefined)).toEqual({ amount: 1.5, currency: "EUR" })
+    expect(UsageService.displayCost(1.5, "EUR", {})).toEqual({ amount: 1.5, currency: "EUR" })
+  })
+
+  test("displayCost converts to the configured display currency", () => {
+    const result = UsageService.displayCost(1.5, "USD", { currency: "CNY" })
+    expect(result.currency).toBe("CNY")
+    expect(result.amount).toBeCloseTo(1.5 * 7.15, 10)
+  })
+
+  test("displayCost prefers user-provided rates", () => {
+    const result = UsageService.displayCost(1.5, "USD", { currency: "CNY", exchangeRates: { CNY: 7.2 } })
+    expect(result).toEqual({ amount: 10.8, currency: "CNY" })
+  })
+
+  test("displayCost never relabels when conversion is impossible", () => {
+    expect(UsageService.displayCost(1.5, "USD", { currency: "XYZ" })).toEqual({ amount: 1.5, currency: "USD" })
+    expect(UsageService.displayCost(1.5, "XYZ", { currency: "CNY" })).toEqual({ amount: 1.5, currency: "XYZ" })
+    expect(UsageService.displayCost(1.5, "USD", { currency: "CNY", exchangeRates: { CNY: 0 } })).toEqual({
+      amount: 1.5,
+      currency: "USD",
+    })
   })
 
   it.effect("loads context limits from providers and caches by directory/provider/model", () => {
@@ -311,6 +347,79 @@ describe("acp usage", () => {
       Effect.provide(
         fakeLayer({
           messages: Effect.succeed([assistant({ cost: 1, providerID: "missing" })]),
+        }),
+      ),
+    )
+  })
+
+  it.effect("reports the provider currency when no display currency is configured", () => {
+    const updates: SessionNotification[] = []
+    return Effect.gen(function* () {
+      const usage = yield* UsageService.Service
+      yield* usage.sendUpdate({
+        connection: connection(updates),
+        sessionID: "ses_1",
+        directory: "/workspace",
+      })
+
+      expect(updates[0]?.update).toMatchObject({
+        cost: { amount: 1, currency: "EUR" },
+      })
+    }).pipe(
+      Effect.provide(
+        fakeLayer({
+          messages: Effect.succeed([assistant({ cost: 1 })]),
+          providers: () => Effect.succeed(providers(128_000, "EUR")),
+        }),
+      ),
+    )
+  })
+
+  it.effect("converts usage cost to the configured display currency", () => {
+    const updates: SessionNotification[] = []
+    return Effect.gen(function* () {
+      const usage = yield* UsageService.Service
+      yield* usage.sendUpdate({
+        connection: connection(updates),
+        sessionID: "ses_1",
+        directory: "/workspace",
+      })
+
+      const update = updates[0]?.update
+      expect(update).toMatchObject({ sessionUpdate: "usage_update" })
+      if (update?.sessionUpdate !== "usage_update") return
+      if (!update.cost) return
+      expect(update.cost.currency).toBe("CNY")
+      expect(update.cost.amount).toBeCloseTo(1.5 * 7.2, 10)
+    }).pipe(
+      Effect.provide(
+        fakeLayer({
+          messages: Effect.succeed([assistant({ cost: 1.5 })]),
+          display: () => Effect.succeed({ currency: "CNY", exchangeRates: { CNY: 7.2 } }),
+        }),
+      ),
+    )
+  })
+
+  it.effect("keeps the provider currency when the display currency has no rate", () => {
+    const updates: SessionNotification[] = []
+    return Effect.gen(function* () {
+      const usage = yield* UsageService.Service
+      yield* usage.sendUpdate({
+        connection: connection(updates),
+        sessionID: "ses_1",
+        directory: "/workspace",
+      })
+
+      expect(updates[0]?.update).toMatchObject({
+        cost: { amount: 1.5, currency: "EUR" },
+      })
+    }).pipe(
+      Effect.provide(
+        fakeLayer({
+          messages: Effect.succeed([assistant({ cost: 1.5 })]),
+          providers: () => Effect.succeed(providers(128_000, "EUR")),
+          display: () => Effect.succeed({ currency: "XYZ" }),
         }),
       ),
     )

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1999,6 +1999,12 @@ export type Config = {
       }
   instructions?: Array<string>
   layout?: LayoutConfig
+  display?: {
+    currency?: string
+    exchangeRates?: {
+      [key: string]: number
+    }
+  }
   permission?: PermissionConfig
   tools?: {
     [key: string]: boolean
@@ -2071,6 +2077,7 @@ export type Model = {
       read: number
       write: number
     }
+    currency?: string
     tiers?: Array<{
       input: number
       output: number

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -21459,6 +21459,21 @@
           "layout": {
             "$ref": "#/components/schemas/LayoutConfig"
           },
+          "display": {
+            "type": "object",
+            "properties": {
+              "currency": {
+                "type": "string"
+              },
+              "exchangeRates": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
           "permission": {
             "$ref": "#/components/schemas/PermissionConfig"
           },
@@ -21695,6 +21710,9 @@
                 },
                 "required": ["read", "write"],
                 "additionalProperties": false
+              },
+              "currency": {
+                "type": "string"
               },
               "tiers": {
                 "type": "array",

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -24,6 +24,7 @@ import { useSDK } from "../../context/sdk"
 import { useRoute } from "../../context/route"
 import { useProject } from "../../context/project"
 import { useSync } from "../../context/sync"
+import { formatCost, sourceCurrency } from "../../util/cost-display"
 import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
@@ -95,11 +96,6 @@ export type PromptRef = {
   focus(): void
   submit(): void
 }
-
-const money = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-})
 
 const DRAFT_RETENTION_MIN_CHARS = 20
 
@@ -277,7 +273,7 @@ export function Prompt(props: PromptProps) {
     const cost = session?.cost ?? 0
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
+      cost: cost > 0 ? formatCost(cost, sourceCurrency(model), sync.data.config.display) : undefined,
     }
   })
 

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -2,13 +2,9 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo } from "solid-js"
+import { formatCost, sourceCurrency } from "../../util/cost-display"
 
 const id = "internal:sidebar-context"
-
-const money = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-})
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
@@ -22,6 +18,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       return {
         tokens: 0,
         percent: null,
+        currency: "USD",
       }
     }
 
@@ -31,6 +28,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     return {
       tokens,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+      currency: sourceCurrency(model),
     }
   })
 
@@ -41,7 +39,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
       </text>
       <text fg={theme().textMuted}>{state().tokens.toLocaleString()} tokens</text>
       <text fg={theme().textMuted}>{state().percent ?? 0}% used</text>
-      <text fg={theme().textMuted}>{money.format(cost())} spent</text>
+      <text fg={theme().textMuted}>{formatCost(cost(), state().currency, props.api.state.config.display)} spent</text>
     </box>
   )
 }

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "../../context/theme"
 import { SplitBorder } from "../../ui/border"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
+import { formatCost, sourceCurrency } from "../../util/cost-display"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 
@@ -43,14 +44,9 @@ export function SubagentFooter() {
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = session()?.cost ?? 0
 
-    const money = new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-    })
-
     return {
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
-      cost: cost > 0 ? money.format(cost) : undefined,
+      cost: cost > 0 ? formatCost(cost, sourceCurrency(model), sync.data.config.display) : undefined,
     }
   })
 

--- a/packages/tui/src/util/cost-display.ts
+++ b/packages/tui/src/util/cost-display.ts
@@ -1,0 +1,14 @@
+import type { Config } from "@opencode-ai/sdk/v2"
+import { Currency } from "@opencode-ai/core/currency"
+
+export function formatCost(amount: number, source: string, display: Config["display"]): string {
+  const target = display?.currency?.trim()
+  if (!target) return Currency.format(amount, source)
+  const converted = Currency.convert(amount, source, target, display?.exchangeRates)
+  if (converted === undefined) return Currency.format(amount, source)
+  return Currency.format(converted, target)
+}
+
+export function sourceCurrency(model: { cost?: { currency?: string } } | undefined): string {
+  return model?.cost?.currency ?? "USD"
+}

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -501,6 +501,37 @@ Set your UI theme in `tui.json`.
 
 ---
 
+### Display
+
+You can choose the currency OpenCode uses to display usage costs with the `display.currency` option. It accepts an ISO 4217 code such as `"CNY"`, `"EUR"`, or `"JPY"`.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "display": {
+    "currency": "CNY"
+  }
+}
+```
+
+Costs are tracked in the currency configured for the model's provider (USD by default). When `display.currency` is set, displayed amounts are converted from that source currency. When it is not set, costs are shown in the source currency. If no exchange rate is available for a currency pair, the original amount and currency are shown unchanged — values are never relabeled without conversion.
+
+OpenCode ships a table of approximate display exchange rates. These are meant for display only and are not billing-authoritative. You can override them or add missing currencies with the `display.exchangeRates` option, expressed as units per 1 USD:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "display": {
+    "currency": "CNY",
+    "exchangeRates": {
+      "CNY": 7.15
+    }
+  }
+}
+```
+
+---
+
 ### Agents
 
 You can configure specialized agents for specific tasks through the `agent` option.


### PR DESCRIPTION
### Issue for this PR

Closes #32485

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This is needed for users whose model pricing is in a non-USD currency (e.g. CNY/RMB) to see usage costs in their own currency.

The PR is self-contained and depends on no unmerged PR (#39425 was closed as superseded). The first commit is the provider-currency propagation from #39425 (kagura-agent's authorship preserved, fixing #38667); the second adds the display-currency feature (closes #32485).

Adds `display.currency` and `display.exchangeRates` config options:

```json
{
  "display": {
    "currency": "CNY",
    "exchangeRates": { "CNY": 7.15 }
  }
}
```

Costs stay tracked in the provider's source currency. When `display.currency` is set, amounts are converted at the display boundaries: ACP `usage_update` (both paths), TUI (sidebar, prompt footer, subagent footer) and the app (context usage, context tab) — all routed through one core `Currency` utility. When it is unset, or no rate exists for the pair, the original amount and currency are shown — values are never relabeled without conversion. An invalid user rate disables conversion for that currency rather than silently falling back. `display.exchangeRates` (units per 1 USD) overrides the built-in approximate rate table, which is display-only and not billing-authoritative.

This supersedes the approach in #32487 (auto-closed after going stale, not rejected): since the provider currency is propagated from provider config, no separate global source-currency knob is needed — custom prices configured in RMB are covered by the provider-level `currency` field.

Docs: new "Display" section in `packages/web/src/content/docs/config.mdx`. Not changed: CLI `stats` / `run` footer, which aggregate costs across models without source-currency information.

### How did you verify your code works?

```
% bun test test/currency.test.ts        # packages/core
 15 pass
 0 fail

% bun test test/acp                     # packages/opencode
 135 pass
 0 fail

% bun typecheck                         # repo root
 30 successful, 30 total
```

New tests cover conversion (identity, cross-rate, overrides, invalid override disables conversion, unknown/empty source currency) and `sendUpdate` behavior (source-currency passthrough with no config, USD→CNY conversion, no-relabel fallback). Existing app/tui session tests still pass, oxlint clean on changed files, SDK regenerated with `script/generate.ts`, config decode verified.

### Screenshots / recordings

N/A — formatting goes through `Intl.NumberFormat` with the resolved currency (e.g. with `exchangeRates: { "CNY": 7.2 }`, a $1.50 session shows CN¥10.80). Happy to add screenshots if helpful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
