### PR TITLE
fix(tui): keep permission prompt buttons visible for long commands

### DIFF
--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -179,20 +179,18 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
               </Match>
               <Match when={true}>
-                <box paddingLeft={1} gap={1} flexGrow={1} minHeight={0}>
-                  <text fg={theme.textMuted} flexShrink={0}>
-                    This will allow the following patterns until OpenCode is restarted
-                  </text>
-                  <ScrollableBody>
+                <box paddingLeft={1} gap={1}>
+                  <text fg={theme.textMuted}>This will allow the following patterns until OpenCode is restarted</text>
+                  <box>
                     <For each={props.request.always}>
                       {(pattern) => (
-                        <text fg={theme.text} wrapMode="word" width="100%">
+                        <text fg={theme.text}>
                           {"- "}
                           {pattern}
                         </text>
                       )}
                     </For>
-                  </ScrollableBody>
+                  </box>
                 </box>
               </Match>
             </Switch>
@@ -335,19 +333,11 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 title: `Access external directory ${dir}`,
                 body: (
                   <Show when={patterns.length > 0}>
-                    <box paddingLeft={1} gap={1} flexGrow={1} minHeight={0}>
-                      <text fg={theme.textMuted} flexShrink={0}>
-                        Patterns
-                      </text>
-                      <ScrollableBody>
-                        <For each={patterns}>
-                          {(p) => (
-                            <text fg={theme.text} wrapMode="word" width="100%">
-                              {"- " + p}
-                            </text>
-                          )}
-                        </For>
-                      </ScrollableBody>
+                    <box paddingLeft={1} gap={1}>
+                      <text fg={theme.textMuted}>Patterns</text>
+                      <box>
+                        <For each={patterns}>{(p) => <text fg={theme.text}>{"- " + p}</text>}</For>
+                      </box>
                     </box>
                   </Show>
                 ),

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -87,6 +87,43 @@ function EditBody(props: { request: PermissionRequest }) {
   )
 }
 
+function ScrollableBody(props: { children: JSX.Element }) {
+  const { theme } = useTheme()
+  const tuiConfig = useTuiConfig()
+  const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
+
+  return (
+    <box paddingLeft={1} flexGrow={1} minHeight={0}>
+      <scrollbox
+        height="100%"
+        scrollAcceleration={scrollAcceleration()}
+        verticalScrollbarOptions={{
+          trackOptions: {
+            backgroundColor: theme.background,
+            foregroundColor: theme.borderActive,
+          },
+        }}
+      >
+        {props.children}
+      </scrollbox>
+    </box>
+  )
+}
+
+function ScrollableText(props: { text: string; prefix?: string; muted?: boolean }) {
+  const { theme } = useTheme()
+
+  return (
+    <Show when={props.text}>
+      <ScrollableBody>
+        <text fg={props.muted ? theme.textMuted : theme.text} wrapMode="word" width="100%">
+          {(props.prefix ?? "") + props.text}
+        </text>
+      </ScrollableBody>
+    </Show>
+  )
+}
+
 function TextBody(props: { title: string; description?: string; icon?: string }) {
   const { theme } = useTheme()
   return (
@@ -100,9 +137,7 @@ function TextBody(props: { title: string; description?: string; icon?: string })
         <text fg={theme.textMuted}>{props.title}</text>
       </box>
       <Show when={props.description}>
-        <box paddingLeft={1}>
-          <text fg={theme.text}>{props.description}</text>
-        </box>
+        <ScrollableText text={props.description ?? ""} />
       </Show>
     </>
   )
@@ -144,18 +179,20 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
               </Match>
               <Match when={true}>
-                <box paddingLeft={1} gap={1}>
-                  <text fg={theme.textMuted}>This will allow the following patterns until OpenCode is restarted</text>
-                  <box>
+                <box paddingLeft={1} gap={1} flexGrow={1} minHeight={0}>
+                  <text fg={theme.textMuted} flexShrink={0}>
+                    This will allow the following patterns until OpenCode is restarted
+                  </text>
+                  <ScrollableBody>
                     <For each={props.request.always}>
                       {(pattern) => (
-                        <text fg={theme.text}>
+                        <text fg={theme.text} wrapMode="word" width="100%">
                           {"- "}
                           {pattern}
                         </text>
                       )}
                     </For>
-                  </box>
+                  </ScrollableBody>
                 </box>
               </Match>
             </Switch>
@@ -212,13 +249,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "→",
                 title: `Read ${pathFormatter.format(filePath)}`,
-                body: (
-                  <Show when={filePath}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Path: " + pathFormatter.format(filePath)}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={pathFormatter.format(filePath)} prefix="Path: " muted />,
               }
             }
 
@@ -227,13 +258,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "✱",
                 title: `Glob "${pattern}"`,
-                body: (
-                  <Show when={pattern}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Pattern: " + pattern}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={pattern} prefix="Pattern: " muted />,
               }
             }
 
@@ -242,13 +267,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "✱",
                 title: `Grep "${pattern}"`,
-                body: (
-                  <Show when={pattern}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Pattern: " + pattern}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={pattern} prefix="Pattern: " muted />,
               }
             }
 
@@ -258,13 +277,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "→",
                 title: `List ${pathFormatter.format(dir)}`,
-                body: (
-                  <Show when={dir}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Path: " + pathFormatter.format(dir)}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={pathFormatter.format(dir)} prefix="Path: " muted />,
               }
             }
 
@@ -273,13 +286,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "#",
                 title: "Shell command",
-                body: (
-                  <Show when={command}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.text}>{"$ " + command}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={command} prefix="$ " />,
               }
             }
 
@@ -289,13 +296,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "#",
                 title: `${Locale.titlecase(type)} Task`,
-                body: (
-                  <Show when={desc}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.text}>{"◉ " + desc}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={desc} prefix="◉ " />,
               }
             }
 
@@ -304,13 +305,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "%",
                 title: `WebFetch ${url}`,
-                body: (
-                  <Show when={url}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"URL: " + url}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={url} prefix="URL: " muted />,
               }
             }
 
@@ -319,13 +314,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               return {
                 icon: "◈",
                 title: `${webSearchProviderLabel(data.provider)} "${query}"`,
-                body: (
-                  <Show when={query}>
-                    <box paddingLeft={1}>
-                      <text fg={theme.textMuted}>{"Query: " + query}</text>
-                    </box>
-                  </Show>
-                ),
+                body: <ScrollableText text={query} prefix="Query: " muted />,
               }
             }
 
@@ -346,11 +335,19 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                 title: `Access external directory ${dir}`,
                 body: (
                   <Show when={patterns.length > 0}>
-                    <box paddingLeft={1} gap={1}>
-                      <text fg={theme.textMuted}>Patterns</text>
-                      <box>
-                        <For each={patterns}>{(p) => <text fg={theme.text}>{"- " + p}</text>}</For>
-                      </box>
+                    <box paddingLeft={1} gap={1} flexGrow={1} minHeight={0}>
+                      <text fg={theme.textMuted} flexShrink={0}>
+                        Patterns
+                      </text>
+                      <ScrollableBody>
+                        <For each={patterns}>
+                          {(p) => (
+                            <text fg={theme.text} wrapMode="word" width="100%">
+                              {"- " + p}
+                            </text>
+                          )}
+                        </For>
+                      </ScrollableBody>
                     </box>
                   </Show>
                 ),

--- a/packages/tui/test/cli/tui/permission-prompt.test.tsx
+++ b/packages/tui/test/cli/tui/permission-prompt.test.tsx
@@ -1,0 +1,179 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import type { GlobalEvent, PermissionRequest, ToolPart } from "@opencode-ai/sdk/v2"
+import { expect, test } from "bun:test"
+import { onCleanup, onMount } from "solid-js"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { createEventSource, createFetch, directory } from "../../fixture/tui-sdk"
+import { tmpdir } from "../../fixture/fixture"
+import { ArgsProvider } from "../../../src/context/args"
+import { ExitProvider } from "../../../src/context/exit"
+import { KVProvider } from "../../../src/context/kv"
+import { LocationProvider } from "../../../src/context/location"
+import { PermissionProvider } from "../../../src/context/permission"
+import { ProjectProvider } from "../../../src/context/project"
+import { SDKProvider } from "../../../src/context/sdk"
+import { SyncProvider, useSync } from "../../../src/context/sync"
+import { ThemeProvider } from "../../../src/context/theme"
+import { TuiConfigProvider } from "../../../src/config"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../../src/keymap"
+import { PermissionPrompt } from "../../../src/routes/session/permission"
+
+const sessionID = "ses_permission_test"
+const messageID = "msg_permission_test"
+const partID = "prt_permission_test"
+const callID = "call_permission_test"
+
+function global(payload: GlobalEvent["payload"]): GlobalEvent {
+  return { directory: "/tmp/other", project: "proj_test", payload }
+}
+
+function toolPart(input: Record<string, unknown>): ToolPart {
+  return {
+    id: partID,
+    sessionID,
+    messageID,
+    type: "tool",
+    callID,
+    tool: "bash",
+    state: { status: "running", input, time: { start: 0 } },
+  }
+}
+
+function bashRequest(command: string): PermissionRequest {
+  return {
+    id: "perm_permission_test",
+    sessionID,
+    permission: "bash",
+    patterns: [],
+    metadata: {},
+    always: [],
+    tool: { messageID, callID },
+  }
+}
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+async function mountPrompt(request: PermissionRequest, options?: { width?: number; height?: number; state?: string }) {
+  const calls = createFetch()
+  const events = createEventSource()
+  let sync!: ReturnType<typeof useSync>
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  function Probe() {
+    sync = useSync()
+    onMount(done)
+    return <box />
+  }
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const resolvedConfig = createTuiResolvedConfig({ leader_timeout: 1000 })
+    const off = registerOpencodeKeymap(keymap, renderer, resolvedConfig)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts paths={options?.state ? { state: options.state } : undefined}>
+        <ArgsProvider>
+          <KVProvider>
+            <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
+              <PermissionProvider>
+                <ProjectProvider>
+                  <ExitProvider exit={() => {}}>
+                    <SyncProvider>
+                      <Probe />
+                      <OpencodeKeymapProvider keymap={keymap}>
+                        <TuiConfigProvider config={resolvedConfig}>
+                          <ThemeProvider mode="dark">
+                            <LocationProvider location={{ directory, workspaceID: "ws_test" }}>
+                              <PermissionPrompt request={request} directory={directory} />
+                            </LocationProvider>
+                          </ThemeProvider>
+                        </TuiConfigProvider>
+                      </OpencodeKeymapProvider>
+                    </SyncProvider>
+                  </ExitProvider>
+                </ProjectProvider>
+              </PermissionProvider>
+            </SDKProvider>
+          </KVProvider>
+        </ArgsProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, {
+    width: options?.width ?? 60,
+    height: options?.height ?? 12,
+  })
+  await ready
+  return {
+    app,
+    sync,
+    emit: events.emit,
+    async cleanup() {
+      app.renderer.destroy()
+    },
+  }
+}
+
+test("long shell command keeps permission buttons visible", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const command = "echo " + "longword ".repeat(400) + "UNIQUE_TAIL_MARKER"
+  const prompt = await mountPrompt(bashRequest(command), { height: 12, state: tmp.path })
+
+  try {
+    prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ command }) } }))
+    await wait(() => {
+      const part = prompt.sync.data.part[messageID]?.[0]
+      return part?.type === "tool" && part.state.status === "running"
+    })
+    await wait(() => prompt.app.captureCharFrame().includes("Allow once"))
+    const frame = prompt.app.captureCharFrame()
+
+    expect(frame).toContain("Allow always")
+    expect(frame).toContain("Reject")
+    expect(frame).toContain("$ echo")
+    expect(frame).toContain("▀")
+    expect(frame).not.toContain("UNIQUE_TAIL_MARKER")
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("short shell command renders fully with buttons visible", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const command = "echo hello"
+  const prompt = await mountPrompt(bashRequest(command), { height: 12, state: tmp.path })
+
+  try {
+    prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ command }) } }))
+    await wait(() => {
+      const part = prompt.sync.data.part[messageID]?.[0]
+      return part?.type === "tool" && part.state.status === "running"
+    })
+    await wait(() => prompt.app.captureCharFrame().includes("Allow once"))
+    const frame = prompt.app.captureCharFrame()
+
+    expect(frame).toContain("$ echo hello")
+    expect(frame).toContain("Allow always")
+    expect(frame).toContain("Reject")
+    expect(frame).not.toContain("▀")
+  } finally {
+    await prompt.cleanup()
+  }
+})

--- a/packages/tui/test/cli/tui/permission-prompt.test.tsx
+++ b/packages/tui/test/cli/tui/permission-prompt.test.tsx
@@ -30,26 +30,26 @@ function global(payload: GlobalEvent["payload"]): GlobalEvent {
   return { directory: "/tmp/other", project: "proj_test", payload }
 }
 
-function toolPart(input: Record<string, unknown>): ToolPart {
+function toolPart(input: Record<string, unknown>, tool = "bash"): ToolPart {
   return {
     id: partID,
     sessionID,
     messageID,
     type: "tool",
     callID,
-    tool: "bash",
+    tool,
     state: { status: "running", input, time: { start: 0 } },
   }
 }
 
-function bashRequest(command: string): PermissionRequest {
+function permissionRequest(permission: string, always: string[] = []): PermissionRequest {
   return {
     id: "perm_permission_test",
     sessionID,
-    permission: "bash",
+    permission,
     patterns: [],
     metadata: {},
-    always: [],
+    always,
     tool: { messageID, callID },
   }
 }
@@ -133,7 +133,7 @@ test("long shell command keeps permission buttons visible", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")
   const command = "echo " + "longword ".repeat(400) + "UNIQUE_TAIL_MARKER"
-  const prompt = await mountPrompt(bashRequest(command), { height: 12, state: tmp.path })
+  const prompt = await mountPrompt(permissionRequest("bash"), { height: 12, state: tmp.path })
 
   try {
     prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ command }) } }))
@@ -147,8 +147,54 @@ test("long shell command keeps permission buttons visible", async () => {
     expect(frame).toContain("Allow always")
     expect(frame).toContain("Reject")
     expect(frame).toContain("$ echo")
-    expect(frame).toContain("▀")
     expect(frame).not.toContain("UNIQUE_TAIL_MARKER")
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("long shell command with an unbroken token keeps permission buttons visible", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const command = "echo " + "x".repeat(2000) + "TAIL_NO_SPACE"
+  const prompt = await mountPrompt(permissionRequest("bash"), { height: 12, state: tmp.path })
+
+  try {
+    prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ command }) } }))
+    await wait(() => {
+      const part = prompt.sync.data.part[messageID]?.[0]
+      return part?.type === "tool" && part.state.status === "running"
+    })
+    await wait(() => prompt.app.captureCharFrame().includes("Allow once"))
+    const frame = prompt.app.captureCharFrame()
+
+    expect(frame).toContain("Allow always")
+    expect(frame).toContain("Reject")
+    expect(frame).toContain("$ echo")
+    expect(frame).not.toContain("TAIL_NO_SPACE")
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("read permission shows a long path in a bounded body with buttons visible", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const filePath = `/${"deep".repeat(120)}/file${"x".repeat(300)}.txt`
+  const prompt = await mountPrompt(permissionRequest("read"), { height: 12, state: tmp.path })
+
+  try {
+    prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ filePath }, "read") } }))
+    await wait(() => {
+      const part = prompt.sync.data.part[messageID]?.[0]
+      return part?.type === "tool" && part.state.status === "running"
+    })
+    await wait(() => prompt.app.captureCharFrame().includes("Allow once"))
+    const frame = prompt.app.captureCharFrame()
+
+    expect(frame).toContain("Allow always")
+    expect(frame).toContain("Reject")
+    expect(frame).toContain("deep")
   } finally {
     await prompt.cleanup()
   }
@@ -158,7 +204,7 @@ test("short shell command renders fully with buttons visible", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")
   const command = "echo hello"
-  const prompt = await mountPrompt(bashRequest(command), { height: 12, state: tmp.path })
+  const prompt = await mountPrompt(permissionRequest("bash"), { height: 12, state: tmp.path })
 
   try {
     prompt.emit(global({ id: "evt_part", type: "message.part.updated", properties: { sessionID, time: 1, part: toolPart({ command }) } }))
@@ -172,7 +218,6 @@ test("short shell command renders fully with buttons visible", async () => {
     expect(frame).toContain("$ echo hello")
     expect(frame).toContain("Allow always")
     expect(frame).toContain("Reject")
-    expect(frame).not.toContain("▀")
   } finally {
     await prompt.cleanup()
   }


### PR DESCRIPTION
### Issue for this PR
Closes #40793

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI permission prompt rendered command text as a plain `<text>` node with no wrapping and no height limit. A long shell command pushed the Allow/Reject buttons off-screen, so the request could not be answered. The desktop app has the same bug (#40968).

All text-based permission bodies (bash, task, webfetch, websearch, read, glob, grep, list) now render in a bounded scrollbox with `wrapMode="word"`. The buttons stay visible; long content scrolls instead of overflowing.

### How did you verify your code works?

- Added `packages/tui/test/cli/tui/permission-prompt.test.tsx`. It mounts `PermissionPrompt`, injects a permission request via `message.part.updated`, and checks that:
  - a 2000+ char command keeps all three buttons visible and its tail outside the viewport
  - a command with a single unbroken 2000+ char token does the same
  - a long read path keeps the buttons visible
  - a short command renders fully
- The long-command test fails with the old plain `<text>` rendering and passes with the fix (verified both ways).
- `bun run typecheck` in `packages/tui`: clean.
- Full `packages/tui` suite: 196 pass. One pre-existing Windows-only failure in `runtime.test.tsx`, unrelated.

### Screenshots / recordings
Rendered with the TUI renderer test harness (15-row terminal, long heredoc commit command).

Before (dev): command text is clipped with no scrollbar, the tail is unreachable.

```
┃
┃  △ Permission required
┃    # Shell command
┃
┃  $ git commit -m "$(cat <<'EOF'
┃  fix: long description line fix: long description line fix: long description line fix: long
┃  description line fix: long description line fix: long description line fix: long description
┃  line fix: long description line fix: long description line fix: long description line fix:
┃  long description line fix: long description line fix: long description line fix: long
┃  description line fix: long description line fix: long description line fix: long description
┃  line fix: long description line fix: long description line fix: long description line fix:
┃
┃
┃   Allow once   Allow always   Reject                 ctrl+f fullscreen  ⇆ select  enter confirm
┃
```

After (this PR): the body is a bounded scroll area with a scrollbar; the full command is reachable and the buttons stay visible.

```
┃
┃  △ Permission required
┃    # Shell command
┃
┃  $ git commit -m "$(cat <<'EOF'                                                               █
┃  fix: long description line fix: long description line fix: long description line fix: long   █
┃  description line fix: long description line fix: long description line fix: long description █
┃  line fix: long description line fix: long description line fix: long description line fix:   ▀
┃  long description line fix: long description line fix: long description line fix: long
┃  description line fix: long description line fix: long description line fix: long description
┃  line fix: long description line fix: long description line fix: long description line fix:
┃
┃
┃   Allow once   Allow always   Reject                 ctrl+f fullscreen  ⇆ select  enter confirm
┃
```

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
