### PR TITLE
feat(lsp): allow per-server diagnostics wait timeouts

### DIFF
--- a/packages/core/src/config/lsp.ts
+++ b/packages/core/src/config/lsp.ts
@@ -12,6 +12,14 @@ export class Server extends Schema.Class<Server>("ConfigV2.LSP.Server")({
   disabled: Schema.Boolean.pipe(Schema.optional),
   env: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
   initialization: Schema.Record(Schema.String, Schema.Unknown).pipe(Schema.optional),
+  // How long to wait for diagnostics, in milliseconds. Defaults suit servers
+  // that respond quickly; a large C++ translation unit can take far longer to
+  // parse than the default wait, in which case the client gives up and reports
+  // no diagnostics at all — indistinguishable from a clean file.
+  timeout: Schema.Struct({
+    document: Schema.Number.pipe(Schema.optional),
+    full: Schema.Number.pipe(Schema.optional),
+  }).pipe(Schema.optional),
 }) {}
 
 export const Entry = Schema.Union([Disabled, Server])

--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -14,6 +14,15 @@ export const Entry = Schema.Union([
     disabled: Schema.optional(Schema.Boolean),
     env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
     initialization: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+    // Must mirror the v2 schema. A v1 config is decoded against this struct
+    // before migrate.ts passes `lsp` through untouched, so any field absent
+    // here is silently stripped and never reaches the LSP client.
+    timeout: Schema.optional(
+      Schema.Struct({
+        document: Schema.optional(Schema.Number),
+        full: Schema.optional(Schema.Number),
+      }),
+    ),
   }),
 ]).pipe((schema) => schema)
 

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -129,6 +129,13 @@ export async function create(input: {
 }) {
   const instance = input.instance
 
+  // Servers parsing very large translation units (e.g. clangd on an Unreal
+  // Engine codebase) can take far longer than the defaults to publish
+  // diagnostics. When the wait expires the client reports nothing, which is
+  // indistinguishable from a clean file, so allow per-server overrides.
+  const documentWaitTimeout = input.server.timeout?.document ?? DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS
+  const fullWaitTimeout = input.server.timeout?.full ?? DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS
+
   const connection = createMessageConnection(
     new StreamMessageReader(input.server.process.stdout as any),
     new StreamMessageWriter(input.server.process.stdin as any),
@@ -502,13 +509,13 @@ export async function create(input: {
       path: request.path,
       version: request.version,
       after: startedAt,
-      timeout: DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS,
+      timeout: documentWaitTimeout,
     })
 
-    while (Date.now() - startedAt < DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS) {
+    while (Date.now() - startedAt < documentWaitTimeout) {
       const result = await requestDocumentDiagnostics(request.path)
       if (result.matched) return
-      const remaining = DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS - (Date.now() - startedAt)
+      const remaining = documentWaitTimeout - (Date.now() - startedAt)
       if (remaining <= 0) return
       const next = await Promise.race([
         pushWait.then((ready) => (ready ? "push" : ("timeout" as const))),
@@ -524,13 +531,13 @@ export async function create(input: {
       path: request.path,
       version: request.version,
       after: startedAt,
-      timeout: DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS,
+      timeout: fullWaitTimeout,
     })
 
-    while (Date.now() - startedAt < DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS) {
+    while (Date.now() - startedAt < fullWaitTimeout) {
       const result = await requestFullDiagnostics(request.path)
       if (result.handled || result.matched) return
-      const remaining = DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS - (Date.now() - startedAt)
+      const remaining = fullWaitTimeout - (Date.now() - startedAt)
       if (remaining <= 0) return
       const next = await Promise.race([
         pushWait.then((ready) => (ready ? "push" : ("timeout" as const))),

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -176,6 +176,7 @@ const layer = Layer.effect(
                     env: { ...process.env, ...item.env },
                   }),
                   initialization: item.initialization,
+                  timeout: item.timeout,
                 }),
               }
             }

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -25,6 +25,10 @@ const output = (cmd: string[], opts: Process.RunOptions = {}) => Process.text(cm
 export interface Handle {
   process: ChildProcessWithoutNullStreams
   initialization?: Record<string, any>
+  timeout?: {
+    document?: number
+    full?: number
+  }
 }
 
 type RootFunction = (file: string, ctx: InstanceContext) => Promise<string | undefined>


### PR DESCRIPTION
### Issue for this PR

Closes #41218

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS` (5s) and `DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS` (10s) in `lsp/client.ts` are hardcoded. If a language server takes longer than that to produce diagnostics, the wait expires and the client returns nothing — which callers cannot distinguish from "the file is clean". That's the bug: silence and success look identical.

I hit this with clangd on an Unreal Engine project. One translation unit pulls in ~3,764 transitive headers and clangd needs about 20s to parse it, so the wait always expired and `debug lsp diagnostics` returned only the `.clangd` config file, never the file I asked about. It was not a misconfiguration — the same file compiles cleanly with `clang++ -fsyntax-only` using the flags from `compile_commands.json`, and a deliberately broken copy reports its error correctly.

This adds an optional per-server `timeout: { document, full }`, falling back to the existing constants when unset:

```jsonc
"lsp": {
  "clangd": {
    "command": ["clangd", "--compile-commands-dir=..."],
    "timeout": { "document": 60000, "full": 120000 }
  }
}
```

Why it works: `create()` in `client.ts` already receives `input.server`, and `spawn()` in `lsp.ts` already builds that object from the user's config, so the value just needs carrying through and reading at the six places the two constants are used.

One thing worth flagging for anyone adding LSP config fields later: the field has to be declared in **both** `config/lsp.ts` and `v1/config/lsp.ts`. A v1 config is decoded against v1's `Entry` before `migrate.ts` passes `lsp` through untouched, so a field present only in v2 gets silently stripped and never reaches the client. I patched only v2 first and the option appeared to do nothing.

Five files, +35/-6. I deliberately left `DIAGNOSTICS_REQUEST_TIMEOUT_MS` and `INITIALIZE_TIMEOUT_MS` alone — the latter is #23982 and belongs in its own change.

### How did you verify your code works?

Ran the same command against the same file and the same clangd, changing only the config.

Before, and after with no `timeout` set (confirming defaults are unchanged):

```
$ opencode debug lsp diagnostics .../HGGameUserSettings.cpp
{
  "/work/ascent/UE/.clangd": []
}
```

~11s, requested file absent entirely.

After, with `timeout` configured, on a file containing a deliberate error:

```
zz_check.cpp: 2 diagnostics, 1 error
  Use of undeclared identifier 'this_symbol_does_not_exist'
```

~13s.

Also checked in a real session that the automatic post-edit path works: writing a broken `.cpp` now attaches `Error [3:13] Use of undeclared identifier 'this_symbol_does_not_exist'` to the write tool result, where before it attached nothing.

`bun typecheck` passes (30/30 packages) — the pre-push hook ran it.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
