### PR TITLE
fix(opencode): preserve literal %xx in workspace directory paths

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -12,21 +12,13 @@ export class InstanceContextMiddleware extends HttpApiMiddleware.Service<
   }
 >()("@opencode/ExperimentalHttpApiInstanceContext") {}
 
-function decode(input: string): string {
-  try {
-    return decodeURIComponent(input)
-  } catch {
-    return input
-  }
-}
-
 function provideInstanceContext<E>(
   effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E>,
   store: InstanceStore.Interface,
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
+    const ctx = yield* store.load({ directory: route.directory })
     return yield* effect.pipe(
       Effect.provideService(InstanceRef, ctx),
       Effect.provideService(WorkspaceRef, route.workspaceID),

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -83,8 +83,20 @@ function selectedV2WorkspaceID(
   return workspaceID.value
 }
 
+function decodeDirectoryHeader(input: string): string {
+  try {
+    return decodeURIComponent(input)
+  } catch {
+    return input
+  }
+}
+
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  const query = url.searchParams.get("directory")
+  if (query) return query
+  const header = request.headers["x-opencode-directory"]
+  if (header) return decodeDirectoryHeader(header)
+  return process.cwd()
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -189,6 +189,28 @@ describe("HttpApi instance context middleware", () => {
     }),
   )
 
+  it.live("preserves literal percent-encoded sequences in directory paths", () =>
+    Effect.gen(function* () {
+      const parent = yield* tmpdirScoped()
+      const directory = path.join(parent, "User%2e%20Name")
+      yield* Effect.promise(() => mkdir(directory, { recursive: true }))
+      yield* Project.use.fromDirectory(directory)
+      yield* serveProbe()
+
+      const encoded = encodeURIComponent(directory)
+      const query = yield* HttpClient.get(`/probe?directory=${encoded}`)
+      expect(query.status).toBe(200)
+      expect(yield* query.json).toMatchObject({ directory })
+
+      const header = yield* HttpClientRequest.get("/probe").pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", encoded),
+        HttpClient.execute,
+      )
+      expect(header.status).toBe(200)
+      expect(yield* header.json).toMatchObject({ directory })
+    }),
+  )
+
   it.live("provides selected workspace id on control-plane routes", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })


### PR DESCRIPTION
### Issue for this PR

Fixes #40269

### Type of change

- [x] Bug fix

### What does this PR do?

Workspace directory paths were decoded twice on some routes: query params are already URL-decoded once, and `instance-context` called `decodeURIComponent` again. On Windows this turned literal folder names like `User%2e%20Name` into `User. Name`, causing session creation and prompts to fail.

Decode `x-opencode-directory` headers once in workspace routing and pass the resolved directory through instance context without re-decoding.

### How did you verify your code works?

Added `preserves literal percent-encoded sequences in directory paths` to `httpapi-instance-context.test.ts`, covering both query-param and header routing.

Ran the new test plus the existing URI decoding fallback test locally.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
