### PR TITLE
fix(opencode): match permission tool keys case-insensitively

### DIFF
--- a/packages/core/src/util/wildcard.ts
+++ b/packages/core/src/util/wildcard.ts
@@ -12,3 +12,16 @@ export function match(input: string, pattern: string) {
 
   return new RegExp("^" + escaped + "$", process.platform === "win32" ? "si" : "s").test(normalized)
 }
+
+export function matchPermission(input: string, pattern: string) {
+  const normalized = input.replaceAll("\\", "/")
+  let escaped = pattern
+    .replaceAll("\\", "/")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".")
+
+  if (escaped.endsWith(" .*")) escaped = escaped.slice(0, -3) + "( .*)?"
+
+  return new RegExp("^" + escaped + "$", "si").test(normalized)
+}

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -29,7 +29,7 @@ export function evaluate(permission: string, pattern: string, ...rulesets: Permi
   return (
     rulesets
       .flat()
-      .findLast((rule) => Wildcard.match(permission, rule.permission) && Wildcard.match(pattern, rule.pattern)) ?? {
+      .findLast((rule) => Wildcard.matchPermission(permission, rule.permission) && Wildcard.match(pattern, rule.pattern)) ?? {
       action: "ask",
       permission,
       pattern: "*",
@@ -74,7 +74,7 @@ const layer = Layer.effect(
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {
           return yield* new PermissionV1.DeniedError({
-            ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
+            ruleset: ruleset.filter((rule) => Wildcard.matchPermission(request.permission, rule.permission)),
           })
         }
         if (rule.action === "allow") continue
@@ -207,7 +207,7 @@ export function disabled(tools: string[], ruleset: PermissionV1.Ruleset): Set<st
   return new Set(
     tools.filter((tool) => {
       const permission = edits.includes(tool) ? "edit" : reads.includes(tool) ? "read" : tool
-      const rule = ruleset.findLast((rule) => Wildcard.match(permission, rule.permission))
+      const rule = ruleset.findLast((rule) => Wildcard.matchPermission(permission, rule.permission))
       return rule?.pattern === "*" && rule.action === "deny"
     }),
   )

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -173,6 +173,20 @@ test("fromConfig - documented fallback-first example", () => {
   expect(Permission.evaluate("read", "foo.ts", ruleset).action).toBe("ask")
 })
 
+test("evaluate - permission tool keys are case-insensitive", () => {
+  const ruleset = Permission.fromConfig({ read: "allow", glob: "deny", bash: { "*": "allow" } })
+  expect(Permission.evaluate("Read", "foo.ts", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("GLOB", "src/**", ruleset).action).toBe("deny")
+  expect(Permission.evaluate("Bash", "Test-Path foo", ruleset).action).toBe("allow")
+})
+
+test("evaluate - path patterns stay case-sensitive on Unix", () => {
+  if (process.platform === "win32") return
+  const ruleset = Permission.fromConfig({ read: { "src/CaseSensitive.ts": "allow" } })
+  expect(Permission.evaluate("read", "src/CaseSensitive.ts", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("read", "src/casesensitive.ts", ruleset).action).toBe("ask")
+})
+
 test("fromConfig - expands exact tilde to home directory", () => {
   const result = Permission.fromConfig({ external_directory: { "~": "allow" } })
   expect(result).toEqual([{ permission: "external_directory", pattern: os.homedir(), action: "allow" }])


### PR DESCRIPTION
### Issue for this PR

Fixes #36690

### Type of change

- [x] Bug fix

### What does this PR do?

Permission config keys like `read` and `glob` did not match when the runtime permission name used different casing (for example `Read`). Tool-key matching is now case-insensitive via `Wildcard.matchPermission`, while file path patterns keep existing platform-specific case behavior.

### How did you verify your code works?

Added tests in `packages/opencode/test/permission/next.test.ts` for mixed-case tool keys and Unix path case sensitivity.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
