### PR TITLE
fix(core): normalize file watcher paths to forward slashes

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -41,6 +41,10 @@ function getBackend() {
   if (process.platform === "linux") return "inotify"
 }
 
+export function normalizeEventPath(file: string): string {
+  return process.platform === "win32" ? file.replaceAll("\\", "/") : file
+}
+
 function protecteds(dir: string) {
   return Protected.paths().filter((item) => {
     const relative = path.relative(dir, item)
@@ -85,9 +89,10 @@ const layer = Layer.effect(
 
     const callback: ParcelWatcher.SubscribeCallback = (_error, updates) => {
       for (const update of updates) {
-        if (update.type === "create") runFork(events.publish(Event.Updated, { file: update.path, event: "add" }))
-        if (update.type === "update") runFork(events.publish(Event.Updated, { file: update.path, event: "change" }))
-        if (update.type === "delete") runFork(events.publish(Event.Updated, { file: update.path, event: "unlink" }))
+        const file = normalizeEventPath(update.path)
+        if (update.type === "create") runFork(events.publish(Event.Updated, { file, event: "add" }))
+        if (update.type === "update") runFork(events.publish(Event.Updated, { file, event: "change" }))
+        if (update.type === "delete") runFork(events.publish(Event.Updated, { file, event: "unlink" }))
       }
     }
 

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun"
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { ConfigProvider, Deferred, Duration, Effect, Fiber, Layer, Option, Stream } from "effect"
@@ -16,6 +16,14 @@ import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 const describeWatcher = Watcher.hasNativeBinding() && !process.env.CI ? describe : describe.skip
+
+test("normalizeEventPath converts backslashes on Windows", () => {
+  if (process.platform !== "win32") {
+    expect(Watcher.normalizeEventPath("foo/bar")).toBe("foo/bar")
+    return
+  }
+  expect(Watcher.normalizeEventPath("foo\\bar\\baz.txt")).toBe("foo/bar/baz.txt")
+})
 
 type WatcherEvent = { file: string; event: "add" | "change" | "unlink" }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #35329

### Type of change

- [x] Bug fix

### What does this PR do?

The native file watcher emits backslash paths on Windows, but the rest of OpenCode compares paths with forward slashes. Normalize watcher event paths to `/` on win32 before publishing `file.watcher.updated` events.

### How did you verify your code works?

Added `normalizeEventPath converts backslashes on Windows` in `packages/core/test/filesystem/watcher.test.ts`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
