### PR TITLE
fix(tui): compensate scroll on message prune

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1,5 +1,6 @@
 import {
   batch,
+  createComputed,
   createContext,
   createEffect,
   createMemo,
@@ -74,7 +75,7 @@ import { setPreLayoutSiblingMargin } from "../../util/layout"
 import { useTuiConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
-import { getScrollAcceleration } from "../../util/scroll"
+import { getScrollAcceleration, compensatePruneScrollTop } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
 import { DialogRetryAction } from "../../component/dialog-retry-action"
@@ -344,6 +345,25 @@ export function Session() {
   let seeded = false
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef | undefined
+
+  // When the oldest messages are pruned while the user is scrolled up reading a
+  // backlog, the scrollbox holds scrollTop fixed and the reading position
+  // drifts down the transcript. This runs before the message list is re-rendered
+  // (the pruned children are still laid out) and compensates scrollTop by the
+  // height of the content that disappeared above the first surviving message.
+  createComputed(() => {
+    const list = messages()
+    if (!scroll || scroll.isDestroyed) return
+    const compensated = compensatePruneScrollTop({
+      children: scroll.getChildren(),
+      messageIDs: new Set(list.map((message) => message.id)),
+      scrollTop: scroll.scrollTop,
+      scrollHeight: scroll.scrollHeight,
+      viewportHeight: scroll.viewport.height,
+    })
+    if (compensated !== scroll.scrollTop) scroll.scrollTop = compensated
+  })
+
   const bind = (r: PromptRef | undefined) => {
     prompt = r
     promptRef.set(r)
@@ -1491,7 +1511,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const backgroundShortcut = useCommandShortcut("session.background")
 
   return (
-    <>
+    <box id={props.message.id} flexShrink={0}>
       <For each={props.parts}>
         {(part, index) => {
           const component = createMemo(() => PART_MAPPING[part.type as keyof typeof PART_MAPPING])
@@ -1572,7 +1592,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           </box>
         </Match>
       </Switch>
-    </>
+    </box>
   )
 }
 

--- a/packages/tui/src/util/scroll.ts
+++ b/packages/tui/src/util/scroll.ts
@@ -25,3 +25,47 @@ export function getScrollAcceleration(tuiConfig?: ScrollConfig): ScrollAccelerat
 
   return new CustomSpeedScroll(3)
 }
+
+export type ScrollChild = {
+  id?: string
+  y: number
+  height: number
+}
+
+// The TUI keeps at most 100 messages per session (see `context/sync.tsx`).
+// When a new message pushes the session past the limit, the oldest message is
+// pruned. The scrollbox holds scrollTop fixed while the user has scrolled up to
+// read a backlog, so removing content from the top shifts the reading position
+// down the transcript. Given the layout captured *before* the pruned messages
+// are removed, this returns the scrollTop that keeps the reading position
+// stable: it moves up by the height of the content that disappeared above the
+// first surviving message.
+export function compensatePruneScrollTop(input: {
+  children: ScrollChild[]
+  messageIDs: ReadonlySet<string>
+  scrollTop: number
+  scrollHeight: number
+  viewportHeight: number
+}): number {
+  const { children, messageIDs, scrollTop, scrollHeight, viewportHeight } = input
+  const maxScrollTop = Math.max(0, scrollHeight - viewportHeight)
+  // Sticky scroll already keeps the viewport glued to the bottom.
+  if (scrollTop >= maxScrollTop - 1) return scrollTop
+
+  // Message boxes carry an id (the top spacer box does not). The oldest
+  // surviving message anchors the measurement: everything between it and the
+  // content above the oldest message was pruned.
+  const messageBoxes = children.filter((child) => child.id !== undefined)
+  const oldest = messageBoxes[0]
+  if (!oldest || messageIDs.has(oldest.id!)) return scrollTop
+  const anchor = messageBoxes.find((child) => child.id !== undefined && messageIDs.has(child.id))
+  if (!anchor) return scrollTop
+
+  const index = children.indexOf(oldest)
+  const above = children[index - 1]
+  if (!above) return scrollTop
+
+  const removedHeight = anchor.y - (above.y + above.height)
+  if (removedHeight <= 0) return scrollTop
+  return Math.max(0, scrollTop - removedHeight)
+}

--- a/packages/tui/test/util/scroll-prune.test.tsx
+++ b/packages/tui/test/util/scroll-prune.test.tsx
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { createComputed, createSignal, For } from "solid-js"
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { compensatePruneScrollTop } from "../../src/util/scroll"
+
+describe("compensatePruneScrollTop", () => {
+  const spacer = { y: 0, height: 1 }
+  const message = (id: string, y: number, height = 2) => ({ id, y, height })
+
+  test("returns scrollTop unchanged when no oldest message was pruned", () => {
+    const children = [spacer, message("m0", 1), message("m1", 4)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m0", "m1", "m2"]),
+        scrollTop: 50,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(50)
+  })
+
+  test("compensates by the height of pruned content above the first surviving message", () => {
+    // Spacer (1) + m0 (2) + m1 margin (1) => m1 top = 4. Pruning m0 removes
+    // m0's height and the margin m1 loses as it becomes the top message.
+    const children = [spacer, message("m0", 1), message("m1", 4), message("m2", 7)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m1", "m2", "m3"]),
+        scrollTop: 50,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(47)
+  })
+
+  test("accounts for the first surviving message losing its top margin", () => {
+    // m0 pruned; m1 was 1px below m0 and becomes the top message with no margin.
+    const children = [spacer, message("m0", 1), message("m1", 4), message("m2", 7)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m1", "m2"]),
+        scrollTop: 50,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(50 - (4 - 1))
+  })
+
+  test("clamps to zero and never goes below the top", () => {
+    const children = [spacer, message("m0", 1), message("m1", 4)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m1"]),
+        scrollTop: 2,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(0)
+  })
+
+  test("leaves scrollTop alone when already at the sticky bottom", () => {
+    const children = [spacer, message("m0", 1), message("m1", 4)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m1"]),
+        scrollTop: 85,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(85)
+  })
+
+  test("does nothing when no surviving message anchors the measurement", () => {
+    const children = [spacer, message("m0", 1), message("m1", 4)]
+    expect(
+      compensatePruneScrollTop({
+        children,
+        messageIDs: new Set(["m9"]),
+        scrollTop: 50,
+        scrollHeight: 100,
+        viewportHeight: 15,
+      }),
+    ).toBe(50)
+  })
+})
+
+describe("session scroll pruning", () => {
+  let testSetup: Awaited<ReturnType<typeof testRender>> | undefined
+
+  beforeEach(async () => {
+    if (testSetup) testSetup.renderer.destroy()
+  })
+
+  afterEach(() => {
+    if (testSetup) testSetup.renderer.destroy()
+  })
+
+  test("keeps the reading position stable when oldest messages are pruned", async () => {
+    type Msg = { id: string; role: "user" | "assistant"; text: string }
+    const [messages, setMessages] = createSignal<Msg[]>([])
+    let scroll: ScrollBoxRenderable | undefined
+
+    // Mirror the Session route wiring: compensation runs before the message
+    // list is re-rendered so it can read the pre-prune layout. Both user
+    // message boxes and assistant message wrapper boxes carry the message id
+    // (the AssistantMessage route wraps its parts in `<box id={message.id}>`).
+    const Wiring = () => {
+      createComputed(() => {
+        const list = messages()
+        if (!scroll || scroll.isDestroyed) return
+        const compensated = compensatePruneScrollTop({
+          children: scroll.getChildren(),
+          messageIDs: new Set(list.map((message) => message.id)),
+          scrollTop: scroll.scrollTop,
+          scrollHeight: scroll.scrollHeight,
+          viewportHeight: scroll.viewport.height,
+        })
+        if (compensated !== scroll.scrollTop) scroll.scrollTop = compensated
+      })
+      return (
+        <scrollbox
+          ref={(r) => {
+            scroll = r
+          }}
+          width={50}
+          height={15}
+          stickyScroll={true}
+          stickyStart="bottom"
+        >
+          <box height={1} />
+          <For each={messages()}>
+            {(msg) => (
+              <box id={`msg-${msg.id}`} marginTop={1}>
+                <text>{msg.text}</text>
+              </box>
+            )}
+          </For>
+        </scrollbox>
+      )
+    }
+
+    testSetup = await testRender(() => <Wiring />, { width: 80, height: 24 })
+    await testSetup.renderOnce()
+
+    for (let i = 0; i < 100; i++) {
+      const role = i % 2 === 0 ? "user" : "assistant"
+      const lines = role === "assistant" ? 4 : 2
+      const text = Array.from({ length: lines }, (_, l) => `Message ${i} line ${l}`).join("\n")
+      setMessages((prev) => [...prev, { id: String(i), role, text }])
+      await testSetup.renderOnce()
+    }
+
+    // User scrolls up to read a backlog.
+    scroll!.scrollBy(-10)
+    await testSetup.renderOnce()
+
+    const visible = scroll!
+      .getChildren()
+      .filter((child) => child.id !== undefined && child.y >= 0)
+      .sort((a, b) => a.y - b.y)
+    const topMsg = visible[0]
+    expect(topMsg).toBeDefined()
+    expect(topMsg!.y).toBeGreaterThanOrEqual(0)
+
+    // Simulate sync.tsx pruning: each new message past the 100 limit shifts the
+    // oldest message off the top, alternating user and assistant messages.
+    for (let i = 100; i < 106; i++) {
+      const role = i % 2 === 0 ? "user" : "assistant"
+      const text = role === "assistant" ? "assistant output\nline two\nline three\nline four" : `new user msg ${i}`
+      setMessages((prev) => [...prev.slice(1), { id: String(i), role, text }])
+      await testSetup.renderOnce()
+    }
+
+    const after = scroll!.getChildren().find((child) => child.id === topMsg.id)
+    expect(after?.y).toBe(topMsg.y)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41243

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

While the agent is producing output, a user can scroll up to read earlier messages. Once a session exceeds 100 messages, every new message prunes the oldest one off the top of the message store (`packages/tui/src/context/sync.tsx`). The scrollbox holds `scrollTop` fixed while scrolled up, so removing content above the reading position drifts the viewport down the transcript on every new message.

This PR compensates the scroll position when the oldest messages are pruned, keeping the reading position stable while the user is scrolled up:

- `packages/tui/src/util/scroll.ts`: `compensatePruneScrollTop` returns a `scrollTop` moved up by the height of content that disappeared above the first surviving message, computed from the layout captured before the prune.
- `packages/tui/src/routes/session/index.tsx`: runs it in a `createComputed` watching the message list, so it executes before the list re-renders while the pre-prune child layout is still available. Sticky-bottom following is untouched — when the user is at the bottom, compensation is skipped and the scrollbox re-sticks as usual.
- `AssistantMessage` now wraps its parts in `<box id={message.id}>` so every message (user and assistant) renders an identifiable box. Previously only user messages carried an id, so pruned assistant messages could not be measured.

### How did you verify your code works?

Added `packages/tui/test/util/scroll-prune.test.tsx`: unit tests for `compensatePruneScrollTop` plus a render test (`testRender` from `@opentui/solid`) mirroring the session wiring. It fills 100 alternating user/assistant messages, scrolls up 10 lines, then simulates the `sync.tsx` prune on each new message and asserts the message pinned at the top of the viewport stays at the same viewport line — without the fix it drifts from `y = 2` to `y = -22` across 6 prunes.

Verified `bun typecheck` (packages/tui) passes and the full `packages/tui` suite passes (200 tests, 8 snapshots unchanged).

### Screenshots / recordings

N/A (terminal UI; no recording).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR