### PR TITLE
docs(www): fix bash prefix in V2 install commands

### DIFF
--- a/packages/www/content/docs/index.mdx
+++ b/packages/www/content/docs/index.mdx
@@ -20,10 +20,26 @@ description: "Get started with OpenCode."
 You can also install it with the following package managers.
 
 <Tabs>
-  <Tab title="npm">```bash npm install -g @opencode-ai/cli@next ```</Tab>
-  <Tab title="bun">```bash bun install -g --trust @opencode-ai/cli@next ```</Tab>
-  <Tab title="pnpm">```bash pnpm add -g --allow-build=@opencode-ai/cli @opencode-ai/cli@next ```</Tab>
-  <Tab title="Yarn">```bash yarn global add @opencode-ai/cli@next ```</Tab>
+  <Tab title="npm">
+    ```bash
+    npm install -g @opencode-ai/cli@next
+    ```
+  </Tab>
+  <Tab title="bun">
+    ```bash
+    bun install -g --trust @opencode-ai/cli@next
+    ```
+  </Tab>
+  <Tab title="pnpm">
+    ```bash
+    pnpm add -g --allow-build=@opencode-ai/cli @opencode-ai/cli@next
+    ```
+  </Tab>
+  <Tab title="Yarn">
+    ```bash
+    yarn global add @opencode-ai/cli@next
+    ```
+  </Tab>
 </Tabs>
 
 The package uses a trusted postinstall script to select the native `opencode2` binary for your platform. The Bun and pnpm


### PR DESCRIPTION
### Issue for this PR

Closes #41250

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The V2 installation commands were rendered as `bash npm install...`, making the `bash` syntax label look like part of the command.

This updates the npm, Bun, pnpm, and Yarn examples to use proper multiline fenced code blocks. The `bash` label is now treated as the code-block language instead of visible command text.

### How did you verify your code works?

Ran the V2 docs site locally with `bun dev` and confirmed the installation commands render without the `bash` prefix. Also ran `bun typecheck` and `bun validate` from `packages/www`.

### Screenshots / recordings

Before:

<img width="883" height="140" alt="image" src="https://github.com/user-attachments/assets/8e3df1ca-9997-4bc9-9e87-80f3e418bae8" />
<img width="724" height="118" alt="image" src="https://github.com/user-attachments/assets/2d7a71be-3e1b-4d67-8a39-da454f43fdf2" />

After:

<img width="719" height="109" alt="image" src="https://github.com/user-attachments/assets/5430c284-6d40-4fd4-bce5-16140f4828e7" />
<img width="753" height="115" alt="image" src="https://github.com/user-attachments/assets/3b0abbd4-f90a-46ff-bc5e-b7e8470f278d" />
<img width="766" height="127" alt="image" src="https://github.com/user-attachments/assets/6165a8d0-37aa-44a0-859e-b2e2e58659db" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR