### PR TITLE
fix(plugin): bind OAuth callback servers to loopback instead of 0.0.0.0

### DIFF
--- a/packages/opencode/src/plugin/digitalocean.ts
+++ b/packages/opencode/src/plugin/digitalocean.ts
@@ -11,6 +11,7 @@ const DO_API_BASE = "https://api.digitalocean.com"
 const DO_GENAI_API = `${DO_API_BASE}/v2/gen-ai`
 const DO_INFERENCE_BASE = "https://inference.do-ai.run/v1"
 const OAUTH_PORT = 1456
+const OAUTH_CALLBACK_HOST = "127.0.0.1"
 const OAUTH_REDIRECT_PATH = "/auth/callback"
 const OAUTH_TOKEN_PATH = "/auth/token"
 const ROUTER_REFRESH_INTERVAL_MS = 5 * 60 * 1000
@@ -126,7 +127,7 @@ async function startOAuthServer(): Promise<void> {
   })
 
   await new Promise<void>((resolve, reject) => {
-    oauthServer!.listen(OAUTH_PORT, () => {
+    oauthServer!.listen(OAUTH_PORT, OAUTH_CALLBACK_HOST, () => {
       resolve()
     })
     oauthServer!.on("error", reject)

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -11,6 +11,7 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
+const OAUTH_CALLBACK_HOST = "127.0.0.1"
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 const ALLOWED_MODELS = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
 const DISALLOWED_MODELS = new Set(["gpt-5.5-pro"])
@@ -217,7 +218,7 @@ async function startOAuthServer(): Promise<{ port: number; redirectUri: string }
   })
 
   await new Promise<void>((resolve, reject) => {
-    oauthServer!.listen(OAUTH_PORT, () => {
+    oauthServer!.listen(OAUTH_PORT, OAUTH_CALLBACK_HOST, () => {
       resolve()
     })
     oauthServer!.on("error", reject)


### PR DESCRIPTION
Fixes #41255.

`codex.ts` and `digitalocean.ts` call `listen(port, cb)` without a hostname, so Node binds `0.0.0.0` and the OAuth callback port is reachable from the LAN for the duration of the login flow. The callback only ever needs to accept a redirect from the local browser.

This matches what the code base already does elsewhere:

- `packages/opencode/src/mcp/oauth-callback.ts` — `const OAUTH_CALLBACK_HOST = "127.0.0.1"`, used at `listen(currentPort, OAUTH_CALLBACK_HOST, …)`
- `packages/opencode/src/plugin/snowflake-cortex.ts` — `listen(0, OAUTH_CALLBACK_HOST, …)`

so I reused the same constant name in both plugins rather than inlining the literal.

### Deliberately unchanged

The `redirect_uri` literals stay exactly as they are (`http://localhost:<port>/auth/callback`). They must remain byte-identical to the values registered with the providers, otherwise the flow breaks with `redirect_uri mismatch`.

Binding `127.0.0.1` while the redirect URI still says `localhost` is safe in practice: `localhost` may resolve to `::1` first, but browsers and `fetch` fall back to `127.0.0.1` via Happy Eyeballs. Verified locally — with the server bound to `127.0.0.1` only, `fetch("http://localhost:<port>")` still returns 200.

### Testing

- Confirmed on a downstream fork carrying the identical call sites: before the change, connecting to the host's non-loopback IPv4 on the callback port succeeds; after it, the connection is refused while `127.0.0.1` keeps working and the browser redirect completes normally.
- No behaviour change for the local flow — only the bind address is narrowed.

I don't have credentials for either provider, so I could not exercise a full end-to-end sign-in against DigitalOcean/Codex; happy to adjust if you'd prefer a shared constant in one place instead of one per plugin.
