### PR TITLE
fix(cli): forward attach mini options

### DIFF
--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -58,6 +58,19 @@ export const AttachCommand = cmd({
       .option("replay-limit", {
         type: "number",
         describe: "cap visible mini replay to the newest N messages",
+      })
+      .option("model", {
+        type: "string",
+        alias: ["m"],
+        describe: "model to use in the format of provider/model",
+      })
+      .option("prompt", {
+        type: "string",
+        describe: "prompt to use",
+      })
+      .option("agent", {
+        type: "string",
+        describe: "agent to use",
       }),
   handler: async (args) => {
     if (args.replay === true) {
@@ -88,6 +101,9 @@ export const AttachCommand = cmd({
         continue: args.continue,
         session: args.session,
         fork: args.fork,
+        model: args.model,
+        agent: args.agent,
+        prompt: args.prompt,
         replay: noReplay ? false : undefined,
         replayLimit: args.replayLimit,
       })

--- a/packages/opencode/test/cli/tui/attach.test.ts
+++ b/packages/opencode/test/cli/tui/attach.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import yargs from "yargs"
+import { AttachCommand } from "../../../src/cli/cmd/attach"
 
 describe("tui attach", () => {
   test("loads the TUI integration lazily", async () => {
@@ -7,5 +9,26 @@ describe("tui attach", () => {
     expect(source).toContain('await import("../tui/layer")')
     expect(source).toMatch(/await import\(["']@\/plugin\/tui\/runtime["']\)/)
     expect(source).not.toContain('import("./app")')
+  })
+
+  test("accepts mini input options", async () => {
+    const args = await yargs([])
+      .command({ ...AttachCommand, handler: () => {} })
+      .exitProcess(false)
+      .parse([
+        "attach",
+        "http://127.0.0.1:4096",
+        "--mini",
+        "--model",
+        "test/model",
+        "--agent",
+        "plan",
+        "--prompt",
+        "hello",
+      ])
+
+    expect(args.model).toBe("test/model")
+    expect(args.agent).toBe("plan")
+    expect(args.prompt).toBe("hello")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #38483

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

accepts `model`, `agent`, and `prompt` cli options when running opencode in attach mode.

### How did you verify your code works?

ran `bun dev attach <server-url> --mini --prompt hi --agent plan` and confirmed it accepts and runs with the options.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
