### PR TITLE
fix(tui): show selected mini agent

### DIFF
--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -388,7 +388,7 @@ export function RunFooterView(props: RunFooterViewProps) {
       return "EXIT"
     }
 
-    return shell() ? "SHELL" : "BUILD"
+    return shell() ? "SHELL" : props.agent.toUpperCase()
   })
   const modeColor = createMemo(() => {
     if (exiting()) {

--- a/packages/opencode/test/cli/run/footer.view.test.tsx
+++ b/packages/opencode/test/cli/run/footer.view.test.tsx
@@ -164,6 +164,7 @@ async function renderFooter(
     width?: number
     height?: number
     state?: Partial<FooterState>
+    agent?: string
     onCycle?: () => void
     onSubmit?: (prompt: RunPrompt) => boolean
   } = {},
@@ -199,7 +200,7 @@ async function renderFooter(
           theme={input.theme ?? (() => RUN_THEME_FALLBACK)}
           tuiConfig={config}
           backgroundSubagents={input.backgroundSubagents ?? true}
-          agent="opencode"
+          agent={input.agent ?? "build"}
           onSubmit={input.onSubmit ?? (() => true)}
           onPermissionReply={() => {}}
           onQuestionReply={() => {}}
@@ -1147,18 +1148,18 @@ test("direct footer shows full usage metadata when room is available", async () 
   }
 })
 
-test("direct footer mode label keeps left padding without a status pill", async () => {
-  const app = await renderFooter()
+test("direct footer mode label shows the selected agent with left padding", async () => {
+  const app = await renderFooter({ agent: "Plan" })
 
   try {
     await app.renderOnce()
     const statusline = app
       .captureCharFrame()
       .split("\n")
-      .find((line) => line.includes("BUILD") && line.includes("cmd"))
+      .find((line) => line.includes("PLAN") && line.includes("cmd"))
 
     expect(statusline).toBeDefined()
-    expect(statusline?.startsWith(" BUILD ")).toBe(true)
+    expect(statusline?.startsWith(" PLAN ")).toBe(true)
   } finally {
     app.cleanup()
   }


### PR DESCRIPTION
### Issue for this PR

Closes #41259

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

shows correct agent label in mini mode when launched with `--agent plan` option

### How did you verify your code works?

ran `bun dev --mini --prompt "what agent mode is running" --agent plan` and verified the correct label shows.

### Screenshots / recordings

<img width="1286" height="234" alt="image" src="https://github.com/user-attachments/assets/59dcbcc8-3f64-49ac-844f-fc146c7d47a4" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR