### PR TITLE
feat(app): add All files option to review v2 changes dropdown

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -86,7 +86,7 @@ export type LocalProject = Partial<Project> & { worktree: string; expanded: bool
 export type HomeProjectSelection = { server: ServerConnection.Key; directory?: string }
 
 export type ReviewDiffStyle = "unified" | "split"
-export type ReviewChangeMode = "git" | "branch" | "turn"
+export type ReviewChangeMode = "git" | "branch" | "turn" | "all"
 export type ReviewPanelSource = "context-button" | "other"
 
 export type LayoutRoute =
@@ -811,7 +811,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         const s = createMemo(() => store.sessionView[key()] ?? { scroll: {} })
         const reviewMode = createMemo(() => {
           const mode = s().reviewMode
-          if (mode === "git" || mode === "branch" || mode === "turn") return mode
+          if (mode === "git" || mode === "branch" || mode === "turn" || mode === "all") return mode
         })
         const reviewFile = createMemo(() => {
           const file = s().reviewFile

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -108,7 +108,7 @@ type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
 const emptyFollowups: FollowupItem[] = []
 
-type ChangeMode = "git" | "branch" | "turn"
+type ChangeMode = "git" | "branch" | "turn" | "all"
 type VcsMode = "git" | "branch"
 
 const sessionViewState = () => ({
@@ -663,6 +663,7 @@ export default function Page() {
       list.push("branch")
     }
     list.push("turn")
+    list.push("all")
     return list
   })
   const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
@@ -701,6 +702,7 @@ export default function Page() {
   })
   const refreshVcs = debounce(() => void queryClient.invalidateQueries({ queryKey: vcsKey() }), 100)
   const reviewDiffs = () => {
+    if (reviewMode() === "all") return []
     if (reviewMode() === "git" || reviewMode() === "branch")
       // avoids suspense
       return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
@@ -715,6 +717,7 @@ export default function Page() {
   const reviewCount = () => reviewDiffs().length
   const hasReview = () => reviewCount() > 0
   const reviewReady = () => {
+    if (reviewMode() === "all") return true
     if (reviewMode() === "git" || reviewMode() === "branch") return !vcsQuery.isPending
     return true
   }
@@ -1164,6 +1167,7 @@ export default function Page() {
   const changesLabel = (option: ChangeMode) => {
     if (option === "git") return language.t("ui.sessionReview.title.git")
     if (option === "branch") return language.t("ui.sessionReview.title.branch")
+    if (option === "all") return language.t("session.files.all")
     return language.t("ui.sessionReview.title.lastTurn")
   }
 
@@ -1226,6 +1230,7 @@ export default function Page() {
   )
 
   const reviewEmptyText = createMemo(() => {
+    if (reviewMode() === "all") return language.t("session.files.empty")
     if (reviewMode() === "git") return language.t("session.review.noUncommittedChanges")
     if (reviewMode() === "branch") return language.t("session.review.noBranchChanges")
     return language.t("session.review.noChanges")
@@ -1250,6 +1255,9 @@ export default function Page() {
   }
 
   const reviewEmptyV2 = () => {
+    if (reviewMode() === "all") {
+      return <div class="px-6 py-4 text-text-weak">{language.t("session.files.empty")}</div>
+    }
     if ((reviewMode() === "git" || reviewMode() === "branch") && !reviewReady()) {
       return <div class="px-6 py-4 text-text-weak">{language.t("session.review.loadingChanges")}</div>
     }
@@ -1314,6 +1322,8 @@ export default function Page() {
       return activeReviewFile()
     },
     onSelectFile: focusReviewDiff,
+    onOpenFile: openReviewFile,
+    allFiles: reviewMode() === "all",
     get diffStyle() {
       return layout.review.diffStyle()
     },

--- a/packages/app/src/pages/session/v2/review-panel-v2.tsx
+++ b/packages/app/src/pages/session/v2/review-panel-v2.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createResource, createSignal, Show, type JSX } from "solid-js"
+import { createQuery } from "@tanstack/solid-query"
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import {
@@ -19,8 +20,10 @@ import type {
   SessionReviewLineComment,
 } from "@opencode-ai/session-ui/session-review"
 import FileTreeV2 from "@/components/file-tree-v2"
+import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
+import { useSessionLayout } from "@/pages/session/session-layout"
 import {
   filterRenderableDiff,
   filterReviewFiles,
@@ -42,6 +45,8 @@ export type ReviewPanelV2Props = {
   loadDiff?: (path: string, version?: number) => Promise<RenderDiff | undefined>
   activeFile?: string
   onSelectFile: (path: string) => void
+  onOpenFile?: (path: string) => void
+  allFiles?: boolean
   diffStyle: SessionReviewDiffStyle
   onDiffStyleChange?: (style: SessionReviewDiffStyle) => void
   state: ReviewPanelV2State
@@ -123,6 +128,8 @@ export function ReviewPanelV2(props: ReviewPanelV2Props) {
           state={props.state}
           diffsReady={props.diffsReady}
           onSelectFile={props.onSelectFile}
+          onOpenFile={props.onOpenFile}
+          allFiles={props.allFiles}
           diffs={diffs}
           filteredFiles={filteredFiles}
           searching={searching}
@@ -173,6 +180,8 @@ function ReviewPanelV2Sidebar(props: {
   state: ReviewPanelV2State
   diffsReady: () => boolean
   onSelectFile: (path: string) => void
+  onOpenFile?: (path: string) => void
+  allFiles?: boolean
   diffs: () => RenderDiff[]
   filteredFiles: () => string[]
   searching: () => boolean
@@ -180,10 +189,27 @@ function ReviewPanelV2Sidebar(props: {
   activeDiff: () => string | undefined
 }) {
   const language = useLanguage()
+  const file = useFile()
+  const { workspaceKey } = useSessionLayout()
   const [explicitHighlight, setExplicitHighlight] = createSignal<string | undefined>()
+  const query = createMemo(() => props.state.filter().trim())
+  const allFilesSearch = createQuery(() => {
+    const value = query()
+    return {
+      queryKey: ["session-review-all-files", workspaceKey(), value] as const,
+      enabled: props.allFiles === true && value.length > 0,
+      queryFn: ({ signal }) => file.searchFiles(value, { limit: 200, signal }),
+    }
+  })
+  const allFilesSearching = createMemo(() => props.allFiles === true && query().length > 0)
+  const allFilesLoading = createMemo(() => props.allFiles === true && query().length > 0 && allFilesSearch.isPending)
+  const allFilesResults = createMemo(() => {
+    if (allFilesLoading()) return []
+    return [...new Set(allFilesSearch.data ?? [])]
+  })
   const highlightedPath = createMemo(() => {
     if (!props.searching()) return undefined
-    const files = props.filteredFiles()
+    const files = props.allFiles ? allFilesResults() : props.filteredFiles()
     if (files.length === 0) return undefined
     const explicit = explicitHighlight()
     if (explicit && files.includes(explicit)) return explicit
@@ -192,10 +218,38 @@ function ReviewPanelV2Sidebar(props: {
 
   const onFilterKeyDown = (event: KeyboardEvent & { currentTarget: HTMLInputElement }) => {
     if (!props.searching()) return
-    applyFileListKeyDown(event, props.filteredFiles(), highlightedPath(), {
+    const files = props.allFiles ? allFilesResults() : props.filteredFiles()
+    applyFileListKeyDown(event, files, highlightedPath(), {
       onHighlight: setExplicitHighlight,
-      onSelect: props.onSelectFile,
+      onSelect:
+        props.allFiles && props.onOpenFile
+          ? props.onOpenFile
+          : props.onSelectFile,
     })
+  }
+
+  const fileTree = () => {
+    if (props.allFiles) {
+      // "All files" shows the complete live directory tree; opening a file
+      // hands off to the file-browser tab instead of the diff preview.
+      return (
+        <FileTreeV2
+          kinds={props.kinds()}
+          draggable={false}
+          active={props.activeDiff()}
+          onFileClick={(node) => (props.onOpenFile ? props.onOpenFile(node.path) : props.onSelectFile(node.path))}
+        />
+      )
+    }
+    return (
+      <FileTreeV2
+        allowed={props.filteredFiles()}
+        kinds={props.kinds()}
+        draggable={false}
+        active={props.activeDiff()}
+        onFileClick={(node) => props.onSelectFile(node.path)}
+      />
+    )
   }
 
   return (
@@ -222,32 +276,36 @@ function ReviewPanelV2Sidebar(props: {
         }
       >
         <Show
-          when={props.searching()}
+          when={!props.searching()}
           fallback={
-            <FileTreeV2
-              allowed={props.filteredFiles()}
-              kinds={props.kinds()}
-              draggable={false}
-              active={props.activeDiff()}
-              onFileClick={(node) => props.onSelectFile(node.path)}
-            />
+            <Show
+              when={(props.allFiles ? allFilesResults() : props.filteredFiles()).length > 0}
+              fallback={
+                <div class="px-2 py-2 text-12-regular text-text-weak">
+                  {allFilesLoading()
+                    ? language.t("common.loading") + language.t("common.loading.ellipsis")
+                    : language.t("palette.empty")}
+                </div>
+              }
+            >
+              <SessionFileListV2
+                files={props.allFiles ? allFilesResults() : props.filteredFiles()}
+                kinds={props.kinds()}
+                active={props.activeDiff()}
+                highlighted={highlightedPath()}
+                onFileClick={(path) => {
+                  setExplicitHighlight(path)
+                  if (props.allFiles && props.onOpenFile) {
+                    props.onOpenFile(path)
+                    return
+                  }
+                  props.onSelectFile(path)
+                }}
+              />
+            </Show>
           }
         >
-          <Show
-            when={props.filteredFiles().length > 0}
-            fallback={<div class="px-2 py-2 text-12-regular text-text-weak">{language.t("palette.empty")}</div>}
-          >
-            <SessionFileListV2
-              files={props.filteredFiles()}
-              kinds={props.kinds()}
-              active={props.activeDiff()}
-              highlighted={highlightedPath()}
-              onFileClick={(path) => {
-                setExplicitHighlight(path)
-                props.onSelectFile(path)
-              }}
-            />
-          </Show>
+          {fileTree()}
         </Show>
       </Show>
     </SessionReviewV2Sidebar>


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an **"All files"** option to the review v2 changes-mode dropdown, showing
the full project tree in the sidebar instead of only changed files.

- New `"all"` mode renders the complete live directory tree; changed files keep
  their A/D/M markers.
- Clicking a file opens it as a file tab; sidebar filter searches the workspace.
- No diffs or VCS queries; other modes unchanged.

### How did you verify your code works?

- Ran the app locally and verified the updated UI manually
- `bun x oxlint`: 0 errors; `bun x tsc`: pre-existing baseline error only

### Screenshots / recordings
<img width="989" height="849" alt="image" src="https://github.com/user-attachments/assets/ca4c3f6c-a6b9-41cb-abb5-cbed4d2c0592" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
