### PR TITLE
refactor(llm): fold cache policy and option merge into one request rebuild

### DIFF
--- a/packages/llm/src/cache-policy.ts
+++ b/packages/llm/src/cache-policy.ts
@@ -96,16 +96,31 @@ const markMessages = (
   return next
 }
 
-export const applyCachePolicy = (request: LLMRequest): LLMRequest => {
-  if (!RESPECTS_INLINE_HINTS.has(request.model.route.id)) return request
+// Compute only the fields the policy changes, as an `LLMRequest.update` patch,
+// or `undefined` when nothing changes. Returning a patch (rather than a rebuilt
+// request) lets the caller fold this into a single `LLMRequest.update` alongside
+// other option merges, so the O(n) message-history schema re-decode inside the
+// constructor is paid once per request instead of once per merge step.
+export const cachePolicyPatch = (request: LLMRequest): Partial<LLMRequest.Input> | undefined => {
+  if (!RESPECTS_INLINE_HINTS.has(request.model.route.id)) return undefined
   const policy = resolve(request.cache)
-  if (!policy.tools && !policy.system && !policy.messages) return request
+  if (!policy.tools && !policy.system && !policy.messages) return undefined
 
   const hint = makeHint(policy.ttlSeconds)
   const tools = policy.tools ? markLastTool(request.tools, hint) : request.tools
   const system = policy.system ? markLastSystem(request.system, hint) : request.system
   const messages = policy.messages ? markMessages(request.messages, policy.messages, hint) : request.messages
 
-  if (tools === request.tools && system === request.system && messages === request.messages) return request
-  return LLMRequest.update(request, { tools, system, messages })
+  const patch: Partial<LLMRequest.Input> = {
+    ...(tools !== request.tools ? { tools } : undefined),
+    ...(system !== request.system ? { system } : undefined),
+    ...(messages !== request.messages ? { messages } : undefined),
+  }
+  if (Object.keys(patch).length === 0) return undefined
+  return patch
+}
+
+export const applyCachePolicy = (request: LLMRequest): LLMRequest => {
+  const patch = cachePolicyPatch(request)
+  return patch ? LLMRequest.update(request, patch) : request
 }

--- a/packages/llm/src/route/client.ts
+++ b/packages/llm/src/route/client.ts
@@ -8,7 +8,7 @@ import { HttpTransport } from "./transport"
 import type { Transport, TransportRuntime } from "./transport"
 import { WebSocketExecutor } from "./transport"
 import type { Protocol } from "./protocol"
-import { applyCachePolicy } from "../cache-policy"
+import { cachePolicyPatch } from "../cache-policy"
 import * as ProviderShared from "../protocols/shared"
 import type { LLMError, LLMEvent, PreparedRequestOf, ProtocolID, ProviderOptions } from "../schema"
 import {
@@ -164,11 +164,15 @@ export interface GenerateMethod {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/LLMClient") {}
 
-const resolveRequestOptions = (request: LLMRequest) => {
+// Merge route/model/request defaults into an `LLMRequest.update` patch touching
+// only the option fields (generation/providerOptions/http). Kept as a patch so
+// `compile` can fold it together with the cache-policy patch and rebuild the
+// request — which re-decodes the whole message history — exactly once.
+const resolveRequestOptionsPatch = (request: LLMRequest): Partial<LLMRequest.Input> => {
   const routeDefaults = request.model.route.defaults
   const modelDefaults = request.model.defaults
   const generation = mergeGenerationOptions(routeDefaults.generation, modelDefaults?.generation, request.generation)
-  return LLMRequest.update(request, {
+  return {
     generation: generation ?? new GenerationOptions({}),
     providerOptions: mergeProviderOptions(
       routeDefaults.providerOptions,
@@ -176,7 +180,7 @@ const resolveRequestOptions = (request: LLMRequest) => {
       request.providerOptions,
     ),
     http: mergeHttpOptions(routeDefaults.http, modelDefaults?.http, request.http),
-  })
+  }
 }
 
 export interface MakeInput<Body, Frame, Event, State> {
@@ -342,7 +346,14 @@ export function make<Body, Prepared, Frame, Event, State>(
 // validated provider body plus transport-private prepared data, but does not
 // execute transport.
 const compile = Effect.fn("LLM.compile")(function* (request: LLMRequest) {
-  const resolved = applyCachePolicy(resolveRequestOptions(request))
+  // The option merge (generation/providerOptions/http) and the cache-policy
+  // markings (tools/system/messages) touch disjoint fields and both read only
+  // from the original request, so folding them into one `LLMRequest.update`
+  // rebuilds — and re-decodes the full message history — once instead of twice.
+  const resolved = LLMRequest.update(request, {
+    ...resolveRequestOptionsPatch(request),
+    ...cachePolicyPatch(request),
+  })
   const route = resolved.model.route
 
   const body = yield* route.body

--- a/packages/llm/test/perf/cache-policy-single-update.bench.test.ts
+++ b/packages/llm/test/perf/cache-policy-single-update.bench.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { LLM, LLMRequest, Message } from "../../src"
+import { Auth } from "../../src/route"
+import * as AnthropicMessages from "../../src/protocols/anthropic-messages"
+import { applyCachePolicy, cachePolicyPatch } from "../../src/cache-policy"
+import { GenerationOptions, mergeGenerationOptions, mergeHttpOptions, mergeProviderOptions } from "../../src/schema"
+
+const anthropicModel = AnthropicMessages.route
+  .with({ endpoint: { baseURL: "https://api.anthropic.test/v1/" }, auth: Auth.header("x-api-key", "test") })
+  .model({ id: "claude-sonnet-4-5" })
+
+// Build a realistic long conversation: alternating user/assistant turns, each
+// message carrying a few hundred chars of text — the shape that makes the
+// per-turn full-history LLMRequest re-decode expensive.
+function buildRequest(turns: number): LLMRequest {
+  const messages = []
+  for (let i = 0; i < turns; i++) {
+    messages.push(Message.user(`user message ${i} ` + "x".repeat(400)))
+    messages.push(Message.assistant(`assistant reply ${i} ` + "y".repeat(400)))
+  }
+  return LLM.request({
+    model: anthropicModel,
+    system: "You are concise. " + "s".repeat(2000),
+    tools: [
+      { name: "read", description: "read a file", inputSchema: { type: "object", properties: {} } },
+      { name: "edit", description: "edit a file", inputSchema: { type: "object", properties: {} } },
+    ],
+    messages,
+    cache: "auto",
+  })
+}
+
+// Mirror client.ts resolveRequestOptionsPatch so the bench exercises the same
+// two-step-vs-one-step shapes the real compile path takes.
+const optionsPatch = (request: LLMRequest): Partial<LLMRequest.Input> => {
+  const routeDefaults = request.model.route.defaults
+  const modelDefaults = request.model.defaults
+  const generation = mergeGenerationOptions(routeDefaults.generation, modelDefaults?.generation, request.generation)
+  return {
+    generation: generation ?? new GenerationOptions({}),
+    providerOptions: mergeProviderOptions(routeDefaults.providerOptions, modelDefaults?.providerOptions, request.providerOptions),
+    http: mergeHttpOptions(routeDefaults.http, modelDefaults?.http, request.http),
+  }
+}
+
+// OLD shape: two sequential full-history reconstructions.
+const twoStep = (request: LLMRequest): LLMRequest =>
+  applyCachePolicy(LLMRequest.update(request, optionsPatch(request)))
+
+// NEW shape: one reconstruction folding both disjoint patches.
+const oneStep = (request: LLMRequest): LLMRequest =>
+  LLMRequest.update(request, { ...optionsPatch(request), ...cachePolicyPatch(request) })
+
+describe("cache-policy single-update", () => {
+  test("one-step is byte-identical to two-step for Anthropic", () =>
+    Effect.gen(function* () {
+      const req = buildRequest(30)
+      const a = twoStep(req)
+      const b = oneStep(req)
+      // Compare the fully-encoded provider bodies — the ground truth the
+      // transport actually sends.
+      const bodyA = yield* anthropicModel.route.body.from(a)
+      const bodyB = yield* anthropicModel.route.body.from(b)
+      expect(JSON.stringify(bodyB)).toBe(JSON.stringify(bodyA))
+    }).pipe(Effect.runPromise))
+
+  test("benchmark: two-step vs one-step", () => {
+    const req = buildRequest(60) // 120 messages
+    const N = 300
+    // warmup
+    for (let i = 0; i < 50; i++) {
+      twoStep(req)
+      oneStep(req)
+    }
+    let t = performance.now()
+    for (let i = 0; i < N; i++) twoStep(req)
+    const twoMs = performance.now() - t
+    t = performance.now()
+    for (let i = 0; i < N; i++) oneStep(req)
+    const oneMs = performance.now() - t
+    const perTurnSaved = (twoMs - oneMs) / N
+    console.log(
+      `two-step=${(twoMs / N).toFixed(3)}ms/turn  one-step=${(oneMs / N).toFixed(3)}ms/turn  saved=${perTurnSaved.toFixed(3)}ms/turn (${(twoMs / oneMs).toFixed(2)}x)`,
+    )
+    expect(oneMs).toBeLessThan(twoMs)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41269

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`compile()` ran the option merge and the cache policy as two separate `LLMRequest.update` calls. The constructor re-decodes the whole message history each time, so long conversations paid that decode twice per request. The two merges write disjoint fields (generation/providerOptions/http vs tools/system/messages) and both read only from the original request, so I changed each to return a patch and applied one update. Same output, one rebuild instead of two.

### How did you verify your code works?

`bun test` in `packages/llm` (cache-policy and adapter suites pass). I also added a small benchmark, `test/perf/cache-policy-single-update.bench.test.ts`, that builds a realistic request and compares the two-update path against the folded one. It reports about 1.9x on the rebuild step locally.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR