### PR TITLE
refactor(opencode): skip per-token schema validation in AI-SDK adapter

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -18,13 +18,19 @@ export function adapterState() {
   }
 }
 
+// Compile the schema validators ONCE. `Schema.is(schema)` rebuilds the refinement
+// function on every call, and these run per streamed token (providerMetadata is
+// called on every delta) — recompiling per token was a chunk of streaming CPU.
+const isFinishReason = Schema.is(FinishReason)
+const isProviderMetadata = Schema.is(ProviderMetadata)
+
 function finishReason(value: string | undefined): FinishReason {
-  return Schema.is(FinishReason)(value) ? value : "unknown"
+  return isFinishReason(value) ? value : "unknown"
 }
 
 function providerMetadata(value: unknown): ProviderMetadata | undefined {
   if (value == null) return undefined
-  return Schema.is(ProviderMetadata)(value) ? value : undefined
+  return isProviderMetadata(value) ? value : undefined
 }
 
 // Temporary AI SDK bridge: Copilot billing survives only in raw provider chunks here.
@@ -134,13 +140,19 @@ export function toLLMEvents(
         ]
       })
 
+    // Hot path: text-delta / reasoning-delta / tool-input-delta fire per streamed
+    // token. Returning a plain typed literal skips the Effect Schema validation the
+    // LLMEvent.*Delta() constructors run inside `.make()` on every call. The
+    // explicit type arg keeps the literal checked structurally against the LLMEvent
+    // union, so a shape drift is a typecheck error, not a runtime surprise.
     case "text-delta":
-      return Effect.succeed([
-        LLMEvent.textDelta({
+      return Effect.succeed<ReadonlyArray<LLMEvent>>([
+        {
+          type: "text-delta",
           id: currentTextID(state, event.id),
           text: event.text,
           providerMetadata: providerMetadata(event.providerMetadata),
-        }),
+        },
       ])
 
     case "text-end":
@@ -167,12 +179,13 @@ export function toLLMEvents(
       })
 
     case "reasoning-delta":
-      return Effect.succeed([
-        LLMEvent.reasoningDelta({
+      return Effect.succeed<ReadonlyArray<LLMEvent>>([
+        {
+          type: "reasoning-delta",
           id: currentReasoningID(state, event.id),
           text: event.text,
           providerMetadata: providerMetadata(event.providerMetadata),
-        }),
+        },
       ])
 
     case "reasoning-end":
@@ -200,12 +213,13 @@ export function toLLMEvents(
       })
 
     case "tool-input-delta":
-      return Effect.succeed([
-        LLMEvent.toolInputDelta({
+      return Effect.succeed<ReadonlyArray<LLMEvent>>([
+        {
+          type: "tool-input-delta",
           id: event.id,
           name: state.toolNames[event.id] ?? "unknown",
           text: event.delta ?? "",
-        }),
+        },
       ])
 
     case "tool-input-end":


### PR DESCRIPTION
### Issue for this PR

Closes #41270

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`toLLMEvents` runs per streamed token. It rebuilt the `Schema.is` refinement on every `providerMetadata` call, and the `LLMEvent.*Delta` constructors ran schema validation on objects the adapter had just built itself. I hoisted the two validators to module scope so they compile once, and for the three per-token delta events I return a plain typed literal instead of the validating constructor. The function return type still checks those literals against the `LLMEvent` union, so a wrong shape is a type error rather than something that slips through at runtime. Lower frequency events keep the validated constructors.

### How did you verify your code works?

`bun test packages/opencode/test/session/llm.test.ts` passes (28 tests, covers the native and AI-SDK streaming paths), and `tsc` is clean. The type annotation on the literals is what guards against shape drift.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR