### PR TITLE
fix(opencode): preserve task id on foreground failure

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -325,8 +325,16 @@ export const TaskTool = Tool.define(
               background.waitForPromotion(nextSession.id),
             )
             if (result?.metadata?.background === true) return backgroundResult()
-            if (result?.status === "error") return yield* Effect.fail(new Error(result.error ?? "Task failed"))
-            if (result?.status === "cancelled") return yield* Effect.fail(new Error("Task cancelled"))
+            if (result?.status === "error" || result?.status === "cancelled")
+              return yield* Effect.fail(
+                new Error(
+                  renderOutput({
+                    sessionID: nextSession.id,
+                    state: "error",
+                    text: result.status === "error" ? (result.error ?? "Task failed") : "Task cancelled",
+                  }),
+                ),
+              )
             return {
               title: params.description,
               metadata,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -3,7 +3,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
-import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { Agent } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -252,6 +252,98 @@ describe("tool.task", () => {
       expect(result.output).toContain(`<task id="${child.id}" state="completed">`)
       expect(seen?.sessionID).toBe(child.id)
       expect(seen?.variant).toBe("xhigh")
+    }),
+  )
+
+  it.instance("foreground task failure includes the child session id", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const exit = yield* def
+        .execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: {
+              promptOps: {
+                ...stubOps(),
+                prompt: () => Effect.die(new Error("Usage limit exceeded")),
+              } satisfies TaskPromptOps,
+            },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      const child = (yield* sessions.children(chat.id))[0]
+      expect(child).toBeDefined()
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (child && Exit.isFailure(exit)) {
+        expect(Cause.squash(exit.cause)).toMatchObject({
+          message: `<task id="${child.id}" state="error">\n<task_error>\nUsage limit exceeded\n</task_error>\n</task>`,
+        })
+      }
+    }),
+  )
+
+  it.instance("foreground task cancellation includes the child session id", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const ready = yield* Deferred.make<void>()
+
+      const fiber = yield* def
+        .execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: {
+              promptOps: {
+                ...stubOps(),
+                prompt: () => Deferred.succeed(ready, undefined).pipe(Effect.andThen(Effect.never)),
+              } satisfies TaskPromptOps,
+            },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.forkChild)
+
+      yield* Deferred.await(ready)
+      const job = (yield* jobs.list())[0]
+      expect(job).toBeDefined()
+      if (!job) return
+      yield* jobs.cancel(job.id)
+      const exit = yield* Fiber.join(fiber).pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.squash(exit.cause)).toMatchObject({
+          message: `<task id="${job.id}" state="error">\n<task_error>\nTask cancelled\n</task_error>\n</task>`,
+        })
+      }
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #39196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

on foreground sub-agent  failure/cancellation, use `renderOutput` to include task ID in error message displayed to the agent, which allows it invoke the sub-agent on the same session again via the task ID.

### How did you verify your code works?

asked agent to start a foreground sub-agent which I cancel, and then report the task ID that it sees.

<img width="1282" height="967" alt="image" src="https://github.com/user-attachments/assets/3ee8bc60-532c-4a9f-b8a9-790eaf4aba34" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
