### PR TITLE
docs: Add installation link for OpenCode extension

### DIFF
--- a/packages/web/src/content/docs/ide.mdx
+++ b/packages/web/src/content/docs/ide.mdx
@@ -32,6 +32,8 @@ If on the other hand you want to use your own IDE when you run `/editor` or `/ex
 
 Search for **OpenCode** in the Extension Marketplace and click **Install**.
 
+[Install Now](https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode)
+
 ---
 
 ### Troubleshooting


### PR DESCRIPTION
### Issue for this PR

Closes #31500 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This pull request adds a direct installation link for the OpenCode extension to the documentation, making it easier for users to install the extension from the VS Code Marketplace.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

The updated documentation now has a "[Install Now](https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode)" link to the OpenCode installation instructions in `ide.mdx`. Verified by seeing the preview of the ide.mdx file.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._