### PR TITLE
fix(tui): readable mouse text selection in light themes

### DIFF
--- a/.wr/41281.yaml
+++ b/.wr/41281.yaml
@@ -1,0 +1,38 @@
+# Compact plan for OpenCode #41281
+issue: 41281
+title: "TUI: unreadable mouse text selection in light mode (default opencode theme)"
+repo: opencode
+repo_remote: anomalyco/opencode
+cwd: /Users/saifer/Documents/WEBS/opencode
+stack: opentui
+branch: wr-41281-light-selection-contrast
+
+paths:
+  - packages/tui/src/theme/index.ts
+  - packages/tui/src/context/theme.tsx
+  - packages/tui/src/routes/session/index.tsx
+  - packages/tui/test/theme.test.ts
+
+ac:
+  - opencode light theme mouse selection has readable contrast
+  - copy-on-select unchanged
+  - dark mode no regression
+  - luminance-aware fallback when selection colors omitted
+  - theme exposes selectionBg/selectionFg for text/code/diff/markdown content
+
+out_of_scope:
+  - Desktop/web
+  - New picker themes
+  - Full audit of every <text> in TUI chrome
+
+hints:
+  entry: "textSelectionColors + ThemeProvider selectionBg/Fg"
+  pattern: "closed PR #13352 tint(backgroundPanel, primary) + pass selectionBg/Fg to content"
+  tests: "cd packages/tui && bun test test/theme.test.ts"
+
+risk:
+  sensitive: false
+  areas: [tui, theme]
+
+next:
+  after_pr: "Closes #41281"

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -15,6 +15,7 @@ import {
   setSystemTheme,
   subscribeThemes,
   terminalMode,
+  textSelectionColors,
   tint,
   upsertTheme,
   type ThemeJson,
@@ -72,6 +73,7 @@ export {
   resolveTheme,
   selectedForeground,
   terminalMode,
+  textSelectionColors,
   tint,
   upsertTheme,
   type Theme,
@@ -268,6 +270,10 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     createEffect(() => renderer.setBackgroundColor(values().background))
 
+    const selection = createMemo(() => textSelectionColors(values(), store.mode))
+    const selectionBg = createMemo(() => selection().selectionBg)
+    const selectionFg = createMemo(() => selection().selectionFg)
+
     const syntax = createSyntaxStyleMemo(() => generateSyntax(values()))
     const subtleSyntax = createSyntaxStyleMemo(() => generateSubtleSyntax(values()))
 
@@ -285,6 +291,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       has: hasTheme,
       syntax,
       subtleSyntax,
+      selectionBg,
+      selectionFg,
       mode: () => store.mode,
       locked: () => store.lock !== undefined,
       lock: () => pin(store.mode),

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -191,7 +191,7 @@ export function Session() {
   const paths = useTuiPaths()
   const tuiConfig = useTuiConfig()
   const kv = useKV()
-  const { theme } = useTheme()
+  const { theme, selectionBg, selectionFg } = useTheme()
   const promptRef = usePromptRef()
   const session = createMemo(() => sync.session.get(route.sessionID))
   const location = createMemo(() => {
@@ -1234,15 +1234,17 @@ export function Session() {
                                 paddingLeft={2}
                                 backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
                               >
-                                <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
-                                <text fg={theme.textMuted}>
+                                <text fg={theme.textMuted} selectionBg={selectionBg()} selectionFg={selectionFg()}>
+                                  {revert()!.reverted.length} message reverted
+                                </text>
+                                <text fg={theme.textMuted} selectionBg={selectionBg()} selectionFg={selectionFg()}>
                                   <span style={{ fg: theme.text }}>{redoShortcut()}</span> or /redo to restore
                                 </text>
                                 <Show when={revert()!.diffFiles?.length}>
                                   <box marginTop={1}>
                                     <For each={revert()!.diffFiles}>
                                       {(file) => (
-                                        <text fg={theme.text}>
+                                        <text fg={theme.text} selectionBg={selectionBg()} selectionFg={selectionFg()}>
                                           {file.filename}
                                           <Show when={file.additions > 0}>
                                             <span style={{ fg: theme.diffAdded }}> +{file.additions}</span>
@@ -1383,7 +1385,7 @@ function UserMessage(props: {
     return texts.join("\n\n")
   })
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
-  const { theme } = useTheme()
+  const { theme, selectionBg, selectionFg } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending !== undefined && props.index > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
@@ -1417,7 +1419,9 @@ function UserMessage(props: {
             backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
             flexShrink={0}
           >
-            <text fg={theme.text}>{text()}</text>
+            <text fg={theme.text} selectionBg={selectionBg()} selectionFg={selectionFg()}>
+              {text()}
+            </text>
             <Show when={files().length}>
               <box flexDirection="row" paddingBottom={metadataVisible() ? 1 : 0} paddingTop={1} gap={1} flexWrap="wrap">
                 <For each={files()}>
@@ -1585,7 +1589,7 @@ const PART_MAPPING = {
 const INLINE_TOOL_ICON_WIDTH = 2
 
 function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
-  const { theme } = useTheme()
+  const { theme, selectionBg, selectionFg } = useTheme()
   const ctx = use()
   // Collapsed by default in hide mode: a single line throughout, so the
   // layout never shifts. Click to open the full markdown block, click to close.
@@ -1639,6 +1643,8 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
               content={summary().body}
               conceal={ctx.conceal()}
               fg={theme.textMuted}
+              selectionBg={selectionBg()}
+              selectionFg={selectionFg()}
             />
           </box>
         </Show>
@@ -1693,19 +1699,25 @@ function ReasoningHeader(props: {
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, selectionBg, selectionFg } = useTheme()
   return (
     <Show when={props.part.text.trim()}>
       <box ref={(el: BoxRenderable) => alwaysSeparate.add(el)} paddingLeft={3} marginTop={1} flexShrink={0}>
-        <markdown
-          syntaxStyle={syntax()}
+        {/*
+          Use CodeRenderable (not MarkdownRenderable) so OpenTUI can apply explicit
+          selectionBg/selectionFg. Markdown does not expose those props yet; without them
+          light themes invert to unreadable black-on-black (#41281).
+        */}
+        <code
+          filetype="markdown"
+          drawUnstyledText={false}
           streaming={true}
-          internalBlockMode="top-level"
+          syntaxStyle={syntax()}
           content={props.part.text.trim()}
-          tableOptions={{ style: "grid" }}
           conceal={ctx.conceal()}
           fg={theme.markdownText}
-          bg={theme.background}
+          selectionBg={selectionBg()}
+          selectionFg={selectionFg()}
         />
       </box>
     </Show>
@@ -2052,7 +2064,7 @@ function BlockTool(props: {
 }
 
 function Shell(props: ToolProps) {
-  const { theme } = useTheme()
+  const { theme, selectionBg, selectionFg } = useTheme()
   const pathFormatter = usePathFormatter()
   const ctx = use()
   const isRunning = createMemo(() => props.part.state.status === "running")
@@ -2089,11 +2101,11 @@ function Shell(props: ToolProps) {
           onClick={collapsed().overflow ? () => setExpanded((prev) => !prev) : undefined}
         >
           <box gap={1}>
-            <Show when={isRunning()} fallback={<text fg={theme.text}>$ {stringValue(props.input.command)}</text>}>
+            <Show when={isRunning()} fallback={<text fg={theme.text} selectionBg={selectionBg()} selectionFg={selectionFg()}>$ {stringValue(props.input.command)}</text>}>
               <Spinner color={theme.text}>{stringValue(props.input.command)}</Spinner>
             </Show>
             <Show when={output()}>
-              <text fg={theme.text}>{limited()}</text>
+              <text fg={theme.text} selectionBg={selectionBg()} selectionFg={selectionFg()}>{limited()}</text>
             </Show>
             <Show when={collapsed().overflow}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
@@ -2111,7 +2123,7 @@ function Shell(props: ToolProps) {
 }
 
 function Write(props: ToolProps) {
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, selectionBg, selectionFg } = useTheme()
   const pathFormatter = usePathFormatter()
   const code = createMemo(() => {
     return stringValue(props.input.content) ?? ""
@@ -2128,6 +2140,8 @@ function Write(props: ToolProps) {
               filetype={filetype(stringValue(props.input.filePath))}
               syntaxStyle={syntax()}
               content={code()}
+              selectionBg={selectionBg()}
+              selectionFg={selectionFg()}
             />
           </line_number>
           <Diagnostics diagnostics={props.metadata.diagnostics} filePath={stringValue(props.input.filePath) ?? ""} />
@@ -2402,7 +2416,7 @@ function Execute(props: ToolProps) {
 
 function Edit(props: ToolProps) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, selectionBg, selectionFg } = useTheme()
   const pathFormatter = usePathFormatter()
 
   const view = createMemo(() => {
@@ -2430,6 +2444,8 @@ function Edit(props: ToolProps) {
               width="100%"
               wrapMode={ctx.diffWrapMode()}
               fg={theme.text}
+              selectionBg={selectionBg()}
+              selectionFg={selectionFg()}
               addedBg={theme.diffAddedBg}
               removedBg={theme.diffRemovedBg}
               contextBg={theme.diffContextBg}
@@ -2455,7 +2471,7 @@ function Edit(props: ToolProps) {
 
 function ApplyPatch(props: ToolProps) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme, syntax, selectionBg, selectionFg } = useTheme()
   const pathFormatter = usePathFormatter()
 
   const files = createMemo(() => parseApplyPatchFiles(props.metadata.files))
@@ -2478,6 +2494,8 @@ function ApplyPatch(props: ToolProps) {
           width="100%"
           wrapMode={ctx.diffWrapMode()}
           fg={theme.text}
+          selectionBg={selectionBg()}
+          selectionFg={selectionFg()}
           addedBg={theme.diffAddedBg}
           removedBg={theme.diffRemovedBg}
           contextBg={theme.diffContextBg}

--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -350,6 +350,31 @@ export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
   return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
 }
 
+function relativeLuminance(color: RGBA): number {
+  return 0.299 * color.r + 0.587 * color.g + 0.114 * color.b
+}
+
+/**
+ * Mouse drag / copy-on-select colors for OpenTUI text buffers.
+ * OpenTUI inverts fg/bg when these are omitted, which is unreadable on light themes.
+ */
+export function textSelectionColors(
+  theme: Theme,
+  mode: "dark" | "light",
+): { selectionBg: RGBA; selectionFg: RGBA } {
+  const selectionBg = tint(theme.backgroundPanel, theme.primary, mode === "light" ? 0.22 : 0.32)
+  // Prefer theme text when it contrasts with the highlight; otherwise pick black/white.
+  const textLum = relativeLuminance(theme.text)
+  const bgLum = relativeLuminance(selectionBg)
+  const selectionFg =
+    Math.abs(textLum - bgLum) >= 0.35
+      ? theme.text
+      : bgLum > 0.55
+        ? RGBA.fromInts(0, 0, 0)
+        : RGBA.fromInts(255, 255, 255)
+  return { selectionBg, selectionFg }
+}
+
 export function terminalMode(colors: TerminalColors): "dark" | "light" | undefined {
   const bg = colors.defaultBackground
   if (!bg) return

--- a/packages/tui/test/theme.test.ts
+++ b/packages/tui/test/theme.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { TerminalColors } from "@opentui/core"
-import { DEFAULT_THEMES, addTheme, allThemes, hasTheme, resolveTheme, terminalMode } from "../src/theme"
+import { DEFAULT_THEMES, addTheme, allThemes, hasTheme, resolveTheme, terminalMode, textSelectionColors } from "../src/theme"
 import { discoverThemes } from "../src/context/theme"
 import { tmpdir } from "./fixture/fixture"
 
@@ -66,6 +66,22 @@ test("terminalMode derives mode from refreshed background", () => {
 
 test("terminalMode does not derive mode from ANSI slot zero", () => {
   expect(terminalMode(terminalColors(null, ["#000000"]))).toBeUndefined()
+})
+
+test("textSelectionColors keep contrast on opencode light theme", () => {
+  const theme = resolveTheme(DEFAULT_THEMES.opencode, "light")
+  const { selectionBg, selectionFg } = textSelectionColors(theme, "light")
+  const bgLum = 0.299 * selectionBg.r + 0.587 * selectionBg.g + 0.114 * selectionBg.b
+  const fgLum = 0.299 * selectionFg.r + 0.587 * selectionFg.g + 0.114 * selectionFg.b
+  expect(Math.abs(bgLum - fgLum)).toBeGreaterThanOrEqual(0.35)
+})
+
+test("textSelectionColors keep contrast on opencode dark theme", () => {
+  const theme = resolveTheme(DEFAULT_THEMES.opencode, "dark")
+  const { selectionBg, selectionFg } = textSelectionColors(theme, "dark")
+  const bgLum = 0.299 * selectionBg.r + 0.587 * selectionBg.g + 0.114 * selectionBg.b
+  const fgLum = 0.299 * selectionFg.r + 0.587 * selectionFg.g + 0.114 * selectionFg.b
+  expect(Math.abs(bgLum - fgLum)).toBeGreaterThanOrEqual(0.35)
 })
 
 test("custom theme precedence follows directory order", async () => {


### PR DESCRIPTION
## Summary
- Add luminance-aware `textSelectionColors()` and expose `selectionBg` / `selectionFg` from the TUI theme context
- Apply those colors to selectable session content (`text` / `code` / `diff`) so OpenTUI does not fall back to invert (black-on-black in light mode)
- Assistant message bodies use `code` with `filetype="markdown"` because `MarkdownRenderable` still has no selection color props

Closes #41281

Related: #5295, #12861

## Test plan
- [ ] `cd packages/tui && bun test test/theme.test.ts`
- [ ] Light mode + default `opencode` theme: drag-select assistant/user text — readable contrast
- [ ] Dark mode: selection still readable
- [ ] Copy-on-select still copies

## Validation evidence
```
cd packages/tui && bun test test/theme.test.ts
10 pass, 0 fail (includes textSelectionColors light/dark contrast)

cd packages/tui && bun run typecheck
tsgo --noEmit (pass)
```

## wr-context
See `.wr/41281.yaml` on this branch.

Made with [Cursor](https://cursor.com)