### PR TITLE
fix(app): sync web frontend version with binary (inject OPENCODE_VERSION at build time)

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -119,7 +119,7 @@ const clearAuthToken = () => {
 const platform: Platform = {
   platform: "web",
   draftStore: createBrowserDraftStore(),
-  version: pkg.version,
+  version: import.meta.env.VITE_OPENCODE_VERSION ?? pkg.version,
   openExternal,
   restart,
   notify,

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -2,6 +2,7 @@ interface ImportMetaEnv {
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
   readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
+  readonly VITE_OPENCODE_VERSION?: string
 
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_ENVIRONMENT?: string

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -12,6 +12,13 @@ const channel = (() => {
   return "dev"
 })()
 
+// Version injected at build time by packages/opencode/script/build.ts (OPENCODE_VERSION).
+// Falls back to the app package.json version so local/dev builds still have a version.
+const version = (() => {
+  const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"))
+  return process.env.OPENCODE_VERSION ?? pkg.version
+})()
+
 /**
  * @type {import("vite").PluginOption}
  */
@@ -27,6 +34,7 @@ export default [
         },
         define: {
           "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+          "import.meta.env.VITE_OPENCODE_VERSION": JSON.stringify(version),
         },
         worker: {
           format: "es",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -27,7 +27,7 @@ const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
   const appDir = path.join(import.meta.dirname, "../../app")
   const dist = path.join(appDir, "dist")
-  await $`OPENCODE_CHANNEL=${Script.channel} bun run --cwd ${appDir} build`
+  await $`OPENCODE_CHANNEL=${Script.channel} OPENCODE_VERSION=${Script.version} bun run --cwd ${appDir} build`
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
     .map((file) => file.replaceAll("\\", "/"))
     .filter((file) => !file.endsWith(".map"))


### PR DESCRIPTION
## Problem

The web frontend bundled in `opencode-ai` releases consistently reports **one version behind** the CLI binary (the N-1 pattern from #36232, also reported in #41280, #30958, #24286, #29301).

Example: `opencode-ai@1.18.15` embeds a web bundle whose `platform.version` is `"1.18.14"` — verified in the served bundle:

```js
const Ntt = "1.18.14", Vtt = { version: Ntt }
```

## Root cause

`packages/app/src/entry.tsx` builds the web `Platform` object with:

```ts
import pkg from "../package.json"
const platform: Platform = {
  platform: "web",
  version: pkg.version,
  ...
}
```

The version is read from `packages/app/package.json` **at build time**. But the release workflow (`publish.yml`) bumps the release version via `Script.version` (env `OPENCODE_VERSION`), and **never bumps `packages/app/package.json`**. So the embedded frontend always carries the previous release's version string. The binary itself is correct (it uses `Script.version` directly), which is why `opencode --version` says 1.18.15 while the web UI says 1.18.14.

## Fix

Inject the release version into the app build, mirroring how `OPENCODE_CHANNEL` is already injected, and read it in `entry.tsx` with a fallback to `package.json` for local dev builds:

1. `packages/opencode/script/build.ts` — pass `OPENCODE_VERSION=${Script.version}` when building the web UI (was already passed for the binary via `OPENCODE_VERSION` define).
2. `packages/app/vite.js` — define `import.meta.env.VITE_OPENCODE_VERSION` from `process.env.OPENCODE_VERSION`, falling back to `packages/app/package.json` version (so `bun dev` / local builds still work without the env var).
3. `packages/app/src/entry.tsx` — `version: import.meta.env.VITE_OPENCODE_VERSION ?? pkg.version`.
4. `packages/app/src/env.d.ts` — declare the new env var.

Verified logic: with `OPENCODE_VERSION=1.18.15` the bundle version resolves to `1.18.15`; without it (dev), it falls back to `package.json`.

Fixes #36232
Closes #41280
