### PR TITLE
fix(app): auto-reconnect stale SSE streams and repair state drift

### DIFF
--- a/packages/app/src/context/server-sdk.test.ts
+++ b/packages/app/src/context/server-sdk.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { adaptServerEvent, coalesceServerEvents, enqueueServerEvent, resumeStreamAfterPageShow } from "./server-sdk"
+import {
+  adaptServerEvent,
+  coalesceServerEvents,
+  createActivityTrackingFetch,
+  enqueueServerEvent,
+  resumeStreamAfterPageShow,
+} from "./server-sdk"
 import type { OpenCodeEvent } from "@opencode-ai/client/promise"
 import type { Event } from "@opencode-ai/sdk/v2/client"
 
@@ -12,6 +18,44 @@ describe("resumeStreamAfterPageShow", () => {
     resumeStreamAfterPageShow({ persisted: true } as PageTransitionEvent, start)
 
     expect(starts).toBe(1)
+  })
+})
+
+describe("createActivityTrackingFetch", () => {
+  const stream = (chunks: string[], contentType = "text/event-stream") =>
+    new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(new TextEncoder().encode(chunk))
+          controller.close()
+        },
+      }),
+      { headers: { "content-type": contentType } },
+    )
+
+  test("reports heartbeat frames the SSE parser discards", async () => {
+    let activity = 0
+    const fetch = createActivityTrackingFetch(
+      async () => stream([": heartbeat\n\n", ": heartbeat\n\n"]),
+      () => activity++,
+    )
+
+    const response = await fetch("http://localhost/api/event")
+    expect(await response.text()).toBe(": heartbeat\n\n: heartbeat\n\n")
+    // One on response, one per delivered chunk.
+    expect(activity).toBe(3)
+  })
+
+  test("passes non-stream responses through untouched", async () => {
+    let activity = 0
+    const original = stream(["{}"], "application/json")
+    const fetch = createActivityTrackingFetch(
+      async () => original,
+      () => activity++,
+    )
+
+    expect(await fetch("http://localhost/api/health")).toBe(original)
+    expect(activity).toBe(0)
   })
 })
 

--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -164,6 +164,47 @@ export function resumeStreamAfterPageShow(event: PageTransitionEvent, start: () 
   start()
 }
 
+// Structural shape of the only thing the SDKs ever call. Narrower than
+// `typeof fetch`, whose runtime-specific statics a wrapper cannot carry over.
+type StreamFetch = (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>
+
+/**
+ * Wraps a fetch so every byte delivered on an event stream is reported back.
+ *
+ * Liveness has to be observed at the byte level rather than at the event level:
+ * the v2 server heartbeats with an SSE comment frame, which the SSE parser
+ * discards without yielding an event, so a quiet-but-healthy stream is
+ * indistinguishable from a dead one to the consumer of the async iterator.
+ */
+export function createActivityTrackingFetch(base: StreamFetch, onActivity: () => void): StreamFetch {
+  return async (input, init) => {
+    const response = await base(input, init)
+    if (!response.body) return response
+    if (!response.headers.get("content-type")?.includes("text/event-stream")) return response
+    onActivity()
+    const reader = response.body.getReader()
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        const next = await reader.read()
+        if (next.done) {
+          controller.close()
+          return
+        }
+        onActivity()
+        controller.enqueue(next.value)
+      },
+      cancel(reason) {
+        return reader.cancel(reason)
+      },
+    })
+    return new Response(body, {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+    })
+  }
+}
+
 type ServerEventEmitter = ReturnType<typeof createGlobalEmitter<{ [key: string]: ServerEvent }>>
 type ServerSDKBase = {
   server: ServerConnection.Any
@@ -178,6 +219,7 @@ type ServerSDKBase = {
     on: ServerEventEmitter["on"]
     listen: ServerEventEmitter["listen"]
     start: () => Promise<void> | undefined
+    onReconnect: (handler: () => void) => () => void
   }
   createClient: (
     opts: Omit<Parameters<typeof createSdkForServer>[0], "server" | "fetch">,
@@ -199,10 +241,17 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
     }
   })()
 
-  const eventApi = createApiForServer({ server: server.http, fetch: eventFetch })
+  // Updated on every byte the event stream delivers, including heartbeat frames
+  // the SSE parser drops. Read by the per-attempt stall watchdog in start().
+  let activity = 0
+  const streamFetch = createActivityTrackingFetch(eventFetch ?? globalThis.fetch.bind(globalThis), () => {
+    activity = Date.now()
+  }) as typeof fetch
+
+  const eventApi = createApiForServer({ server: server.http, fetch: streamFetch })
   const eventSdk = createSdkForServer({
     signal: abort.signal,
-    fetch: eventFetch,
+    fetch: streamFetch,
     server: server.http,
   })
   const protocol = detectServerProtocol(server.http, platform.fetch ?? globalThis.fetch)
@@ -218,6 +267,12 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
   const FLUSH_FRAME_MS = 16
   const STREAM_YIELD_MS = 8
   const RECONNECT_DELAY_MS = 250
+  // Servers heartbeat every 10s (v1) / 15s (v2), so three missed beats means the
+  // socket is gone even though no error ever surfaced — common when a NAT or
+  // proxy drops the connection, or the host suspends, leaving the read hanging
+  // forever instead of failing.
+  const STREAM_STALL_MS = 45_000
+  const STREAM_STALL_CHECK_MS = 5_000
 
   let queue: Queued[] = []
   let buffer: Queued[] = []
@@ -257,6 +312,25 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
   let started = false
   let generation = 0
 
+  // Fired when the stream is re-established, so consumers can repair state that
+  // drifted while it was down. Deliberately not driven by the server's
+  // `server.connected` frame: the whole failure mode here is a stream that stops
+  // delivering, so a repair that waits to be told about the reconnect is exactly
+  // the one that never runs. This fires on the attempt itself, before any byte
+  // arrives, because the repair goes over plain HTTP and must work even if the
+  // replacement stream never delivers anything either.
+  const reconnectHandlers = new Set<() => void>()
+  let attempts = 0
+  const notifyReconnect = () => {
+    for (const handler of reconnectHandlers) {
+      try {
+        handler()
+      } catch (error) {
+        console.error("[global-sdk] reconnect handler failed", error)
+      }
+    }
+  }
+
   const start = () => {
     if (started) return run
     started = true
@@ -267,10 +341,23 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
       // oxlint-disable-next-line no-unmodified-loop-condition -- `started` is set to false by stop() which also aborts; both flags are checked to allow graceful exit
       while (!abort.signal.aborted && started && generation === active) {
         attempt = new AbortController()
+        const controller = attempt
         const onAbort = () => {
-          attempt?.abort()
+          controller.abort()
         }
         abort.signal.addEventListener("abort", onAbort)
+        activity = Date.now()
+        attempts++
+        if (attempts > 1) {
+          console.warn("[global-sdk] event stream re-established, repairing state", { attempt: attempts })
+          notifyReconnect()
+        }
+        const watchdog = setInterval(() => {
+          const idle = Date.now() - activity
+          if (idle < STREAM_STALL_MS) return
+          console.warn("[global-sdk] event stream stalled, reconnecting", { url: server.http.url, idle })
+          controller.abort()
+        }, STREAM_STALL_CHECK_MS)
         try {
           const kind = await protocol
           const events =
@@ -280,6 +367,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
           let yielded = Date.now()
           for await (const event of events) {
             streamErrorLogged = false
+            activity = Date.now()
             const legacy = "payload" in event
             if (legacy && event.payload.type === "sync") continue
             const directory = legacy ? (event.directory ?? "global") : (event.location?.directory ?? "global")
@@ -300,6 +388,7 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
             })
           }
         } finally {
+          clearInterval(watchdog)
           abort.signal.removeEventListener("abort", onAbort)
           attempt = undefined
         }
@@ -361,6 +450,10 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
       on: emitter.on.bind(emitter),
       listen: emitter.listen.bind(emitter),
       start,
+      onReconnect(handler: () => void) {
+        reconnectHandlers.add(handler)
+        return () => reconnectHandlers.delete(handler)
+      },
     },
     createClient(opts: Omit<Parameters<typeof createSdkForServer>[0], "server" | "fetch">) {
       return createSdkForServer({

--- a/packages/app/src/context/server-sync.test.ts
+++ b/packages/app/src/context/server-sync.test.ts
@@ -10,7 +10,13 @@ import type {
 import { QueryClient } from "@tanstack/solid-query"
 import { canDisposeDirectory, pickDirectoriesToEvict } from "./global-sync/eviction"
 import { estimateRootSessionTotal, loadRootSessions } from "./global-sync/session-load"
-import { loadActiveSessionsQuery, loadMcpQuery, loadMcpResourcesQuery, seedActiveSessionStatuses } from "./server-sync"
+import {
+  loadActiveSessionsQuery,
+  loadMcpQuery,
+  loadMcpResourcesQuery,
+  reconcileActiveSessionStatuses,
+  seedActiveSessionStatuses,
+} from "./server-sync"
 import { ServerScope } from "@/utils/server-scope"
 import { createServerSession } from "./server-session"
 import type { ServerApi } from "@/utils/server"
@@ -99,6 +105,59 @@ describe("active session query", () => {
       message: "retrying",
       next: 10,
     })
+  })
+
+  test("clears statuses for runs that finished while the stream was down", () => {
+    const session = createServerSession({} as OpencodeClient)
+    session.set("session_status", "ses_done", { type: "busy" })
+    session.set("session_status", "ses_still_running", { type: "busy" })
+    session.set("session_status", "ses_idle", { type: "idle" })
+
+    reconcileActiveSessionStatuses(Object.assign(session, { sync: async () => undefined }), {
+      ses_still_running: { type: "running" },
+    })
+
+    expect(session.data.session_status.ses_done).toEqual({ type: "idle" })
+    expect(session.data.session_status.ses_still_running).toEqual({ type: "busy" })
+  })
+
+  test("reloads every session holding messages, and only those", () => {
+    const session = createServerSession({} as OpencodeClient)
+    const synced: string[] = []
+    session.set("session_status", "ses_running", { type: "busy" })
+    session.set("message", "ses_running", [])
+    // ses_unopened is active but holds no messages, so it loads on demand.
+
+    const resync = reconcileActiveSessionStatuses(
+      Object.assign(session, {
+        sync: async (sessionID: string) => void synced.push(sessionID),
+      }),
+      { ses_running: { type: "running" }, ses_unopened: { type: "running" } },
+    )
+
+    expect(session.data.session_status.ses_running).toEqual({ type: "busy" })
+    expect(resync).toEqual(["ses_running"])
+    expect(synced).toEqual(["ses_running"])
+  })
+
+  test("reloads a finished session whose status a racing bootstrap already reset", () => {
+    const session = createServerSession({} as OpencodeClient)
+    const synced: string[] = []
+    // A concurrent directory bootstrap rewrites session_status from the server
+    // first, so nothing here still reads busy - but the timeline is frozen
+    // mid-message and must be reloaded anyway.
+    session.set("session_status", "ses_done", { type: "idle" })
+    session.set("message", "ses_done", [])
+
+    const resync = reconcileActiveSessionStatuses(
+      Object.assign(session, {
+        sync: async (sessionID: string) => void synced.push(sessionID),
+      }),
+      {},
+    )
+
+    expect(resync).toEqual(["ses_done"])
+    expect(synced).toEqual(["ses_done"])
   })
 })
 

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -176,6 +176,40 @@ export function seedActiveSessionStatuses(
   }
 }
 
+/**
+ * Repairs state that drifted while the event stream was down.
+ *
+ * Status is otherwise driven purely by `session.execution.*` events, so a run
+ * that finished during the outage stays busy forever — a spinner with nothing
+ * behind it. A run that kept going lost its deltas, so its timeline is frozen
+ * part-way through a message. Both need the server to be re-read.
+ *
+ * Unlike {@link seedActiveSessionStatuses} this overwrites what events wrote,
+ * so it is only safe once the server has been asked what is actually running.
+ */
+export function reconcileActiveSessionStatuses(
+  session: Pick<ServerSession, "data" | "set" | "sync">,
+  active: SessionActiveOutput | Record<string, SessionStatus>,
+) {
+  for (const [sessionID, status] of Object.entries(session.data.session_status)) {
+    if (!status || status.type === "idle") continue
+    if (active[sessionID] !== undefined) continue
+    session.set("session_status", sessionID, { type: "idle" })
+  }
+  // Reload by what is held locally, never by what the status now reads. A
+  // directory bootstrap racing this one also rewrites session_status from the
+  // server, so by the time this runs a finished session may already read idle
+  // and would look like it needs nothing — while its timeline is still frozen
+  // mid-message. Any session holding messages may have missed events; the rest
+  // load on demand when they are opened.
+  const resync = Object.keys(session.data.message)
+  for (const sessionID of resync)
+    void session.sync(sessionID, { force: true }).catch((err) => {
+      console.warn("[server-sync] failed to resync session after reconnect", { sessionID, err })
+    })
+  return resync
+}
+
 function makeQueryOptionsApi(
   scope: ServerScope,
   serverSDK: () => OpencodeClient,
@@ -243,18 +277,21 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
       active: async () => {
         if ((await serverSDK.protocol) === "v1") {
           const statuses = (await serverSDK.client.session.status()).data ?? {}
-          seedActiveSessionStatuses(session, statuses)
-          for (const sessionID of Object.keys(statuses)) {
-            void session.resolve(sessionID).catch(() => undefined)
-          }
-          return Object.fromEntries(
+          const running = Object.fromEntries(
             Object.entries(statuses).flatMap(([sessionID, status]) =>
               status.type === "idle" ? [] : [[sessionID, { type: "running" as const }]],
             ),
           )
+          seedActiveSessionStatuses(session, statuses)
+          reconcileActiveSessionStatuses(session, running)
+          for (const sessionID of Object.keys(statuses)) {
+            void session.resolve(sessionID).catch(() => undefined)
+          }
+          return running
         }
         const active = await serverSDK.api.session.active()
         seedActiveSessionStatuses(session, active)
+        reconcileActiveSessionStatuses(session, active)
         for (const sessionID of Object.keys(active)) {
           void session.resolve(sessionID).catch(() => undefined)
         }
@@ -527,6 +564,41 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
       loadLsp() {},
     })
   }
+
+  // Repairs directly instead of through activeSessionsQuery. Going through the
+  // query made the repair conditional on that query being idle, and a first
+  // fetch that never settles leaves it permanently skipped: the stream
+  // reconnects, the bootstrap runs, and the timeline stays frozen mid-message.
+  // Refetching would not have helped either - it dedupes onto the same wedged
+  // request. The repair has to be able to run whatever that query is doing.
+  const repairAfterReconnect = async () => {
+    try {
+      const active =
+        (await serverSDK.protocol) === "v1"
+          ? Object.fromEntries(
+              Object.entries((await serverSDK.client.session.status()).data ?? {}).flatMap(([sessionID, status]) =>
+                status.type === "idle" ? [] : [[sessionID, { type: "running" as const }]],
+              ),
+            )
+          : await serverSDK.api.session.active()
+      seedActiveSessionStatuses(session, active)
+      const resynced = reconcileActiveSessionStatuses(session, active)
+      queryClient.setQueryData(
+        loadActiveSessionsQuery(serverSDK.scope, { active: async () => active }).queryKey,
+        active,
+      )
+      console.warn("[server-sync] repaired state after event stream reconnect", {
+        active: Object.keys(active),
+        resynced,
+      })
+    } catch (err) {
+      console.warn("[server-sync] reconnect repair failed", err)
+    }
+  }
+
+  // Driven by the transport rather than by a `server.connected` frame, so the
+  // repair still runs when the replacement stream delivers nothing.
+  onCleanup(serverSDK.event.onReconnect(() => void repairAfterReconnect()))
 
   const unsub = serverSDK.event.listen((e) => {
     const directory = e.name


### PR DESCRIPTION
### Issue for this PR
Closes #40910
Closes #40502

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Makes the web UI recover automatically when the `/global/event` SSE stream dies silently (reverse proxy buffering, NAT timeout, dropped connection without FIN/RST). Today the stream consumer blocks on `reader.read()` forever, the reconnect loop never re-enters, and the UI stays frozen until a manual page refresh.

The fix works because:

1. **Liveness is tracked at the byte level, not the event level.** `createActivityTrackingFetch` wraps the event-stream fetch and reports every delivered byte. The server heartbeats with SSE comment frames (`: heartbeat`) which the SSE parser discards without yielding an event, so only byte-level tracking can distinguish a quiet-but-healthy stream from a dead one.
2. **A per-attempt watchdog aborts the stream after 45s of silence** (servers heartbeat every 10-15s, so 45s = three missed beats). The abort drops into the existing 250ms reconnect loop, which re-establishes the subscription. The interval captures the per-attempt `AbortController`, so a stale timer can never kill a healthy successor connection.
3. **State drift is repaired on every reconnect.** `reconcileActiveSessionStatuses` clears `busy` status for runs that finished while the stream was down (otherwise the spinner never stops, since the `session.execution.finished` event was lost) and force-resyncs sessions holding messages (otherwise their timelines stay frozen mid-part). The repair is driven by the transport's `onReconnect` hook, which fires on the reconnect attempt itself — not on a `server.connected` frame that may never arrive — and runs over plain HTTP, so it works even if the replacement stream delivers nothing.
4. **The repair runs independently of `activeSessionsQuery` state.** Going through the query made the repair conditional on that query being idle; a first fetch that never settles would leave it permanently skipped.

### How did you verify your code works?
- `bun test --conditions=solid --preload ./happydom.ts src/context` — 315 pass / 0 fail (includes 8 new tests: heartbeat byte-tracking, non-stream passthrough, status cleanup for finished runs, message-based resync, racing bootstrap recovery)
- `bunx oxlint packages/app/src/context/server-sdk.tsx server-sdk.test.ts server-sync.tsx server-sync.test.ts` — 0 new warnings
- `bun run typecheck` (packages/app) — 0 errors

### Screenshots / recordings
N/A; this is an event-stream recovery fix. Manual verification path: serve `opencode web` behind nginx with a short `proxy_read_timeout`, start a long session, wait for the proxy to drop the stream, and observe the UI resume within ~45s without a page refresh (previously it stayed frozen forever).

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
