### PR TITLE
fix(core): settle shell spawn failures

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -645,7 +645,9 @@ const layer = Layer.effect(
             yield* execution.awaitIdle(input.sessionID)
             const started = yield* Effect.gen(function* () {
               const shell = yield* Shell.Service
-              return yield* shell.create({ command: input.command, cwd: session.location.directory, timeout: 0 })
+              return yield* shell
+                .create({ command: input.command, cwd: session.location.directory, timeout: 0 })
+                .pipe(Effect.orDie)
             }).pipe(Effect.provide(locations.get(session.location)))
             yield* bus.publish(
               SessionEvent.Shell.Started,

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,7 +1,7 @@
 export * as Shell from "./shell"
 
 import path from "path"
-import { Context, Deferred, Duration, Effect, Fiber, Layer, PlatformError, Schema, Stream } from "effect"
+import { Cause, Context, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
@@ -18,6 +18,16 @@ import { PluginHooks } from "./plugin/hooks"
 export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Shell.NotFoundError", {
   id: Shell.ID,
 }) {}
+
+export class StartError extends Schema.TaggedErrorClass<StartError>()("Shell.StartError", {
+  command: Schema.String,
+  cause: Schema.Defect(),
+}) {
+  override get message() {
+    const detail = this.cause instanceof Error ? this.cause.message : String(this.cause)
+    return `Failed to start shell command: ${this.command}: ${detail}`
+  }
+}
 
 // Exited processes stay observable (status, exit code, retained output) until removed explicitly.
 // Cap retention so abandoned commands do not accumulate unbounded state and output files.
@@ -50,7 +60,7 @@ export interface Interface {
   readonly create: <E = never, R = never>(
     input: Shell.CreateInput,
     before?: (input: ShellCreateBefore) => Effect.Effect<void, E, R>,
-  ) => Effect.Effect<Shell.Info, E | PlatformError.PlatformError, R>
+  ) => Effect.Effect<Shell.Info, E | StartError, R>
   // Currently running commands only; exited shells are retained for get/output but excluded here.
   readonly list: () => Effect.Effect<Shell.Info[]>
   readonly get: (id: Shell.ID) => Effect.Effect<Shell.Info, NotFoundError>
@@ -213,7 +223,7 @@ export const layer = (options?: ShellSelect.Options) =>
         // Spawn through the Environment and stream combined output to the file. The handle is scope-bound, so
         // the managing fiber keeps its scope open until the command terminates (it awaits `done` at the
         // end). `create` returns once `ready` resolves with the registered session.
-        const ready = Deferred.makeUnsafe<Active, PlatformError.PlatformError>()
+        const ready = Deferred.makeUnsafe<Active, StartError>()
         runFork(
           Effect.scoped(
             Effect.gen(function* () {
@@ -327,7 +337,11 @@ export const layer = (options?: ShellSelect.Options) =>
               // release (kill) the process before its exit is observed.
               yield* Deferred.await(session.done).pipe(Effect.catch(() => Effect.void))
             }),
-          ).pipe(Effect.catch((error) => Deferred.fail(ready, error))),
+          ).pipe(
+            Effect.catchCause((cause) =>
+              Deferred.fail(ready, new StartError({ command: invocation.command, cause: Cause.squash(cause) })),
+            ),
+          ),
         )
 
         const session = yield* Deferred.await(ready)

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,7 +1,7 @@
 export * as Shell from "./shell"
 
 import path from "path"
-import { Context, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Context, Deferred, Duration, Effect, Fiber, Layer, PlatformError, Schema, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
@@ -50,7 +50,7 @@ export interface Interface {
   readonly create: <E = never, R = never>(
     input: Shell.CreateInput,
     before?: (input: ShellCreateBefore) => Effect.Effect<void, E, R>,
-  ) => Effect.Effect<Shell.Info, E, R>
+  ) => Effect.Effect<Shell.Info, E | PlatformError.PlatformError, R>
   // Currently running commands only; exited shells are retained for get/output but excluded here.
   readonly list: () => Effect.Effect<Shell.Info[]>
   readonly get: (id: Shell.ID) => Effect.Effect<Shell.Info, NotFoundError>
@@ -213,7 +213,7 @@ export const layer = (options?: ShellSelect.Options) =>
         // Spawn through the Environment and stream combined output to the file. The handle is scope-bound, so
         // the managing fiber keeps its scope open until the command terminates (it awaits `done` at the
         // end). `create` returns once `ready` resolves with the registered session.
-        const ready = Deferred.makeUnsafe<Active>()
+        const ready = Deferred.makeUnsafe<Active, PlatformError.PlatformError>()
         runFork(
           Effect.scoped(
             Effect.gen(function* () {
@@ -327,7 +327,7 @@ export const layer = (options?: ShellSelect.Options) =>
               // release (kill) the process before its exit is observed.
               yield* Deferred.await(session.done).pipe(Effect.catch(() => Effect.void))
             }),
-          ).pipe(Effect.catch(() => Effect.void)),
+          ).pipe(Effect.catch((error) => Deferred.fail(ready, error))),
         )
 
         const session = yield* Deferred.await(ready)

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,10 +1,11 @@
 export * as Shell from "./shell"
 
 import path from "path"
-import { Cause, Context, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Context, Deferred, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
+import { AppProcess } from "@opencode-ai/util/process"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Config } from "./config"
 import { Bus } from "./bus"
@@ -18,16 +19,6 @@ import { PluginHooks } from "./plugin/hooks"
 export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Shell.NotFoundError", {
   id: Shell.ID,
 }) {}
-
-export class StartError extends Schema.TaggedErrorClass<StartError>()("Shell.StartError", {
-  command: Schema.String,
-  cause: Schema.Defect(),
-}) {
-  override get message() {
-    const detail = this.cause instanceof Error ? this.cause.message : String(this.cause)
-    return `Failed to start shell command: ${this.command}: ${detail}`
-  }
-}
 
 // Exited processes stay observable (status, exit code, retained output) until removed explicitly.
 // Cap retention so abandoned commands do not accumulate unbounded state and output files.
@@ -60,7 +51,7 @@ export interface Interface {
   readonly create: <E = never, R = never>(
     input: Shell.CreateInput,
     before?: (input: ShellCreateBefore) => Effect.Effect<void, E, R>,
-  ) => Effect.Effect<Shell.Info, E | StartError, R>
+  ) => Effect.Effect<Shell.Info, E | AppProcess.AppProcessError, R>
   // Currently running commands only; exited shells are retained for get/output but excluded here.
   readonly list: () => Effect.Effect<Shell.Info[]>
   readonly get: (id: Shell.ID) => Effect.Effect<Shell.Info, NotFoundError>
@@ -223,19 +214,23 @@ export const layer = (options?: ShellSelect.Options) =>
         // Spawn through the Environment and stream combined output to the file. The handle is scope-bound, so
         // the managing fiber keeps its scope open until the command terminates (it awaits `done` at the
         // end). `create` returns once `ready` resolves with the registered session.
-        const ready = Deferred.makeUnsafe<Active, StartError>()
+        const ready = Deferred.makeUnsafe<Active, AppProcess.AppProcessError>()
         runFork(
           Effect.scoped(
             Effect.gen(function* () {
-              const handle = yield* environment.spawner.spawn(
-                ChildProcess.make(invocation.shell, args, {
-                  cwd: invocation.cwd,
-                  env: invocation.env,
-                  stdin: "ignore",
-                  detached: process.platform !== "win32",
-                  forceKillAfter: Duration.seconds(3),
-                }),
-              )
+              const handle = yield* environment.spawner
+                .spawn(
+                  ChildProcess.make(invocation.shell, args, {
+                    cwd: invocation.cwd,
+                    env: invocation.env,
+                    stdin: "ignore",
+                    detached: process.platform !== "win32",
+                    forceKillAfter: Duration.seconds(3),
+                  }),
+                )
+                .pipe(
+                  Effect.mapError((cause) => new AppProcess.AppProcessError({ command: invocation.command, cause })),
+                )
               const session: Active = {
                 info: produce(info, (draft) => {
                   draft.pid = handle.pid
@@ -337,11 +332,7 @@ export const layer = (options?: ShellSelect.Options) =>
               // release (kill) the process before its exit is observed.
               yield* Deferred.await(session.done).pipe(Effect.catch(() => Effect.void))
             }),
-          ).pipe(
-            Effect.catchCause((cause) =>
-              Deferred.fail(ready, new StartError({ command: invocation.command, cause: Cause.squash(cause) })),
-            ),
-          ),
+          ).pipe(Effect.catchTag("AppProcessError", (error) => Deferred.fail(ready, error))),
         )
 
         const session = yield* Deferred.await(ready)

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -286,6 +286,30 @@ describe("ShellTool", () => {
     ),
   )
 
+  it.live(
+    "reports a command that fails to spawn",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withSession(tmp.path, (registry) =>
+            executeTool(registry, call({ command: "printf before\0after" })),
+          ).pipe(
+            Effect.andThen((settled) =>
+              Effect.sync(() => {
+                expect(settled.status).toBe("error")
+                if (settled.status !== "error") return
+                expect(settled.error?.message).toContain("ChildProcess.spawn")
+              }),
+            ),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 2_000 },
+  )
+
   it.live("permissions compound commands separately", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -295,16 +295,15 @@ describe("ShellTool", () => {
           reset()
           const command = "printf before\0after"
           return withSession(tmp.path, (registry) =>
-            Effect.gen(function* () {
-              const shell = yield* Shell.Service
-              const error = yield* shell.create({ command, timeout: 100 }).pipe(Effect.flip)
-              expect(error).toBeInstanceOf(Shell.StartError)
-
-              const settled = yield* executeTool(registry, call({ command }))
-              expect(settled.status).toBe("error")
-              if (settled.status !== "error") return
-              expect(settled.error?.message).toContain("Failed to start shell command")
-            }),
+            executeTool(registry, call({ command })).pipe(
+              Effect.andThen((settled) =>
+                Effect.sync(() => {
+                  expect(settled.status).toBe("error")
+                  if (settled.status !== "error") return
+                  expect(settled.error?.message).toContain("Command failed")
+                }),
+              ),
+            ),
           )
         },
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -293,16 +293,18 @@ describe("ShellTool", () => {
         Effect.promise(() => tmpdir()),
         (tmp) => {
           reset()
+          const command = "printf before\0after"
           return withSession(tmp.path, (registry) =>
-            executeTool(registry, call({ command: "printf before\0after" })),
-          ).pipe(
-            Effect.andThen((settled) =>
-              Effect.sync(() => {
-                expect(settled.status).toBe("error")
-                if (settled.status !== "error") return
-                expect(settled.error?.message).toContain("ChildProcess.spawn")
-              }),
-            ),
+            Effect.gen(function* () {
+              const shell = yield* Shell.Service
+              const error = yield* shell.create({ command, timeout: 100 }).pipe(Effect.flip)
+              expect(error).toBeInstanceOf(Shell.StartError)
+
+              const settled = yield* executeTool(registry, call({ command }))
+              expect(settled.status).toBe("error")
+              if (settled.status !== "error") return
+              expect(settled.error?.message).toContain("Failed to start shell command")
+            }),
           )
         },
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),

--- a/packages/server/src/handlers/shell.ts
+++ b/packages/server/src/handlers/shell.ts
@@ -21,7 +21,9 @@ export const ShellHandler = HttpApiBuilder.group(Api, "server.shell", (handlers)
         Effect.fn(function* (ctx) {
           const shell = yield* Shell.Service
           const location = yield* Location.Service
-          return yield* response(shell.create({ ...ctx.payload, cwd: ctx.payload.cwd || location.directory }))
+          return yield* response(
+            shell.create({ ...ctx.payload, cwd: ctx.payload.cwd || location.directory }).pipe(Effect.orDie),
+          )
         }),
       )
       .handle(

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -256,35 +256,35 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   }
 
   const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.try({
-      try: () => launch(command.command, command.args, opts),
-      catch: (err) => toPlatformError("spawn", toError(err), command),
-    }).pipe(
-      Effect.flatMap((proc) =>
-        Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
-          const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-          let end = false
-          let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
-          proc.on("error", (err) => {
-            resume(Effect.fail(toPlatformError("spawn", err, command)))
-          })
-          proc.on("exit", (...args) => {
-            exit = args
-          })
-          proc.on("close", (...args) => {
-            if (end) return
-            end = true
-            Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
-          })
-          proc.on("spawn", () => {
-            resume(Effect.succeed([proc, signal]))
-          })
-          return Effect.sync(() => {
-            proc.kill("SIGTERM")
-          })
-        }),
-      ),
-    )
+    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
+      const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+      let proc: NodeChildProcess.ChildProcess
+      try {
+        proc = launch(command.command, command.args, opts)
+      } catch (err) {
+        resume(Effect.fail(toPlatformError("spawn", toError(err), command)))
+        return Effect.void
+      }
+      let end = false
+      let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
+      proc.on("error", (err) => {
+        resume(Effect.fail(toPlatformError("spawn", err, command)))
+      })
+      proc.on("exit", (...args) => {
+        exit = args
+      })
+      proc.on("close", (...args) => {
+        if (end) return
+        end = true
+        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+      })
+      proc.on("spawn", () => {
+        resume(Effect.succeed([proc, signal]))
+      })
+      return Effect.sync(() => {
+        proc.kill("SIGTERM")
+      })
+    })
 
   const killGroup = (
     command: ChildProcess.StandardCommand,

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -256,29 +256,35 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   }
 
   const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
-      const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-      const proc = launch(command.command, command.args, opts)
-      let end = false
-      let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
-      proc.on("error", (err) => {
-        resume(Effect.fail(toPlatformError("spawn", err, command)))
-      })
-      proc.on("exit", (...args) => {
-        exit = args
-      })
-      proc.on("close", (...args) => {
-        if (end) return
-        end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
-      })
-      proc.on("spawn", () => {
-        resume(Effect.succeed([proc, signal]))
-      })
-      return Effect.sync(() => {
-        proc.kill("SIGTERM")
-      })
-    })
+    Effect.try({
+      try: () => launch(command.command, command.args, opts),
+      catch: (err) => toPlatformError("spawn", toError(err), command),
+    }).pipe(
+      Effect.flatMap((proc) =>
+        Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
+          const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+          let end = false
+          let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
+          proc.on("error", (err) => {
+            resume(Effect.fail(toPlatformError("spawn", err, command)))
+          })
+          proc.on("exit", (...args) => {
+            exit = args
+          })
+          proc.on("close", (...args) => {
+            if (end) return
+            end = true
+            Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+          })
+          proc.on("spawn", () => {
+            resume(Effect.succeed([proc, signal]))
+          })
+          return Effect.sync(() => {
+            proc.kill("SIGTERM")
+          })
+        }),
+      ),
+    )
 
   const killGroup = (
     command: ChildProcess.StandardCommand,


### PR DESCRIPTION
## What

Prevent shell commands that fail synchronously during process creation from leaving the shell tool and its session busy forever.

## Before / After

**Before:** A command containing an invalid process argument, such as an embedded NUL byte, makes `cross-spawn` throw synchronously. The detached shell setup fiber dies before completing its readiness deferred, so `Shell.create` waits forever and the tool remains `running`.

**After:** Synchronous process-creation throws enter the adapter's existing `PlatformError` channel. The shell service maps that spawn failure to the existing `AppProcessError` and fails its readiness deferred, allowing the shell tool to settle with an error and the session to continue.

## How

- `packages/util/src/cross-spawn-spawner.ts` wraps synchronous `cross-spawn` invocation failures as `PlatformError`.
- `packages/core/src/shell.ts` maps only process-spawn failures to `AppProcessError` before registering shell state, then fails the readiness deferred with that error.
- Session-shell and HTTP shell-create boundaries retain their existing public error surfaces by treating unexpected process-creation failures as defects.
- `packages/core/test/tool-shell.test.ts` reproduces the original NUL-byte trigger through the real shell tool and verifies that it settles with an error.

## Scope

This only addresses failures before a shell process is successfully created. It does not change timeout, process-tree termination, or background-shell behavior.

## Testing

- `bun run typecheck`
- `bun run test test/tool-shell.test.ts` from `packages/core` (20 passed)
- `bun run test` from `packages/util` (4 passed)
- `bun run test` from `packages/core` (1600 passed, 16 skipped, 2 unrelated failures: recorded HTTP transport timeout and user-plugin config pollution)
- `bun run lint` (existing repository-wide lint failure in `packages/session-ui/src/v2/components/prompt-input/index.tsx`)
- `bun run lint:effect-patterns` (existing repository diagnostics outside this change)
