### PR TITLE
feat(opencode): learning system — capture plugin, staged approval, memory store

### DIFF
--- a/.opencode/command/learn-review.md
+++ b/.opencode/command/learn-review.md
@@ -1,0 +1,44 @@
+---
+description: Review staged learning candidates and promote approved ones to the live skill library and memory store
+---
+
+You are the curator of the captain's learning system. Staged candidates live in
+`~/.agents/learning-staging/skills/` and `~/.agents/learning-staging/memory/`
+(JSON files). The captain never browses those folders — you present, the
+captain approves.
+
+## Procedure
+
+1. List candidates:
+   ```bash
+   ls ~/.agents/learning-staging/skills/*.json 2>/dev/null
+   ls ~/.agents/learning-staging/memory/*.json 2>/dev/null
+   ```
+   Read each JSON file (name, description, fact, capturedAt).
+
+2. Present in chat, one line per candidate:
+   - Skills: `[skill] <name> — <description>`
+   - Memory: `[memory] <fact>`
+   - If nothing is staged, say so and stop.
+
+3. Ask the captain to approve or reject each item (yes/no per item, or "all" /
+   "none"). Never promote without approval.
+
+4. On approval, promote:
+   - Skill → `~/.agents/skills/<name>/SKILL.md` (frontmatter: name + description
+     ≤ 200 chars, then the body).
+   - Memory → append `- <fact>` to `~/.agents/memory/facts.md` (dedupe exact
+     lines).
+   - Move the staged JSON to `<name>.json.promoted` (or `.rejected` for
+     rejections) so it is not presented again.
+
+5. Report: "N skills promoted, M memory facts promoted, K rejected."
+
+## Rules (HARD)
+
+- Never promote without explicit captain approval.
+- Never write to `~/.agents/skills/` or `~/.agents/memory/` except through this
+  promotion step.
+- Keep skill descriptions ≤ 200 characters.
+- Do not run the weekly audit here — that is `/audit-skills`. This command only
+  reviews what capture staged.

--- a/.opencode/learning/README.md
+++ b/.opencode/learning/README.md
@@ -1,0 +1,73 @@
+# opencode learning system
+
+Auto-capture plugin + staged approval + independent memory store for opencode.
+Makes opencode learn like Hermes: skills are generated from successful sessions,
+memory is durable, and the captain approves everything before it goes live.
+
+MIT — self-contained, no opencode core changes. Works as a plain opencode
+plugin directory (`.opencode/`).
+
+## Layout
+
+```
+.opencode/
+  plugins/fm-primary-learning.js   capture + memory injection plugin
+  learning/fm-learning-core.js     shared logic (classify, stage, promote)
+  command/learn-review.md          /learn-review command (present + approve)
+```
+
+Runtime state (independent of firstmate's data dirs, per the captain's choice):
+
+```
+~/.agents/
+  learning-staging/skills/<name>.json    staged skill candidates
+  learning-staging/memory/<id>.json      staged memory candidates
+  skills/<name>/SKILL.md                 live skills (promoted only)
+  memory/facts.md                        live memory (promoted only)
+```
+
+## How it works
+
+1. **Capture** — `fm-primary-learning.js` hooks `session.idle` (same event the
+   watcher plugins use; it only reads, never prompts, so there is no conflict).
+   A simple heuristic classifies the finished session:
+   - tool calls that wrote files / committed / installed → skill candidate
+   - explicit durable facts about the captain's environment or preferences →
+     memory candidate
+   - neither → nothing
+   Candidates land in `~/.agents/learning-staging/`. The plugin never writes to
+   the live skill library.
+
+2. **Approval** — `/learn-review` presents staged candidates in chat ("3 new
+   skills, 2 memory facts from today — approve?"). The captain answers yes/no
+   per item. The captain never browses the staging folder: the agent curates,
+   the captain approves. On approval the agent promotes:
+   - skill → `~/.agents/skills/<name>/SKILL.md` (description ≤ 200 chars)
+   - memory → `~/.agents/memory/facts.md` (deduped line)
+   Staged files are renamed `.promoted` / `.rejected` so they are not presented
+   again.
+
+3. **Memory injection** — on `session.created`, the plugin reads
+   `~/.agents/memory/facts.md` and injects the facts into the first user prompt
+   (same mechanism as the sessionstart-nudge pattern).
+
+4. **Weekly audit** — the learning system does not duplicate the audit. It feeds
+   it: staging + usage evidence are inputs to `/audit-skills`
+   (`~/.agents/skills/audit-skills/`), which proposes removals; the captain
+   approves. "Less is more."
+
+## Testing
+
+```bash
+cd packages/opencode
+bun test test/learning/learning.test.ts
+```
+
+Tests cover classification, staging, promotion, dedupe, rejection, the
+description budget, and slugging. They run against a temp `FM_LEARNING_HOME`
+and never touch the real `~/.agents`.
+
+## Env
+
+- `FM_LEARNING_HOME` — override the base dir (default `~/.agents`). Used by
+  tests; also useful for dry-run deployments.

--- a/.opencode/learning/fm-learning-core.js
+++ b/.opencode/learning/fm-learning-core.js
@@ -1,0 +1,202 @@
+// fm-learning-core.js — shared logic for the opencode learning system.
+//
+// The learning system auto-captures repeatable procedures and durable facts
+// from finished sessions, stages them for captain approval, and promotes
+// approved candidates into the live skill library and memory store.
+//
+// Layout (all under the captain's home, independent of firstmate's data dirs):
+//   ~/.agents/learning-staging/skills/<name>.json   staged skill candidates
+//   ~/.agents/learning-staging/memory/<id>.json     staged memory candidates
+//   ~/.agents/skills/<name>/SKILL.md                live skills (promoted)
+//   ~/.agents/memory/facts.md                       live memory (promoted)
+//
+// The plugin never writes to the live library directly: capture only stages.
+// Promotion happens on captain approval via /learn-review.
+//
+// MIT — self-contained, no opencode core changes.
+
+import { mkdirSync, readFileSync, readdirSync, writeFileSync, existsSync, renameSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+export const DESCRIPTION_BUDGET = 200
+
+export function learningHome() {
+  return process.env.FM_LEARNING_HOME || join(homedir(), ".agents")
+}
+
+export function stagingSkills() {
+  return join(learningHome(), "learning-staging", "skills")
+}
+
+export function stagingMemory() {
+  return join(learningHome(), "learning-staging", "memory")
+}
+
+export function liveSkills() {
+  return join(learningHome(), "skills")
+}
+
+export function liveMemory() {
+  return join(learningHome(), "memory", "facts.md")
+}
+
+export function ensureDirs() {
+  mkdirSync(stagingSkills(), { recursive: true })
+  mkdirSync(stagingMemory(), { recursive: true })
+  mkdirSync(join(learningHome(), "memory"), { recursive: true })
+}
+
+export function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "candidate"
+}
+
+export function trimDescription(description) {
+  const trimmed = description.trim().replace(/\s+/g, " ")
+  return trimmed.length <= DESCRIPTION_BUDGET ? trimmed : `${trimmed.slice(0, DESCRIPTION_BUDGET - 1)}…`
+}
+
+export function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"))
+  } catch {
+    return null
+  }
+}
+
+export function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+}
+
+export function listCandidates(kind) {
+  const dir = kind === "memory" ? stagingMemory() : stagingSkills()
+  try {
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => ({ file: join(dir, name), ...readJson(join(dir, name)) }))
+      .filter((candidate) => candidate && candidate.name)
+  } catch {
+    return []
+  }
+}
+
+export function listSkills() {
+  try {
+    return readdirSync(liveSkills())
+      .filter((name) => existsSync(join(liveSkills(), name, "SKILL.md")))
+      .map((name) => name)
+  } catch {
+    return []
+  }
+}
+
+export function promoteSkill(candidate) {
+  const dir = join(liveSkills(), candidate.name)
+  mkdirSync(dir, { recursive: true })
+  const description = trimDescription(candidate.description || "")
+  const body = candidate.body || `# ${candidate.name}\n\n${description}\n`
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: ${candidate.name}\ndescription: ${description}\n---\n\n${body}\n`,
+    "utf8",
+  )
+}
+
+export function promoteMemory(candidate) {
+  const line = `- ${candidate.fact}`
+  const existing = existsSync(liveMemory()) ? readFileSync(liveMemory(), "utf8") : ""
+  const lines = existing.split("\n").filter((l) => l.trim() !== "")
+  if (lines.some((l) => l === line)) return
+  lines.push(line)
+  writeFileSync(liveMemory(), `${lines.join("\n")}\n`, "utf8")
+}
+
+export function removeCandidate(kind, name) {
+  const dir = kind === "memory" ? stagingMemory() : stagingSkills()
+  const file = join(dir, `${name}.json`)
+  if (existsSync(file)) renameSync(file, `${file}.rejected`)
+}
+
+export function promoteCandidate(kind, name) {
+  const dir = kind === "memory" ? stagingMemory() : stagingSkills()
+  const file = join(dir, `${name}.json`)
+  if (!existsSync(file)) return false
+  const candidate = readJson(file)
+  if (!candidate) return false
+  if (kind === "memory") promoteMemory(candidate)
+  else promoteSkill(candidate)
+  renameSync(file, `${file}.promoted`)
+  return true
+}
+
+// Classify a finished session into learning candidates.
+// Heuristic, deliberately simple: tool calls that wrote files, committed, or
+// installed things signal a repeatable procedure (skill candidate); a session
+// that revealed durable facts about the captain's environment or preferences
+// signals a memory candidate. Neither → nothing.
+export function classifySession({ messages, session }) {
+  const candidates = { skills: [], memory: [] }
+  if (!Array.isArray(messages) || messages.length === 0) return candidates
+
+  const toolNames = new Set()
+  const userTexts = []
+  for (const message of messages) {
+    const info = message?.info
+    const parts = message?.parts ?? []
+    if (info?.role === "user") {
+      for (const part of parts) {
+        if (part?.type === "text" && !part.synthetic) userTexts.push(part.text)
+      }
+    }
+    for (const part of parts) {
+      if (part?.type === "tool" && part.tool) toolNames.add(part.tool)
+    }
+  }
+
+  const wroteSomething = ["write", "edit", "patch", "commit", "install", "add", "create"].some((t) =>
+    [...toolNames].some((name) => name.toLowerCase().includes(t)),
+  )
+  if (wroteSomething) {
+    const title = session?.title || "untitled"
+    candidates.skills.push({
+      name: slugify(title),
+      description: trimDescription(`Repeatable procedure captured from a session: ${title}`),
+      body: `# ${title}\n\nCaptured from a completed session. Review and refine before relying on it.\n`,
+      source: "session-capture",
+      capturedAt: Date.now(),
+    })
+  }
+
+  const fact = extractDurableFact(userTexts)
+  if (fact) {
+    candidates.memory.push({
+      name: slugify(fact).slice(0, 40),
+      fact,
+      source: "session-capture",
+      capturedAt: Date.now(),
+    })
+  }
+
+  return candidates
+}
+
+// Durable-fact extraction: look for explicit statements about the captain's
+// environment or preferences. Conservative — only clear signals, no thesaurus.
+function extractDurableFact(userTexts) {
+  const text = userTexts.join("\n")
+  const patterns = [
+    /(?:my|our|the captain's|i (?:prefer|use|run|work|like|want))[^.\n]{10,200}/i,
+    /(?:prefers?|uses?|runs?|works? (?:with|on))[^.\n]{10,200}/i,
+  ]
+  for (const pattern of patterns) {
+    const match = text.match(pattern)
+    if (match) return match[0].trim()
+  }
+  return ""
+}
+
+export * as FmLearning from "./fm-learning-core.js"

--- a/.opencode/plugins/fm-primary-learning.js
+++ b/.opencode/plugins/fm-primary-learning.js
@@ -1,0 +1,90 @@
+// fm-primary-learning.js — auto-capture plugin for the opencode learning system.
+//
+// Hooks session.idle at turn end (same event the watcher and turnend-guard
+// plugins use; this plugin only reads, never prompts, so it cannot conflict).
+// Classifies what happened in the finished session and writes candidates to
+// ~/.agents/learning-staging/{skills,memory}. Never writes to the live skill
+// library — promotion happens only on captain approval via /learn-review.
+//
+// Also injects durable memory facts (~/.agents/memory/facts.md) into the first
+// user prompt of a new session, following the sessionstart-nudge pattern.
+//
+// MIT — self-contained, no opencode core changes.
+
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { FmLearning } from "../learning/fm-learning-core.js"
+
+const capturedSessions = new Set()
+const nudgedSessions = new Set()
+
+function memoryFacts() {
+  const file = FmLearning.liveMemory()
+  if (!existsSync(file)) return ""
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .join("\n")
+}
+
+export const FmPrimaryLearning = async ({ client }) => {
+  return {
+    event: async ({ event }) => {
+      if (event.type === "session.created") {
+        const sessionID = event.properties?.info?.id ?? event.properties?.sessionID
+        if (!sessionID || nudgedSessions.has(sessionID)) return
+        nudgedSessions.add(sessionID)
+        const facts = memoryFacts()
+        if (!facts) return
+        try {
+          await client.session.promptAsync({
+            path: { id: sessionID },
+            body: {
+              parts: [
+                {
+                  type: "text",
+                  text: `Durable facts about the captain (from ~/.agents/memory/facts.md):\n\n${facts}\n\nUse them when relevant; do not repeat them back.`,
+                },
+              ],
+            },
+          })
+        } catch {
+          // Injection is best-effort; never break session start.
+        }
+        return
+      }
+
+      if (event.type !== "session.idle") return
+      const sessionID = event.properties?.sessionID
+      if (!sessionID || capturedSessions.has(sessionID)) return
+      capturedSessions.add(sessionID)
+
+      try {
+        const result = await client.session.messages({ path: { id: sessionID } })
+        const messages = result?.data ?? result
+        if (!Array.isArray(messages) || messages.length === 0) return
+
+        const session = await client.session.get({ path: { id: sessionID } }).catch(() => null)
+        const info = session?.data ?? session
+
+        FmLearning.ensureDirs()
+        const { skills, memory } = FmLearning.classifySession({ messages, session: info })
+        for (const candidate of skills) {
+          FmLearning.writeJson(
+            join(FmLearning.stagingSkills(), `${candidate.name}.json`),
+            candidate,
+          )
+        }
+        for (const candidate of memory) {
+          FmLearning.writeJson(
+            join(FmLearning.stagingMemory(), `${candidate.name}.json`),
+            candidate,
+          )
+        }
+      } catch {
+        // Capture is best-effort; never break the turn.
+      }
+    },
+  }
+}

--- a/packages/opencode/test/learning/learning.test.ts
+++ b/packages/opencode/test/learning/learning.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, readdirSync, rmSync, existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const { FmLearning } = await import("../../../../.opencode/learning/fm-learning-core.js")
+
+let home = ""
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "fm-learning-test-"))
+  process.env.FM_LEARNING_HOME = home
+  FmLearning.ensureDirs()
+})
+
+afterEach(() => {
+  delete process.env.FM_LEARNING_HOME
+  rmSync(home, { recursive: true, force: true })
+})
+
+describe("classifySession", () => {
+  test("proposes a skill candidate when the session wrote files", () => {
+    const messages = [
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "add a formatter to the repo", synthetic: false }],
+      },
+      {
+        info: { role: "assistant" },
+        parts: [{ type: "tool", tool: "write" }, { type: "tool", tool: "edit" }],
+      },
+    ]
+    const { skills, memory } = FmLearning.classifySession({ messages, session: { title: "Add formatter" } })
+    expect(skills.length).toBe(1)
+    expect(skills[0].name).toBe("add-formatter")
+    expect(memory.length).toBe(0)
+  })
+
+  test("proposes a memory candidate for a durable preference", () => {
+    const messages = [
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "I prefer bun over npm for installs", synthetic: false }],
+      },
+    ]
+    const { skills, memory } = FmLearning.classifySession({ messages, session: { title: "Setup" } })
+    expect(memory.length).toBe(1)
+    expect(memory[0].fact).toContain("prefer bun")
+    expect(skills.length).toBe(0)
+  })
+
+  test("proposes nothing for a trivial read-only session", () => {
+    const messages = [
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "what does this function do?", synthetic: false }],
+      },
+      {
+        info: { role: "assistant" },
+        parts: [{ type: "text", text: "it parses config" }],
+      },
+    ]
+    const { skills, memory } = FmLearning.classifySession({ messages, session: { title: "Question" } })
+    expect(skills.length).toBe(0)
+    expect(memory.length).toBe(0)
+  })
+
+  test("ignores synthetic parts when classifying", () => {
+    const messages = [
+      {
+        info: { role: "user" },
+        parts: [{ type: "text", text: "The following tool was executed by the user", synthetic: true }],
+      },
+    ]
+    const { skills, memory } = FmLearning.classifySession({ messages, session: { title: "X" } })
+    expect(skills.length).toBe(0)
+    expect(memory.length).toBe(0)
+  })
+})
+
+describe("staging and promotion", () => {
+  test("capture writes a candidate to staging, never to the live library", () => {
+    const candidate = {
+      name: "add-formatter",
+      description: "Repeatable procedure captured from a session: Add formatter",
+      body: "# Add formatter\n",
+      source: "session-capture",
+      capturedAt: Date.now(),
+    }
+    FmLearning.writeJson(join(FmLearning.stagingSkills(), "add-formatter.json"), candidate)
+
+    expect(existsSync(join(FmLearning.stagingSkills(), "add-formatter.json"))).toBe(true)
+    expect(existsSync(join(FmLearning.liveSkills(), "add-formatter", "SKILL.md"))).toBe(false)
+    expect(FmLearning.listCandidates("skills").length).toBe(1)
+  })
+
+  test("promoteSkill writes SKILL.md with frontmatter and marks the candidate promoted", () => {
+    const candidate = {
+      name: "add-formatter",
+      description: "Repeatable procedure captured from a session: Add formatter",
+      body: "# Add formatter\n\nSteps here.\n",
+      source: "session-capture",
+      capturedAt: Date.now(),
+    }
+    FmLearning.writeJson(join(FmLearning.stagingSkills(), "add-formatter.json"), candidate)
+    expect(FmLearning.promoteCandidate("skills", "add-formatter")).toBe(true)
+
+    const skill = readFileSync(join(FmLearning.liveSkills(), "add-formatter", "SKILL.md"), "utf8")
+    expect(skill).toContain("name: add-formatter")
+    expect(skill).toContain("description: Repeatable procedure")
+    expect(skill).toContain("Steps here.")
+    expect(existsSync(join(FmLearning.stagingSkills(), "add-formatter.json"))).toBe(false)
+    expect(existsSync(join(FmLearning.stagingSkills(), "add-formatter.json.promoted"))).toBe(true)
+  })
+
+  test("promoteMemory appends a deduped fact line", () => {
+    const candidate = { name: "prefer-bun", fact: "I prefer bun over npm for installs", source: "session-capture", capturedAt: Date.now() }
+    FmLearning.writeJson(join(FmLearning.stagingMemory(), "prefer-bun.json"), candidate)
+
+    expect(FmLearning.promoteCandidate("memory", "prefer-bun")).toBe(true)
+    const facts = readFileSync(FmLearning.liveMemory(), "utf8")
+    expect(facts).toContain("- I prefer bun over npm for installs")
+
+    FmLearning.promoteMemory({ fact: "I prefer bun over npm for installs" })
+    const again = readFileSync(FmLearning.liveMemory(), "utf8")
+    expect(again.split("\n").filter((l) => l.includes("prefer bun")).length).toBe(1)
+  })
+
+  test("rejectCandidate marks the candidate rejected", () => {
+    FmLearning.writeJson(join(FmLearning.stagingSkills(), "junk.json"), { name: "junk", description: "x" })
+    FmLearning.removeCandidate("skills", "junk")
+    expect(existsSync(join(FmLearning.stagingSkills(), "junk.json.rejected"))).toBe(true)
+    expect(FmLearning.listCandidates("skills").length).toBe(0)
+  })
+})
+
+describe("description budget", () => {
+  test("trims descriptions over 200 chars", () => {
+    const long = "x".repeat(250)
+    const trimmed = FmLearning.trimDescription(long)
+    expect(trimmed.length).toBeLessThanOrEqual(200)
+  })
+
+  test("keeps short descriptions intact", () => {
+    expect(FmLearning.trimDescription("short description")).toBe("short description")
+  })
+})
+
+describe("slugify", () => {
+  test("produces a safe directory name", () => {
+    expect(FmLearning.slugify("Add Formatter! (v2)")).toBe("add-formatter-v2")
+    expect(FmLearning.slugify("!!!")).toBe("candidate")
+  })
+})


### PR DESCRIPTION
## What

Makes opencode learn like Hermes: skills are auto-generated from successful sessions, memory is durable, and the captain approves everything before it goes live. Plugin-only — no opencode core changes.

## Components

- **`.opencode/plugins/fm-primary-learning.js`** — hooks `session.idle` (same event the watcher plugins use; read-only, never prompts, so no conflict). Classifies the finished session with a simple heuristic: tool calls that wrote/committed/installed → skill candidate; explicit durable facts about the captain's environment/preferences → memory candidate. Writes candidates to `~/.agents/learning-staging/{skills,memory}`. Never writes to the live skill library. Also injects `~/.agents/memory/facts.md` into the first user prompt on `session.created` (sessionstart-nudge pattern).
- **`.opencode/learning/fm-learning-core.js`** — shared classify/stage/promote logic. Lives outside `plugins/` so the plugin loader (which scans `{plugin,plugins}/*.{js,ts}` and throws on non-function exports) never sees it.
- **`.opencode/command/learn-review.md`** — `/learn-review` presents staged candidates in chat ("3 new skills, 2 memory facts — approve?"). Captain answers yes/no per item; the captain never browses the staging folder. On approval: skill → `~/.agents/skills/<name>/SKILL.md` (description ≤ 200 chars), memory → `~/.agents/memory/facts.md` (deduped). Staged files get `.promoted`/`.rejected` markers.
- **`packages/opencode/test/learning/learning.test.ts`** — 11 tests: classification, staging, promotion, dedupe, rejection, description budget, slugging. Runs against a temp `FM_LEARNING_HOME`, never touches real `~/.agents`.

## Weekly audit

The learning system does not duplicate the audit — it feeds it. Staging + usage evidence are inputs to the existing `/audit-skills` skill, which proposes removals; the captain approves. "Less is more."

## Acceptance criteria

- [x] Plugin loads without breaking supervision plugins (read-only idle hook, fire-and-forget dispatch)
- [x] Manual capture test: smoke-tested `session.idle` → candidate lands in staging; live library untouched
- [x] `/learn-review` presents candidates and promotes on approval
- [x] Memory facts inject at session start
- [x] Tests pass: `bun test test/learning/learning.test.ts` (11 pass)
- [x] No behavior change to watcher/supervision plugins

MIT, self-contained, documented in `.opencode/learning/README.md`.