### PR TITLE
fix(ai): break ToolResultValue type circularity

### DIFF
--- a/packages/ai/src/schema/messages.ts
+++ b/packages/ai/src/schema/messages.ts
@@ -45,35 +45,34 @@ const isToolResultValue = (value: unknown): value is ToolResultValue =>
   (value.type === "text" || value.type === "json" || value.type === "error" || value.type === "content") &&
   "value" in value
 
-export const ToolResultValue = Object.assign(
-  Schema.Union([
-    Schema.Struct({
-      type: Schema.Literal("json"),
-      value: Schema.Unknown,
-    }),
-    Schema.Struct({
-      type: Schema.Literal("text"),
-      value: Schema.Unknown,
-    }),
-    Schema.Struct({
-      type: Schema.Literal("error"),
-      value: Schema.Unknown,
-    }),
-    Schema.Struct({
-      type: Schema.Literal("content"),
-      value: Schema.Array(Tool.Content),
-    }),
-  ]).annotate({ identifier: "LLM.ToolResult" }),
-  {
-    is: isToolResultValue,
-    make: (value: unknown, type: ToolResultValue["type"] = "json"): ToolResultValue => {
-      if (isToolResultValue(value)) return value
-      if (type === "content") return { type, value: Array.isArray(value) ? value : [] }
-      return { type, value }
-    },
+const toolResultValueSchema = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("json"),
+    value: Schema.Unknown,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("text"),
+    value: Schema.Unknown,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("error"),
+    value: Schema.Unknown,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("content"),
+    value: Schema.Array(Tool.Content),
+  }),
+]).annotate({ identifier: "LLM.ToolResult" })
+export type ToolResultValue = Schema.Schema.Type<typeof toolResultValueSchema>
+
+export const ToolResultValue = Object.assign(toolResultValueSchema, {
+  is: isToolResultValue,
+  make: (value: unknown, type: ToolResultValue["type"] = "json"): ToolResultValue => {
+    if (isToolResultValue(value)) return value
+    if (type === "content") return { type, value: Array.isArray(value) ? value : [] }
+    return { type, value }
   },
-)
-export type ToolResultValue = Schema.Schema.Type<typeof ToolResultValue>
+})
 
 export interface ToolOutput {
   readonly structured: unknown


### PR DESCRIPTION
## What

Derives the \`ToolResultValue\` type from the bare union schema instead of the \`Object.assign\` result, matching the pattern \`SystemPart\` already uses in the same file.

## Why

\`type ToolResultValue = Schema.Schema.Type<typeof ToolResultValue>\` referenced the assigned const, whose \`is\`/\`make\` members reference the type back — a circularity that tsgo resolves order-dependently. On current \`v2\`, adding **any new file** to \`packages/core\` (even \`export const x = 1\`) shifts check order and degrades \`ToolResultValue\` to \`any\`, producing phantom errors in \`test/session-runner-tool-events.test.ts\`:

\`\`\`
error TS2345 ... Property 'result' is optional in type '{ ... result?: any ... }' but required ...
\`\`\`

This is why #41187's CI typecheck fails in a file it never touches. Clean full builds of v2 pass only by accident of the current file-set.

## Testing

- Reproduced: pristine \`origin/v2\` + one-line probe file in \`packages/core/src\` → 2 typecheck errors; with this fix → 0.
- \`packages/ai\`: typecheck green; test suite unchanged (478 pass, 9 pre-existing failures identical on clean \`origin/v2\`).
- \`packages/core\`: typecheck green with and without added files.