### PR TITLE
fix(core): flush plugin reload generations

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -233,7 +233,7 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const watcher = yield* Watcher.Service
     const fs = yield* FSUtil.Service
-    const ready = yield* Deferred.make<void>()
+    const ready = { current: yield* Deferred.make<void>() }
     let observed = 0
 
     // Configured local plugin files can live outside config roots, where the
@@ -291,7 +291,13 @@ const layer = Layer.effect(
       bus.subscribe([Event.Updated, SdkPlugins.Updated]),
     ).pipe(
       // Make accepted work visible to flush before coalescing the burst.
-      Stream.mapEffect(() => Effect.sync(() => ++observed)),
+      Stream.mapEffect(() =>
+        Effect.gen(function* () {
+          observed++
+          if (yield* Deferred.isDone(ready.current)) ready.current = yield* Deferred.make<void>()
+          return observed
+        }),
+      ),
     )
     yield* Stream.concat(Stream.succeed(0), updates).pipe(
       // Keep observing updates while activation runs, retaining only the latest generation request.
@@ -300,12 +306,12 @@ const layer = Layer.effect(
       Stream.runForEach((target) =>
         Effect.gen(function* () {
           yield* activate()
-          if (observed === target) yield* Deferred.succeed(ready, undefined)
+          if (observed === target) yield* Deferred.succeed(ready.current, undefined)
         }).pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }))),
       ),
       Effect.forkScoped({ startImmediately: true }),
     )
-    return Service.of({ flush: Deferred.await(ready) })
+    return Service.of({ flush: Effect.suspend(() => Deferred.await(ready.current)) })
   }),
 )
 

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -305,11 +305,13 @@ describe("LocationServiceMap", () => {
           )
           yield* Deferred.await(started)
 
-          yield* PluginSupervisor.Service.use((supervisor) => supervisor.flush).pipe(
+          const flushFiber = yield* PluginSupervisor.Service.use((supervisor) => supervisor.flush).pipe(
             Effect.provide(context),
-            Effect.timeout("1 second"),
+            Effect.forkChild({ startImmediately: true }),
           )
+          expect(flushFiber.pollUnsafe()).toBeUndefined()
           yield* Deferred.succeed(release, undefined)
+          yield* Fiber.join(flushFiber)
           yield* Deferred.await(completed)
         }),
       ),


### PR DESCRIPTION
## What

Makes `PluginSupervisor.flush` wait for the current plugin activation generation, including hot reloads after startup, and repairs the regression test so it cannot deadlock.

## Before / After

**Before:** `5b3997294757758c8d0e4fc13196a4c3211286fa` introduced `flush` as an await of one startup `Deferred`. Once startup completed, every later `flush` returned immediately even if a hot reload was active. Its "keeps flush open while later hot reload runs" test synchronously awaited that flush before releasing the deliberately blocked activation. Depending on update observation timing, the test either passed for the wrong reason (flush returned too early) or deadlocked until Bun's 5-second timeout.

**After:** accepting work replaces a completed generation barrier, activation completes the current barrier only after all observed work settles, and each `flush` resolves the barrier current at execution time. The test forks flush, verifies it remains pending, releases activation, and joins it.

## How

- `packages/core/src/plugin/supervisor.ts` rotates the readiness `Deferred` when post-ready work is observed.
- `flush` uses `Effect.suspend` so callers await the current generation rather than the startup generation captured while constructing the service.
- `packages/core/test/location-layer.test.ts` exercises the intended ordering without blocking its own release step.

This is a fix rather than a revert because the plugin readiness behavior introduced by the culprit commit is required; only its one-shot generation tracking was incomplete.

## Scope

This PR only addresses plugin flush generation tracking. The independent recorded OpenAI cassette mismatch and TUI CI races are handled in separate PRs.

## Testing

- `cd packages/core && bun typecheck` passes.
- `cd packages/core && bun run test test/location-layer.test.ts` passes three consecutive runs: 18 tests each, 0 failures.
- `cd packages/core && bun run test` passes all location-layer tests. The full suite still reports the independent recorded session-runner timeout and the documented local-only `PluginSupervisor config > logs invalid packages and continues loading` failure caused by global user plugins.
- The repository pre-push typecheck passes all 33 configured package tasks.
