### PR TITLE
feat(console): expose AI SDK package in Zen models API

### DIFF
--- a/packages/console/app/src/routes/zen/go/v1/models.ts
+++ b/packages/console/app/src/routes/zen/go/v1/models.ts
@@ -1,12 +1,16 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { ZenData } from "@opencode-ai/console-core/model.js"
-import { buildModelsResponse, buildOptionsResponse } from "../../util/modelsHandler"
+import { buildModelsResponse, buildOptionsResponse, getNpm } from "../../util/modelsHandler"
 
 export async function OPTIONS(_input: APIEvent) {
   return buildOptionsResponse()
 }
 
 export async function GET(_input: APIEvent) {
-  const models = Object.keys(ZenData.list("lite").models)
+  const catalog = ZenData.list("lite")
+  const models = Object.entries(catalog.models).map(([id, model]) => ({
+    id,
+    npm: getNpm(model, catalog.providers),
+  }))
   return buildModelsResponse(models)
 }

--- a/packages/console/app/src/routes/zen/util/modelsHandler.ts
+++ b/packages/console/app/src/routes/zen/util/modelsHandler.ts
@@ -1,3 +1,15 @@
+import type { ZenData } from "@opencode-ai/console-core/model.js"
+
+const npmByFormat: Record<ZenData.Format, string> = {
+  anthropic: "@ai-sdk/anthropic",
+  google: "@ai-sdk/google",
+  openai: "@ai-sdk/openai",
+  "oa-compat": "@ai-sdk/openai-compatible",
+}
+
+type CatalogModel = ReturnType<typeof ZenData.list>["models"][string]
+type CatalogProviders = ReturnType<typeof ZenData.list>["providers"]
+
 export async function buildOptionsResponse() {
   return new Response(null, {
     status: 200,
@@ -9,17 +21,28 @@ export async function buildOptionsResponse() {
   })
 }
 
-export async function buildModelsResponse(models: string[]) {
+export function getNpm(model: CatalogModel, providers: CatalogProviders) {
+  const format = Array.isArray(model)
+    ? model[0]?.formatFilter
+    : model.providers
+        .map((provider) => providers[provider.id]?.format)
+        .find((format): format is ZenData.Format => format !== undefined)
+
+  return npmByFormat[format ?? "oa-compat"]
+}
+
+export async function buildModelsResponse(models: { id: string; npm: string }[]) {
   return new Response(
     JSON.stringify({
       object: "list",
       data: models
-        .filter((id) => !id.startsWith("alpha-"))
-        .map((id) => ({
-          id,
+        .filter((model) => !model.id.startsWith("alpha-"))
+        .map((model) => ({
+          id: model.id,
           object: "model",
           created: Math.floor(Date.now() / 1000),
           owned_by: "opencode",
+          npm: model.npm,
         })),
     }),
     {

--- a/packages/console/app/src/routes/zen/v1/models.ts
+++ b/packages/console/app/src/routes/zen/v1/models.ts
@@ -4,13 +4,14 @@ import { and, Database, eq, isNull } from "@opencode-ai/console-core/drizzle/ind
 import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
 import { WorkspaceTable } from "@opencode-ai/console-core/schema/workspace.sql.js"
 import { ModelTable } from "@opencode-ai/console-core/schema/model.sql.js"
-import { buildOptionsResponse, buildModelsResponse } from "~/routes/zen/util/modelsHandler"
+import { buildOptionsResponse, buildModelsResponse, getNpm } from "~/routes/zen/util/modelsHandler"
 
 export async function OPTIONS(_input: APIEvent) {
   return buildOptionsResponse()
 }
 
 export async function GET(input: APIEvent) {
+  const catalog = ZenData.list("full")
   const disabledModels = await (() => {
     const apiKey = input.request.headers.get("authorization")?.split(" ")[1]
     if (!apiKey) return [] as string[]
@@ -28,9 +29,13 @@ export async function GET(input: APIEvent) {
     )
   })()
 
-  const models = Object.keys(ZenData.list("full").models)
-    .filter((id) => !id.endsWith(":global"))
-    .filter((id) => !disabledModels.includes(id))
+  const models = Object.entries(catalog.models)
+    .filter(([id]) => !id.endsWith(":global"))
+    .filter(([id]) => !disabledModels.includes(id))
+    .map(([id, model]) => ({
+      id,
+      npm: getNpm(model, catalog.providers),
+    }))
 
   return buildModelsResponse(models)
 }


### PR DESCRIPTION
### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Zen `GET /v1/models` response now includes an `npm` field for each model. The value is derived from the model's configured API format, matching the AI SDK packages documented for each Zen endpoint: Anthropic, Google, OpenAI, or OpenAI-compatible.

This is to match [models.dev](https://models.dev/api.json)'s API.

The shared response builder is used by both the full Zen model list and the Go model list, so both endpoints expose the same metadata shape.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/console/app`.
- Ran `bun typecheck` from `packages/console/core`.

### Screenshots / recordings

Not applicable; this is an API response change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
