### PR TITLE
fix: bound workspace sync connect with a timeout

### DIFF
--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -185,12 +185,18 @@ const layer = Layer.effect(
       url: URL | string,
       headers: HeadersInit | undefined,
     ) {
-      const response = yield* http.execute(
-        HttpClientRequest.get(route(url, "/global/event"), {
-          headers: new Headers(headers),
-          accept: "text/event-stream",
-        }),
-      )
+      // Bound the connect phase only — the stream itself stays open indefinitely.
+      // Without a timeout, a target that accepts the connection but never answers
+      // wedges the sync loop before its retry/backoff can run, and the workspace
+      // reports "connecting" forever.
+      const response = yield* http
+        .execute(
+          HttpClientRequest.get(route(url, "/global/event"), {
+            headers: new Headers(headers),
+            accept: "text/event-stream",
+          }),
+        )
+        .pipe(Effect.timeout("10 seconds"))
       if (response.status < 200 || response.status >= 300) {
         return yield* new SyncHttpError({
           message: `Workspace sync HTTP failure: ${response.status}`,


### PR DESCRIPTION
Bounds the connect phase of the workspace sync SSE request with a 10 second `Effect.timeout`. Only header arrival is bounded — the established stream stays open indefinitely as before.

On timeout the existing catch in `syncWorkspaceLoop` marks the workspace `error`, logs a warning, and the loop's exponential backoff retries — instead of the fiber hanging inside `http.execute` with the status stuck on `connecting` and `startSync` refusing to replace it.

Verified with `bun test test/control-plane/workspace.test.ts` (34 pass, 1 skip). Reproduced the original hang in a real deployment where a loopback proxy accepted the connection during a startup race but never answered; with the timeout the loop recovers on the next attempt.

Fixes #41315
