### PR TITLE
fix(cli): preserve Bun conditions when starting service

### DIFF
--- a/packages/cli/src/util/process.ts
+++ b/packages/cli/src/util/process.ts
@@ -6,15 +6,15 @@ export function selfCommand() {
   const runtime = path.basename(process.execPath, path.extname(process.execPath)).toLowerCase()
   if (runtime !== "bun" && runtime !== "node" && runtime !== "nodejs") return [process.execPath]
   if (!entrypoint) throw new Error("Failed to resolve CLI entrypoint")
-  if (runtime === "node" || runtime === "nodejs") return [process.execPath, ...nodeFlags(), entrypoint]
-  return [process.execPath, entrypoint]
+  return [process.execPath, ...runtimeFlags(runtime), entrypoint]
 }
 
-function nodeFlags() {
+function runtimeFlags(runtime: "bun" | "node" | "nodejs") {
   return process.execArgv.flatMap((arg, index, args) => {
     if (index > 0 && args[index - 1] === "--conditions") return []
     if (arg === "--conditions") return args[index + 1] ? [arg, args[index + 1]] : []
     if (arg.startsWith("--conditions=")) return [arg]
+    if (runtime === "bun") return []
     if (
       arg === "--experimental-ffi" ||
       arg === "--use-system-ca" ||


### PR DESCRIPTION
### Issue for this PR

Closes #41324

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves `--conditions` when the V2 CLI reconstructs its Bun command to start a managed service.

Previously, the source CLI started with `--conditions=browser`, but `selfCommand()` dropped that option from the child command. The child could then fail while resolving `react/jsx-dev-runtime`.

Node-specific flag handling remains unchanged.

### How did you verify your code works?

- Started and health-checked an isolated managed service from the modified source.
- Ran `bun typecheck` from `packages/cli`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
