### PR TITLE
fix(core): escape literal wildcards and anchor patch insertions

### DIFF
--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -139,7 +139,9 @@ function computeReplacements(lines: ReadonlyArray<string>, path: string, chunks:
       lineIndex = context + 1
     }
     if (chunk.oldLines.length === 0) {
-      replacements.push([lines.length, 0, chunk.newLines])
+      // A pure insertion with a located @@ anchor goes right after the anchor
+      // line; without one it still appends at the end of the file.
+      replacements.push([chunk.changeContext ? lineIndex : lines.length, 0, chunk.newLines])
       continue
     }
     let oldLines = chunk.oldLines

--- a/packages/core/src/util/wildcard.ts
+++ b/packages/core/src/util/wildcard.ts
@@ -2,11 +2,15 @@ export * as Wildcard from "./wildcard"
 
 export function match(input: string, pattern: string) {
   const normalized = input.replaceAll("\\", "/")
+  // Escaped glob characters (\*, \?, \\) must match literally, so keep them
+  // aside before the remaining backslashes are normalized to path separators.
   let escaped = pattern
+    .replace(/\\[*?\\]/g, (value) => (value === "\\*" ? "\u0001" : value === "\\?" ? "\u0002" : "\u0003"))
     .replaceAll("\\", "/")
     .replace(/[.+^${}()|[\]\\]/g, "\\$&")
     .replace(/\*/g, ".*")
     .replace(/\?/g, ".")
+    .replace(/[\u0001\u0002\u0003]/g, (value) => (value === "\u0001" ? "\\*" : value === "\u0002" ? "\\?" : "/"))
 
   if (escaped.endsWith(" .*")) escaped = escaped.slice(0, -3) + "( .*)?"
 

--- a/packages/core/test/patch.test.ts
+++ b/packages/core/test/patch.test.ts
@@ -31,6 +31,26 @@ describe("Patch", () => {
     expect(Patch.joinBom(update.content, update.bom)).toBe("\uFEFFnew\n")
   })
 
+  test("anchors a pure insertion at the @@ context line", () => {
+    expect(
+      Patch.derive("update.txt", [{ oldLines: [], newLines: ["inserted"], changeContext: "line2" }], "line1\nline2\nline3\n")
+        .content,
+    ).toBe("line1\nline2\ninserted\nline3\n")
+  })
+
+  test("positions context-anchored insertions before later replacements", () => {
+    expect(
+      Patch.derive(
+        "update.txt",
+        [
+          { oldLines: [], newLines: ["A"], changeContext: "line1" },
+          { oldLines: ["line3"], newLines: ["L3"] },
+        ],
+        "line1\nline2\nline3\n",
+      ).content,
+    ).toBe("line1\nA\nline2\nL3\n")
+  })
+
   test("matches EOF-anchored chunks from the end", () => {
     expect(
       Patch.derive(

--- a/packages/core/test/wildcard.test.ts
+++ b/packages/core/test/wildcard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { Wildcard } from "@opencode-ai/core/util/wildcard"
+
+describe("Wildcard", () => {
+  test("matches glob tokens", () => {
+    expect(Wildcard.match("file1.txt", "file?.txt")).toBe(true)
+    expect(Wildcard.match("file12.txt", "file?.txt")).toBe(false)
+    expect(Wildcard.match("foo+bar", "foo+bar")).toBe(true)
+    expect(Wildcard.match("src/foo.ts", "src/*.ts")).toBe(true)
+    expect(Wildcard.match("src/foo.ts", "src/*.js")).toBe(false)
+  })
+
+  test("escaped glob characters match literally", () => {
+    expect(Wildcard.match("config?.json", "config\\?.json")).toBe(true)
+    expect(Wildcard.match("configX.json", "config\\?.json")).toBe(false)
+    expect(Wildcard.match("*", "\\*")).toBe(true)
+    expect(Wildcard.match("anything.ts", "\\*")).toBe(false)
+    expect(Wildcard.match("a*b", "a\\*b")).toBe(true)
+    expect(Wildcard.match("aXb", "a\\*b")).toBe(false)
+  })
+
+  test("escaped backslash matches a literal backslash", () => {
+    expect(Wildcard.match("a\\b", "a\\\\b")).toBe(true)
+    expect(Wildcard.match("a/b", "a\\\\b")).toBe(true)
+    expect(Wildcard.match("aXb", "a\\\\b")).toBe(false)
+  })
+
+  test("trailing space plus wildcard matches commands with or without args", () => {
+    expect(Wildcard.match("kill -9 44165", "kill *")).toBe(true)
+    expect(Wildcard.match("ls", "ls *")).toBe(true)
+    expect(Wildcard.match("git status", "git *")).toBe(true)
+    expect(Wildcard.match("lstmeval", "ls *")).toBe(false)
+  })
+
+  test("normalizes slashes for cross-platform globbing", () => {
+    expect(Wildcard.match("C:\\Windows\\System32\\drivers", "C:/Windows/System32/*")).toBe(true)
+    expect(Wildcard.match("C:\\Windows\\System32\\*", "C:/Windows/System32/*")).toBe(true)
+  })
+})

--- a/packages/opencode/src/util/wildcard.ts
+++ b/packages/opencode/src/util/wildcard.ts
@@ -2,11 +2,15 @@ import { sortBy, pipe } from "remeda"
 
 export function match(str: string, pattern: string) {
   if (str) str = str.replaceAll("\\", "/")
-  if (pattern) pattern = pattern.replaceAll("\\", "/")
-  let escaped = pattern
+  // Escaped glob characters (\*, \?, \\) must match literally, so keep them
+  // aside before the remaining backslashes are normalized to path separators.
+  let escaped = (pattern ?? "")
+    .replace(/\\[*?\\]/g, (value) => (value === "\\*" ? "\u0001" : value === "\\?" ? "\u0002" : "\u0003"))
+    .replaceAll("\\", "/") // remaining backslashes are path separators
     .replace(/[.+^${}()|[\]\\]/g, "\\$&") // escape special regex chars
     .replace(/\*/g, ".*") // * becomes .*
     .replace(/\?/g, ".") // ? becomes .
+    .replace(/[\u0001\u0002\u0003]/g, (value) => (value === "\u0001" ? "\\*" : value === "\u0002" ? "\\?" : "/"))
 
   // If pattern ends with " *" (space + wildcard), make the trailing part optional
   // This allows "ls *" to match both "ls" and "ls -la"

--- a/packages/opencode/test/util/wildcard.test.ts
+++ b/packages/opencode/test/util/wildcard.test.ts
@@ -27,6 +27,15 @@ test("match with trailing space+wildcard matches command with or without args", 
   expect(Wildcard.match("git commit -m foo", "git *")).toBe(true)
 })
 
+test("match escapes literal glob characters", () => {
+  expect(Wildcard.match("config?.json", "config\\?.json")).toBe(true)
+  expect(Wildcard.match("configX.json", "config\\?.json")).toBe(false)
+  expect(Wildcard.match("*", "\\*")).toBe(true)
+  expect(Wildcard.match("anything.ts", "\\*")).toBe(false)
+  expect(Wildcard.match("a\\b", "a\\\\b")).toBe(true)
+  expect(Wildcard.match("aXb", "a\\\\b")).toBe(false)
+})
+
 test("all picks the most specific pattern", () => {
   const rules = {
     "*": "deny",
@@ -76,13 +85,13 @@ test("allStructured handles sed flags", () => {
 
 test("match normalizes slashes for cross-platform globbing", () => {
   expect(Wildcard.match("C:\\Windows\\System32\\*", "C:/Windows/System32/*")).toBe(true)
-  expect(Wildcard.match("C:/Windows/System32/drivers", "C:\\Windows\\System32\\*")).toBe(true)
+  expect(Wildcard.match("C:/Windows/System32/drivers", "C:/Windows/System32/*")).toBe(true)
 })
 
 test("match handles case-insensitivity on Windows", () => {
   if (process.platform === "win32") {
     expect(Wildcard.match("C:\\windows\\system32\\hosts", "C:/Windows/System32/*")).toBe(true)
-    expect(Wildcard.match("c:/windows/system32/hosts", "C:\\Windows\\System32\\*")).toBe(true)
+    expect(Wildcard.match("c:/windows/system32/hosts", "C:/Windows/System32/*")).toBe(true)
   } else {
     // Unix paths are case-sensitive
     expect(Wildcard.match("/users/test/file", "/Users/test/*")).toBe(false)


### PR DESCRIPTION
### Issue for this PR

Closes #41333

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the two things from #41333.

First, the wildcard matcher in `packages/core/src/util/wildcard.ts` (and the legacy copy in `packages/opencode/src/util/wildcard.ts`) had no way to match a literal `*`, `?`, or `\` in a permission resource. The only escape character was collapsed to a path separator before the regex was built, so `\*` and `\?` always behaved as wildcards. The change protects `\*`, `\?`, and `\\` before normalization so they match literally; plain `\` still works as a path separator. One consequence worth flagging: a Windows-style pattern like `C:\Windows\*` now means "a file literally named `*`" instead of "everything in `C:\Windows`", so patterns should use forward slashes (`C:/Windows/*`). The tests were updated to use `/`.

Second, `apply_patch` ignored the `@@` anchor for pure insertions. A chunk with a change context but no `-` or context lines (`oldLines.length === 0`) was always appended at the end of the file, so `@@ after the imports` followed by only `+` lines landed at the bottom. Insertions now go right after the located context line; chunks without an anchor still append at EOF.

### How did you verify your code works?

- `bun test test/wildcard.test.ts test/patch.test.ts` in `packages/core`: 13 pass, 0 fail.
- `bun test test/util/wildcard.test.ts` in `packages/opencode`: the 9 wildcard tests pass (the new escape cases plus the existing glob and slash tests). The package test preload in this checkout fails on a missing drizzle-orm subpath, but the wildcard tests themselves all pass.
- Checked the escape cases from the issue directly (`config\?.json`, `\*`, `a\\b`) against the updated function to confirm literal matching and no regression on the trailing ` *` command rule.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
