### PR TITLE
fix(cli): add fish shell completion support

### DIFF
--- a/packages/opencode/src/cli/completion.ts
+++ b/packages/opencode/src/cli/completion.ts
@@ -1,0 +1,102 @@
+import { UI } from "./ui"
+import { EOL } from "os"
+
+const completionFishTemplate = `# opencode fish completion
+complete -f -c opencode -a '(opencode --get-yargs-completions (commandline -o)[2..-1])'`
+
+const completionBashTemplate = `###-begin-{{app_name}}-completions-###
+#
+# yargs command completion script
+#
+# Installation: {{app_path}} {{completion_command}} >> ~/.bashrc
+#    or {{app_path}} {{completion_command}} >> ~/.bash_profile on OSX.
+#
+
+_{{app_name}}_yargs_completions()
+{
+    local cur_word args type_list
+
+    cur_word="\${COMP_WORDS[COMP_CWORD]}"
+    args=("\${COMP_WORDS[@]}")
+
+    # ask yargs to generate completions.
+    # see https://stackoverflow.com/a/40944195/7080036 for the spaces-handling awk
+    mapfile -t type_list < <({{app_path}} --get-yargs-completions "\${args[@]}")
+    mapfile -t COMPREPLY < <(compgen -W "$( printf '%q ' "\${type_list[@]}" )" -- "\${cur_word}" |
+        awk '/ / { print "\\""$0"\\"" } /^[^ ]+$/ { print $0 }')
+
+    # if no match was found, fall back to filename completion
+    if [ \${#COMPREPLY[@]} -eq 0 ]; then
+      COMPREPLY=()
+    fi
+
+    return 0
+}
+complete -o bashdefault -o default -F _{{app_name}}_yargs_completions {{app_name}}
+###-end-{{app_name}}-completions-###`
+
+const completionZshTemplate = `#compdef {{app_name}}
+###-begin-{{app_name}}-completions-###
+#
+# yargs command completion script
+#
+# Installation: {{app_path}} {{completion_command}} >> ~/.zshrc
+#    or {{app_path}} {{completion_command}} >> ~/.zprofile on OSX.
+#
+
+_{{app_name}}_yargs_completions()
+{
+  local reply
+  local si=\$IFS
+  IFS=\$'\\n' reply=(\$(COMP_CWORD="\$((CURRENT-1))" COMP_LINE="\$BUFFER" COMP_POINT="\$CURSOR" {{app_path}} --get-yargs-completions "\${words[@]}"))
+  IFS=\$si
+  if [[ \${#reply} -gt 0 ]]; then
+    _describe 'values' reply
+  else
+    _default
+  fi
+}
+if [[ "'\${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _{{app_name}}_yargs_completions "\$@"
+else
+  compdef _{{app_name}}_yargs_completions {{app_name}}
+fi
+###-end-{{app_name}}-completions-###`
+
+export async function showCompletionScript(shell?: string) {
+  const args = process.argv.slice(2)
+  const shellArg = args.find(arg => ["bash", "zsh", "fish"].includes(arg))
+  const targetShell = shell || shellArg
+
+  // Get the command name from the first non-flag argument
+  let cmd = "completion"
+  for (const arg of args) {
+    if (!arg.startsWith("-") && arg !== "completion" && !["bash", "zsh", "fish"].includes(arg)) {
+      cmd = arg
+      break
+    }
+  }
+
+  // Use the script name
+  const $0 = process.argv[1] || "opencode"
+
+  let script = ""
+  let name = "opencode"
+
+  if (targetShell === "fish") {
+    script = completionFishTemplate
+  } else if (targetShell === "zsh") {
+    script = completionZshTemplate
+  } else {
+    // Default to bash
+    script = completionBashTemplate
+  }
+
+  // Replace template variables
+  script = script.replace(/{{app_name}}/g, name)
+  script = script.replace(/{{completion_command}}/g, cmd)
+  script = script.replace(/{{app_path}}/g, $0)
+
+  // Output the script
+  process.stdout.write(script + EOL)
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -30,6 +30,10 @@ import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
 
+// Fish shell completion template
+const completionFishTemplate = `# opencode fish completion
+complete -f -c opencode -a '(opencode --get-yargs-completions (commandline -o)[2..-1])'`
+
 const args = hideBin(process.argv)
 
 function show(out: string) {
@@ -40,6 +44,55 @@ function show(out: string) {
     return
   }
   process.stderr.write(out)
+}
+
+// Custom completion command that supports fish shell
+const completionCommand = {
+  command: "completion [shell]",
+  describe: "generate shell completion script",
+  builder: (y: any) => {
+    return y
+      .positional("shell", {
+        describe: "shell to generate completions for (bash, zsh, fish)",
+        type: "string",
+        choices: ["bash", "zsh", "fish"],
+      })
+      .option("bash", {
+        alias: "b",
+        describe: "generate bash completions",
+        type: "boolean",
+      })
+      .option("zsh", {
+        alias: "z",
+        describe: "generate zsh completions",
+        type: "boolean",
+      })
+      .option("fish", {
+        alias: "f",
+        describe: "generate fish completions",
+        type: "boolean",
+      })
+  },
+  handler: async (argv: any) => {
+    const { showCompletionScript } = await import("@/cli/completion")
+    let shell: string | undefined
+    if (argv.shell && ["bash", "zsh", "fish"].includes(argv.shell)) {
+      shell = argv.shell
+    } else if (argv.fish) {
+      shell = "fish"
+    } else if (argv.zsh) {
+      shell = "zsh"
+    } else if (argv.bash) {
+      shell = "bash"
+    } else {
+      // Fallback to $SHELL environment variable
+      const shellEnv = process.env.SHELL || ""
+      if (shellEnv.includes("fish")) shell = "fish"
+      else if (shellEnv.includes("zsh")) shell = "zsh"
+      else shell = "bash"
+    }
+    await showCompletionScript(shell)
+  }
 }
 
 const cli = yargs(args)
@@ -77,7 +130,7 @@ const cli = yargs(args)
     process.env.OPENCODE_PID = String(process.pid)
   })
   .usage("")
-  .completion("completion", "generate shell completion script")
+  .command(completionCommand)
   .command(AcpCommand)
   .command(McpCommand)
   .command(TuiThreadCommand)


### PR DESCRIPTION
### Description

Fixes issue #41232 where `opencode completion fish` incorrectly emitted bash/zsh completion scripts instead of proper fish syntax.

### Changes

- Added new `packages/opencode/src/cli/completion.ts` with completion templates for bash, zsh, and fish
- Modified `packages/opencode/src/index.ts` to add a custom `completion` command that:
  - Accepts a positional `shell` argument (`bash`, `zsh`, `fish`)
  - Supports flags `--bash/-b`, `--zsh/-z`, `--fish/-f`
  - Falls back to `$SHELL` environment variable for auto-detection

### Verification

- `opencode completion fish` → outputs fish completion script ✅
- `opencode completion bash` → outputs bash completion script ✅
- `opencode completion zsh` → outputs zsh completion script ✅
- `opencode completion --fish` → outputs fish completion script ✅
- `SHELL=/bin/fish opencode completion` → auto-detects fish ✅
- `SHELL=/bin/zsh opencode completion` → auto-detects zsh ✅
- `SHELL=/bin/bash opencode completion` → auto-detects bash ✅
- TypeScript typecheck passes ✅

### Plugins

N/A

### OpenCode version

Current dev branch

### Steps to reproduce

1. Run `opencode completion fish` and look at the output. It is now a proper fish completion script.
2. In fish, run `opencode completion fish | source`.
3. fish no longer reports "Unsupported use of '='".

### Screenshot and/or share link

N/A

### Operating System

Linux (tested on Arch Linux)

### Terminal

Any terminal supporting fish shell