### PR TITLE
fix(codegen): write prettier-stable generated manifests

### DIFF
--- a/packages/httpapi-codegen/src/index.ts
+++ b/packages/httpapi-codegen/src/index.ts
@@ -1316,7 +1316,15 @@ export function write(
         }).pipe(Effect.flatMap((content) => fs.writeFileString(join(directory, file.path), content))),
       { concurrency: 8, discard: true },
     )
-    yield* fs.writeFileString(manifest, JSON.stringify(output.files.map((file) => file.path).sort(), null, 2) + "\n")
+    // Format the manifest with the same prettier settings as the repo-wide
+    // format pass, so `check:generated` stays clean after the generate bot
+    // reformats the tree.
+    const manifestJson = JSON.stringify(output.files.map((file) => file.path).sort())
+    const manifestContent = yield* Effect.tryPromise({
+      try: () => format(manifestJson, { filepath: manifest, parser: "json", printWidth: 120 }),
+      catch: (error) => new GenerationError({ reason: `Failed to format ${manifest}: ${String(error)}` }),
+    })
+    yield* fs.writeFileString(manifest, manifestContent)
   })
 }
 

--- a/packages/httpapi-codegen/test/write.test.ts
+++ b/packages/httpapi-codegen/test/write.test.ts
@@ -16,7 +16,7 @@ describe("HttpApiCodegen.write", () => {
 
       expect(writes).toEqual([
         { path: "/generated/session.ts", content: "export const session = {}\n" },
-        { path: "/generated/.httpapi-codegen.json", content: '[\n  "session.ts"\n]\n' },
+        { path: "/generated/.httpapi-codegen.json", content: '["session.ts"]\n' },
       ])
     }).pipe(
       Effect.provideService(


### PR DESCRIPTION
## What

Formats the \`.httpapi-codegen.json\` manifest through prettier (json parser, repo print width) at write time, instead of raw \`JSON.stringify(..., null, 2)\`.

## Why

The last red job on v2 CI. The generate bot (running on v2 since #41207) executes \`script/generate.ts\`, which ends with a repo-wide prettier pass — collapsing the short manifest arrays to single-line before committing. \`check:generated\` in \`packages/client\` regenerates without that pass, producing multi-line manifests, and \`git diff --exit-code\` fails:

\`\`\`
-["client-error.ts", "client.ts", "index.ts"]
+[
+  "client-error.ts",
...
\`\`\`

Generated \`.ts\` files were already prettier-formatted at write time; the manifest was the one artifact that wasn't. Making it prettier-stable at the source fixes the check regardless of whether the bot's format pass runs afterward.

## Testing

- \`packages/httpapi-codegen\`: typecheck green, 87/87 tests (manifest expectation updated to the prettier-stable form).
- \`packages/client\`: \`bun run check:generated\` passes against the committed (bot-formatted) manifests — regeneration is now byte-identical.