### PR TITLE
fix(tui): undo latest pending prompt

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -84,6 +84,7 @@ import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
 import { PluginSlot } from "../../plugin/render"
 import { usePlugin } from "../../plugin/context"
+import { undoMessage } from "./undo"
 import {
   cacheReuseDrop,
   createSessionRows,
@@ -656,19 +657,24 @@ export function Session() {
       group: "Session",
       slash: { name: "undo" },
       run: () => {
+        const admitted = pendingUsers().at(-1)
         const boundary = session()?.revert?.messageID
-        const message = messages().findLast(
-          (message): message is SessionMessageUser =>
-            message.type === "user" && !!message.text.trim() && (!boundary || message.id < boundary),
-        )
+        const message = admitted
+          ? { id: admitted.id, ...admitted.data }
+          : messages().findLast(
+              (message): message is SessionMessageUser =>
+                message.type === "user" && !!message.text.trim() && (!boundary || message.id < boundary),
+            )
         if (!message) {
           toast.show({ message: "Nothing to undo", variant: "error", duration: 3000 })
           dialog.clear()
           return
         }
-        void client.api.session.revert
-          .stage({ sessionID: route.sessionID, messageID: message.id })
-          .catch((error) => toast.show({ message: errorMessage(error), variant: "error", duration: 5000 }))
+        void undoMessage(client.api, {
+          sessionID: route.sessionID,
+          messageID: message.id,
+          pending: admitted !== undefined,
+        }).catch((error) => toast.show({ message: errorMessage(error), variant: "error", duration: 5000 }))
         prompt()?.set({
           ...projectedPromptInput(message),
           pasted: [],

--- a/packages/tui/src/routes/session/undo.ts
+++ b/packages/tui/src/routes/session/undo.ts
@@ -1,0 +1,14 @@
+import type { OpenCodeClient } from "@opencode-ai/client"
+
+export async function undoMessage(
+  client: OpenCodeClient,
+  input: { readonly sessionID: string; readonly messageID: string; readonly pending: boolean },
+) {
+  const revert = () => client.session.revert.stage(input).then(() => undefined)
+  if (!input.pending) return revert()
+
+  return client.session.pending.cancel({ sessionID: input.sessionID, inputID: input.messageID }).catch((error) => {
+    if (typeof error !== "object" || error === null || !("_tag" in error) || error._tag !== "ConflictError") throw error
+    return revert()
+  })
+}

--- a/packages/tui/test/cli/tui/undo.test.ts
+++ b/packages/tui/test/cli/tui/undo.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test"
+import { OpenCode } from "@opencode-ai/client"
+import { undoMessage } from "../../../src/routes/session/undo"
+
+test.each([
+  { name: "projected", pending: false, cancelStatus: 204, expected: ["revert"] },
+  { name: "pending", pending: true, cancelStatus: 204, expected: ["cancel"] },
+  { name: "promoted race", pending: true, cancelStatus: 409, expected: ["cancel", "revert"] },
+])("undo routes $name messages", async ({ pending, cancelStatus, expected }) => {
+  const calls: string[] = []
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: Object.assign(
+      async (input: URL | RequestInfo, init?: BunFetchRequestInit | RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init)
+        const operation = request.method === "DELETE" ? "cancel" : "revert"
+        calls.push(operation)
+        if (operation === "cancel") {
+          if (cancelStatus === 409)
+            return Response.json({ _tag: "ConflictError", message: "Input was promoted" }, { status: 409 })
+          return new Response(null, { status: 204 })
+        }
+        return Response.json({ data: { messageID: "msg_user" } })
+      },
+      { preconnect: fetch.preconnect },
+    ),
+  })
+
+  await undoMessage(client, { sessionID: "ses_test", messageID: "msg_user", pending })
+
+  expect(calls).toEqual([...expected])
+})
+
+test("undo does not reinterpret transport failures as promotion races", async () => {
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: Object.assign(
+      async () => {
+        throw new Error("offline")
+      },
+      { preconnect: fetch.preconnect },
+    ),
+  })
+
+  await expect(
+    undoMessage(client, { sessionID: "ses_test", messageID: "msg_user", pending: true }),
+  ).rejects.toMatchObject({ reason: "Transport" })
+})


### PR DESCRIPTION
## What

Make `/undo` remove the newest pending user prompt before reverting projected session history. This applies equally to queued and steering follow-ups and restores the removed prompt to the composer.

Fixes #39736.

## Before / After

**Before**

1. A queued or steering follow-up was admitted and shown optimistically while a response was active.
2. `/undo` selected that user message but sent it to the history revert endpoint.
3. Because the input had not been promoted into history, revert failed with `MessageNotFoundError` and the pending prompt remained.

**After**

1. `/undo` selects the newest pending user input by admission order.
2. It cancels that input through the existing durable pending-input endpoint and restores its content to the composer.
3. If promotion wins the cancellation race, the expected conflict falls back to normal history revert.
4. With no pending user input, `/undo` retains its existing projected-history behavior.

## How

- `packages/tui/src/routes/session/index.tsx` prioritizes `pendingUsers()` when selecting the undo target.
- `packages/tui/src/routes/session/undo.ts` routes pending targets to cancellation and handles only the expected promotion conflict as a revert fallback.
- `packages/tui/test/cli/tui/undo.test.ts` covers projected, pending, promotion-race, and transport-failure paths.

## Scope

- Uses the existing `session.pending.cancel` API and `session.input.cancelled` event; no protocol or core lifecycle changes.
- Synthetic pending inputs and compaction barriers remain untouched.
- Redo remains specific to staged history reverts; cancelling a pending prompt does not create a redo boundary.

## Testing

- `packages/tui`: `bun run test`, 612 passed and 5 skipped.
- `packages/tui`: `bun typecheck`.
- Push hook: repository Turbo typecheck, 33 packages passed.
- OpenCode Drive scripted TUI walkthrough with a simulated model, covering queued cancellation, steering cancellation, and projected-history revert.

## Demo

The recording uses OpenCode Drive with a simulated streaming model. The first two `/undo` actions remove and restore a steering prompt, then a queued prompt. After streaming completes, the third `/undo` follows the existing history-revert path and displays `1 message reverted`.

https://github.com/user-attachments/assets/4816661c-05c0-4015-b1c9-e6eaeb922a6f

## Flow

```mermaid
flowchart TD
    Undo[/undo/] --> Pending{Pending user input?}
    Pending -->|Yes| Cancel[Cancel newest pending input]
    Cancel --> Conflict{Already promoted?}
    Conflict -->|No| Restore[Restore prompt to composer]
    Conflict -->|Yes| Revert[Stage history revert]
    Pending -->|No| Revert
    Revert --> Restore
```
