### PR TITLE
fix(tui): show completed write output

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2659,7 +2659,7 @@ function Write(props: ToolProps) {
 
   return (
     <Switch>
-      <Match when={props.metadata.diagnostics !== undefined}>
+      <Match when={props.part.state.status === "completed"}>
         <BlockTool
           path={{ label: "# Wrote", value: pathFormatter.format(stringValue(props.input.path)) }}
           part={props.part}


### PR DESCRIPTION
## What

Show the syntax-highlighted file contents after the V2 `write` tool completes.

## Before / After

**Before:** The write renderer used `metadata.diagnostics` as its completion signal. V2 writes do not emit diagnostics yet, so successful writes remained as a compact `Write <path>` row and hid the content already present in `input.content`.

**After:** A completed write switches to the existing code-block presentation based on the durable tool status. Diagnostics remain optional and render when available.

## How

- `packages/tui/src/routes/session/index.tsx` keys the write block on `state.status === "completed"` instead of optional diagnostics metadata.
- Audited the other mutation renderers: `edit` and `patch` already key their expanded views from final diff/file metadata emitted by their V2 tools.

## Scope

This does not add V2 LSP diagnostics to write or edit tools.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/mini/tool.test.ts test/mini/entry.body.test.ts test/mini/scrollback.surface.test.ts test/cli/tui/inline-tool-wrap-snapshot.test.tsx` in `packages/tui` (49 passed)
- Repository pre-push typecheck (32 packages passed)

## Demo

An OpenCode Drive before/after capture exposed that Drive 1.4.2's controlled-tool plugin still used the old plugin API and could not control `write`. anomalyco/opencode-drive#53 fixes that integration. No misleading failed-tool recording is attached while that dependency is pending.
