### PR TITLE
fix(app): correct todo progress count order

### DIFF
--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -737,7 +737,7 @@ export const dict: Record<string, string> = {
   "session.todo.title": "টোডোস",
   "session.todo.collapse": "সঙ্কুচিত",
   "session.todo.expand": "প্রসারিত করুন",
-  "session.todo.progress": "{{done}} এর মধ্যে {{total}} todos সম্পন্ন হয়েছে",
+  "session.todo.progress": "{{total}} এর মধ্যে {{done}} todos সম্পন্ন হয়েছে",
   "session.question.progress": "{{total}} প্রশ্নের {{current}}",
   "session.question.minimize": "প্রশ্ন ছোট করুন",
   "session.question.restore": "প্রশ্ন পুনরুদ্ধার করুন",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -1085,7 +1085,7 @@ export const dict = {
   "session.review.noVcs.createGit.description": "このプロジェクトの変更を追跡、レビュー、元に戻す",
   "session.review.noVcs.createGit.actionLoading": "Git リポジトリを作成中...",
   "session.review.noVcs.createGit.action": "Git リポジトリを作成",
-  "session.todo.progress": "{{done}} 個中 {{total}} 個の Todo が完了",
+  "session.todo.progress": "{{total}} 個中 {{done}} 個の Todo が完了",
   "session.question.progress": "{{total}} 問中 {{current}} 問",
   "session.header.open.finder": "Finder",
   "session.header.open.fileExplorer": "エクスプローラー",


### PR DESCRIPTION
### Issue for this PR

Closes #41369

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Japanese `session.todo.progress` translation placed `{{done}}` before `{{total}}`, so the Desktop app displayed `0 個中 3 個の Todo が完了` when three todos were still pending.

The Bengali translation had the same placeholder order.

This changes only those two locale entries. The `SessionTodoDock` already passes `done` and `total` correctly, so no runtime logic change is needed. The CLI/TUI is unaffected because it does not render this summary label.

### How did you verify your code works?

- Manually verified that `done=0, total=3` renders with the total before the completed count.
- `git diff --check` passes.
- The full test suite and build were not run because Bun is unavailable in the local environment.

### Screenshots / recordings

The original screenshot is included in #41369. No after-screenshot was produced because the local build environment was unavailable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR