### PR TITLE
fix(core): render a tag when a task error has no message

### DIFF
--- a/packages/core/src/background-job.ts
+++ b/packages/core/src/background-job.ts
@@ -106,8 +106,13 @@ function snapshot(job: Active): Info {
 }
 
 function errorText(error: unknown) {
-  if (error instanceof Error) return error.message
-  return String(error)
+  if (error instanceof Error) {
+    if (error.message.trim()) return error.message
+    if ("_tag" in error && typeof error._tag === "string" && error._tag.trim()) return error._tag
+    if (error.name.trim()) return error.name
+  }
+  const text = String(error)
+  return text.trim() ? text : "Unknown error"
 }
 
 /**

--- a/packages/core/src/background-job.ts
+++ b/packages/core/src/background-job.ts
@@ -107,9 +107,9 @@ function snapshot(job: Active): Info {
 
 function errorText(error: unknown) {
   if (error instanceof Error) {
-    if (error.message.trim()) return error.message
+    if (typeof error.message === "string" && error.message.trim()) return error.message
     if ("_tag" in error && typeof error._tag === "string" && error._tag.trim()) return error._tag
-    if (error.name.trim()) return error.name
+    if (typeof error.name === "string" && error.name.trim()) return error.name
   }
   const text = String(error)
   return text.trim() ? text : "Unknown error"

--- a/packages/core/test/background-job.test.ts
+++ b/packages/core/test/background-job.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect } from "bun:test"
 import { BackgroundJob } from "@opencode-ai/core/background-job"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Deferred, Effect, Exit, Scope } from "effect"
+import { Deferred, Effect, Exit, Schema, Scope } from "effect"
 import { it } from "./lib/effect"
 
 const jobsLayer = LayerNode.compile(BackgroundJob.node)
 
+class MessageLessError extends Schema.TaggedErrorClass<MessageLessError>()("MessageLessError", {}) {}
+
 describe("BackgroundJob", () => {
+  it.live("renders a tag when a failed error has no message", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const tagged = yield* jobs.start({ type: "test", run: Effect.fail(new MessageLessError()) })
+      const withMessage = yield* jobs.start({ type: "test", run: Effect.fail(new Error("real message")) })
+
+      expect((yield* jobs.wait({ id: tagged.id })).info?.error).toBe("MessageLessError")
+      expect((yield* jobs.wait({ id: withMessage.id })).info?.error).toBe("real message")
+    }).pipe(Effect.provide(jobsLayer)),
+  )
+
   it.live("tracks process-local work through explicit observation", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service

--- a/packages/core/test/background-job.test.ts
+++ b/packages/core/test/background-job.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test"
 import { BackgroundJob } from "@opencode-ai/core/background-job"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Deferred, Effect, Exit, Schema, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Schema, Scope } from "effect"
 import { it } from "./lib/effect"
 
 const jobsLayer = LayerNode.compile(BackgroundJob.node)
@@ -17,6 +17,21 @@ describe("BackgroundJob", () => {
 
       expect((yield* jobs.wait({ id: tagged.id })).info?.error).toBe("MessageLessError")
       expect((yield* jobs.wait({ id: withMessage.id })).info?.error).toBe("real message")
+    }).pipe(Effect.provide(jobsLayer)),
+  )
+
+  it.live("renders TimeoutError when a timed-out job settles", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const job = yield* jobs.start({
+        type: "test",
+        run: Effect.timeoutOrElse(Effect.never, {
+          duration: "1 millis",
+          orElse: () => Effect.fail(new Cause.TimeoutError()),
+        }),
+      })
+
+      expect((yield* jobs.wait({ id: job.id, timeout: 1_000 })).info?.error).toBe("TimeoutError")
     }).pipe(Effect.provide(jobsLayer)),
   )
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -257,7 +257,7 @@ export const TaskTool = Tool.define(
         yield* background.wait({ id: jobID }).pipe(
           Effect.flatMap((result) => {
             if (result.info?.status === "completed") return inject("completed", result.info.output ?? "")
-            if (result.info?.status === "error") return inject("error", result.info.error ?? "")
+            if (result.info?.status === "error") return inject("error", result.info.error || "Task failed")
             return Effect.void
           }),
           Effect.forkIn(scope, { startImmediately: true }),
@@ -336,7 +336,7 @@ export const TaskTool = Tool.define(
               background.waitForPromotion(nextSession.id),
             )
             if (result?.metadata?.background === true) return backgroundResult()
-            if (result?.status === "error") return yield* Effect.fail(new Error(result.error ?? "Task failed"))
+            if (result?.status === "error") return yield* Effect.fail(new Error(result.error || "Task failed"))
             if (result?.status === "cancelled") return yield* Effect.fail(new Error("Task cancelled"))
             return {
               title: params.description,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -956,6 +956,91 @@ describe("tool.task", () => {
     }),
   )
 
+  background.instance("notifies the parent with a fallback when a background task error is blank", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const injected = yield* Deferred.make<SessionPrompt.PromptInput>()
+      let error = ""
+      const fakeBackground: BackgroundJob.Interface = {
+        list: () => Effect.succeed([]),
+        get: () => Effect.succeed(undefined),
+        start: (input) =>
+          Effect.succeed({
+            id: input.id ?? "task",
+            type: input.type,
+            title: input.title,
+            status: "running",
+            started_at: 0,
+            metadata: input.metadata,
+          }),
+        extend: () => Effect.succeed(false),
+        wait: () => Effect.succeed({ timedOut: false, info: { id: "task", type: "task", status: "error", started_at: 0, error } }),
+        waitForPromotion: () => Effect.never,
+        promote: () => Effect.succeed(undefined),
+        cancel: () => Effect.succeed(undefined),
+      }
+      const task = yield* TaskTool.pipe(Effect.provideService(BackgroundJob.Service, fakeBackground))
+      const def = yield* task.init()
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+        prompt: (input) => {
+          if (input.sessionID === chat.id) return Deferred.succeed(injected, input).pipe(Effect.as(reply(input, "injected")))
+          return Effect.succeed(reply(input, "done"))
+        },
+      }
+      const execute = () =>
+        def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+            background: true,
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+      yield* execute()
+      const blank = yield* Deferred.await(injected)
+      expect(blank.parts[0]?.type).toBe("text")
+      if (blank.parts[0]?.type === "text") expect(blank.parts[0].text).toContain("Task failed")
+
+      error = "real task error"
+      const injectedReal = yield* Deferred.make<SessionPrompt.PromptInput>()
+      const realPromptOps = { ...promptOps, prompt: (input: SessionPrompt.PromptInput) => Deferred.succeed(injectedReal, input).pipe(Effect.as(reply(input, "injected"))) }
+      yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          background: true,
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: realPromptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+      const real = yield* Deferred.await(injectedReal)
+      expect(real.parts[0]?.type).toBe("text")
+      if (real.parts[0]?.type === "text") expect(real.parts[0].text).toContain("real task error")
+    }),
+  )
+
   background.instance("background task completion does not wait for the parent async prompt", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -894,6 +894,68 @@ describe("tool.task", () => {
     }),
   )
 
+  it.instance("uses a fallback when a foreground task error string is blank", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      let error = ""
+      const fakeBackground: BackgroundJob.Interface = {
+        list: () => Effect.succeed([]),
+        get: () => Effect.succeed(undefined),
+        start: (input) =>
+          Effect.succeed({
+            id: input.id ?? "task",
+            type: input.type,
+            title: input.title,
+            status: "running",
+            started_at: 0,
+            metadata: input.metadata,
+          }),
+        extend: () => Effect.succeed(false),
+        wait: () => Effect.succeed({ timedOut: false, info: { id: "task", type: "task", status: "error", started_at: 0, error } }),
+        waitForPromotion: () => Effect.never,
+        promote: () => Effect.succeed(undefined),
+        cancel: () => Effect.succeed(undefined),
+      }
+      const task = yield* TaskTool.pipe(Effect.provideService(BackgroundJob.Service, fakeBackground))
+      const def = yield* task.init()
+      const execute = () =>
+        def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "general",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps: stubOps() },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+      const blank = yield* execute().pipe(Effect.exit)
+      expect(Exit.isFailure(blank)).toBe(true)
+      if (Exit.isFailure(blank)) {
+        const failure = Cause.squash(blank.cause)
+        expect(failure).toBeInstanceOf(Error)
+        if (failure instanceof Error) expect(failure.message).toBe("Task failed")
+      }
+
+      error = "real task error"
+      const real = yield* execute().pipe(Effect.exit)
+      expect(Exit.isFailure(real)).toBe(true)
+      if (Exit.isFailure(real)) {
+        const failure = Cause.squash(real.cause)
+        expect(failure).toBeInstanceOf(Error)
+        if (failure instanceof Error) expect(failure.message).toBe("real task error")
+      }
+    }),
+  )
+
   background.instance("background task completion does not wait for the parent async prompt", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service


### PR DESCRIPTION
### Issue for this PR

Closes #41375

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A subagent task that fails with a tagged error reaches the parent as a frame with an empty error string. Two defects combine, one per commit.

**`errorText` returns `""` for most tagged errors.** `Schema.TaggedErrorClass` populates `.message` only from a field literally named `message`. Of the 114 `TaggedErrorClass` definitions in `packages/opencode/src` and `packages/core/src`, 37 have one — the other 77 have a blank `.message`. `errorText` in `packages/core/src/background-job.ts` returned `error.message` verbatim, so `settle` stored an empty string as the job's error.

It now prefers a non-blank `message`, then `_tag`, then `name`, then a non-blank `String(error)`, and never returns an empty string. Tagged errors carry their tag on both `_tag` and `name`; `_tag` is preferred because a plain `new Error("")` has `name === "Error"`, which is less useful but still better than nothing. Errors that already carry a real message take the first branch and are unaffected.

**`??` does not fire on an empty string.** Both consumers in `packages/opencode/src/tool/task.ts` used `result.error ?? "Task failed"`. `??` substitutes only for `null`/`undefined`, so a blank error passed straight through and the fallback was unreachable in exactly the case it was written for. Both now use `||`.

Either fix alone is incomplete: fixing only `errorText` leaves `??` dead code for any other blank-string source, and fixing only `??` throws away the tag that would have named the failure.

This is diagnosability, not behaviour. It does not change which errors occur or when a task fails — it makes the resulting frame say what went wrong.

### How did you verify your code works?

Red-first, with a mutation check on each fix: revert the source change, keep the test, confirm it goes red again.

```
core     bun typecheck && bun test test/background-job.test.ts     5 pass, 0 fail
opencode bun typecheck && bun test test/tool/task.test.ts          21 pass, 0 fail
opencode bun test                                                  3259 pass, 0 fail
```

Mutation, both source files reverted with tests kept:

```
core     4 pass, 1 fail   Expected "MessageLessError", Received ""
opencode 20 pass, 1 fail  Expected "Task failed", Received ""
```

Each test has a regression arm asserting an error with a real message still renders that message unchanged.

`errorText` is module-private, so it is tested through its observable effect — settle a job with a message-less tagged error, then read `info.error` — rather than exporting it for the test.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
