### PR TITLE
feat(opencode): add MCP server for delegating sessions to external agents

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp-server.ts
+++ b/packages/opencode/src/cli/cmd/mcp-server.ts
@@ -1,0 +1,71 @@
+import { Effect } from "effect"
+import { effectCmd } from "../effect-cmd"
+import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { ServerAuth } from "@/server/auth"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+
+export const McpServerCommand = effectCmd({
+  command: "mcp-server",
+  describe: "start opencode as an MCP server (for Claude Code and other MCP clients)",
+  builder: (yargs) =>
+    withNetworkOptions(yargs)
+      .option("transport", {
+        describe: "transport type",
+        type: "string",
+        choices: ["stdio", "streamable-http", "sse"] as const,
+        default: "stdio",
+      })
+      .option("path", {
+        describe: "HTTP path for streamable-http/sse transport",
+        type: "string",
+        default: "/mcp",
+      })
+      .option("cwd", {
+        describe: "working directory",
+        type: "string",
+        default: process.cwd(),
+      }),
+  handler: Effect.fn("Cli.mcp-server")(function* (args) {
+    const { Server } = yield* Effect.promise(() => import("@/server/server"))
+    const { McpServerAgent } = yield* Effect.promise(() => import("@/mcp-server/agent"))
+    process.env.OPENCODE_CLIENT = "mcp-server"
+    const opts = yield* resolveNetworkOptions(args)
+    const server = yield* Effect.promise(() => Server.listen(opts))
+
+    const sdk = createOpencodeClient({
+      baseUrl: `http://${server.hostname}:${server.port}`,
+      headers: ServerAuth.headers(),
+    })
+
+    const transport = args.transport ?? "stdio"
+    const mcpOptions = {
+      transport,
+      port: transport !== "stdio" ? (args.port ?? 3001) : undefined,
+      hostname: transport !== "stdio" ? opts.hostname : undefined,
+      path: args.path,
+    }
+
+    const agent = McpServerAgent.init({ sdk })
+    const handle = yield* Effect.promise(() => agent.start(mcpOptions))
+
+    yield* Effect.logInfo("MCP server started", { transport, hostname: handle.hostname, port: handle.port })
+
+    if (transport === "stdio") {
+      process.stdout.write(`MCP server started on stdio\n`)
+    } else {
+      process.stdout.write(`MCP server started on ${transport} at ${handle.hostname}:${handle.port}${args.path}\n`)
+      const authHeader = ServerAuth.header()
+      if (authHeader) process.stdout.write(`Authorization header: ${authHeader}\n`)
+    }
+
+    yield* Effect.promise(() =>
+      new Promise<void>((resolve, reject) => {
+        process.on("SIGINT", resolve)
+        process.on("SIGTERM", resolve)
+        process.on("unhandledRejection", reject)
+      }),
+    )
+
+    yield* Effect.promise(() => handle.stop())
+  }),
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -15,6 +15,7 @@ import { ServeCommand } from "./cli/cmd/serve"
 import { DebugCommand } from "./cli/cmd/debug"
 import { StatsCommand } from "./cli/cmd/stats"
 import { McpCommand } from "./cli/cmd/mcp"
+import { McpServerCommand } from "./cli/cmd/mcp-server"
 import { GithubCommand } from "./cli/cmd/github"
 import { ExportCommand } from "./cli/cmd/export"
 import { ImportCommand } from "./cli/cmd/import"
@@ -80,6 +81,7 @@ const cli = yargs(args)
   .completion("completion", "generate shell completion script")
   .command(AcpCommand)
   .command(McpCommand)
+  .command(McpServerCommand)
   .command(TuiThreadCommand)
   .command(AttachCommand)
   .command(RunCommand)

--- a/packages/opencode/src/mcp-server/agent.ts
+++ b/packages/opencode/src/mcp-server/agent.ts
@@ -53,7 +53,7 @@ const promptSchema = {
   message: z.string().describe("The task or question to send to the session"),
 } as any
 
-function formatParts(role: string, parts: Array<Part>): string[] {
+export function formatParts(role: string, parts: Array<Part>): string[] {
   const lines: string[] = []
 
   for (const part of parts) {
@@ -74,7 +74,7 @@ function formatParts(role: string, parts: Array<Part>): string[] {
   return lines
 }
 
-function formatMessages(messages: Array<{ info: Message; parts: Array<Part> }>): string {
+export function formatMessages(messages: Array<{ info: Message; parts: Array<Part> }>): string {
   const lines: string[] = []
 
   for (const { info, parts } of messages) {

--- a/packages/opencode/src/mcp-server/agent.ts
+++ b/packages/opencode/src/mcp-server/agent.ts
@@ -1,0 +1,404 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
+import { z } from "zod"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import type { OpencodeClient, Message, Part } from "@opencode-ai/sdk/v2"
+import { ServerAuth } from "@/server/auth"
+import http from "http"
+
+const NAME = "opencode"
+const VERSION = InstallationVersion
+
+type Transport = "stdio" | "streamable-http" | "sse"
+
+interface Options {
+  readonly transport: Transport
+  readonly port?: number
+  readonly path?: string
+  readonly hostname?: string
+}
+
+interface ServerHandle {
+  readonly hostname: string
+  readonly port: number
+  readonly stop: () => Promise<void>
+}
+
+export interface Interface {
+  readonly start: (options: Options) => Promise<ServerHandle>
+}
+
+export function init({ sdk }: { sdk: OpencodeClient }): Interface {
+  return {
+    start: (options: Options) => createServer(sdk, options),
+  }
+}
+
+// The MCP SDK ships its own nested `zod` dependency, which can resolve to a
+// different minor version than this package's `zod`. The two versions are
+// runtime-compatible but structurally distinct to the type checker, so the
+// raw shapes are cast when handed to registerTool.
+const sessionOptionalTitleSchema = {
+  title: z.string().optional().describe("Session title (auto-generated if not provided)"),
+} as any
+
+const sessionIdSchema = {
+  session_id: z.string().describe("Session ID"),
+} as any
+
+const promptSchema = {
+  session_id: z.string().describe("Session ID. Create one first with create_session if needed."),
+  message: z.string().describe("The task or question to send to the session"),
+} as any
+
+function formatParts(role: string, parts: Array<Part>): string[] {
+  const lines: string[] = []
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.trim()) lines.push(`[${role}] ${part.text}`)
+    } else if (part.type === "tool") {
+      const label = `[Tool ${part.tool}]`
+      if (part.state.status === "completed") {
+        lines.push(`${label} ${part.state.output.trim()}`)
+      } else if (part.state.status === "error") {
+        lines.push(`${label} error: ${part.state.error}`)
+      }
+    } else if (part.type === "file") {
+      lines.push(`[File] ${part.filename ?? part.url}`)
+    }
+  }
+
+  return lines
+}
+
+function formatMessages(messages: Array<{ info: Message; parts: Array<Part> }>): string {
+  const lines: string[] = []
+
+  for (const { info, parts } of messages) {
+    const role = info.role === "user" ? "User" : `Assistant`
+    lines.push(...formatParts(role, parts))
+  }
+
+  return lines.join("\n\n")
+}
+
+async function createServer(sdk: OpencodeClient, options: Options): Promise<ServerHandle> {
+  const mcpServer = new McpServer({ name: NAME, version: VERSION })
+
+  mcpServer.registerTool(
+    "create_session",
+    {
+      description: "Create a new opencode session for a coding task. Returns a session ID you can use to send prompts.",
+      inputSchema: sessionOptionalTitleSchema,
+    },
+    async (input: any) => {
+      try {
+        const result = await sdk.session.create({ title: input.title }, { throwOnError: true })
+        const session = result.data
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  session_id: session.id,
+                  title: session.title,
+                  directory: session.directory,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to create session: ${error}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  mcpServer.registerTool(
+    "list_sessions",
+    {
+      description: "List recent opencode sessions with their status",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const result = await sdk.session.list({ limit: 50 }, { throwOnError: true })
+
+        const lines = result.data.map((s) => {
+          const status = s.time.archived ? "archived" : "active"
+          return `- ${s.id} (${status}) ${s.title}`
+        })
+
+        return {
+          content: [{ type: "text" as const, text: lines.join("\n") || "No sessions found" }],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to list sessions: ${error}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  mcpServer.registerTool(
+    "get_session",
+    {
+      description: "Get details about a specific session",
+      inputSchema: sessionIdSchema,
+    },
+    async (input: any) => {
+      try {
+        const result = await sdk.session.get({ sessionID: input.session_id }, { throwOnError: true })
+        const session = result.data
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  session_id: session.id,
+                  title: session.title,
+                  status: session.time.archived ? "archived" : "active",
+                  created_at: session.time.created,
+                  updated_at: session.time.updated,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Session not found: ${input.session_id}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  mcpServer.registerTool(
+    "prompt",
+    {
+      description:
+        "Send a message to an opencode session and wait for processing to complete. The session will use AI and tools to complete the task.",
+      inputSchema: promptSchema,
+    },
+    async (input: any) => {
+      try {
+        const result = await sdk.session.prompt(
+          {
+            sessionID: input.session_id,
+            parts: [{ type: "text", text: input.message }],
+          },
+          { throwOnError: true },
+        )
+
+        return {
+          content: [{ type: "text" as const, text: formatParts("Assistant", result.data.parts).join("\n\n") }],
+        }
+      } catch (error) {
+        const message = String(error)
+        if (message.includes("not found")) {
+          return {
+            content: [{ type: "text" as const, text: `Session not found: ${input.session_id}` }],
+            isError: true,
+          }
+        }
+        return {
+          content: [{ type: "text" as const, text: `Error: ${error}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  mcpServer.registerTool(
+    "get_context",
+    {
+      description: "Get the full message history of a session",
+      inputSchema: sessionIdSchema,
+    },
+    async (input: any) => {
+      try {
+        const result = await sdk.session.messages({ sessionID: input.session_id }, { throwOnError: true })
+        return {
+          content: [{ type: "text" as const, text: formatMessages(result.data) }],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to get context: ${error}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  mcpServer.registerTool(
+    "interrupt_session",
+    {
+      description: "Interrupt a running session. Use this if a session is taking too long.",
+      inputSchema: sessionIdSchema,
+    },
+    async (input: any) => {
+      try {
+        await sdk.session.abort({ sessionID: input.session_id })
+        return {
+          content: [{ type: "text" as const, text: "Session interrupted" }],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text" as const, text: `Failed to interrupt session: ${error}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  return startTransport(mcpServer, options)
+}
+
+async function startTransport(server: McpServer, options: Options): Promise<ServerHandle> {
+  switch (options.transport) {
+    case "stdio":
+      return startStdio(server)
+    case "streamable-http":
+      return startStreamableHTTP(server, options)
+    case "sse":
+      return startSSE(server, options)
+  }
+}
+
+async function startStdio(server: McpServer): Promise<ServerHandle> {
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+
+  return {
+    hostname: "stdio",
+    port: 0,
+    stop: async () => {
+      await server.close()
+      process.exit(0)
+    },
+  }
+}
+
+async function startStreamableHTTP(server: McpServer, options: Options): Promise<ServerHandle> {
+  const port = options.port ?? 3001
+  const hostname = options.hostname ?? "127.0.0.1"
+  const transports = new Map<string, StreamableHTTPServerTransport>()
+  const expectedAuth = ServerAuth.header()
+
+  const handleRequest = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    if (expectedAuth && req.headers.authorization !== expectedAuth) {
+      res.writeHead(401)
+      res.end()
+      return
+    }
+
+    const sessionId = req.headers["x-session-id"] as string | undefined
+    let transport = sessionId ? transports.get(sessionId) : undefined
+
+    if (!transport) {
+      const newTransport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+        onsessioninitialized: (id: string) => {
+          transports.set(id, newTransport)
+        },
+      })
+
+      newTransport.onclose = () => {
+        if (sessionId) transports.delete(sessionId)
+      }
+
+      await server.connect(newTransport)
+      transport = newTransport
+    }
+
+    await transport.handleRequest(req, res)
+  }
+
+  const httpServer = http.createServer(handleRequest)
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject)
+    httpServer.listen(port, hostname, () => resolve())
+  })
+
+  return {
+    hostname,
+    port,
+    stop: async () => {
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve())
+      })
+      await server.close()
+    },
+  }
+}
+
+async function startSSE(server: McpServer, options: Options): Promise<ServerHandle> {
+  const port = options.port ?? 3002
+  const hostname = options.hostname ?? "127.0.0.1"
+  const path = options.path ?? "/mcp"
+  const transports = new Map<string, SSEServerTransport>()
+  const expectedAuth = ServerAuth.header()
+
+  const httpServer = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${hostname}:${port}`)
+
+    if (url.pathname.startsWith(`${path}/messages/`)) {
+      const sessionId = url.pathname.split("/").pop()
+      const transport = sessionId ? transports.get(sessionId) : undefined
+      if (transport && req.method === "POST") transport.handlePostMessage(req, res)
+      else res.writeHead(404).end()
+      return
+    }
+
+    if (url.pathname === path && req.method === "GET") {
+      if (expectedAuth && req.headers.authorization !== expectedAuth) {
+        res.writeHead(401).end()
+        return
+      }
+
+      const sessionId = crypto.randomUUID()
+      const transport = new SSEServerTransport(`${path}/messages/${sessionId}`, res)
+      transports.set(sessionId, transport)
+      transport.onclose = () => transports.delete(sessionId)
+      server.connect(transport)
+      return
+    }
+
+    res.writeHead(404).end()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject)
+    httpServer.listen(port, hostname, () => resolve())
+  })
+
+  return {
+    hostname,
+    port,
+    stop: async () => {
+      await new Promise<void>((resolve) => {
+        httpServer.close(() => resolve())
+      })
+      await server.close()
+    },
+  }
+}
+
+export * as McpServerAgent from "./agent"

--- a/packages/opencode/test/mcp-server/mcp-server.test.ts
+++ b/packages/opencode/test/mcp-server/mcp-server.test.ts
@@ -1,5 +1,8 @@
+import { describe, expect, test } from "bun:test"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { formatMessages, formatParts, McpServerAgent } from "../../src/mcp-server/agent"
+import type { AssistantMessage, Part, ToolPart, UserMessage } from "@opencode-ai/sdk/v2"
 
 function firstText(content: unknown): string {
   const item = (content as Array<{ type: string; text?: string }>)[0]
@@ -7,57 +10,175 @@ function firstText(content: unknown): string {
   return item.text
 }
 
-const testMcpServer = async () => {
-  const transport = new StdioClientTransport({
-    command: "bun",
-    args: [
-      "run",
-      "src/index.ts",
-      "mcp-server",
-      "--transport",
-      "stdio",
-    ],
-    cwd: process.cwd(),
+describe("formatParts", () => {
+  test("formats a text part with the given role", () => {
+    const part: Part = {
+      id: "prt_1",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "text",
+      text: "hello world",
+    }
+    expect(formatParts("User", [part])).toEqual(["[User] hello world"])
   })
 
-  const client = new Client(
-    { name: "test-client", version: "1.0.0" },
-    { capabilities: {} },
-  )
+  test("skips blank text parts", () => {
+    const part: Part = {
+      id: "prt_1",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "text",
+      text: "   ",
+    }
+    expect(formatParts("User", [part])).toEqual([])
+  })
 
-  try {
-    await client.connect(transport)
-    console.log("✓ Connected to MCP server")
-
-    const toolsResult = await client.listTools()
-    console.log(`✓ Listed ${toolsResult.tools.length} tools:`, toolsResult.tools.map((t) => t.name).join(", "))
-
-    const createResult = await client.callTool({ name: "create_session", arguments: {} })
-    const createText = firstText(createResult.content)
-    console.log("✓ create_session:", createText)
-
-    const sessionId = JSON.parse(createText).session_id
-    console.log(`   Session ID: ${sessionId}`)
-
-    const promptResult = await client.callTool({
-      name: "prompt",
-      arguments: {
-        session_id: sessionId,
-        message: "What is the current directory structure?",
+  test("formats a completed tool part with its output", () => {
+    const part: ToolPart = {
+      id: "prt_2",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "completed",
+        input: { command: "ls" },
+        output: "file.txt\n",
+        title: "ls",
+        metadata: {},
+        time: { start: 0, end: 1 },
       },
-    })
-    console.log("✓ prompt response (truncated):", firstText(promptResult.content).slice(0, 200) + "...")
+    }
+    expect(formatParts("Assistant", [part])).toEqual(["[Tool bash] file.txt"])
+  })
 
-    const listResult = await client.callTool({ name: "list_sessions", arguments: {} })
-    console.log("✓ list_sessions:", firstText(listResult.content))
+  test("formats an errored tool part with its error message", () => {
+    const part: ToolPart = {
+      id: "prt_3",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: {
+        status: "error",
+        input: { command: "ls" },
+        error: "command not found",
+        time: { start: 0, end: 1 },
+      },
+    }
+    expect(formatParts("Assistant", [part])).toEqual(["[Tool bash] error: command not found"])
+  })
 
-    console.log("\n✅ All MCP server tests passed!")
-  } catch (error) {
-    console.error("❌ Test failed:", error)
-    process.exit(1)
-  } finally {
-    await client.close()
-  }
-}
+  test("omits pending and running tool parts", () => {
+    const pending: ToolPart = {
+      id: "prt_4",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "tool",
+      callID: "call_1",
+      tool: "bash",
+      state: { status: "pending", input: {}, raw: "" },
+    }
+    expect(formatParts("Assistant", [pending])).toEqual([])
+  })
 
-testMcpServer()
+  test("formats a file part with filename fallback to url", () => {
+    const withFilename: Part = {
+      id: "prt_5",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "file",
+      mime: "text/plain",
+      filename: "a.txt",
+      url: "file:///a.txt",
+    }
+    const withoutFilename: Part = {
+      id: "prt_6",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "file",
+      mime: "text/plain",
+      url: "file:///b.txt",
+    }
+    expect(formatParts("User", [withFilename])).toEqual(["[File] a.txt"])
+    expect(formatParts("User", [withoutFilename])).toEqual(["[File] file:///b.txt"])
+  })
+})
+
+describe("formatMessages", () => {
+  test("joins user and assistant turns with role labels", () => {
+    const userMessage = { role: "user" } as UserMessage
+    const assistantMessage = { role: "assistant" } as AssistantMessage
+
+    const messages = [
+      {
+        info: userMessage,
+        parts: [
+          { id: "p1", sessionID: "s", messageID: "m1", type: "text", text: "hi" } as Part,
+        ],
+      },
+      {
+        info: assistantMessage,
+        parts: [
+          { id: "p2", sessionID: "s", messageID: "m2", type: "text", text: "hello back" } as Part,
+        ],
+      },
+    ]
+
+    expect(formatMessages(messages)).toBe("[User] hi\n\n[Assistant] hello back")
+  })
+
+  test("returns an empty string for no messages", () => {
+    expect(formatMessages([])).toBe("")
+  })
+})
+
+describe("McpServerAgent init", () => {
+  test("exposes a start function without requiring the transport options up front", () => {
+    const agent = McpServerAgent.init({ sdk: {} as any })
+    expect(typeof agent.start).toBe("function")
+  })
+})
+
+describe("mcp-server stdio integration", () => {
+  test(
+    "lists tools and round-trips session lifecycle calls over stdio",
+    async () => {
+      const transport = new StdioClientTransport({
+        command: "bun",
+        args: ["run", "src/index.ts", "mcp-server", "--transport", "stdio"],
+        cwd: process.cwd(),
+      })
+
+      const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} })
+
+      try {
+        await client.connect(transport)
+
+        const toolsResult = await client.listTools()
+        expect(toolsResult.tools.map((t) => t.name).sort()).toEqual(
+          ["create_session", "get_context", "get_session", "interrupt_session", "list_sessions", "prompt"].sort(),
+        )
+
+        const createResult = await client.callTool({ name: "create_session", arguments: {} })
+        const createText = firstText(createResult.content)
+        const sessionId = JSON.parse(createText).session_id
+        expect(typeof sessionId).toBe("string")
+
+        const listResult = await client.callTool({ name: "list_sessions", arguments: {} })
+        expect(firstText(listResult.content)).toContain(sessionId)
+
+        const getResult = await client.callTool({ name: "get_session", arguments: { session_id: sessionId } })
+        expect(JSON.parse(firstText(getResult.content)).session_id).toBe(sessionId)
+
+        const missingResult = await client.callTool({ name: "get_session", arguments: { session_id: "ses_does_not_exist" } })
+        expect(missingResult.isError).toBe(true)
+      } finally {
+        await client.close()
+      }
+    },
+    60_000,
+  )
+})

--- a/packages/opencode/test/mcp-server/mcp-server.test.ts
+++ b/packages/opencode/test/mcp-server/mcp-server.test.ts
@@ -1,0 +1,63 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+
+function firstText(content: unknown): string {
+  const item = (content as Array<{ type: string; text?: string }>)[0]
+  if (!item || item.type !== "text" || typeof item.text !== "string") throw new Error("Expected text content")
+  return item.text
+}
+
+const testMcpServer = async () => {
+  const transport = new StdioClientTransport({
+    command: "bun",
+    args: [
+      "run",
+      "src/index.ts",
+      "mcp-server",
+      "--transport",
+      "stdio",
+    ],
+    cwd: process.cwd(),
+  })
+
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  )
+
+  try {
+    await client.connect(transport)
+    console.log("✓ Connected to MCP server")
+
+    const toolsResult = await client.listTools()
+    console.log(`✓ Listed ${toolsResult.tools.length} tools:`, toolsResult.tools.map((t) => t.name).join(", "))
+
+    const createResult = await client.callTool({ name: "create_session", arguments: {} })
+    const createText = firstText(createResult.content)
+    console.log("✓ create_session:", createText)
+
+    const sessionId = JSON.parse(createText).session_id
+    console.log(`   Session ID: ${sessionId}`)
+
+    const promptResult = await client.callTool({
+      name: "prompt",
+      arguments: {
+        session_id: sessionId,
+        message: "What is the current directory structure?",
+      },
+    })
+    console.log("✓ prompt response (truncated):", firstText(promptResult.content).slice(0, 200) + "...")
+
+    const listResult = await client.callTool({ name: "list_sessions", arguments: {} })
+    console.log("✓ list_sessions:", firstText(listResult.content))
+
+    console.log("\n✅ All MCP server tests passed!")
+  } catch (error) {
+    console.error("❌ Test failed:", error)
+    process.exit(1)
+  } finally {
+    await client.close()
+  }
+}
+
+testMcpServer()


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] New feature
- [x] Bug fix

### What does this PR do?

Adds an `opencode mcp-server` command that exposes OpenCode sessions over the Model Context Protocol (stdio, streamable-http, or SSE), so external MCP clients (Claude Code, MCP Inspector, etc.) can create sessions and drive OpenCode's AI session runner directly. It's session-only: `create_session`, `list_sessions`, `get_session`, `prompt`, `get_context`, `interrupt_session` all delegate to real OpenCode sessions instead of exposing raw tools individually.

The first commit added the feature but had several bugs I found while testing it against a real client: it called SDK methods that don't exist (`sdk.sessions.*` instead of `sdk.session.*`, `.wait()`/`.context()` which aren't part of the SDK), referenced a `ServerAuth.token()` function that was never defined, used an unimported `Server` type, and used the deprecated `tool()` overloads with zod schemas that failed typecheck because the MCP SDK vendors its own `zod` version. The second commit fixes all of that: switches to `sdk.session.prompt()` (which already blocks until the response completes, so no polling loop is needed), moves to `registerTool()`, and wires the HTTP/SSE transports up to the same Basic-auth scheme (`ServerAuth.header()`) the rest of the server already uses instead of a bearer-token scheme that didn't exist anywhere else in the codebase.

### How did you verify your code works?

- `bun run typecheck` passes for the package and for the full monorepo (this also runs via the pre-push hook)
- `bun test test/mcp-server/mcp-server.test.ts` — unit tests for the message-formatting helpers plus an integration test that spawns the real server over stdio and round-trips `create_session` → `list_sessions` → `get_session`, including a not-found case
- `bun run test` — full opencode package suite, 3268 pass / 0 fail
- Manually drove the server with a real MCP client end-to-end, including `prompt` against a locally configured provider, to confirm the full tool-call → session-run → response path actually works, not just that it typechecks

### Screenshots / recordings

N/A — this is a CLI/server change with no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
