### PR TITLE
feat(desktop): add LAN mobile remote control

### DIFF
--- a/packages/app/e2e/smoke/remote-mobile.spec.ts
+++ b/packages/app/e2e/smoke/remote-mobile.spec.ts
@@ -1,0 +1,310 @@
+import { expect, test } from "@playwright/test"
+import * as http from "node:http"
+import type { AddressInfo } from "node:net"
+import { createRemoteGateway } from "../../../desktop/src/main/remote-gateway"
+import { markup as remoteMobileMarkup } from "../../../opencode/src/remote/mobile"
+
+const SESSION_ID = "ses_remote_e2e"
+const TICKET = "ticket-remote-e2e"
+const TOKEN = "grant-remote-e2e"
+
+type RemoteMessage = {
+  info: { role: "user" | "assistant" }
+  parts: Array<{ type: "text"; text: string }>
+}
+
+type RemotePermission = {
+  id: string
+  permission: string
+  patterns: string[]
+}
+
+type RemoteQuestion = {
+  id: string
+  questions: Array<{
+    question: string
+    header: string
+    multiple: boolean
+    custom: boolean
+    options: Array<{ label: string; description?: string }>
+  }>
+}
+
+type RemoteFixtureState = {
+  ticketRedeemed: boolean
+  messages: RemoteMessage[]
+  status: "idle" | "busy"
+  permissions: RemotePermission[]
+  questions: RemoteQuestion[]
+  prompt?: string
+  aborted: boolean
+  permissionReply?: string
+  questionAnswers?: string[][]
+}
+
+test.use({
+  viewport: { width: 390, height: 844 },
+  video: "on",
+})
+
+test.describe("smoke: mobile remote control", () => {
+  test("pairs and controls a desktop session through the LAN gateway", async ({ page, request }, testInfo) => {
+    const upstream = await startRemoteUpstream()
+    const gateway = createRemoteGateway({ upstreamUrl: upstream.origin })
+
+    try {
+      const info = await gateway.start()
+      const gatewayOrigin = `http://127.0.0.1:${info.port}`
+
+      const blocked = await request.get(`${gatewayOrigin}/session/${SESSION_ID}`)
+      expect(blocked.status()).toBe(404)
+
+      await page.goto(`${gatewayOrigin}/remote/mobile#ticket=${TICKET}`)
+
+      await expect(page).toHaveURL(`${gatewayOrigin}/remote/mobile`)
+      await expect(page.getByText("Remote E2E Session", { exact: true })).toBeVisible()
+      await expect(page.getByText("Desktop session is ready.", { exact: true })).toBeVisible()
+      await expect(page.getByText("idle · live", { exact: true })).toBeVisible()
+      await expect(page.getByRole("heading", { name: "Permission: bash" })).toBeVisible()
+      await expect(page.getByRole("heading", { name: "OpenCode needs your answer" })).toBeVisible()
+
+      await testInfo.attach("remote-mobile-paired", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+      })
+
+      await page.getByRole("button", { name: "Allow once" }).click()
+      await expect.poll(() => upstream.state.permissionReply).toBe("once")
+      await expect(page.getByRole("heading", { name: "Permission: bash" })).toBeHidden()
+
+      const question = page.getByRole("group", { name: "Continue?" })
+      await question.getByRole("radio", { name: /Yes/ }).check()
+      await page.getByRole("button", { name: "Submit" }).click()
+      await expect.poll(() => upstream.state.questionAnswers).toEqual([["Yes"]])
+      await expect(page.getByRole("heading", { name: "OpenCode needs your answer" })).toBeHidden()
+
+      const prompt = page.getByPlaceholder("Send an instruction to OpenCode…")
+      await prompt.fill("Summarize the latest changes")
+      await page.getByRole("button", { name: "Send" }).click()
+
+      await expect.poll(() => upstream.state.prompt).toBe("Summarize the latest changes")
+      await expect(prompt).toHaveValue("")
+      await expect(page.getByText("Summarize the latest changes", { exact: true })).toBeVisible()
+      await expect(page.getByText("Acknowledged from desktop.", { exact: true })).toBeVisible()
+      await expect(page.getByText("busy · live", { exact: true })).toBeVisible()
+
+      await testInfo.attach("remote-mobile-active", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+      })
+
+      await page.getByRole("button", { name: "Stop" }).click()
+      await expect.poll(() => upstream.state.aborted).toBe(true)
+      await expect(page.getByText("idle · live", { exact: true })).toBeVisible()
+    } finally {
+      await gateway.stop()
+      await upstream.close()
+    }
+  })
+})
+
+async function startRemoteUpstream() {
+  const streams = new Set<http.ServerResponse>()
+  const state: RemoteFixtureState = {
+    ticketRedeemed: false,
+    messages: [
+      {
+        info: { role: "assistant" },
+        parts: [{ type: "text", text: "Desktop session is ready." }],
+      },
+    ],
+    status: "idle",
+    permissions: [{ id: "per_remote_e2e", permission: "bash", patterns: ["git status"] }],
+    questions: [
+      {
+        id: "que_remote_e2e",
+        questions: [
+          {
+            question: "Continue?",
+            header: "Continue?",
+            multiple: false,
+            custom: false,
+            options: [
+              { label: "Yes", description: "Proceed with the task" },
+              { label: "No" },
+            ],
+          },
+        ],
+      },
+    ],
+    aborted: false,
+  }
+
+  const emit = (type: string) => {
+    const data = `event: message\ndata: ${JSON.stringify({ id: `evt_${type}`, type, properties: { sessionID: SESSION_ID } })}\n\n`
+    for (const stream of streams) {
+      if (stream.destroyed || stream.writableEnded) continue
+      stream.write(data)
+    }
+  }
+
+  const server = http.createServer((request, response) => {
+    void handleRemoteRequest({ request, response, state, streams, emit }).catch((error) => {
+      if (!response.headersSent) response.writeHead(500, { "content-type": "text/plain; charset=utf-8" })
+      response.end(error instanceof Error ? error.message : String(error))
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening)
+      reject(error)
+    }
+    const onListening = () => {
+      server.off("error", onError)
+      resolve()
+    }
+    server.once("error", onError)
+    server.once("listening", onListening)
+    server.listen(0, "127.0.0.1")
+  })
+
+  const address = server.address() as AddressInfo
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    state,
+    close: async () => {
+      for (const stream of streams) stream.end()
+      streams.clear()
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+        server.closeIdleConnections()
+        server.closeAllConnections()
+      })
+    },
+  }
+}
+
+async function handleRemoteRequest(input: {
+  request: http.IncomingMessage
+  response: http.ServerResponse
+  state: RemoteFixtureState
+  streams: Set<http.ServerResponse>
+  emit: (type: string) => void
+}) {
+  const { request, response, state, streams, emit } = input
+  const method = request.method ?? "GET"
+  const url = new URL(request.url ?? "/", "http://remote.test")
+
+  if (method === "GET" && url.pathname === "/remote/mobile") {
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "content-security-policy":
+        "default-src 'none'; connect-src 'self'; img-src 'self' data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+      "permissions-policy": "camera=(), microphone=(), geolocation=()",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    })
+    response.end(remoteMobileMarkup())
+    return
+  }
+
+  if (method === "POST" && url.pathname === "/remote/pair") {
+    const payload = await readJson(request)
+    if (state.ticketRedeemed || payload.ticket !== TICKET) {
+      response.writeHead(403).end()
+      return
+    }
+    state.ticketRedeemed = true
+    return json(response, { token: TOKEN, sessionID: SESSION_ID, expires_in: 3600 })
+  }
+
+  if (url.pathname.startsWith(`/remote/session/${SESSION_ID}`)) {
+    if (request.headers.authorization !== `Bearer ${TOKEN}`) {
+      response.writeHead(403).end()
+      return
+    }
+  }
+
+  const sessionRoot = `/remote/session/${SESSION_ID}`
+  if (method === "GET" && url.pathname === sessionRoot) {
+    return json(response, {
+      session: { title: "Remote E2E Session" },
+      messages: state.messages,
+      status: { type: state.status },
+      permissions: state.permissions,
+      questions: state.questions,
+    })
+  }
+
+  if (method === "GET" && url.pathname === `${sessionRoot}/events`) {
+    response.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache, no-transform",
+      "x-accel-buffering": "no",
+    })
+    streams.add(response)
+    response.write(
+      `event: message\ndata: ${JSON.stringify({ id: "evt_connected", type: "server.connected", properties: { sessionID: SESSION_ID } })}\n\n`,
+    )
+    request.once("close", () => streams.delete(response))
+    return
+  }
+
+  if (method === "POST" && url.pathname === `${sessionRoot}/permission/per_remote_e2e`) {
+    const payload = await readJson(request)
+    state.permissionReply = typeof payload.reply === "string" ? payload.reply : undefined
+    state.permissions = []
+    json(response, true)
+    emit("permission.replied")
+    return
+  }
+
+  if (method === "POST" && url.pathname === `${sessionRoot}/question/que_remote_e2e`) {
+    const payload = await readJson(request)
+    state.questionAnswers = Array.isArray(payload.answers) ? (payload.answers as string[][]) : undefined
+    state.questions = []
+    json(response, true)
+    emit("question.replied")
+    return
+  }
+
+  if (method === "POST" && url.pathname === `${sessionRoot}/message`) {
+    const payload = await readJson(request)
+    const parts = Array.isArray(payload.parts) ? payload.parts : []
+    const first = parts[0] as { type?: unknown; text?: unknown } | undefined
+    const text = first?.type === "text" && typeof first.text === "string" ? first.text : ""
+    state.prompt = text
+    state.status = "busy"
+    state.messages.push(
+      { info: { role: "user" }, parts: [{ type: "text", text }] },
+      { info: { role: "assistant" }, parts: [{ type: "text", text: "Acknowledged from desktop." }] },
+    )
+    response.writeHead(204).end()
+    emit("message.updated")
+    return
+  }
+
+  if (method === "POST" && url.pathname === `${sessionRoot}/abort`) {
+    state.aborted = true
+    state.status = "idle"
+    json(response, true)
+    emit("session.status")
+    return
+  }
+
+  response.writeHead(404).end()
+}
+
+async function readJson(request: http.IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  if (chunks.length === 0) return {}
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>
+}
+
+function json(response: http.ServerResponse, value: unknown) {
+  response.writeHead(200, { "content-type": "application/json; charset=utf-8" })
+  response.end(JSON.stringify(value))
+}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -33,6 +33,7 @@ import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { reviewTooltipKeybind } from "../command-tooltip-keybind"
 import { useTitlebarRightMount } from "../titlebar"
+import { SessionRemoteControl } from "./session-remote-control"
 
 const OPEN_APPS = [
   "vscode",
@@ -440,6 +441,7 @@ export function SessionHeader() {
                     </div>
                   </Show>
                   <div class="flex items-center gap-1">
+                    <SessionRemoteControl />
                     <Show when={status()}>
                       <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
                         <StatusPopover />
@@ -531,6 +533,7 @@ function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
 
   return (
     <div class="flex items-center gap-2">
+      <SessionRemoteControl />
       <Show when={props.state.statusVisible}>
         <Tooltip placement="bottom" value={props.state.statusLabel}>
           <StatusPopoverV2 />

--- a/packages/app/src/components/session/session-remote-control.tsx
+++ b/packages/app/src/components/session/session-remote-control.tsx
@@ -1,0 +1,226 @@
+import { Button } from "@opencode-ai/ui/button"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { Icon } from "@opencode-ai/ui/icon"
+import { Spinner } from "@opencode-ai/ui/spinner"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { createMemo, Show } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+import { useServer } from "@/context/server"
+import { useSessionLayout } from "@/pages/session/session-layout"
+import { decode64 } from "@/utils/base64"
+import { encodeRemoteQr, REMOTE_QR_QUIET_ZONE, REMOTE_QR_SIZE, remoteQrPath } from "@/utils/remote-qr"
+import { showToast } from "@/utils/toast"
+
+type PairingResult = {
+  ticket: string
+  expires_in: number
+}
+
+type RemoteDialogProps = {
+  url: string
+  modules: boolean[][]
+  onDisconnect: () => Promise<void>
+}
+
+export function SessionRemoteControl() {
+  const platform = usePlatform()
+  const server = useServer()
+  const language = useLanguage()
+  const dialog = useDialog()
+  const { params } = useSessionLayout()
+  const [state, setState] = createStore({ loading: false })
+
+  const directory = createMemo(() => decode64(params.dir) ?? "")
+  const sidecar = createMemo(() => {
+    const current = server.current
+    if (current?.type !== "sidecar" || current.variant !== "base") return
+    return current
+  })
+  const available = createMemo(
+    () =>
+      platform.platform === "desktop" &&
+      !!platform.startRemoteGateway &&
+      !!params.id &&
+      !!directory() &&
+      !!sidecar(),
+  )
+
+  const adminRequest = async (method: "POST" | "DELETE") => {
+    const current = sidecar()
+    const sessionID = params.id
+    const cwd = directory()
+    if (!current || !sessionID || !cwd) throw new Error("remote_admin_unavailable")
+
+    const url = new URL(`/session/${encodeURIComponent(sessionID)}/remote`, current.http.url)
+    url.searchParams.set("directory", cwd)
+    const headers = new Headers()
+    if (current.http.username !== undefined || current.http.password !== undefined) {
+      headers.set(
+        "authorization",
+        `Basic ${btoa(`${current.http.username ?? ""}:${current.http.password ?? ""}`)}`,
+      )
+    }
+    return (platform.fetch ?? fetch)(url, { method, headers })
+  }
+
+  const fail = (reason?: "no-lan") => {
+    showToast({
+      variant: "error",
+      title: language.t("session.remote.error.title"),
+      description: language.t(
+        reason === "no-lan" ? "session.remote.error.noLan" : "session.remote.error.description",
+      ),
+    })
+  }
+
+  const open = async () => {
+    if (state.loading || !available() || !platform.startRemoteGateway) return
+    setState("loading", true)
+    try {
+      const gateway = await platform.startRemoteGateway()
+      const base = gateway.urls[0]
+      if (!base) {
+        await platform.stopRemoteGateway?.().catch(() => undefined)
+        fail("no-lan")
+        return
+      }
+
+      const response = await adminRequest("POST")
+      if (!response.ok) throw new Error("remote_pair_failed")
+      const pairing = (await response.json()) as Partial<PairingResult>
+      if (typeof pairing.ticket !== "string" || typeof pairing.expires_in !== "number") {
+        throw new Error("remote_pair_invalid")
+      }
+
+      const mobile = new URL("/remote/mobile", base)
+      const url = `${mobile.toString()}#ticket=${encodeURIComponent(pairing.ticket)}`
+      const modules = encodeRemoteQr(url)
+      dialog.show(() => (
+        <RemoteControlDialog
+          url={url}
+          modules={modules}
+          onDisconnect={async () => {
+            const revoke = await adminRequest("DELETE")
+            if (!revoke.ok) throw new Error("remote_revoke_failed")
+          }}
+        />
+      ))
+    } catch {
+      fail()
+    } finally {
+      setState("loading", false)
+    }
+  }
+
+  return (
+    <Show when={available()}>
+      <Tooltip placement="bottom" value={language.t("session.remote.title")}>
+        <Button
+          type="button"
+          variant="ghost"
+          class="titlebar-icon w-8 h-6 p-0 box-border shrink-0"
+          disabled={state.loading}
+          onClick={() => void open()}
+          aria-label={language.t("session.remote.open")}
+        >
+          <Show when={!state.loading} fallback={<Spinner class="size-3.5" />}>
+            <Icon name="share" size="small" />
+          </Show>
+        </Button>
+      </Tooltip>
+    </Show>
+  )
+}
+
+function RemoteControlDialog(props: RemoteDialogProps) {
+  const language = useLanguage()
+  const dialog = useDialog()
+  const [state, setState] = createStore({ copying: false, disconnecting: false })
+  const size = REMOTE_QR_SIZE + REMOTE_QR_QUIET_ZONE * 2
+  const path = createMemo(() => remoteQrPath(props.modules, REMOTE_QR_QUIET_ZONE))
+
+  const copy = async () => {
+    if (state.copying) return
+    setState("copying", true)
+    try {
+      await navigator.clipboard.writeText(props.url)
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: language.t("session.remote.linkCopied"),
+      })
+    } catch {
+      showToast({
+        variant: "error",
+        title: language.t("session.remote.error.title"),
+        description: language.t("session.remote.error.description"),
+      })
+    } finally {
+      setState("copying", false)
+    }
+  }
+
+  const disconnect = async () => {
+    if (state.disconnecting) return
+    setState("disconnecting", true)
+    try {
+      await props.onDisconnect()
+      showToast({
+        variant: "success",
+        icon: "circle-check",
+        title: language.t("session.remote.disconnected"),
+      })
+      dialog.close()
+    } catch {
+      showToast({
+        variant: "error",
+        title: language.t("session.remote.error.title"),
+        description: language.t("session.remote.error.description"),
+      })
+    } finally {
+      setState("disconnecting", false)
+    }
+  }
+
+  return (
+    <Dialog title={language.t("session.remote.title")} description={language.t("session.remote.description")}>
+      <div class="flex flex-col gap-4 min-w-0">
+        <div class="flex justify-center rounded-lg bg-white p-3 self-center">
+          <svg
+            class="size-56 max-w-full"
+            viewBox={`0 0 ${size} ${size}`}
+            role="img"
+            aria-label={language.t("session.remote.open")}
+            shape-rendering="crispEdges"
+          >
+            <rect width={size} height={size} fill="white" />
+            <path d={path()} fill="black" />
+          </svg>
+        </div>
+
+        <p class="text-12-regular text-text-weak text-center">{language.t("session.remote.networkNote")}</p>
+        <code class="block max-w-[420px] overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-surface-raised-base px-3 py-2 text-11-regular text-text-weak">
+          {props.url}
+        </code>
+
+        <div class="flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={() => void copy()} disabled={state.copying}>
+            <Show when={!state.copying} fallback={<Spinner class="size-3.5" />}>
+              <Icon name="copy" size="small" />
+            </Show>
+            {language.t("session.remote.copyLink")}
+          </Button>
+          <Button type="button" variant="ghost" onClick={() => void disconnect()} disabled={state.disconnecting}>
+            <Show when={!state.disconnecting} fallback={<Spinner class="size-3.5" />}>
+              <Icon name="close-small" size="small" />
+            </Show>
+            {language.t("session.remote.disconnect")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/session/session-remote-control.tsx
+++ b/packages/app/src/components/session/session-remote-control.tsx
@@ -14,11 +14,6 @@ import { decode64 } from "@/utils/base64"
 import { encodeRemoteQr, REMOTE_QR_QUIET_ZONE, REMOTE_QR_SIZE, remoteQrPath } from "@/utils/remote-qr"
 import { showToast } from "@/utils/toast"
 
-type PairingResult = {
-  ticket: string
-  expires_in: number
-}
-
 type RemoteDialogProps = {
   url: string
   modules: boolean[][]
@@ -34,37 +29,19 @@ export function SessionRemoteControl() {
   const [state, setState] = createStore({ loading: false })
 
   const directory = createMemo(() => decode64(params.dir) ?? "")
-  const sidecar = createMemo(() => {
+  const localSidecar = createMemo(() => {
     const current = server.current
-    if (current?.type !== "sidecar" || current.variant !== "base") return
-    return current
+    return current?.type === "sidecar" && current.variant === "base"
   })
   const available = createMemo(
     () =>
       platform.platform === "desktop" &&
-      !!platform.startRemoteGateway &&
+      !!platform.createRemotePairing &&
+      !!platform.revokeRemotePairing &&
       !!params.id &&
       !!directory() &&
-      !!sidecar(),
+      localSidecar(),
   )
-
-  const adminRequest = async (method: "POST" | "DELETE") => {
-    const current = sidecar()
-    const sessionID = params.id
-    const cwd = directory()
-    if (!current || !sessionID || !cwd) throw new Error("remote_admin_unavailable")
-
-    const url = new URL(`/session/${encodeURIComponent(sessionID)}/remote`, current.http.url)
-    url.searchParams.set("directory", cwd)
-    const headers = new Headers()
-    if (current.http.username !== undefined || current.http.password !== undefined) {
-      headers.set(
-        "authorization",
-        `Basic ${btoa(`${current.http.username ?? ""}:${current.http.password ?? ""}`)}`,
-      )
-    }
-    return (platform.fetch ?? fetch)(url, { method, headers })
-  }
 
   const fail = (reason?: "no-lan") => {
     showToast({
@@ -77,39 +54,26 @@ export function SessionRemoteControl() {
   }
 
   const open = async () => {
-    if (state.loading || !available() || !platform.startRemoteGateway) return
+    const sessionID = params.id
+    const cwd = directory()
+    if (state.loading || !available() || !platform.createRemotePairing || !sessionID || !cwd) return
+
     setState("loading", true)
     try {
-      const gateway = await platform.startRemoteGateway()
-      const base = gateway.urls[0]
-      if (!base) {
-        await platform.stopRemoteGateway?.().catch(() => undefined)
-        fail("no-lan")
-        return
-      }
-
-      const response = await adminRequest("POST")
-      if (!response.ok) throw new Error("remote_pair_failed")
-      const pairing = (await response.json()) as Partial<PairingResult>
-      if (typeof pairing.ticket !== "string" || typeof pairing.expires_in !== "number") {
-        throw new Error("remote_pair_invalid")
-      }
-
-      const mobile = new URL("/remote/mobile", base)
-      const url = `${mobile.toString()}#ticket=${encodeURIComponent(pairing.ticket)}`
-      const modules = encodeRemoteQr(url)
+      const pairing = await platform.createRemotePairing(sessionID, cwd)
+      const modules = encodeRemoteQr(pairing.url)
       dialog.show(() => (
         <RemoteControlDialog
-          url={url}
+          url={pairing.url}
           modules={modules}
           onDisconnect={async () => {
-            const revoke = await adminRequest("DELETE")
-            if (!revoke.ok) throw new Error("remote_revoke_failed")
+            if (!platform.revokeRemotePairing) throw new Error("remote_revoke_unavailable")
+            await platform.revokeRemotePairing(sessionID, cwd)
           }}
         />
       ))
-    } catch {
-      fail()
+    } catch (error) {
+      fail(error instanceof Error && error.message.includes("No local network address") ? "no-lan" : undefined)
     } finally {
       setState("loading", false)
     }

--- a/packages/app/src/components/session/session-remote-control.tsx
+++ b/packages/app/src/components/session/session-remote-control.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { createMemo, Show } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
@@ -15,8 +15,7 @@ import { encodeRemoteQr, REMOTE_QR_QUIET_ZONE, REMOTE_QR_SIZE, remoteQrPath } fr
 import { showToast } from "@/utils/toast"
 
 type RemoteDialogProps = {
-  url: string
-  modules: boolean[][]
+  urls: string[]
   onDisconnect: () => Promise<void>
 }
 
@@ -61,11 +60,10 @@ export function SessionRemoteControl() {
     setState("loading", true)
     try {
       const pairing = await platform.createRemotePairing(sessionID, cwd)
-      const modules = encodeRemoteQr(pairing.url)
+      const urls = pairing.urls.length > 0 ? pairing.urls : [pairing.url]
       dialog.show(() => (
         <RemoteControlDialog
-          url={pairing.url}
-          modules={modules}
+          urls={urls}
           onDisconnect={async () => {
             if (!platform.revokeRemotePairing) throw new Error("remote_revoke_unavailable")
             await platform.revokeRemotePairing(sessionID, cwd)
@@ -102,15 +100,17 @@ export function SessionRemoteControl() {
 function RemoteControlDialog(props: RemoteDialogProps) {
   const language = useLanguage()
   const dialog = useDialog()
-  const [state, setState] = createStore({ copying: false, disconnecting: false })
+  const [state, setState] = createStore({ copying: false, disconnecting: false, index: 0 })
   const size = REMOTE_QR_SIZE + REMOTE_QR_QUIET_ZONE * 2
-  const path = createMemo(() => remoteQrPath(props.modules, REMOTE_QR_QUIET_ZONE))
+  const url = createMemo(() => props.urls[state.index] ?? props.urls[0]!)
+  const modules = createMemo(() => encodeRemoteQr(url()))
+  const path = createMemo(() => remoteQrPath(modules(), REMOTE_QR_QUIET_ZONE))
 
   const copy = async () => {
     if (state.copying) return
     setState("copying", true)
     try {
-      await navigator.clipboard.writeText(props.url)
+      await navigator.clipboard.writeText(url())
       showToast({
         variant: "success",
         icon: "circle-check",
@@ -166,8 +166,25 @@ function RemoteControlDialog(props: RemoteDialogProps) {
         </div>
 
         <p class="text-12-regular text-text-weak text-center">{language.t("session.remote.networkNote")}</p>
+        <Show when={props.urls.length > 1}>
+          <div class="flex flex-wrap items-center justify-center gap-1.5">
+            <For each={props.urls}>
+              {(item, index) => (
+                <Button
+                  type="button"
+                  size="small"
+                  variant={state.index === index() ? "secondary" : "ghost"}
+                  aria-pressed={state.index === index()}
+                  onClick={() => setState("index", index())}
+                >
+                  {new URL(item).hostname}
+                </Button>
+              )}
+            </For>
+          </div>
+        </Show>
         <code class="block max-w-[420px] overflow-hidden text-ellipsis whitespace-nowrap rounded-md bg-surface-raised-base px-3 py-2 text-11-regular text-text-weak">
-          {props.url}
+          {url()}
         </code>
 
         <div class="flex items-center justify-end gap-2">

--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -5,6 +5,7 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { pluralCategory, type UiI18nPluralKey } from "@opencode-ai/ui/context/i18n"
 import { Persist, persisted } from "@/utils/persist"
 import { dict as en } from "@/i18n/en"
+import { dict as remoteEn } from "@/i18n/remote"
 import { dict as uiEn } from "@opencode-ai/ui/i18n/en"
 import {
   createDesktopNativeBundle,
@@ -26,7 +27,7 @@ function localeDirection(locale: Locale): Direction {
   return RTL_LOCALES.has(locale) ? "rtl" : "ltr"
 }
 
-type RawDictionary = typeof en & typeof uiEn
+type RawDictionary = typeof en & typeof remoteEn & typeof uiEn
 type Dictionary = i18n.Flatten<RawDictionary>
 type PluralKey =
   | UiI18nPluralKey
@@ -43,7 +44,7 @@ const LOCALES: readonly Locale[] = DESKTOP_NATIVE_LOCALES
 
 const INTL = DESKTOP_NATIVE_LOCALE_TAGS
 
-const base = i18n.flatten({ ...en, ...uiEn })
+const base = i18n.flatten({ ...en, ...remoteEn, ...uiEn })
 const dicts = new Map<Locale, Dictionary>([["en", base]])
 
 const merge = (app: Promise<Source>, ui: Promise<Source>) =>

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -20,6 +20,11 @@ type SaveFilePickerOptions = { title?: string; defaultPath?: string }
 type PlatformName = "web" | "desktop"
 type DesktopOS = "macos" | "windows" | "linux"
 
+export type RemoteGatewayInfo = {
+  port: number
+  urls: string[]
+}
+
 export type FatalRendererErrorLog = {
   error: string
   url: string
@@ -82,6 +87,15 @@ type PlatformBase = {
 
   /** Set the default server URL to use on app startup (platform-specific) */
   setDefaultServer?(url: ServerConnection.Key | null): Promise<void> | void
+
+  /** Start the desktop LAN gateway for mobile remote control. */
+  startRemoteGateway?(): Promise<RemoteGatewayInfo>
+
+  /** Stop the desktop LAN gateway for mobile remote control. */
+  stopRemoteGateway?(): Promise<void>
+
+  /** Read the active desktop LAN gateway, if any. */
+  getRemoteGatewayStatus?(): Promise<RemoteGatewayInfo | null>
 
   /** Manage WSL sidecar servers (Electron on Windows only) */
   wslServers?: WslServersPlatform

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -20,9 +20,10 @@ type SaveFilePickerOptions = { title?: string; defaultPath?: string }
 type PlatformName = "web" | "desktop"
 type DesktopOS = "macos" | "windows" | "linux"
 
-export type RemoteGatewayInfo = {
-  port: number
+export type RemotePairingInfo = {
+  url: string
   urls: string[]
+  expiresIn: number
 }
 
 export type FatalRendererErrorLog = {
@@ -88,14 +89,11 @@ type PlatformBase = {
   /** Set the default server URL to use on app startup (platform-specific) */
   setDefaultServer?(url: ServerConnection.Key | null): Promise<void> | void
 
-  /** Start the desktop LAN gateway for mobile remote control. */
-  startRemoteGateway?(): Promise<RemoteGatewayInfo>
+  /** Create a one-time mobile remote-control pairing for a local desktop session. */
+  createRemotePairing?(sessionID: string, directory: string): Promise<RemotePairingInfo>
 
-  /** Stop the desktop LAN gateway for mobile remote control. */
-  stopRemoteGateway?(): Promise<void>
-
-  /** Read the active desktop LAN gateway, if any. */
-  getRemoteGatewayStatus?(): Promise<RemoteGatewayInfo | null>
+  /** Revoke mobile remote access for a local desktop session. */
+  revokeRemotePairing?(sessionID: string, directory: string): Promise<void>
 
   /** Manage WSL sidecar servers (Electron on Windows only) */
   wslServers?: WslServersPlatform

--- a/packages/app/src/i18n/remote.ts
+++ b/packages/app/src/i18n/remote.ts
@@ -1,0 +1,13 @@
+export const dict = {
+  "session.remote.title": "Remote control",
+  "session.remote.open": "Open remote control",
+  "session.remote.description": "Scan this QR code with a phone on the same local network to control this session.",
+  "session.remote.networkNote": "The phone and this computer must be on the same local network.",
+  "session.remote.copyLink": "Copy link",
+  "session.remote.linkCopied": "Remote link copied",
+  "session.remote.disconnect": "Disconnect phone",
+  "session.remote.disconnected": "Remote access disconnected",
+  "session.remote.error.title": "Remote control unavailable",
+  "session.remote.error.description": "Could not create a local remote-control link for this session.",
+  "session.remote.error.noLan": "No local network address is available for remote control.",
+} as const

--- a/packages/app/src/utils/remote-qr.test.ts
+++ b/packages/app/src/utils/remote-qr.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { encodeRemoteQr, REMOTE_QR_SIZE, remoteQrPath } from "./remote-qr"
+
+describe("remote qr", () => {
+  test("encodes a representative LAN pairing URL", () => {
+    const value = `http://192.168.1.10:4123/remote/mobile#ticket=${"a".repeat(43)}`
+    const modules = encodeRemoteQr(value)
+
+    expect(modules).toHaveLength(REMOTE_QR_SIZE)
+    expect(modules.every((row) => row.length === REMOTE_QR_SIZE)).toBe(true)
+    expect(modules.flat().filter(Boolean)).toHaveLength(878)
+    expect(remoteQrPath(modules)).toContain("M4 4h1v1h-1z")
+  })
+
+  test("is deterministic", () => {
+    const value = `http://10.0.0.5:4096/remote/mobile#ticket=${"b".repeat(43)}`
+    expect(encodeRemoteQr(value)).toEqual(encodeRemoteQr(value))
+  })
+
+  test("rejects values larger than the version 6 byte capacity", () => {
+    expect(() => encodeRemoteQr("x".repeat(135))).toThrow("remote_qr_payload_too_long")
+  })
+})

--- a/packages/app/src/utils/remote-qr.ts
+++ b/packages/app/src/utils/remote-qr.ts
@@ -1,0 +1,187 @@
+const VERSION = 6
+const SIZE = 17 + VERSION * 4
+const DATA_CODEWORDS = 136
+const BLOCK_DATA_CODEWORDS = 68
+const ECC_CODEWORDS = 18
+const MAX_BYTE_PAYLOAD = 134
+const REMAINDER_BITS = 7
+
+export function encodeRemoteQr(value: string) {
+  const bytes = new TextEncoder().encode(value)
+  if (bytes.length > MAX_BYTE_PAYLOAD) throw new Error("remote_qr_payload_too_long")
+
+  const data = encodeData(bytes)
+  const divisor = reedSolomonDivisor(ECC_CODEWORDS)
+  const blocks = [data.slice(0, BLOCK_DATA_CODEWORDS), data.slice(BLOCK_DATA_CODEWORDS)]
+  const ecc = blocks.map((block) => reedSolomonRemainder(block, divisor))
+  const codewords: number[] = []
+
+  for (let i = 0; i < BLOCK_DATA_CODEWORDS; i++) {
+    codewords.push(blocks[0]![i]!, blocks[1]![i]!)
+  }
+  for (let i = 0; i < ECC_CODEWORDS; i++) {
+    codewords.push(ecc[0]![i]!, ecc[1]![i]!)
+  }
+
+  const dataBits = codewords.flatMap((byte) => byteBits(byte))
+  dataBits.push(...Array(REMAINDER_BITS).fill(0))
+
+  const modules = Array.from({ length: SIZE }, () => Array<boolean>(SIZE).fill(false))
+  const functionModules = Array.from({ length: SIZE }, () => Array<boolean>(SIZE).fill(false))
+
+  const setFunction = (x: number, y: number, dark: boolean) => {
+    if (x < 0 || y < 0 || x >= SIZE || y >= SIZE) return
+    modules[y]![x] = dark
+    functionModules[y]![x] = true
+  }
+
+  for (let i = 0; i < SIZE; i++) {
+    setFunction(6, i, i % 2 === 0)
+    setFunction(i, 6, i % 2 === 0)
+  }
+
+  drawFinder(setFunction, 3, 3)
+  drawFinder(setFunction, SIZE - 4, 3)
+  drawFinder(setFunction, 3, SIZE - 4)
+  drawAlignment(setFunction, 34, 34)
+  drawFormat(setFunction, 0)
+
+  let bitIndex = 0
+  let upward = true
+  for (let right = SIZE - 1; right >= 1; right -= 2) {
+    if (right === 6) right -= 1
+    for (let vertical = 0; vertical < SIZE; vertical++) {
+      const y = upward ? SIZE - 1 - vertical : vertical
+      for (let offset = 0; offset < 2; offset++) {
+        const x = right - offset
+        if (functionModules[y]![x]) continue
+        let bit = dataBits[bitIndex++] ?? 0
+        if ((x + y) % 2 === 0) bit ^= 1
+        modules[y]![x] = bit !== 0
+      }
+    }
+    upward = !upward
+  }
+
+  if (bitIndex !== dataBits.length) throw new Error("remote_qr_layout_mismatch")
+  return modules
+}
+
+export function remoteQrPath(modules: boolean[][], quietZone = 4) {
+  const path: string[] = []
+  for (let y = 0; y < modules.length; y++) {
+    const row = modules[y]!
+    for (let x = 0; x < row.length; x++) {
+      if (!row[x]) continue
+      path.push(`M${x + quietZone} ${y + quietZone}h1v1h-1z`)
+    }
+  }
+  return path.join("")
+}
+
+export const REMOTE_QR_SIZE = SIZE
+export const REMOTE_QR_QUIET_ZONE = 4
+
+function encodeData(bytes: Uint8Array) {
+  const bits: number[] = []
+  appendBits(bits, 0b0100, 4)
+  appendBits(bits, bytes.length, 8)
+  for (const byte of bytes) appendBits(bits, byte, 8)
+
+  const capacity = DATA_CODEWORDS * 8
+  const terminator = Math.min(4, capacity - bits.length)
+  bits.push(...Array(Math.max(0, terminator)).fill(0))
+  while (bits.length % 8 !== 0) bits.push(0)
+
+  const result: number[] = []
+  for (let i = 0; i < bits.length; i += 8) {
+    let value = 0
+    for (let j = 0; j < 8; j++) value = (value << 1) | bits[i + j]!
+    result.push(value)
+  }
+
+  for (let pad = 0; result.length < DATA_CODEWORDS; pad++) result.push(pad % 2 === 0 ? 0xec : 0x11)
+  return result
+}
+
+function appendBits(target: number[], value: number, count: number) {
+  for (let i = count - 1; i >= 0; i--) target.push((value >>> i) & 1)
+}
+
+function byteBits(value: number) {
+  return Array.from({ length: 8 }, (_, i) => (value >>> (7 - i)) & 1)
+}
+
+function drawFinder(setFunction: (x: number, y: number, dark: boolean) => void, centerX: number, centerY: number) {
+  for (let dy = -4; dy <= 4; dy++) {
+    for (let dx = -4; dx <= 4; dx++) {
+      const distance = Math.max(Math.abs(dx), Math.abs(dy))
+      setFunction(centerX + dx, centerY + dy, distance !== 2 && distance !== 4)
+    }
+  }
+}
+
+function drawAlignment(
+  setFunction: (x: number, y: number, dark: boolean) => void,
+  centerX: number,
+  centerY: number,
+) {
+  for (let dy = -2; dy <= 2; dy++) {
+    for (let dx = -2; dx <= 2; dx++) {
+      setFunction(centerX + dx, centerY + dy, Math.max(Math.abs(dx), Math.abs(dy)) !== 1)
+    }
+  }
+}
+
+function drawFormat(setFunction: (x: number, y: number, dark: boolean) => void, mask: number) {
+  const data = (1 << 3) | mask
+  let remainder = data
+  for (let i = 0; i < 10; i++) remainder = (remainder << 1) ^ ((remainder >>> 9) * 0x537)
+  const bits = ((data << 10) | remainder) ^ 0x5412
+  const dark = (index: number) => ((bits >>> index) & 1) !== 0
+
+  for (let i = 0; i <= 5; i++) setFunction(8, i, dark(i))
+  setFunction(8, 7, dark(6))
+  setFunction(8, 8, dark(7))
+  setFunction(7, 8, dark(8))
+  for (let i = 9; i < 15; i++) setFunction(14 - i, 8, dark(i))
+
+  for (let i = 0; i < 8; i++) setFunction(SIZE - 1 - i, 8, dark(i))
+  for (let i = 8; i < 15; i++) setFunction(8, SIZE - 15 + i, dark(i))
+  setFunction(8, SIZE - 8, true)
+}
+
+function reedSolomonDivisor(degree: number) {
+  const result = new Uint8Array(degree)
+  result[degree - 1] = 1
+  let root = 1
+
+  for (let i = 0; i < degree; i++) {
+    for (let j = 0; j < degree; j++) {
+      result[j] = finiteFieldMultiply(result[j]!, root)
+      if (j + 1 < degree) result[j] ^= result[j + 1]!
+    }
+    root = finiteFieldMultiply(root, 0x02)
+  }
+  return result
+}
+
+function reedSolomonRemainder(data: number[], divisor: Uint8Array) {
+  const result = new Uint8Array(divisor.length)
+  for (const byte of data) {
+    const factor = byte ^ result[0]!
+    result.copyWithin(0, 1)
+    result[result.length - 1] = 0
+    for (let i = 0; i < divisor.length; i++) result[i] ^= finiteFieldMultiply(divisor[i]!, factor)
+  }
+  return result
+}
+
+function finiteFieldMultiply(x: number, y: number) {
+  let z = 0
+  for (let i = 7; i >= 0; i--) {
+    z = (z << 1) ^ ((z >>> 7) * 0x11d)
+    if (((y >>> i) & 1) !== 0) z ^= x
+  }
+  return z & 0xff
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -25,6 +25,7 @@ import { createUpdaterSubscriptions } from "./updater-subscriptions"
 import { createDesktopDraftStore } from "./draft-store"
 import { nativeT } from "./native-translations"
 import { createRemoteGatewayController } from "./remote-gateway-controller"
+import { createRemotePairingController } from "./remote-pairing-controller"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -55,11 +56,21 @@ type Deps = {
   setNativeTranslations: (bundle: DesktopNativeBundle) => void
 }
 
+function remotePairingTarget(sessionID: unknown, directory: unknown) {
+  if (typeof sessionID !== "string" || sessionID.length === 0) throw new Error("Invalid remote session ID")
+  if (typeof directory !== "string" || directory.length === 0) throw new Error("Invalid remote session directory")
+  return { sessionID, directory }
+}
+
 export function registerIpcHandlers(deps: Deps) {
   const drafts = createDesktopDraftStore(join(app.getPath("userData"), "drafts.sqlite"))
   const updaterSubscriptions = createUpdaterSubscriptions()
   const remoteGateway = createRemoteGatewayController({
     getUpstreamUrl: () => deps.awaitInitialization().then((data) => data.url),
+  })
+  const remotePairing = createRemotePairingController({
+    getSidecar: deps.awaitInitialization,
+    gateway: remoteGateway,
   })
   app.once("will-quit", updaterSubscriptions.clear)
   app.on("before-quit", () => drafts.flush())
@@ -72,9 +83,14 @@ export function registerIpcHandlers(deps: Deps) {
     return deps.killSidecar()
   })
   ipcMain.handle("await-initialization", () => deps.awaitInitialization())
-  ipcMain.handle("remote-gateway-start", () => remoteGateway.start())
-  ipcMain.handle("remote-gateway-stop", () => remoteGateway.stop())
-  ipcMain.handle("remote-gateway-status", () => remoteGateway.status() ?? null)
+  ipcMain.handle("remote-pairing-create", (_event: IpcMainInvokeEvent, sessionID: unknown, directory: unknown) => {
+    const target = remotePairingTarget(sessionID, directory)
+    return remotePairing.create(target.sessionID, target.directory)
+  })
+  ipcMain.handle("remote-pairing-revoke", (_event: IpcMainInvokeEvent, sessionID: unknown, directory: unknown) => {
+    const target = remotePairingTarget(sessionID, directory)
+    return remotePairing.revoke(target.sessionID, target.directory)
+  })
   ipcMain.handle("consume-initial-deep-links", () => deps.consumeInitialDeepLinks())
   ipcMain.handle("get-default-server-url", () => deps.getDefaultServerUrl())
   ipcMain.handle("set-default-server-url", (_event: IpcMainInvokeEvent, url: string | null) =>

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -24,6 +24,7 @@ import type { UpdaterController } from "./updater-controller"
 import { createUpdaterSubscriptions } from "./updater-subscriptions"
 import { createDesktopDraftStore } from "./draft-store"
 import { nativeT } from "./native-translations"
+import { createRemoteGatewayController } from "./remote-gateway-controller"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -57,13 +58,23 @@ type Deps = {
 export function registerIpcHandlers(deps: Deps) {
   const drafts = createDesktopDraftStore(join(app.getPath("userData"), "drafts.sqlite"))
   const updaterSubscriptions = createUpdaterSubscriptions()
+  const remoteGateway = createRemoteGatewayController({
+    getUpstreamUrl: () => deps.awaitInitialization().then((data) => data.url),
+  })
   app.once("will-quit", updaterSubscriptions.clear)
   app.on("before-quit", () => drafts.flush())
   app.once("will-quit", () => drafts.close())
+  app.once("will-quit", () => void remoteGateway.stop())
   app.on("browser-window-created", (_event, win) => win.on("session-end", () => drafts.flush()))
 
-  ipcMain.handle("kill-sidecar", () => deps.killSidecar())
+  ipcMain.handle("kill-sidecar", async () => {
+    await remoteGateway.stop()
+    return deps.killSidecar()
+  })
   ipcMain.handle("await-initialization", () => deps.awaitInitialization())
+  ipcMain.handle("remote-gateway-start", () => remoteGateway.start())
+  ipcMain.handle("remote-gateway-stop", () => remoteGateway.stop())
+  ipcMain.handle("remote-gateway-status", () => remoteGateway.status() ?? null)
   ipcMain.handle("consume-initial-deep-links", () => deps.consumeInitialDeepLinks())
   ipcMain.handle("get-default-server-url", () => deps.getDefaultServerUrl())
   ipcMain.handle("set-default-server-url", (_event: IpcMainInvokeEvent, url: string | null) =>

--- a/packages/desktop/src/main/remote-gateway-controller.test.ts
+++ b/packages/desktop/src/main/remote-gateway-controller.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { RemoteGatewayInfo } from "./remote-gateway"
 import { createRemoteGatewayController } from "./remote-gateway-controller"
 
-function fakeGateway(info: RemoteGatewayInfo) {
+function fakeGateway(info: RemoteGatewayInfo, beforeStop?: Promise<void>) {
   let running: RemoteGatewayInfo | undefined
   let starts = 0
   let stops = 0
@@ -15,6 +15,7 @@ function fakeGateway(info: RemoteGatewayInfo) {
       },
       stop: async () => {
         stops += 1
+        await beforeStop
         running = undefined
       },
       status: () => running,
@@ -22,6 +23,14 @@ function fakeGateway(info: RemoteGatewayInfo) {
     starts: () => starts,
     stops: () => stops,
   }
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
 }
 
 describe("remote gateway controller", () => {
@@ -67,6 +76,36 @@ describe("remote gateway controller", () => {
 
     await controller.start()
     expect(created).toHaveLength(2)
+    expect(created[1]?.starts()).toBe(1)
+  })
+
+  test("start waits for an in-flight stop before replacing the gateway", async () => {
+    const gate = deferred()
+    const created: ReturnType<typeof fakeGateway>[] = []
+    const controller = createRemoteGatewayController({
+      getUpstreamUrl: async () => "http://127.0.0.1:4096",
+      createGateway: () => {
+        const fake = fakeGateway(
+          { port: 7000 + created.length, urls: [] },
+          created.length === 0 ? gate.promise : undefined,
+        )
+        created.push(fake)
+        return fake.gateway
+      },
+    })
+
+    await controller.start()
+    const stopping = controller.stop()
+    const restarting = controller.start()
+    await Promise.resolve()
+
+    expect(created).toHaveLength(1)
+    gate.resolve()
+    await stopping
+
+    expect(await restarting).toEqual({ port: 7001, urls: [] })
+    expect(created).toHaveLength(2)
+    expect(created[0]?.stops()).toBe(1)
     expect(created[1]?.starts()).toBe(1)
   })
 

--- a/packages/desktop/src/main/remote-gateway-controller.test.ts
+++ b/packages/desktop/src/main/remote-gateway-controller.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import type { RemoteGatewayInfo } from "./remote-gateway"
+import { createRemoteGatewayController } from "./remote-gateway-controller"
+
+function fakeGateway(info: RemoteGatewayInfo) {
+  let running: RemoteGatewayInfo | undefined
+  let starts = 0
+  let stops = 0
+  return {
+    gateway: {
+      start: async () => {
+        starts += 1
+        running = info
+        return info
+      },
+      stop: async () => {
+        stops += 1
+        running = undefined
+      },
+      status: () => running,
+    },
+    starts: () => starts,
+    stops: () => stops,
+  }
+}
+
+describe("remote gateway controller", () => {
+  test("starts lazily and reuses the active gateway", async () => {
+    const fake = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    let upstreamCalls = 0
+    let factoryCalls = 0
+    const controller = createRemoteGatewayController({
+      getUpstreamUrl: async () => {
+        upstreamCalls += 1
+        return "http://127.0.0.1:4096"
+      },
+      createGateway: (url) => {
+        factoryCalls += 1
+        expect(url).toBe("http://127.0.0.1:4096")
+        return fake.gateway
+      },
+    })
+
+    const [first, second] = await Promise.all([controller.start(), controller.start()])
+    expect(first).toEqual(second)
+    expect(controller.status()).toEqual(first)
+    expect(upstreamCalls).toBe(1)
+    expect(factoryCalls).toBe(1)
+    expect(fake.starts()).toBe(1)
+  })
+
+  test("stop is idempotent and the controller can restart", async () => {
+    const created: ReturnType<typeof fakeGateway>[] = []
+    const controller = createRemoteGatewayController({
+      getUpstreamUrl: async () => "http://127.0.0.1:4096",
+      createGateway: () => {
+        const fake = fakeGateway({ port: 5000 + created.length, urls: [] })
+        created.push(fake)
+        return fake.gateway
+      },
+    })
+
+    await controller.start()
+    await Promise.all([controller.stop(), controller.stop()])
+    expect(controller.status()).toBeUndefined()
+    expect(created[0]?.stops()).toBe(1)
+
+    await controller.start()
+    expect(created).toHaveLength(2)
+    expect(created[1]?.starts()).toBe(1)
+  })
+
+  test("failed start can be retried", async () => {
+    let attempts = 0
+    const fake = fakeGateway({ port: 6000, urls: [] })
+    const controller = createRemoteGatewayController({
+      getUpstreamUrl: async () => {
+        attempts += 1
+        if (attempts === 1) throw new Error("sidecar unavailable")
+        return "http://127.0.0.1:4096"
+      },
+      createGateway: () => fake.gateway,
+    })
+
+    await expect(controller.start()).rejects.toThrow("sidecar unavailable")
+    expect(controller.status()).toBeUndefined()
+    expect(await controller.start()).toEqual({ port: 6000, urls: [] })
+    expect(attempts).toBe(2)
+  })
+})

--- a/packages/desktop/src/main/remote-gateway-controller.ts
+++ b/packages/desktop/src/main/remote-gateway-controller.ts
@@ -13,6 +13,7 @@ export function createRemoteGatewayController(options: RemoteGatewayControllerOp
   let stopping: Promise<void> | undefined
 
   const start = async () => {
+    if (stopping) await stopping
     if (gateway?.status()) return gateway.status()!
     if (starting) return starting
 

--- a/packages/desktop/src/main/remote-gateway-controller.ts
+++ b/packages/desktop/src/main/remote-gateway-controller.ts
@@ -1,0 +1,57 @@
+import { createRemoteGateway, type RemoteGatewayInfo } from "./remote-gateway"
+
+type Gateway = ReturnType<typeof createRemoteGateway>
+
+type RemoteGatewayControllerOptions = {
+  getUpstreamUrl: () => Promise<string>
+  createGateway?: (upstreamUrl: string) => Gateway
+}
+
+export function createRemoteGatewayController(options: RemoteGatewayControllerOptions) {
+  let gateway: Gateway | undefined
+  let starting: Promise<RemoteGatewayInfo> | undefined
+  let stopping: Promise<void> | undefined
+
+  const start = async () => {
+    if (gateway?.status()) return gateway.status()!
+    if (starting) return starting
+
+    starting = options
+      .getUpstreamUrl()
+      .then((upstreamUrl) => {
+        const next = options.createGateway?.(upstreamUrl) ?? createRemoteGateway({ upstreamUrl })
+        gateway = next
+        return next.start()
+      })
+      .catch((error) => {
+        gateway = undefined
+        throw error
+      })
+      .finally(() => {
+        starting = undefined
+      })
+
+    return starting
+  }
+
+  const stop = async () => {
+    if (stopping) return stopping
+
+    stopping = (async () => {
+      await starting?.catch(() => undefined)
+      const current = gateway
+      gateway = undefined
+      if (current) await current.stop()
+    })().finally(() => {
+      stopping = undefined
+    })
+
+    return stopping
+  }
+
+  return {
+    start,
+    stop,
+    status: () => gateway?.status(),
+  }
+}

--- a/packages/desktop/src/main/remote-gateway-forwarding.test.ts
+++ b/packages/desktop/src/main/remote-gateway-forwarding.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import * as http from "node:http"
+import type { AddressInfo } from "node:net"
+import { createRemoteGateway } from "./remote-gateway"
+
+const servers: http.Server[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+          server.closeIdleConnections()
+          server.closeAllConnections()
+        }),
+    ),
+  )
+})
+
+describe("remote gateway forwarding identity", () => {
+  test("strips client-supplied forwarding identity before proxying", async () => {
+    let seen: http.IncomingHttpHeaders = {}
+    const upstream = await listen((request, response) => {
+      seen = request.headers
+      response.end("ok")
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    await new Promise<void>((resolve, reject) => {
+      const request = http.request(
+        {
+          host: "127.0.0.1",
+          port: info.port,
+          path: "/remote/mobile",
+          headers: {
+            forwarded: "for=203.0.113.10;proto=https",
+            "x-forwarded-for": "203.0.113.10",
+            "x-forwarded-host": "attacker.invalid",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+            "x-real-ip": "203.0.113.10",
+          },
+        },
+        (response) => {
+          response.resume()
+          response.on("end", resolve)
+        },
+      )
+      request.on("error", reject)
+      request.end()
+    })
+
+    expect(seen.forwarded).toBeUndefined()
+    expect(seen["x-forwarded-for"]).toBeUndefined()
+    expect(seen["x-forwarded-port"]).toBeUndefined()
+    expect(seen["x-real-ip"]).toBeUndefined()
+    expect(seen["x-forwarded-host"]).toBe(`127.0.0.1:${info.port}`)
+    expect(seen["x-forwarded-proto"]).toBe("http")
+
+    await gateway.stop()
+  })
+})
+
+async function listen(handler: http.RequestListener) {
+  const server = http.createServer(handler)
+  servers.push(server)
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server
+}
+
+function origin(server: http.Server) {
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -124,7 +124,33 @@ describe("remote gateway", () => {
     await gateway.stop()
   })
 
-  test("strips Connection-declared hop-by-hop request headers", async () => {
+  test("refreshes advertised LAN addresses while keeping the gateway port", async () => {
+    const upstream = await listen((_request, response) => response.end("ok"))
+    let address = "192.168.50.12"
+    const gateway = createRemoteGateway({
+      upstreamUrl: origin(upstream),
+      networkInterfaces: () => ({ wifi: [networkAddress(address)] }),
+    })
+
+    const first = await gateway.start()
+    expect(first.urls).toEqual([`http://192.168.50.12:${first.port}`])
+
+    address = "192.168.60.24"
+    expect(gateway.status()).toEqual({
+      port: first.port,
+      urls: [`http://192.168.60.24:${first.port}`],
+    })
+
+    const second = await gateway.start()
+    expect(second).toEqual({
+      port: first.port,
+      urls: [`http://192.168.60.24:${first.port}`],
+    })
+
+    await gateway.stop()
+  })
+
+  test("strips fixed and Connection-declared hop-by-hop request headers", async () => {
     let seen: http.IncomingHttpHeaders = {}
     const upstream = await listen((request, response) => {
       seen = request.headers
@@ -136,19 +162,23 @@ describe("remote gateway", () => {
     await rawRequest(info.port, {
       connection: "keep-alive, x-remote-hop",
       "keep-alive": "timeout=5",
+      "proxy-connection": "keep-alive",
       "x-remote-hop": "secret",
       "x-end-to-end": "keep",
     })
 
+    expect(seen["keep-alive"]).toBeUndefined()
+    expect(seen["proxy-connection"]).toBeUndefined()
     expect(seen["x-remote-hop"]).toBeUndefined()
     expect(seen["x-end-to-end"]).toBe("keep")
 
     await gateway.stop()
   })
 
-  test("strips Connection-declared hop-by-hop response headers", async () => {
+  test("strips fixed and Connection-declared hop-by-hop response headers", async () => {
     const upstream = await listen((_request, response) => {
       response.setHeader("connection", "x-remote-hop")
+      response.setHeader("proxy-connection", "keep-alive")
       response.setHeader("x-remote-hop", "secret")
       response.setHeader("x-end-to-end", "keep")
       response.end("ok")
@@ -157,6 +187,7 @@ describe("remote gateway", () => {
     const info = await gateway.start()
 
     const response = await fetch(`http://127.0.0.1:${info.port}/remote/mobile`)
+    expect(response.headers.get("proxy-connection")).toBeNull()
     expect(response.headers.get("x-remote-hop")).toBeNull()
     expect(response.headers.get("x-end-to-end")).toBe("keep")
 

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import * as http from "node:http"
+import type { AddressInfo } from "node:net"
+import { createRemoteGateway } from "./remote-gateway"
+
+const servers: http.Server[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve())
+          server.closeIdleConnections()
+        }),
+    ),
+  )
+})
+
+describe("remote gateway", () => {
+  test("proxies only /remote routes", async () => {
+    const upstream = await listen((request, response) => {
+      response.setHeader("content-type", "application/json")
+      response.end(JSON.stringify({ url: request.url, authorization: request.headers.authorization ?? null }))
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    const remote = await fetch(`http://127.0.0.1:${info.port}/remote/session/test`, {
+      headers: { authorization: "Bearer remote-token" },
+    })
+    expect(remote.status).toBe(200)
+    expect(await remote.json()).toEqual({
+      url: "/remote/session/test",
+      authorization: "Bearer remote-token",
+    })
+
+    const blocked = await fetch(`http://127.0.0.1:${info.port}/session/test`)
+    expect(blocked.status).toBe(404)
+
+    await gateway.stop()
+  })
+
+  test("forwards request bodies and response headers", async () => {
+    const upstream = await listen((request, response) => {
+      const chunks: Buffer[] = []
+      for await (const chunk of request) chunks.push(Buffer.from(chunk))
+      response.setHeader("x-remote-test", "ok")
+      response.end(Buffer.concat(chunks))
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    const response = await fetch(`http://127.0.0.1:${info.port}/remote/pair/redeem`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket: "one-time" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-remote-test")).toBe("ok")
+    expect(await response.json()).toEqual({ ticket: "one-time" })
+
+    await gateway.stop()
+  })
+
+  test("start and stop are idempotent", async () => {
+    const upstream = await listen((_request, response) => response.end("ok"))
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+
+    const first = await gateway.start()
+    const second = await gateway.start()
+    expect(second).toEqual(first)
+
+    await gateway.stop()
+    await gateway.stop()
+  })
+})
+
+async function listen(handler: http.RequestListener) {
+  const server = http.createServer(handler)
+  servers.push(server)
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  return server
+}
+
+function origin(server: http.Server) {
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import * as http from "node:http"
 import type { AddressInfo } from "node:net"
+import type { NetworkInterfaceInfo } from "node:os"
 import { createRemoteGateway } from "./remote-gateway"
 
 const servers: http.Server[] = []
@@ -65,6 +66,68 @@ describe("remote gateway", () => {
     await gateway.stop()
   })
 
+  test("publishes only private IPv4 LAN addresses", async () => {
+    const upstream = await listen((_request, response) => response.end("ok"))
+    const gateway = createRemoteGateway({
+      upstreamUrl: origin(upstream),
+      networkInterfaces: () => ({
+        wan: [networkAddress("203.0.113.8")],
+        docker: [networkAddress("172.17.0.1")],
+        corporate: [networkAddress("10.20.30.40")],
+        wifi: [networkAddress("192.168.50.12")],
+        loopback: [networkAddress("127.0.0.1", true)],
+      }),
+    })
+    const info = await gateway.start()
+
+    expect(info.urls).toEqual([
+      `http://192.168.50.12:${info.port}`,
+      `http://10.20.30.40:${info.port}`,
+      `http://172.17.0.1:${info.port}`,
+    ])
+
+    await gateway.stop()
+  })
+
+  test("strips Connection-declared hop-by-hop request headers", async () => {
+    let seen: http.IncomingHttpHeaders = {}
+    const upstream = await listen((request, response) => {
+      seen = request.headers
+      response.end("ok")
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    await rawRequest(info.port, {
+      connection: "keep-alive, x-remote-hop",
+      "keep-alive": "timeout=5",
+      "x-remote-hop": "secret",
+      "x-end-to-end": "keep",
+    })
+
+    expect(seen["x-remote-hop"]).toBeUndefined()
+    expect(seen["x-end-to-end"]).toBe("keep")
+
+    await gateway.stop()
+  })
+
+  test("strips Connection-declared hop-by-hop response headers", async () => {
+    const upstream = await listen((_request, response) => {
+      response.setHeader("connection", "x-remote-hop")
+      response.setHeader("x-remote-hop", "secret")
+      response.setHeader("x-end-to-end", "keep")
+      response.end("ok")
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    const response = await fetch(`http://127.0.0.1:${info.port}/remote/mobile`)
+    expect(response.headers.get("x-remote-hop")).toBeNull()
+    expect(response.headers.get("x-end-to-end")).toBe("keep")
+
+    await gateway.stop()
+  })
+
   test("stop closes active streaming connections", async () => {
     const upstream = await listen((_request, response) => {
       response.writeHead(200, { "content-type": "text/event-stream" })
@@ -107,4 +170,26 @@ async function listen(handler: http.RequestListener) {
 function origin(server: http.Server) {
   const address = server.address() as AddressInfo
   return `http://127.0.0.1:${address.port}`
+}
+
+function networkAddress(address: string, internal = false): NetworkInterfaceInfo {
+  return {
+    address,
+    netmask: "255.255.255.0",
+    family: "IPv4",
+    mac: "00:00:00:00:00:00",
+    internal,
+    cidr: `${address}/24`,
+  }
+}
+
+function rawRequest(port: number, headers: http.OutgoingHttpHeaders) {
+  return new Promise<void>((resolve, reject) => {
+    const request = http.request({ host: "127.0.0.1", port, path: "/remote/mobile", headers }, (response) => {
+      response.resume()
+      response.on("end", resolve)
+    })
+    request.on("error", reject)
+    request.end()
+  })
 }

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -12,6 +12,7 @@ afterEach(async () => {
         new Promise<void>((resolve) => {
           server.close(() => resolve())
           server.closeIdleConnections()
+          server.closeAllConnections()
         }),
     ),
   )
@@ -62,6 +63,22 @@ describe("remote gateway", () => {
     expect(await response.json()).toEqual({ ticket: "one-time" })
 
     await gateway.stop()
+  })
+
+  test("stop closes active streaming connections", async () => {
+    const upstream = await listen((_request, response) => {
+      response.writeHead(200, { "content-type": "text/event-stream" })
+      response.write("data: connected\n\n")
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    const response = await fetch(`http://127.0.0.1:${info.port}/remote/session/test/events`)
+    expect(response.status).toBe(200)
+    expect(response.body).not.toBeNull()
+
+    await gateway.stop()
+    await response.body?.cancel().catch(() => undefined)
   })
 
   test("start and stop are idempotent", async () => {

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -43,6 +43,28 @@ describe("remote gateway", () => {
     await gateway.stop()
   })
 
+  test("pins absolute-form request targets to the configured upstream", async () => {
+    let upstreamHits = 0
+    let foreignHits = 0
+    const upstream = await listen((request, response) => {
+      upstreamHits += 1
+      response.end(request.url)
+    })
+    const foreign = await listen((_request, response) => {
+      foreignHits += 1
+      response.end("foreign")
+    })
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    const body = await rawGet(info.port, `${origin(foreign)}/remote/probe?x=1`)
+    expect(body).toBe("/remote/probe?x=1")
+    expect(upstreamHits).toBe(1)
+    expect(foreignHits).toBe(0)
+
+    await gateway.stop()
+  })
+
   test("forwards request bodies and response headers", async () => {
     const upstream = await listen((request, response) => {
       const chunks: Buffer[] = []
@@ -188,6 +210,18 @@ function rawRequest(port: number, headers: http.OutgoingHttpHeaders) {
     const request = http.request({ host: "127.0.0.1", port, path: "/remote/mobile", headers }, (response) => {
       response.resume()
       response.on("end", resolve)
+    })
+    request.on("error", reject)
+    request.end()
+  })
+}
+
+function rawGet(port: number, path: string) {
+  return new Promise<string>((resolve, reject) => {
+    const request = http.request({ host: "127.0.0.1", port, path }, (response) => {
+      const chunks: Buffer[] = []
+      response.on("data", (chunk) => chunks.push(Buffer.from(chunk)))
+      response.on("end", () => resolve(Buffer.concat(chunks).toString()))
     })
     request.on("error", reject)
     request.end()

--- a/packages/desktop/src/main/remote-gateway.test.ts
+++ b/packages/desktop/src/main/remote-gateway.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import * as http from "node:http"
-import type { AddressInfo } from "node:net"
+import { connect, type AddressInfo } from "node:net"
 import type { NetworkInterfaceInfo } from "node:os"
 import { createRemoteGateway } from "./remote-gateway"
 
@@ -62,6 +62,19 @@ describe("remote gateway", () => {
     expect(upstreamHits).toBe(1)
     expect(foreignHits).toBe(0)
 
+    await gateway.stop()
+  })
+
+  test("rejects malformed request targets without crashing", async () => {
+    const upstream = await listen((_request, response) => response.end("ok"))
+    const gateway = createRemoteGateway({ upstreamUrl: origin(upstream) })
+    const info = await gateway.start()
+
+    for (const target of ["http://[::1", "http://%zz/remote", "//[::1", "http://example.com:99999/remote"]) {
+      expect(await rawTarget(info.port, target)).toContain(" 400 ")
+    }
+
+    expect((await fetch(`http://127.0.0.1:${info.port}/remote/mobile`)).status).toBe(200)
     await gateway.stop()
   })
 
@@ -225,5 +238,18 @@ function rawGet(port: number, path: string) {
     })
     request.on("error", reject)
     request.end()
+  })
+}
+
+function rawTarget(port: number, target: string) {
+  return new Promise<string>((resolve, reject) => {
+    const socket = connect(port, "127.0.0.1", () =>
+      socket.write(`GET ${target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`),
+    )
+    let body = ""
+    socket.setEncoding("utf8")
+    socket.on("data", (chunk) => (body += chunk))
+    socket.on("close", () => resolve(body.split("\r\n")[0] ?? ""))
+    socket.on("error", reject)
   })
 }

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -1,0 +1,177 @@
+import * as http from "node:http"
+import * as https from "node:https"
+import type { AddressInfo } from "node:net"
+import { networkInterfaces } from "node:os"
+
+export type RemoteGatewayInfo = {
+  port: number
+  urls: string[]
+}
+
+type Logger = {
+  log(message: string, meta?: Record<string, unknown>): void
+  warn(message: string, meta?: Record<string, unknown>): void
+}
+
+type RemoteGatewayOptions = {
+  upstreamUrl: string
+  logger?: Logger
+}
+
+const blockedRequestHeaders = new Set([
+  "connection",
+  "host",
+  "proxy-authorization",
+  "proxy-authenticate",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+
+const blockedResponseHeaders = new Set(["connection", "proxy-authenticate", "trailer", "transfer-encoding", "upgrade"])
+
+export function createRemoteGateway(options: RemoteGatewayOptions) {
+  const upstream = new URL(options.upstreamUrl)
+  if (upstream.protocol !== "http:" && upstream.protocol !== "https:") {
+    throw new Error(`Unsupported remote gateway upstream protocol: ${upstream.protocol}`)
+  }
+
+  let server: http.Server | undefined
+  let info: RemoteGatewayInfo | undefined
+
+  const start = async (): Promise<RemoteGatewayInfo> => {
+    if (server && info) return info
+
+    const next = http.createServer((request, response) => {
+      if (!isRemotePath(request.url)) {
+        response.writeHead(404).end()
+        return
+      }
+
+      proxyRequest(upstream, request, response, options.logger)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        next.off("listening", onListening)
+        reject(error)
+      }
+      const onListening = () => {
+        next.off("error", onError)
+        resolve()
+      }
+      next.once("error", onError)
+      next.once("listening", onListening)
+      next.listen(0, "0.0.0.0")
+    })
+
+    const address = next.address()
+    if (!address || typeof address === "string") {
+      await closeServer(next)
+      throw new Error("Remote gateway did not expose a TCP address")
+    }
+
+    server = next
+    info = {
+      port: address.port,
+      urls: lanUrls(address.port),
+    }
+    options.logger?.log("remote gateway started", { port: info.port, urls: info.urls })
+    return info
+  }
+
+  const stop = async () => {
+    const current = server
+    server = undefined
+    info = undefined
+    if (!current) return
+    await closeServer(current)
+    options.logger?.log("remote gateway stopped")
+  }
+
+  return {
+    start,
+    stop,
+    status: () => info,
+  }
+}
+
+function isRemotePath(rawUrl: string | undefined) {
+  const pathname = new URL(rawUrl ?? "/", "http://localhost").pathname
+  return pathname === "/remote" || pathname.startsWith("/remote/")
+}
+
+function proxyRequest(
+  upstream: URL,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  logger?: Logger,
+) {
+  const target = new URL(request.url ?? "/", upstream)
+  const requestImpl = target.protocol === "https:" ? https.request : http.request
+  const headers = Object.fromEntries(
+    Object.entries(request.headers).filter(([name]) => !blockedRequestHeaders.has(name.toLowerCase())),
+  )
+
+  headers["x-forwarded-host"] = request.headers.host
+  headers["x-forwarded-proto"] = "http"
+
+  const proxy = requestImpl(
+    target,
+    {
+      method: request.method,
+      headers,
+    },
+    (upstreamResponse) => {
+      const responseHeaders = Object.fromEntries(
+        Object.entries(upstreamResponse.headers).filter(([name]) => !blockedResponseHeaders.has(name.toLowerCase())),
+      )
+      response.writeHead(upstreamResponse.statusCode ?? 502, responseHeaders)
+      upstreamResponse.pipe(response)
+    },
+  )
+
+  proxy.on("error", (error) => {
+    logger?.warn("remote gateway proxy failed", { error: error.message })
+    if (!response.headersSent) response.writeHead(502)
+    response.end()
+  })
+
+  request.on("aborted", () => proxy.destroy())
+  response.on("close", () => {
+    if (!response.writableEnded) proxy.destroy()
+  })
+  request.pipe(proxy)
+}
+
+function lanUrls(port: number) {
+  const addresses = new Set<string>()
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.internal || entry.family !== "IPv4") continue
+      addresses.add(entry.address)
+    }
+  }
+  return [...addresses].sort(privateAddressRank).map((address) => `http://${address}:${port}`)
+}
+
+function privateAddressRank(a: string, b: string) {
+  return Number(!isPrivateIPv4(a)) - Number(!isPrivateIPv4(b)) || a.localeCompare(b)
+}
+
+function isPrivateIPv4(address: string) {
+  if (address.startsWith("10.")) return true
+  if (address.startsWith("192.168.")) return true
+  const match = /^172\.(\d+)\./.exec(address)
+  if (!match) return false
+  const second = Number(match[1])
+  return second >= 16 && second <= 31
+}
+
+function closeServer(server: http.Server) {
+  return new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+    server.closeIdleConnections()
+  })
+}

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -173,5 +173,6 @@ function closeServer(server: http.Server) {
   return new Promise<void>((resolve, reject) => {
     server.close((error) => (error ? reject(error) : resolve()))
     server.closeIdleConnections()
+    server.closeAllConnections()
   })
 }

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -109,8 +109,12 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
   }
 }
 
+function requestURL(rawUrl: string | undefined) {
+  return new URL(rawUrl ?? "/", "http://remote.invalid")
+}
+
 function isRemotePath(rawUrl: string | undefined) {
-  const pathname = new URL(rawUrl ?? "/", "http://localhost").pathname
+  const pathname = requestURL(rawUrl).pathname
   return pathname === "/remote" || pathname.startsWith("/remote/")
 }
 
@@ -146,7 +150,11 @@ function proxyRequest(
   response: http.ServerResponse,
   logger?: Logger,
 ) {
-  const target = new URL(request.url ?? "/", upstream)
+  const incoming = requestURL(request.url)
+  const target = new URL(upstream)
+  target.pathname = incoming.pathname
+  target.search = incoming.search
+  target.hash = ""
   const requestImpl = target.protocol === "https:" ? https.request : http.request
   const headers = hopByHop(request.headers, blockedRequestHeaders)
 

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -56,12 +56,17 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
         response.writeHead(403).end()
         return
       }
-      if (!isRemotePath(request.url)) {
+      const incoming = requestURL(request.url)
+      if (!incoming) {
+        response.writeHead(400).end()
+        return
+      }
+      if (!isRemotePath(incoming.pathname)) {
         response.writeHead(404).end()
         return
       }
 
-      proxyRequest(upstream, request, response, options.logger)
+      proxyRequest(upstream, incoming, request, response, options.logger)
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -110,11 +115,14 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
 }
 
 function requestURL(rawUrl: string | undefined) {
-  return new URL(rawUrl ?? "/", "http://remote.invalid")
+  try {
+    return new URL(rawUrl ?? "/", "http://remote.invalid")
+  } catch {
+    return
+  }
 }
 
-function isRemotePath(rawUrl: string | undefined) {
-  const pathname = requestURL(rawUrl).pathname
+function isRemotePath(pathname: string) {
   return pathname === "/remote" || pathname.startsWith("/remote/")
 }
 
@@ -146,11 +154,11 @@ function hopByHop(headers: http.IncomingHttpHeaders, fixed: Set<string>) {
 
 function proxyRequest(
   upstream: URL,
+  incoming: URL,
   request: http.IncomingMessage,
   response: http.ServerResponse,
   logger?: Logger,
 ) {
-  const incoming = requestURL(request.url)
   const target = new URL(upstream)
   target.pathname = incoming.pathname
   target.search = incoming.search

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -20,6 +20,7 @@ type RemoteGatewayOptions = {
 
 const blockedRequestHeaders = new Set([
   "connection",
+  "forwarded",
   "host",
   "keep-alive",
   "proxy-authorization",
@@ -29,6 +30,11 @@ const blockedRequestHeaders = new Set([
   "trailer",
   "transfer-encoding",
   "upgrade",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-port",
+  "x-forwarded-proto",
+  "x-real-ip",
 ])
 
 const blockedResponseHeaders = new Set([

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -1,6 +1,5 @@
 import * as http from "node:http"
 import * as https from "node:https"
-import type { AddressInfo } from "node:net"
 import { networkInterfaces } from "node:os"
 
 export type RemoteGatewayInfo = {
@@ -16,11 +15,13 @@ type Logger = {
 type RemoteGatewayOptions = {
   upstreamUrl: string
   logger?: Logger
+  networkInterfaces?: typeof networkInterfaces
 }
 
 const blockedRequestHeaders = new Set([
   "connection",
   "host",
+  "keep-alive",
   "proxy-authorization",
   "proxy-authenticate",
   "te",
@@ -29,7 +30,14 @@ const blockedRequestHeaders = new Set([
   "upgrade",
 ])
 
-const blockedResponseHeaders = new Set(["connection", "proxy-authenticate", "trailer", "transfer-encoding", "upgrade"])
+const blockedResponseHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
 
 export function createRemoteGateway(options: RemoteGatewayOptions) {
   const upstream = new URL(options.upstreamUrl)
@@ -44,6 +52,10 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
     if (server && info) return info
 
     const next = http.createServer((request, response) => {
+      if (!isAllowedNetworkRequest(request)) {
+        response.writeHead(403).end()
+        return
+      }
       if (!isRemotePath(request.url)) {
         response.writeHead(404).end()
         return
@@ -75,7 +87,7 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
     server = next
     info = {
       port: address.port,
-      urls: lanUrls(address.port),
+      urls: lanUrls(address.port, (options.networkInterfaces ?? networkInterfaces)()),
     }
     options.logger?.log("remote gateway started", { port: info.port, urls: info.urls })
     return info
@@ -102,6 +114,32 @@ function isRemotePath(rawUrl: string | undefined) {
   return pathname === "/remote" || pathname.startsWith("/remote/")
 }
 
+function normalizeIPv4(address: string | undefined) {
+  if (!address) return
+  if (address.startsWith("::ffff:")) return address.slice("::ffff:".length)
+  return address
+}
+
+function isAllowedNetworkAddress(address: string | undefined) {
+  const value = normalizeIPv4(address)
+  if (!value) return false
+  if (value === "::1" || value.startsWith("127.")) return true
+  return isPrivateIPv4(value)
+}
+
+function isAllowedNetworkRequest(request: http.IncomingMessage) {
+  return isAllowedNetworkAddress(request.socket.localAddress) && isAllowedNetworkAddress(request.socket.remoteAddress)
+}
+
+function hopByHop(headers: http.IncomingHttpHeaders, fixed: Set<string>) {
+  const blocked = new Set(fixed)
+  for (const token of headers.connection?.split(",") ?? []) {
+    const name = token.trim().toLowerCase()
+    if (name) blocked.add(name)
+  }
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => !blocked.has(name.toLowerCase())))
+}
+
 function proxyRequest(
   upstream: URL,
   request: http.IncomingMessage,
@@ -110,11 +148,9 @@ function proxyRequest(
 ) {
   const target = new URL(request.url ?? "/", upstream)
   const requestImpl = target.protocol === "https:" ? https.request : http.request
-  const headers = Object.fromEntries(
-    Object.entries(request.headers).filter(([name]) => !blockedRequestHeaders.has(name.toLowerCase())),
-  )
+  const headers = hopByHop(request.headers, blockedRequestHeaders)
 
-  headers["x-forwarded-host"] = request.headers.host
+  if (request.headers.host) headers["x-forwarded-host"] = request.headers.host
   headers["x-forwarded-proto"] = "http"
 
   const proxy = requestImpl(
@@ -124,9 +160,7 @@ function proxyRequest(
       headers,
     },
     (upstreamResponse) => {
-      const responseHeaders = Object.fromEntries(
-        Object.entries(upstreamResponse.headers).filter(([name]) => !blockedResponseHeaders.has(name.toLowerCase())),
-      )
+      const responseHeaders = hopByHop(upstreamResponse.headers, blockedResponseHeaders)
       response.writeHead(upstreamResponse.statusCode ?? 502, responseHeaders)
       upstreamResponse.pipe(response)
     },
@@ -145,11 +179,11 @@ function proxyRequest(
   request.pipe(proxy)
 }
 
-function lanUrls(port: number) {
+function lanUrls(port: number, interfaces: ReturnType<typeof networkInterfaces>) {
   const addresses = new Set<string>()
-  for (const entries of Object.values(networkInterfaces())) {
+  for (const entries of Object.values(interfaces)) {
     for (const entry of entries ?? []) {
-      if (entry.internal || entry.family !== "IPv4") continue
+      if (entry.internal || entry.family !== "IPv4" || !isPrivateIPv4(entry.address)) continue
       addresses.add(entry.address)
     }
   }
@@ -157,7 +191,13 @@ function lanUrls(port: number) {
 }
 
 function privateAddressRank(a: string, b: string) {
-  return Number(!isPrivateIPv4(a)) - Number(!isPrivateIPv4(b)) || a.localeCompare(b)
+  return privateRangeRank(a) - privateRangeRank(b) || a.localeCompare(b)
+}
+
+function privateRangeRank(address: string) {
+  if (address.startsWith("192.168.")) return 0
+  if (address.startsWith("10.")) return 1
+  return 2
 }
 
 function isPrivateIPv4(address: string) {

--- a/packages/desktop/src/main/remote-gateway.ts
+++ b/packages/desktop/src/main/remote-gateway.ts
@@ -24,6 +24,7 @@ const blockedRequestHeaders = new Set([
   "keep-alive",
   "proxy-authorization",
   "proxy-authenticate",
+  "proxy-connection",
   "te",
   "trailer",
   "transfer-encoding",
@@ -34,6 +35,7 @@ const blockedResponseHeaders = new Set([
   "connection",
   "keep-alive",
   "proxy-authenticate",
+  "proxy-connection",
   "trailer",
   "transfer-encoding",
   "upgrade",
@@ -45,11 +47,22 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
     throw new Error(`Unsupported remote gateway upstream protocol: ${upstream.protocol}`)
   }
 
+  const getNetworkInterfaces = options.networkInterfaces ?? networkInterfaces
   let server: http.Server | undefined
   let info: RemoteGatewayInfo | undefined
 
+  const currentInfo = () => {
+    if (!server || !info) return
+    info = {
+      port: info.port,
+      urls: lanUrls(info.port, getNetworkInterfaces()),
+    }
+    return info
+  }
+
   const start = async (): Promise<RemoteGatewayInfo> => {
-    if (server && info) return info
+    const current = currentInfo()
+    if (current) return current
 
     const next = http.createServer((request, response) => {
       if (!isAllowedNetworkRequest(request)) {
@@ -92,7 +105,7 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
     server = next
     info = {
       port: address.port,
-      urls: lanUrls(address.port, (options.networkInterfaces ?? networkInterfaces)()),
+      urls: lanUrls(address.port, getNetworkInterfaces()),
     }
     options.logger?.log("remote gateway started", { port: info.port, urls: info.urls })
     return info
@@ -110,7 +123,7 @@ export function createRemoteGateway(options: RemoteGatewayOptions) {
   return {
     start,
     stop,
-    status: () => info,
+    status: currentInfo,
   }
 }
 

--- a/packages/desktop/src/main/remote-pairing-controller-race.test.ts
+++ b/packages/desktop/src/main/remote-pairing-controller-race.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import type { RemoteGatewayInfo } from "./remote-gateway"
+import { createRemotePairingController } from "./remote-pairing-controller"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function fakeGateway(info: RemoteGatewayInfo) {
+  let current: RemoteGatewayInfo | undefined
+  let stops = 0
+  return {
+    gateway: {
+      start: async () => {
+        current = info
+        return info
+      },
+      stop: async () => {
+        stops += 1
+        current = undefined
+      },
+      status: () => current,
+    },
+    stops: () => stops,
+  }
+}
+
+describe("remote pairing prune races", () => {
+  test("a revoke cannot stop the gateway while create is pruning stale sessions", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const pruneStarted = deferred<void>()
+    const pruneResponse = deferred<Response>()
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        if (request.method === "GET") {
+          pruneStarted.resolve()
+          return pruneResponse.promise
+        }
+        if (request.method === "DELETE") return Response.json(true)
+        return Response.json({ ticket: "ticket", expires_in: 300 })
+      },
+    })
+
+    await controller.create("session-a", "/tmp/a")
+    const creating = controller.create("session-b", "/tmp/b")
+    await pruneStarted.promise
+
+    await controller.revoke("session-a", "/tmp/a")
+    expect(gateway.stops()).toBe(0)
+
+    pruneResponse.resolve(new Response(null, { status: 404 }))
+    await expect(creating).resolves.toMatchObject({ expiresIn: 300 })
+    expect(gateway.stops()).toBe(0)
+
+    await controller.revoke("session-b", "/tmp/b")
+    expect(gateway.stops()).toBe(1)
+  })
+})

--- a/packages/desktop/src/main/remote-pairing-controller.test.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import type { RemoteGatewayInfo } from "./remote-gateway"
+import { createRemotePairingController } from "./remote-pairing-controller"
+
+function fakeGateway(info: RemoteGatewayInfo) {
+  let current: RemoteGatewayInfo | undefined
+  let starts = 0
+  let stops = 0
+  return {
+    gateway: {
+      start: async () => {
+        starts += 1
+        current = info
+        return info
+      },
+      stop: async () => {
+        stops += 1
+        current = undefined
+      },
+      status: () => current,
+    },
+    starts: () => starts,
+    stops: () => stops,
+  }
+}
+
+describe("remote pairing controller", () => {
+  test("creates a mobile URL while keeping Basic auth in the main-process request", async () => {
+    const gateway = fakeGateway({
+      port: 4123,
+      urls: ["http://192.168.1.10:4123", "http://10.0.0.5:4123"],
+    })
+    let request: Request | undefined
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({
+        url: "http://127.0.0.1:4096",
+        username: "opencode",
+        password: "server-secret",
+      }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        request = new Request(input, init)
+        return Response.json({ ticket: "one-time-ticket", expires_in: 300 })
+      },
+    })
+
+    const result = await controller.create("session 1", "/tmp/project")
+
+    expect(gateway.starts()).toBe(1)
+    expect(request?.method).toBe("POST")
+    expect(request?.url).toBe(
+      "http://127.0.0.1:4096/session/session%201/remote?directory=%2Ftmp%2Fproject",
+    )
+    expect(request?.headers.get("authorization")).toBe(`Basic ${btoa("opencode:server-secret")}`)
+    expect(result).toEqual({
+      url: "http://192.168.1.10:4123/remote/mobile#ticket=one-time-ticket",
+      urls: [
+        "http://192.168.1.10:4123/remote/mobile#ticket=one-time-ticket",
+        "http://10.0.0.5:4123/remote/mobile#ticket=one-time-ticket",
+      ],
+      expiresIn: 300,
+    })
+  })
+
+  test("stops a newly-created gateway when no LAN address is available", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: [] })
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+    })
+
+    await expect(controller.create("session", "/tmp/project")).rejects.toThrow("No local network address")
+    expect(gateway.starts()).toBe(1)
+    expect(gateway.stops()).toBe(1)
+  })
+
+  test("revoke sends an authenticated DELETE without stopping the shared gateway", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    let request: Request | undefined
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({
+        url: "http://127.0.0.1:4096",
+        username: null,
+        password: "server-secret",
+      }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        request = new Request(input, init)
+        return Response.json(true)
+      },
+    })
+
+    await controller.revoke("session", "/tmp/project")
+
+    expect(request?.method).toBe("DELETE")
+    expect(request?.headers.get("authorization")).toBe(`Basic ${btoa("opencode:server-secret")}`)
+    expect(gateway.stops()).toBe(0)
+  })
+})

--- a/packages/desktop/src/main/remote-pairing-controller.test.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.test.ts
@@ -24,6 +24,14 @@ function fakeGateway(info: RemoteGatewayInfo) {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
 describe("remote pairing controller", () => {
   test("creates a mobile URL while keeping Basic auth in the main-process request", async () => {
     const gateway = fakeGateway({
@@ -98,6 +106,23 @@ describe("remote pairing controller", () => {
     expect(gateway.stops()).toBe(0)
   })
 
+  test("does not stop a gateway it did not start after a paired session disconnects", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    await gateway.gateway.start()
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (_input, init) =>
+        init?.method === "DELETE" ? Response.json(true) : Response.json({ ticket: "ticket", expires_in: 300 }),
+    })
+
+    await controller.create("session", "/tmp/project")
+    await controller.revoke("session", "/tmp/project")
+
+    expect(gateway.starts()).toBe(1)
+    expect(gateway.stops()).toBe(0)
+  })
+
   test("stops the gateway when the last tracked remote session disconnects", async () => {
     const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
     const controller = createRemotePairingController({
@@ -128,6 +153,73 @@ describe("remote pairing controller", () => {
     expect(gateway.stops()).toBe(0)
 
     await controller.revoke("session-b", "/tmp/b")
+    expect(gateway.stops()).toBe(1)
+  })
+
+  test("keeps a successful pairing alive when a concurrent pairing fails", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const successRequest = deferred<void>()
+    const failedRequest = deferred<void>()
+    const successResponse = deferred<Response>()
+    const failedResponse = deferred<Response>()
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        if (request.method === "DELETE") return Response.json(true)
+        if (request.url.includes("session-success")) {
+          successRequest.resolve()
+          return successResponse.promise
+        }
+        failedRequest.resolve()
+        return failedResponse.promise
+      },
+    })
+
+    const success = controller.create("session-success", "/tmp/success")
+    const failed = controller.create("session-failed", "/tmp/failed")
+    await Promise.all([successRequest.promise, failedRequest.promise])
+
+    failedResponse.resolve(new Response(null, { status: 500 }))
+    await expect(failed).rejects.toThrow("status 500")
+    expect(gateway.stops()).toBe(0)
+
+    successResponse.resolve(Response.json({ ticket: "ticket", expires_in: 300 }))
+    await expect(success).resolves.toMatchObject({ expiresIn: 300 })
+    expect(gateway.stops()).toBe(0)
+
+    await controller.revoke("session-success", "/tmp/success")
+    expect(gateway.stops()).toBe(1)
+  })
+
+  test("does not stop the gateway while another pairing is in flight", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const pendingRequest = deferred<void>()
+    const pendingResponse = deferred<Response>()
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        if (request.method === "DELETE") return Response.json(true)
+        if (request.url.includes("session-pending")) {
+          pendingRequest.resolve()
+          return pendingResponse.promise
+        }
+        return Response.json({ ticket: "ticket", expires_in: 300 })
+      },
+    })
+
+    await controller.create("session-active", "/tmp/active")
+    const pending = controller.create("session-pending", "/tmp/pending")
+    await pendingRequest.promise
+
+    await controller.revoke("session-active", "/tmp/active")
+    expect(gateway.stops()).toBe(0)
+
+    pendingResponse.resolve(new Response(null, { status: 500 }))
+    await expect(pending).rejects.toThrow("status 500")
     expect(gateway.stops()).toBe(1)
   })
 })

--- a/packages/desktop/src/main/remote-pairing-controller.test.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.test.ts
@@ -156,6 +156,31 @@ describe("remote pairing controller", () => {
     expect(gateway.stops()).toBe(1)
   })
 
+  test("prunes deleted tracked sessions before deciding whether the gateway is idle", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const deleted = new Set<string>()
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (input, init) => {
+        const request = new Request(input, init)
+        if (request.method === "GET") {
+          const sessionID = request.url.match(/\/session\/([^/?]+)/)?.[1]
+          return new Response(null, { status: sessionID && deleted.has(decodeURIComponent(sessionID)) ? 404 : 200 })
+        }
+        if (request.method === "DELETE") return Response.json(true)
+        return Response.json({ ticket: "ticket", expires_in: 300 })
+      },
+    })
+
+    await controller.create("session-a", "/tmp/a")
+    await controller.create("session-b", "/tmp/b")
+    deleted.add("session-a")
+
+    await controller.revoke("session-b", "/tmp/b")
+    expect(gateway.stops()).toBe(1)
+  })
+
   test("keeps a successful pairing alive when a concurrent pairing fails", async () => {
     const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
     const successRequest = deferred<void>()
@@ -168,6 +193,7 @@ describe("remote pairing controller", () => {
       fetch: async (input, init) => {
         const request = new Request(input, init)
         if (request.method === "DELETE") return Response.json(true)
+        if (request.method === "GET") return new Response(null, { status: 200 })
         if (request.url.includes("session-success")) {
           successRequest.resolve()
           return successResponse.promise
@@ -203,6 +229,7 @@ describe("remote pairing controller", () => {
       fetch: async (input, init) => {
         const request = new Request(input, init)
         if (request.method === "DELETE") return Response.json(true)
+        if (request.method === "GET") return new Response(null, { status: 200 })
         if (request.url.includes("session-pending")) {
           pendingRequest.resolve()
           return pendingResponse.promise

--- a/packages/desktop/src/main/remote-pairing-controller.test.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.test.ts
@@ -74,8 +74,9 @@ describe("remote pairing controller", () => {
     expect(gateway.stops()).toBe(1)
   })
 
-  test("revoke sends an authenticated DELETE without stopping the shared gateway", async () => {
+  test("revoke sends an authenticated DELETE without stopping an untracked shared gateway", async () => {
     const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    await gateway.gateway.start()
     let request: Request | undefined
     const controller = createRemotePairingController({
       getSidecar: async () => ({
@@ -95,5 +96,38 @@ describe("remote pairing controller", () => {
     expect(request?.method).toBe("DELETE")
     expect(request?.headers.get("authorization")).toBe(`Basic ${btoa("opencode:server-secret")}`)
     expect(gateway.stops()).toBe(0)
+  })
+
+  test("stops the gateway when the last tracked remote session disconnects", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (_input, init) =>
+        init?.method === "DELETE" ? Response.json(true) : Response.json({ ticket: "ticket", expires_in: 300 }),
+    })
+
+    await controller.create("session", "/tmp/project")
+    await controller.revoke("session", "/tmp/project")
+
+    expect(gateway.stops()).toBe(1)
+  })
+
+  test("keeps the shared gateway until all tracked remote sessions disconnect", async () => {
+    const gateway = fakeGateway({ port: 4123, urls: ["http://192.168.1.10:4123"] })
+    const controller = createRemotePairingController({
+      getSidecar: async () => ({ url: "http://127.0.0.1:4096", username: null, password: null }),
+      gateway: gateway.gateway,
+      fetch: async (_input, init) =>
+        init?.method === "DELETE" ? Response.json(true) : Response.json({ ticket: "ticket", expires_in: 300 }),
+    })
+
+    await controller.create("session-a", "/tmp/a")
+    await controller.create("session-b", "/tmp/b")
+    await controller.revoke("session-a", "/tmp/a")
+    expect(gateway.stops()).toBe(0)
+
+    await controller.revoke("session-b", "/tmp/b")
+    expect(gateway.stops()).toBe(1)
   })
 })

--- a/packages/desktop/src/main/remote-pairing-controller.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.ts
@@ -21,6 +21,24 @@ type PairingPayload = {
 
 export function createRemotePairingController(options: RemotePairingControllerOptions) {
   const sessions = new Set<string>()
+  let creating = 0
+  let ownsGateway = false
+  let stopping: Promise<void> | undefined
+
+  const stopIfIdle = () => {
+    if (!ownsGateway || creating > 0 || sessions.size > 0) return Promise.resolve()
+    if (stopping) return stopping
+
+    stopping = options.gateway
+      .stop()
+      .then(() => {
+        ownsGateway = false
+      })
+      .finally(() => {
+        stopping = undefined
+      })
+    return stopping
+  }
 
   const request = async (method: "POST" | "DELETE", sessionID: string, directory: string) => {
     const sidecar = await options.getSidecar()
@@ -37,16 +55,22 @@ export function createRemotePairingController(options: RemotePairingControllerOp
   }
 
   const create = async (sessionID: string, directory: string): Promise<RemotePairingInfo> => {
-    const existing = options.gateway.status()
-    if (!existing) sessions.clear()
-    const gateway = existing ?? (await options.gateway.start())
+    if (stopping) await stopping
 
-    if (gateway.urls.length === 0) {
-      if (!existing) await options.gateway.stop()
-      throw new Error("No local network address is available for remote control")
+    const existing = options.gateway.status()
+    if (!existing && creating === 0) {
+      sessions.clear()
+      ownsGateway = false
     }
 
+    creating += 1
     try {
+      const gateway = existing ?? (await options.gateway.start())
+      if (!existing) ownsGateway = true
+      if (gateway.urls.length === 0) {
+        throw new Error("No local network address is available for remote control")
+      }
+
       const response = await request("POST", sessionID, directory)
       if (!response.ok) throw new Error(`Remote pairing failed with status ${response.status}`)
 
@@ -66,16 +90,19 @@ export function createRemotePairingController(options: RemotePairingControllerOp
         urls,
         expiresIn: payload.expires_in,
       }
-    } catch (error) {
-      if (!existing) await options.gateway.stop().catch(() => undefined)
-      throw error
+    } finally {
+      creating -= 1
+      await stopIfIdle().catch(() => undefined)
     }
   }
 
   const revoke = async (sessionID: string, directory: string) => {
+    if (stopping) await stopping
+
     const response = await request("DELETE", sessionID, directory)
     if (!response.ok) throw new Error(`Remote revoke failed with status ${response.status}`)
-    if (sessions.delete(sessionID) && sessions.size === 0) await options.gateway.stop()
+    if (!sessions.delete(sessionID)) return
+    await stopIfIdle()
   }
 
   return { create, revoke }

--- a/packages/desktop/src/main/remote-pairing-controller.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.ts
@@ -1,0 +1,77 @@
+import { Buffer } from "node:buffer"
+import type { RemotePairingInfo, ServerReadyData } from "../preload/types"
+import type { RemoteGatewayInfo } from "./remote-gateway"
+
+type Gateway = {
+  start(): Promise<RemoteGatewayInfo>
+  stop(): Promise<void>
+  status(): RemoteGatewayInfo | undefined
+}
+
+type RemotePairingControllerOptions = {
+  getSidecar: () => Promise<ServerReadyData>
+  gateway: Gateway
+  fetch?: typeof globalThis.fetch
+}
+
+type PairingPayload = {
+  ticket?: unknown
+  expires_in?: unknown
+}
+
+export function createRemotePairingController(options: RemotePairingControllerOptions) {
+  const request = async (method: "POST" | "DELETE", sessionID: string, directory: string) => {
+    const sidecar = await options.getSidecar()
+    const url = new URL(`/session/${encodeURIComponent(sessionID)}/remote`, sidecar.url)
+    url.searchParams.set("directory", directory)
+
+    const headers = new Headers()
+    if (sidecar.password) {
+      const username = sidecar.username ?? "opencode"
+      headers.set("authorization", `Basic ${Buffer.from(`${username}:${sidecar.password}`).toString("base64")}`)
+    }
+
+    return (options.fetch ?? globalThis.fetch)(url, { method, headers })
+  }
+
+  const create = async (sessionID: string, directory: string): Promise<RemotePairingInfo> => {
+    const existing = options.gateway.status()
+    const gateway = existing ?? (await options.gateway.start())
+
+    if (gateway.urls.length === 0) {
+      if (!existing) await options.gateway.stop()
+      throw new Error("No local network address is available for remote control")
+    }
+
+    try {
+      const response = await request("POST", sessionID, directory)
+      if (!response.ok) throw new Error(`Remote pairing failed with status ${response.status}`)
+
+      const payload = (await response.json()) as PairingPayload
+      if (typeof payload.ticket !== "string" || typeof payload.expires_in !== "number") {
+        throw new Error("Remote pairing returned an invalid response")
+      }
+
+      const urls = gateway.urls.map((base) => {
+        const mobile = new URL("/remote/mobile", base)
+        return `${mobile.toString()}#ticket=${encodeURIComponent(payload.ticket as string)}`
+      })
+
+      return {
+        url: urls[0]!,
+        urls,
+        expiresIn: payload.expires_in,
+      }
+    } catch (error) {
+      if (!existing) await options.gateway.stop().catch(() => undefined)
+      throw error
+    }
+  }
+
+  const revoke = async (sessionID: string, directory: string) => {
+    const response = await request("DELETE", sessionID, directory)
+    if (!response.ok) throw new Error(`Remote revoke failed with status ${response.status}`)
+  }
+
+  return { create, revoke }
+}

--- a/packages/desktop/src/main/remote-pairing-controller.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.ts
@@ -73,16 +73,17 @@ export function createRemotePairingController(options: RemotePairingControllerOp
   const create = async (sessionID: string, directory: string): Promise<RemotePairingInfo> => {
     if (stopping) await stopping
 
-    const existing = options.gateway.status()
-    if (!existing && creating === 0) {
-      sessions.clear()
-      ownsGateway = false
-    } else if (existing && creating === 0) {
-      await pruneSessions()
-    }
-
     creating += 1
     try {
+      const initial = options.gateway.status()
+      if (!initial && creating === 1) {
+        sessions.clear()
+        ownsGateway = false
+      } else if (initial && creating === 1) {
+        await pruneSessions()
+      }
+
+      const existing = options.gateway.status()
       const gateway = existing ?? (await options.gateway.start())
       if (!existing) ownsGateway = true
       if (gateway.urls.length === 0) {

--- a/packages/desktop/src/main/remote-pairing-controller.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.ts
@@ -20,6 +20,8 @@ type PairingPayload = {
 }
 
 export function createRemotePairingController(options: RemotePairingControllerOptions) {
+  const sessions = new Set<string>()
+
   const request = async (method: "POST" | "DELETE", sessionID: string, directory: string) => {
     const sidecar = await options.getSidecar()
     const url = new URL(`/session/${encodeURIComponent(sessionID)}/remote`, sidecar.url)
@@ -36,6 +38,7 @@ export function createRemotePairingController(options: RemotePairingControllerOp
 
   const create = async (sessionID: string, directory: string): Promise<RemotePairingInfo> => {
     const existing = options.gateway.status()
+    if (!existing) sessions.clear()
     const gateway = existing ?? (await options.gateway.start())
 
     if (gateway.urls.length === 0) {
@@ -57,6 +60,7 @@ export function createRemotePairingController(options: RemotePairingControllerOp
         return `${mobile.toString()}#ticket=${encodeURIComponent(payload.ticket as string)}`
       })
 
+      sessions.add(sessionID)
       return {
         url: urls[0]!,
         urls,
@@ -71,6 +75,7 @@ export function createRemotePairingController(options: RemotePairingControllerOp
   const revoke = async (sessionID: string, directory: string) => {
     const response = await request("DELETE", sessionID, directory)
     if (!response.ok) throw new Error(`Remote revoke failed with status ${response.status}`)
+    if (sessions.delete(sessionID) && sessions.size === 0) await options.gateway.stop()
   }
 
   return { create, revoke }

--- a/packages/desktop/src/main/remote-pairing-controller.ts
+++ b/packages/desktop/src/main/remote-pairing-controller.ts
@@ -20,13 +20,43 @@ type PairingPayload = {
 }
 
 export function createRemotePairingController(options: RemotePairingControllerOptions) {
-  const sessions = new Set<string>()
+  const sessions = new Map<string, string>()
   let creating = 0
   let ownsGateway = false
   let stopping: Promise<void> | undefined
 
-  const stopIfIdle = () => {
-    if (!ownsGateway || creating > 0 || sessions.size > 0) return Promise.resolve()
+  const request = async (method: "GET" | "POST" | "DELETE", path: string, directory: string) => {
+    const sidecar = await options.getSidecar()
+    const url = new URL(path, sidecar.url)
+    url.searchParams.set("directory", directory)
+
+    const headers = new Headers()
+    if (sidecar.password) {
+      const username = sidecar.username ?? "opencode"
+      headers.set("authorization", `Basic ${Buffer.from(`${username}:${sidecar.password}`).toString("base64")}`)
+    }
+
+    return (options.fetch ?? globalThis.fetch)(url, { method, headers })
+  }
+
+  const adminRequest = (method: "POST" | "DELETE", sessionID: string, directory: string) =>
+    request(method, `/session/${encodeURIComponent(sessionID)}/remote`, directory)
+
+  const pruneSessions = async () => {
+    if (!ownsGateway || sessions.size === 0) return
+    const snapshot = [...sessions.entries()]
+    await Promise.all(
+      snapshot.map(async ([sessionID, directory]) => {
+        const response = await request("GET", `/session/${encodeURIComponent(sessionID)}`, directory).catch(() => undefined)
+        if (response?.status === 404 && sessions.get(sessionID) === directory) sessions.delete(sessionID)
+      }),
+    )
+  }
+
+  const stopIfIdle = async (prune = false) => {
+    if (!ownsGateway || creating > 0) return
+    if (prune) await pruneSessions()
+    if (!ownsGateway || creating > 0 || sessions.size > 0) return
     if (stopping) return stopping
 
     stopping = options.gateway
@@ -40,20 +70,6 @@ export function createRemotePairingController(options: RemotePairingControllerOp
     return stopping
   }
 
-  const request = async (method: "POST" | "DELETE", sessionID: string, directory: string) => {
-    const sidecar = await options.getSidecar()
-    const url = new URL(`/session/${encodeURIComponent(sessionID)}/remote`, sidecar.url)
-    url.searchParams.set("directory", directory)
-
-    const headers = new Headers()
-    if (sidecar.password) {
-      const username = sidecar.username ?? "opencode"
-      headers.set("authorization", `Basic ${Buffer.from(`${username}:${sidecar.password}`).toString("base64")}`)
-    }
-
-    return (options.fetch ?? globalThis.fetch)(url, { method, headers })
-  }
-
   const create = async (sessionID: string, directory: string): Promise<RemotePairingInfo> => {
     if (stopping) await stopping
 
@@ -61,6 +77,8 @@ export function createRemotePairingController(options: RemotePairingControllerOp
     if (!existing && creating === 0) {
       sessions.clear()
       ownsGateway = false
+    } else if (existing && creating === 0) {
+      await pruneSessions()
     }
 
     creating += 1
@@ -71,7 +89,7 @@ export function createRemotePairingController(options: RemotePairingControllerOp
         throw new Error("No local network address is available for remote control")
       }
 
-      const response = await request("POST", sessionID, directory)
+      const response = await adminRequest("POST", sessionID, directory)
       if (!response.ok) throw new Error(`Remote pairing failed with status ${response.status}`)
 
       const payload = (await response.json()) as PairingPayload
@@ -84,7 +102,7 @@ export function createRemotePairingController(options: RemotePairingControllerOp
         return `${mobile.toString()}#ticket=${encodeURIComponent(payload.ticket as string)}`
       })
 
-      sessions.add(sessionID)
+      sessions.set(sessionID, directory)
       return {
         url: urls[0]!,
         urls,
@@ -99,10 +117,10 @@ export function createRemotePairingController(options: RemotePairingControllerOp
   const revoke = async (sessionID: string, directory: string) => {
     if (stopping) await stopping
 
-    const response = await request("DELETE", sessionID, directory)
+    const response = await adminRequest("DELETE", sessionID, directory)
     if (!response.ok) throw new Error(`Remote revoke failed with status ${response.status}`)
     if (!sessions.delete(sessionID)) return
-    await stopIfIdle()
+    await stopIfIdle(true)
   }
 
   return { create, revoke }

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -14,9 +14,8 @@ const api: ElectronAPI = {
   killSidecar: () => ipcRenderer.invoke("kill-sidecar"),
   installCli: () => ipcRenderer.invoke("install-cli"),
   awaitInitialization: () => ipcRenderer.invoke("await-initialization"),
-  startRemoteGateway: () => ipcRenderer.invoke("remote-gateway-start"),
-  stopRemoteGateway: () => ipcRenderer.invoke("remote-gateway-stop"),
-  getRemoteGatewayStatus: () => ipcRenderer.invoke("remote-gateway-status"),
+  createRemotePairing: (sessionID, directory) => ipcRenderer.invoke("remote-pairing-create", sessionID, directory),
+  revokeRemotePairing: (sessionID, directory) => ipcRenderer.invoke("remote-pairing-revoke", sessionID, directory),
   wslServers: {
     getState: () => ipcRenderer.invoke("wsl-servers-get-state"),
     subscribe: (cb) => {

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -14,6 +14,9 @@ const api: ElectronAPI = {
   killSidecar: () => ipcRenderer.invoke("kill-sidecar"),
   installCli: () => ipcRenderer.invoke("install-cli"),
   awaitInitialization: () => ipcRenderer.invoke("await-initialization"),
+  startRemoteGateway: () => ipcRenderer.invoke("remote-gateway-start"),
+  stopRemoteGateway: () => ipcRenderer.invoke("remote-gateway-stop"),
+  getRemoteGatewayStatus: () => ipcRenderer.invoke("remote-gateway-status"),
   wslServers: {
     getState: () => ipcRenderer.invoke("wsl-servers-get-state"),
     subscribe: (cb) => {

--- a/packages/desktop/src/preload/types.ts
+++ b/packages/desktop/src/preload/types.ts
@@ -22,9 +22,10 @@ export type ServerReadyData = {
   password: string | null
 }
 
-export type RemoteGatewayInfo = {
-  port: number
+export type RemotePairingInfo = {
+  url: string
   urls: string[]
+  expiresIn: number
 }
 
 export type WslServersAPI = WslServersPlatform
@@ -51,9 +52,8 @@ export type ElectronAPI = {
   killSidecar: () => Promise<void>
   installCli: () => Promise<string>
   awaitInitialization: () => Promise<ServerReadyData>
-  startRemoteGateway: () => Promise<RemoteGatewayInfo>
-  stopRemoteGateway: () => Promise<void>
-  getRemoteGatewayStatus: () => Promise<RemoteGatewayInfo | null>
+  createRemotePairing: (sessionID: string, directory: string) => Promise<RemotePairingInfo>
+  revokeRemotePairing: (sessionID: string, directory: string) => Promise<void>
   wslServers: WslServersAPI
   updater: UpdaterAPI
   consumeInitialDeepLinks: () => Promise<string[]>

--- a/packages/desktop/src/preload/types.ts
+++ b/packages/desktop/src/preload/types.ts
@@ -22,6 +22,11 @@ export type ServerReadyData = {
   password: string | null
 }
 
+export type RemoteGatewayInfo = {
+  port: number
+  urls: string[]
+}
+
 export type WslServersAPI = WslServersPlatform
 export type UpdaterAPI = {
   subscribe: (cb: (state: UpdaterState) => void) => Promise<() => void>
@@ -46,6 +51,9 @@ export type ElectronAPI = {
   killSidecar: () => Promise<void>
   installCli: () => Promise<string>
   awaitInitialization: () => Promise<ServerReadyData>
+  startRemoteGateway: () => Promise<RemoteGatewayInfo>
+  stopRemoteGateway: () => Promise<void>
+  getRemoteGatewayStatus: () => Promise<RemoteGatewayInfo | null>
   wslServers: WslServersAPI
   updater: UpdaterAPI
   consumeInitialDeepLinks: () => Promise<string[]>

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -282,9 +282,8 @@ const createPlatform = (windowState: DesktopWindowState): Platform => {
       await window.api.setDefaultServerUrl(url)
     },
 
-    startRemoteGateway: () => window.api.startRemoteGateway(),
-    stopRemoteGateway: () => window.api.stopRemoteGateway(),
-    getRemoteGatewayStatus: () => window.api.getRemoteGatewayStatus(),
+    createRemotePairing: (sessionID, directory) => window.api.createRemotePairing(sessionID, directory),
+    revokeRemotePairing: (sessionID, directory) => window.api.revokeRemotePairing(sessionID, directory),
 
     wslServers: wslServersApi,
 

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -282,6 +282,10 @@ const createPlatform = (windowState: DesktopWindowState): Platform => {
       await window.api.setDefaultServerUrl(url)
     },
 
+    startRemoteGateway: () => window.api.startRemoteGateway(),
+    stopRemoteGateway: () => window.api.stopRemoteGateway(),
+    getRemoteGatewayStatus: () => window.api.getRemoteGatewayStatus(),
+
     wslServers: wslServersApi,
 
     getDisplayBackend: async () => {

--- a/packages/opencode/src/remote/access.ts
+++ b/packages/opencode/src/remote/access.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto"
+import { createHash, randomBytes } from "node:crypto"
 import type { SessionID } from "@/session/schema"
 
 const PAIR_TTL_MS = 5 * 60 * 1000
@@ -21,57 +21,62 @@ function token() {
   return randomBytes(32).toString("base64url")
 }
 
+function key(value: string) {
+  return createHash("sha256").update(value).digest("base64url")
+}
+
 function prune(now = Date.now()) {
-  for (const [key, value] of pairings) {
-    if (value.expiresAt <= now) pairings.delete(key)
+  for (const [id, value] of pairings) {
+    if (value.expiresAt <= now) pairings.delete(id)
   }
-  for (const [key, value] of grants) {
-    if (value.expiresAt <= now) grants.delete(key)
+  for (const [id, value] of grants) {
+    if (value.expiresAt <= now) grants.delete(id)
+  }
+}
+
+export function pair(sessionID: SessionID, now = Date.now()) {
+  prune(now)
+  const ticket = token()
+  pairings.set(key(ticket), { sessionID, expiresAt: now + PAIR_TTL_MS })
+  return { ticket, expires_in: Math.floor(PAIR_TTL_MS / 1000) }
+}
+
+export function redeem(ticket: string, now = Date.now()) {
+  prune(now)
+  const ticketKey = key(ticket)
+  const pairing = pairings.get(ticketKey)
+  if (!pairing) return
+  pairings.delete(ticketKey)
+  if (pairing.expiresAt <= now) return
+
+  const accessToken = token()
+  grants.set(key(accessToken), { sessionID: pairing.sessionID, expiresAt: now + GRANT_TTL_MS })
+  return {
+    token: accessToken,
+    sessionID: pairing.sessionID,
+    expires_in: Math.floor(GRANT_TTL_MS / 1000),
   }
 }
 
-export namespace RemoteAccess {
-  export function pair(sessionID: SessionID, now = Date.now()) {
-    prune(now)
-    const ticket = token()
-    pairings.set(ticket, { sessionID, expiresAt: now + PAIR_TTL_MS })
-    return { ticket, expires_in: Math.floor(PAIR_TTL_MS / 1000) }
+export function authorized(accessToken: string, sessionID: string, now = Date.now()) {
+  prune(now)
+  const grant = grants.get(key(accessToken))
+  if (!grant || grant.expiresAt <= now) return false
+  return grant.sessionID === sessionID
+}
+
+export function revoke(sessionID: SessionID) {
+  for (const [id, value] of pairings) {
+    if (value.sessionID === sessionID) pairings.delete(id)
   }
-
-  export function redeem(ticket: string, now = Date.now()) {
-    prune(now)
-    const pairing = pairings.get(ticket)
-    if (!pairing) return
-    pairings.delete(ticket)
-    if (pairing.expiresAt <= now) return
-
-    const accessToken = token()
-    grants.set(accessToken, { sessionID: pairing.sessionID, expiresAt: now + GRANT_TTL_MS })
-    return {
-      token: accessToken,
-      sessionID: pairing.sessionID,
-      expires_in: Math.floor(GRANT_TTL_MS / 1000),
-    }
-  }
-
-  export function authorized(accessToken: string, sessionID: string, now = Date.now()) {
-    prune(now)
-    const grant = grants.get(accessToken)
-    if (!grant || grant.expiresAt <= now) return false
-    return grant.sessionID === sessionID
-  }
-
-  export function revoke(sessionID: SessionID) {
-    for (const [key, value] of pairings) {
-      if (value.sessionID === sessionID) pairings.delete(key)
-    }
-    for (const [key, value] of grants) {
-      if (value.sessionID === sessionID) grants.delete(key)
-    }
-  }
-
-  export function resetForTest() {
-    pairings.clear()
-    grants.clear()
+  for (const [id, value] of grants) {
+    if (value.sessionID === sessionID) grants.delete(id)
   }
 }
+
+export function resetForTest() {
+  pairings.clear()
+  grants.clear()
+}
+
+export * as RemoteAccess from "./access"

--- a/packages/opencode/src/remote/access.ts
+++ b/packages/opencode/src/remote/access.ts
@@ -34,8 +34,21 @@ function prune(now = Date.now()) {
   }
 }
 
+function revokePairings(sessionID: SessionID) {
+  for (const [id, value] of pairings) {
+    if (value.sessionID === sessionID) pairings.delete(id)
+  }
+}
+
+function revokeGrants(sessionID: SessionID) {
+  for (const [id, value] of grants) {
+    if (value.sessionID === sessionID) grants.delete(id)
+  }
+}
+
 export function pair(sessionID: SessionID, now = Date.now()) {
   prune(now)
+  revokePairings(sessionID)
   const ticket = token()
   pairings.set(key(ticket), { sessionID, expiresAt: now + PAIR_TTL_MS })
   return { ticket, expires_in: Math.floor(PAIR_TTL_MS / 1000) }
@@ -49,6 +62,7 @@ export function redeem(ticket: string, now = Date.now()) {
   pairings.delete(ticketKey)
   if (pairing.expiresAt <= now) return
 
+  revokeGrants(pairing.sessionID)
   const accessToken = token()
   grants.set(key(accessToken), { sessionID: pairing.sessionID, expiresAt: now + GRANT_TTL_MS })
   return {
@@ -66,12 +80,8 @@ export function authorized(accessToken: string, sessionID: string, now = Date.no
 }
 
 export function revoke(sessionID: SessionID) {
-  for (const [id, value] of pairings) {
-    if (value.sessionID === sessionID) pairings.delete(id)
-  }
-  for (const [id, value] of grants) {
-    if (value.sessionID === sessionID) grants.delete(id)
-  }
+  revokePairings(sessionID)
+  revokeGrants(sessionID)
 }
 
 export function resetForTest() {

--- a/packages/opencode/src/remote/access.ts
+++ b/packages/opencode/src/remote/access.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from "node:crypto"
+import type { SessionID } from "@/session/schema"
+
+const PAIR_TTL_MS = 5 * 60 * 1000
+const GRANT_TTL_MS = 12 * 60 * 60 * 1000
+
+type Pairing = {
+  sessionID: SessionID
+  expiresAt: number
+}
+
+type Grant = {
+  sessionID: SessionID
+  expiresAt: number
+}
+
+const pairings = new Map<string, Pairing>()
+const grants = new Map<string, Grant>()
+
+function token() {
+  return randomBytes(32).toString("base64url")
+}
+
+function prune(now = Date.now()) {
+  for (const [key, value] of pairings) {
+    if (value.expiresAt <= now) pairings.delete(key)
+  }
+  for (const [key, value] of grants) {
+    if (value.expiresAt <= now) grants.delete(key)
+  }
+}
+
+export namespace RemoteAccess {
+  export function pair(sessionID: SessionID, now = Date.now()) {
+    prune(now)
+    const ticket = token()
+    pairings.set(ticket, { sessionID, expiresAt: now + PAIR_TTL_MS })
+    return { ticket, expires_in: Math.floor(PAIR_TTL_MS / 1000) }
+  }
+
+  export function redeem(ticket: string, now = Date.now()) {
+    prune(now)
+    const pairing = pairings.get(ticket)
+    if (!pairing) return
+    pairings.delete(ticket)
+    if (pairing.expiresAt <= now) return
+
+    const accessToken = token()
+    grants.set(accessToken, { sessionID: pairing.sessionID, expiresAt: now + GRANT_TTL_MS })
+    return {
+      token: accessToken,
+      sessionID: pairing.sessionID,
+      expires_in: Math.floor(GRANT_TTL_MS / 1000),
+    }
+  }
+
+  export function authorized(accessToken: string, sessionID: string, now = Date.now()) {
+    prune(now)
+    const grant = grants.get(accessToken)
+    if (!grant || grant.expiresAt <= now) return false
+    return grant.sessionID === sessionID
+  }
+
+  export function revoke(sessionID: SessionID) {
+    for (const [key, value] of pairings) {
+      if (value.sessionID === sessionID) pairings.delete(key)
+    }
+    for (const [key, value] of grants) {
+      if (value.sessionID === sessionID) grants.delete(key)
+    }
+  }
+
+  export function resetForTest() {
+    pairings.clear()
+    grants.clear()
+  }
+}

--- a/packages/opencode/src/remote/event.ts
+++ b/packages/opencode/src/remote/event.ts
@@ -1,0 +1,45 @@
+const forwardedTypes = new Set([
+  "session.created",
+  "session.updated",
+  "session.deleted",
+  "session.error",
+  "session.status",
+  "session.idle",
+  "message.updated",
+  "message.removed",
+  "message.part.updated",
+  "message.part.removed",
+  "message.part.delta",
+  "permission.asked",
+  "permission.replied",
+  "question.asked",
+  "question.replied",
+  "question.rejected",
+])
+
+type EventData = {
+  id: string
+  type: string
+  data: unknown
+}
+
+function belongsToSession(value: unknown, sessionID: string) {
+  if (!value || typeof value !== "object") return false
+  const data = value as Record<string, unknown>
+  if (data.sessionID === sessionID) return true
+  for (const key of ["info", "part", "message"]) {
+    const nested = data[key]
+    if (nested && typeof nested === "object" && (nested as Record<string, unknown>).sessionID === sessionID) return true
+  }
+  return false
+}
+
+export function shouldForward(event: Pick<EventData, "type" | "data">, sessionID: string) {
+  return forwardedTypes.has(event.type) && belongsToSession(event.data, sessionID)
+}
+
+export function signal(event: Pick<EventData, "id" | "type">) {
+  return { id: event.id, type: event.type, properties: {} }
+}
+
+export * as RemoteEvent from "./event"

--- a/packages/opencode/src/remote/mobile.ts
+++ b/packages/opencode/src/remote/mobile.ts
@@ -1,0 +1,401 @@
+import { HttpServerResponse } from "effect/unstable/http"
+
+const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark light" />
+  <title>OpenCode Remote</title>
+  <style>
+    :root { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color-scheme: dark light; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: Canvas; color: CanvasText; }
+    button, textarea, input { font: inherit; }
+    button { cursor: pointer; }
+    .shell { min-height: 100dvh; display: grid; grid-template-rows: auto 1fr auto; }
+    header { position: sticky; top: 0; z-index: 5; padding: max(12px, env(safe-area-inset-top)) 16px 12px; border-bottom: 1px solid color-mix(in srgb, CanvasText 14%, transparent); background: color-mix(in srgb, Canvas 94%, transparent); backdrop-filter: blur(12px); }
+    header strong { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .status { margin-top: 4px; font-size: 12px; opacity: .65; }
+    main { width: min(820px, 100%); margin: 0 auto; padding: 18px 14px 180px; }
+    .empty { opacity: .6; text-align: center; padding: 56px 16px; }
+    .message { margin: 0 0 14px; padding: 12px 14px; border: 1px solid color-mix(in srgb, CanvasText 12%, transparent); border-radius: 14px; background: color-mix(in srgb, CanvasText 3%, transparent); }
+    .message.user { margin-left: max(0px, 12%); }
+    .role { margin-bottom: 7px; font-size: 11px; text-transform: uppercase; letter-spacing: .08em; opacity: .55; }
+    .text { white-space: pre-wrap; overflow-wrap: anywhere; line-height: 1.45; }
+    .tool { margin-top: 8px; padding: 8px 10px; border-radius: 9px; background: color-mix(in srgb, CanvasText 5%, transparent); font-size: 12px; opacity: .8; }
+    .requests { display: grid; gap: 12px; margin: 0 0 18px; }
+    .request { padding: 12px; border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 12px; }
+    .request h3 { margin: 0 0 8px; font-size: 14px; }
+    .request p { margin: 6px 0 10px; font-size: 13px; opacity: .75; white-space: pre-wrap; overflow-wrap: anywhere; }
+    .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+    .actions button, .composer button { border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); border-radius: 9px; padding: 8px 11px; background: color-mix(in srgb, CanvasText 7%, transparent); color: inherit; }
+    .actions button.primary, .composer button.primary { background: CanvasText; color: Canvas; }
+    fieldset { border: 0; padding: 0; margin: 10px 0; }
+    legend { font-size: 13px; font-weight: 600; margin-bottom: 6px; }
+    label.option { display: flex; gap: 8px; padding: 5px 0; font-size: 13px; align-items: flex-start; }
+    label.option span small { display: block; opacity: .6; margin-top: 2px; }
+    .custom { width: 100%; border: 1px solid color-mix(in srgb, CanvasText 16%, transparent); border-radius: 8px; padding: 8px; background: Canvas; color: CanvasText; }
+    .composer { position: fixed; left: 0; right: 0; bottom: 0; z-index: 6; padding: 10px 12px max(10px, env(safe-area-inset-bottom)); background: color-mix(in srgb, Canvas 95%, transparent); border-top: 1px solid color-mix(in srgb, CanvasText 14%, transparent); backdrop-filter: blur(12px); }
+    .composer-inner { width: min(820px, 100%); margin: 0 auto; display: grid; grid-template-columns: 1fr auto; gap: 8px; }
+    textarea { min-height: 52px; max-height: 180px; resize: vertical; width: 100%; border: 1px solid color-mix(in srgb, CanvasText 16%, transparent); border-radius: 12px; padding: 10px 12px; background: Canvas; color: CanvasText; }
+    .composer-actions { display: flex; flex-direction: column; gap: 7px; }
+    .error { color: #d94c4c; }
+    [hidden] { display: none !important; }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header>
+      <strong id="title">OpenCode Remote</strong>
+      <div class="status" id="status">Connecting…</div>
+    </header>
+    <main>
+      <section class="requests" id="requests"></section>
+      <section id="messages"><div class="empty">Pairing with desktop…</div></section>
+    </main>
+    <div class="composer" id="composer" hidden>
+      <div class="composer-inner">
+        <textarea id="prompt" rows="2" placeholder="Send an instruction to OpenCode…"></textarea>
+        <div class="composer-actions">
+          <button class="primary" id="send" type="button">Send</button>
+          <button id="stop" type="button">Stop</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>
+    (function () {
+      "use strict"
+
+      var STORAGE_KEY = "opencode.remote.grant.v1"
+      var state = { token: "", sessionID: "", refreshTimer: 0, streamAbort: null, connected: false }
+      var title = document.getElementById("title")
+      var status = document.getElementById("status")
+      var messages = document.getElementById("messages")
+      var requests = document.getElementById("requests")
+      var composer = document.getElementById("composer")
+      var prompt = document.getElementById("prompt")
+      var send = document.getElementById("send")
+      var stop = document.getElementById("stop")
+
+      function setStatus(text, error) {
+        status.textContent = text
+        status.className = error ? "status error" : "status"
+      }
+
+      function api(path, init) {
+        var options = init || {}
+        var headers = new Headers(options.headers || {})
+        headers.set("Authorization", "Bearer " + state.token)
+        if (options.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json")
+        return fetch(path, Object.assign({}, options, { headers: headers })).then(function (response) {
+          if (response.status === 401 || response.status === 403) {
+            sessionStorage.removeItem(STORAGE_KEY)
+            throw new Error("Remote access expired or was replaced by another phone.")
+          }
+          if (!response.ok) throw new Error("Request failed (" + response.status + ")")
+          if (response.status === 204) return null
+          var type = response.headers.get("content-type") || ""
+          return type.indexOf("application/json") >= 0 ? response.json() : response.text()
+        })
+      }
+
+      function saveGrant(grant) {
+        state.token = grant.token
+        state.sessionID = grant.sessionID
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify({ token: grant.token, sessionID: grant.sessionID }))
+      }
+
+      function restoreGrant() {
+        try {
+          var raw = sessionStorage.getItem(STORAGE_KEY)
+          if (!raw) return false
+          var grant = JSON.parse(raw)
+          if (!grant || typeof grant.token !== "string" || typeof grant.sessionID !== "string") return false
+          state.token = grant.token
+          state.sessionID = grant.sessionID
+          return true
+        } catch (_) {
+          return false
+        }
+      }
+
+      async function redeemTicket() {
+        var fragment = new URLSearchParams(location.hash.slice(1))
+        var ticket = fragment.get("ticket")
+        if (location.hash) history.replaceState(null, "", location.pathname + location.search)
+        if (!ticket) return restoreGrant()
+
+        var response = await fetch("/remote/pair", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ticket: ticket }),
+        })
+        if (!response.ok) throw new Error("Pairing link is invalid or has expired.")
+        saveGrant(await response.json())
+        return true
+      }
+
+      function clear(node) {
+        while (node.firstChild) node.removeChild(node.firstChild)
+      }
+
+      function node(tag, className, text) {
+        var element = document.createElement(tag)
+        if (className) element.className = className
+        if (text !== undefined) element.textContent = text
+        return element
+      }
+
+      function textForMessage(message) {
+        var parts = Array.isArray(message.parts) ? message.parts : []
+        return parts.filter(function (part) { return part && part.type === "text" && typeof part.text === "string" })
+          .map(function (part) { return part.text })
+          .join("\n")
+      }
+
+      function renderMessages(data) {
+        clear(messages)
+        if (!Array.isArray(data.messages) || data.messages.length === 0) {
+          messages.appendChild(node("div", "empty", "No messages yet."))
+          return
+        }
+
+        data.messages.forEach(function (message) {
+          var role = message.info && message.info.role === "user" ? "user" : "assistant"
+          var card = node("article", "message " + role)
+          card.appendChild(node("div", "role", role))
+          var text = textForMessage(message)
+          if (text) card.appendChild(node("div", "text", text))
+
+          var parts = Array.isArray(message.parts) ? message.parts : []
+          parts.filter(function (part) { return part && part.type === "tool" }).forEach(function (part) {
+            var toolName = typeof part.tool === "string" ? part.tool : "tool"
+            var toolStatus = part.state && typeof part.state.status === "string" ? part.state.status : ""
+            card.appendChild(node("div", "tool", toolName + (toolStatus ? " · " + toolStatus : "")))
+          })
+          messages.appendChild(card)
+        })
+      }
+
+      async function replyPermission(requestID, reply) {
+        await api("/remote/session/" + encodeURIComponent(state.sessionID) + "/permission/" + encodeURIComponent(requestID), {
+          method: "POST",
+          body: JSON.stringify({ reply: reply }),
+        })
+        await refresh()
+      }
+
+      function renderPermissions(items) {
+        items.forEach(function (item) {
+          var card = node("section", "request")
+          card.appendChild(node("h3", "", "Permission: " + item.permission))
+          if (Array.isArray(item.patterns) && item.patterns.length) card.appendChild(node("p", "", item.patterns.join("\n")))
+          var actions = node("div", "actions")
+          ;[["Allow once", "once"], ["Always allow", "always"], ["Reject", "reject"]].forEach(function (entry) {
+            var button = node("button", entry[1] === "once" ? "primary" : "", entry[0])
+            button.type = "button"
+            button.addEventListener("click", function () { replyPermission(item.id, entry[1]).catch(fail) })
+            actions.appendChild(button)
+          })
+          card.appendChild(actions)
+          requests.appendChild(card)
+        })
+      }
+
+      async function replyQuestion(requestID, answers) {
+        await api("/remote/session/" + encodeURIComponent(state.sessionID) + "/question/" + encodeURIComponent(requestID), {
+          method: "POST",
+          body: JSON.stringify({ answers: answers }),
+        })
+        await refresh()
+      }
+
+      async function rejectQuestion(requestID) {
+        await api("/remote/session/" + encodeURIComponent(state.sessionID) + "/question/" + encodeURIComponent(requestID) + "/reject", { method: "POST" })
+        await refresh()
+      }
+
+      function renderQuestions(items) {
+        items.forEach(function (item) {
+          var form = node("form", "request")
+          form.appendChild(node("h3", "", "OpenCode needs your answer"))
+          var fields = []
+
+          ;(item.questions || []).forEach(function (question, questionIndex) {
+            var fieldset = node("fieldset", "")
+            fieldset.appendChild(node("legend", "", question.question || question.header || "Question"))
+            var group = "q-" + item.id + "-" + questionIndex
+            var controls = []
+            ;(question.options || []).forEach(function (option) {
+              var label = node("label", "option")
+              var input = document.createElement("input")
+              input.type = question.multiple ? "checkbox" : "radio"
+              input.name = group
+              input.value = option.label
+              var words = node("span", "", option.label)
+              if (option.description) words.appendChild(node("small", "", option.description))
+              label.appendChild(input)
+              label.appendChild(words)
+              fieldset.appendChild(label)
+              controls.push(input)
+            })
+            var custom = null
+            if (question.custom !== false) {
+              custom = document.createElement("input")
+              custom.type = "text"
+              custom.className = "custom"
+              custom.placeholder = "Custom answer"
+              fieldset.appendChild(custom)
+            }
+            fields.push({ controls: controls, custom: custom })
+            form.appendChild(fieldset)
+          })
+
+          var actions = node("div", "actions")
+          var submit = node("button", "primary", "Submit")
+          submit.type = "submit"
+          var reject = node("button", "", "Dismiss")
+          reject.type = "button"
+          reject.addEventListener("click", function () { rejectQuestion(item.id).catch(fail) })
+          actions.appendChild(submit)
+          actions.appendChild(reject)
+          form.appendChild(actions)
+          form.addEventListener("submit", function (event) {
+            event.preventDefault()
+            var answers = fields.map(function (field) {
+              var selected = field.controls.filter(function (control) { return control.checked }).map(function (control) { return control.value })
+              var custom = field.custom && field.custom.value.trim()
+              if (custom) selected.push(custom)
+              return selected
+            })
+            replyQuestion(item.id, answers).catch(fail)
+          })
+          requests.appendChild(form)
+        })
+      }
+
+      function renderRequests(data) {
+        clear(requests)
+        renderPermissions(Array.isArray(data.permissions) ? data.permissions : [])
+        renderQuestions(Array.isArray(data.questions) ? data.questions : [])
+      }
+
+      async function refresh() {
+        var data = await api("/remote/session/" + encodeURIComponent(state.sessionID))
+        title.textContent = data.session && data.session.title ? data.session.title : "OpenCode Remote"
+        var kind = data.status && data.status.type ? data.status.type : "idle"
+        setStatus(state.connected ? kind + " · live" : kind + " · connecting")
+        renderRequests(data)
+        renderMessages(data)
+        composer.hidden = false
+      }
+
+      function scheduleRefresh() {
+        clearTimeout(state.refreshTimer)
+        state.refreshTimer = setTimeout(function () { refresh().catch(fail) }, 180)
+      }
+
+      async function streamEvents() {
+        if (state.streamAbort) state.streamAbort.abort()
+        var controller = new AbortController()
+        state.streamAbort = controller
+        var response = await fetch("/remote/session/" + encodeURIComponent(state.sessionID) + "/events", {
+          headers: { Authorization: "Bearer " + state.token, Accept: "text/event-stream" },
+          signal: controller.signal,
+        })
+        if (!response.ok || !response.body) throw new Error("Live connection failed (" + response.status + ")")
+        state.connected = true
+        scheduleRefresh()
+
+        var reader = response.body.getReader()
+        var decoder = new TextDecoder()
+        var buffer = ""
+        while (true) {
+          var result = await reader.read()
+          if (result.done) break
+          buffer += decoder.decode(result.value, { stream: true })
+          var boundary
+          while ((boundary = buffer.indexOf("\n\n")) >= 0) {
+            var block = buffer.slice(0, boundary).replace(/\r/g, "")
+            buffer = buffer.slice(boundary + 2)
+            if (block.split("\n").some(function (line) { return line.indexOf("data:") === 0 })) scheduleRefresh()
+          }
+        }
+        state.connected = false
+        scheduleRefresh()
+      }
+
+      async function reconnectLoop() {
+        while (state.token && state.sessionID) {
+          try {
+            await streamEvents()
+          } catch (error) {
+            if (state.streamAbort && state.streamAbort.signal.aborted) return
+            state.connected = false
+            setStatus(error instanceof Error ? error.message : String(error), true)
+          }
+          await new Promise(function (resolve) { setTimeout(resolve, 1200) })
+        }
+      }
+
+      async function submitPrompt() {
+        var text = prompt.value.trim()
+        if (!text) return
+        send.disabled = true
+        try {
+          await api("/remote/session/" + encodeURIComponent(state.sessionID) + "/message", {
+            method: "POST",
+            body: JSON.stringify({ parts: [{ type: "text", text: text }] }),
+          })
+          prompt.value = ""
+          scheduleRefresh()
+        } finally {
+          send.disabled = false
+        }
+      }
+
+      async function abortSession() {
+        await api("/remote/session/" + encodeURIComponent(state.sessionID) + "/abort", { method: "POST" })
+        scheduleRefresh()
+      }
+
+      function fail(error) {
+        setStatus(error instanceof Error ? error.message : String(error), true)
+      }
+
+      send.addEventListener("click", function () { submitPrompt().catch(fail) })
+      stop.addEventListener("click", function () { abortSession().catch(fail) })
+      prompt.addEventListener("keydown", function (event) {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault()
+          submitPrompt().catch(fail)
+        }
+      })
+
+      redeemTicket().then(function (paired) {
+        if (!paired) throw new Error("Open this page from a fresh OpenCode Remote QR code.")
+        return refresh()
+      }).then(function () {
+        reconnectLoop()
+      }).catch(fail)
+    })()
+  </script>
+</body>
+</html>`
+
+export function response() {
+  return HttpServerResponse.text(html, {
+    contentType: "text/html; charset=utf-8",
+    headers: {
+      "cache-control": "no-store",
+      "content-security-policy": "default-src 'none'; connect-src 'self'; img-src 'self' data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'",
+      "permissions-policy": "camera=(), microphone=(), geolocation=()",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+  })
+}
+
+export * as RemoteMobile from "./mobile"

--- a/packages/opencode/src/remote/mobile.ts
+++ b/packages/opencode/src/remote/mobile.ts
@@ -1,6 +1,6 @@
 import { HttpServerResponse } from "effect/unstable/http"
 
-const html = `<!doctype html>
+const html = String.raw`<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -69,6 +69,7 @@ const html = `<!doctype html>
       "use strict"
 
       var STORAGE_KEY = "opencode.remote.grant.v1"
+      var EXPIRED_MESSAGE = "Remote access expired or was replaced by another phone."
       var state = { token: "", sessionID: "", refreshTimer: 0, streamAbort: null, connected: false }
       var title = document.getElementById("title")
       var status = document.getElementById("status")
@@ -84,16 +85,27 @@ const html = `<!doctype html>
         status.className = error ? "status error" : "status"
       }
 
+      function expireRemoteAccess() {
+        sessionStorage.removeItem(STORAGE_KEY)
+        state.token = ""
+        state.sessionID = ""
+        state.connected = false
+        clearTimeout(state.refreshTimer)
+        state.refreshTimer = 0
+        if (state.streamAbort && !state.streamAbort.signal.aborted) state.streamAbort.abort()
+        state.streamAbort = null
+        composer.hidden = true
+        setStatus(EXPIRED_MESSAGE, true)
+        return new Error(EXPIRED_MESSAGE)
+      }
+
       function api(path, init) {
         var options = init || {}
         var headers = new Headers(options.headers || {})
         headers.set("Authorization", "Bearer " + state.token)
         if (options.body && !headers.has("Content-Type")) headers.set("Content-Type", "application/json")
         return fetch(path, Object.assign({}, options, { headers: headers })).then(function (response) {
-          if (response.status === 401 || response.status === 403) {
-            sessionStorage.removeItem(STORAGE_KEY)
-            throw new Error("Remote access expired or was replaced by another phone.")
-          }
+          if (response.status === 401 || response.status === 403) throw expireRemoteAccess()
           if (!response.ok) throw new Error("Request failed (" + response.status + ")")
           if (response.status === 204) return null
           var type = response.headers.get("content-type") || ""
@@ -112,11 +124,15 @@ const html = `<!doctype html>
           var raw = sessionStorage.getItem(STORAGE_KEY)
           if (!raw) return false
           var grant = JSON.parse(raw)
-          if (!grant || typeof grant.token !== "string" || typeof grant.sessionID !== "string") return false
+          if (!grant || typeof grant.token !== "string" || typeof grant.sessionID !== "string") {
+            sessionStorage.removeItem(STORAGE_KEY)
+            return false
+          }
           state.token = grant.token
           state.sessionID = grant.sessionID
           return true
         } catch (_) {
+          sessionStorage.removeItem(STORAGE_KEY)
           return false
         }
       }
@@ -293,6 +309,7 @@ const html = `<!doctype html>
       }
 
       function scheduleRefresh() {
+        if (!state.token || !state.sessionID) return
         clearTimeout(state.refreshTimer)
         state.refreshTimer = setTimeout(function () { refresh().catch(fail) }, 180)
       }
@@ -305,6 +322,7 @@ const html = `<!doctype html>
           headers: { Authorization: "Bearer " + state.token, Accept: "text/event-stream" },
           signal: controller.signal,
         })
+        if (response.status === 401 || response.status === 403) throw expireRemoteAccess()
         if (!response.ok || !response.body) throw new Error("Live connection failed (" + response.status + ")")
         state.connected = true
         scheduleRefresh()
@@ -317,9 +335,9 @@ const html = `<!doctype html>
           if (result.done) break
           buffer += decoder.decode(result.value, { stream: true })
           var boundary
-          while ((boundary = buffer.indexOf("\n\n")) >= 0) {
-            var block = buffer.slice(0, boundary).replace(/\r/g, "")
-            buffer = buffer.slice(boundary + 2)
+          while ((boundary = /\r\n\r\n|\n\n|\r\r/.exec(buffer))) {
+            var block = buffer.slice(0, boundary.index).replace(/\r/g, "")
+            buffer = buffer.slice(boundary.index + boundary[0].length)
             if (block.split("\n").some(function (line) { return line.indexOf("data:") === 0 })) scheduleRefresh()
           }
         }
@@ -332,10 +350,12 @@ const html = `<!doctype html>
           try {
             await streamEvents()
           } catch (error) {
+            if (!state.token || !state.sessionID) return
             if (state.streamAbort && state.streamAbort.signal.aborted) return
             state.connected = false
             setStatus(error instanceof Error ? error.message : String(error), true)
           }
+          if (!state.token || !state.sessionID) return
           await new Promise(function (resolve) { setTimeout(resolve, 1200) })
         }
       }
@@ -384,6 +404,10 @@ const html = `<!doctype html>
   </script>
 </body>
 </html>`
+
+export function markup() {
+  return html
+}
 
 export function response() {
   return HttpServerResponse.text(html, {

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -21,6 +21,7 @@ import { ProjectCopyApi } from "./groups/project-copy"
 import { ProviderApi } from "./groups/provider"
 import { PtyApi, PtyConnectApi } from "./groups/pty"
 import { QuestionApi } from "./groups/question"
+import { RemoteAdminApi, RemoteApi, RemotePairApi } from "./groups/remote"
 import { SessionApi } from "./groups/session"
 import { SyncApi } from "./groups/sync"
 import { TuiApi } from "./groups/tui"
@@ -82,6 +83,9 @@ export const OpenCodeHttpApi = HttpApi.make("opencode")
   .addHttpApi(InstanceHttpApi)
   .addHttpApi(ServerApi)
   .addHttpApi(PtyConnectApi)
+  .addHttpApi(RemoteAdminApi)
+  .addHttpApi(RemotePairApi)
+  .addHttpApi(RemoteApi)
   .annotate(HttpApi.AdditionalSchemas, [
     EventSchema,
     Question.Replied,

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -21,7 +21,6 @@ import { ProjectCopyApi } from "./groups/project-copy"
 import { ProviderApi } from "./groups/provider"
 import { PtyApi, PtyConnectApi } from "./groups/pty"
 import { QuestionApi } from "./groups/question"
-import { RemoteAdminApi, RemoteApi, RemotePairApi } from "./groups/remote"
 import { SessionApi } from "./groups/session"
 import { SyncApi } from "./groups/sync"
 import { TuiApi } from "./groups/tui"
@@ -83,9 +82,6 @@ export const OpenCodeHttpApi = HttpApi.make("opencode")
   .addHttpApi(InstanceHttpApi)
   .addHttpApi(ServerApi)
   .addHttpApi(PtyConnectApi)
-  .addHttpApi(RemoteAdminApi)
-  .addHttpApi(RemotePairApi)
-  .addHttpApi(RemoteApi)
   .annotate(HttpApi.AdditionalSchemas, [
     EventSchema,
     Question.Replied,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -1,10 +1,7 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
-import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Question } from "@/question"
 import { QuestionID } from "@/question/schema"
 import { SessionID } from "@/session/schema"
-import { Session } from "@/session/session"
-import { SessionStatus } from "@/session/status"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import { ApiNotFoundError } from "../errors"
@@ -27,12 +24,42 @@ export const RemoteRedeemResult = Schema.Struct({
   expires_in: Schema.Number,
 })
 
+const RemoteMessagePart = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("text"),
+    text: Schema.String,
+  }),
+  Schema.Struct({
+    type: Schema.Literal("tool"),
+    tool: Schema.String,
+    state: Schema.Struct({
+      status: Schema.Literals(["pending", "running", "completed", "error"]),
+    }),
+  }),
+])
+
+const RemotePermission = Schema.Struct({
+  id: PermissionV1.ID,
+  permission: Schema.String,
+  patterns: Schema.Array(Schema.String),
+})
+
+const RemoteQuestion = Schema.Struct({
+  id: QuestionID,
+  questions: Schema.Array(Question.Info),
+})
+
 export const RemoteBootstrap = Schema.Struct({
-  session: Session.Info,
-  messages: Schema.Array(SessionV1.WithParts),
-  status: SessionStatus.Info,
-  permissions: Schema.Array(PermissionV1.Request),
-  questions: Schema.Array(Question.Request),
+  session: Schema.Struct({ title: Schema.String }),
+  messages: Schema.Array(
+    Schema.Struct({
+      info: Schema.Struct({ role: Schema.Literals(["user", "assistant"]) }),
+      parts: Schema.Array(RemoteMessagePart),
+    }),
+  ),
+  status: Schema.Struct({ type: Schema.Literals(["idle", "retry", "busy"]) }),
+  permissions: Schema.Array(RemotePermission),
+  questions: Schema.Array(RemoteQuestion),
 })
 
 export const RemoteMessagePayload = Schema.Struct({

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -12,7 +12,6 @@ import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import { RemoteAuthorization } from "../middleware/remote-authorization"
 import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
-import { PromptPayload } from "./session"
 
 const remoteRoot = "/remote"
 
@@ -34,6 +33,15 @@ export const RemoteBootstrap = Schema.Struct({
   status: SessionStatus.Info,
   permissions: Schema.Array(PermissionV1.Request),
   questions: Schema.Array(Question.Request),
+})
+
+export const RemoteMessagePayload = Schema.Struct({
+  parts: Schema.Array(
+    Schema.Struct({
+      type: Schema.Literal("text"),
+      text: Schema.String,
+    }),
+  ),
 })
 
 export const RemotePermissionReply = Schema.Struct({
@@ -95,7 +103,7 @@ export const RemoteApi = HttpApi.make("remote").add(
       HttpApiEndpoint.post("message", `${remoteRoot}/session/:sessionID/message`, {
         params: { sessionID: SessionID },
         query: WorkspaceRoutingQuery,
-        payload: PromptPayload,
+        payload: RemoteMessagePayload,
         success: HttpApiSchema.NoContent,
         error: [HttpApiError.BadRequest, HttpApiError.Forbidden, ApiNotFoundError],
       }),

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -1,0 +1,133 @@
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Question } from "@/question"
+import { QuestionID } from "@/question/schema"
+import { SessionID } from "@/session/schema"
+import { Session } from "@/session/session"
+import { SessionStatus } from "@/session/status"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { ApiNotFoundError } from "../errors"
+import { Authorization } from "../middleware/authorization"
+import { InstanceContextMiddleware } from "../middleware/instance-context"
+import { RemoteAuthorization } from "../middleware/remote-authorization"
+import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
+import { PromptPayload } from "./session"
+
+const remoteRoot = "/remote"
+
+export const RemotePairToken = Schema.Struct({
+  ticket: Schema.String,
+  expires_in: Schema.Number,
+})
+
+export const RemoteRedeemInput = Schema.Struct({ ticket: Schema.String })
+export const RemoteRedeemResult = Schema.Struct({
+  token: Schema.String,
+  sessionID: SessionID,
+  expires_in: Schema.Number,
+})
+
+export const RemoteBootstrap = Schema.Struct({
+  session: Session.Info,
+  messages: Schema.Array(SessionV1.WithParts),
+  status: SessionStatus.Info,
+  permissions: Schema.Array(PermissionV1.Request),
+  questions: Schema.Array(Question.Request),
+})
+
+export const RemotePermissionReply = Schema.Struct({
+  reply: PermissionV1.Reply,
+  message: Schema.optional(Schema.String),
+})
+
+export const RemoteQuestionReply = Schema.Struct({
+  answers: Schema.Array(Question.Answer),
+})
+
+export const RemoteAdminApi = HttpApi.make("remote-admin").add(
+  HttpApiGroup.make("remote-admin")
+    .add(
+      HttpApiEndpoint.post("pair", "/session/:sessionID/remote", {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        success: RemotePairToken,
+        error: ApiNotFoundError,
+      }),
+      HttpApiEndpoint.delete("revoke", "/session/:sessionID/remote", {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        success: Schema.Boolean,
+        error: ApiNotFoundError,
+      }),
+    )
+    .middleware(InstanceContextMiddleware)
+    .middleware(WorkspaceRoutingMiddleware)
+    .middleware(Authorization)
+    .annotateMerge(OpenApi.annotations({ title: "remote admin", description: "Manage session remote access." })),
+)
+
+export const RemotePairApi = HttpApi.make("remote-pair").add(
+  HttpApiGroup.make("remote-pair").add(
+    HttpApiEndpoint.post("redeem", `${remoteRoot}/pair`, {
+      payload: RemoteRedeemInput,
+      success: RemoteRedeemResult,
+      error: HttpApiError.Forbidden,
+    }),
+  ),
+)
+
+export const RemoteApi = HttpApi.make("remote").add(
+  HttpApiGroup.make("remote")
+    .add(
+      HttpApiEndpoint.get("bootstrap", `${remoteRoot}/session/:sessionID`, {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        success: RemoteBootstrap,
+        error: [HttpApiError.Forbidden, ApiNotFoundError],
+      }),
+      HttpApiEndpoint.get("events", `${remoteRoot}/session/:sessionID/events`, {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        success: Schema.String.pipe(HttpApiSchema.asText({ contentType: "text/event-stream" })),
+        error: HttpApiError.Forbidden,
+      }),
+      HttpApiEndpoint.post("message", `${remoteRoot}/session/:sessionID/message`, {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        payload: PromptPayload,
+        success: HttpApiSchema.NoContent,
+        error: [HttpApiError.BadRequest, HttpApiError.Forbidden, ApiNotFoundError],
+      }),
+      HttpApiEndpoint.post("abort", `${remoteRoot}/session/:sessionID/abort`, {
+        params: { sessionID: SessionID },
+        query: WorkspaceRoutingQuery,
+        success: Schema.Boolean,
+        error: HttpApiError.Forbidden,
+      }),
+      HttpApiEndpoint.post("permission", `${remoteRoot}/session/:sessionID/permission/:requestID`, {
+        params: { sessionID: SessionID, requestID: PermissionV1.ID },
+        query: WorkspaceRoutingQuery,
+        payload: RemotePermissionReply,
+        success: Schema.Boolean,
+        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+      }),
+      HttpApiEndpoint.post("question", `${remoteRoot}/session/:sessionID/question/:requestID`, {
+        params: { sessionID: SessionID, requestID: QuestionID },
+        query: WorkspaceRoutingQuery,
+        payload: RemoteQuestionReply,
+        success: Schema.Boolean,
+        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+      }),
+      HttpApiEndpoint.post("questionReject", `${remoteRoot}/session/:sessionID/question/:requestID/reject`, {
+        params: { sessionID: SessionID, requestID: QuestionID },
+        query: WorkspaceRoutingQuery,
+        success: Schema.Boolean,
+        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+      }),
+    )
+    .middleware(InstanceContextMiddleware)
+    .middleware(WorkspaceRoutingMiddleware)
+    .middleware(RemoteAuthorization)
+    .annotateMerge(OpenApi.annotations({ title: "remote", description: "Session-scoped mobile remote control." })),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -145,20 +145,20 @@ export const RemoteApi = HttpApi.make("remote").add(
         query: WorkspaceRoutingQuery,
         payload: RemotePermissionReply,
         success: Schema.Boolean,
-        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+        error: HttpApiError.BadRequest,
       }),
       HttpApiEndpoint.post("question", `${remoteRoot}/session/:sessionID/question/:requestID`, {
         params: { sessionID: SessionID, requestID: QuestionID },
         query: WorkspaceRoutingQuery,
         payload: RemoteQuestionReply,
         success: Schema.Boolean,
-        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+        error: HttpApiError.BadRequest,
       }),
       HttpApiEndpoint.post("questionReject", `${remoteRoot}/session/:sessionID/question/:requestID/reject`, {
         params: { sessionID: SessionID, requestID: QuestionID },
         query: WorkspaceRoutingQuery,
         success: Schema.Boolean,
-        error: [HttpApiError.BadRequest, HttpApiError.Forbidden],
+        error: HttpApiError.BadRequest,
       }),
     )
     .middleware(InstanceContextMiddleware)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -87,7 +87,7 @@ export const RemoteAdminApi = HttpApi.make("remote-admin").add(
         params: { sessionID: SessionID },
         query: WorkspaceRoutingQuery,
         success: RemotePairToken,
-        error: ApiNotFoundError,
+        error: [HttpApiError.BadRequest, ApiNotFoundError],
       }),
       HttpApiEndpoint.delete("revoke", "/session/:sessionID/remote", {
         params: { sessionID: SessionID },

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/remote.ts
@@ -93,7 +93,6 @@ export const RemoteAdminApi = HttpApi.make("remote-admin").add(
         params: { sessionID: SessionID },
         query: WorkspaceRoutingQuery,
         success: Schema.Boolean,
-        error: ApiNotFoundError,
       }),
     )
     .middleware(InstanceContextMiddleware)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -122,8 +122,9 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
       .handle("message", (ctx) =>
         Effect.gen(function* () {
           yield* requireSession(ctx.params.sessionID)
+          const parts = ctx.payload.parts.map((part) => ({ type: "text" as const, text: part.text }))
           yield* prompt
-            .prompt({ ...ctx.payload, sessionID: ctx.params.sessionID })
+            .prompt({ sessionID: ctx.params.sessionID, parts })
             .pipe(
               Effect.catchCause((cause) =>
                 Effect.logError("remote prompt failed", { sessionID: ctx.params.sessionID, cause: Cause.pretty(cause) }),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -108,6 +108,16 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
     const events = yield* EventV2Bridge.Service
     const scope = yield* Scope.Scope
 
+    const unsubscribeDeleted = yield* events.listen((event) =>
+      Effect.sync(() => {
+        if (event.type !== "session.deleted") return
+        const sessionID = (event.data as { sessionID?: unknown }).sessionID
+        if (typeof sessionID !== "string") return
+        RemoteAccess.revoke(sessionID as Parameters<typeof RemoteAccess.revoke>[0])
+      }),
+    )
+    yield* Effect.addFinalizer(() => unsubscribeDeleted)
+
     const requireSession = (sessionID: Parameters<typeof RemoteAccess.revoke>[0]) =>
       SessionError.mapStorageNotFound(sessions.get(sessionID))
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -107,14 +107,28 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
         Effect.gen(function* () {
           const session = yield* requireSession(ctx.params.sessionID)
           const messages = yield* SessionError.mapStorageNotFound(sessions.messages({ sessionID: ctx.params.sessionID }))
+          const currentStatus = yield* status.get(ctx.params.sessionID)
           const pendingPermissions = (yield* permission.list()).filter((item) => item.sessionID === ctx.params.sessionID)
           const pendingQuestions = (yield* question.list()).filter((item) => item.sessionID === ctx.params.sessionID)
           return {
-            session,
-            messages,
-            status: yield* status.get(ctx.params.sessionID),
-            permissions: pendingPermissions,
-            questions: pendingQuestions,
+            session: { title: session.title },
+            messages: messages.map((message) => ({
+              info: { role: message.info.role },
+              parts: message.parts.flatMap((part) => {
+                if (part.type === "text") return [{ type: "text" as const, text: part.text }]
+                if (part.type === "tool") {
+                  return [{ type: "tool" as const, tool: part.tool, state: { status: part.state.status } }]
+                }
+                return []
+              }),
+            })),
+            status: { type: currentStatus.type },
+            permissions: pendingPermissions.map((item) => ({
+              id: item.id,
+              permission: item.permission,
+              patterns: item.patterns,
+            })),
+            questions: pendingQuestions.map((item) => ({ id: item.id, questions: item.questions })),
           }
         }),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -139,10 +139,19 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
       .handleRaw("events", (ctx) => remoteEventResponse(events, ctx.params.sessionID))
       .handle("message", (ctx) =>
         Effect.gen(function* () {
-          yield* requireSession(ctx.params.sessionID)
+          const session = yield* requireSession(ctx.params.sessionID)
           const parts = ctx.payload.parts.map((part) => ({ type: "text" as const, text: part.text }))
+          const model = session.model
+            ? { providerID: session.model.providerID, modelID: session.model.id }
+            : undefined
           yield* prompt
-            .prompt({ sessionID: ctx.params.sessionID, parts })
+            .prompt({
+              sessionID: ctx.params.sessionID,
+              parts,
+              agent: session.agent,
+              model,
+              variant: session.model?.variant,
+            })
             .pipe(
               Effect.catchCause((cause) =>
                 Effect.logError("remote prompt failed", { sessionID: ctx.params.sessionID, cause: Cause.pretty(cause) }),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -2,6 +2,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { Permission } from "@/permission"
 import { Question } from "@/question"
 import { RemoteAccess } from "@/remote/access"
+import { RemoteEvent } from "@/remote/event"
 import { SessionPrompt } from "@/session/prompt"
 import { Session } from "@/session/session"
 import { SessionStatus } from "@/session/status"
@@ -22,17 +23,6 @@ function eventID() {
   return EventV2.ID.create()
 }
 
-function belongsToSession(value: unknown, sessionID: string) {
-  if (!value || typeof value !== "object") return false
-  const data = value as Record<string, unknown>
-  if (data.sessionID === sessionID) return true
-  for (const key of ["info", "part", "message"]) {
-    const nested = data[key]
-    if (nested && typeof nested === "object" && (nested as Record<string, unknown>).sessionID === sessionID) return true
-  }
-  return false
-}
-
 function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
   return Effect.gen(function* () {
     const queue = yield* Queue.unbounded<EventV2.Payload>()
@@ -40,8 +30,8 @@ function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
     yield* Effect.addFinalizer(() => unsubscribe)
 
     const output = Stream.fromQueue(queue).pipe(
-      Stream.filter((event) => belongsToSession(event.data, sessionID)),
-      Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
+      Stream.filter((event) => RemoteEvent.shouldForward(event, sessionID)),
+      Stream.map((event) => RemoteEvent.signal(event)),
     )
     const heartbeat = Stream.tick("10 seconds").pipe(
       Stream.drop(1),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -1,0 +1,176 @@
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Permission } from "@/permission"
+import { Question } from "@/question"
+import { RemoteAccess } from "@/remote/access"
+import { SessionPrompt } from "@/session/prompt"
+import { Session } from "@/session/session"
+import { SessionStatus } from "@/session/status"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Cause, Effect, Queue, Scope } from "effect"
+import * as Stream from "effect/Stream"
+import { HttpServerResponse } from "effect/unstable/http"
+import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
+import * as Sse from "effect/unstable/encoding/Sse"
+import { RemoteAdminApi, RemoteApi, RemotePairApi } from "../groups/remote"
+import * as SessionError from "./session-errors"
+
+function eventData(data: unknown): Sse.Event {
+  return { _tag: "Event", event: "message", id: undefined, data: JSON.stringify(data) }
+}
+
+function eventID() {
+  return EventV2.ID.create()
+}
+
+function belongsToSession(value: unknown, sessionID: string) {
+  if (!value || typeof value !== "object") return false
+  const data = value as Record<string, unknown>
+  if (data.sessionID === sessionID) return true
+  for (const key of ["info", "part", "message"]) {
+    const nested = data[key]
+    if (nested && typeof nested === "object" && (nested as Record<string, unknown>).sessionID === sessionID) return true
+  }
+  return false
+}
+
+function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
+  return Effect.gen(function* () {
+    const queue = yield* Queue.unbounded<EventV2.Payload>()
+    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
+    yield* Effect.addFinalizer(() => unsubscribe)
+
+    const output = Stream.fromQueue(queue).pipe(
+      Stream.filter((event) => belongsToSession(event.data, sessionID)),
+      Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
+    )
+    const heartbeat = Stream.tick("10 seconds").pipe(
+      Stream.drop(1),
+      Stream.map(() => ({ id: eventID(), type: "server.heartbeat", properties: {} })),
+    )
+
+    return HttpServerResponse.stream(
+      Stream.make({ id: eventID(), type: "server.connected", properties: { sessionID } }).pipe(
+        Stream.concat(output.pipe(Stream.merge(heartbeat, { haltStrategy: "left" }))),
+        Stream.map(eventData),
+        Stream.pipeThroughChannel(Sse.encode()),
+        Stream.encodeText,
+      ),
+      {
+        contentType: "text/event-stream",
+        headers: {
+          "Cache-Control": "no-cache, no-transform",
+          "X-Accel-Buffering": "no",
+          "X-Content-Type-Options": "nosniff",
+        },
+      },
+    )
+  })
+}
+
+export const remoteAdminHandlers = HttpApiBuilder.group(RemoteAdminApi, "remote-admin", (handlers) =>
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    const requireSession = (sessionID: Parameters<typeof RemoteAccess.pair>[0]) =>
+      SessionError.mapStorageNotFound(sessions.get(sessionID))
+
+    return handlers
+      .handle("pair", (ctx) =>
+        Effect.gen(function* () {
+          yield* requireSession(ctx.params.sessionID)
+          return RemoteAccess.pair(ctx.params.sessionID)
+        }),
+      )
+      .handle("revoke", (ctx) =>
+        Effect.gen(function* () {
+          yield* requireSession(ctx.params.sessionID)
+          RemoteAccess.revoke(ctx.params.sessionID)
+          return true
+        }),
+      )
+  }),
+)
+
+export const remotePairHandlers = HttpApiBuilder.group(RemotePairApi, "remote-pair", (handlers) =>
+  Effect.succeed(
+    handlers.handle("redeem", (ctx) => {
+      const grant = RemoteAccess.redeem(ctx.payload.ticket)
+      return grant ? Effect.succeed(grant) : Effect.fail(new HttpApiError.Forbidden({}))
+    }),
+  ),
+)
+
+export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handlers) =>
+  Effect.gen(function* () {
+    const sessions = yield* Session.Service
+    const prompt = yield* SessionPrompt.Service
+    const status = yield* SessionStatus.Service
+    const permission = yield* Permission.Service
+    const question = yield* Question.Service
+    const events = yield* EventV2Bridge.Service
+    const scope = yield* Scope.Scope
+
+    const requireSession = (sessionID: Parameters<typeof RemoteAccess.revoke>[0]) =>
+      SessionError.mapStorageNotFound(sessions.get(sessionID))
+
+    return handlers
+      .handle("bootstrap", (ctx) =>
+        Effect.gen(function* () {
+          const session = yield* requireSession(ctx.params.sessionID)
+          const messages = yield* SessionError.mapStorageNotFound(sessions.messages({ sessionID: ctx.params.sessionID }))
+          const pendingPermissions = (yield* permission.list()).filter((item) => item.sessionID === ctx.params.sessionID)
+          const pendingQuestions = (yield* question.list()).filter((item) => item.sessionID === ctx.params.sessionID)
+          return {
+            session,
+            messages,
+            status: yield* status.get(ctx.params.sessionID),
+            permissions: pendingPermissions,
+            questions: pendingQuestions,
+          }
+        }),
+      )
+      .handleRaw("events", (ctx) => remoteEventResponse(events, ctx.params.sessionID))
+      .handle("message", (ctx) =>
+        Effect.gen(function* () {
+          yield* requireSession(ctx.params.sessionID)
+          yield* prompt
+            .prompt({ ...ctx.payload, sessionID: ctx.params.sessionID })
+            .pipe(
+              Effect.catchCause((cause) =>
+                Effect.logError("remote prompt failed", { sessionID: ctx.params.sessionID, cause: Cause.pretty(cause) }),
+              ),
+              Effect.forkIn(scope, { startImmediately: true }),
+            )
+          return HttpApiSchema.NoContent.make()
+        }),
+      )
+      .handle("abort", (ctx) => prompt.cancel(ctx.params.sessionID).pipe(Effect.as(true)))
+      .handle("permission", (ctx) =>
+        Effect.gen(function* () {
+          const request = (yield* permission.list()).find((item) => item.id === ctx.params.requestID)
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          yield* permission
+            .reply({ requestID: ctx.params.requestID, reply: ctx.payload.reply, message: ctx.payload.message })
+            .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+          return true
+        }),
+      )
+      .handle("question", (ctx) =>
+        Effect.gen(function* () {
+          const request = (yield* question.list()).find((item) => item.id === ctx.params.requestID)
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          yield* question
+            .reply({ requestID: ctx.params.requestID, answers: ctx.payload.answers })
+            .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+          return true
+        }),
+      )
+      .handle("questionReject", (ctx) =>
+        Effect.gen(function* () {
+          const request = (yield* question.list()).find((item) => item.id === ctx.params.requestID)
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          yield* question.reject(ctx.params.requestID).pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+          return true
+        }),
+      )
+  }),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -81,8 +81,7 @@ export const remoteAdminHandlers = HttpApiBuilder.group(RemoteAdminApi, "remote-
         }),
       )
       .handle("revoke", (ctx) =>
-        Effect.gen(function* () {
-          yield* requireSession(ctx.params.sessionID)
+        Effect.sync(() => {
           RemoteAccess.revoke(ctx.params.sessionID)
           return true
         }),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -115,7 +115,9 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
             messages: messages.map((message) => ({
               info: { role: message.info.role },
               parts: message.parts.flatMap((part) => {
-                if (part.type === "text") return [{ type: "text" as const, text: part.text }]
+                if (part.type === "text" && !part.synthetic && !part.ignored) {
+                  return [{ type: "text" as const, text: part.text }]
+                }
                 if (part.type === "tool") {
                   return [{ type: "tool" as const, tool: part.tool, state: { status: part.state.status } }]
                 }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -156,7 +156,7 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
       .handle("permission", (ctx) =>
         Effect.gen(function* () {
           const request = (yield* permission.list()).find((item) => item.id === ctx.params.requestID)
-          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.BadRequest({})
           yield* permission
             .reply({ requestID: ctx.params.requestID, reply: ctx.payload.reply, message: ctx.payload.message })
             .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
@@ -166,7 +166,7 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
       .handle("question", (ctx) =>
         Effect.gen(function* () {
           const request = (yield* question.list()).find((item) => item.id === ctx.params.requestID)
-          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.BadRequest({})
           yield* question
             .reply({ requestID: ctx.params.requestID, answers: ctx.payload.answers })
             .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
@@ -176,7 +176,7 @@ export const remoteHandlers = HttpApiBuilder.group(RemoteApi, "remote", (handler
       .handle("questionReject", (ctx) =>
         Effect.gen(function* () {
           const request = (yield* question.list()).find((item) => item.id === ctx.params.requestID)
-          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.Forbidden({})
+          if (!request || request.sessionID !== ctx.params.sessionID) return yield* new HttpApiError.BadRequest({})
           yield* question.reject(ctx.params.requestID).pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
           return true
         }),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -25,14 +25,16 @@ function eventID() {
 
 function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
   return Effect.gen(function* () {
-    const queue = yield* Queue.unbounded<EventV2.Payload>()
-    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
+    const queue = yield* Queue.sliding<ReturnType<typeof RemoteEvent.signal>>(64)
+    const unsubscribe = yield* events.listen((event) =>
+      Effect.sync(() => {
+        if (!RemoteEvent.shouldForward(event, sessionID)) return
+        Queue.offerUnsafe(queue, RemoteEvent.signal(event))
+      }),
+    )
     yield* Effect.addFinalizer(() => unsubscribe)
 
-    const output = Stream.fromQueue(queue).pipe(
-      Stream.filter((event) => RemoteEvent.shouldForward(event, sessionID)),
-      Stream.map((event) => RemoteEvent.signal(event)),
-    )
+    const output = Stream.fromQueue(queue)
     const heartbeat = Stream.tick("10 seconds").pipe(
       Stream.drop(1),
       Stream.map(() => ({ id: eventID(), type: "server.heartbeat", properties: {} })),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -9,7 +9,7 @@ import { SessionStatus } from "@/session/status"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Cause, Effect, Queue, Scope } from "effect"
 import * as Stream from "effect/Stream"
-import { HttpServerResponse } from "effect/unstable/http"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
 import { RemoteAdminApi, RemoteApi, RemotePairApi } from "../groups/remote"
@@ -23,8 +23,15 @@ function eventID() {
   return EventV2.ID.create()
 }
 
+function bearer(request: HttpServerRequest.HttpServerRequest) {
+  const match = /^Bearer\s+(.+)$/i.exec(request.headers.authorization ?? "")
+  return match?.[1]
+}
+
 function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
   return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const token = bearer(request)
     const queue = yield* Queue.sliding<ReturnType<typeof RemoteEvent.signal>>(64)
     const unsubscribe = yield* events.listen((event) =>
       Effect.sync(() => {
@@ -43,6 +50,7 @@ function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
     return HttpServerResponse.stream(
       Stream.make({ id: eventID(), type: "server.connected", properties: { sessionID } }).pipe(
         Stream.concat(output.pipe(Stream.merge(heartbeat, { haltStrategy: "left" }))),
+        Stream.takeWhile(() => !!token && RemoteAccess.authorized(token, sessionID)),
         Stream.map(eventData),
         Stream.pipeThroughChannel(Sse.encode()),
         Stream.encodeText,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/remote.ts
@@ -1,3 +1,5 @@
+import { Workspace } from "@/control-plane/workspace"
+import { WorkspaceAdapterRuntime } from "@/control-plane/workspace-adapter-runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Permission } from "@/permission"
 import { Question } from "@/question"
@@ -70,13 +72,24 @@ function remoteEventResponse(events: EventV2.Interface, sessionID: string) {
 export const remoteAdminHandlers = HttpApiBuilder.group(RemoteAdminApi, "remote-admin", (handlers) =>
   Effect.gen(function* () {
     const sessions = yield* Session.Service
+    const workspaces = yield* Workspace.Service
     const requireSession = (sessionID: Parameters<typeof RemoteAccess.pair>[0]) =>
       SessionError.mapStorageNotFound(sessions.get(sessionID))
+    const requireLocalSession = (sessionID: Parameters<typeof RemoteAccess.pair>[0]) =>
+      Effect.gen(function* () {
+        const session = yield* requireSession(sessionID)
+        if (!session.workspaceID) return session
+        const workspace = yield* workspaces.get(session.workspaceID)
+        if (!workspace) return yield* new HttpApiError.BadRequest({})
+        const target = yield* WorkspaceAdapterRuntime.target(workspace)
+        if (target.type !== "local") return yield* new HttpApiError.BadRequest({})
+        return session
+      })
 
     return handlers
       .handle("pair", (ctx) =>
         Effect.gen(function* () {
-          yield* requireSession(ctx.params.sessionID)
+          yield* requireLocalSession(ctx.params.sessionID)
           return RemoteAccess.pair(ctx.params.sessionID)
         }),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/remote-authorization.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/remote-authorization.ts
@@ -1,0 +1,35 @@
+import { RemoteAccess } from "@/remote/access"
+import { Effect, Layer } from "effect"
+import { HttpServerRequest } from "effect/unstable/http"
+import { HttpApiError, HttpApiMiddleware } from "effect/unstable/httpapi"
+
+export class RemoteAuthorization extends HttpApiMiddleware.Service<RemoteAuthorization>()(
+  "@opencode/ExperimentalHttpApiRemoteAuthorization",
+  { error: HttpApiError.UnauthorizedNoContent },
+) {}
+
+function bearer(request: HttpServerRequest.HttpServerRequest) {
+  const match = /^Bearer\s+(.+)$/i.exec(request.headers.authorization ?? "")
+  return match?.[1]
+}
+
+function sessionID(request: HttpServerRequest.HttpServerRequest) {
+  return new URL(request.url, "http://localhost").pathname.match(/^\/remote\/session\/([^/]+)(?:\/|$)/)?.[1]
+}
+
+export const remoteAuthorizationLayer = Layer.effect(
+  RemoteAuthorization,
+  Effect.succeed(
+    RemoteAuthorization.of((effect) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest
+        const token = bearer(request)
+        const session = sessionID(request)
+        if (!token || !session || !RemoteAccess.authorized(token, session)) {
+          return yield* new HttpApiError.Unauthorized({})
+        }
+        return yield* effect
+      }),
+    ),
+  ),
+)

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -28,6 +28,7 @@ import { Vcs } from "@/project/vcs"
 import { ProviderAuth } from "@/provider/auth"
 import { Provider } from "@/provider/provider"
 import { Question } from "@/question"
+import { RemoteMobile } from "@/remote/mobile"
 import { SessionCompaction } from "@/session/compaction"
 import { Instruction } from "@/session/instruction"
 import { LLM } from "@/session/llm"
@@ -134,6 +135,7 @@ const cors = (corsOptions?: CorsOptions) =>
 // - rootApiRoutes: typed /global/* and control routes; auth is declared by RootHttpApi.
 // - eventApiRoutes: typed SSE route with instance routing context and its existing API contract.
 // - ptyConnectApiRoutes: typed WebSocket upgrade route with ticket-aware auth.
+// - remoteMobileRoute: public shell only; the pairing ticket stays in the URL fragment and API calls require scoped auth.
 // - instanceApiRoutes: remaining typed instance routes.
 // - uiRoute: raw catch-all fallback; auth is router middleware so public static assets can bypass it.
 const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.layer))
@@ -201,6 +203,10 @@ const docResponse = lazy(() => HttpServerResponse.jsonUnsafe(OpenApi.fromApi(Pub
 
 const docRoute = HttpRouter.use((router) => router.add("GET", "/doc", () => Effect.succeed(docResponse()))).pipe(
   Layer.provide(authOnlyRouterLayer),
+)
+
+const remoteMobileRoute = HttpRouter.use((router) =>
+  router.add("GET", "/remote/mobile", () => Effect.succeed(RemoteMobile.response())),
 )
 
 const uiRoute = HttpRouter.use((router) =>
@@ -295,6 +301,7 @@ export function createRoutes(
     instanceRoutes,
     serverRoutes,
     docRoute,
+    remoteMobileRoute,
     uiRoute,
   ).pipe(
     Layer.provide([

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -79,8 +79,10 @@ import {
   ptyConnectAuthorizationLayer,
   serverAuthorizationLayer,
 } from "./middleware/authorization"
+import { remoteAuthorizationLayer } from "./middleware/remote-authorization"
 import { EventApi } from "./groups/event"
 import { PtyConnectApi } from "./groups/pty"
+import { RemoteAdminApi, RemoteApi, RemotePairApi } from "./groups/remote"
 import { eventHandlers } from "./handlers/event"
 import { configHandlers } from "./handlers/config"
 import { controlHandlers } from "./handlers/control"
@@ -96,6 +98,7 @@ import { projectCopyHandlers } from "./handlers/project-copy"
 import { providerHandlers } from "./handlers/provider"
 import { ptyConnectHandlers, ptyHandlers } from "./handlers/pty"
 import { questionHandlers } from "./handlers/question"
+import { remoteAdminHandlers, remoteHandlers, remotePairHandlers } from "./handlers/remote"
 import { sessionHandlers } from "./handlers/session"
 import { syncHandlers } from "./handlers/sync"
 import { tuiHandlers } from "./handlers/tui"
@@ -150,6 +153,15 @@ const eventApiRoutes = HttpApiBuilder.layer(EventApi).pipe(
 const ptyConnectApiRoutes = HttpApiBuilder.layer(PtyConnectApi).pipe(
   Layer.provide(ptyConnectHandlers),
   Layer.provide([ptyConnectHttpApiAuthLayer, workspaceRoutingLive, instanceContextLayer]),
+)
+const remoteAdminApiRoutes = HttpApiBuilder.layer(RemoteAdminApi).pipe(
+  Layer.provide(remoteAdminHandlers),
+  Layer.provide([httpApiAuthLayer, workspaceRoutingLive, instanceContextLayer]),
+)
+const remotePairApiRoutes = HttpApiBuilder.layer(RemotePairApi).pipe(Layer.provide(remotePairHandlers))
+const remoteApiRoutes = HttpApiBuilder.layer(RemoteApi).pipe(
+  Layer.provide(remoteHandlers),
+  Layer.provide([remoteAuthorizationLayer, workspaceRoutingLive, instanceContextLayer]),
 )
 const instanceApiRoutes = HttpApiBuilder.layer(InstanceHttpApi).pipe(
   Layer.provide([
@@ -277,6 +289,9 @@ export function createRoutes(
     rootApiRoutes,
     eventApiRoutes,
     ptyConnectApiRoutes,
+    remoteAdminApiRoutes,
+    remotePairApiRoutes,
+    remoteApiRoutes,
     instanceRoutes,
     serverRoutes,
     docRoute,

--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -9,6 +9,7 @@ const RULES: Array<Rule> = [
 ]
 
 export function isLocalWorkspaceRoute(method: string, path: string) {
+  if (/^\/session\/[^/]+\/remote$/.test(path)) return true
   for (const rule of RULES) {
     if (rule.method && rule.method !== method) continue
     const match = rule.exact ? path === rule.path : path === rule.path || path.startsWith(rule.path + "/")

--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -22,6 +22,7 @@ export function getWorkspaceRouteSessionID(url: URL) {
 
   const id =
     url.pathname.match(/^\/session\/([^/]+)(?:\/|$)/)?.[1] ??
+    url.pathname.match(/^\/remote\/session\/([^/]+)(?:\/|$)/)?.[1] ??
     url.pathname.match(/^\/experimental\/session\/([^/]+)\/background$/)?.[1]
   if (!id) return null
 

--- a/packages/opencode/test/remote/access.test.ts
+++ b/packages/opencode/test/remote/access.test.ts
@@ -17,6 +17,24 @@ describe("RemoteAccess", () => {
     expect(RemoteAccess.authorized(grant!.token, other, 2_000)).toBe(false)
   })
 
+  test("new pairing invalidates the previous pending ticket for the same session", () => {
+    const session = SessionID.make("ses_remote_pair_replace")
+    const first = RemoteAccess.pair(session, 1_000)
+    const second = RemoteAccess.pair(session, 2_000)
+
+    expect(RemoteAccess.redeem(first.ticket, 3_000)).toBeUndefined()
+    expect(RemoteAccess.redeem(second.ticket, 3_000)?.sessionID).toBe(session)
+  })
+
+  test("new grant invalidates the previous phone grant for the same session", () => {
+    const session = SessionID.make("ses_remote_grant_replace")
+    const first = RemoteAccess.redeem(RemoteAccess.pair(session, 1_000).ticket, 2_000)!
+    const second = RemoteAccess.redeem(RemoteAccess.pair(session, 3_000).ticket, 4_000)!
+
+    expect(RemoteAccess.authorized(first.token, session, 4_000)).toBe(false)
+    expect(RemoteAccess.authorized(second.token, session, 4_000)).toBe(true)
+  })
+
   test("expired pairing ticket is rejected", () => {
     const session = SessionID.make("ses_remote_expired")
     const pair = RemoteAccess.pair(session, 1_000)

--- a/packages/opencode/test/remote/access.test.ts
+++ b/packages/opencode/test/remote/access.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { RemoteAccess } from "@/remote/access"
+import { SessionID } from "@/session/schema"
+
+afterEach(() => RemoteAccess.resetForTest())
+
+describe("RemoteAccess", () => {
+  test("pairing tickets are one-use and create a session-scoped grant", () => {
+    const session = SessionID.make("ses_remote_a")
+    const other = SessionID.make("ses_remote_b")
+    const pair = RemoteAccess.pair(session, 1_000)
+
+    const grant = RemoteAccess.redeem(pair.ticket, 2_000)
+    expect(grant?.sessionID).toBe(session)
+    expect(RemoteAccess.redeem(pair.ticket, 2_000)).toBeUndefined()
+    expect(RemoteAccess.authorized(grant!.token, session, 2_000)).toBe(true)
+    expect(RemoteAccess.authorized(grant!.token, other, 2_000)).toBe(false)
+  })
+
+  test("expired pairing ticket is rejected", () => {
+    const session = SessionID.make("ses_remote_expired")
+    const pair = RemoteAccess.pair(session, 1_000)
+    expect(RemoteAccess.redeem(pair.ticket, 1_000 + pair.expires_in * 1_000 + 1)).toBeUndefined()
+  })
+
+  test("revoke invalidates issued grants", () => {
+    const session = SessionID.make("ses_remote_revoke")
+    const pair = RemoteAccess.pair(session, 1_000)
+    const grant = RemoteAccess.redeem(pair.ticket, 2_000)!
+
+    RemoteAccess.revoke(session)
+    expect(RemoteAccess.authorized(grant.token, session, 2_000)).toBe(false)
+  })
+})

--- a/packages/opencode/test/remote/event.test.ts
+++ b/packages/opencode/test/remote/event.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { RemoteEvent } from "@/remote/event"
+
+describe("remote events", () => {
+  test("allows only session-scoped UI refresh events", () => {
+    expect(
+      RemoteEvent.shouldForward(
+        { type: "message.part.updated", data: { sessionID: "ses_target", part: { output: "sensitive" } } },
+        "ses_target",
+      ),
+    ).toBe(true)
+    expect(
+      RemoteEvent.shouldForward(
+        { type: "message.part.updated", data: { sessionID: "ses_other" } },
+        "ses_target",
+      ),
+    ).toBe(false)
+    expect(
+      RemoteEvent.shouldForward(
+        { type: "session.diff", data: { sessionID: "ses_target", diff: "private patch" } },
+        "ses_target",
+      ),
+    ).toBe(false)
+    expect(
+      RemoteEvent.shouldForward(
+        { type: "future.internal.event", data: { sessionID: "ses_target", secret: "private" } },
+        "ses_target",
+      ),
+    ).toBe(false)
+  })
+
+  test("recognizes nested session ownership for known event shapes", () => {
+    expect(
+      RemoteEvent.shouldForward(
+        { type: "message.updated", data: { info: { sessionID: "ses_target" } } },
+        "ses_target",
+      ),
+    ).toBe(true)
+  })
+
+  test("strips event payloads from the mobile stream", () => {
+    const input = {
+      id: "evt_1",
+      type: "permission.asked",
+      data: { sessionID: "ses_target", metadata: { command: "private command" } },
+    }
+    expect(RemoteEvent.signal(input)).toEqual({ id: "evt_1", type: "permission.asked", properties: {} })
+  })
+})

--- a/packages/opencode/test/remote/message.test.ts
+++ b/packages/opencode/test/remote/message.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { Exit, Schema } from "effect"
+import { RemoteMessagePayload } from "@/server/routes/instance/httpapi/groups/remote"
+
+const decode = Schema.decodeUnknownExit(RemoteMessagePayload)
+
+describe("remote message payload", () => {
+  test("accepts text-only prompts", () => {
+    expect(Exit.isSuccess(decode({ parts: [{ type: "text", text: "continue" }] }))).toBe(true)
+  })
+
+  test("rejects privileged prompt part types", () => {
+    const payloads = [
+      { parts: [{ type: "file", mime: "text/plain", url: "file:///etc/passwd" }] },
+      { parts: [{ type: "agent", name: "build" }] },
+      { parts: [{ type: "subtask", prompt: "read secrets", description: "test", agent: "build" }] },
+    ]
+
+    for (const payload of payloads) expect(Exit.isFailure(decode(payload))).toBe(true)
+  })
+})

--- a/packages/opencode/test/remote/mobile.test.ts
+++ b/packages/opencode/test/remote/mobile.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { Script } from "node:vm"
+import { RemoteMobile } from "@/remote/mobile"
+
+function clientScript() {
+  const match = RemoteMobile.markup().match(/<script>([\s\S]*?)<\/script>/)
+  if (!match?.[1]) throw new Error("remote mobile script not found")
+  return match[1]
+}
+
+describe("remote mobile", () => {
+  test("emits parseable browser JavaScript", () => {
+    const script = clientScript()
+
+    expect(() => new Script(script)).not.toThrow()
+    expect(script).toContain('.join("\\n")')
+    expect(script).toContain('/\\r\\n\\r\\n|\\n\\n|\\r\\r/')
+  })
+
+  test("contains explicit access-expiry handling", () => {
+    const script = clientScript()
+
+    expect(script).toContain("function expireRemoteAccess()")
+    expect(script).toContain("state.token = \"\"")
+    expect(script).toContain("state.sessionID = \"\"")
+    expect(script).toContain("response.status === 401 || response.status === 403")
+  })
+})

--- a/packages/opencode/test/remote/public.test.ts
+++ b/packages/opencode/test/remote/public.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { OpenApi } from "effect/unstable/httpapi"
+import { PublicApi } from "@/server/routes/instance/httpapi/public"
+
+describe("remote public api", () => {
+  test("keeps the desktop remote protocol out of public OpenAPI", () => {
+    const spec = OpenApi.fromApi(PublicApi) as { paths?: Record<string, unknown> }
+    const paths = Object.keys(spec.paths ?? {})
+
+    expect(paths).not.toContain("/remote/pair")
+    expect(paths).not.toContain("/remote/session/{sessionID}")
+    expect(paths).not.toContain("/session/{sessionID}/remote")
+  })
+})

--- a/packages/opencode/test/server/httpapi-remote-revoke.test.ts
+++ b/packages/opencode/test/server/httpapi-remote-revoke.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Schema } from "effect"
+import { RemoteAccess } from "@/remote/access"
+import { SessionID } from "@/session/schema"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+import { testEffect } from "../lib/effect"
+import { httpApiLayer, request, requestInDirectory } from "./httpapi-layer"
+
+const SessionResponse = Schema.Struct({ id: SessionID })
+const PairingResponse = Schema.Struct({ ticket: Schema.String })
+const GrantResponse = Schema.Struct({ token: Schema.String, sessionID: SessionID })
+
+function jsonBody(body: unknown, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set("content-type", "application/json")
+  return { ...init, headers, body: JSON.stringify(body) }
+}
+
+function bearer(token: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set("authorization", `Bearer ${token}`)
+  return { ...init, headers }
+}
+
+afterEach(async () => {
+  RemoteAccess.resetForTest()
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+const it = testEffect(httpApiLayer)
+
+describe("remote revoke lifecycle", () => {
+  it.instance(
+    "revokes access after the paired session has already been deleted",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const created = yield* requestInDirectory("/session", directory, { method: "POST" })
+        expect(created.status).toBe(200)
+        const session = Schema.decodeUnknownSync(SessionResponse)(yield* created.json)
+
+        const paired = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "POST" })
+        expect(paired.status).toBe(200)
+        const pairing = Schema.decodeUnknownSync(PairingResponse)(yield* paired.json)
+
+        const redeemed = yield* request("/remote/pair", jsonBody({ ticket: pairing.ticket }, { method: "POST" }))
+        expect(redeemed.status).toBe(200)
+        const grant = Schema.decodeUnknownSync(GrantResponse)(yield* redeemed.json)
+
+        const removed = yield* requestInDirectory(`/session/${session.id}`, directory, { method: "DELETE" })
+        expect(removed.status).toBe(200)
+
+        const revoked = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "DELETE" })
+        expect(revoked.status).toBe(200)
+        expect(yield* revoked.json).toBe(true)
+
+        const expired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(expired.status).toBe(401)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+})

--- a/packages/opencode/test/server/httpapi-remote-revoke.test.ts
+++ b/packages/opencode/test/server/httpapi-remote-revoke.test.ts
@@ -33,7 +33,7 @@ const it = testEffect(httpApiLayer)
 
 describe("remote revoke lifecycle", () => {
   it.instance(
-    "revokes access after the paired session has already been deleted",
+    "revokes access when the paired session is deleted and keeps admin revoke idempotent",
     () =>
       Effect.gen(function* () {
         const { directory } = yield* TestInstance
@@ -52,12 +52,15 @@ describe("remote revoke lifecycle", () => {
         const removed = yield* requestInDirectory(`/session/${session.id}`, directory, { method: "DELETE" })
         expect(removed.status).toBe(200)
 
+        const expiredAfterDelete = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(expiredAfterDelete.status).toBe(401)
+
         const revoked = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "DELETE" })
         expect(revoked.status).toBe(200)
         expect(yield* revoked.json).toBe(true)
 
-        const expired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
-        expect(expired.status).toBe(401)
+        const stillExpired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(stillExpired.status).toBe(401)
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/server/httpapi-remote.test.ts
+++ b/packages/opencode/test/server/httpapi-remote.test.ts
@@ -151,6 +151,27 @@ describe("remote HttpApi", () => {
         const crossSession = yield* request(`/remote/session/${other.id}`, bearer(grant.token))
         expect(crossSession.status).toBe(401)
 
+        const stalePermission = yield* request(
+          `/remote/session/${session.id}/permission/per_missing`,
+          bearer(grant.token, jsonBody({ reply: "once" }, { method: "POST" })),
+        )
+        expect(stalePermission.status).toBe(400)
+
+        const staleQuestion = yield* request(
+          `/remote/session/${session.id}/question/que_missing`,
+          bearer(grant.token, jsonBody({ answers: [["stale"]] }, { method: "POST" })),
+        )
+        expect(staleQuestion.status).toBe(400)
+
+        const staleQuestionReject = yield* request(
+          `/remote/session/${session.id}/question/que_missing/reject`,
+          bearer(grant.token, { method: "POST" }),
+        )
+        expect(staleQuestionReject.status).toBe(400)
+
+        const stillAuthorized = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(stillAuthorized.status).toBe(200)
+
         const privilegedPrompt = yield* request(
           `/remote/session/${session.id}/message`,
           bearer(

--- a/packages/opencode/test/server/httpapi-remote.test.ts
+++ b/packages/opencode/test/server/httpapi-remote.test.ts
@@ -91,6 +91,25 @@ describe("remote HttpApi", () => {
         expect(createdOther.status).toBe(200)
         const other = Schema.decodeUnknownSync(SessionResponse)(yield* createdOther.json)
 
+        const seeded = yield* requestInDirectory(
+          `/session/${session.id}/message`,
+          directory,
+          jsonBody(
+            {
+              agent: "build",
+              model: { providerID: "test", modelID: "test" },
+              noReply: true,
+              parts: [
+                { type: "text", text: "visible phone text" },
+                { type: "text", text: "hidden synthetic file contents", synthetic: true },
+                { type: "text", text: "hidden ignored text", ignored: true },
+              ],
+            },
+            { method: "POST" },
+          ),
+        )
+        expect(seeded.status).toBe(200)
+
         const paired = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "POST" })
         expect(paired.status).toBe(200)
         const pairing = Schema.decodeUnknownSync(PairingResponse)(yield* paired.json)
@@ -113,13 +132,21 @@ describe("remote HttpApi", () => {
 
         const bootstrap = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
         expect(bootstrap.status).toBe(200)
-        expect(yield* bootstrap.json).toMatchObject({
+        const bootstrapBody = yield* bootstrap.json
+        expect(bootstrapBody).toMatchObject({
           session: { title: session.title },
-          messages: [],
+          messages: [
+            {
+              info: { role: "user" },
+              parts: [{ type: "text", text: "visible phone text" }],
+            },
+          ],
           status: { type: "idle" },
           permissions: [],
           questions: [],
         })
+        expect(JSON.stringify(bootstrapBody)).not.toContain("hidden synthetic file contents")
+        expect(JSON.stringify(bootstrapBody)).not.toContain("hidden ignored text")
 
         const crossSession = yield* request(`/remote/session/${other.id}`, bearer(grant.token))
         expect(crossSession.status).toBe(401)

--- a/packages/opencode/test/server/httpapi-remote.test.ts
+++ b/packages/opencode/test/server/httpapi-remote.test.ts
@@ -12,6 +12,19 @@ const SessionResponse = Schema.Struct({
   title: Schema.String,
 })
 
+const SessionStateResponse = Schema.Struct({
+  id: SessionID,
+  title: Schema.String,
+  agent: Schema.optional(Schema.String),
+  model: Schema.optional(
+    Schema.Struct({
+      id: Schema.String,
+      providerID: Schema.String,
+      variant: Schema.optional(Schema.String),
+    }),
+  ),
+})
+
 const PairingResponse = Schema.Struct({
   ticket: Schema.String,
   expires_in: Schema.Number,
@@ -50,6 +63,15 @@ const readEvent = (reader: Queue.Dequeue<Uint8Array>) =>
       }),
     )
     return Schema.decodeUnknownSync(EventData)(JSON.parse(new TextDecoder().decode(value).replace(/^data: /, "")))
+  })
+
+const readEventType = (reader: Queue.Dequeue<Uint8Array>, type: string) =>
+  Effect.gen(function* () {
+    for (let index = 0; index < 12; index += 1) {
+      const event = yield* readEvent(reader)
+      if (event.type === type) return event
+    }
+    return yield* Effect.fail(new Error(`remote event not received: ${type}`))
   })
 
 const openRemoteEventStream = (sessionID: string, token: string) =>
@@ -226,6 +248,62 @@ describe("remote HttpApi", () => {
 
         const expired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
         expect(expired.status).toBe(401)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "inherits the session agent and model for text-only mobile prompts",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const created = yield* requestInDirectory("/session", directory, { method: "POST" })
+        const session = Schema.decodeUnknownSync(SessionResponse)(yield* created.json)
+
+        const seeded = yield* requestInDirectory(
+          `/session/${session.id}/message`,
+          directory,
+          jsonBody(
+            {
+              agent: "plan",
+              model: { providerID: "test", modelID: "test" },
+              noReply: true,
+              parts: [{ type: "text", text: "seed plan mode" }],
+            },
+            { method: "POST" },
+          ),
+        )
+        expect(seeded.status).toBe(200)
+
+        const paired = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "POST" })
+        const pairing = Schema.decodeUnknownSync(PairingResponse)(yield* paired.json)
+        const redeemed = yield* request(
+          "/remote/pair",
+          jsonBody({ ticket: pairing.ticket }, { method: "POST" }),
+        )
+        const grant = Schema.decodeUnknownSync(GrantResponse)(yield* redeemed.json)
+
+        const { reader } = yield* openRemoteEventStream(session.id, grant.token)
+        expect((yield* readEvent(reader)).type).toBe("server.connected")
+
+        const sent = yield* request(
+          `/remote/session/${session.id}/message`,
+          bearer(
+            grant.token,
+            jsonBody({ parts: [{ type: "text", text: "continue from phone" }] }, { method: "POST" }),
+          ),
+        )
+        expect(sent.status).toBe(204)
+        expect((yield* readEventType(reader, "message.updated")).type).toBe("message.updated")
+
+        const state = yield* requestInDirectory(`/session/${session.id}`, directory)
+        expect(state.status).toBe(200)
+        const current = Schema.decodeUnknownSync(SessionStateResponse)(yield* state.json)
+        expect(current.agent).toBe("plan")
+        expect(current.model).toMatchObject({ id: "test", providerID: "test" })
+
+        const revoked = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "DELETE" })
+        expect(revoked.status).toBe(200)
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/server/httpapi-remote.test.ts
+++ b/packages/opencode/test/server/httpapi-remote.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Effect, Queue, Schema, Stream } from "effect"
+import { Effect, Fiber, Queue, Schema, Stream } from "effect"
 import { RemoteAccess } from "@/remote/access"
 import { SessionID } from "@/session/schema"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
@@ -78,11 +78,11 @@ const openRemoteEventStream = (sessionID: string, token: string) =>
   Effect.gen(function* () {
     const response = yield* request(`/remote/session/${sessionID}/events`, bearer(token))
     const reader = yield* Queue.unbounded<Uint8Array>()
-    yield* response.stream.pipe(
+    const fiber = yield* response.stream.pipe(
       Stream.runForEach((value) => Queue.offer(reader, value)),
       Effect.forkScoped,
     )
-    return { response, reader }
+    return { response, reader, fiber }
   })
 
 afterEach(async () => {
@@ -210,7 +210,7 @@ describe("remote HttpApi", () => {
         expect(abort.status).toBe(200)
         expect(yield* abort.json).toBe(true)
 
-        const { response: events, reader } = yield* openRemoteEventStream(session.id, grant.token)
+        const { response: events, reader, fiber } = yield* openRemoteEventStream(session.id, grant.token)
         expect(events.status).toBe(200)
         expect(events.headers["content-type"]).toContain("text/event-stream")
         expect(events.headers["cache-control"]).toBe("no-cache, no-transform")
@@ -248,6 +248,19 @@ describe("remote HttpApi", () => {
 
         const expired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
         expect(expired.status).toBe(401)
+
+        const updateAfterRevoke = yield* requestInDirectory(
+          `/session/${session.id}`,
+          directory,
+          jsonBody({ title: "revoked stream probe" }, { method: "PATCH" }),
+        )
+        expect(updateAfterRevoke.status).toBe(200)
+        yield* Fiber.join(fiber).pipe(
+          Effect.timeoutOrElse({
+            duration: "5 seconds",
+            orElse: () => Effect.fail(new Error("remote event stream stayed open after revoke")),
+          }),
+        )
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/server/httpapi-remote.test.ts
+++ b/packages/opencode/test/server/httpapi-remote.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Effect, Queue, Schema, Stream } from "effect"
+import { RemoteAccess } from "@/remote/access"
+import { SessionID } from "@/session/schema"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+import { testEffect } from "../lib/effect"
+import { httpApiLayer, request, requestInDirectory } from "./httpapi-layer"
+
+const SessionResponse = Schema.Struct({
+  id: SessionID,
+  title: Schema.String,
+})
+
+const PairingResponse = Schema.Struct({
+  ticket: Schema.String,
+  expires_in: Schema.Number,
+})
+
+const GrantResponse = Schema.Struct({
+  token: Schema.String,
+  sessionID: SessionID,
+  expires_in: Schema.Number,
+})
+
+const EventData = Schema.Struct({
+  id: Schema.optional(Schema.String),
+  type: Schema.String,
+  properties: Schema.Record(Schema.String, Schema.Any),
+})
+
+function bearer(token: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set("authorization", `Bearer ${token}`)
+  return { ...init, headers }
+}
+
+function jsonBody(body: unknown, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  headers.set("content-type", "application/json")
+  return { ...init, headers, body: JSON.stringify(body) }
+}
+
+const readEvent = (reader: Queue.Dequeue<Uint8Array>) =>
+  Effect.gen(function* () {
+    const value = yield* Queue.take(reader).pipe(
+      Effect.timeoutOrElse({
+        duration: "5 seconds",
+        orElse: () => Effect.fail(new Error("timed out waiting for remote event")),
+      }),
+    )
+    return Schema.decodeUnknownSync(EventData)(JSON.parse(new TextDecoder().decode(value).replace(/^data: /, "")))
+  })
+
+const openRemoteEventStream = (sessionID: string, token: string) =>
+  Effect.gen(function* () {
+    const response = yield* request(`/remote/session/${sessionID}/events`, bearer(token))
+    const reader = yield* Queue.unbounded<Uint8Array>()
+    yield* response.stream.pipe(
+      Stream.runForEach((value) => Queue.offer(reader, value)),
+      Effect.forkScoped,
+    )
+    return { response, reader }
+  })
+
+afterEach(async () => {
+  RemoteAccess.resetForTest()
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+const it = testEffect(httpApiLayer)
+
+describe("remote HttpApi", () => {
+  it.instance(
+    "runs pairing, scoped access, live events, and revoke through the production route tree",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+
+        const mobile = yield* request("/remote/mobile")
+        expect(mobile.status).toBe(200)
+        expect(mobile.headers["content-type"]).toContain("text/html")
+        expect(yield* mobile.text).toContain("OpenCode Remote")
+
+        const created = yield* requestInDirectory("/session", directory, { method: "POST" })
+        expect(created.status).toBe(200)
+        const session = Schema.decodeUnknownSync(SessionResponse)(yield* created.json)
+
+        const createdOther = yield* requestInDirectory("/session", directory, { method: "POST" })
+        expect(createdOther.status).toBe(200)
+        const other = Schema.decodeUnknownSync(SessionResponse)(yield* createdOther.json)
+
+        const paired = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "POST" })
+        expect(paired.status).toBe(200)
+        const pairing = Schema.decodeUnknownSync(PairingResponse)(yield* paired.json)
+        expect(pairing.expires_in).toBeGreaterThan(0)
+
+        const redeemed = yield* request(
+          "/remote/pair",
+          jsonBody({ ticket: pairing.ticket }, { method: "POST" }),
+        )
+        expect(redeemed.status).toBe(200)
+        const grant = Schema.decodeUnknownSync(GrantResponse)(yield* redeemed.json)
+        expect(grant.sessionID).toBe(session.id)
+        expect(grant.expires_in).toBeGreaterThan(0)
+
+        const reusedTicket = yield* request(
+          "/remote/pair",
+          jsonBody({ ticket: pairing.ticket }, { method: "POST" }),
+        )
+        expect(reusedTicket.status).toBe(403)
+
+        const bootstrap = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(bootstrap.status).toBe(200)
+        expect(yield* bootstrap.json).toMatchObject({
+          session: { title: session.title },
+          messages: [],
+          status: { type: "idle" },
+          permissions: [],
+          questions: [],
+        })
+
+        const crossSession = yield* request(`/remote/session/${other.id}`, bearer(grant.token))
+        expect(crossSession.status).toBe(401)
+
+        const privilegedPrompt = yield* request(
+          `/remote/session/${session.id}/message`,
+          bearer(
+            grant.token,
+            jsonBody(
+              { parts: [{ type: "file", mime: "text/plain", url: "file:///etc/passwd" }] },
+              { method: "POST" },
+            ),
+          ),
+        )
+        expect(privilegedPrompt.status).toBe(400)
+
+        const abort = yield* request(`/remote/session/${session.id}/abort`, bearer(grant.token, { method: "POST" }))
+        expect(abort.status).toBe(200)
+        expect(yield* abort.json).toBe(true)
+
+        const { response: events, reader } = yield* openRemoteEventStream(session.id, grant.token)
+        expect(events.status).toBe(200)
+        expect(events.headers["content-type"]).toContain("text/event-stream")
+        expect(events.headers["cache-control"]).toBe("no-cache, no-transform")
+        expect(events.headers["x-accel-buffering"]).toBe("no")
+        expect(events.headers["x-content-type-options"]).toBe("nosniff")
+        expect(yield* readEvent(reader)).toMatchObject({
+          type: "server.connected",
+          properties: { sessionID: session.id },
+        })
+
+        const updateOther = yield* requestInDirectory(
+          `/session/${other.id}`,
+          directory,
+          jsonBody({ title: "other updated" }, { method: "PATCH" }),
+        )
+        expect(updateOther.status).toBe(200)
+
+        const quiet = yield* Queue.take(reader).pipe(
+          Effect.as("event" as const),
+          Effect.timeoutOrElse({ duration: "250 millis", orElse: () => Effect.succeed("open" as const) }),
+        )
+        expect(quiet).toBe("open")
+
+        const updateTarget = yield* requestInDirectory(
+          `/session/${session.id}`,
+          directory,
+          jsonBody({ title: "target updated" }, { method: "PATCH" }),
+        )
+        expect(updateTarget.status).toBe(200)
+        expect(yield* readEvent(reader)).toMatchObject({ type: "session.updated", properties: {} })
+
+        const revoked = yield* requestInDirectory(`/session/${session.id}/remote`, directory, { method: "DELETE" })
+        expect(revoked.status).toBe(200)
+        expect(yield* revoked.json).toBe(true)
+
+        const expired = yield* request(`/remote/session/${session.id}`, bearer(grant.token))
+        expect(expired.status).toBe(401)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+})

--- a/packages/opencode/test/server/workspace-routing.test.ts
+++ b/packages/opencode/test/server/workspace-routing.test.ts
@@ -19,6 +19,12 @@ describe("isLocalWorkspaceRoute", () => {
     expect(isLocalWorkspaceRoute("POST", "/session")).toBe(false)
   })
 
+  test("remote admin pairing stays on the control plane", () => {
+    expect(isLocalWorkspaceRoute("POST", "/session/ses_abc/remote")).toBe(true)
+    expect(isLocalWorkspaceRoute("DELETE", "/session/ses_abc/remote")).toBe(true)
+    expect(isLocalWorkspaceRoute("POST", "/session/ses_abc/remote/extra")).toBe(false)
+  })
+
   test("/session/status is forwarded regardless of method", () => {
     expect(isLocalWorkspaceRoute("GET", "/session/status")).toBe(false)
     expect(isLocalWorkspaceRoute("POST", "/session/status")).toBe(false)


### PR DESCRIPTION
### Issue for this PR

Related to #10288

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds LAN-only remote control for an existing OpenCode Desktop session.

From the session header, the user can open **Remote Control**, scan a QR code with a phone on the same local network, and control that session through a session-scoped mobile interface.

The remote interface supports:

- viewing visible session messages and status
- sending text prompts
- aborting the current run
- answering permission requests
- answering questions

The implementation intentionally does not expose the full sidecar API, terminal access, filesystem access, or Internet/relay access.

Pairing uses a short-lived one-time ticket which is exchanged for a revocable session-scoped grant. The Desktop LAN gateway only proxies `/remote/*`.

This is a draft PR mainly to get feedback on whether this narrower LAN-only approach fits the project direction.

### How did you verify your code works?

Added targeted unit/integration coverage for pairing, session-scoped authorization, cross-session rejection, bootstrap/event filtering, text-only prompts, revoke/session deletion, pairing lifecycle races, LAN address changes, and gateway boundaries.

Also ran a browser-level Chromium/Playwright smoke test of the production mobile UI covering pairing, permission reply, question reply, sending a prompt, live refresh, and stop/abort.

The browser flow completed without page errors. Physical phone-to-Desktop LAN testing and upstream CI are still pending.

### Screenshots / recordings
<img width="390" height="844" alt="remote-control-demo" src="https://github.com/user-attachments/assets/fc12167d-6ab0-456e-8b88-1a1fcdd95cd8" />


### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
