### PR TITLE
fix: web UI version baked in release binaries matches the release

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -119,7 +119,7 @@ const clearAuthToken = () => {
 const platform: Platform = {
   platform: "web",
   draftStore: createBrowserDraftStore(),
-  version: pkg.version,
+  version: import.meta.env.VITE_APP_VERSION ?? pkg.version,
   openExternal,
   restart,
   notify,

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -2,6 +2,7 @@ interface ImportMetaEnv {
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
   readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
+  readonly VITE_APP_VERSION?: string
 
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_ENVIRONMENT?: string

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -5,6 +5,9 @@ import { fileURLToPath } from "url"
 
 const theme = fileURLToPath(new URL("./public/oc-theme-preload.js", import.meta.url))
 
+const appVersion =
+  process.env.OPENCODE_VERSION ?? JSON.parse(readFileSync(fileURLToPath(new URL("./package.json", import.meta.url)), "utf8")).version
+
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
   if (raw === "dev" || raw === "beta" || raw === "prod") return raw
@@ -27,6 +30,7 @@ export default [
         },
         define: {
           "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+          "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
         },
         worker: {
           format: "es",


### PR DESCRIPTION
Fixes #41280.

**Root cause** (traced via release artifacts and CI logs):
- `build-cli` checks out the workflow_dispatch commit. The version bump of all package.json files only happens later, in the publish job (`script/publish.ts` -> `prepareReleaseFiles()`), which also commits it.
- The CLI version comes from the `OPENCODE_VERSION` env (version job output) - always correct.
- The web UI bakes `pkg.version` from the checked-out `packages/app/package.json` - always the previous version on release builds (v1.18.15 shipped a UI reporting 1.18.14; chunks in the released binaries match the pre-bump commit's build exactly).

So every release binary reports a web UI version one release behind. The bundle code itself is the release code (the bump commit only differs by version strings, ~300 bytes of chunk delta) - the defect is the version string.

**Fix**: bake the web UI version from `OPENCODE_VERSION` (the same source the CLI uses), falling back to `packages/app/package.json` for local dev without the env var. Follows the existing `VITE_OPENCODE_CHANNEL` define pattern in `packages/app/vite.js`.

Verified locally:
- `OPENCODE_VERSION=9.9.9-test vite build` -> main chunk contains `version:"9.9.9-test"`
- no env -> `version:"1.18.15"` (from package.json)
- full `script/build.ts --single` -> compiled binary embeds UI with `var n="9.9.9-e2e"`
