### PR TITLE
feat(tui): add opt-in Kitty key release events

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.boot.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.boot.ts
@@ -82,6 +82,7 @@ function runTuiConfig(config: Config | undefined): RunTuiConfig {
     keybinds: config.keybinds,
     leader_timeout: config.leader_timeout,
     diff_style: config.diff_style ?? "auto",
+    kitty_keyboard: config.kitty_keyboard,
   }
 }
 

--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -186,7 +186,7 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
       autoFocus: false,
       openConsoleOnError: false,
       exitOnCtrlC: false,
-      useKittyKeyboard: { events: process.platform === "win32" },
+      useKittyKeyboard: { events: process.platform === "win32" || input.tuiConfig.kitty_keyboard.events },
       screenMode: "split-footer",
       footerHeight: FOOTER_HEIGHT,
       externalOutputMode: "capture-stdout",

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -286,7 +286,7 @@ export type QuestionReply = Parameters<OpencodeClient["question"]["reply"]>[0]
 
 export type QuestionReject = Parameters<OpencodeClient["question"]["reject"]>[0]
 
-export type RunTuiConfig = Pick<TuiConfig.Resolved, "keybinds" | "leader_timeout" | "diff_style">
+export type RunTuiConfig = Pick<TuiConfig.Resolved, "keybinds" | "leader_timeout" | "diff_style" | "kitty_keyboard">
 
 // Lifecycle phase of a scrollback entry. "start" opens the entry, "progress"
 // appends content (coalesced in the footer queue), "final" closes it.

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -196,7 +196,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
               targetFps: 60,
               gatherStats: false,
               exitOnCtrlC: false,
-              useKittyKeyboard: {},
+              useKittyKeyboard: { events: input.config.kitty_keyboard.events },
               autoFocus: false,
               openConsoleOnError: false,
               useMouse: !Flag.OPENCODE_DISABLE_MOUSE && input.config.mouse,

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -39,6 +39,12 @@ export const Cursor = Schema.Struct({
   }),
 }).annotate({ description: "Terminal cursor settings" })
 
+export const KittyKeyboard = Schema.Struct({
+  events: Schema.optional(Schema.Boolean).annotate({
+    description: "Request Kitty keyboard press, repeat, and release events. Enable only in terminals that support it.",
+  }),
+}).annotate({ description: "Kitty keyboard protocol settings" })
+
 export const AttentionSounds = Schema.Record(AttentionSoundName, Schema.optionalKey(Schema.String))
 export type AttentionSoundPaths = Schema.Schema.Type<typeof AttentionSounds>
 export const Attention = Schema.Struct({
@@ -72,10 +78,14 @@ export const Info = Schema.Struct({
   diff_style: Schema.optional(DiffStyle),
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  kitty_keyboard: Schema.optional(KittyKeyboard),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "cursor"> & {
+export type Resolved = Omit<
+  Info,
+  "attention" | "keybinds" | "leader_timeout" | "mouse" | "cursor" | "kitty_keyboard"
+> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -90,6 +100,9 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
   cursor?: {
     style: "block" | "underline" | "line" | "default"
     blinking: boolean
+  }
+  kitty_keyboard: {
+    events: boolean
   }
 }
 
@@ -126,6 +139,9 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
     mouse: input.mouse ?? true,
+    kitty_keyboard: {
+      events: input.kitty_keyboard?.events ?? false,
+    },
     cursor: input.cursor
       ? {
           style: input.cursor.style ?? "block",

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -32,6 +32,7 @@ test("validates config constraints", () => {
       scroll_speed: 0.001,
       diff_style: "stacked",
       cursor: { blinking: false },
+      kitty_keyboard: { events: true },
       plugin: ["example-plugin"],
     }),
   ).toMatchObject({
@@ -39,6 +40,7 @@ test("validates config constraints", () => {
     attention: { volume: 1 },
     diff_style: "stacked",
     cursor: { blinking: false },
+    kitty_keyboard: { events: true },
   })
   expect(() => decodeInfo({ leader_timeout: 0 })).toThrow()
   expect(() => decodeInfo({ attention: { volume: 1.1 } })).toThrow()
@@ -64,6 +66,7 @@ test("resolves host-neutral defaults", () => {
   expect(config.keybinds.has("terminal.suspend")).toBe(true)
   expect(config.keybinds.has("session.list")).toBe(true)
   expect(config.cursor).toBeUndefined()
+  expect(config.kitty_keyboard).toEqual({ events: false })
 })
 
 test("resolves overrides without mutating input", () => {
@@ -81,6 +84,7 @@ test("resolves overrides without mutating input", () => {
     },
     keybinds: { session_list: "ctrl+l" },
     cursor: { blinking: false },
+    kitty_keyboard: { events: true },
   }
   const config = resolve(input, { terminalSuspend: true })
 
@@ -90,6 +94,7 @@ test("resolves overrides without mutating input", () => {
     leader_timeout: 750,
     attention: input.attention,
     cursor: { style: "block", blinking: false },
+    kitty_keyboard: { events: true },
   })
   expect(config.keybinds.get("session.list")).toHaveLength(1)
   expect(input.keybinds).toEqual({ session_list: "ctrl+l" })

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -291,6 +291,8 @@ Use `OPENCODE_TUI_CONFIG` to point to a custom TUI config file.
 
 When `cursor.style` is `"default"`, the terminal default cursor is restored, so `cursor.blinking` has no effect.
 
+Set `kitty_keyboard.events` to `true` only when your terminal reliably supports the Kitty keyboard protocol. It enables press, repeat, and release events; some xterm.js-based terminals report releases incorrectly.
+
 Set `attention.enabled` to turn on TUI desktop notifications and sounds. See [TUI attention](/docs/tui#attention).
 
 Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and automatically migrated when possible.

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -401,9 +401,24 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
 - `cursor` - Controls the terminal cursor in TUI input fields. `style` defaults to `"block"`, can be `"underline"`, `"line"`, or `"default"`; `blinking` defaults to `true`. When `style` is `"default"`, the terminal default cursor is restored, so `blinking` has no effect.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
+- `kitty_keyboard.events` - Request Kitty keyboard press, repeat, and release events. Disabled by default. Enable it only in terminals with reliable Kitty keyboard support; some xterm.js-based terminals report release events incorrectly.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.
 
 Use `OPENCODE_TUI_CONFIG` to load a custom TUI config path.
+
+### Kitty keyboard events
+
+To receive Kitty keyboard press, repeat, and release events, add this opt-in setting:
+
+```json title="tui.json"
+{
+  "kitty_keyboard": {
+    "events": true
+  }
+}
+```
+
+Enable it only in terminals with reliable Kitty keyboard support. Some xterm.js-based terminals report release events incorrectly.
 
 ### Attention
 


### PR DESCRIPTION
### Issue for this PR

Closes #37692

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

I ran into this while building [opencode-voice](https://github.com/ihxnnxs/opencode-voice), a local voice input plugin for OpenCode.

For hold-to-talk, the plugin needs to know when a key is released. OpenCode supports release keybindings, but users could not turn on Kitty keyboard release events in `tui.json`.

This PR adds an opt-in setting:

```json
{
  "kitty_keyboard": {
    "events": true
  }
}
```
It is off by default because some xterm.js terminals handle release events badly.
The setting is used by both OpenCode TUI renderer paths. This makes hold-to-talk and other release-based keybindings possible in terminals with solid Kitty keyboard support, without changing the default behavior for everyone else.
How did you verify your code works?
- Ran bun test test/config.test.tsx in packages/tui - 9 tests passed
- Ran bun run typecheck in packages/tui
- Ran bun run typecheck in packages/opencode
- Ran Prettier and git diff --check
The full pre-push check could not finish because pkg.pr.new was down and @solidjs/start could not be downloaded.
Screenshots / recordings
N/A. This is a TUI config and keyboard input change.
Checklist
- I have tested my changes locally
- I have not included unrelated changes in this PR