### PR TITLE
fix(opencode): ignore negative retry hints

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -48,7 +48,7 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
       const retryAfterMs = headers["retry-after-ms"]
       if (retryAfterMs) {
         const parsedMs = Number.parseFloat(retryAfterMs)
-        if (!Number.isNaN(parsedMs)) {
+        if (!Number.isNaN(parsedMs) && parsedMs >= 0) {
           return cap(parsedMs)
         }
       }
@@ -56,7 +56,7 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
       const retryAfter = headers["retry-after"]
       if (retryAfter) {
         const parsedSeconds = Number.parseFloat(retryAfter)
-        if (!Number.isNaN(parsedSeconds)) {
+        if (!Number.isNaN(parsedSeconds) && parsedSeconds >= 0) {
           // convert seconds to milliseconds
           return cap(Math.ceil(parsedSeconds * 1000))
         }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -62,6 +62,11 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(1, error)).toBe(2000)
   })
 
+  test("ignores negative retry hints", () => {
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "-1" }))).toBe(2000)
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "-1" }))).toBe(2000)
+  })
+
   test("ignores malformed date retry hints", () => {
     const error = apiError({ "retry-after": "Invalid Date String" })
     expect(SessionRetry.delay(1, error)).toBe(2000)


### PR DESCRIPTION
### Issue for this PR

Closes #41424

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I ignored negative numeric `retry-after` and `retry-after-ms` values. 
Now negative numerics uses the existing exponential backoff!

### How did you verify your code works?

I ran
> bun test test/session/retry.test.ts --test-name-pattern 'session.retry.delay'

11 tests passed, including negative `retry-after` and `retry-after-ms` cases.

### Screenshots / recordings

Not a UI change unfortunately!

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
