### PR TITLE
fix(app): resolve message identity by id when creation time shifts

### DIFF
--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -418,6 +418,22 @@ describe("applyDirectoryEvent", () => {
     expect(store.part.msg_a).toBeUndefined()
   })
 
+  test("replaces a message when an update shifts its creation time", () => {
+    const sessionID = "ses_1"
+    const [store, setStore] = createStore(baseState({ message: { [sessionID]: [userMessage("msg_a", sessionID, 1)] } }))
+
+    applyDirectoryEvent({
+      event: { type: "message.updated", properties: { info: userMessage("msg_a", sessionID, 2) } },
+      store,
+      setStore,
+      push() {},
+      directory: "/tmp",
+      loadLsp() {},
+    })
+
+    expect(store.message[sessionID]).toEqual([userMessage("msg_a", sessionID, 2)])
+  })
+
   test("upserts and prunes message parts", () => {
     const sessionID = "ses_1"
     const messageID = "msg_1"

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -285,7 +285,9 @@ export function applyDirectoryEvent(input: {
         "message",
         info.sessionID,
         produce((draft) => {
-          draft.splice(result.index, 0, info)
+          const existing = draft.findIndex((message) => message.id === info.id)
+          if (existing >= 0) draft.splice(existing, 1)
+          draft.splice(Binary.search(draft, messageKey(info), messageKey).index, 0, info)
         }),
       )
       break

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1260,6 +1260,61 @@ describe("server session", () => {
     expect(store.data.part[stale.id]).toEqual([{ ...stalePart, text: "stale live" }])
   })
 
+  test("replaces a stored message when an update shifts its creation time", async () => {
+    const stale = userMessage("message")
+    const store = createServerSession(messageClient(response([{ info: stale, parts: [] }])))
+    await store.sync("child")
+    const live = { ...stale, time: { created: 2 } }
+
+    store.apply({ type: "message.updated", properties: { info: live } })
+
+    expect(store.data.message.child).toEqual([live])
+  })
+
+  test("confirms an optimistic message when the server shifts its creation time", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    const confirmed = { ...message, time: { created: 2 } }
+
+    store.apply({ type: "message.updated", properties: { info: confirmed } })
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([confirmed])
+  })
+
+  test("removes a time-shifted message without leaving a ghost row", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.apply({ type: "message.updated", properties: { info: { ...message, time: { created: 2 } } } })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+
+    expect(store.data.message.child).toEqual([])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("confirms optimistic content when a refresh shifts its creation time", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const server = { ...message, time: { created: 2 } }
+    const store = createServerSession(messageClient(response([]), pending.promise))
+    await store.sync("child")
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    const refreshing = store.sync("child", { force: true })
+    pending.resolve(response([{ info: server, parts: [part] }]))
+    await refreshing
+
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([server])
+    expect(store.data.part[message.id]).toEqual([part])
+  })
+
   test("keeps fetched message metadata when only a part changes", async () => {
     const pending = deferredResponse()
     const stale = userMessage("message")

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -111,7 +111,7 @@ function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) {
   const observed: { messageID: string; parts: Part[] }[] = []
   for (const item of items) {
     const result = Binary.search(session, messageKey(item.message), messageKey)
-    const found = result.found
+    const found = result.found || session.some((message) => message.id === item.message.id)
     if (!found) session.splice(result.index, 0, item.message)
     const current = part.get(item.message.id)
     const confirmed = found ? item.parts.filter((part) => current?.some((value) => value.id === part.id)) : []
@@ -1054,8 +1054,8 @@ export function createServerSession(
         if (result.found) setData("message", info.sessionID, result.index, reconcile(info))
         if (!result.found)
           setData("message", info.sessionID, (value = []) => {
-            const next = value.slice()
-            next.splice(result.index, 0, info)
+            const next = value.filter((message) => message.id !== info.id)
+            next.splice(Binary.search(next, messageKey(info), messageKey).index, 0, info)
             return next
           })
         return

--- a/packages/app/src/context/sync-optimistic.test.ts
+++ b/packages/app/src/context/sync-optimistic.test.ts
@@ -87,6 +87,21 @@ describe("sync optimistic reducers", () => {
     expect(page.session.map((message) => message.id)).toEqual(["msg_a", "msg_z"])
   })
 
+  test("mergeOptimisticPage treats a time-shifted same-id message as found", () => {
+    const sessionID = "ses_1"
+    const page = mergeOptimisticPage(
+      {
+        session: [userMessage("msg_2", sessionID, 2)],
+        part: [{ id: "msg_2", part: [textPart("prt_1", sessionID, "msg_2")] }],
+        complete: true,
+      },
+      [{ message: userMessage("msg_2", sessionID, 1), parts: [textPart("prt_1", sessionID, "msg_2")] }],
+    )
+
+    expect(page.session).toEqual([userMessage("msg_2", sessionID, 2)])
+    expect(page.confirmed).toEqual(["msg_2"])
+  })
+
   test("mergeOptimisticPage keeps missing optimistic parts until the server has them", () => {
     const sessionID = "ses_1"
     const page = mergeOptimisticPage(

--- a/packages/app/src/context/sync.tsx
+++ b/packages/app/src/context/sync.tsx
@@ -69,7 +69,7 @@ export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) 
 
   for (const item of items) {
     const result = Binary.search(session, messageKey(item.message), messageKey)
-    const found = result.found
+    const found = result.found || session.some((message) => message.id === item.message.id)
     if (!found) session.splice(result.index, 0, item.message)
 
     const current = part.get(item.message.id)


### PR DESCRIPTION
### Issue for this PR

Closes #41428

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#41001 (91132551) started ordering stored messages by creation time and switched message lookups to an exact match on `time.created + id`. But the same message can legitimately appear with two different `time.created` values: the optimistic user message is stamped with the client's `Date.now()` while the server persists the same message id with its own clock. Any skew makes the keys differ, so the `message.updated` handler misses the existing row and splices the server copy in as a second row with the same id. The stale row sticks around until a full refetch: the fork dialog lists the prompt twice, `message.removed` deletes only the first match and leaves a ghost row, and `mergeOptimisticPage` never runs its confirmed/observed bookkeeping for the time-shifted item.

The fix keeps the creation-time ordering from #41001 but treats the id as the message's identity when the exact key misses: the `message.updated` handlers (`server-session.ts`, global-sync `event-reducer.ts`) drop any same-id row before inserting the update at its sorted position, and both `mergeOptimisticPage` implementations count a same-id row as found so no duplicate is inserted and confirmation fires. Per-session arrays are small, so the extra linear scan only runs on the rare key miss.

### How did you verify your code works?

From `packages/app`:

- Added six tests covering the streaming update (no refresh), the optimistic submit/confirm flow, `message.removed` after a time-shifted update, refresh-time optimistic confirmation, and the same-id case in both `mergeOptimisticPage`s. Without the fix they fail (`bun test --conditions=solid --preload ./happydom.ts src/context/server-session.test.ts src/context/global-sync/event-reducer.test.ts src/context/sync-optimistic.test.ts` → 96 pass, 6 fail); with it all pass (102 pass, 0 fail).
- `bun test --conditions=solid --preload ./happydom.ts src/context` → 316 pass, 0 fail.
- `bun run test:unit` → 724 pass, 0 fail.
- `bun run typecheck` → clean.
- `test:browser` / Playwright e2e were not run locally; this is a state-store change covered by the unit tests above.

### Screenshots / recordings

N/A — state-store fix, unit-tested.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
