### PR TITLE
fix(app): preserve raw file path punctuation

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -13,6 +13,16 @@ describe("file path helpers", () => {
     expect(path.pathFromTab("other://src/app.ts")).toBeUndefined()
   })
 
+  test("preserves URL punctuation in raw filesystem paths", () => {
+    const path = createPathHelpers(() => "/repo")
+    const literal = "notes/why%20now#draft?.md"
+    const tab = "file://notes/why%2520now%23draft%3F.md"
+
+    expect(path.normalize(literal)).toBe(literal)
+    expect(path.tab(literal)).toBe(tab)
+    expect(path.pathFromTab(tab)).toBe(literal)
+  })
+
   test("normalizes Windows absolute paths with mixed separators", () => {
     const path = createPathHelpers(() => "C:\\repo")
     expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src\\app.ts")

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -105,7 +105,9 @@ export function createPathHelpers(scope: () => string) {
   const normalize = (input: string) => {
     const root = scope()
 
-    let path = unquoteGitPath(decodeFilePath(stripQueryAndHash(stripFileProtocol(input))))
+    const url = input.startsWith("file://")
+    const value = url ? decodeFilePath(stripQueryAndHash(stripFileProtocol(input))) : input
+    let path = unquoteGitPath(value)
 
     // Separator-agnostic prefix stripping for Cygwin/native Windows compatibility
     // Only case-insensitive on Windows (drive letter or UNC paths)


### PR DESCRIPTION
### Issue for this PR

Closes #41433

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`normalize` previously stripped query/hash and decoded percent sequences for every input, including raw filesystem paths. It now applies URL parsing only to `file://` inputs, preserving literal `%`, `#`, and `?` in raw paths. The regression test covers raw normalization and the file-tab round trip.

### How did you verify your code works?

- `bun test src/context/file/path.test.ts` (42 pass)
- `bun --bun run typecheck` in `packages/app`
- Focused oxlint (0 errors)

### Screenshots / recordings

Not applicable; this is path normalization logic with a unit reproduction.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR