### PR TITLE
docs: Add opencode-docker to ecosystem documentations

### DIFF
--- a/packages/web/src/content/docs/ar/ecosystem.mdx
+++ b/packages/web/src/content/docs/ar/ecosystem.mdx
@@ -67,6 +67,7 @@ description: مشاريع وتكاملات مبنية باستخدام OpenCode.
 | [OpenWork](https://github.com/different-ai/openwork)                                       | بديل مفتوح المصدر لـ Claude Cowork، مدعوم بواسطة OpenCode                 |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | مدير امتدادات OpenCode مع ملفات تعريف محمولة ومعزولة.                     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | تطبيق عميل لسطح المكتب والويب والجوال وعن بعد لـ OpenCode                 |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | حاوية Docker معززة بالأمان لتشغيل OpenCode في عزلة                       |
 
 ---
 

--- a/packages/web/src/content/docs/bs/ecosystem.mdx
+++ b/packages/web/src/content/docs/bs/ecosystem.mdx
@@ -67,6 +67,7 @@ Također možete pogledati [awesome-opencode](https://github.com/awesome-opencod
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa otvorenog koda Claudeu Coworku, pokretana pomoću OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode menadžer ekstenzija sa prenosivim, izolovanim profilima.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile i Remote Client aplikacija za OpenCode           |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Sigurnosno ojačan Docker kontejner za pokretanje OpenCode-a u izolaciji |
 
 ---
 

--- a/packages/web/src/content/docs/da/ecosystem.mdx
+++ b/packages/web/src/content/docs/da/ecosystem.mdx
@@ -67,6 +67,7 @@ Du kan også tjekke [awesome-opencode](https://github.com/awesome-opencode/aweso
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et open source-alternativ til Claude Cowork, drevet af OpenCode        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode udvidelsesmanager med bærbare, isolerede profiler.            |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop-, web-, mobil- og fjernklientapp til OpenCode                  |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Sikkerhedshærdet Docker-container til kørsel af OpenCode i isolation  |
 
 ---
 

--- a/packages/web/src/content/docs/de/ecosystem.mdx
+++ b/packages/web/src/content/docs/de/ecosystem.mdx
@@ -67,6 +67,7 @@ Sie können sich auch [awesome-opencode](https://github.com/awesome-opencode/awe
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Eine Open-Source-Alternative zu Claude Cowork, unterstützt von OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode Erweiterungsmanager mit portablen, isolierten Profilen.             |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop-, Web-, Mobil- und Remote-Client-App für OpenCode                    |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Sicherheitsgehärteter Docker-Container zum Ausführen von OpenCode in Isolation |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Security-hardened Docker container for running OpenCode in isolation |
 
 ---
 

--- a/packages/web/src/content/docs/es/ecosystem.mdx
+++ b/packages/web/src/content/docs/es/ecosystem.mdx
@@ -67,6 +67,7 @@ También puedes consultar [awesome-opencode](https://github.com/awesome-opencode
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Una alternativa de código abierto a Claude Cowork, impulsada por OpenCode            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Administrador de extensiones OpenCode con perfiles portátiles y aislados.            |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplicación de escritorio, web, móvil y de cliente remoto para OpenCode               |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Contenedor Docker con seguridad reforzada para ejecutar OpenCode de forma aislada |
 
 ---
 

--- a/packages/web/src/content/docs/fr/ecosystem.mdx
+++ b/packages/web/src/content/docs/fr/ecosystem.mdx
@@ -67,6 +67,7 @@ Vous pouvez également consulter [awesome-opencode](https://github.com/awesome-o
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Une alternative open-source à Claude Cowork, propulsée par OpenCode         |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestionnaire d'extensions OpenCode avec profils portables et isolés.        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Application client Bureau, Web, Mobile et Distante pour OpenCode            |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Conteneur Docker renforcé pour exécuter OpenCode de manière isolée          |
 
 ---
 

--- a/packages/web/src/content/docs/it/ecosystem.mdx
+++ b/packages/web/src/content/docs/it/ecosystem.mdx
@@ -67,6 +67,7 @@ Puoi anche dare un'occhiata a [awesome-opencode](https://github.com/awesome-open
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa open source a Claude Cowork, alimentata da OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestore di estensioni OpenCode con profili portabili e isolati       |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | App client Desktop, Web, Mobile e remota per OpenCode                |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Contenitore Docker rinforzato per eseguire OpenCode in isolamento |
 
 ---
 

--- a/packages/web/src/content/docs/ja/ecosystem.mdx
+++ b/packages/web/src/content/docs/ja/ecosystem.mdx
@@ -67,6 +67,7 @@ OpenCode 関連プロジェクトをこのリストに追加したいですか? 
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode を利用した、Claude Cowork に代わるオープンソース                        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 移植可能な独立したプロファイルを備えた OpenCode 拡張機能マネージャー。           |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 用のデスクトップ、Web、モバイル、およびリモートクライアントアプリ       |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | 分離された環境で OpenCode を実行するためのセキュリティ強化済み Docker コンテナ   |
 
 ---
 

--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -67,6 +67,7 @@ OpenCode를 기반으로 만들어진 커뮤니티 프로젝트 모음입니다.
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode 기반의 Claude Cowork 대체 오픈소스 프로젝트입니다.            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 휴대형 격리 프로필을 지원하는 OpenCode extension manager입니다.        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode용 Desktop/Web/Mobile/Remote client app입니다.                 |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | OpenCode를 격리된 환경에서 실행하기 위한 보안 강화 Docker 컨테이너         |
 
 ---
 

--- a/packages/web/src/content/docs/nb/ecosystem.mdx
+++ b/packages/web/src/content/docs/nb/ecosystem.mdx
@@ -67,6 +67,7 @@ Du kan også sjekke ut [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et åpen kildekode-alternativ til Claude Cowork, drevet av OpenCode  |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode utvidelsesbehandler med bærbare, isolerte profiler.        |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile og Remote Client App for OpenCode              |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Sikkerhetsherdet Docker-beholder for å kjøre OpenCode i isolasjon   |
 
 ---
 

--- a/packages/web/src/content/docs/pl/ecosystem.mdx
+++ b/packages/web/src/content/docs/pl/ecosystem.mdx
@@ -67,6 +67,7 @@ Możesz również sprawdzić [awesome-opencode](https://github.com/awesome-openc
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Otwartoźródłowa alternatywa dla Claude Cowork, napędzana przez OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Menedżer rozszerzeń OpenCode z przenośnymi, izolowanymi profilami.      |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplikacja kliencka Desktop, Web, Mobile i Remote dla OpenCode           |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Wzmocniony zabezpieczeniami kontener Docker do uruchamiania OpenCode w izolacji |
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -67,6 +67,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Uma alternativa de código aberto ao Claude Cowork, alimentada pelo OpenCode     |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gerenciador de extensões OpenCode com perfis portáteis e isolados.              |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Aplicativo Desktop, Web, Mobile e Cliente Remoto para OpenCode                  |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Contêiner Docker com segurança reforçada para executar OpenCode em isolamento |
 
 ---
 

--- a/packages/web/src/content/docs/ru/ecosystem.mdx
+++ b/packages/web/src/content/docs/ru/ecosystem.mdx
@@ -67,6 +67,7 @@ description: Проекты и интеграции, созданные с по�
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Альтернатива Claude Cowork с открытым исходным кодом на базе OpenCode                         |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Менеджер расширений OpenCode с переносимыми изолированными профилями                          |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Настольное, веб-, мобильное и удаленное клиентское приложение для OpenCode                    |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | Укреплённый Docker-контейнер для запуска OpenCode в изоляции            |
 
 ---
 

--- a/packages/web/src/content/docs/th/ecosystem.mdx
+++ b/packages/web/src/content/docs/th/ecosystem.mdx
@@ -67,6 +67,7 @@ description: โปรเจ็กต์และการผสานรวม�
 | [OpenWork](https://github.com/different-ai/openwork)                                       | ทางเลือกโอเพ่นซอร์สแทน Claude Cowork ซึ่งขับเคลื่อนโดย OpenCode           |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | ตัวจัดการส่วนขยาย OpenCode พร้อมโปรไฟล์แบบพกพาและแยกส่วน                  |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | แอปเดสก์ท็อป เว็บ มือถือ และไคลเอ็นต์ระยะไกลสำหรับ OpenCode               |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | คอนเทนเนอร์ Docker ที่เสริมความปลอดภัยสำหรับรัน OpenCode แบบแยกสภาพแวดล้อม |
 
 ---
 

--- a/packages/web/src/content/docs/tr/ecosystem.mdx
+++ b/packages/web/src/content/docs/tr/ecosystem.mdx
@@ -67,6 +67,7 @@ Ayrıca ekosistemi ve topluluğu bir araya getiren [awesome-opencode](https://gi
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode tarafından desteklenen, Claude Cowork'e açık kaynaklı bir alternatif   |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Taşınabilir, izole profillere sahip OpenCode eklenti yöneticisi                 |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode için Masaüstü, Web, Mobil ve Uzak İstemci Uygulaması                   |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | OpenCode'u izole ortamda çalıştırmak için güvenliği artırılmış Docker kapsayıcısı |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -67,6 +67,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的开源替代方案，由 OpenCode 驱动                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 扩展管理器，支持可移植的隔离配置                     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 的桌面、Web、移动和远程客户端应用                    |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | 用于隔离环境中运行 OpenCode 的安全强化 Docker 容器          |
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-tw/ecosystem.mdx
@@ -67,6 +67,7 @@ description: 基於 OpenCode 建置的專案與整合。
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的開源替代方案，由 OpenCode 驅動                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 擴充功能管理器，支援可攜式的隔離設定                 |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 的桌面、Web、行動和遠端用戶端應用程式                |
+| [opencode-docker](https://github.com/pkhamre/opencode-docker)                              | 用於隔離環境中執行 OpenCode 的安全強化 Docker 容器            |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #41439

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Adds opencode-docker to the Projects table on the Ecosystem docs page, plus the same row to all 17 translated copies so the description reads naturally in each language. The project is a security-hardened Docker container for running the OpenCode CLI in isolation.

I added the row in English first, then repeated it across the locale directories, translating the one-line description to match the style of neighboring entries. No other rows were touched.

The change is purely additive documentation, so there's nothing behavioral to reason about. The only real risk is a mistranslated description or a broken markdown table, both checked against the existing formatting.

### How did you verify your code works?

I built the docs, ran the Astro server locally with `bun install` and `bun run dev`, and verified that the docs looked intact while the new content row was added to the Ecosystem pages.

### Screenshots / recordings

Not relevant for this PR.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR