### PR TITLE
docs: add opencode-gadgets to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-gadgets](https://github.com/Narwhster/opencode-gadgets)                                  | Turn repeatable agent work into reusable OpenCode plugin tools                                     |
 
 ---
 


### PR DESCRIPTION
Closes #41446

Adds a row for [opencode-gadgets](https://github.com/Narwhster/opencode-gadgets) to the ecosystem Plugins table.