### PR TITLE
fix(core): align Copilot response continuation

### DIFF
--- a/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
@@ -127,7 +127,7 @@ export async function convertToOpenAIResponsesInput({
               input.push({
                 role: "assistant",
                 content: [{ type: "output_text", text: part.text }],
-                id: (part.providerOptions?.copilot?.itemId as string) ?? undefined,
+                id: store ? ((part.providerOptions?.copilot?.itemId as string) ?? undefined) : undefined,
               })
               break
             }
@@ -143,7 +143,7 @@ export async function convertToOpenAIResponsesInput({
                 input.push({
                   type: "local_shell_call",
                   call_id: part.toolCallId,
-                  id: (part.providerOptions?.copilot?.itemId as string) ?? undefined,
+                  id: store ? ((part.providerOptions?.copilot?.itemId as string) ?? undefined) : undefined,
                   action: {
                     type: "exec",
                     command: parsedInput.action.command,
@@ -162,7 +162,7 @@ export async function convertToOpenAIResponsesInput({
                 call_id: part.toolCallId,
                 name: part.toolName,
                 arguments: JSON.stringify(part.input),
-                id: (part.providerOptions?.copilot?.itemId as string) ?? undefined,
+                id: store ? ((part.providerOptions?.copilot?.itemId as string) ?? undefined) : undefined,
               })
               break
             }
@@ -206,50 +206,20 @@ export async function convertToOpenAIResponsesInput({
                       summary: [],
                     }
                   }
-                } else {
-                  const summaryParts: Array<{
-                    type: "summary_text"
-                    text: string
-                  }> = []
-
-                  if (part.text.length > 0) {
-                    summaryParts.push({
-                      type: "summary_text",
-                      text: part.text,
-                    })
-                  } else if (reasoningMessage !== undefined) {
-                    warnings.push({
-                      type: "other",
-                      message: `Cannot append empty reasoning part to existing reasoning sequence. Skipping reasoning part: ${JSON.stringify(part)}.`,
-                    })
+                } else if (providerOptions?.reasoningEncryptedContent != null && reasoningMessage === undefined) {
+                  reasoningMessages[reasoningId] = {
+                    type: "reasoning",
+                    id: reasoningId,
+                    encrypted_content: providerOptions.reasoningEncryptedContent,
+                    summary: [],
                   }
-
-                  if (reasoningMessage === undefined) {
-                    reasoningMessages[reasoningId] = {
-                      type: "reasoning",
-                      id: reasoningId,
-                      encrypted_content: providerOptions?.reasoningEncryptedContent,
-                      summary: summaryParts,
-                    }
-                    input.push(reasoningMessages[reasoningId])
-                  } else {
-                    reasoningMessage.summary.push(...summaryParts)
-                  }
+                  input.push(reasoningMessages[reasoningId])
                 }
               } else {
-                const encryptedContent = providerOptions?.reasoningEncryptedContent
-                if (encryptedContent != null) {
-                  input.push({
-                    type: "reasoning",
-                    encrypted_content: encryptedContent,
-                    summary: part.text.length > 0 ? [{ type: "summary_text", text: part.text }] : [],
-                  })
-                } else {
-                  warnings.push({
-                    type: "other",
-                    message: `Non-OpenAI reasoning parts are not supported. Skipping reasoning part: ${JSON.stringify(part)}.`,
-                  })
-                }
+                warnings.push({
+                  type: "other",
+                  message: `Non-OpenAI reasoning parts are not supported. Skipping reasoning part: ${JSON.stringify(part)}.`,
+                })
               }
               break
             }

--- a/packages/core/src/github-copilot/responses/openai-responses-api-types.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-api-types.ts
@@ -71,7 +71,7 @@ export type OpenAIResponsesComputerCall = {
 
 export type OpenAIResponsesLocalShellCall = {
   type: "local_shell_call"
-  id: string
+  id?: string
   call_id: string
   action: {
     type: "exec"
@@ -205,7 +205,7 @@ export type OpenAIResponsesTool =
 
 export type OpenAIResponsesReasoning = {
   type: "reasoning"
-  id?: string
+  id: string
   encrypted_content?: string | null
   summary: Array<{
     type: "summary_text"

--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -214,8 +214,11 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     let include: OpenAIResponsesIncludeOptions = openaiOptions?.include
 
     function addInclude(key: OpenAIResponsesIncludeValue) {
+      if (include?.includes(key)) return
       include = include != null ? [...include, key] : [key]
     }
+
+    if (openaiOptions?.store === false) addInclude("reasoning.encrypted_content")
 
     function hasOpenAITool(id: string) {
       return tools?.find((tool) => tool.type === "provider" && tool.id === id) != null
@@ -840,7 +843,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       {
         canonicalId: string // the item.id from output_item.added
         encryptedContent?: string | null
-        summaryParts: number[]
+        summaryParts: Record<number, "active" | "can-conclude" | "concluded">
       }
     > = {}
 
@@ -960,11 +963,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   },
                 })
               } else if (isResponseOutputItemAddedReasoningChunk(value)) {
-                if (activeReasoning[value.output_index]) return
+                if (activeReasoning[value.output_index]) {
+                  currentReasoningOutputIndex = value.output_index
+                  return
+                }
                 activeReasoning[value.output_index] = {
                   canonicalId: value.item.id,
                   encryptedContent: value.item.encrypted_content,
-                  summaryParts: [0],
+                  summaryParts: { 0: "active" },
                 }
                 currentReasoningOutputIndex = value.output_index
 
@@ -1118,14 +1124,14 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
               } else if (isResponseOutputItemDoneReasoningChunk(value)) {
                 const activeReasoningPart = activeReasoning[value.output_index]
                 if (activeReasoningPart) {
-                  const summaryIndex = activeReasoningPart.summaryParts.at(-1)
-                  if (summaryIndex !== undefined) {
+                  for (const [summaryIndex, status] of Object.entries(activeReasoningPart.summaryParts)) {
+                    if (status === "concluded") continue
                     controller.enqueue({
                       type: "reasoning-end",
                       id: `${activeReasoningPart.canonicalId}:${summaryIndex}`,
                       providerMetadata: {
                         copilot: {
-                          itemId: activeReasoningPart.canonicalId,
+                          itemId: value.item.id,
                           reasoningEncryptedContent: value.item.encrypted_content ?? null,
                         },
                       },
@@ -1230,18 +1236,19 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 currentReasoningOutputIndex !== null ? activeReasoning[currentReasoningOutputIndex] : null
 
               // the first reasoning start is pushed in isResponseOutputItemAddedReasoningChunk.
-              if (activeItem && value.summary_index > 0 && !activeItem.summaryParts.includes(value.summary_index)) {
-                const previousSummaryIndex = activeItem.summaryParts.at(-1)
-                if (previousSummaryIndex !== undefined) {
+              if (activeItem && value.summary_index > 0 && activeItem.summaryParts[value.summary_index] === undefined) {
+                for (const [summaryIndex, status] of Object.entries(activeItem.summaryParts)) {
+                  if (status !== "can-conclude") continue
                   controller.enqueue({
                     type: "reasoning-end",
-                    id: `${activeItem.canonicalId}:${previousSummaryIndex}`,
+                    id: `${activeItem.canonicalId}:${summaryIndex}`,
                     providerMetadata: {
                       copilot: { itemId: activeItem.canonicalId },
                     },
                   })
+                  activeItem.summaryParts[Number(summaryIndex)] = "concluded"
                 }
-                activeItem.summaryParts.push(value.summary_index)
+                activeItem.summaryParts[value.summary_index] = "active"
 
                 controller.enqueue({
                   type: "reasoning-start",
@@ -1254,6 +1261,22 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                   },
                 })
               }
+            } else if (isResponseReasoningSummaryPartDoneChunk(value)) {
+              const activeItem =
+                currentReasoningOutputIndex !== null ? activeReasoning[currentReasoningOutputIndex] : null
+              if (!activeItem || activeItem.summaryParts[value.summary_index] !== "active") return
+              if (body.store === false) {
+                activeItem.summaryParts[value.summary_index] = "can-conclude"
+                return
+              }
+              controller.enqueue({
+                type: "reasoning-end",
+                id: `${activeItem.canonicalId}:${value.summary_index}`,
+                providerMetadata: {
+                  copilot: { itemId: activeItem.canonicalId },
+                },
+              })
+              activeItem.summaryParts[value.summary_index] = "concluded"
             } else if (isResponseReasoningSummaryTextDeltaChunk(value)) {
               const activeItem =
                 currentReasoningOutputIndex !== null ? activeReasoning[currentReasoningOutputIndex] : null
@@ -1315,6 +1338,16 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             if (currentTextId) {
               controller.enqueue({ type: "text-end", id: currentTextId })
               currentTextId = null
+            }
+            for (const activeItem of Object.values(activeReasoning)) {
+              for (const [summaryIndex, status] of Object.entries(activeItem.summaryParts)) {
+                if (status === "concluded") continue
+                controller.enqueue({
+                  type: "reasoning-end",
+                  id: `${activeItem.canonicalId}:${summaryIndex}`,
+                  providerMetadata: { copilot: { itemId: activeItem.canonicalId } },
+                })
+              }
             }
 
             const providerMetadata: SharedV3ProviderMetadata = {
@@ -1564,6 +1597,12 @@ const responseReasoningSummaryTextDeltaSchema = z.object({
   delta: z.string(),
 })
 
+const responseReasoningSummaryPartDoneSchema = z.object({
+  type: z.literal("response.reasoning_summary_part.done"),
+  item_id: z.string(),
+  summary_index: z.number(),
+})
+
 const openaiResponsesChunkSchema = z.union([
   textDeltaChunkSchema,
   responseFinishedChunkSchema,
@@ -1576,6 +1615,7 @@ const openaiResponsesChunkSchema = z.union([
   responseCodeInterpreterCallCodeDoneSchema,
   responseAnnotationAddedSchema,
   responseReasoningSummaryPartAddedSchema,
+  responseReasoningSummaryPartDoneSchema,
   responseReasoningSummaryTextDeltaSchema,
   errorChunkSchema,
   z.object({ type: z.string() }).loose(), // fallback for unknown chunks
@@ -1662,6 +1702,12 @@ function isResponseReasoningSummaryPartAddedChunk(
   chunk: z.infer<typeof openaiResponsesChunkSchema>,
 ): chunk is z.infer<typeof responseReasoningSummaryPartAddedSchema> {
   return chunk.type === "response.reasoning_summary_part.added"
+}
+
+function isResponseReasoningSummaryPartDoneChunk(
+  chunk: z.infer<typeof openaiResponsesChunkSchema>,
+): chunk is z.infer<typeof responseReasoningSummaryPartDoneSchema> {
+  return chunk.type === "response.reasoning_summary_part.done"
 }
 
 function isResponseReasoningSummaryTextDeltaChunk(

--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -198,12 +198,13 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       providerOptions,
       schema: openaiResponsesProviderOptionsSchema,
     })
+    const store = openaiOptions?.store ?? false
 
     const { input, warnings: inputWarnings } = await convertToOpenAIResponsesInput({
       prompt,
       systemMessageMode: modelConfig.systemMessageMode,
       fileIdPrefixes: this.config.fileIdPrefixes,
-      store: openaiOptions?.store ?? true,
+      store,
       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
     })
 
@@ -218,7 +219,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       include = include != null ? [...include, key] : [key]
     }
 
-    if (openaiOptions?.store === false) addInclude("reasoning.encrypted_content")
+    addInclude("reasoning.encrypted_content")
 
     function hasOpenAITool(id: string) {
       return tools?.find((tool) => tool.type === "provider" && tool.id === id) != null
@@ -285,7 +286,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
       metadata: openaiOptions?.metadata,
       parallel_tool_calls: openaiOptions?.parallelToolCalls,
       previous_response_id: openaiOptions?.previousResponseId,
-      store: openaiOptions?.store,
+      store,
       user: openaiOptions?.user,
       instructions: openaiOptions?.instructions,
       service_tier: openaiOptions?.serviceTier,

--- a/packages/core/src/plugin/provider/github-copilot.ts
+++ b/packages/core/src/plugin/provider/github-copilot.ts
@@ -1,5 +1,4 @@
 import type { IntegrationOAuthMethodRegistration } from "@opencode-ai/plugin/effect/integration"
-import { Message } from "@opencode-ai/ai"
 import { Effect, Option, Schema, Semaphore, Stream } from "effect"
 import { Catalog } from "../../catalog"
 import { Credential } from "../../credential"
@@ -202,12 +201,7 @@ export const GithubCopilotPlugin = define({
           if (!loaded.models.has(Model.ID.make(id))) evt.model.remove(item.provider.id, id)
         }
         for (const [id, model] of loaded.models) {
-          evt.model.update(item.provider.id, id, (draft) => {
-            Object.assign(draft, structuredClone(model))
-            if (Provider.packageName(draft.package) === "@ai-sdk/github-copilot") {
-              draft.settings = Provider.mergeOverlay(draft.settings, { store: false })
-            }
-          })
+          evt.model.update(item.provider.id, id, (draft) => Object.assign(draft, structuredClone(model)))
         }
       } else if (loaded.baseURL) {
         for (const id of item.models.keys()) {
@@ -215,6 +209,12 @@ export const GithubCopilotPlugin = define({
             model.settings = Provider.mergeOverlay(model.settings, { baseURL: loaded.baseURL })
           })
         }
+      }
+      for (const [id, model] of loaded.models ?? item.models) {
+        if (Provider.packageName(model.package) !== "@ai-sdk/github-copilot") continue
+        evt.model.update(item.provider.id, id, (draft) => {
+          draft.settings = Provider.mergeOverlay(draft.settings, { store: false })
+        })
       }
       if (item.models.has(Model.ID.make("gpt-5-chat-latest"))) {
         evt.model.update(item.provider.id, Model.ID.make("gpt-5-chat-latest"), (model) => {
@@ -253,28 +253,6 @@ export const GithubCopilotPlugin = define({
         const text = yield* Effect.promise(() => evt.request.clone().text())
         const body = Option.getOrUndefined(decodeBody(text))
         applyHeaders(evt.request.headers, token, ctx.app, requestMetadata(evt.request.url, body), true)
-      }),
-    )
-    yield* ctx.session.hook("context", (evt) =>
-      Effect.sync(() => {
-        if (evt.model.providerID !== Provider.ID.githubCopilot) return
-        evt.messages = evt.messages.map(
-          (message) =>
-            new Message({
-              ...message,
-              content: message.content.map((part) => {
-                if (!("providerMetadata" in part)) return part
-                const metadata = part.providerMetadata?.copilot
-                if (metadata === undefined || !("itemId" in metadata)) return part
-                const next = { ...metadata }
-                delete next.itemId
-                return {
-                  ...part,
-                  providerMetadata: { ...part.providerMetadata, copilot: next },
-                }
-              }),
-            }),
-        )
       }),
     )
     yield* ctx.aisdk.hook(

--- a/packages/core/src/plugin/provider/github-copilot.ts
+++ b/packages/core/src/plugin/provider/github-copilot.ts
@@ -210,12 +210,6 @@ export const GithubCopilotPlugin = define({
           })
         }
       }
-      for (const [id, model] of loaded.models ?? item.models) {
-        if (Provider.packageName(model.package) !== "@ai-sdk/github-copilot") continue
-        evt.model.update(item.provider.id, id, (draft) => {
-          draft.settings = Provider.mergeOverlay(draft.settings, { store: false })
-        })
-      }
       if (item.models.has(Model.ID.make("gpt-5-chat-latest"))) {
         evt.model.update(item.provider.id, Model.ID.make("gpt-5-chat-latest"), (model) => {
           // This chat-only alias conflicts with the Copilot GPT-5 Responses route,

--- a/packages/core/test/github-copilot/openai-responses-language-model.test.ts
+++ b/packages/core/test/github-copilot/openai-responses-language-model.test.ts
@@ -87,6 +87,35 @@ describe("doGenerate", () => {
     expect(providerMetadata?.copilot?.responseId).toBe("resp_1")
     expect(providerMetadata?.openai).toBeUndefined()
   })
+
+  test("serializes previousResponseId only when explicitly provided", async () => {
+    const requests: Array<Record<string, unknown>> = []
+    const fetchFn = mock(async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      requests.push(JSON.parse(init?.body as string))
+      return new Response(
+        JSON.stringify({
+          id: "resp_1",
+          created_at: 0,
+          model: "gpt-5.5",
+          output: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      )
+    })
+    const model = createModel(fetchFn)
+
+    await model.doGenerate({ prompt: TEST_PROMPT, includeRawChunks: false } as any)
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: { copilot: { previousResponseId: "resp_previous", store: false } },
+    } as any)
+
+    expect(requests[0]?.previous_response_id).toBeUndefined()
+    expect(requests[1]?.previous_response_id).toBe("resp_previous")
+    expect(requests[1]?.include).toEqual(["reasoning.encrypted_content"])
+  })
 })
 
 describe("doStream", () => {
@@ -117,7 +146,11 @@ describe("doStream", () => {
         },
       ]),
     )
-    const result = await model.doStream({ prompt: TEST_PROMPT, includeRawChunks: false } as any)
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: { copilot: { store: false } },
+    } as any)
     const reader = result.stream.getReader()
     const events: LanguageModelV3StreamPart[] = []
     while (true) {
@@ -143,14 +176,74 @@ describe("doStream", () => {
       {
         type: "reasoning-end",
         id: "rs_1:1",
-        providerMetadata: { copilot: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
+        providerMetadata: { copilot: { itemId: "rs_rotated", reasoningEncryptedContent: "encrypted-state" } },
       },
     ])
+
+    const deltas = new Map(
+      events.filter((event) => event.type === "reasoning-delta").map((event) => [event.id, event.delta] as const),
+    )
+    const { input } = await convertToOpenAIResponsesInput({
+      prompt: [
+        {
+          role: "assistant",
+          content: events
+            .filter((event) => event.type === "reasoning-end")
+            .map((event) => ({
+              type: "reasoning" as const,
+              text: deltas.get(event.id) ?? "",
+              providerOptions: event.providerMetadata,
+            })),
+        },
+      ],
+      systemMessageMode: "system",
+      store: false,
+    })
+    expect(input).toEqual([
+      {
+        type: "reasoning",
+        id: "rs_rotated",
+        encrypted_content: "encrypted-state",
+        summary: [],
+      },
+    ])
+  })
+
+  test("closes reasoning when a Copilot stream ends before output_item.done", async () => {
+    const model = createModel(
+      createStreamFetch([
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          item: { type: "reasoning", id: "rs_1", encrypted_content: null },
+        },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_rotated", summary_index: 0, delta: "First" },
+      ]),
+    )
+    const result = await model.doStream({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: { copilot: { store: false } },
+    } as any)
+    const reader = result.stream.getReader()
+    const events: LanguageModelV3StreamPart[] = []
+    while (true) {
+      const item = await reader.read()
+      if (item.done) break
+      if (item.value.type.startsWith("reasoning-")) events.push(item.value)
+    }
+
+    expect(events.map((event) => event.type)).toEqual(["reasoning-start", "reasoning-delta", "reasoning-end"])
+    expect(events.at(-1)).toMatchObject({
+      type: "reasoning-end",
+      id: "rs_1:0",
+      providerMetadata: { copilot: { itemId: "rs_1" } },
+    })
   })
 })
 
 describe("convertToOpenAIResponsesInput", () => {
-  test("echoes a stale tool-call itemId from the copilot namespace as the function_call id", async () => {
+  test("omits response item IDs from stateless function calls", async () => {
     const { input } = await convertToOpenAIResponsesInput({
       prompt: [
         {
@@ -176,12 +269,11 @@ describe("convertToOpenAIResponsesInput", () => {
         call_id: "call_1",
         name: "bash",
         arguments: JSON.stringify({ command: "ls" }),
-        id: "fc_999",
       },
     ])
   })
 
-  test("omits the function_call id once the stale copilot itemId has been stripped", async () => {
+  test("preserves response item IDs for stored function calls", async () => {
     const { input } = await convertToOpenAIResponsesInput({
       prompt: [
         {
@@ -192,16 +284,16 @@ describe("convertToOpenAIResponsesInput", () => {
               toolCallId: "call_1",
               toolName: "bash",
               input: { command: "ls" },
-              providerOptions: {},
+              providerOptions: { copilot: { itemId: "fc_999" } },
             },
           ],
         },
       ],
       systemMessageMode: "system",
-      store: false,
+      store: true,
     })
 
-    expect((input[0] as any).id).toBeUndefined()
+    expect((input[0] as any).id).toBe("fc_999")
   })
 
   test("preserves reasoning items keyed by the copilot namespace instead of dropping them", async () => {
@@ -228,12 +320,12 @@ describe("convertToOpenAIResponsesInput", () => {
         type: "reasoning",
         id: "rs_1",
         encrypted_content: "enc_1",
-        summary: [{ type: "summary_text", text: "thinking..." }],
+        summary: [],
       },
     ])
   })
 
-  test("preserves encrypted reasoning with no copilot itemId", async () => {
+  test("drops encrypted reasoning with no completed copilot itemId", async () => {
     const { input, warnings } = await convertToOpenAIResponsesInput({
       prompt: [
         {
@@ -251,14 +343,8 @@ describe("convertToOpenAIResponsesInput", () => {
       store: false,
     })
 
-    expect(warnings).toEqual([])
-    expect(input).toEqual([
-      {
-        type: "reasoning",
-        encrypted_content: "enc_1",
-        summary: [{ type: "summary_text", text: "thinking..." }],
-      },
-    ])
+    expect(input).toEqual([])
+    expect(warnings).toHaveLength(1)
   })
 
   test("drops reasoning with neither a copilot itemId nor encrypted content", async () => {

--- a/packages/core/test/github-copilot/openai-responses-language-model.test.ts
+++ b/packages/core/test/github-copilot/openai-responses-language-model.test.ts
@@ -88,7 +88,7 @@ describe("doGenerate", () => {
     expect(providerMetadata?.openai).toBeUndefined()
   })
 
-  test("serializes previousResponseId only when explicitly provided", async () => {
+  test("defaults to stateless encrypted reasoning and keeps previousResponseId opt-in", async () => {
     const requests: Array<Record<string, unknown>> = []
     const fetchFn = mock(async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
       requests.push(JSON.parse(init?.body as string))
@@ -111,10 +111,20 @@ describe("doGenerate", () => {
       includeRawChunks: false,
       providerOptions: { copilot: { previousResponseId: "resp_previous", store: false } },
     } as any)
+    await model.doGenerate({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+      providerOptions: { copilot: { store: true } },
+    } as any)
 
     expect(requests[0]?.previous_response_id).toBeUndefined()
+    expect(requests[0]?.store).toBe(false)
+    expect(requests[0]?.include).toEqual(["reasoning.encrypted_content"])
     expect(requests[1]?.previous_response_id).toBe("resp_previous")
+    expect(requests[1]?.store).toBe(false)
     expect(requests[1]?.include).toEqual(["reasoning.encrypted_content"])
+    expect(requests[2]?.store).toBe(true)
+    expect(requests[2]?.include).toEqual(["reasoning.encrypted_content"])
   })
 })
 

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -350,24 +350,6 @@ describe("GithubCopilotPlugin", () => {
     }),
   )
 
-  it.effect("defaults bundled Copilot models to stateless responses without model sync", () =>
-    Effect.gen(function* () {
-      const catalog = yield* Catalog.Service
-      yield* catalog.transform((catalog) => {
-        catalog.provider.update(Provider.ID.githubCopilot, () => {})
-        catalog.model.update(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4"), (model) => {
-          model.package = Provider.aisdk("@ai-sdk/github-copilot")
-          model.settings = { endpoint: "responses" }
-        })
-      })
-      yield* addPlugin()
-      expect(required(yield* catalog.model.get(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4"))).settings).toEqual({
-        endpoint: "responses",
-        store: false,
-      })
-    }),
-  )
-
   it.effect("does not disable gpt-5-chat-latest for non-Copilot providers", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -1,6 +1,5 @@
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { App } from "@opencode-ai/core/app"
-import { Message } from "@opencode-ai/ai"
 import { Agent } from "@opencode-ai/schema/agent"
 import { Session } from "@opencode-ai/schema/session"
 import { describe, expect, test } from "bun:test"
@@ -139,43 +138,6 @@ describe("GithubCopilotPlugin", () => {
       expect(event.request.headers.get("x-initiator")).toBe("user")
       expect(event.request.headers.get("anthropic-beta")).toBe("interleaved-thinking-2025-05-14")
       expect(event.request.headers.get("x-github-api-version")).toBe("2026-06-01")
-    }),
-  )
-
-  it.effect("strips stale Copilot item IDs before serialization", () =>
-    Effect.gen(function* () {
-      yield* addPlugin()
-      const event = yield* (yield* PluginHooks.Service).trigger("session", "context", {
-        sessionID: Session.ID.make("ses_test"),
-        agent: Agent.ID.make("build"),
-        model: Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("gpt-5.4") }),
-        system: [],
-        messages: [
-          Message.assistant([
-            {
-              type: "reasoning",
-              text: "thinking",
-              providerMetadata: {
-                copilot: { itemId: "rs_1", reasoningEncryptedContent: "encrypted" },
-              },
-            },
-            {
-              type: "tool-call",
-              id: "call_1",
-              name: "read",
-              input: {},
-              providerMetadata: { copilot: { itemId: "fc_1", other: "value" } },
-            },
-          ]),
-        ],
-        tools: {},
-      })
-      expect(event.messages[0]?.content).toMatchObject([
-        { providerMetadata: { copilot: { reasoningEncryptedContent: "encrypted" } } },
-        { providerMetadata: { copilot: { other: "value" } } },
-      ])
-      expect(event.messages[0]?.content).not.toHaveProperty("0.providerMetadata.copilot.itemId")
-      expect(event.messages[0]?.content).not.toHaveProperty("1.providerMetadata.copilot.itemId")
     }),
   )
 
@@ -385,6 +347,24 @@ describe("GithubCopilotPlugin", () => {
         required(yield* catalog.model.get(Provider.ID.make("github-copilot"), Model.ID.make("gpt-5-chat-latest")))
           .enabled,
       ).toBe(false)
+    }),
+  )
+
+  it.effect("defaults bundled Copilot models to stateless responses without model sync", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* catalog.transform((catalog) => {
+        catalog.provider.update(Provider.ID.githubCopilot, () => {})
+        catalog.model.update(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4"), (model) => {
+          model.package = Provider.aisdk("@ai-sdk/github-copilot")
+          model.settings = { endpoint: "responses" }
+        })
+      })
+      yield* addPlugin()
+      expect(required(yield* catalog.model.get(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4"))).settings).toEqual({
+        endpoint: "responses",
+        store: false,
+      })
     }),
   )
 


### PR DESCRIPTION
## Summary

- align stateless Copilot Responses continuation with the official VS Code Copilot client
- persist the final completed reasoning item ID together with encrypted state
- omit response item IDs from stateless text and tool-call reconstruction while preserving tool `call_id`
- handle reasoning summary completion explicitly and keep stream lifecycles balanced
- retain `previousResponseId` as an opt-in provider option without enabling it

## Verification

- 35 focused Core tests
- Core typecheck
- full 33-package pre-push typecheck
- live `github-copilot/gpt-5.4` high reasoning run through tool execution and continuation

## Stack

Targets #40997 (`auth-forms`) so the Copilot SDK correction can be reviewed independently.