### PR TITLE
fix(session): omit tool definitions for models that cannot call tools

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -205,7 +205,12 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   }
 })
 
-function resolveTools(input: Pick<PrepareInput, "tools" | "agent" | "permission" | "user">) {
+function resolveTools(input: Pick<PrepareInput, "tools" | "agent" | "permission" | "user" | "model">) {
+  // Some providers reject a request that carries tool definitions at all when the
+  // model cannot call tools, rather than ignoring them — Vertex Gemini image
+  // models answer "Unable to submit request because the model does not support
+  // function calling". Sending them is never useful, so drop the whole set.
+  if (!input.model.capabilities.toolcall) return {}
   const disabled = Permission.disabled(
     Object.keys(input.tools),
     Permission.merge(input.agent.permission, input.permission ?? []),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -586,6 +586,64 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.tools.lookup.strict).toBe(false)
   })
 
+  const prepareWithTools = (model: any) =>
+    Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: model.providerID, modelID: model.api.id },
+        } as any,
+        sessionID,
+        model,
+        agent: {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [],
+        } as any,
+        system: [],
+        messages: [{ role: "user", content: "Hello" }],
+        tools: {
+          lookup: {
+            description: "Look up a value",
+            inputSchema: jsonSchema({ type: "object", properties: {} }),
+          },
+        },
+        provider: { id: model.providerID, options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (_name: string, _input: unknown, output: unknown) => Effect.succeed(output),
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+
+  test("omits tools for a model that cannot call tools", async () => {
+    // Some providers reject a request carrying tool definitions at all rather
+    // than ignoring them: Vertex Gemini image models answer "Unable to submit
+    // request because the model does not support function calling", so every
+    // send fails until the definitions are dropped.
+    const model = createGpt5Model("gemini-2.5-flash-image")
+    model.capabilities.toolcall = false
+
+    const result = await prepareWithTools(model)
+
+    expect(result.tools).toEqual({})
+  })
+
+  test("keeps tools for a model that can call tools", async () => {
+    const result = await prepareWithTools(createGpt5Model("gpt-5.2"))
+
+    expect(Object.keys(result.tools)).toEqual(["lookup"])
+  })
+
   test("gpt-5.1 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.1")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })


### PR DESCRIPTION
### Issue for this PR

Closes #41464

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`capabilities.toolcall` is set from provider config but never read when building a request, so `resolveTools` declares every tool even to models that can't call any. Providers that reject function calling then fail every send — Vertex Gemini image models answer `Unable to submit request because the model does not support function calling`.

The fix is one guard in `resolveTools`: return no tools when `!input.model.capabilities.toolcall`. `model` is already on the same input, so nothing new is threaded through.

Suppressing the whole set (rather than filtering individual tools) is what's needed, because these providers reject on the *presence* of any declaration. Doing it in `resolveTools` covers every send path at once; the guard sits before the provider-specific tweaks, so the `github-copilot` `_noop` path still engages on an empty set exactly as it does today when an agent wildcard-deny empties it.

### How did you verify your code works?

Captured the outgoing provider request from a source build against a recording endpoint, stock `build` agent, no config overrides:

| Model | `tools` field | declarations |
|---|---|---|
| `gemini-2.5-flash-image` (`toolcall: false`) | absent | 0 (was 12) |
| `gemini-3.6-flash` (`toolcall: true`), same session | present | 12 |

Two tests added next to the existing `LLMRequestPrep.prepare` coverage in `test/provider/transform.test.ts`. I checked the negative one fails without the guard (exactly 1 failure), so it's real coverage.

`bun test test/provider/` 536 pass · `bun test test/session/` 396 pass, 0 fail · `bun run typecheck` clean.

Not verified: live Vertex traffic — the endpoint was a local recording proxy, so the 400 is reproduced by request shape, not by Google's response.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
