### PR TITLE
fix(opencode): retry empty unknown responses

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -636,14 +636,30 @@ const layer = Layer.effect(
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
             ctx.reasoningMap = {}
+            let generated = false
             yield* status.set(ctx.sessionID, { type: "busy" })
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(
-              Stream.tap((event) => handleEvent(event)),
+              Stream.tap((event) => {
+                if (
+                  (event.type === "text-delta" && event.text.length > 0) ||
+                  (event.type === "reasoning-delta" && event.text.length > 0) ||
+                  event.type === "tool-input-start" ||
+                  event.type === "tool-call"
+                ) {
+                  generated = true
+                }
+                return handleEvent(event)
+              }),
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
+            if (ctx.assistantMessage.finish === "unknown" && !generated) {
+              yield* new SessionRetry.EmptyResponseError({
+                message: "The model returned an empty response with an unknown finish reason",
+              })
+            }
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -1,11 +1,15 @@
 import type { NamedError } from "@opencode-ai/core/util/error"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { Cause, Clock, Duration, Effect, Schedule } from "effect"
+import { Cause, Clock, Duration, Effect, Schedule, Schema } from "effect"
 import { MessageV2 } from "./message-v2"
 import { iife } from "@/util/iife"
 import { isRecord } from "@/util/record"
 
 export type Err = ReturnType<NamedError["toObject"]>
+
+export class EmptyResponseError extends Schema.TaggedErrorClass<EmptyResponseError>()("SessionEmptyResponseError", {
+  message: Schema.String,
+}) {}
 
 export const GO_UPSELL_MESSAGE = "Free usage exceeded, subscribe to Go"
 export const GO_UPSELL_URL = "https://opencode.ai/go"
@@ -180,7 +184,8 @@ export function policy(opts: {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
-      const retry = retryable(error, opts.provider)
+      const retry =
+        meta.input instanceof EmptyResponseError ? { message: meta.input.message } : retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -604,6 +604,68 @@ it.live("session.processor effect tests retry recognized structured json errors"
   ),
 )
 
+it.live("session.processor effect tests retry empty responses with unknown finish reasons", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.push(
+          raw({
+            chunks: [
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: { role: "assistant" }, finish_reason: null }],
+              },
+              {
+                id: "chatcmpl-test",
+                object: "chat.completion.chunk",
+                choices: [{ delta: {}, finish_reason: "unknown_reason" }],
+              },
+            ],
+          }),
+          reply().text("after").stop(),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "retry empty")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "retry empty" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
+        expect(handle.message.error).toBeUndefined()
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests retry OpenAI-compatible midstream server errors", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #41469

### Type of change

- [x] Bug fix

### What does this PR do?

When a provider returns an **empty completion** (0 tokens, no text/reasoning/tool output, finish reason maps to `unknown`), opencode records it as a normal completed turn and the session loop exits silently — no error surfaced, no retry. The conversation appears to stop mid-task.

This PR makes the processor treat such turns as transient failures:

- `packages/opencode/src/session/processor.ts`: track whether the stream generated any text/reasoning/tool output; if `finish === "unknown"` and nothing was generated, throw `SessionRetry.EmptyResponseError`.
- `packages/opencode/src/session/retry.ts`: add `EmptyResponseError` and retry it like other transient failures (existing backoff policy).
- Test added covering the empty-response retry path.

This is a rebased port of #40531 (same fix, currently conflicting with `dev`) so it is mergeable as-is.

### How did you verify your code works?

- New test passes: `bun test session/processor-effect.test.ts -t "retry empty"`
- Full suite: `bun test session/processor-effect.test.ts` — 16 pass / 1 fail (the failure is the pre-existing `midstream server errors` test, failing on `dev` without this change too)
- `bun typecheck` passes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR