### PR TITLE
fix(tui): coalesce part stream deltas per frame to prevent stalls

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -23,6 +23,7 @@ import { createSimpleContext } from "./helper"
 import { useSDK } from "./sdk"
 import { useEvent } from "./event"
 import { createSignal, onCleanup, onMount } from "solid-js"
+import { createDeltaBuffer } from "./delta-buffer"
 
 type LocationData = {
   agent?: AgentV2Info[]
@@ -121,7 +122,64 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       },
     }
 
+    // Reasoning and text parts can stream thousands of deltas; applying each one
+    // immediately rewrites the accumulating text on every token, stalling the UI
+    // while a thinking block is expanded. Coalesce per frame instead.
+    const deltaBuffer = createDeltaBuffer(
+      (flush) => {
+        if (typeof requestAnimationFrame === "function") requestAnimationFrame(flush)
+        else setTimeout(flush, 16)
+      },
+      (item) => {
+        message.update(item.sessionID, (draft) => {
+          const assistant = message.assistant(draft, item.messageID)
+          if (item.kind === "tool") {
+            const match = message.latestTool(assistant, item.partID)
+            if (match?.state.status === "pending") match.state.input += item.delta
+            return
+          }
+          const match =
+            item.kind === "text" ? message.latestText(assistant, item.partID) : message.latestReasoning(assistant, item.partID)
+          if (match) match.text += item.delta
+        })
+      },
+    )
+
     function handleEvent(event: V2Event) {
+      // Terminating events replace the whole part text, so once any pending
+      // deltas are coalesced they must be applied before the replacement.
+      switch (event.type) {
+        case "session.next.text.delta":
+          deltaBuffer.push({
+            kind: "text",
+            sessionID: event.data.sessionID,
+            messageID: event.data.assistantMessageID,
+            partID: event.data.textID,
+            delta: event.data.delta,
+          })
+          break
+        case "session.next.reasoning.delta":
+          deltaBuffer.push({
+            kind: "reasoning",
+            sessionID: event.data.sessionID,
+            messageID: event.data.assistantMessageID,
+            partID: event.data.reasoningID,
+            delta: event.data.delta,
+          })
+          break
+        case "session.next.tool.input.delta":
+          deltaBuffer.push({
+            kind: "tool",
+            sessionID: event.data.sessionID,
+            messageID: event.data.assistantMessageID,
+            partID: event.data.callID,
+            delta: event.data.delta,
+          })
+          break
+
+        default:
+          deltaBuffer.drain()
+      }
       switch (event.type) {
         case "catalog.updated":
           void Promise.all([
@@ -251,12 +309,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             })
           })
           break
-        case "session.next.text.delta":
-          message.update(event.data.sessionID, (draft) => {
-            const match = message.latestText(message.assistant(draft, event.data.assistantMessageID), event.data.textID)
-            if (match) match.text += event.data.delta
-          })
-          break
         case "session.next.text.ended":
           message.update(event.data.sessionID, (draft) => {
             const match = message.latestText(message.assistant(draft, event.data.assistantMessageID), event.data.textID)
@@ -272,12 +324,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               time: { created: event.data.timestamp },
               state: { status: "pending", input: "" },
             })
-          })
-          break
-        case "session.next.tool.input.delta":
-          message.update(event.data.sessionID, (draft) => {
-            const match = message.latestTool(message.assistant(draft, event.data.assistantMessageID), event.data.callID)
-            if (match?.state.status === "pending") match.state.input += event.data.delta
           })
           break
         case "session.next.tool.input.ended":
@@ -352,15 +398,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             })
           })
           break
-        case "session.next.reasoning.delta":
-          message.update(event.data.sessionID, (draft) => {
-            const match = message.latestReasoning(
-              message.assistant(draft, event.data.assistantMessageID),
-              event.data.reasoningID,
-            )
-            if (match) match.text += event.data.delta
-          })
-          break
         case "session.next.reasoning.ended":
           message.update(event.data.sessionID, (draft) => {
             const match = message.latestReasoning(
@@ -410,7 +447,10 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           location: { directory: metadata.directory, workspaceID: metadata.workspace },
         } as V2Event)
       })
-      onCleanup(unsub)
+      onCleanup(() => {
+        unsub()
+        deltaBuffer.drain()
+      })
     })
 
     const result = {

--- a/packages/tui/src/context/delta-buffer.test.ts
+++ b/packages/tui/src/context/delta-buffer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import { createDeltaBuffer, type PendingDelta } from "./delta-buffer"
+
+function makeBuffer(history: PendingDelta[] = []) {
+  const calls: string[] = []
+  const queue: Array<() => void> = []
+  const buffer = createDeltaBuffer(
+    (flush) => {
+      calls.push("schedule")
+      queue.push(flush)
+    },
+    (item) => history.push(item),
+  )
+  const tick = () => queue.shift()?.()
+  return { buffer, queue, calls, tick }
+}
+
+const base = { sessionID: "s", messageID: "m" } as const
+
+describe("createDeltaBuffer", () => {
+  test("coalesces consecutive deltas for the same part into one application", () => {
+    const applied: PendingDelta[] = []
+    const { buffer, tick } = makeBuffer(applied)
+
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "a" })
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "b" })
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "c" })
+
+    expect(applied).toEqual([])
+    tick()
+    expect(applied).toEqual([{ kind: "reasoning", ...base, partID: "r1", delta: "abc" }])
+    for (const item of applied) expect(item).not.toBe(undefined)
+  })
+
+  test("keeps distinct parts and kinds separate within one flush", () => {
+    const applied: PendingDelta[] = []
+    const { buffer, tick } = makeBuffer(applied)
+
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "a" })
+    buffer.push({ kind: "text", ...base, partID: "t1", delta: "x" })
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "b" })
+    buffer.push({ kind: "tool", ...base, partID: "t1", delta: "y" })
+
+    tick()
+    expect(applied).toEqual([
+      { kind: "reasoning", ...base, partID: "r1", delta: "ab" },
+      { kind: "text", ...base, partID: "t1", delta: "x" },
+      { kind: "tool", ...base, partID: "t1", delta: "y" },
+    ])
+  })
+
+  test("drains pending deltas immediately without waiting for the schedule", () => {
+    const applied: PendingDelta[] = []
+    const { buffer, tick } = makeBuffer(applied)
+
+    buffer.push({ kind: "reasoning", ...base, partID: "r1", delta: "a" })
+    buffer.drain()
+    expect(applied).toEqual([{ kind: "reasoning", ...base, partID: "r1", delta: "a" }])
+
+    tick()
+    expect(applied).toEqual([{ kind: "reasoning", ...base, partID: "r1", delta: "a" }])
+  })
+
+  test("a stale scheduled flush after drain is a no-op", () => {
+    const applied: PendingDelta[] = []
+    const { buffer, tick } = makeBuffer(applied)
+
+    buffer.push({ kind: "text", ...base, partID: "t1", delta: "a" })
+    buffer.drain()
+    buffer.push({ kind: "text", ...base, partID: "t1", delta: "b" })
+
+    tick()
+    expect(applied).toEqual([
+      { kind: "text", ...base, partID: "t1", delta: "a" },
+      { kind: "text", ...base, partID: "t1", delta: "b" },
+    ])
+  })
+
+  test("schedules at most one flush while deltas keep arriving", () => {
+    const { buffer, calls } = makeBuffer()
+
+    for (let i = 0; i < 100; i++) {
+      buffer.push({ kind: "text", ...base, partID: "t1", delta: String(i) })
+    }
+    expect(calls.length).toBe(1)
+  })
+})

--- a/packages/tui/src/context/delta-buffer.ts
+++ b/packages/tui/src/context/delta-buffer.ts
@@ -1,0 +1,46 @@
+export type DeltaKind = "text" | "reasoning" | "tool"
+
+export type PendingDelta = {
+  kind: DeltaKind
+  sessionID: string
+  messageID: string
+  partID: string
+  delta: string
+}
+
+/**
+ * Coalesces per-part stream deltas so a fast token stream rewrites shared store
+ * state at most once per scheduled flush instead of once per event. Reasoning
+ * blocks can stream thousands of deltas; applying each one immediately keeps
+ * re-rendering the accumulating text, which stalls the UI while expanded.
+ */
+export function createDeltaBuffer(schedule: (flush: () => void) => void, apply: (item: PendingDelta) => void) {
+  let pending = new Map<string, PendingDelta>()
+  let scheduled = false
+
+  const flush = () => {
+    scheduled = false
+    if (pending.size === 0) return
+    const items = [...pending.values()]
+    pending = new Map()
+    for (const item of items) apply(item)
+  }
+
+  return {
+    push(input: PendingDelta) {
+      const key = `${input.kind}:${input.sessionID}:${input.messageID}:${input.partID}`
+      const existing = pending.get(key)
+      if (existing) existing.delta += input.delta
+      else pending.set(key, { ...input })
+      if (!scheduled) {
+        scheduled = true
+        schedule(flush)
+      }
+    },
+    // Apply anything pending immediately so terminating events that replace the
+    // full text (text/reasoning/tool-input ended) observe the final deltas.
+    drain() {
+      flush()
+    },
+  }
+}


### PR DESCRIPTION
## Problem

Clicking to expand a streaming `<thinking>` block in the TUI can stall the UI until reasoning finishes.

Root cause chain:
1. The LLM stream emits `session.next.reasoning.delta` (and `text.delta` / `tool.input.delta`) events **per chunk, unbuffered** (`packages/core/src/session/runner/publish-llm-event.ts:278`).
2. The TUI store applied **every** delta synchronously: `match.text += event.data.delta` on each event (`packages/tui/src/context/data.tsx`).
3. While a reasoning block is expanded, every store write re-renders its markdown block and OpenTUI re-parses + re-highlights the **entire accumulated text** on each token — O(N) work per delta, O(N²) over the stream. Long thinking blocks (thousands of tokens) pin the render loop and the TUI appears frozen.

Note the web app already avoids this exact problem with per-part delta accumulation (`part_text_accum_delta`, #26822); the TUI had no equivalent.

## Change

Adds a per-frame delta coalescer (`packages/tui/src/context/delta-buffer.ts`):
- Deltas accumulate per `(kind, sessionID, messageID, partID)`; the store is rewritten at most **once per animation frame** instead of once per event.
- `drain()` runs before any non-delta event (e.g. `*.ended`) so terminating events that replace the full part text still observe the final accumulated deltas; also drains on provider unmount.
- Covers `text.delta`, `reasoning.delta`, and `tool.input.delta` (identical pattern, same fix).

## Testing

- New unit tests for `createDeltaBuffer` (coalescing, per-part isolation, drain semantics, stale flush no-op, single-schedule). `bun test` passes 5/5.
- Could not run `tsgo --noEmit` in this environment (tool not installed); changes are type-annotated to match the module's existing usage.
- Not yet manually verified in a live TUI session.

## Follow-up (not included)

- The v2 session durable-store path (`packages/core/src/session/message-updater.ts:358`) performs the same per-delta full-text rewrite; worth batching there separately.