### PR TITLE
fix(ui): only trap focus in the topmost dialog

### DIFF
--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -81,6 +81,18 @@ function init() {
     let dispose: (() => void) | undefined
     let setClosing: ((closing: boolean) => void) | undefined
 
+    // Only the topmost dialog may be modal. Kobalte ties its focus trap to `modal`, so a stacked
+    // dialog left modal underneath keeps trapping focus and pulls it straight back to its own last
+    // focused control: clicks reach a text input in the dialog above, but `focus` never lands on it
+    // and typing is impossible. An entry not yet in the stack is the one being mounted, so it counts
+    // as topmost. Scroll locking stays on every layer so stacking does not change page scrolling.
+    const topMost = () => {
+      const items = stack()
+      const index = items.findIndex((item) => item.id === id)
+      if (index === -1) return true
+      return index === items.length - 1
+    }
+
     const node = runWithOwner(owner, () =>
       createRoot((d: () => void) => {
         dispose = d
@@ -88,10 +100,14 @@ function init() {
         setClosing = setClosingSignal
         return (
           <Kobalte
-            modal
+            modal={topMost()}
+            preventScroll
             open={!closing()}
             onOpenChange={(open: boolean) => {
               if (open) return
+              // A covered dialog is non-modal, so Kobalte would dismiss it on the first interaction
+              // with the dialog above. Only the topmost layer may close itself.
+              if (!topMost()) return
               close(id)
             }}
           >


### PR DESCRIPTION
### Issue for this PR

Closes #41382

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Settings → Servers → "Add server" opens a dialog through `dialog.push`, which stacks it on top of the settings dialog. Both were mounted as `modal`. Kobalte ties its focus trap to `modal` (`createFocusScope({ trapFocus: () => isOpen() && modal() })`), so the covered settings dialog kept trapping focus and pulled it straight back to its own last focused control — the servers tab trigger. Mouse events reached the inputs of the dialog on top, nothing was `preventDefault`ed, but `focus` never landed on them, so typing did nothing. Buttons still worked because a click activates on mouseup without needing to retain focus, which is why only the text fields looked broken.

This makes only the topmost dialog modal. Two details matter: `preventScroll` is now passed explicitly, because it defaults to `modal()` and would otherwise drop the scroll lock on covered dialogs; and `onOpenChange` ignores close requests from a non-topmost layer, because a non-modal dialog is dismissed by Kobalte on the first interaction outside it, and the dialog above it counts as outside — without that guard, opening the form closed the settings dialog underneath.

Every other dialog in the app uses `dialog.show()`, which replaces the stack, so it only ever holds one entry and `topMost()` is always true for them. Their behaviour is unchanged. Only the stacked server dialogs are affected.

### How did you verify your code works?

Ran the desktop app on Windows and drove the real renderer over CDP, so the clicks are real trusted input rather than `.click()` calls. Same scenario both times: `Ctrl+,` → Servers tab → "+" → "Add server", then click the URL field and type.

Without the patch:

```
focusFinal   : "BUTTON"
valeurSaisie : ""
traceFocus   : focusout -> INPUT couche=1
               focusin  -> BUTTON "Général" couche=0
```

With the patch:

```
focusFinal   : the URL input
valeurSaisie : "http://127.0.0.1:4096"
traceFocus   : focusin -> INPUT couche=1
```

Also checked that both dialogs stay stacked, that Cancel closes only the top one, and that Escape still closes the remaining dialog. `tsgo --noEmit` passes on `packages/ui`; `bun test src` in `packages/ui` is 27/27. The 3 failures in `packages/app` unit tests are pre-existing i18n plural-key ones, identical with and without this change.

### Screenshots / recordings

No visual change — the dialog renders identically. The fix only restores focus delivery to its inputs, which the console traces above capture better than a screenshot would.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
