### PR TITLE
fix(cli): keep OTLP failures best effort

### DIFF
--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -17,50 +17,6 @@ test("managed service ports are stable per installation channel", () => {
   expect(ServiceConfig.defaultPort("preview-a")).not.toBe(ServiceConfig.defaultPort("preview-b"))
 })
 
-test("service status ignores OTLP export failures", async () => {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-status-"))
-  const requests: string[] = []
-  const server = Bun.serve({
-    port: 0,
-    fetch(request) {
-      requests.push(new URL(request.url).pathname)
-      return new Response("rejected", { status: 403 })
-    },
-  })
-  try {
-    const child = Bun.spawn(
-      [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "service", "status"],
-      {
-        env: {
-          ...process.env,
-          HOME: root,
-          OPENCODE_TEST_HOME: root,
-          OTEL_EXPORTER_OTLP_ENDPOINT: server.url.toString().replace(/\/$/, ""),
-          OTEL_EXPORTER_OTLP_HEADERS: "",
-          XDG_CACHE_HOME: path.join(root, "cache"),
-          XDG_CONFIG_HOME: path.join(root, "config"),
-          XDG_DATA_HOME: path.join(root, "data"),
-          XDG_STATE_HOME: path.join(root, "state"),
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      },
-    )
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-      child.exited,
-    ])
-
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: `stopped${os.EOL}`, stderr: "", exitCode: 0 })
-    expect(requests).toContain("/v1/logs")
-    expect(requests).toContain("/v1/traces")
-  } finally {
-    server.stop(true)
-    await fs.rm(root, { recursive: true, force: true })
-  }
-}, 30_000)
-
 test("local channel stores service config with the local service filename", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-"))
   try {

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -17,6 +17,50 @@ test("managed service ports are stable per installation channel", () => {
   expect(ServiceConfig.defaultPort("preview-a")).not.toBe(ServiceConfig.defaultPort("preview-b"))
 })
 
+test("service status ignores OTLP export failures", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-status-"))
+  const requests: string[] = []
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      requests.push(new URL(request.url).pathname)
+      return new Response("rejected", { status: 403 })
+    },
+  })
+  try {
+    const child = Bun.spawn(
+      [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "service", "status"],
+      {
+        env: {
+          ...process.env,
+          HOME: root,
+          OPENCODE_TEST_HOME: root,
+          OTEL_EXPORTER_OTLP_ENDPOINT: server.url.toString().replace(/\/$/, ""),
+          OTEL_EXPORTER_OTLP_HEADERS: "",
+          XDG_CACHE_HOME: path.join(root, "cache"),
+          XDG_CONFIG_HOME: path.join(root, "config"),
+          XDG_DATA_HOME: path.join(root, "data"),
+          XDG_STATE_HOME: path.join(root, "state"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    )
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ])
+
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: `stopped${os.EOL}`, stderr: "", exitCode: 0 })
+    expect(requests).toContain("/v1/logs")
+    expect(requests).toContain("/v1/traces")
+  } finally {
+    server.stop(true)
+    await fs.rm(root, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test("local channel stores service config with the local service filename", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-"))
   try {

--- a/packages/util/src/observability.ts
+++ b/packages/util/src/observability.ts
@@ -45,7 +45,7 @@ export function layer(
         Layer.orDie,
         Layer.merge(Layer.succeed(References.MinimumLogLevel, Logging.minimumLogLevel())),
       )
-      return Layer.merge(logs, yield* Effect.promise(() => Otlp.tracingLayer(options, app)))
+      return Layer.merge(logs, yield* Otlp.tracingLayer(options, app))
     }),
   ).pipe(Layer.catchCause(() => local))
 }

--- a/packages/util/src/observability/otlp.ts
+++ b/packages/util/src/observability/otlp.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer, Scope } from "effect"
+import { Effect, Layer, Scope } from "effect"
 import { OtlpLogger } from "effect/unstable/observability"
 import { runID } from "./shared.js"
 
@@ -71,36 +71,39 @@ export function loggers(options: Options | undefined, app: App) {
   ]
 }
 
-export async function tracingLayer(options: Options | undefined, app: App) {
+export const tracingLayer = Effect.fnUntraced(function* (options: Options | undefined, app: App) {
   if (!options?.endpoint) return Layer.empty
-  const NodeSdk = await import("@effect/opentelemetry/NodeSdk")
-  const OTLP = await import("@opentelemetry/exporter-trace-otlp-http")
-  const SdkBase = await import("@opentelemetry/sdk-trace-base")
-  const { AsyncLocalStorageContextManager } = await import("@opentelemetry/context-async-hooks")
-  const { context } = await import("@opentelemetry/api")
+  const [{ layer }, { OTLPTraceExporter }, { BatchSpanProcessor }, { AsyncLocalStorageContextManager }, { context }] =
+    yield* Effect.all(
+      [
+        Effect.promise(() => import("@effect/opentelemetry/NodeSdk")),
+        Effect.promise(() => import("@opentelemetry/exporter-trace-otlp-http")),
+        Effect.promise(() => import("@opentelemetry/sdk-trace-base")),
+        Effect.promise(() => import("@opentelemetry/context-async-hooks")),
+        Effect.promise(() => import("@opentelemetry/api")),
+      ],
+      { concurrency: "unbounded" },
+    )
 
   // The Effect Node SDK does not register a global context manager, but the AI SDK uses it to parent spans.
   const manager = new AsyncLocalStorageContextManager()
   manager.enable()
   context.setGlobalContextManager(manager)
 
-  const tracing = NodeSdk.layer(() => ({
+  const tracing = layer(() => ({
     resource: resource(app),
-    spanProcessor: new SdkBase.BatchSpanProcessor(
-      new OTLP.OTLPTraceExporter({
+    spanProcessor: new BatchSpanProcessor(
+      new OTLPTraceExporter({
         url: `${options.endpoint}/v1/traces`,
         headers: parseHeaders(options.headers),
       }),
     ),
   }))
   return Layer.effectContext(
-    Effect.gen(function* () {
-      // OTLP delivery is best-effort, including defects from rejected SDK shutdown promises.
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void).pipe(Effect.ignoreCause))
-      return yield* Layer.buildWithScope(tracing, scope)
-    }),
+    Effect.acquireRelease(Scope.make(), (scope, exit) =>
+      Scope.close(scope, exit).pipe(Effect.ignoreCause),
+    ).pipe(Effect.flatMap((scope) => Layer.buildWithScope(tracing, scope))),
   )
-}
+})
 
 export * as Otlp from "./otlp.js"

--- a/packages/util/src/observability/otlp.ts
+++ b/packages/util/src/observability/otlp.ts
@@ -1,4 +1,4 @@
-import { Layer } from "effect"
+import { Effect, Exit, Layer, Scope } from "effect"
 import { OtlpLogger } from "effect/unstable/observability"
 import { runID } from "./shared.js"
 
@@ -84,7 +84,7 @@ export async function tracingLayer(options: Options | undefined, app: App) {
   manager.enable()
   context.setGlobalContextManager(manager)
 
-  return NodeSdk.layer(() => ({
+  const tracing = NodeSdk.layer(() => ({
     resource: resource(app),
     spanProcessor: new SdkBase.BatchSpanProcessor(
       new OTLP.OTLPTraceExporter({
@@ -93,6 +93,14 @@ export async function tracingLayer(options: Options | undefined, app: App) {
       }),
     ),
   }))
+  return Layer.effectContext(
+    Effect.gen(function* () {
+      // OTLP delivery is best-effort, including defects from rejected SDK shutdown promises.
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void).pipe(Effect.ignoreCause))
+      return yield* Layer.buildWithScope(tracing, scope)
+    }),
+  )
 }
 
 export * as Otlp from "./otlp.js"


### PR DESCRIPTION
## Summary

- keep OTLP trace delivery best-effort when the exporter rejects during shutdown
- manage dynamic SDK loading and tracing scope ownership with Effect
- preserve the standard OTLP exporter and `BatchSpanProcessor`

## Problem

A CLI command can complete and write valid output, but an OTLP failure during the tracing scope finalizer can still change the process exit code to 1. Desktop treats that result as a failed sidecar command and cannot finish initialization.

`@effect/opentelemetry` awaits `forceFlush()` and `shutdown()` with `Effect.promise`, then applies `Effect.ignore`. A rejected Promise is an Effect defect, and `Effect.ignore` does not consume defects.

`tracingLayer` now returns an Effect directly. Dynamic imports use `Effect.promise` and `Effect.all`. The tracing SDK runs in a telemetry-only scope owned by `Effect.acquireRelease`, and cleanup uses `Effect.ignoreCause`. Delivery failure cannot replace the command result. SDK acquisition and configuration failures still use the existing local observability fallback.

## References

- OpenTelemetry error handling specification: https://opentelemetry.io/docs/specs/otel/error-handling/
- OpenTelemetry JavaScript Node SDK shutdown example: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-sdk-node/README.md
- OpenTelemetry JavaScript `BatchSpanProcessor` API: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_sdk-trace-node.BatchSpanProcessor.html
- Effect change to ignore OTEL shutdown errors: https://github.com/Effect-TS/effect/pull/2131
- Current Effect `NodeSdk` lifecycle implementation: https://github.com/Effect-TS/effect/blob/main/packages/opentelemetry/src/NodeSdk.ts

## Testing

- `bun test --timeout 30000 test/effect/observability.test.ts` in `packages/core`
- `bun typecheck` in `packages/util`
- `bun src/index.ts service status` in `packages/cli` with an unavailable OTLP endpoint; output was only `stopped` and exit code was 0
- compiled a Windows x64 `opencode2.exe`; an unavailable OTLP endpoint produced only `stopped` and exit code 0

The full pre-push typecheck did not complete under local Bun `1.4.0-canary.1`. It stopped on the existing `packages/core/src/shell.ts:164` Buffer type error. The repository expects Bun `1.3.14`.