### PR TITLE
feat(desktop): close to tray instead of exiting

### DIFF
--- a/packages/desktop/src/main/close-behavior.test.ts
+++ b/packages/desktop/src/main/close-behavior.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { resolveCloseAction } from "./close-behavior"
+
+const win = { isQuitting: false, otherWindows: 0, platform: "win32" as NodeJS.Platform }
+
+describe("resolveCloseAction", () => {
+  test("hides the last window while the app is running (windows)", () => {
+    expect(resolveCloseAction(win)).toBe("hide")
+  })
+
+  test("hides the last window while the app is running (linux)", () => {
+    expect(resolveCloseAction({ ...win, platform: "linux" })).toBe("hide")
+  })
+
+  test("closes a window when others remain open", () => {
+    expect(resolveCloseAction({ ...win, otherWindows: 1 })).toBe("close")
+    expect(resolveCloseAction({ ...win, otherWindows: 3 })).toBe("close")
+  })
+
+  test("closes every window during a real quit", () => {
+    expect(resolveCloseAction({ ...win, isQuitting: true })).toBe("close")
+    expect(resolveCloseAction({ ...win, isQuitting: true, otherWindows: 2 })).toBe("close")
+  })
+
+  test("keeps native close behavior on macOS (no interception)", () => {
+    expect(resolveCloseAction({ ...win, platform: "darwin" })).toBe("close")
+    expect(resolveCloseAction({ ...win, platform: "darwin", isQuitting: true })).toBe("close")
+    expect(resolveCloseAction({ ...win, platform: "darwin", otherWindows: 0 })).toBe("close")
+  })
+})

--- a/packages/desktop/src/main/close-behavior.ts
+++ b/packages/desktop/src/main/close-behavior.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure decision logic for the window close event.
+ *
+ * Tray mode (Windows/Linux only): closing the LAST window hides it to the
+ * system tray so background work (agents, servers) keeps running; closing a
+ * window while others remain open closes it normally. During a real quit
+ * (tray "Quit", app menu quit, Cmd+Q, SIGTERM) every window closes normally.
+ *
+ * macOS is intentionally untouched: it keeps the native close-to-Dock
+ * behavior (window closes, app stays in the Dock, `activate` restores it),
+ * exactly as before this feature.
+ *
+ * Kept free of Electron imports so unit tests can cover every branch.
+ */
+export type CloseAction = "hide" | "close"
+
+export function resolveCloseAction(input: {
+  isQuitting: boolean
+  /** Number of OTHER windows still open (excluding the one being closed). */
+  otherWindows: number
+  /** Process platform; darwin keeps its native close behavior. */
+  platform: NodeJS.Platform
+}): CloseAction {
+  if (input.platform === "darwin") return "close"
+  if (input.isQuitting) return "close"
+  if (input.otherWindows > 0) return "close"
+  return "hide"
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -32,14 +32,17 @@ import {
   type SidecarListener,
 } from "./server"
 import { setupAutoUpdater, showUpdaterDialog } from "./updater"
+import { createTray } from "./tray"
 import { safeWebContentsURL } from "./window-state"
 import {
   getLastFocusedWindow,
+  iconPath,
   registerRendererProtocol,
   setRelaunchHandler,
   setAppQuitting,
   setBackgroundColor,
   setDockIcon,
+  showMainWindow,
   restoreMainWindows,
 } from "./windows"
 import { createWslServersController } from "./wsl/servers"
@@ -409,13 +412,17 @@ const main = Effect.gen(function* () {
   yield* Fiber.await(loadingTask)
 
   app.on("window-all-closed", () => {
-    if (process.platform === "darwin") return
-    app.quit()
+    // Tray mode: the app stays alive in the system tray (Windows/Linux) or
+    // the Dock (macOS) when every window is closed/hidden, so background
+    // agent work keeps running. A real quit goes through `before-quit`
+    // (sets the quitting flag) and exits normally.
   })
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length > 0) return
     restoreMainWindows()
   })
+
+  createTray(iconPath(), () => showMainWindow())
 
   const windows = restoreMainWindows()
   if (windows.length) createMenu(menuDeps)

--- a/packages/desktop/src/main/tray.test.ts
+++ b/packages/desktop/src/main/tray.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test"
+
+let createTray: (iconPath: string, onShow: () => void) => unknown
+let destroyTray: () => void
+
+const state = {
+  trayCreated: 0,
+  trayDestroyed: 0,
+  toolTip: "",
+  menu: undefined as undefined | { label?: string; type?: string; click?: () => void }[],
+  clickHandler: undefined as undefined | (() => void),
+  doubleClickHandler: undefined as undefined | (() => void),
+  quitCalls: 0,
+}
+
+beforeAll(async () => {
+  const api = {
+    app: {
+      quit: () => {
+        state.quitCalls++
+      },
+    },
+    Menu: {
+      buildFromTemplate: (template: { label?: string; type?: string; click?: () => void }[]) => {
+        state.menu = template
+        return template
+      },
+    },
+    nativeImage: {
+      createFromPath: () => ({ isEmpty: () => false }),
+    },
+    Tray: function Tray() {
+      state.trayCreated++
+      return {
+        setToolTip: (tip: string) => {
+          state.toolTip = tip
+        },
+        setContextMenu: () => {},
+        on: (event: string, handler: () => void) => {
+          if (event === "click") state.clickHandler = handler
+          if (event === "double-click") state.doubleClickHandler = handler
+        },
+        destroy: () => {
+          state.trayDestroyed++
+        },
+      }
+    },
+  }
+  mock.module("electron", () => ({ ...api, default: api }))
+  const mod = await import("./tray")
+  createTray = mod.createTray
+  destroyTray = mod.destroyTray
+})
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true })
+}
+
+beforeEach(() => {
+  // Reset the module-level tray singleton so every test starts clean;
+  // otherwise the idempotent createTray returns the instance created by an
+  // earlier test and no new Tray is constructed.
+  destroyTray()
+  state.trayCreated = 0
+  state.trayDestroyed = 0
+  state.toolTip = ""
+  state.menu = undefined
+  state.clickHandler = undefined
+  state.doubleClickHandler = undefined
+  state.quitCalls = 0
+  setPlatform("win32")
+})
+
+afterAll(() => {
+  setPlatform(originalPlatform)
+  mock.restore()
+})
+
+describe("tray", () => {
+  test("creates a tray with Show and Quit entries on windows", () => {
+    const tray = createTray("/fake/icon.ico", () => {})
+    expect(tray).toBeDefined()
+    expect(state.trayCreated).toBe(1)
+    expect(state.toolTip).toBe("OpenCode")
+    const labels = state.menu?.map((item) => item.label ?? item.type)
+    expect(labels).toEqual(["Show OpenCode", "separator", "Quit"])
+  })
+
+  test("is idempotent: creating again returns the same instance", () => {
+    createTray("/fake/icon.ico", () => {})
+    createTray("/fake/icon.ico", () => {})
+    expect(state.trayCreated).toBe(1)
+  })
+
+  test("single and double click both restore the window", () => {
+    const show = mock(() => {})
+    createTray("/fake/icon.ico", show)
+    state.clickHandler?.()
+    state.doubleClickHandler?.()
+    expect(show).toHaveBeenCalledTimes(2)
+  })
+
+  test("tray Show entry restores the window", () => {
+    const show = mock(() => {})
+    createTray("/fake/icon.ico", show)
+    const showEntry = state.menu?.find((item) => item.label === "Show OpenCode")
+    showEntry?.click?.()
+    expect(show).toHaveBeenCalledTimes(1)
+  })
+
+  test("tray Quit entry quits the app", () => {
+    createTray("/fake/icon.ico", () => {})
+    const quitEntry = state.menu?.find((item) => item.label === "Quit")
+    quitEntry?.click?.()
+    expect(state.quitCalls).toBe(1)
+  })
+
+  test("does not create a tray on macOS", () => {
+    setPlatform("darwin")
+    expect(createTray("/fake/icon.png", () => {})).toBeUndefined()
+    expect(state.trayCreated).toBe(0)
+  })
+
+  test("destroy removes the tray instance", () => {
+    createTray("/fake/icon.ico", () => {})
+    destroyTray()
+    expect(state.trayDestroyed).toBe(1)
+    // A destroyed tray can be recreated.
+    createTray("/fake/icon.ico", () => {})
+    expect(state.trayCreated).toBe(2)
+  })
+})

--- a/packages/desktop/src/main/tray.ts
+++ b/packages/desktop/src/main/tray.ts
@@ -1,0 +1,56 @@
+/**
+ * System tray support for tray mode (Windows/Linux).
+ *
+ * macOS does not get a tray: the app stays in the Dock, `activate` restores
+ * the window, and closing a window keeps the app alive (see index.ts).
+ *
+ * The tray holds the app alive when every window is hidden and offers
+ * "Show OpenCode" / "Quit". Quitting goes through `app.quit()` so the
+ * `before-quit` 鈫?`setAppQuitting` path lets windows close normally.
+ */
+import { app, Menu, nativeImage, Tray } from "electron"
+
+// Module-scope reference so the Tray is never garbage-collected; a collected
+// tray drops its icon and stops responding for the rest of the session.
+let tray: Tray | undefined
+
+// E2E hooks (intentionally exposed on globalThis for testability, matching
+// the __getIsQuitting pattern in index.ts).
+declare global {
+  var __getTrayInstance: (() => Tray | undefined) | undefined
+  var __triggerTrayMenuAction: ((label: string) => void) | undefined
+}
+
+function buildTrayMenu(onShow: () => void) {
+  return Menu.buildFromTemplate([
+    { label: "Show OpenCode", click: onShow },
+    { type: "separator" },
+    { label: "Quit", click: () => app.quit() },
+  ])
+}
+
+export function createTray(iconPath: string, onShow: () => void): Tray | undefined {
+  if (process.platform === "darwin") return undefined
+  if (tray) return tray
+
+  tray = new Tray(nativeImage.createFromPath(iconPath))
+  tray.setToolTip("OpenCode")
+  tray.setContextMenu(buildTrayMenu(onShow))
+  tray.on("click", onShow)
+  tray.on("double-click", onShow)
+
+  globalThis.__getTrayInstance = () => tray
+  globalThis.__triggerTrayMenuAction = (label: string) => {
+    const item = buildTrayMenu(onShow).items.find((entry) => entry.label === label)
+    if (item?.click) item.click()
+  }
+
+  return tray
+}
+
+export function destroyTray(): void {
+  tray?.destroy()
+  tray = undefined
+  globalThis.__getTrayInstance = undefined
+  globalThis.__triggerTrayMenuAction = undefined
+}

--- a/packages/desktop/src/main/window-registry.test.ts
+++ b/packages/desktop/src/main/window-registry.test.ts
@@ -88,4 +88,13 @@ describe("window registry", () => {
     expect(app.state.stored).toEqual(["b"])
     expect(app.cleaned).toEqual(["a"])
   })
+
+  test("reports the quit flag for close interception", () => {
+    const app = setup()
+    expect(app.registry.isQuitting()).toBe(false)
+    app.registry.setQuitting()
+    expect(app.registry.isQuitting()).toBe(true)
+    app.registry.setQuitting(false)
+    expect(app.registry.isQuitting()).toBe(false)
+  })
 })

--- a/packages/desktop/src/main/window-registry.ts
+++ b/packages/desktop/src/main/window-registry.ts
@@ -20,6 +20,9 @@ export function createWindowRegistry<W>(persistence: {
     setQuitting(value = true) {
       quitting = value
     },
+    isQuitting() {
+      return quitting
+    },
     register(id: string, window: W) {
       windows.set(id, window)
       const ids = persisted()

--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -14,6 +14,7 @@ import { PINCH_ZOOM_ENABLED_KEY, WINDOW_IDS_KEY } from "./store-keys"
 import { createUnresponsiveSampler } from "./unresponsive"
 import { nativeT } from "./native-translations"
 import { createWindowRegistry } from "./window-registry"
+import { resolveCloseAction } from "./close-behavior"
 import { safeWindowURL } from "./window-state"
 import { resolveExternalURL, resolveLocalFilePath } from "./external-url"
 
@@ -89,7 +90,7 @@ function iconsDir() {
   return app.isPackaged ? join(process.resourcesPath, "icons") : join(root, "../../resources/icons")
 }
 
-function iconPath() {
+export function iconPath() {
   const ext = process.platform === "win32" ? "ico" : "png"
   return join(iconsDir(), `icon.${ext}`)
 }
@@ -157,6 +158,21 @@ export function getLastFocusedWindow() {
 export function restoreMainWindows() {
   const ids = registry.persisted()
   return (ids.length ? ids : [randomUUID()]).map((id) => createMainWindow(id))
+}
+
+/**
+ * Restore the main window from the tray/Dock: show + focus an existing
+ * window, or create a fresh one when none survives (e.g. macOS closed it).
+ */
+export function showMainWindow() {
+  const existing =
+    getLastFocusedWindow() ?? BrowserWindow.getAllWindows().find((win) => !win.isDestroyed())
+  if (existing) {
+    existing.show()
+    existing.focus()
+    return
+  }
+  createMainWindow()
 }
 
 export function setDockIcon() {
@@ -272,6 +288,24 @@ function registerWindow(win: BrowserWindow, id: string) {
   registry.register(id, win)
 
   win.on("focus", () => registry.focused(id))
+  // Tray mode: closing the LAST window hides it to the tray instead of
+  // quitting, so background work keeps running. A real quit (tray "Quit",
+  // app menu, Cmd+Q, SIGTERM) sets the quitting flag first, so every window
+  // closes normally and the process can exit.
+  win.on("close", (event) => {
+    const otherWindows = BrowserWindow.getAllWindows().filter(
+      (candidate) => candidate !== win && !candidate.isDestroyed(),
+    ).length
+    const action = resolveCloseAction({
+      isQuitting: registry.isQuitting(),
+      otherWindows,
+      platform: process.platform,
+    })
+    if (action === "hide") {
+      event.preventDefault()
+      win.hide()
+    }
+  })
   // Windows never emits before-quit on OS shutdown/logoff, but each window
   // gets session-end before it closes; flag the quit so ids stay persisted.
   win.on("session-end", () => registry.setQuitting())


### PR DESCRIPTION
### Issue for this PR

Closes #18134

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds close-to-tray behavior to the desktop app on Windows and Linux:

- Closing the last window hides it to the system tray instead of quitting, so background agent work keeps running
- Tray menu offers "Show OpenCode" / "Quit"; single or double click on the tray icon restores the window
- Real quit paths (tray Quit, app menu, Cmd+Q, SIGTERM) still close normally
- macOS is intentionally untouched — its native close-to-Dock behavior is preserved

### How did you verify your code works?

- 20 unit tests pass (close-behavior / tray / window-registry)
- Real Windows 11 run: closing the window hides it to the tray and the process stays alive; tray "Show" restores the window; tray "Quit" exits cleanly
- Launching a second instance while hidden in tray restores the existing window instead of creating a duplicate
- PR changes only 8 files (+304/-3), all under `packages/desktop/src/main`

### Screenshots / recordings

None (system tray behavior, verified through runtime checks above)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR