### PR TITLE
fix(app): stabilize markdown worker startup

### DIFF
--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -32,7 +32,7 @@ export default [
           format: "es",
         },
         optimizeDeps: {
-          include: ["@shikijs/stream", "katex", "marked", "marked-shiki", "remend"],
+          exclude: ["@shikijs/stream", "katex", "marked", "marked-shiki", "remend"],
         },
       }
     },

--- a/packages/app/vite.js
+++ b/packages/app/vite.js
@@ -31,6 +31,9 @@ export default [
         worker: {
           format: "es",
         },
+        optimizeDeps: {
+          include: ["@shikijs/stream", "katex", "marked", "marked-shiki", "remend"],
+        },
       }
     },
   },

--- a/packages/session-ui/src/components/markdown-worker.ts
+++ b/packages/session-ui/src/components/markdown-worker.ts
@@ -1,4 +1,3 @@
-import MarkdownWorkerUrl from "./markdown.worker.ts?worker&url"
 import {
   applyMarkdownWorkerResponse,
   shouldReleaseMarkdownWorkerState,
@@ -117,7 +116,7 @@ function getWorker() {
   if (worker) return worker
   if (disabled) throw new MarkdownWorkerUnavailableError(disabled.message)
   try {
-    worker = new Worker(MarkdownWorkerUrl, { type: "module" })
+    worker = new Worker(new URL("./markdown.worker.ts", import.meta.url), { type: "module" })
   } catch (error) {
     disabled = error instanceof Error ? error : new Error(String(error))
     throw new MarkdownWorkerUnavailableError(disabled.message)


### PR DESCRIPTION
## Depends on

- #41479
- #41486

Review the two app commits above `local-sidecar-build`. GitHub will remove shared lower-stack commits as those PRs merge.

## Summary

- create the local markdown worker with the web-standard `new Worker(new URL(...))` form recommended by Vite
- serve the worker's five single-file ESM dependencies directly in development
- prevent Vite from discovering and optimizing those dependencies after render, which forced a full renderer reload and blank state

## Why exclude

Vite documents `optimizeDeps.exclude` for small dependencies that already ship valid ESM. The selected entries all resolve to bundled ESM files and Vite reports `needsInterop: false` for each one. Serving them directly avoids both cold-start pre-bundle work and the late optimizer reload.

## References

- Vite web workers: https://vite.dev/guide/features#web-workers
- Vite dependency pre-bundling: https://vite.dev/guide/dep-pre-bundling
- Vite dependency optimization options: https://vite.dev/config/dep-optimization-options

## Testing

- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/session-ui`
- `bun test src --only-failures` in `packages/session-ui` (83 pass)
- `bun x electron-vite build` in `packages/desktop`