### PR TITLE
docs: add opencode-usage plugin to ecosystem list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-usage](https://github.com/Booy1x/opencode-usage)                                         | Show OpenCode Go subscription usage in chat and a browser dashboard                                |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes # (no related issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the [opencode-usage](https://github.com/Booy1x/opencode-usage) plugin to the ecosystem Plugins list.

It is a local plugin that shows OpenCode Go subscription usage (Rolling / Weekly / Monthly limits) directly in chat (/usage) and in a local browser dashboard (/usage-open). It is a pure Bun implementation with no runtime dependencies: it fetches the Go console page with the user's auth cookie and parses the usage limits from the server-rendered HTML.

### How did you verify your code works?

- Ran the plugin locally: /usage and /usage-open both render the current usage correctly.
- Verified the fetched page parses rolling/weekly/monthly usage accurately.
- This PR only adds a table row to the ecosystem docs; no runtime code is changed.

### Screenshots / recordings

N/A (docs-only change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR