### PR TITLE
Add Velvet Connect brand experience and documentation

### DIFF
--- a/packages/web/src/content/docs/ANTHROPIC_API_KEY
+++ b/packages/web/src/content/docs/ANTHROPIC_API_KEY
@@ -1,0 +1,7 @@
+Language/framework: Swift with SwiftUI for the iOS app; Supabase is planned for the backend.
+Deployment target: None — just CI for now. Future releases will likely use TestFlight/App Store and Supabase, which aren’t among the listed options.
+Delivery preference: Continuous Delivery — validate changes automatically, deploy to staging, and require manual approval for production.
+Test/build commands: Not established yet. Once the Xcode project exists, use xcodebuild build and xcodebuild test.
+Trigger branch: main. No Dockerfile currently exists.
+Secrets/registries: None are documented in the repository yet. Supabase credentials and Apple signing/App Store Connect secrets will eventually be needed.
+The repository is still in the MVP planning/foundation stage, so the workflow should initially be a lightweight CI starter that can expand once source code and tests are added.


### PR DESCRIPTION
docs(app): add Velvet Connect brand experience and documentation

### Issue for this PR
Production build currently fails because the required index.html entry file is missing. This must be added before the PR is ready to merge.

Closes #
N/A — no linked issue

### Type of change

- [ ] Bug fix
- [ x] New feature
- [ ] Refactor / code improvement
- [ x] Documentation

### What does this PR do?

This Pr adds the initial Velvet Connect frontend, including the landing-page experience,brand assets, reusuable UI components, theme support, prototype navigation, and placeholder screens for future development.


### How did you verify your code works?

- Reviewed the application structure and UI implementation
- Installed the project dependencies successfully
- Attempted a production build with npm run build 
- The build currently fails because the archive is missing the required index.html entry file
- Manual browser testing has not yet been completed

### Screenshots / recordings
No screenshots or recordings available yet

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x ] I have tested my changes locally
- [ x] I have not included unrelated changes in this PR


