### PR TITLE
fix(ui): correct OC-2 weak icon color

### DIFF
--- a/packages/ui/src/theme/themes/oc-2.json
+++ b/packages/ui/src/theme/themes/oc-2.json
@@ -25,7 +25,7 @@
       "border-weak-base": "#DBDBDB",
       "border-weaker-base": "#E8E8E8",
       "icon-base": "#8F8F8F",
-      "icon-weak-base": "C7C7C7",
+      "icon-weak-base": "#C7C7C7",
       "surface-raised-base": "#F3F3F3",
       "surface-raised-base-hover": "#EDEDED",
       "surface-base": "#F8F8F8",


### PR DESCRIPTION
### Issue for this PR

Closes #41503

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Adds the missing `#` to the OC-2 light theme `icon-weak-base` color token.
- Ensures the resolved token is a valid CSS color instead of falling back at computed-value time.

### How did you verify your code works?

- Parsed `packages/ui/src/theme/themes/oc-2.json` with Bun.
- Ran `bun typecheck` from `packages/ui`.
- The pre-push `bun turbo typecheck` hook passed across the workspace.
- Ran `bun test src --only-failures` from `packages/ui`; one existing marked regression test fails due to installed `marked` output differing from its expectation.

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR