### PR TITLE
fix(app): route review diffs through workspace

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -676,9 +676,16 @@ export default function Page() {
     const mode = reviewMode()
     if (mode === "git" || mode === "branch") return mode
   })
+  const vcsWorkspace = createMemo(() => info()?.workspaceID)
   const vcsKey = createMemo(
     () =>
-      ["session-vcs", sdk().directory, sync().data.vcs?.branch ?? "", sync().data.vcs?.default_branch ?? ""] as const,
+      [
+        "session-vcs",
+        sdk().directory,
+        vcsWorkspace() ?? "",
+        sync().data.vcs?.branch ?? "",
+        sync().data.vcs?.default_branch ?? "",
+      ] as const,
   )
   const vcsQuery = createQuery(() => {
     const mode = vcsMode()
@@ -690,7 +697,10 @@ export default function Page() {
       queryFn: mode
         ? () =>
             sdk()
-              .api.vcs.diff({ location: { directory: sdk().directory }, mode: mode === "git" ? "working" : mode })
+              .api.vcs.diff({
+                location: { directory: sdk().directory, workspace: vcsWorkspace() },
+                mode: mode === "git" ? "working" : mode,
+              })
               .then((result) => result.data)
               .catch((error) => {
                 console.debug("[session-review] failed to load vcs diff", { mode, error })
@@ -739,7 +749,7 @@ export default function Page() {
           queryFn: () =>
             sdk()
               .api.vcs.diff({
-                location: { directory: scope },
+                location: { directory: scope, workspace: vcsWorkspace() },
                 mode: mode === "git" ? "working" : mode,
                 context,
               })

--- a/packages/app/src/utils/server-compat.test.ts
+++ b/packages/app/src/utils/server-compat.test.ts
@@ -184,6 +184,20 @@ describe("createCompatibleApi", () => {
     expect(url.searchParams.get("limit")).toBe("20")
   })
 
+  test("routes V1 diffs through the requested workspace", async () => {
+    const { api, requests } = setup("v1")
+    await api.vcs.diff({
+      location: { directory: "/repo", workspace: "workspace-1" },
+      mode: "working",
+    })
+
+    const url = new URL(requests[0]!.url)
+    expect(url.pathname).toBe("/vcs/diff")
+    expect(url.searchParams.get("directory")).toBe("/repo")
+    expect(url.searchParams.get("workspace")).toBe("workspace-1")
+    expect(url.searchParams.get("mode")).toBe("git")
+  })
+
   test("routes V1 permission replies through the requested directory", async () => {
     const { api, requests } = setup("v1")
     await api.permission.reply({

--- a/packages/app/src/utils/server-compat.ts
+++ b/packages/app/src/utils/server-compat.ts
@@ -344,6 +344,7 @@ function createV1Api(input: CompatibleInput): CompatibleApi {
         const result = await legacy(value.location).vcs.diff({
           mode: value.mode === "working" ? "git" : value.mode,
           context: value.context,
+          workspace: value.location?.workspace,
         })
         return located(
           (result.data ?? []).map((file) => ({


### PR DESCRIPTION
## Summary

- route Git and branch review diff requests through the session workspace
- include workspace identity in review diff cache keys and lazy file requests
- preserve workspace routing through the V1 compatibility endpoint

## Validation

- `bun test --conditions=solid --preload ./happydom.ts ./src/utils/server-compat.test.ts`
- `bun typecheck` in `packages/app`
- repository pre-push typecheck (30 packages)
- production review-pane benchmark passed with no regression

## Screenshots

Not applicable; this fixes request routing without changing presentation.