### PR TITLE
fix(tui): keep custom answer input focused while typing

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -343,6 +343,13 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
     if (!(target instanceof HTMLElement)) return
     if (event.altKey || event.ctrlKey || event.metaKey) return
 
+    const digit = Number(event.key)
+    if (!Number.isNaN(digit) && digit >= 1 && digit <= Math.min(count(), 9)) {
+      event.preventDefault()
+      selectOption(digit - 1)
+      return
+    }
+
     if (event.key === "ArrowDown" || event.key === "ArrowRight") {
       event.preventDefault()
       move(1)

--- a/packages/opencode/src/cli/cmd/run/footer.question.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.question.tsx
@@ -247,24 +247,29 @@ export function RunQuestionBody(props: {
     }
   })
 
+  let prevEditing = false
   createEffect(() => {
-    if (!state().editing || !area || area.isDestroyed) {
+    const editing = state().editing
+    if (!editing || !area || area.isDestroyed) {
+      prevEditing = editing
       return
     }
 
-    if (area.plainText !== input()) {
-      area.setText(input())
-      area.cursorOffset = input().length
-    }
-
-    queueMicrotask(() => {
-      if (!area || area.isDestroyed || !state().editing) {
-        return
+    if (!prevEditing) {
+      prevEditing = true
+      if (area.plainText !== input()) {
+        area.setText(input())
       }
 
-      area.focus()
-      area.cursorOffset = area.plainText.length
-    })
+      queueMicrotask(() => {
+        if (!area || area.isDestroyed || !state().editing) {
+          return
+        }
+
+        area.focus()
+        area.cursorOffset = area.plainText.length
+      })
+    }
   })
 
   return (

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -22,6 +22,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
   const tabs = createMemo(() => (single() ? 1 : questions().length + 1)) // questions + confirm tab (no confirm for single select)
   const [tabHover, setTabHover] = createSignal<number | "confirm" | null>(null)
+  const [textareaTarget, setTextareaTarget] = createSignal<TextareaRenderable>()
   const [store, setStore] = createStore({
     tab: 0,
     answers: [] as QuestionAnswer[],
@@ -131,6 +132,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   })
 
   useBindings(() => ({
+    target: textareaTarget,
+    priority: 1,
     mode: QUESTION_MODE,
     enabled: store.editing && !confirm(),
     commands: [
@@ -427,6 +430,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                       <textarea
                         ref={(val: TextareaRenderable) => {
                           textarea = val
+                          setTextareaTarget(val)
                           val.traits = { status: "ANSWER" }
                           queueMicrotask(() => {
                             val.focus()


### PR DESCRIPTION
### Issue for this PR

Closes #30393
Closes #41514

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Selecting "Type your own answer" in a question prompt opens the custom text input, but the input can't be typed into / submitted. Per #30393, the focused `@opentui/core` `<textarea>` swallows the Enter key, so the `return -> submit` binding never fires and typing is unreliable. Root causes and fixes:

1. **TUI (`packages/tui/src/routes/session/question.tsx`)**: the editing-mode `useBindings` had no `target`, so the keymap didn't route keys to the `<textarea>` and the focused textarea captured Enter. Added `target: textareaTarget` and `priority: 1`, matching the `DialogPrompt` pattern which submits a focused textarea through the keymap.
2. **CLI direct mode (`packages/opencode/src/cli/cmd/run/footer.question.tsx`)**: a `createEffect` re-ran on every keystroke (each `onContentChange` updates state), re-setting the textarea text and calling `area.focus()` on every character, fighting the user's input. Now it only syncs/focuses on the editing-mode transition.
3. **App (`packages/app/src/pages/session/composer/session-question-dock.tsx`)**: added the `1`–`9` digit shortcuts to `nav()` for parity with the TUI, and as a direct way to reach the custom option.

### How did you verify your code works?

- `bun typecheck` passes clean in `packages/tui`, `packages/opencode`, and `packages/app`.
- Question unit tests pass (`bun test test/cli/run/question.shared.test.ts test/tool/question.test.ts` -> 7 pass, 0 fail).
- Changes only reuse already-imported types and existing helpers.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR