### PR TITLE
fix(opencode): detect Copilot PDF input support

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -88,6 +88,9 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
   const image =
     (remote.capabilities.supports.vision ?? false) ||
     (remote.capabilities.limits.vision?.supported_media_types ?? []).some((item) => item.startsWith("image/"))
+  const pdf =
+    (remote.capabilities.supports.vision ?? false) &&
+    (remote.capabilities.limits.vision?.supported_media_types?.includes("application/pdf") ?? false)
 
   const isMsgApi = remote.supported_endpoints?.includes("/v1/messages")
   const endpoint: CopilotEndpoint | undefined = isMsgApi
@@ -127,7 +130,7 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
         audio: false,
         image,
         video: false,
-        pdf: false,
+        pdf,
       },
       output: {
         text: true,

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -187,6 +187,74 @@ test("converts Copilot AIC token prices to USD per million tokens", async () => 
   expect(models["ignored-non-chat-record"]).toBeUndefined()
 })
 
+test("detects PDF input support when vision and media type are advertised", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "pdf-model",
+              name: "PDF Model",
+              version: "pdf-model-2026-06-01",
+              capabilities: {
+                family: "pdf-model",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                  vision: {
+                    max_prompt_image_size: 10000000,
+                    max_prompt_images: 10,
+                    supported_media_types: ["application/pdf"],
+                  },
+                },
+                supports: {
+                  streaming: true,
+                  vision: true,
+                  tool_calls: true,
+                },
+              },
+            },
+            {
+              model_picker_enabled: true,
+              id: "vision-only-model",
+              name: "Vision Only Model",
+              version: "vision-only-model-2026-06-01",
+              capabilities: {
+                family: "vision-only-model",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                  vision: {
+                    max_prompt_image_size: 10000000,
+                    max_prompt_images: 10,
+                    supported_media_types: ["image/png"],
+                  },
+                },
+                supports: {
+                  streaming: true,
+                  vision: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const models = (await CopilotModels.get("https://api.githubcopilot.com")).models
+  const model = models["pdf-model"]
+
+  expect(model.capabilities.input.pdf).toBe(true)
+  expect(models["vision-only-model"].capabilities.input.pdf).toBe(false)
+})
+
 test("uses zero cost when Copilot reports a zero billing batch size", async () => {
   globalThis.fetch = mock(() =>
     Promise.resolve(


### PR DESCRIPTION
### Issue for this PR

Closes #41521

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some GitHub Copilot models support PDF input, but OpenCode was not exposing that capability in their model metadata.

This change marks PDF input as supported only when Copilot advertises both vision support and `application/pdf` in its supported media types. Models with vision support but without PDF in their advertised media types remain marked as not accepting PDF input.

### How did you verify your code works?

Ran:

`cd packages/opencode && bun test test/plugin/github-copilot-models.test.ts`

All 7 tests pass, including cases for PDF support when both capabilities are advertised and vision-only support without PDF support.

### Screenshots / recordings

Not applicable; this is a non-UI logic change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR