### PR TITLE
feat(opencode): disable agents skill discovery

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -28,6 +28,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
     broad: bool("OPENCODE_DISABLE_CLAUDE_CODE"),
     direct: bool("OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"),
   }).pipe(Config.map((flags) => flags.broad || flags.direct)),
+  disableAgentsSkills: bool("OPENCODE_DISABLE_AGENTS"),
   enableExa: Config.all({
     experimental,
     enabled: bool("OPENCODE_ENABLE_EXA"),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -177,6 +177,7 @@ const discoverSkills = Effect.fnUntraced(function* (
   global: Global.Interface,
   disableExternalSkills: boolean,
   disableClaudeCodeSkills: boolean,
+  disableAgentsSkills: boolean,
   directory: string,
   worktree: string,
 ) {
@@ -185,7 +186,7 @@ const discoverSkills = Effect.fnUntraced(function* (
   const externalDirs: string[] = []
   if (!disableExternalSkills) {
     if (!disableClaudeCodeSkills) externalDirs.push(CLAUDE_EXTERNAL_DIR)
-    externalDirs.push(AGENTS_EXTERNAL_DIR)
+    if (!disableAgentsSkills) externalDirs.push(AGENTS_EXTERNAL_DIR)
 
     for (const dir of externalDirs) {
       const root = path.join(global.home, dir)
@@ -265,6 +266,7 @@ const layer = Layer.effect(
           global,
           flags.disableExternalSkills,
           flags.disableClaudeCodeSkills,
+          flags.disableAgentsSkills,
           ctx.directory,
           ctx.worktree,
         )

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -113,6 +113,7 @@ describe("RuntimeFlags", () => {
       expect(flags.disableLspDownload).toBe(false)
       expect(flags.disableClaudeCodePrompt).toBe(false)
       expect(flags.disableClaudeCodeSkills).toBe(false)
+      expect(flags.disableAgentsSkills).toBe(false)
       expect(flags.enableExa).toBe(false)
       expect(flags.experimentalIconDiscovery).toBe(false)
       expect(flags.experimentalOxfmt).toBe(false)
@@ -339,6 +340,7 @@ describe("RuntimeFlags", () => {
       expect(flags.disableLspDownload).toBe(false)
       expect(flags.disableClaudeCodePrompt).toBe(false)
       expect(flags.disableClaudeCodeSkills).toBe(false)
+      expect(flags.disableAgentsSkills).toBe(false)
       expect(flags.enableExa).toBe(false)
       expect(flags.experimentalIconDiscovery).toBe(false)
       expect(flags.experimentalOxfmt).toBe(false)
@@ -369,6 +371,14 @@ describe("RuntimeFlags", () => {
       const flags = yield* readFlags.pipe(Effect.provide(fromConfig({ OPENCODE_DISABLE_CLAUDE_CODE: "true" })))
 
       expect(flags.disableClaudeCodeSkills).toBe(true)
+    }),
+  )
+
+  it.effect("disableAgentsSkills reads OPENCODE_DISABLE_AGENTS", () =>
+    Effect.gen(function* () {
+      const flags = yield* readFlags.pipe(Effect.provide(fromConfig({ OPENCODE_DISABLE_AGENTS: "true" })))
+
+      expect(flags.disableAgentsSkills).toBe(true)
     }),
   )
 })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -24,6 +24,13 @@ const itWithoutClaudeCodeSkills = testEffect(
     testInstanceStoreLayer,
   ),
 )
+const itWithoutAgentsSkills = testEffect(
+  Layer.mergeAll(
+    LayerNode.compile(Skill.node, [[RuntimeFlags.node, RuntimeFlags.layer({ disableAgentsSkills: true })]]),
+    node,
+    testInstanceStoreLayer,
+  ),
+)
 const itWithoutExternalSkills = testEffect(
   Layer.mergeAll(
     LayerNode.compile(Skill.node, [[RuntimeFlags.node, RuntimeFlags.layer({ disableExternalSkills: true })]]),
@@ -475,6 +482,43 @@ description: A skill in the .agents/skills directory.
           const skill = yield* Skill.Service
           const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
           expect(list.map((s) => s.name)).toEqual(["agent-skill"])
+        }),
+      { git: true },
+    ),
+  )
+
+  itWithoutAgentsSkills.live("skips .agents skills when disabled", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+                `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
+
+# Claude Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".agents", "skills", "agent-skill", "SKILL.md"),
+                `---
+name: agent-skill
+description: A skill in the .agents/skills directory.
+---
+
+# Agent Skill
+`,
+              ),
+            ]),
+          )
+
+          const skill = yield* Skill.Service
+          const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
+          expect(list.map((s) => s.name)).toEqual(["claude-skill"])
         }),
       { git: true },
     ),

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -696,6 +696,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
 | `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
 | `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_AGENTS`             | boolean | Disable loading `.agents/skills`                  |
 | `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
 | `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -29,6 +29,10 @@ It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.cla
 
 Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
 
+:::caution
+To skip Claude Code-compatible skills, set `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1`. To skip agent-compatible skills, set `OPENCODE_DISABLE_AGENTS=1`.
+:::
+
 ---
 
 ## Write frontmatter


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Our repository uses several agent harnesses setups including Claude and Codex. When we first set up Opencode only Claude Code support existed and we were able to exclude its skills with `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1`.

Eventually support for the `.agents` directory was also added but no similar disabling flag was included. This causes repos to index both `.opencode` and `.agents`. In large repos this causes context bloat as well as OOM crashes.

This PR adds support for `OPENCODE_DISABLE_AGENTS=1` which mirrors functionality of the Claude Code flag to disable indexing for the `.agents` directory.

### How did you verify your code works?

Aside from the tests I:
- ran `bun run --cwd packages/opencode build --single --skip-install` to build locally
- smoke-tested the build `packages/opencode/dist/opencode-darwin-arm64/bin/opencode --version`
- went to my repo and ran `~/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode debug skill`
- it listed skills under `.agents`
- ran it again with `OPENCODE_DISABLE_AGENTS=1 \
  /Users/leonardo/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode \
  debug skill`
- it listed no skills

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
