### PR TITLE
fix(ui): add missing # to icon-weak-base in oc-2 light theme

### DIFF
--- a/packages/ui/src/theme/themes/oc-2.json
+++ b/packages/ui/src/theme/themes/oc-2.json
@@ -25,7 +25,7 @@
       "border-weak-base": "#DBDBDB",
       "border-weaker-base": "#E8E8E8",
       "icon-base": "#8F8F8F",
-      "icon-weak-base": "C7C7C7",
+      "icon-weak-base": "#C7C7C7",
       "surface-raised-base": "#F3F3F3",
       "surface-raised-base-hover": "#EDEDED",
       "surface-base": "#F8F8F8",


### PR DESCRIPTION
## Summary

Fixes #41503

The `oc-2` light theme declares `icon-weak-base` without a leading `#`:

```json
"icon-weak-base": "C7C7C7",
```

This causes the CSS custom property `--icon-weak-base` to resolve to an invalid value, so consumers fall back to transparent (background) or the inherited color (text), breaking light-mode UI elements that use this token.

## Fix

Add the missing `#`:

```diff
-      "icon-weak-base": "C7C7C7",
+      "icon-weak-base": "#C7C7C7",
```

The value `#C7C7C7` matches `text-weaker` declared a few lines above, confirming it is the intended color.

Dark mode is unaffected (already correct: `"icon-weak-base": "#343434"`).

## Affected components (light mode only)

- `dialog-release-notes.tsx` — inactive carousel indicators rendered transparent
- `diff-changes.tsx` — `<rect>` fill inherited `fill: none` from SVG parent
- `file-tree.tsx` — icon color inherited parent text instead of weak grey
- `settings-keybinds.tsx`, `settings-models.tsx` — same icon color issue

## Verification

This is a one-character fix in the theme JSON. No tests needed — the change is syntactically identical to every other color value in the same file.