### PR TITLE
docs(cli): document mini, no-replay, and replay-limit flags

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -29,20 +29,23 @@ opencode [project]
 
 #### Flags
 
-| Flag                                        | Short | Description                                                             |
-| ------------------------------------------- | ----- | ----------------------------------------------------------------------- |
-| <nobr><code>{"--continue"}</code></nobr>    | `-c`  | Continue the last session                                               |
-| <nobr><code>{"--session"}</code></nobr>     | `-s`  | Session ID to continue                                                  |
-| <nobr><code>{"--fork"}</code></nobr>        |       | Fork the session when continuing (use with `--continue` or `--session`) |
-| <nobr><code>{"--prompt"}</code></nobr>      |       | Prompt to use                                                           |
-| <nobr><code>{"--model"}</code></nobr>       | `-m`  | Model to use in the form of provider/model                              |
-| <nobr><code>{"--agent"}</code></nobr>       |       | Agent to use                                                            |
-| <nobr><code>{"--auto"}</code></nobr>        |       | Auto-approve permissions that are not explicitly denied                 |
-| <nobr><code>{"--port"}</code></nobr>        |       | Port to listen on                                                       |
-| <nobr><code>{"--hostname"}</code></nobr>    |       | Hostname to listen on                                                   |
-| <nobr><code>{"--mdns"}</code></nobr>        |       | Enable mDNS discovery                                                   |
-| <nobr><code>{"--mdns-domain"}</code></nobr> |       | Custom mDNS domain name                                                 |
-| <nobr><code>{"--cors"}</code></nobr>        |       | Additional browser origin(s) to allow CORS                              |
+| Flag                                         | Short | Description                                                             |
+| -------------------------------------------- | ----- | ----------------------------------------------------------------------- |
+| <nobr><code>{"--continue"}</code></nobr>     | `-c`  | Continue the last session                                               |
+| <nobr><code>{"--session"}</code></nobr>      | `-s`  | Session ID to continue                                                  |
+| <nobr><code>{"--fork"}</code></nobr>         |       | Fork the session when continuing (use with `--continue` or `--session`) |
+| <nobr><code>{"--prompt"}</code></nobr>       |       | Prompt to use                                                           |
+| <nobr><code>{"--model"}</code></nobr>        | `-m`  | Model to use in the form of provider/model                              |
+| <nobr><code>{"--agent"}</code></nobr>        |       | Agent to use                                                            |
+| <nobr><code>{"--auto"}</code></nobr>         |       | Auto-approve permissions that are not explicitly denied                 |
+| <nobr><code>{"--port"}</code></nobr>         |       | Port to listen on                                                       |
+| <nobr><code>{"--hostname"}</code></nobr>     |       | Hostname to listen on                                                   |
+| <nobr><code>{"--mdns"}</code></nobr>         |       | Enable mDNS discovery                                                   |
+| <nobr><code>{"--mdns-domain"}</code></nobr>  |       | Custom mDNS domain name                                                 |
+| <nobr><code>{"--cors"}</code></nobr>         |       | Additional browser origin(s) to allow CORS                              |
+| <nobr><code>{"--mini"}</code></nobr>         |       | Start the minimal interactive interface                                 |
+| <nobr><code>{"--no-replay"}</code></nobr>    |       | Disable mini session history replay on resume and after resize          |
+| <nobr><code>{"--replay-limit"}</code></nobr> |       | Cap visible mini replay to the newest N messages                        |
 
 ---
 
@@ -116,14 +119,17 @@ opencode attach http://10.20.30.40:4096
 
 #### Flags
 
-| Flag                                     | Short | Description                                                                |
-| ---------------------------------------- | ----- | -------------------------------------------------------------------------- |
-| <nobr><code>{"--dir"}</code></nobr>      |       | Working directory to start TUI in                                          |
-| <nobr><code>{"--continue"}</code></nobr> | `-c`  | Continue the last session                                                  |
-| <nobr><code>{"--session"}</code></nobr>  | `-s`  | Session ID to continue                                                     |
-| <nobr><code>{"--fork"}</code></nobr>     |       | Fork the session when continuing (use with `--continue` or `--session`)    |
-| <nobr><code>{"--password"}</code></nobr> | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
-| <nobr><code>{"--username"}</code></nobr> | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+| Flag                                         | Short | Description                                                                |
+| -------------------------------------------- | ----- | -------------------------------------------------------------------------- |
+| <nobr><code>{"--dir"}</code></nobr>          |       | Working directory to start TUI in                                          |
+| <nobr><code>{"--continue"}</code></nobr>     | `-c`  | Continue the last session                                                  |
+| <nobr><code>{"--session"}</code></nobr>      | `-s`  | Session ID to continue                                                     |
+| <nobr><code>{"--fork"}</code></nobr>         |       | Fork the session when continuing (use with `--continue` or `--session`)    |
+| <nobr><code>{"--password"}</code></nobr>     | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
+| <nobr><code>{"--username"}</code></nobr>     | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
+| <nobr><code>{"--mini"}</code></nobr>         |       | Start the minimal interactive interface                                    |
+| <nobr><code>{"--no-replay"}</code></nobr>    |       | Disable mini session history replay on resume and after resize             |
+| <nobr><code>{"--replay-limit"}</code></nobr> |       | Cap visible mini replay to the newest N messages                           |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #41537

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the `--mini`, `--no-replay`, and `--replay-limit` flags to the `tui` and `attach` flag tables in the CLI reference (`docs/cli.mdx`). These options are registered with user-facing descriptions in `packages/opencode/src/cli/cmd/tui.ts` and `packages/opencode/src/cli/cmd/attach.ts` but were missing from the docs, so users could not discover them.

### How did you verify your code works?

- `bunx prettier --check packages/web/src/content/docs/cli.mdx` passes.
- Verified each flag description matches the `describe` value in `tui.ts`/`attach.ts`.
- Confirmed no other docs page documents these flags (no duplicate rows).

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A — docs table change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
