### PR TITLE
fix(question): reject empty prompts

### DIFF
--- a/packages/core/src/tool/question.ts
+++ b/packages/core/src/tool/question.ts
@@ -23,7 +23,9 @@ Usage notes:
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label`
 
 export const Input = Schema.Struct({
-  questions: Schema.Array(QuestionV2.Prompt).annotate({ description: "Questions to ask" }),
+  questions: Schema.Array(QuestionV2.Prompt).check(Schema.isMinLength(1)).annotate({
+    description: "Questions to ask",
+  }),
 })
 
 export const Output = Schema.Struct({

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -12,6 +12,11 @@ import { testEffect } from "./lib/effect"
 import { toolIdentity, executeTool, settleTool, toolDefinitions } from "./lib/tool"
 
 const sessionID = SessionV2.ID.make("ses_question_tool_test")
+const prompt = {
+  question: "What should happen?",
+  header: "Action",
+  options: [{ label: "Build", description: "Build it" }],
+}
 const assertions: PermissionV2.AssertInput[] = []
 let captured: QuestionV2.AskInput | undefined
 let reject = false
@@ -63,7 +68,12 @@ describe("QuestionTool", () => {
         yield* settleTool(registry, {
           sessionID,
           ...toolIdentity,
-          call: { type: "tool-call", id: "call-question-denied", name: "question", input: { questions: [] } },
+          call: {
+            type: "tool-call",
+            id: "call-question-denied",
+            name: "question",
+            input: { questions: [prompt] },
+          },
         }),
       ).toEqual({ result: { type: "error", value: "Permission denied: question" } })
       expect(capturedInput()).toBeUndefined()
@@ -79,11 +89,7 @@ describe("QuestionTool", () => {
       deny = false
       const registry = yield* ToolRegistry.Service
       const questions = [
-        {
-          question: "What should happen?",
-          header: "Action",
-          options: [{ label: "Build", description: "Build it" }],
-        },
+        prompt,
         {
           question: "Which environment?",
           header: "Environment",
@@ -91,7 +97,9 @@ describe("QuestionTool", () => {
         },
       ]
 
-      expect((yield* toolDefinitions(registry)).map((definition) => definition.name)).toEqual(["question"])
+      expect(yield* toolDefinitions(registry)).toMatchObject([
+        { name: "question", inputSchema: { properties: { questions: { allOf: [{ minItems: 1 }] } } } },
+      ])
       expect(
         yield* settleTool(registry, {
           sessionID,
@@ -123,6 +131,23 @@ describe("QuestionTool", () => {
     }),
   )
 
+  it.effect("rejects empty questions before asking", () =>
+    Effect.gen(function* () {
+      captured = undefined
+      deny = false
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* settleTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-question-empty", name: "question", input: { questions: [] } },
+        }),
+      ).toMatchObject({ result: { type: "error", value: expect.stringContaining("Invalid tool input") } })
+      expect(capturedInput()).toBeUndefined()
+    }),
+  )
+
   it.effect("does not invent tool ownership metadata without a durable registry source", () =>
     Effect.gen(function* () {
       captured = undefined
@@ -133,11 +158,11 @@ describe("QuestionTool", () => {
       yield* executeTool(registryService, {
         sessionID,
         ...toolIdentity,
-        call: { type: "tool-call", id: "call-question", name: "question", input: { questions: [] } },
+        call: { type: "tool-call", id: "call-question", name: "question", input: { questions: [prompt] } },
       })
       expect(capturedInput()).toEqual({
         sessionID,
-        questions: [],
+        questions: [prompt],
         tool: { messageID: toolIdentity.assistantMessageID, callID: "call-question" },
       })
     }),
@@ -152,7 +177,7 @@ describe("QuestionTool", () => {
       const fiber = yield* executeTool(registryService, {
         sessionID,
         ...toolIdentity,
-        call: { type: "tool-call", id: "call-question", name: "question", input: { questions: [] } },
+        call: { type: "tool-call", id: "call-question", name: "question", input: { questions: [prompt] } },
       }).pipe(Effect.forkScoped)
 
       const exit = yield* Fiber.await(fiber)

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -4,7 +4,9 @@ import { Question } from "../question"
 import DESCRIPTION from "./question.txt"
 
 export const Parameters = Schema.Struct({
-  questions: Schema.mutable(Schema.Array(Question.Prompt)).annotate({ description: "Questions to ask" }),
+  questions: Schema.mutable(Schema.Array(Question.Prompt)).check(Schema.isMinLength(1)).annotate({
+    description: "Questions to ask",
+  }),
 })
 
 type Metadata = {

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -243,6 +243,7 @@ exports[`tool parameters JSON Schema (wire shape) question 1`] = `
         ],
         "type": "object",
       },
+      "minItems": 1,
       "type": "array",
     },
   },

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -212,6 +212,9 @@ describe("tool parameters", () => {
     test("rejects missing questions", () => {
       expect(accepts(Question, {})).toBe(false)
     })
+    test("rejects empty questions", () => {
+      expect(accepts(Question, { questions: [] })).toBe(false)
+    })
   })
 
   describe("read", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #41549

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Requires at least one prompt in both question tool schemas. This rejects empty calls before they can register an unanswerable pending question, and exposes `minItems: 1` to providers.

### How did you verify your code works?

- `bun test test/tool/parameters.test.ts` in `packages/opencode`
- `bun test test/tool-question.test.ts` in `packages/core`
- Pre-push workspace typecheck
- Prettier and Oxlint on changed source and test files

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
