### PR TITLE
feat(tui): marquee hovered tab titles

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -16,7 +16,7 @@ import {
   type SessionTab,
   type SessionTabUnread,
 } from "../context/session-tabs-model"
-import { createAnimatable, spring } from "../ui/animation"
+import { createAnimatable, spring, tween } from "../ui/animation"
 import { Locale } from "../util/locale"
 import { stringWidth } from "../util/string-width"
 import { TabPulse, unreadGlowIntensity } from "./tab-pulse"
@@ -26,7 +26,7 @@ import { projectName } from "../util/project"
 import { marqueeText } from "../util/marquee"
 
 // A long title fades out over its last cells instead of cutting hard.
-const FADE_WIDTH = 6
+const FADE_WIDTH = 4
 const MARQUEE_DELAY = 600
 const MARQUEE_INTERVAL = 100
 
@@ -49,27 +49,30 @@ const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: NEW_SESSION_TAB_T
 const glowTextColor = (base: RGBA, glow: RGBA, index: number, width: number) =>
   tint(base, glow, 0.12 * unreadGlowIntensity(index, width))
 
-function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: number, leading: boolean) {
-  const start = leading && index < FADE_WIDTH ? FADE_WIDTH - index : 0
+function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: number, leading: number) {
+  const fade = (position: number) => (position <= 0 ? 0 : 0.2 + 0.72 * ((position - 1) / Math.max(1, FADE_WIDTH - 1)))
+  const start = index < FADE_WIDTH ? FADE_WIDTH - index : 0
   const end = index - (length - FADE_WIDTH) + 1
-  const position = Math.max(start, end)
-  if (position <= 0) return color
-  const progress = position / FADE_WIDTH
-  return tint(color, background, 0.92 * progress * progress * (3 - 2 * progress))
+  const opacity = Math.max(fade(start) * leading, fade(end))
+  return opacity === 0 ? color : tint(color, background, opacity)
 }
 
-function createMarqueeOffset(hovered: () => string | undefined) {
+function createMarquee(hovered: () => string | undefined, animations: () => boolean) {
   const [offset, setOffset] = createSignal(0)
+  const leading = createAnimatable({ opacity: 0 }, { enabled: animations, transition: tween({ duration: 0.25 }) })
 
   createEffect(() => {
     if (!hovered()) {
       setOffset(0)
+      leading.jump({ opacity: 0 })
       return
     }
     setOffset(0)
+    leading.jump({ opacity: 0 })
     let interval: ReturnType<typeof setInterval> | undefined
     const delay = setTimeout(() => {
       setOffset(1)
+      leading.animate({ opacity: 1 })
       interval = setInterval(() => setOffset((value) => value + 1), MARQUEE_INTERVAL)
     }, MARQUEE_DELAY)
     onCleanup(() => {
@@ -78,7 +81,7 @@ function createMarqueeOffset(hovered: () => string | undefined) {
     })
   })
 
-  return offset
+  return { offset, leading: () => leading.value().opacity }
 }
 
 export function SessionTabs(
@@ -104,7 +107,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
   const separatorUpperPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.04))
   const separatorLowerPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.05))
   const [hovered, setHovered] = createSignal<string>()
-  const marqueeOffset = createMarqueeOffset(hovered)
+  const marquee = createMarquee(hovered, animations)
   const [dragging, setDragging] = createSignal<string>()
   const [preview, setPreview] = createSignal<{ sessionID: string; index: number }>()
   const newTab = () => tabs.newTab?.() ?? false
@@ -180,10 +183,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const numberWidth = () => 2
               const titleWidth = () => Math.max(1, width() - numberWidth() - 2 - (hovered() === tab.sessionID ? 1 : 0))
               const title = () => tab.title ?? "Untitled session"
-              const scrolling = () => hovered() === tab.sessionID && marqueeOffset() > 0
+              const scrolling = () => hovered() === tab.sessionID && marquee.offset() > 0
               const visibleTitle = createMemo(() =>
                 scrolling()
-                  ? marqueeText(title(), titleWidth(), marqueeOffset())
+                  ? marqueeText(title(), titleWidth(), marquee.offset())
                   : Locale.takeWidth(title(), titleWidth()),
               )
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
@@ -248,7 +251,13 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   ? glowTextColor(foreground(), glowColor(), 1 + numberWidth() + index, width())
                   : foreground()
                 return titleFades()
-                  ? fadeTitleColor(color, pulseBackground(), index, visibleTitleParts().length, scrolling())
+                  ? fadeTitleColor(
+                      color,
+                      pulseBackground(),
+                      index,
+                      visibleTitleParts().length,
+                      scrolling() ? marquee.leading() : 0,
+                    )
                   : color
               }
               const release = () => {
@@ -426,7 +435,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const [hovered, setHovered] = createSignal<string>()
-  const marqueeOffset = createMarqueeOffset(hovered)
+  const marquee = createMarquee(hovered, animations)
   const [dragging, setDragging] = createSignal<string>()
   // A drag reorders a local preview and persists one move on release instead of writing
   // per slot crossing; the preview holds after release until the store reflects the move,
@@ -606,10 +615,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           // Hovering reveals the close mark, so the title's right bound shifts left of it.
           const availableTitleWidth = () =>
             Math.max(1, width() - 1 - numberWidth() - (hovered() === tab.sessionID ? 2 : 0))
-          const scrolling = () => hovered() === tab.sessionID && marqueeOffset() > 0
+          const scrolling = () => hovered() === tab.sessionID && marquee.offset() > 0
           const visibleTitle = createMemo(() =>
             scrolling()
-              ? marqueeText(title(), availableTitleWidth(), marqueeOffset())
+              ? marqueeText(title(), availableTitleWidth(), marquee.offset())
               : Locale.takeWidth(title(), availableTitleWidth()),
           )
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
@@ -626,7 +635,13 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
             const base = foreground()
             const color = glows() ? glowTextColor(base, glowColor(), 1 + numberWidth() + index, width()) : base
             return titleFades()
-              ? fadeTitleColor(color, background(), index, visibleTitleParts().length, scrolling())
+              ? fadeTitleColor(
+                  color,
+                  background(),
+                  index,
+                  visibleTitleParts().length,
+                  scrolling() ? marquee.leading() : 0,
+                )
               : color
           }
           // The running sweep's level under the number cell, reported by the pulse renderable.

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1,5 +1,5 @@
 import { RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
-import { For, Show, createComputed, createEffect, createMemo, createSignal, untrack } from "solid-js"
+import { For, Show, createComputed, createEffect, createMemo, createSignal, onCleanup, untrack } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useConfig } from "../config"
 import { useSessionTabs } from "../context/session-tabs"
@@ -23,9 +23,12 @@ import { TabPulse, unreadGlowIntensity } from "./tab-pulse"
 import { tint } from "../theme/color"
 import { SESSION_SIDEBAR_WIDTH } from "../ui/layout"
 import { projectName } from "../util/project"
+import { marqueeText } from "../util/marquee"
 
 // A long title fades out over its last cells instead of cutting hard.
 const FADE_WIDTH = 4
+const MARQUEE_DELAY = 600
+const MARQUEE_INTERVAL = 100
 
 type ContextController = ReturnType<typeof useSessionTabs>
 export type SessionTabsStatus = Omit<ReturnType<ContextController["status"]>, "unread"> & {
@@ -45,6 +48,29 @@ export type SessionTabsController = Pick<ContextController, "tabs" | "current" |
 const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: NEW_SESSION_TAB_TITLE }
 const glowTextColor = (base: RGBA, glow: RGBA, index: number, width: number) =>
   tint(base, glow, 0.12 * unreadGlowIntensity(index, width))
+
+function createMarqueeOffset(hovered: () => string | undefined) {
+  const [offset, setOffset] = createSignal(0)
+
+  createEffect(() => {
+    if (!hovered()) {
+      setOffset(0)
+      return
+    }
+    setOffset(0)
+    let interval: ReturnType<typeof setInterval> | undefined
+    const delay = setTimeout(() => {
+      setOffset(1)
+      interval = setInterval(() => setOffset((value) => value + 1), MARQUEE_INTERVAL)
+    }, MARQUEE_DELAY)
+    onCleanup(() => {
+      clearTimeout(delay)
+      if (interval) clearInterval(interval)
+    })
+  })
+
+  return offset
+}
 
 export function SessionTabs(
   props: { controller?: SessionTabsController; animations?: boolean; orientation?: "horizontal" | "vertical" } = {},
@@ -69,6 +95,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
   const separatorUpperPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.04))
   const separatorLowerPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.05))
   const [hovered, setHovered] = createSignal<string>()
+  const marqueeOffset = createMarqueeOffset(hovered)
   const [dragging, setDragging] = createSignal<string>()
   const [preview, setPreview] = createSignal<{ sessionID: string; index: number }>()
   const newTab = () => tabs.newTab?.() ?? false
@@ -144,9 +171,16 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const numberWidth = () => 2
               const titleWidth = () => Math.max(1, width() - numberWidth() - 2 - (hovered() === tab.sessionID ? 1 : 0))
               const title = () => tab.title ?? "Untitled session"
-              const visibleTitle = createMemo(() => Locale.takeWidth(title(), titleWidth()))
+              const scrolling = () => hovered() === tab.sessionID && marqueeOffset() > 0
+              const visibleTitle = createMemo(() =>
+                scrolling()
+                  ? marqueeText(title(), titleWidth(), marqueeOffset())
+                  : Locale.takeWidth(title(), titleWidth()),
+              )
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
-              const titleFades = createMemo(() => stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH)
+              const titleFades = createMemo(
+                () => !scrolling() && stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH,
+              )
               const detail = createMemo(() => {
                 if (tab === NEW_SESSION_TAB) return Locale.takeWidth("Start a new session", titleWidth())
                 const value = session()
@@ -225,7 +259,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   backgroundColor={background()}
                   onMouseOver={() => setHovered(tab.sessionID)}
                   onMouseOut={() => setHovered(undefined)}
-                  onMouseDown={() => setDragging(tab.sessionID)}
+                  onMouseDown={() => {
+                    setHovered(tab.sessionID)
+                    setDragging(tab.sessionID)
+                  }}
                   onMouseUp={release}
                   onMouseDrag={(event) => {
                     if (!rail || tab === NEW_SESSION_TAB) return
@@ -382,6 +419,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const [hovered, setHovered] = createSignal<string>()
+  const marqueeOffset = createMarqueeOffset(hovered)
   const [dragging, setDragging] = createSignal<string>()
   // A drag reorders a local preview and persists one move on release instead of writing
   // per slot crossing; the preview holds after release until the store reflects the move,
@@ -561,10 +599,15 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           // Hovering reveals the close mark, so the title's right bound shifts left of it.
           const availableTitleWidth = () =>
             Math.max(1, width() - 1 - numberWidth() - (hovered() === tab.sessionID ? 2 : 0))
-          const visibleTitle = createMemo(() => Locale.takeWidth(title(), availableTitleWidth()))
+          const scrolling = () => hovered() === tab.sessionID && marqueeOffset() > 0
+          const visibleTitle = createMemo(() =>
+            scrolling()
+              ? marqueeText(title(), availableTitleWidth(), marqueeOffset())
+              : Locale.takeWidth(title(), availableTitleWidth()),
+          )
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
           const titleFades = createMemo(
-            () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
+            () => !scrolling() && stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
           )
           const foreground = () => {
             if (hovered() === tab.sessionID) return theme.text.default
@@ -611,7 +654,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
               backgroundColor={background()}
               onMouseOver={() => setHovered(tab.sessionID)}
               onMouseOut={() => setHovered(undefined)}
-              onMouseDown={() => setDragging(tab.sessionID)}
+              onMouseDown={() => {
+                setHovered(tab.sessionID)
+                setDragging(tab.sessionID)
+              }}
               onMouseUp={release}
               onMouseDrag={(event) => {
                 if (tab === NEW_SESSION_TAB) return

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -49,6 +49,13 @@ const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: NEW_SESSION_TAB_T
 const glowTextColor = (base: RGBA, glow: RGBA, index: number, width: number) =>
   tint(base, glow, 0.12 * unreadGlowIntensity(index, width))
 
+function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: number, leading: boolean) {
+  const start = leading && index < FADE_WIDTH ? FADE_WIDTH - index : 0
+  const end = index - (length - FADE_WIDTH) + 1
+  const position = Math.max(start, end)
+  return position <= 0 ? color : tint(color, background, 0.2 + 0.72 * ((position - 1) / Math.max(1, FADE_WIDTH - 1)))
+}
+
 function createMarqueeOffset(hovered: () => string | undefined) {
   const [offset, setOffset] = createSignal(0)
 
@@ -178,9 +185,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   : Locale.takeWidth(title(), titleWidth()),
               )
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
-              const titleFades = createMemo(
-                () => !scrolling() && stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH,
-              )
+              const titleFades = createMemo(() => stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
                 if (tab === NEW_SESSION_TAB) return Locale.takeWidth("Start a new session", titleWidth())
                 const value = session()
@@ -240,9 +245,9 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 const color = glows()
                   ? glowTextColor(foreground(), glowColor(), 1 + numberWidth() + index, width())
                   : foreground()
-                if (!titleFades() || index < visibleTitleParts().length - FADE_WIDTH) return color
-                const position = index - (visibleTitleParts().length - FADE_WIDTH)
-                return tint(color, pulseBackground(), 0.2 + 0.72 * (position / Math.max(1, FADE_WIDTH - 1)))
+                return titleFades()
+                  ? fadeTitleColor(color, pulseBackground(), index, visibleTitleParts().length, scrolling())
+                  : color
               }
               const release = () => {
                 setDragging(undefined)
@@ -607,7 +612,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           )
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
           const titleFades = createMemo(
-            () => !scrolling() && stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
+            () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
           )
           const foreground = () => {
             if (hovered() === tab.sessionID) return theme.text.default
@@ -618,9 +623,9 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const characterColor = (index: number) => {
             const base = foreground()
             const color = glows() ? glowTextColor(base, glowColor(), 1 + numberWidth() + index, width()) : base
-            if (!titleFades() || index < visibleTitleParts().length - FADE_WIDTH) return color
-            const position = index - (visibleTitleParts().length - FADE_WIDTH)
-            return tint(color, background(), 0.2 + 0.72 * (position / Math.max(1, FADE_WIDTH - 1)))
+            return titleFades()
+              ? fadeTitleColor(color, background(), index, visibleTitleParts().length, scrolling())
+              : color
           }
           // The running sweep's level under the number cell, reported by the pulse renderable.
           const [sweepLevel, setSweepLevel] = createSignal(0)

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -26,7 +26,7 @@ import { projectName } from "../util/project"
 import { marqueeText } from "../util/marquee"
 
 // A long title fades out over its last cells instead of cutting hard.
-const FADE_WIDTH = 4
+const FADE_WIDTH = 6
 const MARQUEE_DELAY = 600
 const MARQUEE_INTERVAL = 100
 
@@ -53,7 +53,9 @@ function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: nu
   const start = leading && index < FADE_WIDTH ? FADE_WIDTH - index : 0
   const end = index - (length - FADE_WIDTH) + 1
   const position = Math.max(start, end)
-  return position <= 0 ? color : tint(color, background, 0.2 + 0.72 * ((position - 1) / Math.max(1, FADE_WIDTH - 1)))
+  if (position <= 0) return color
+  const progress = position / FADE_WIDTH
+  return tint(color, background, 0.92 * progress * progress * (3 - 2 * progress))
 }
 
 function createMarqueeOffset(hovered: () => string | undefined) {

--- a/packages/tui/src/util/marquee.ts
+++ b/packages/tui/src/util/marquee.ts
@@ -1,0 +1,19 @@
+import { Locale } from "./locale"
+import { stringWidth } from "./string-width"
+
+const GAP = "    "
+
+export function marqueeText(value: string, width: number, offset: number) {
+  if (width <= 0) return ""
+  if (stringWidth(value) <= width || offset <= 0) return Locale.takeWidth(value, width)
+
+  const loop = value + GAP
+  const cursor = offset % stringWidth(loop)
+  const segments = Locale.graphemes(loop + loop)
+  const start = segments.reduce(
+    (state, segment, index) =>
+      state.width >= cursor ? state : { index: index + 1, width: state.width + stringWidth(segment) },
+    { index: 0, width: 0 },
+  ).index
+  return Locale.takeWidth(segments.slice(start).join(""), width)
+}

--- a/packages/tui/test/util/marquee.test.ts
+++ b/packages/tui/test/util/marquee.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { marqueeText } from "../../src/util/marquee"
+import { stringWidth } from "../../src/util/string-width"
+
+describe("marquee text", () => {
+  test("keeps short text stationary", () => {
+    expect(marqueeText("Short", 10, 8)).toBe("Short")
+  })
+
+  test("starts clipped and scrolls through a long title", () => {
+    expect(marqueeText("A long session title", 8, 0)).toBe("A long s")
+    expect(marqueeText("A long session title", 8, 2)).toBe("long ses")
+    expect(marqueeText("A long session title", 8, 15)).toBe("title   ")
+    expect(marqueeText("A long session title", 8, 20)).toBe("    A lo")
+  })
+
+  test("clips wide graphemes to terminal cells", () => {
+    const frame = marqueeText("Plan 🧭 the release", 8, 5)
+    expect(frame).toBe("🧭 the r")
+    expect(stringWidth(frame)).toBeLessThanOrEqual(8)
+  })
+})


### PR DESCRIPTION
## What

Long session titles now marquee while their tab is hovered, revealing the complete title without widening the tab strip or sidebar. The title pauses briefly before scrolling, fades at both clipped edges while moving, and resets as soon as the pointer leaves.

This works in both horizontal and vertical tab layouts. Short titles remain stationary.

## How

- `packages/tui/src/component/session-tabs.tsx` shares one hover-driven marquee clock across the visible tabs and applies its frame to both renderers.
- `packages/tui/src/util/marquee.ts` slices looping text by terminal cell width, including wide Unicode graphemes.
- Mouse-down establishes hover state even when a terminal or simulation sends a click without a preceding motion event.

## Scope

This only changes title rendering while hovering. Tab dimensions, overflow behavior, ordering, and activity animations are unchanged.

## Testing

- `bun run test` in `packages/tui`: 611 passed, 5 skipped
- `bun typecheck` in `packages/tui`
- `bun run lint packages/tui/src/component/session-tabs.tsx packages/tui/src/util/marquee.ts packages/tui/test/util/marquee.test.ts`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3`
- `opencode-drive check /tmp/opencode/tab-marquee-drive.ts`
- OpenCode Drive run against this checkout, creating a simulated session, hovering its long title horizontally, switching layout through Settings, then hovering it vertically

## Demo

The recording is an OpenCode Drive run using the simulated model. It shows the same long session title scrolling in both tab layouts.

https://github.com/user-attachments/assets/cdff1684-4486-4fcd-a63d-18dfd96dd658

| Horizontal | Vertical |
| --- | --- |
| ![Horizontal tab title mid-marquee](https://github.com/user-attachments/assets/c466c8df-238f-4bac-9090-703f4b22bd51) | ![Vertical tab title mid-marquee](https://github.com/user-attachments/assets/7316f3c1-5893-4a77-8359-d27dd718426f) |
