### PR TITLE
fix(tui): delay background work hint

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1329,15 +1329,16 @@ function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
   const theme = useTheme()
   const shortcut = Keymap.useShortcut("session.background")
   const running = createMemo(() => {
+    if (!shortcut()) return
     const current = props.messages.findLast(
       (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
     )
-    const part = current?.content.find((part) => {
+    const part = current?.content.find((part): part is SessionMessageAssistantTool => {
       if (part.type !== "tool" || part.state.status !== "running") return false
-      const display = toolDisplay(part.name)
-      return display === "shell" || display === "subagent"
+      const name = canonicalToolName(part.name)
+      return name === "shell" || name === "subagent"
     })
-    if (!current || !part || part.type !== "tool") return
+    if (!current || !part) return
     return `${current.id}:${part.id}`
   })
   const visible = createDelayedPresence(running, BACKGROUND_TOOL_HINT_DELAY)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -102,11 +102,13 @@ import { useSessionTabs } from "../../context/session-tabs"
 import { createSingleFlight } from "../../util/single-flight"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import { generateThinkingSyntax } from "./thinking-syntax"
+import { createDelayedPresence } from "../../util/delayed-presence"
 
 addDefaultParsers(parsers.parsers)
 
 // Exclude temporary bottom space when measuring the real transcript height.
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
+const BACKGROUND_TOOL_HINT_DELAY = 1_000
 
 // Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
 // The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
@@ -1326,18 +1328,19 @@ function turnTokenToolSummary(tool: SessionMessageAssistantTool) {
 function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
   const theme = useTheme()
   const shortcut = Keymap.useShortcut("session.background")
-  const visible = createMemo(() => {
+  const running = createMemo(() => {
     const current = props.messages.findLast(
       (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
     )
-    return (
-      current?.content.some((part) => {
-        if (part.type !== "tool" || part.state.status !== "running") return false
-        const display = toolDisplay(part.name)
-        return display === "shell" || display === "subagent"
-      }) ?? false
-    )
+    const part = current?.content.find((part) => {
+      if (part.type !== "tool" || part.state.status !== "running") return false
+      const display = toolDisplay(part.name)
+      return display === "shell" || display === "subagent"
+    })
+    if (!current || !part || part.type !== "tool") return
+    return `${current.id}:${part.id}`
   })
+  const visible = createDelayedPresence(running, BACKGROUND_TOOL_HINT_DELAY)
   return (
     <Show when={visible() && shortcut()}>
       {(value) => (

--- a/packages/tui/src/util/delayed-presence.ts
+++ b/packages/tui/src/util/delayed-presence.ts
@@ -1,12 +1,12 @@
 import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js"
 
-export function createDelayedPresence(source: Accessor<string | undefined>, delay: number) {
+export function createDelayedPresence<T>(source: Accessor<T | undefined>, delay: number) {
   const [visible, setVisible] = createSignal(false)
 
   createEffect(() => {
     const value = source()
     setVisible(false)
-    if (!value) return
+    if (value === undefined) return
 
     const timer = setTimeout(() => setVisible(true), delay)
     onCleanup(() => clearTimeout(timer))

--- a/packages/tui/src/util/delayed-presence.ts
+++ b/packages/tui/src/util/delayed-presence.ts
@@ -1,0 +1,16 @@
+import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js"
+
+export function createDelayedPresence(source: Accessor<string | undefined>, delay: number) {
+  const [visible, setVisible] = createSignal(false)
+
+  createEffect(() => {
+    const value = source()
+    setVisible(false)
+    if (!value) return
+
+    const timer = setTimeout(() => setVisible(true), delay)
+    onCleanup(() => clearTimeout(timer))
+  })
+
+  return visible
+}

--- a/packages/tui/test/util/delayed-presence.test.ts
+++ b/packages/tui/test/util/delayed-presence.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createDelayedPresence } from "../../src/util/delayed-presence"
+
+test("shows only after the same value remains present for the delay", async () => {
+  await createRoot(async (dispose) => {
+    const [value, setValue] = createSignal<string>()
+    const visible = createDelayedPresence(value, 40)
+
+    setValue("first")
+    await Bun.sleep(20)
+    expect(visible()).toBe(false)
+
+    setValue("second")
+    await Bun.sleep(25)
+    expect(visible()).toBe(false)
+    await Bun.sleep(25)
+    expect(visible()).toBe(true)
+
+    dispose()
+  })
+})
+
+test("cancels the delay when the value disappears or the owner is disposed", async () => {
+  await createRoot(async (dispose) => {
+    const [value, setValue] = createSignal<string>()
+    const visible = createDelayedPresence(value, 30)
+
+    setValue("running")
+    setValue(undefined)
+    await Bun.sleep(40)
+    expect(visible()).toBe(false)
+
+    setValue("running")
+    dispose()
+    await Bun.sleep(40)
+    expect(visible()).toBe(false)
+  })
+})

--- a/packages/tui/test/util/delayed-presence.test.ts
+++ b/packages/tui/test/util/delayed-presence.test.ts
@@ -1,39 +1,55 @@
-import { expect, test } from "bun:test"
+import { expect, jest, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { createDelayedPresence } from "../../src/util/delayed-presence"
 
 test("shows only after the same value remains present for the delay", async () => {
-  await createRoot(async (dispose) => {
+  jest.useFakeTimers()
+  const scope = createRoot((dispose) => {
     const [value, setValue] = createSignal<string>()
-    const visible = createDelayedPresence(value, 40)
-
-    setValue("first")
-    await Bun.sleep(20)
-    expect(visible()).toBe(false)
-
-    setValue("second")
-    await Bun.sleep(25)
-    expect(visible()).toBe(false)
-    await Bun.sleep(25)
-    expect(visible()).toBe(true)
-
-    dispose()
+    return { dispose, setValue, visible: createDelayedPresence(value, 1_000) }
   })
+
+  try {
+    scope.setValue("first")
+    await Promise.resolve()
+    jest.advanceTimersByTime(500)
+    expect(scope.visible()).toBe(false)
+
+    scope.setValue("second")
+    await Promise.resolve()
+    jest.advanceTimersByTime(999)
+    expect(scope.visible()).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(scope.visible()).toBe(true)
+  } finally {
+    scope.dispose()
+    jest.useRealTimers()
+  }
 })
 
 test("cancels the delay when the value disappears or the owner is disposed", async () => {
-  await createRoot(async (dispose) => {
+  jest.useFakeTimers()
+  const scope = createRoot((dispose) => {
     const [value, setValue] = createSignal<string>()
-    const visible = createDelayedPresence(value, 30)
-
-    setValue("running")
-    setValue(undefined)
-    await Bun.sleep(40)
-    expect(visible()).toBe(false)
-
-    setValue("running")
-    dispose()
-    await Bun.sleep(40)
-    expect(visible()).toBe(false)
+    return { dispose, setValue, visible: createDelayedPresence(value, 1_000) }
   })
+
+  try {
+    scope.setValue("running")
+    await Promise.resolve()
+    jest.advanceTimersByTime(500)
+    scope.setValue(undefined)
+    await Promise.resolve()
+    jest.advanceTimersByTime(1_000)
+    expect(scope.visible()).toBe(false)
+
+    scope.setValue("running")
+    await Promise.resolve()
+    scope.dispose()
+    jest.advanceTimersByTime(1_000)
+    expect(scope.visible()).toBe(false)
+  } finally {
+    scope.dispose()
+    jest.useRealTimers()
+  }
 })


### PR DESCRIPTION
## What

Delay the session hint for moving shell and subagent work to the background until the same work has remained active for one second. Brief work now completes without flashing a hint that is no longer actionable.

## Before / After

**Before:** The background shortcut hint appeared as soon as shell or subagent work entered the running state, including commands that completed almost immediately.

**After:** The hint appears only after the same shell or subagent tool has run for one second. Completion, replacement, or component cleanup cancels the pending timer.

## How

- `packages/tui/src/routes/session/index.tsx` identifies running backgroundable work by assistant message and tool IDs, then applies the delayed visibility gate.
- `packages/tui/src/util/delayed-presence.ts` owns the reactive timer lifecycle and resets visibility whenever its keyed source changes.
- `packages/tui/test/util/delayed-presence.test.ts` covers delayed display, replacement resets, completion cancellation, and owner cleanup.

## Scope

This only changes the V2 TUI hint timing. It does not alter background execution, shortcuts, shell behavior, subagent behavior, or V1 `packages/opencode`.

## Testing

- `cd packages/tui && bun run test test/util/delayed-presence.test.ts` (2 passed)
- `cd packages/tui && bun run test` (611 passed, 5 skipped)
- `cd packages/tui && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks passed)
- `opencode-drive check background-hint-delay-drive.ts`
- Scripted OpenCode Drive run against this checkout using real `sleep 0.1` and `sleep 2` shell commands. The script asserted no hint after the short task and waited for the hint during the long task.

## Demo

The simulated model invokes real local shell commands. The short command completes without the hint; the longer command displays it after the delay.

https://github.com/user-attachments/assets/82d59aac-4761-4d40-b9f7-ba82cdd1c59a
