### PR TITLE
fix(core): resolve provider URL variables at runtime

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -47,6 +47,10 @@ export const layer = Layer.effect(
             input.model
               ? new ModelSelectionError({ message: error.message })
               : new UnavailableError({ message: error.message, service: error.providerID }),
+          "SessionRunnerModel.UnresolvedProviderVariablesError": (error) =>
+            input.model
+              ? new ModelSelectionError({ message: error.message })
+              : new UnavailableError({ message: error.message, service: error.providerID }),
         }),
       )
       if (!resolved)

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -46,7 +46,24 @@ export class UnsupportedPackageError extends Schema.TaggedErrorClass<Unsupported
   }
 }
 
-export type Error = VariantUnavailableError | UnsupportedPackageError | Integration.AuthorizationError
+export class UnresolvedProviderVariablesError extends Schema.TaggedErrorClass<UnresolvedProviderVariablesError>()(
+  "SessionRunnerModel.UnresolvedProviderVariablesError",
+  {
+    providerID: Provider.ID,
+    modelID: ID,
+    variables: Schema.Array(Schema.String),
+  },
+) {
+  override get message() {
+    return `Cannot initialize ${this.providerID}/${this.modelID}: ${this.variables.join(", ")} ${this.variables.length === 1 ? "is" : "are"} required to resolve the provider endpoint`
+  }
+}
+
+export type Error =
+  | VariantUnavailableError
+  | UnsupportedPackageError
+  | UnresolvedProviderVariablesError
+  | Integration.AuthorizationError
 
 export interface Resolved {
   /** Route-level model for provider requests; its id is the provider API model id, which may differ from the catalog id. */
@@ -141,15 +158,19 @@ export const fromCatalogModel = (
   model: Info,
   credential?: Credential.Value,
   dependencies?: Dependencies,
-): Effect.Effect<LanguageModel, UnsupportedPackageError> => {
-  const resolved = produce(model, (draft) => {
-    if (draft.settings?.apiKey === "") delete draft.settings.apiKey
-    if (credential?.type === "key" && credential.metadata !== undefined)
-      draft.body = Provider.mergeOverlay(draft.body, credential.metadata)
-  })
+): Effect.Effect<LanguageModel, UnsupportedPackageError | UnresolvedProviderVariablesError> => {
+  const prepared = prepareRuntimeModel(model, credential)
+  if (prepared.unresolved.length > 0)
+    return Effect.fail(
+      new UnresolvedProviderVariablesError({
+        providerID: model.providerID,
+        modelID: model.id,
+        variables: prepared.unresolved,
+      }),
+    )
+  const resolved = prepared.model
   const packageName = Provider.packageName(resolved.package)
   const key = apiKey(resolved, credential)
-  const configuration = credential?.type === "key" ? credential.configuration : undefined
 
   if (Provider.isAISDK(resolved.package) && packageName === "@ai-sdk/openai") {
     return Effect.succeed(
@@ -176,7 +197,7 @@ export const fromCatalogModel = (
         .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
     )
   }
-  const configured = { ...resolved.settings, ...credential?.metadata, ...configuration }
+  const configured = resolved.settings ?? {}
   const mapping = Provider.isAISDK(resolved.package)
     ? AISDKNative.map({
         packageName,
@@ -190,8 +211,6 @@ export const fromCatalogModel = (
     const runtime = produce(resolved, (draft) => {
       draft.settings = Provider.mergeOverlay(draft.settings, {
         ...nativeCredentialSettings(resolved.package ?? "", credential),
-        ...credential?.metadata,
-        ...configuration,
       })
     })
     return dependencies.loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))
@@ -224,6 +243,94 @@ export const fromCatalogModel = (
       catch: () => unsupported(resolved),
     })
   })
+}
+
+function prepareRuntimeModel(model: Info, credential: Credential.Value | undefined) {
+  const configuration = credential?.type === "key" ? credential.configuration : undefined
+  const variables = providerVariables(model, configuration)
+  const prepared = produce(model, (draft) => {
+    draft.settings = Provider.mergeOverlay(draft.settings, {
+      ...credential?.metadata,
+      ...configuration,
+    })
+    if (draft.settings?.apiKey === "") delete draft.settings.apiKey
+    if (credential?.type === "key" && credential.metadata !== undefined)
+      draft.body = Provider.mergeOverlay(draft.body, credential.metadata)
+    if (typeof draft.settings?.baseURL !== "string") return
+    draft.settings.baseURL = draft.settings.baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
+      return variables[name] ?? nonEmpty(process.env[name]) ?? placeholder
+    })
+  })
+  const baseURL = prepared.settings?.baseURL
+  const unresolved =
+    typeof baseURL === "string"
+      ? Array.from(baseURL.matchAll(/\$\{([^}]+)\}/g), (match) => match[1]).filter(
+          (name, index, names) => names.indexOf(name) === index,
+        )
+      : []
+  return { model: prepared, unresolved }
+}
+
+function providerVariables(
+  model: Info,
+  configuration: Readonly<Record<string, unknown>> | undefined,
+): Record<string, string> {
+  const settings = model.settings ?? {}
+  if (model.providerID === Provider.ID.make("cloudflare-workers-ai")) {
+    const accountID =
+      nonEmpty(process.env.CLOUDFLARE_ACCOUNT_ID) ??
+      stringSetting(settings, "accountId") ??
+      stringSetting(configuration, "accountId")
+    return accountID ? { CLOUDFLARE_ACCOUNT_ID: accountID } : {}
+  }
+  if (model.providerID === Provider.ID.azure) {
+    const resourceName =
+      stringSetting(settings, "resourceName") ??
+      stringSetting(configuration, "resourceName") ??
+      nonEmpty(process.env.AZURE_RESOURCE_NAME) ??
+      nonEmpty(process.env.AZURE_COGNITIVE_SERVICES_RESOURCE_NAME)
+    return resourceName
+      ? {
+          AZURE_RESOURCE_NAME: resourceName,
+          AZURE_COGNITIVE_SERVICES_RESOURCE_NAME: resourceName,
+        }
+      : {}
+  }
+  if (model.providerID === Provider.ID.googleVertex) {
+    const project =
+      stringSetting(settings, "project") ??
+      nonEmpty(process.env.GOOGLE_VERTEX_PROJECT) ??
+      nonEmpty(process.env.GOOGLE_CLOUD_PROJECT) ??
+      nonEmpty(process.env.GCP_PROJECT) ??
+      nonEmpty(process.env.GCLOUD_PROJECT)
+    const location =
+      stringSetting(settings, "location") ??
+      nonEmpty(process.env.GOOGLE_VERTEX_LOCATION) ??
+      nonEmpty(process.env.GOOGLE_CLOUD_LOCATION) ??
+      nonEmpty(process.env.VERTEX_LOCATION) ??
+      "us-central1"
+    return {
+      ...(project ? { GOOGLE_VERTEX_PROJECT: project } : {}),
+      GOOGLE_VERTEX_LOCATION: location,
+      GOOGLE_VERTEX_ENDPOINT:
+        location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`,
+    }
+  }
+  if (model.providerID === Provider.ID.amazonBedrock) {
+    return {
+      AWS_REGION: stringSetting(settings, "region") ?? nonEmpty(process.env.AWS_REGION) ?? "us-east-1",
+    }
+  }
+  return {}
+}
+
+function stringSetting(settings: Readonly<Record<string, unknown>> | undefined, key: string) {
+  const value = settings?.[key]
+  return typeof value === "string" ? nonEmpty(value) : undefined
+}
+
+function nonEmpty(value: string | undefined) {
+  return value === undefined || value === "" ? undefined : value
 }
 
 const nativeCredentialSettings = (specifier: string, credential: Credential.Value | undefined) => {

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -171,6 +171,7 @@ export const fromCatalogModel = (
   const resolved = prepared.model
   const packageName = Provider.packageName(resolved.package)
   const key = apiKey(resolved, credential)
+  const configuration = credential?.type === "key" ? credential.configuration : undefined
 
   if (Provider.isAISDK(resolved.package) && packageName === "@ai-sdk/openai") {
     return Effect.succeed(
@@ -197,7 +198,7 @@ export const fromCatalogModel = (
         .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
     )
   }
-  const configured = resolved.settings ?? {}
+  const configured = { ...resolved.settings, ...credential?.metadata, ...configuration }
   const mapping = Provider.isAISDK(resolved.package)
     ? AISDKNative.map({
         packageName,
@@ -211,6 +212,8 @@ export const fromCatalogModel = (
     const runtime = produce(resolved, (draft) => {
       draft.settings = Provider.mergeOverlay(draft.settings, {
         ...nativeCredentialSettings(resolved.package ?? "", credential),
+        ...credential?.metadata,
+        ...configuration,
       })
     })
     return dependencies.loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))
@@ -246,19 +249,13 @@ export const fromCatalogModel = (
 }
 
 function prepareRuntimeModel(model: Info, credential: Credential.Value | undefined) {
-  const configuration = credential?.type === "key" ? credential.configuration : undefined
-  const variables = providerVariables(model, configuration)
   const prepared = produce(model, (draft) => {
-    draft.settings = Provider.mergeOverlay(draft.settings, {
-      ...credential?.metadata,
-      ...configuration,
-    })
     if (draft.settings?.apiKey === "") delete draft.settings.apiKey
     if (credential?.type === "key" && credential.metadata !== undefined)
       draft.body = Provider.mergeOverlay(draft.body, credential.metadata)
     if (typeof draft.settings?.baseURL !== "string") return
     draft.settings.baseURL = draft.settings.baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
-      return variables[name] ?? nonEmpty(process.env[name]) ?? placeholder
+      return process.env[name] ?? placeholder
     })
   })
   const baseURL = prepared.settings?.baseURL
@@ -269,68 +266,6 @@ function prepareRuntimeModel(model: Info, credential: Credential.Value | undefin
         )
       : []
   return { model: prepared, unresolved }
-}
-
-function providerVariables(
-  model: Info,
-  configuration: Readonly<Record<string, unknown>> | undefined,
-): Record<string, string> {
-  const settings = model.settings ?? {}
-  if (model.providerID === Provider.ID.make("cloudflare-workers-ai")) {
-    const accountID =
-      nonEmpty(process.env.CLOUDFLARE_ACCOUNT_ID) ??
-      stringSetting(settings, "accountId") ??
-      stringSetting(configuration, "accountId")
-    return accountID ? { CLOUDFLARE_ACCOUNT_ID: accountID } : {}
-  }
-  if (model.providerID === Provider.ID.azure) {
-    const resourceName =
-      stringSetting(settings, "resourceName") ??
-      stringSetting(configuration, "resourceName") ??
-      nonEmpty(process.env.AZURE_RESOURCE_NAME) ??
-      nonEmpty(process.env.AZURE_COGNITIVE_SERVICES_RESOURCE_NAME)
-    return resourceName
-      ? {
-          AZURE_RESOURCE_NAME: resourceName,
-          AZURE_COGNITIVE_SERVICES_RESOURCE_NAME: resourceName,
-        }
-      : {}
-  }
-  if (model.providerID === Provider.ID.googleVertex) {
-    const project =
-      stringSetting(settings, "project") ??
-      nonEmpty(process.env.GOOGLE_VERTEX_PROJECT) ??
-      nonEmpty(process.env.GOOGLE_CLOUD_PROJECT) ??
-      nonEmpty(process.env.GCP_PROJECT) ??
-      nonEmpty(process.env.GCLOUD_PROJECT)
-    const location =
-      stringSetting(settings, "location") ??
-      nonEmpty(process.env.GOOGLE_VERTEX_LOCATION) ??
-      nonEmpty(process.env.GOOGLE_CLOUD_LOCATION) ??
-      nonEmpty(process.env.VERTEX_LOCATION) ??
-      "us-central1"
-    return {
-      ...(project ? { GOOGLE_VERTEX_PROJECT: project } : {}),
-      GOOGLE_VERTEX_LOCATION: location,
-      GOOGLE_VERTEX_ENDPOINT:
-        location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`,
-    }
-  }
-  if (model.providerID === Provider.ID.amazonBedrock) {
-    return {
-      AWS_REGION: stringSetting(settings, "region") ?? nonEmpty(process.env.AWS_REGION) ?? "us-east-1",
-    }
-  }
-  return {}
-}
-
-function stringSetting(settings: Readonly<Record<string, unknown>> | undefined, key: string) {
-  const value = settings?.[key]
-  return typeof value === "string" ? nonEmpty(value) : undefined
-}
-
-function nonEmpty(value: string | undefined) {
-  return value === undefined || value === "" ? undefined : value
 }
 
 const nativeCredentialSettings = (specifier: string, credential: Credential.Value | undefined) => {

--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -59,36 +59,8 @@ function environmentNames(provider: ModelsDev.Snapshot) {
 }
 
 function snapshots(data: readonly ModelsDev.Snapshot[]) {
-  return (
-    structuredClone(data)
-      // These deprecated aliases are replaced by the canonical Azure and Google Vertex providers.
-      .filter(
-        (provider) => provider.info.id !== "azure-cognitive-services" && provider.info.id !== "google-vertex-anthropic",
-      )
-      .map((provider) => {
-        const environment = new Set(provider.environment)
-        return {
-          ...provider,
-          info: {
-            ...provider.info,
-            ...(provider.info.settings ? { settings: resolveEnvironment(provider.info.settings, environment) } : {}),
-          },
-          models: provider.models.map((model) => ({
-            ...model,
-            ...(model.settings ? { settings: resolveEnvironment(model.settings, environment) } : {}),
-          })),
-        }
-      })
+  return structuredClone(data).filter(
+    // These deprecated aliases are replaced by the canonical Azure and Google Vertex providers.
+    (provider) => provider.info.id !== "azure-cognitive-services" && provider.info.id !== "google-vertex-anthropic",
   )
-}
-
-function resolveEnvironment(settings: Readonly<Record<string, unknown>>, environment: Set<string>) {
-  if (typeof settings.baseURL !== "string") return settings
-  return {
-    ...settings,
-    baseURL: settings.baseURL.replace(/\$\{([^}]+)\}/g, (value, name: string) => {
-      if (!environment.has(name)) return value
-      return process.env[name] ?? value
-    }),
-  }
 }

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -34,6 +34,8 @@ export const VariantUnavailableError = ModelResolver.VariantUnavailableError
 export type VariantUnavailableError = ModelResolver.VariantUnavailableError
 export const UnsupportedPackageError = ModelResolver.UnsupportedPackageError
 export type UnsupportedPackageError = ModelResolver.UnsupportedPackageError
+export const UnresolvedProviderVariablesError = ModelResolver.UnresolvedProviderVariablesError
+export type UnresolvedProviderVariablesError = ModelResolver.UnresolvedProviderVariablesError
 
 export type Error = ModelNotSelectedError | ModelUnavailableError | ModelResolver.Error
 export type Resolved = ModelResolver.Resolved

--- a/packages/core/src/session/to-session-error.ts
+++ b/packages/core/src/session/to-session-error.ts
@@ -52,7 +52,8 @@ export function toSessionError(cause: unknown): SessionError.Error {
     cause instanceof SessionRunnerModel.ModelNotSelectedError ||
     cause instanceof SessionRunnerModel.ModelUnavailableError ||
     cause instanceof SessionRunnerModel.VariantUnavailableError ||
-    cause instanceof SessionRunnerModel.UnsupportedPackageError
+    cause instanceof SessionRunnerModel.UnsupportedPackageError ||
+    cause instanceof SessionRunnerModel.UnresolvedProviderVariablesError
   )
     return { type: "provider.no-route", message: cause.message }
   if (cause instanceof Integration.AuthorizationError) return { type: "provider.auth", message: cause.message }

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -42,6 +42,27 @@ const model = (packageName: string | undefined, options: ModelOptions = {}) =>
     limit: options.limit ?? { context: 100, output: 20 },
   })
 
+function withEnv<A, E, R>(variables: Record<string, string | undefined>, effect: () => Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = Object.fromEntries(Object.keys(variables).map((key) => [key, process.env[key]]))
+      Object.entries(variables).forEach(([key, value]) => {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      })
+      return previous
+    }),
+    effect,
+    (previous) =>
+      Effect.sync(() => {
+        Object.entries(previous).forEach(([key, value]) => {
+          if (value === undefined) delete process.env[key]
+          else process.env[key] = value
+        })
+      }),
+  )
+}
+
 describe("ModelResolver", () => {
   it.effect("constructs native Azure requests with deployment IDs and projected resource URLs", () =>
     Effect.gen(function* () {
@@ -76,10 +97,10 @@ describe("ModelResolver", () => {
           providerID: Provider.ID.azure,
           modelID: "legacy-deployment",
           settings: {
-            resourceName: "legacy-resource",
-            baseURL: "https://legacy-resource.cognitiveservices.azure.com/openai",
+            baseURL: "https://${AZURE_RESOURCE_NAME}.cognitiveservices.azure.com/openai",
           },
         }),
+        Credential.Key.make({ type: "key", key: "secret", configuration: { resourceName: "legacy-resource" } }),
       )
 
       expect(responses).toMatchObject({ id: "responses-deployment", provider: "azure" })
@@ -107,15 +128,23 @@ describe("ModelResolver", () => {
       const credential = Credential.Key.make({ type: "key", key: "secret" })
       const responses = yield* ModelResolver.fromCatalogModel(
         model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
+          providerID: Provider.ID.amazonBedrock,
           modelID: "openai.gpt-oss-120b",
-          settings: { region: "us-east-2" },
+          settings: {
+            region: "us-east-2",
+            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          },
         }),
         credential,
       )
       const chat = yield* ModelResolver.fromCatalogModel(
         model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
+          providerID: Provider.ID.amazonBedrock,
           modelID: "openai.gpt-oss-safeguard-20b",
-          settings: { region: "us-east-2" },
+          settings: {
+            region: "us-east-2",
+            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          },
         }),
         credential,
       )
@@ -228,6 +257,73 @@ describe("ModelResolver", () => {
       expect(resolved.route.endpoint.baseURL).toBe("https://compatible.example/v1")
       expect(resolved.route.defaults.http?.body).toEqual({})
     }),
+  )
+
+  it.effect("resolves provider URLs from environment and credential configuration", () =>
+    withEnv(
+      {
+        ACME_HOST: "api.acme.test",
+        CLOUDFLARE_ACCOUNT_ID: undefined,
+      },
+      () =>
+        Effect.gen(function* () {
+          const environment = yield* ModelResolver.fromCatalogModel(
+            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+              settings: { baseURL: "https://${ACME_HOST}/v1" },
+            }),
+          )
+          const cloudflareCatalog = model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+            providerID: Provider.ID.make("cloudflare-workers-ai"),
+            settings: {
+              baseURL: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+            },
+          })
+          const cloudflare = yield* ModelResolver.fromCatalogModel(
+            cloudflareCatalog,
+            Credential.Key.make({ type: "key", key: "secret", configuration: { accountId: "account" } }),
+          )
+          const vertex = yield* ModelResolver.fromCatalogModel(
+            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+              providerID: Provider.ID.googleVertex,
+              settings: {
+                project: "project",
+                location: "global",
+                baseURL:
+                  "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}",
+              },
+            }),
+          )
+
+          expect(environment.route.endpoint.baseURL).toBe("https://api.acme.test/v1")
+          expect(cloudflare.route.endpoint.baseURL).toBe("https://api.cloudflare.com/client/v4/accounts/account/ai/v1")
+          expect(cloudflareCatalog.settings?.baseURL).toContain("${CLOUDFLARE_ACCOUNT_ID}")
+          expect(vertex.route.endpoint.baseURL).toBe(
+            "https://aiplatform.googleapis.com/v1/projects/project/locations/global",
+          )
+        }),
+    ),
+  )
+
+  it.effect("rejects unresolved provider URL variables before route construction", () =>
+    withEnv({ REQUIRED_HOST: undefined }, () =>
+      Effect.gen(function* () {
+        const failure = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+            settings: { baseURL: "https://${REQUIRED_HOST}/${REQUIRED_PATH}/v1" },
+          }),
+        ).pipe(Effect.flip)
+
+        expect(failure).toMatchObject({
+          _tag: "SessionRunnerModel.UnresolvedProviderVariablesError",
+          providerID: "test-provider",
+          modelID: "test-model",
+          variables: ["REQUIRED_HOST", "REQUIRED_PATH"],
+        })
+        expect(failure.message).toBe(
+          "Cannot initialize test-provider/test-model: REQUIRED_HOST, REQUIRED_PATH are required to resolve the provider endpoint",
+        )
+      }),
+    ),
   )
 
   it.effect("overlays selected OpenAI variant settings and bodies", () =>

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -97,10 +97,10 @@ describe("ModelResolver", () => {
           providerID: Provider.ID.azure,
           modelID: "legacy-deployment",
           settings: {
-            baseURL: "https://${AZURE_RESOURCE_NAME}.cognitiveservices.azure.com/openai",
+            resourceName: "legacy-resource",
+            baseURL: "https://legacy-resource.cognitiveservices.azure.com/openai",
           },
         }),
-        Credential.Key.make({ type: "key", key: "secret", configuration: { resourceName: "legacy-resource" } }),
       )
 
       expect(responses).toMatchObject({ id: "responses-deployment", provider: "azure" })
@@ -128,23 +128,15 @@ describe("ModelResolver", () => {
       const credential = Credential.Key.make({ type: "key", key: "secret" })
       const responses = yield* ModelResolver.fromCatalogModel(
         model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
-          providerID: Provider.ID.amazonBedrock,
           modelID: "openai.gpt-oss-120b",
-          settings: {
-            region: "us-east-2",
-            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
-          },
+          settings: { region: "us-east-2" },
         }),
         credential,
       )
       const chat = yield* ModelResolver.fromCatalogModel(
         model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
-          providerID: Provider.ID.amazonBedrock,
           modelID: "openai.gpt-oss-safeguard-20b",
-          settings: {
-            region: "us-east-2",
-            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
-          },
+          settings: { region: "us-east-2" },
         }),
         credential,
       )
@@ -259,48 +251,17 @@ describe("ModelResolver", () => {
     }),
   )
 
-  it.effect("resolves provider URLs from environment and credential configuration", () =>
-    withEnv(
-      {
-        ACME_HOST: "api.acme.test",
-        CLOUDFLARE_ACCOUNT_ID: undefined,
-      },
-      () =>
-        Effect.gen(function* () {
-          const environment = yield* ModelResolver.fromCatalogModel(
-            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
-              settings: { baseURL: "https://${ACME_HOST}/v1" },
-            }),
-          )
-          const cloudflareCatalog = model(Provider.aisdk("@ai-sdk/openai-compatible"), {
-            providerID: Provider.ID.make("cloudflare-workers-ai"),
-            settings: {
-              baseURL: "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
-            },
-          })
-          const cloudflare = yield* ModelResolver.fromCatalogModel(
-            cloudflareCatalog,
-            Credential.Key.make({ type: "key", key: "secret", configuration: { accountId: "account" } }),
-          )
-          const vertex = yield* ModelResolver.fromCatalogModel(
-            model(Provider.aisdk("@ai-sdk/openai-compatible"), {
-              providerID: Provider.ID.googleVertex,
-              settings: {
-                project: "project",
-                location: "global",
-                baseURL:
-                  "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}",
-              },
-            }),
-          )
+  it.effect("resolves provider URLs from environment without mutating the catalog model", () =>
+    withEnv({ ACME_HOST: "api.acme.test" }, () =>
+      Effect.gen(function* () {
+        const catalog = model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+          settings: { baseURL: "https://${ACME_HOST}/v1" },
+        })
+        const resolved = yield* ModelResolver.fromCatalogModel(catalog)
 
-          expect(environment.route.endpoint.baseURL).toBe("https://api.acme.test/v1")
-          expect(cloudflare.route.endpoint.baseURL).toBe("https://api.cloudflare.com/client/v4/accounts/account/ai/v1")
-          expect(cloudflareCatalog.settings?.baseURL).toContain("${CLOUDFLARE_ACCOUNT_ID}")
-          expect(vertex.route.endpoint.baseURL).toBe(
-            "https://aiplatform.googleapis.com/v1/projects/project/locations/global",
-          )
-        }),
+        expect(resolved.route.endpoint.baseURL).toBe("https://api.acme.test/v1")
+        expect(catalog.settings?.baseURL).toBe("https://${ACME_HOST}/v1")
+      }),
     ),
   )
 

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -29,6 +29,27 @@ const it = testEffect(layer)
 const models = (file: string) =>
   AppNodeBuilder.build(ModelsDev.node, [[ModelsDev.node, ModelsDev.configured({ file, fetch: false })]])
 
+function withEnv<A, E, R>(variables: Record<string, string | undefined>, effect: () => Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = Object.fromEntries(Object.keys(variables).map((key) => [key, process.env[key]]))
+      Object.entries(variables).forEach(([key, value]) => {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      })
+      return previous
+    }),
+    effect,
+    (previous) =>
+      Effect.sync(() => {
+        Object.entries(previous).forEach(([key, value]) => {
+          if (value === undefined) delete process.env[key]
+          else process.env[key] = value
+        })
+      }),
+  )
+}
+
 describe("ModelsDevPlugin", () => {
   it.effect("projects normalized models.dev snapshots into the catalog", () =>
     Effect.gen(function* () {
@@ -222,58 +243,68 @@ describe("ModelsDevPlugin", () => {
   )
 
   it.effect("preserves provider and model URL templates in the catalog", () =>
-    Effect.gen(function* () {
-      const integrations = yield* Integration.Service
-      const catalog = yield* Catalog.Service
-      const providerID = Provider.ID.make("acme")
-      const modelID = Model.ID.make("gpt-5.4")
-      yield* ModelsDevPlugin.effect(
-        host({
-          catalog: catalogHost(catalog),
-          integration: integrationHost(integrations),
-        }),
-      ).pipe(
-        Effect.provideService(
-          ModelsDev.Service,
-          ModelsDev.Service.of({
-            get: () =>
-              Effect.succeed([
-                {
-                  info: {
-                    id: providerID,
-                    name: "Acme",
-                    package: Provider.aisdk("@ai-sdk/openai-compatible"),
-                    settings: { baseURL: "https://${ACME_HOST}/v1" },
-                  },
-                  environment: ["ACME_HOST", "ACME_MODEL_PATH", "ACME_API_KEY"],
-                  models: [
+    withEnv(
+      {
+        ACME_HOST: "api.acme.test",
+        ACME_MODEL_PATH: undefined,
+        UNDECLARED_HOST: "private.example",
+      },
+      () =>
+        Effect.gen(function* () {
+          const integrations = yield* Integration.Service
+          const catalog = yield* Catalog.Service
+          const providerID = Provider.ID.make("acme")
+          const modelID = Model.ID.make("gpt-5.4")
+          yield* ModelsDevPlugin.effect(
+            host({
+              catalog: catalogHost(catalog),
+              integration: integrationHost(integrations),
+            }),
+          ).pipe(
+            Effect.provideService(
+              ModelsDev.Service,
+              ModelsDev.Service.of({
+                get: () =>
+                  Effect.succeed([
                     {
-                      id: modelID,
-                      modelID,
-                      providerID,
-                      name: "GPT-5.4",
-                      settings: { baseURL: "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1" },
-                      capabilities: { tools: true, input: [], output: [] },
-                      variants: [],
-                      time: { released: Date.parse("2026-01-01") },
-                      cost: [],
-                      status: "active",
-                      enabled: true,
-                      limit: { context: 1_050_000, output: 128_000 },
+                      info: {
+                        id: providerID,
+                        name: "Acme",
+                        package: Provider.aisdk("@ai-sdk/openai-compatible"),
+                        settings: { baseURL: "https://${ACME_HOST}/${UNDECLARED_HOST}/v1" },
+                      },
+                      environment: ["ACME_HOST", "ACME_MODEL_PATH", "ACME_API_KEY"],
+                      models: [
+                        {
+                          id: modelID,
+                          modelID,
+                          providerID,
+                          name: "GPT-5.4",
+                          settings: { baseURL: "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1" },
+                          capabilities: { tools: true, input: [], output: [] },
+                          variants: [],
+                          time: { released: Date.parse("2026-01-01") },
+                          cost: [],
+                          status: "active",
+                          enabled: true,
+                          limit: { context: 1_050_000, output: 128_000 },
+                        },
+                      ],
                     },
-                  ],
-                },
-              ] satisfies readonly ModelsDev.Snapshot[]),
-            refresh: () => Effect.void,
-          }),
-        ),
-      )
+                  ] satisfies readonly ModelsDev.Snapshot[]),
+                refresh: () => Effect.void,
+              }),
+            ),
+          )
 
-      expect((yield* catalog.provider.get(providerID))?.settings?.baseURL).toBe("https://${ACME_HOST}/v1")
-      expect((yield* catalog.model.get(providerID, modelID))?.settings?.baseURL).toBe(
-        "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1",
-      )
-    }),
+          expect((yield* catalog.provider.get(providerID))?.settings?.baseURL).toBe(
+            "https://${ACME_HOST}/${UNDECLARED_HOST}/v1",
+          )
+          expect((yield* catalog.model.get(providerID, modelID))?.settings?.baseURL).toBe(
+            "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1",
+          )
+        }),
+    ),
   )
 
   it.effect("omits legacy provider aliases", () =>

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -29,27 +29,6 @@ const it = testEffect(layer)
 const models = (file: string) =>
   AppNodeBuilder.build(ModelsDev.node, [[ModelsDev.node, ModelsDev.configured({ file, fetch: false })]])
 
-function withEnv<A, E, R>(variables: Record<string, string | undefined>, effect: () => Effect.Effect<A, E, R>) {
-  return Effect.acquireUseRelease(
-    Effect.sync(() => {
-      const previous = Object.fromEntries(Object.keys(variables).map((key) => [key, process.env[key]]))
-      Object.entries(variables).forEach(([key, value]) => {
-        if (value === undefined) delete process.env[key]
-        else process.env[key] = value
-      })
-      return previous
-    }),
-    effect,
-    (previous) =>
-      Effect.sync(() => {
-        Object.entries(previous).forEach(([key, value]) => {
-          if (value === undefined) delete process.env[key]
-          else process.env[key] = value
-        })
-      }),
-  )
-}
-
 describe("ModelsDevPlugin", () => {
   it.effect("projects normalized models.dev snapshots into the catalog", () =>
     Effect.gen(function* () {
@@ -242,69 +221,59 @@ describe("ModelsDevPlugin", () => {
     }).pipe(Effect.provide(models(path.join(import.meta.dir, "fixtures", "models-dev.json")))),
   )
 
-  it.effect("resolves declared environment variables in provider and model URLs", () =>
-    withEnv(
-      {
-        ACME_HOST: "api.acme.test",
-        ACME_MODEL_PATH: undefined,
-        UNDECLARED_HOST: "private.example",
-      },
-      () =>
-        Effect.gen(function* () {
-          const integrations = yield* Integration.Service
-          const catalog = yield* Catalog.Service
-          const providerID = Provider.ID.make("acme")
-          const modelID = Model.ID.make("gpt-5.4")
-          yield* ModelsDevPlugin.effect(
-            host({
-              catalog: catalogHost(catalog),
-              integration: integrationHost(integrations),
-            }),
-          ).pipe(
-            Effect.provideService(
-              ModelsDev.Service,
-              ModelsDev.Service.of({
-                get: () =>
-                  Effect.succeed([
-                    {
-                      info: {
-                        id: providerID,
-                        name: "Acme",
-                        package: Provider.aisdk("@ai-sdk/openai-compatible"),
-                        settings: { baseURL: "https://${ACME_HOST}/${UNDECLARED_HOST}/v1" },
-                      },
-                      environment: ["ACME_HOST", "ACME_MODEL_PATH", "ACME_API_KEY"],
-                      models: [
-                        {
-                          id: modelID,
-                          modelID,
-                          providerID,
-                          name: "GPT-5.4",
-                          settings: { baseURL: "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1" },
-                          capabilities: { tools: true, input: [], output: [] },
-                          variants: [],
-                          time: { released: Date.parse("2026-01-01") },
-                          cost: [],
-                          status: "active",
-                          enabled: true,
-                          limit: { context: 1_050_000, output: 128_000 },
-                        },
-                      ],
-                    },
-                  ] satisfies readonly ModelsDev.Snapshot[]),
-                refresh: () => Effect.void,
-              }),
-            ),
-          )
-
-          expect((yield* catalog.provider.get(providerID))?.settings?.baseURL).toBe(
-            "https://api.acme.test/${UNDECLARED_HOST}/v1",
-          )
-          expect((yield* catalog.model.get(providerID, modelID))?.settings?.baseURL).toBe(
-            "https://api.acme.test/${ACME_MODEL_PATH}/v1",
-          )
+  it.effect("preserves provider and model URL templates in the catalog", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const catalog = yield* Catalog.Service
+      const providerID = Provider.ID.make("acme")
+      const modelID = Model.ID.make("gpt-5.4")
+      yield* ModelsDevPlugin.effect(
+        host({
+          catalog: catalogHost(catalog),
+          integration: integrationHost(integrations),
         }),
-    ),
+      ).pipe(
+        Effect.provideService(
+          ModelsDev.Service,
+          ModelsDev.Service.of({
+            get: () =>
+              Effect.succeed([
+                {
+                  info: {
+                    id: providerID,
+                    name: "Acme",
+                    package: Provider.aisdk("@ai-sdk/openai-compatible"),
+                    settings: { baseURL: "https://${ACME_HOST}/v1" },
+                  },
+                  environment: ["ACME_HOST", "ACME_MODEL_PATH", "ACME_API_KEY"],
+                  models: [
+                    {
+                      id: modelID,
+                      modelID,
+                      providerID,
+                      name: "GPT-5.4",
+                      settings: { baseURL: "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1" },
+                      capabilities: { tools: true, input: [], output: [] },
+                      variants: [],
+                      time: { released: Date.parse("2026-01-01") },
+                      cost: [],
+                      status: "active",
+                      enabled: true,
+                      limit: { context: 1_050_000, output: 128_000 },
+                    },
+                  ],
+                },
+              ] satisfies readonly ModelsDev.Snapshot[]),
+            refresh: () => Effect.void,
+          }),
+        ),
+      )
+
+      expect((yield* catalog.provider.get(providerID))?.settings?.baseURL).toBe("https://${ACME_HOST}/v1")
+      expect((yield* catalog.model.get(providerID, modelID))?.settings?.baseURL).toBe(
+        "https://${ACME_HOST}/${ACME_MODEL_PATH}/v1",
+      )
+    }),
   )
 
   it.effect("omits legacy provider aliases", () =>

--- a/packages/core/test/session-error.test.ts
+++ b/packages/core/test/session-error.test.ts
@@ -19,6 +19,9 @@ import {
   HttpResponseDetails,
 } from "@opencode-ai/ai"
 import { Permission } from "@opencode-ai/core/permission"
+import { ID } from "@opencode-ai/core/model"
+import { ModelResolver } from "@opencode-ai/core/model-resolver"
+import { Provider } from "@opencode-ai/core/provider"
 import { Tool } from "@opencode-ai/schema/tool"
 import { toSessionError } from "@opencode-ai/core/session/to-session-error"
 import { SessionRunnerRetry } from "@opencode-ai/core/session/runner/retry"
@@ -88,6 +91,19 @@ describe("toSessionError", () => {
       type: "provider.internal",
       message: "bad gateway",
       status: 502,
+    })
+  })
+
+  test("preserves unresolved provider endpoint errors", () => {
+    const error = new ModelResolver.UnresolvedProviderVariablesError({
+      providerID: Provider.ID.make("cloudflare-workers-ai"),
+      modelID: ID.make("model"),
+      variables: ["CLOUDFLARE_ACCOUNT_ID"],
+    })
+    expect(toSessionError(error)).toEqual({
+      type: "provider.no-route",
+      message:
+        "Cannot initialize cloudflare-workers-ai/model: CLOUDFLARE_ACCOUNT_ID is required to resolve the provider endpoint",
     })
   })
 


### PR DESCRIPTION
## Summary
- preserve models.dev endpoint templates in the catalog
- resolve `${ENV}` placeholders on a transient model in `ModelResolver`
- fail before network requests when endpoint placeholders remain unresolved

## Why
URL expansion belongs at final model resolution, after provider/model/config overlays are known. This avoids baking process environment values into catalog state and keeps catalog refreshes independent from runtime resolution.

Provider-specific account, resource, project, region, and credential behavior is intentionally out of scope. That will use a provider plugin hook rather than hard-coded ModelResolver logic.

## Testing
- `bun test test/model-resolver.test.ts test/plugin/models-dev.test.ts test/session-error.test.ts`
- `bun typecheck` in `packages/core`
- repository pre-push typecheck (33 tasks passed)
- targeted oxlint