### PR TITLE
fix(session): route all Muse family models to the Meta system prompt

### DIFF
--- a/packages/opencode/src/session/prompt/meta.txt
+++ b/packages/opencode/src/session/prompt/meta.txt
@@ -1,4 +1,4 @@
-You are OpenCode, a coding agent that helps users with software engineering tasks. You are powered by Muse Spark, a large language model trained by Meta MSL.
+You are OpenCode, a coding agent that helps users with software engineering tasks. You are powered by {{MODEL_NAME}}, a large language model trained by Meta MSL.
 
 Use the instructions below and the tools available to assist the user.
 
@@ -61,5 +61,5 @@ Use the instructions below and the tools available to assist the user.
 - NEVER use comments as a place for long-winded chain-of-thought. Long thinking texts must be generated as private reasoning. Comments in code must be appropriately concise.
 
 # User Help & Feedback
-- Users can give feedback or report issues at https://github.com/anomalyco/opencode and mention that they are using Meta Muse Spark.
+- Users can give feedback or report issues at https://github.com/anomalyco/opencode and mention that they are using Meta {{MODEL_NAME}}.
 - When users ask directly about OpenCode (eg. "can OpenCode do...", "are you able to do...") or its features (eg. implement a hook, write a slash command, or install an MCP server), use the WebFetch tool to gather information to answer the question from the OpenCode docs at https://opencode.ai/docs.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -25,7 +25,10 @@ import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 
 export function provider(model: Provider.Model) {
-  if (model.api.id.includes("muse-spark")) return [PROMPT_META]
+  if (model.api.id.includes("muse")) {
+    const name = model.api.id.includes("muse-glimmer") ? "Muse Glimmer" : "Muse Spark"
+    return [PROMPT_META.replaceAll("{{MODEL_NAME}}", name)]
+  }
   if (model.api.id.includes("gpt-4") || model.api.id.includes("o1") || model.api.id.includes("o3"))
     return [PROMPT_BEAST]
   if (model.api.id.includes("gpt")) {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -85,9 +85,21 @@ const it = testEffect(
 
 describe("session.system", () => {
   test("selects the Meta prompt for Muse Spark model IDs", () => {
-    expect(SystemPrompt.provider({ api: { id: "meta/muse-spark-preview" } } as Provider.Model)[0]).toContain(
-      "Meta Muse Spark",
-    )
+    for (const id of ["meta/muse-spark-preview", "muse-spark-1.1", "muse-spark-1.2"]) {
+      const prompt = SystemPrompt.provider({ api: { id } } as Provider.Model)[0]
+      expect(prompt).toContain("powered by Muse Spark,")
+      expect(prompt).toContain("using Meta Muse Spark.")
+      expect(prompt).not.toContain("{{MODEL_NAME}}")
+    }
+  })
+
+  test("selects the Meta prompt for Muse Glimmer model IDs", () => {
+    for (const id of ["meta/muse-glimmer", "meta/muse-glimmer-30b", "muse-glimmer-30b"]) {
+      const prompt = SystemPrompt.provider({ api: { id } } as Provider.Model)[0]
+      expect(prompt).toContain("powered by Muse Glimmer,")
+      expect(prompt).toContain("using Meta Muse Glimmer.")
+      expect(prompt).not.toContain("{{MODEL_NAME}}")
+    }
   })
 
   it.effect("skills output is sorted by name and stable across calls", () =>


### PR DESCRIPTION
The system prompt dispatcher only matched the substring "muse-spark", so newer Muse models such as muse-glimmer / muse-glimmer-30b fell through to PROMPT_DEFAULT instead of receiving PROMPT_META.

Gate PROMPT_META on any "muse" model id and template the model name into the prompt via {{MODEL_NAME}}: render "Muse Glimmer" for muse-glimmer ids and default to "Muse Spark" for every other Muse model.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
