### PR TITLE
fix(tui): show empty state when a flat picker has no matches

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -212,7 +212,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const flatten = createMemo(() => props.flat && store.filter.length > 0)
 
   const grouped = createMemo<[string, DialogSelectOption<T>[]][]>(() => {
-    if (flatten()) return [["", filtered()]]
+    if (flatten()) return filtered().length ? [["", filtered()]] : []
     const result = pipe(
       filtered(),
       groupBy((x) => x.category ?? ""),

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -87,6 +87,7 @@ async function mountSelect(
   initial: DialogSelectOption<string>[],
   current?: string,
   focusCurrent?: boolean,
+  select?: { flat?: boolean },
 ) {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
@@ -124,6 +125,7 @@ async function mountSelect(
             options={options()}
             current={current}
             focusCurrent={focusCurrent}
+            flat={select?.flat}
             onMove={(option) => moved.push(option.value)}
             onSelect={(option) => selected.push(option.value)}
           />
@@ -362,6 +364,34 @@ test("keeps the current option selected when options reorder", async () => {
     await select.app.waitFor(() => select.selected.length === 1)
 
     expect(select.selected).toEqual(["current"])
+  } finally {
+    select.app.renderer.destroy()
+  }
+})
+
+test("shows no-match and still closes after a flat filter goes empty", async () => {
+  await using tmp = await tmpdir()
+  const select = await mountSelect(
+    tmp.path,
+    [
+      { title: "models.dev", value: "models.dev", category: "Projects" },
+      { title: "opencode2", value: "opencode2", category: "Projects" },
+    ],
+    undefined,
+    undefined,
+    { flat: true },
+  )
+
+  try {
+    await select.app.waitForFrame((frame) => frame.includes("models.dev"))
+    await select.app.mockInput.typeText("models")
+    await select.app.waitForFrame((frame) => frame.includes("models.dev") && !frame.includes("opencode2"))
+    await select.app.mockInput.typeText(" missing")
+    await select.app.waitForFrame((frame) => frame.includes("No results found"))
+    expect(select.app.captureCharFrame()).not.toContain("models.dev")
+
+    select.app.mockInput.pressEscape()
+    await select.app.waitForFrame((frame) => !frame.includes("Mutable options") && !frame.includes("No results found"))
   } finally {
     select.app.renderer.destroy()
   }


### PR DESCRIPTION
## Summary

- When a flat picker filter (`/models`, command palette) went from some matches to none, `grouped()` returned `[[\"\", []]]` instead of `[]`.
- That mounted an empty scrollbox with `maxHeight={0}` instead of the no-match view, so the list vanished and the TUI stopped handling input.

## Test plan

- [x] `bun test test/cli/tui/dialog-select.test.tsx` from `packages/tui`
- [ ] Open `/models`, type until there are no matches, confirm \"No results found\" and that escape closes the dialog