### PR TITLE
fix(tui): keep model variant across new session

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -437,7 +437,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (!m) return
             if (route.data.type === "session") {
               setSessionDraft(route.data.sessionID, { ...m, variant: normalizeModelVariant(value) })
-              return
             }
             setPreferences("variant", modelPreferenceKey(m), normalizeModelVariant(value))
             savePreferences()


### PR DESCRIPTION
## What

Changing a model variant in a session, then `/new`, no longer resets the variant on home.

## How

Session `variant.set` was returning before writing `preferences.variant`, which is what home reads. Remove that early return.

## Testing

- `bun typecheck` from `packages/tui`