### PR TITLE
fix(compaction): respect agent variant config during compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -397,7 +397,7 @@ const layer = Layer.effect(
         sessionID: input.sessionID,
         mode: "compaction",
         agent: "compaction",
-        variant: userMessage.model.variant,
+        variant: agent.variant && model.variants?.[agent.variant] ? agent.variant : userMessage.model.variant,
         summary: true,
         path: {
           cwd: ctx.directory,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -222,6 +222,15 @@ function cfg(compaction?: ConfigV1.Info["compaction"]) {
   return Layer.succeed(Config.Service, TestConfig.make({ get: () => Effect.succeed({ ...base, compaction }) }))
 }
 
+function cfgAgent(agent?: ConfigV1.Info["agent"]) {
+  const base = Schema.decodeUnknownSync(ConfigV1.Info)({}) as ConfigV1.Info
+  return Layer.succeed(Config.Service, TestConfig.make({ get: () => Effect.succeed({ ...base, agent }) }))
+}
+
+function modelWithVariant(name: string): Provider.Model {
+  return { ...createModel({ context: 100_000, output: 32_000 }), variants: { [name]: {} } }
+}
+
 const defaultProvider = wide()
 const compactionTestNode = LayerNode.group([
   SessionCompaction.node,
@@ -1659,6 +1668,40 @@ describe("session.compaction.process", () => {
       expect(part?.type).toBe("compaction")
       expect(part?.tail_start_id).toBe(keep.id)
     }).pipe(withCompaction({ config: cfg({ tail_turns: 2, preserve_recent_tokens: 500 }) })),
+  )
+
+  itCompaction.instance(
+    "uses the compaction agent's configured variant for the summary message",
+    () => {
+      const variant = "no-thinking"
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const msg = yield* createUserMessage(session.id, "hello")
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+
+        yield* SessionCompaction.use.process({
+          parentID: msg.id,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        const summary = (yield* ssn.messages({ sessionID: session.id })).find(
+          (item) => item.info.role === "assistant" && item.info.summary,
+        )
+        expect(summary?.info.role).toBe("assistant")
+        if (summary?.info.role === "assistant") {
+          expect(summary.info.variant).toBe(variant)
+        }
+      }).pipe(
+        withCompaction({
+          provider: ProviderTest.fake({ model: modelWithVariant(variant) }),
+          config: cfgAgent({ compaction: { variant } }),
+        }),
+      )
+    },
+    { git: true },
   )
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #41578

### Type of change

- [x] Bug fix

### What does this PR do?

Setting `agent.compaction.variant` in config had no effect. When building the
compaction summary assistant message, `variant` was hardcoded to inherit from
the parent user message (`userMessage.model.variant`), ignoring the compaction
agent's configured variant — even though `agent.compaction.model` is already
honored a few lines above.

The fix resolves the variant from the compaction agent config when it is set and
valid for the resolved model, and otherwise falls back to the previous behavior:

```ts
variant: agent.variant && model.variants?.[agent.variant] ? agent.variant : userMessage.model.variant,
```

This mirrors how a normal turn resolves its variant in `session/prompt.ts`
(`ag.variant && full?.variants?.[ag.variant] ? ag.variant : ...`), and makes
`variant` consistent with the `model` override right above it. The fallback path
is unchanged, so sessions that do not configure a compaction variant behave
exactly as before.

### How did you verify your code works?

Added a unit test in `test/session/compaction.test.ts` that configures
`agent.compaction.variant` and asserts the compaction summary message uses it.

RED (before the fix):

```
expect(summary.info.variant).toBe("no-thinking")
Expected: "no-thinking"
Received: undefined
```

GREEN (after the fix): the whole `test/session/` suite passes — 406 pass, 0 fail
(baseline before this change: 405 pass). `bun run typecheck` for
`packages/opencode` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
