### PR TITLE
docs: Add opencode-openrouter-metadata entry to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-openrouter-metadata](https://github.com/Thermi/opencode-openrouter-metadata)             | Discovery models and metadata in openrouter format from inference endpoints |
 
 ---
 


### PR DESCRIPTION
Add https://github.com/Thermi/opencode-openrouter-metadata to Plugins table.

It is a plugin that discovers models and their metadata from a provider if specified in openrouter format. Useful if you are running a proxy between opencode and openrouter. Saves you from having to list models and their capabilities manually.

### Issue for this PR

#41606

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add a table row in the plugins list for https://github.com/Thermi/opencode-openrouter-metadata

### How did you verify your code works?

Inclusion via plugins array in opencode, verification openrouter information is filled into metadata table of ui and so on. Reasoning levels are visible without manual specification.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
