### PR TITLE
fix(question): reject empty questions array instead of hanging

### DIFF
--- a/packages/core/src/question.ts
+++ b/packages/core/src/question.ts
@@ -6,6 +6,8 @@ import { Question } from "@opencode-ai/schema/question"
 import { EventV2 } from "./event"
 import { SessionSchema } from "./session/schema"
 
+const EMPTY_QUESTIONS_ERROR = "QuestionV2.ask requires at least one question"
+
 export const ID = Question.ID
 export type ID = typeof ID.Type
 
@@ -91,22 +93,26 @@ const layer = Layer.effect(
     )
 
     const ask = Effect.fn("QuestionV2.ask")((input: AskInput) =>
-      Effect.uninterruptibleMask((restore) =>
-        Effect.gen(function* () {
-          const id = ID.ascending()
-          const deferred = yield* Deferred.make<ReadonlyArray<Answer>, RejectedError>()
-          const request: Request = { id, ...input }
-          pending.set(id, { request, deferred })
-          return yield* events.publish(Event.Asked, request).pipe(
-            Effect.andThen(restore(Deferred.await(deferred))),
-            Effect.ensuring(
-              Effect.sync(() => {
-                pending.delete(id)
-              }),
-            ),
-          )
-        }),
-      ),
+      // An empty questions array has nothing to render or answer; registering a
+      // pending request for it would wait forever. Reject it up front instead.
+      input.questions.length === 0
+        ? Effect.die(new Error(EMPTY_QUESTIONS_ERROR))
+        : Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const id = ID.ascending()
+              const deferred = yield* Deferred.make<ReadonlyArray<Answer>, RejectedError>()
+              const request: Request = { id, ...input }
+              pending.set(id, { request, deferred })
+              return yield* events.publish(Event.Asked, request).pipe(
+                Effect.andThen(restore(Deferred.await(deferred))),
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    pending.delete(id)
+                  }),
+                ),
+              )
+            }),
+          ),
     )
 
     const reply = Effect.fn("QuestionV2.reply")((input: ReplyInput) =>

--- a/packages/core/test/question.test.ts
+++ b/packages/core/test/question.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Context, Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
+import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -109,6 +109,16 @@ describe("QuestionV2", () => {
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit)) expect(exit.cause.toString()).toContain("QuestionV2.RejectedError")
       yield* Scope.close(secondScope, Exit.void)
+    }),
+  )
+
+  it.effect("fails fast when asked with no questions instead of registering a dead request", () =>
+    Effect.gen(function* () {
+      const service = yield* QuestionV2.Service
+      const exit = yield* service.ask({ sessionID, questions: [] }).pipe(Effect.timeout("1 second"), Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain("at least one question")
+      expect(yield* service.list()).toEqual([])
     }),
   )
 })

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -24,6 +24,8 @@ export const Replied = QuestionV1.Replied
 export const Rejected = QuestionV1.Rejected
 export const Event = QuestionV1.Event
 
+const EMPTY_QUESTIONS_ERROR = "Question.ask requires at least one question"
+
 export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("QuestionRejectedError", {}) {
   override get message() {
     return "The user dismissed this question"
@@ -89,6 +91,9 @@ const layer = Layer.effect(
       questions: ReadonlyArray<Info>
       tool?: Tool
     }) {
+      // An empty questions array has nothing to render or answer; registering a
+      // pending request for it would wait forever. Reject it up front instead.
+      if (input.questions.length === 0) return yield* Effect.die(new Error(EMPTY_QUESTIONS_ERROR))
       const pending = (yield* InstanceState.get(state)).pending
       const id = QuestionID.ascending()
       yield* Effect.logInfo("asking", { id, questions: input.questions.length })

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -119,6 +119,22 @@ it.instance(
   { git: true },
 )
 
+it.instance(
+  "ask - fails fast when questions is empty",
+  () =>
+    Effect.gen(function* () {
+      const exit = yield* askEffect({
+        sessionID: SessionID.make("ses_test"),
+        questions: [],
+      }).pipe(Effect.timeout("1 second"), Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain("at least one question")
+      // An empty ask must not register a never-resolving pending request.
+      expect(yield* listEffect).toHaveLength(0)
+    }),
+  { git: true },
+)
+
 // reply tests
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #41549

### Type of change

- [x] Bug fix

### What does this PR do?

The question tool accepted an empty `questions` array. `Question.ask` then
registered a pending request that had nothing to render or answer, so the
session waited indefinitely. This happened on both the v1 question tool and the
V2 core question tool, which share the same "register a pending deferred" shape.

The fix rejects an empty `questions` array up front, before a pending request is
registered, in both `Question.ask` (`packages/opencode/src/question/index.ts`)
and `QuestionV2.ask` (`packages/core/src/question.ts`). Both tool call sites
already `.pipe(Effect.orDie)` the result of `ask`, so failing here ends the turn
the same way a dismissed question already does — instead of hanging forever.

### How did you verify your code works?

Added a test at each `ask` layer that asks with an empty `questions` array,
bounds the call with a timeout, and asserts it fails fast (and registers no
pending request) rather than hanging:

- `packages/opencode/test/question/question.test.ts`
- `packages/core/test/question.test.ts`

RED (before the fix): the call hangs and only the timeout fires, so the failure
cause does not contain the guard message. GREEN (after the fix): it fails
immediately with `... requires at least one question`.

Local runs (baseline → with fix):

- `packages/opencode` question tests: 16 → 17 pass, 0 fail
- `packages/core` question tests: 7 → 8 pass, 0 fail
- `bun typecheck` for the `core` and `opencode` packages: pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
