### PR TITLE
fix(tui): collapse execute child details

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2455,6 +2455,7 @@ function InlineTool(props: {
   children: JSX.Element
   part: SessionMessageAssistantTool
   onClick?: () => void
+  onErrorClick?: () => void
 }) {
   const theme = useTheme()
   const renderer = useRenderer()
@@ -2503,6 +2504,7 @@ function InlineTool(props: {
         if (renderer.getSelection()?.getSelectedText()) return
         if (failed()) {
           setErrorExpanded((value) => !value)
+          props.onErrorClick?.()
           return
         }
         props.onClick?.()
@@ -3019,6 +3021,17 @@ function executeCalls(value: unknown): ExecuteCall[] {
   })
 }
 
+export function executeDisplay(value: unknown, expanded: boolean) {
+  if (!expanded) return "execute"
+  return [
+    "execute",
+    ...executeCalls(value).map((call) => {
+      const args = primitiveInputSummary(call.input ?? {})
+      return `↳ ${call.tool}${args ? ` ${args}` : ""}${call.status === "error" ? " (failed)" : ""}`
+    }),
+  ].join("\n")
+}
+
 // The `execute` tool streams child tool calls through metadata, not a child session like Task.
 function Execute(props: ToolProps) {
   const ctx = use()
@@ -3029,14 +3042,9 @@ function Execute(props: ToolProps) {
   const hasRuntimeError = createMemo(() => props.metadata.error === true || props.part.state.status === "error")
   const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
   const showOutput = createMemo(() => output() && hasRuntimeError())
-  const content = createMemo(() => {
-    const lines = ["execute"]
-    for (const call of calls()) {
-      const args = primitiveInputSummary(call.input ?? {})
-      lines.push(`↳ ${call.tool}${args ? ` ${args}` : ""}${call.status === "error" ? " (failed)" : ""}`)
-    }
-    return lines.join("\n")
-  })
+  const [expanded, setExpanded] = createSignal(false)
+  const expandable = createMemo(() => calls().length > 0 || Boolean(showOutput()))
+  const toggle = () => setExpanded((value) => !value)
 
   return (
     <>
@@ -3047,10 +3055,12 @@ function Execute(props: ToolProps) {
         pending="execute"
         complete={true}
         part={props.part}
+        onClick={expandable() ? toggle : undefined}
+        onErrorClick={expandable() ? toggle : undefined}
       >
-        {content()}
+        {executeDisplay(props.metadata.toolCalls, expanded())}
       </InlineTool>
-      <Show when={showOutput()}>
+      <Show when={expanded() && showOutput()}>
         <box paddingLeft={3}>
           <For each={outputPreview().split("\n")}>
             {(line, index) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3024,6 +3024,17 @@ export function executeCallSummary(call: ExecuteCall, last = false) {
   return `${last ? "└─" : "├─"} ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
 }
 
+function blendColor(from: RGBA, to: RGBA, amount: number) {
+  const start = from.toInts()
+  const end = to.toInts()
+  return RGBA.fromInts(
+    Math.round(start[0] + (end[0] - start[0]) * amount),
+    Math.round(start[1] + (end[1] - start[1]) * amount),
+    Math.round(start[2] + (end[2] - start[2]) * amount),
+    Math.round(start[3] + (end[3] - start[3]) * amount),
+  )
+}
+
 function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boolean }) {
   const theme = useTheme()
   const renderer = useRenderer()
@@ -3034,6 +3045,10 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
   const title = createMemo(
     () => `${props.last ? "└─" : "├─"} ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`,
   )
+  const connectorColor = (index: number) => {
+    if (!hover()) return theme.text.subdued
+    return blendColor(theme.text.default, theme.text.subdued, [0.35, 0.7, 1][Math.min(index, 2)] ?? 1)
+  }
 
   return (
     <box
@@ -3059,14 +3074,15 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
         {expanded() ? title() : executeCallSummary(props.call, props.last)}
       </text>
       <Show when={expanded()}>
-        <box
-          border={props.last ? undefined : ["left"]}
-          borderColor={theme.text.subdued}
-          paddingLeft={props.last ? 3 : 2}
-        >
+        <box>
           <For each={input()}>
-            {([key, value]) => (
-              <box flexDirection="row">
+            {([key, value], index) => (
+              <box
+                flexDirection="row"
+                border={props.last ? undefined : ["left"]}
+                borderColor={connectorColor(index())}
+                paddingLeft={props.last ? 3 : 2}
+              >
                 <text flexShrink={0} fg={theme.text.subdued}>
                   {key}:{" "}
                 </text>
@@ -3078,7 +3094,12 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
           </For>
           <Show when={props.error}>
             {(error) => (
-              <box flexDirection="row">
+              <box
+                flexDirection="row"
+                border={props.last ? undefined : ["left"]}
+                borderColor={connectorColor(input().length)}
+                paddingLeft={props.last ? 3 : 2}
+              >
                 <text flexShrink={0} fg={theme.text.feedback.error.default}>
                   error:{" "}
                 </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3034,11 +3034,10 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
   const title = createMemo(
     () => `${props.last ? "└─" : "├─"} ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`,
   )
-  const rail = createMemo(() => (props.last ? "   " : "│  "))
 
   return (
     <box
-      paddingLeft={6}
+      paddingLeft={3 + INLINE_TOOL_ICON_WIDTH}
       onMouseOver={() => expandable() && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
@@ -3060,13 +3059,14 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
         {expanded() ? title() : executeCallSummary(props.call, props.last)}
       </text>
       <Show when={expanded()}>
-        <box paddingLeft={2}>
+        <box
+          border={props.last ? undefined : ["left"]}
+          borderColor={theme.text.subdued}
+          paddingLeft={props.last ? 3 : 2}
+        >
           <For each={input()}>
             {([key, value]) => (
               <box flexDirection="row">
-                <text flexShrink={0} fg={theme.text.subdued}>
-                  {rail()}
-                </text>
                 <text flexShrink={0} fg={theme.text.subdued}>
                   {key}:{" "}
                 </text>
@@ -3079,9 +3079,6 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
           <Show when={props.error}>
             {(error) => (
               <box flexDirection="row">
-                <text flexShrink={0} fg={theme.text.feedback.error.default}>
-                  {rail()}
-                </text>
                 <text flexShrink={0} fg={theme.text.feedback.error.default}>
                   error:{" "}
                 </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -5,6 +5,7 @@ import {
   createMemo,
   createSignal,
   For,
+  Index,
   Match,
   on,
   onCleanup,
@@ -12,6 +13,7 @@ import {
   Show,
   Switch,
   useContext,
+  type Accessor,
 } from "solid-js"
 import path from "node:path"
 import { EOL, tmpdir } from "node:os"
@@ -3020,18 +3022,18 @@ function executeCalls(value: unknown): ExecuteCall[] {
 }
 
 export function executeCallSummary(call: ExecuteCall) {
-  const args = primitiveInputSummary(call.input ?? {})
+  const args = primitiveInputSummary(call.input ?? {}).replace(/\s+/g, " ")
   return `↳ ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
 }
 
-function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
+function ExecuteCallView(props: { call: Accessor<ExecuteCall> }) {
   const theme = useTheme()
   const renderer = useRenderer()
   const [expanded, setExpanded] = createSignal(false)
   const [hover, setHover] = createSignal(false)
-  const input = createMemo(() => Object.entries(props.call.input ?? {}))
-  const expandable = createMemo(() => input().length > 0 || Boolean(props.error))
-  const title = createMemo(() => `↳ ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`)
+  const input = createMemo(() => Object.entries(props.call().input ?? {}))
+  const expandable = createMemo(() => input().length > 0)
+  const title = createMemo(() => `↳ ${props.call().tool}${props.call().status === "error" ? " (failed)" : ""}`)
 
   return (
     <box
@@ -3047,14 +3049,14 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
         wrapMode="none"
         truncate
         fg={
-          props.call.status === "error"
+          props.call().status === "error"
             ? theme.text.feedback.error.default
             : hover()
               ? theme.text.default
               : theme.text.subdued
         }
       >
-        {expanded() ? title() : executeCallSummary(props.call)}
+        {expanded() ? title() : executeCallSummary(props.call())}
       </text>
       <Show when={expanded()}>
         <box paddingLeft={2}>
@@ -3070,18 +3072,6 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
               </box>
             )}
           </For>
-          <Show when={props.error}>
-            {(error) => (
-              <box flexDirection="row">
-                <text flexShrink={0} fg={theme.text.feedback.error.default}>
-                  error:{" "}
-                </text>
-                <text flexGrow={1} wrapMode="word" fg={theme.text.feedback.error.default}>
-                  {error()}
-                </text>
-              </box>
-            )}
-          </Show>
         </box>
       </Show>
     </box>
@@ -3111,10 +3101,8 @@ function Execute(props: ToolProps) {
       >
         execute
       </InlineTool>
-      <For each={calls()}>
-        {(call) => <ExecuteCallView call={call} error={call.status === "error" ? outputPreview() : undefined} />}
-      </For>
-      <Show when={calls().length === 0 && showOutput()}>
+      <Index each={calls()}>{(call) => <ExecuteCallView call={call} />}</Index>
+      <Show when={showOutput()}>
         <box paddingLeft={3}>
           <For each={outputPreview().split("\n")}>
             {(line, index) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3031,7 +3031,7 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
   const [hover, setHover] = createSignal(false)
   const input = createMemo(() => Object.entries(props.call.input ?? {}))
   const expandable = createMemo(() => input().length > 0 || Boolean(props.error))
-  const labelWidth = createMemo(() => Math.min(16, Math.max(8, ...input().map(([key]) => key.length + 2))))
+  const title = createMemo(() => `↳ ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`)
 
   return (
     <box
@@ -3054,15 +3054,15 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
               : theme.text.subdued
         }
       >
-        {executeCallSummary(props.call)}
+        {expanded() ? title() : executeCallSummary(props.call)}
       </text>
       <Show when={expanded()}>
-        <box paddingLeft={2} paddingTop={1} gap={1}>
+        <box paddingLeft={2} paddingTop={1}>
           <For each={input()}>
             {([key, value]) => (
               <box flexDirection="row">
-                <text width={labelWidth()} flexShrink={0} fg={theme.text.subdued}>
-                  {key}
+                <text flexShrink={0} fg={theme.text.subdued}>
+                  {key}:{" "}
                 </text>
                 <text flexGrow={1} wrapMode="word" fg={theme.text.default}>
                   {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
@@ -3073,8 +3073,8 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
           <Show when={props.error}>
             {(error) => (
               <box flexDirection="row">
-                <text width={labelWidth()} flexShrink={0} fg={theme.text.feedback.error.default}>
-                  error
+                <text flexShrink={0} fg={theme.text.feedback.error.default}>
+                  error:{" "}
                 </text>
                 <text flexGrow={1} wrapMode="word" fg={theme.text.feedback.error.default}>
                   {error()}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3019,36 +3019,19 @@ function executeCalls(value: unknown): ExecuteCall[] {
   })
 }
 
-export function executeCallSummary(call: ExecuteCall, last = false) {
+export function executeCallSummary(call: ExecuteCall) {
   const args = primitiveInputSummary(call.input ?? {})
-  return `${last ? "└─" : "├─"} ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
+  return `↳ ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
 }
 
-function blendColor(from: RGBA, to: RGBA, amount: number) {
-  const start = from.toInts()
-  const end = to.toInts()
-  return RGBA.fromInts(
-    Math.round(start[0] + (end[0] - start[0]) * amount),
-    Math.round(start[1] + (end[1] - start[1]) * amount),
-    Math.round(start[2] + (end[2] - start[2]) * amount),
-    Math.round(start[3] + (end[3] - start[3]) * amount),
-  )
-}
-
-function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boolean }) {
+function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
   const theme = useTheme()
   const renderer = useRenderer()
   const [expanded, setExpanded] = createSignal(false)
   const [hover, setHover] = createSignal(false)
   const input = createMemo(() => Object.entries(props.call.input ?? {}))
   const expandable = createMemo(() => input().length > 0 || Boolean(props.error))
-  const title = createMemo(
-    () => `${props.last ? "└─" : "├─"} ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`,
-  )
-  const connectorColor = (index: number) => {
-    if (!hover()) return theme.text.subdued
-    return blendColor(theme.text.default, theme.text.subdued, [0.35, 0.7, 1][Math.min(index, 2)] ?? 1)
-  }
+  const title = createMemo(() => `↳ ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`)
 
   return (
     <box
@@ -3071,18 +3054,13 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
               : theme.text.subdued
         }
       >
-        {expanded() ? title() : executeCallSummary(props.call, props.last)}
+        {expanded() ? title() : executeCallSummary(props.call)}
       </text>
       <Show when={expanded()}>
-        <box>
+        <box paddingLeft={2}>
           <For each={input()}>
-            {([key, value], index) => (
-              <box
-                flexDirection="row"
-                border={props.last ? undefined : ["left"]}
-                borderColor={connectorColor(index())}
-                paddingLeft={props.last ? 3 : 2}
-              >
+            {([key, value]) => (
+              <box flexDirection="row">
                 <text flexShrink={0} fg={theme.text.subdued}>
                   {key}:{" "}
                 </text>
@@ -3094,12 +3072,7 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boole
           </For>
           <Show when={props.error}>
             {(error) => (
-              <box
-                flexDirection="row"
-                border={props.last ? undefined : ["left"]}
-                borderColor={connectorColor(input().length)}
-                paddingLeft={props.last ? 3 : 2}
-              >
+              <box flexDirection="row">
                 <text flexShrink={0} fg={theme.text.feedback.error.default}>
                   error:{" "}
                 </text>
@@ -3139,13 +3112,7 @@ function Execute(props: ToolProps) {
         execute
       </InlineTool>
       <For each={calls()}>
-        {(call, index) => (
-          <ExecuteCallView
-            call={call}
-            error={call.status === "error" ? outputPreview() : undefined}
-            last={index() === calls().length - 1}
-          />
-        )}
+        {(call) => <ExecuteCallView call={call} error={call.status === "error" ? outputPreview() : undefined} />}
       </For>
       <Show when={calls().length === 0 && showOutput()}>
         <box paddingLeft={3}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2455,7 +2455,6 @@ function InlineTool(props: {
   children: JSX.Element
   part: SessionMessageAssistantTool
   onClick?: () => void
-  onErrorClick?: () => void
 }) {
   const theme = useTheme()
   const renderer = useRenderer()
@@ -2504,7 +2503,6 @@ function InlineTool(props: {
         if (renderer.getSelection()?.getSelectedText()) return
         if (failed()) {
           setErrorExpanded((value) => !value)
-          props.onErrorClick?.()
           return
         }
         props.onClick?.()
@@ -3021,15 +3019,73 @@ function executeCalls(value: unknown): ExecuteCall[] {
   })
 }
 
-export function executeDisplay(value: unknown, expanded: boolean) {
-  if (!expanded) return "execute"
-  return [
-    "execute",
-    ...executeCalls(value).map((call) => {
-      const args = primitiveInputSummary(call.input ?? {})
-      return `↳ ${call.tool}${args ? ` ${args}` : ""}${call.status === "error" ? " (failed)" : ""}`
-    }),
-  ].join("\n")
+export function executeCallSummary(call: ExecuteCall) {
+  const args = primitiveInputSummary(call.input ?? {})
+  return `↳ ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
+}
+
+function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
+  const theme = useTheme()
+  const renderer = useRenderer()
+  const [expanded, setExpanded] = createSignal(false)
+  const [hover, setHover] = createSignal(false)
+  const input = createMemo(() => Object.entries(props.call.input ?? {}))
+  const expandable = createMemo(() => input().length > 0 || Boolean(props.error))
+  const labelWidth = createMemo(() => Math.min(16, Math.max(8, ...input().map(([key]) => key.length + 2))))
+
+  return (
+    <box
+      paddingLeft={6}
+      onMouseOver={() => expandable() && setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={() => {
+        if (!expandable() || renderer.getSelection()?.getSelectedText()) return
+        setExpanded((value) => !value)
+      }}
+    >
+      <text
+        wrapMode="none"
+        truncate
+        fg={
+          props.call.status === "error"
+            ? theme.text.feedback.error.default
+            : hover()
+              ? theme.text.default
+              : theme.text.subdued
+        }
+      >
+        {executeCallSummary(props.call)}
+      </text>
+      <Show when={expanded()}>
+        <box paddingLeft={2} paddingTop={1} gap={1}>
+          <For each={input()}>
+            {([key, value]) => (
+              <box flexDirection="row">
+                <text width={labelWidth()} flexShrink={0} fg={theme.text.subdued}>
+                  {key}
+                </text>
+                <text flexGrow={1} wrapMode="word" fg={theme.text.default}>
+                  {typeof value === "string" ? value : JSON.stringify(value, null, 2)}
+                </text>
+              </box>
+            )}
+          </For>
+          <Show when={props.error}>
+            {(error) => (
+              <box flexDirection="row">
+                <text width={labelWidth()} flexShrink={0} fg={theme.text.feedback.error.default}>
+                  error
+                </text>
+                <text flexGrow={1} wrapMode="word" fg={theme.text.feedback.error.default}>
+                  {error()}
+                </text>
+              </box>
+            )}
+          </Show>
+        </box>
+      </Show>
+    </box>
+  )
 }
 
 // The `execute` tool streams child tool calls through metadata, not a child session like Task.
@@ -3042,9 +3098,6 @@ function Execute(props: ToolProps) {
   const hasRuntimeError = createMemo(() => props.metadata.error === true || props.part.state.status === "error")
   const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
   const showOutput = createMemo(() => output() && hasRuntimeError())
-  const [expanded, setExpanded] = createSignal(false)
-  const expandable = createMemo(() => calls().length > 0 || Boolean(showOutput()))
-  const toggle = () => setExpanded((value) => !value)
 
   return (
     <>
@@ -3055,12 +3108,13 @@ function Execute(props: ToolProps) {
         pending="execute"
         complete={true}
         part={props.part}
-        onClick={expandable() ? toggle : undefined}
-        onErrorClick={expandable() ? toggle : undefined}
       >
-        {executeDisplay(props.metadata.toolCalls, expanded())}
+        execute
       </InlineTool>
-      <Show when={expanded() && showOutput()}>
+      <For each={calls()}>
+        {(call) => <ExecuteCallView call={call} error={call.status === "error" ? outputPreview() : undefined} />}
+      </For>
+      <Show when={calls().length === 0 && showOutput()}>
         <box paddingLeft={3}>
           <For each={outputPreview().split("\n")}>
             {(line, index) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3019,19 +3019,22 @@ function executeCalls(value: unknown): ExecuteCall[] {
   })
 }
 
-export function executeCallSummary(call: ExecuteCall) {
+export function executeCallSummary(call: ExecuteCall, last = false) {
   const args = primitiveInputSummary(call.input ?? {})
-  return `↳ ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
+  return `${last ? "└─" : "├─"} ${call.tool}${call.status === "error" ? " (failed)" : ""}${args ? ` ${args}` : ""}`
 }
 
-function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
+function ExecuteCallView(props: { call: ExecuteCall; error?: string; last: boolean }) {
   const theme = useTheme()
   const renderer = useRenderer()
   const [expanded, setExpanded] = createSignal(false)
   const [hover, setHover] = createSignal(false)
   const input = createMemo(() => Object.entries(props.call.input ?? {}))
   const expandable = createMemo(() => input().length > 0 || Boolean(props.error))
-  const title = createMemo(() => `↳ ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`)
+  const title = createMemo(
+    () => `${props.last ? "└─" : "├─"} ${props.call.tool}${props.call.status === "error" ? " (failed)" : ""}`,
+  )
+  const rail = createMemo(() => (props.last ? "   " : "│  "))
 
   return (
     <box
@@ -3054,13 +3057,16 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
               : theme.text.subdued
         }
       >
-        {expanded() ? title() : executeCallSummary(props.call)}
+        {expanded() ? title() : executeCallSummary(props.call, props.last)}
       </text>
       <Show when={expanded()}>
         <box paddingLeft={2}>
           <For each={input()}>
             {([key, value]) => (
               <box flexDirection="row">
+                <text flexShrink={0} fg={theme.text.subdued}>
+                  {rail()}
+                </text>
                 <text flexShrink={0} fg={theme.text.subdued}>
                   {key}:{" "}
                 </text>
@@ -3073,6 +3079,9 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
           <Show when={props.error}>
             {(error) => (
               <box flexDirection="row">
+                <text flexShrink={0} fg={theme.text.feedback.error.default}>
+                  {rail()}
+                </text>
                 <text flexShrink={0} fg={theme.text.feedback.error.default}>
                   error:{" "}
                 </text>
@@ -3112,7 +3121,13 @@ function Execute(props: ToolProps) {
         execute
       </InlineTool>
       <For each={calls()}>
-        {(call) => <ExecuteCallView call={call} error={call.status === "error" ? outputPreview() : undefined} />}
+        {(call, index) => (
+          <ExecuteCallView
+            call={call}
+            error={call.status === "error" ? outputPreview() : undefined}
+            last={index() === calls().length - 1}
+          />
+        )}
       </For>
       <Show when={calls().length === 0 && showOutput()}>
         <box paddingLeft={3}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -3057,7 +3057,7 @@ function ExecuteCallView(props: { call: ExecuteCall; error?: string }) {
         {expanded() ? title() : executeCallSummary(props.call)}
       </text>
       <Show when={expanded()}>
-        <box paddingLeft={2} paddingTop={1}>
+        <box paddingLeft={2}>
           <For each={input()}>
             {([key, value]) => (
               <box flexDirection="row">

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -3,7 +3,7 @@ import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   InlineToolRow,
-  executeDisplay,
+  executeCallSummary,
   isBackgroundSubagent,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -183,15 +183,16 @@ describe("TUI inline tool wrapping", () => {
     expect(parseQuestionAnswers({})).toBeUndefined()
   })
 
-  test("collapses execute calls until expanded", () => {
-    const calls = [
-      { tool: "session.prompt", status: "completed", input: { sessionID: "ses_example", notify: true } },
-      { tool: "session.get", status: "error", input: { nested: { hidden: true } } },
-    ]
-
-    expect(executeDisplay(calls, false)).toBe("execute")
-    expect(executeDisplay(calls, true)).toBe(
-      "execute\n↳ session.prompt [sessionID=ses_example, notify=true]\n↳ session.get (failed)",
+  test("summarizes execute calls on one line", () => {
+    expect(
+      executeCallSummary({
+        tool: "session.prompt",
+        status: "completed",
+        input: { sessionID: "ses_example", notify: true },
+      }),
+    ).toBe("↳ session.prompt [sessionID=ses_example, notify=true]")
+    expect(executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } })).toBe(
+      "↳ session.get (failed)",
     )
   })
 

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -194,6 +194,9 @@ describe("TUI inline tool wrapping", () => {
     expect(executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } })).toBe(
       "↳ session.get (failed)",
     )
+    expect(
+      executeCallSummary({ tool: "session.prompt", status: "completed", input: { text: "first line\nsecond line" } }),
+    ).toBe("↳ session.prompt [text=first line second line]")
   })
 
   test("ignores diagnostics with malformed nested ranges", () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -190,10 +190,10 @@ describe("TUI inline tool wrapping", () => {
         status: "completed",
         input: { sessionID: "ses_example", notify: true },
       }),
-    ).toBe("↳ session.prompt [sessionID=ses_example, notify=true]")
-    expect(executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } })).toBe(
-      "↳ session.get (failed)",
-    )
+    ).toBe("├─ session.prompt [sessionID=ses_example, notify=true]")
+    expect(
+      executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } }, true),
+    ).toBe("└─ session.get (failed)")
   })
 
   test("ignores diagnostics with malformed nested ranges", () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -190,10 +190,10 @@ describe("TUI inline tool wrapping", () => {
         status: "completed",
         input: { sessionID: "ses_example", notify: true },
       }),
-    ).toBe("├─ session.prompt [sessionID=ses_example, notify=true]")
-    expect(
-      executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } }, true),
-    ).toBe("└─ session.get (failed)")
+    ).toBe("↳ session.prompt [sessionID=ses_example, notify=true]")
+    expect(executeCallSummary({ tool: "session.get", status: "error", input: { nested: { hidden: true } } })).toBe(
+      "↳ session.get (failed)",
+    )
   })
 
   test("ignores diagnostics with malformed nested ranges", () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -3,6 +3,7 @@ import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   InlineToolRow,
+  executeDisplay,
   isBackgroundSubagent,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -180,6 +181,18 @@ describe("TUI inline tool wrapping", () => {
     expect(parseQuestions([{}, { question: 1 }, { question: "Continue?" }])).toEqual([{ question: "Continue?" }])
     expect(parseQuestionAnswers([null, ["yes", 1], "no"])).toEqual([[], ["yes"], []])
     expect(parseQuestionAnswers({})).toBeUndefined()
+  })
+
+  test("collapses execute calls until expanded", () => {
+    const calls = [
+      { tool: "session.prompt", status: "completed", input: { sessionID: "ses_example", notify: true } },
+      { tool: "session.get", status: "error", input: { nested: { hidden: true } } },
+    ]
+
+    expect(executeDisplay(calls, false)).toBe("execute")
+    expect(executeDisplay(calls, true)).toBe(
+      "execute\n↳ session.prompt [sessionID=ses_example, notify=true]\n↳ session.get (failed)",
+    )
   })
 
   test("ignores diagnostics with malformed nested ranges", () => {


### PR DESCRIPTION
## What

Keep every Code Mode `execute` child visible while constraining each child to one terminal line by default. Clicking an individual child reveals its full input and error details inline; clicking again collapses only that child.

## Before / After

**Before:** long child inputs wrapped across many lines, so a single `session.prompt` or similar call could occupy most of the session timeline.

**After:** every child remains visible as a truncated one-line summary. Children expand independently, so inspecting one call does not hide or expand its siblings.

## How

- `packages/tui/src/routes/session/index.tsx` renders each nested call through an independently stateful `ExecuteCallView`.
- Collapsed labels use the existing `↳` child icon aligned with the first letter of `execute`, while preserving tool name, failure status, and whitespace-normalized primitive input summaries with terminal truncation.
- Expanded rows replace the bracketed summary with compact `key: value` fields aligned with the child tool name and associate runtime error output with failed children.
- Execute-level errors without child calls retain the existing fallback presentation.
- `packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx` covers compact child summaries and failed status labels.

## Scope

This changes only nested Code Mode `execute` presentation. It does not change execution, metadata, child ordering, or other inline tools.

## Testing

- `bun run test` from `packages/tui`: 619 passed, 5 skipped
- `bun typecheck` from `packages/tui`
- Push hook workspace typecheck: 33 packages passed
- OpenCode Drive scripted run with a real local MCP server: verified multiline input compaction, multi-parameter expansion, expansion persistence across sibling metadata updates, and second-click collapse

## Demo

OpenCode Drive simulated model executing `demo.lookup` and `demo.summarize` through a real local MCP server.

https://github.com/user-attachments/assets/7ff223c3-2df5-4b3a-8e89-199827e6f36e

**Collapsed children**

![execute-children-collapsed.png](https://github.com/user-attachments/assets/92c170ee-4649-4ed4-9736-98f8bdae4959)

**One child expanded**

![execute-child-expanded.png](https://github.com/user-attachments/assets/324c2dcd-61a7-4040-86f6-934d2e7f868b)
