### PR TITLE
fix(app): wire desktop menu accelerators to renderer commands

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -39,6 +39,7 @@ import {
 import { Dynamic } from "solid-js/web"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { CommandProvider, useCommand, type CommandOption } from "@/context/command"
+import { desktopMenuAcceleratorKeybind, desktopMenuActionBinds } from "@/desktop-menu"
 import { CommentsProvider } from "@/context/comments"
 import { FileProvider } from "@/context/file"
 import { ServerSDKProvider } from "@/context/server-sdk"
@@ -329,15 +330,30 @@ function DesktopCommands() {
 
   command.register("desktop", () => {
     const commands: CommandOption[] = []
-    if (platform.platform === "desktop" && platform.exportDebugLogs) {
-      commands.push({
-        id: "logs.export",
-        title: language.t("command.logs.export"),
-        category: language.t("command.category.settings"),
-        onSelect: () => {
-          void platform.exportDebugLogs?.()
-        },
-      })
+    if (platform.platform === "desktop") {
+      if (platform.exportDebugLogs) {
+        commands.push({
+          id: "logs.export",
+          title: language.t("command.logs.export"),
+          category: language.t("command.category.settings"),
+          onSelect: () => {
+            void platform.exportDebugLogs?.()
+          },
+        })
+      }
+      if (platform.os === "windows" || platform.os === "linux") {
+        for (const bind of desktopMenuActionBinds("windows")) {
+          commands.push({
+            id: bind.action,
+            title: bind.labelKey ? language.t(bind.labelKey) : bind.action,
+            keybind: desktopMenuAcceleratorKeybind(bind.accelerator),
+            hidden: true,
+            onSelect: () => {
+              void platform.runDesktopMenuAction?.(bind.action)
+            },
+          })
+        }
+      }
     }
     return commands
   })

--- a/packages/app/src/desktop-menu.test.ts
+++ b/packages/app/src/desktop-menu.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { DESKTOP_MENU } from "./desktop-menu"
+import { matchKeybind, parseKeybind } from "./context/command"
+import {
+  DESKTOP_MENU,
+  desktopMenuAcceleratorKeybind,
+  desktopMenuActionBinds,
+} from "./desktop-menu"
 
 describe("desktop menu", () => {
   test("exports logs through the desktop command registry", () => {
@@ -20,4 +25,35 @@ describe("desktop menu", () => {
     expect(windowMenu?.labelKey).toBe("desktop.menu.window")
     expect(roleItems.length).toBeGreaterThan(0)
   })
+
+  test("desktopMenuActionBinds exposes action accelerators for the in-app menu", () => {
+    const binds = desktopMenuActionBinds("windows")
+
+    expect(binds.map((bind) => bind.action)).toContain("window.new")
+    expect(binds.find((bind) => bind.action === "window.new")?.accelerator).toBe("Ctrl+Shift+N")
+    expect(binds.find((bind) => bind.action === "view.zoomIn")).toBeUndefined()
+  })
+
+  test("desktopMenuAcceleratorKeybind feeds the command keybind matcher", () => {
+    const bind = desktopMenuActionBinds("windows").find((entry) => entry.action === "window.new")
+    expect(bind).toBeDefined()
+
+    const keybind = desktopMenuAcceleratorKeybind(bind!.accelerator)
+    expect(keybind).toBe("ctrl+shift+n")
+    expect(
+      matchKeybind(keybinds(keybind), new KeyboardEvent("keydown", { key: "n", ctrlKey: true, shiftKey: true })),
+    ).toBe(true)
+    expect(matchKeybind(keybinds(keybind), new KeyboardEvent("keydown", { key: "n", ctrlKey: true }))).toBe(false)
+  })
+
+  test("desktopMenuAcceleratorKeybind normalizes punctuation and aliases", () => {
+    expect(desktopMenuAcceleratorKeybind("Ctrl+,")).toBe("ctrl+comma")
+    expect(desktopMenuAcceleratorKeybind("Cmd+Shift+N")).toBe("mod+shift+n")
+    expect(desktopMenuAcceleratorKeybind("Cmd+Option+Up")).toBe("mod+alt+up")
+    expect(desktopMenuAcceleratorKeybind("Ctrl+`")).toBe("ctrl+`")
+  })
 })
+
+function keybinds(config: string) {
+  return parseKeybind(config)
+}

--- a/packages/app/src/desktop-menu.ts
+++ b/packages/app/src/desktop-menu.ts
@@ -300,3 +300,39 @@ export const DESKTOP_MENU: DesktopMenu[] = [
 export function desktopMenuVisible(item: { platforms?: DesktopMenuPlatform[] }, platform: DesktopMenuPlatform) {
   return !item.platforms || item.platforms.includes(platform)
 }
+
+// Desktop variants (windows/linux) render the menu in-app instead of a native
+// menu, so their accelerators must be wired to actions in the renderer.
+export function desktopMenuActionBinds(platform: DesktopMenuPlatform) {
+  const binds: { action: DesktopMenuAction; accelerator: string; labelKey?: DesktopNativeKey }[] = []
+
+  for (const menu of DESKTOP_MENU) {
+    for (const entry of menu.items ?? []) {
+      if (entry.type !== "item" || entry.role || !entry.action) continue
+      if (!desktopMenuVisible(entry, platform)) continue
+      const accelerator = entry.accelerator?.[platform]
+      if (!accelerator) continue
+      binds.push({ action: entry.action, accelerator, labelKey: entry.labelKey })
+    }
+  }
+
+  return binds
+}
+
+// Converts an Electron accelerator ("Ctrl+Shift+N") into the keybind config
+// syntax understood by the renderer command system ("ctrl+shift+n").
+export function desktopMenuAcceleratorKeybind(accelerator: string) {
+  return accelerator
+    .split("+")
+    .map((part) => {
+      const token = part.toLowerCase()
+      if (token === "command" || token === "cmd" || token === "cmdorctrl") return "mod"
+      if (token === "option") return "alt"
+      if (token === "control") return "ctrl"
+      if (token === ",") return "comma"
+      if (token === "+") return "plus"
+      if (token === " ") return "space"
+      return token
+    })
+    .join("+")
+}


### PR DESCRIPTION
### Issue for this PR

Closes #41592

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows/Linux the desktop app renders the Window/View menus in-app instead of using a native Electron menu. The accelerators declared on those menu items (e.g. Ctrl+Shift+N) therefore never reached a handler, so the shortcuts did nothing. Only macOS worked, because it builds a real native menu from the same template.

The fix registers the in-app menu's per-platform accelerators as hidden renderer commands for the `windows` and `linux` platforms. Each keypress dispatches through `platform.runDesktopMenuAction()` into the existing desktop IPC path - the same code path the in-app menu already uses when an item is clicked. Accelerator strings are normalized to the renderer keybind syntax (`Ctrl+Shift+N` -> `ctrl+shift+n`; `Cmd`/`Option` -> `mod`/`alt`; `,` -> `comma`).

### How did you verify your code works?

- Unit tests in `desktop-menu.test.ts` cover binds discovery, keybind matching, and accelerator normalization (all passing).
- `bun typecheck` and `bun test desktop-menu.test.ts` pass in `packages/app`.
- Built and verified locally on Linux: `Ctrl+Shift+N` opens a new window, and the same renderer path covers Windows.

### Screenshots / recordings

N/A - keyboard-shortcut handling change; verified via manual keypress testing rather than a recording.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
