### PR TITLE
refactor(core): move instruction discovery to the config side

### DIFF
--- a/packages/core/src/config/plugin/instruction.ts
+++ b/packages/core/src/config/plugin/instruction.ts
@@ -1,0 +1,118 @@
+export * as ConfigInstructionPlugin from "./instruction"
+
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Global } from "@opencode-ai/util/global"
+import { isAbsolute, join, relative, sep } from "path"
+import { Effect, PubSub, Semaphore, Stream } from "effect"
+import { Watcher } from "../../filesystem/watcher"
+import { InstructionDiscovery } from "../../instruction-discovery"
+import { Instructions } from "../../instructions/index"
+import { Location } from "../../location"
+import { AbsolutePath } from "../../schema"
+
+export const Plugin = define({
+  id: "opencode.config.instruction",
+  effect: Effect.fn(function* () {
+    const discovery = yield* InstructionDiscovery.Service
+    yield* Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const global = yield* Global.Service
+      const location = yield* Location.Service
+      const watcher = yield* Watcher.Service
+      const changes = yield* PubSub.sliding<string>(1)
+      const lock = Semaphore.makeUnsafe(1)
+      const start = yield* fs.resolve(location.directory)
+      const stop = yield* fs.resolve(location.project.directory)
+      const fromProject = relative(stop, start)
+      const insideProject =
+        fromProject === "" || (fromProject !== ".." && !fromProject.startsWith(`..${sep}`) && !isAbsolute(fromProject))
+      const project = discovery.project && insideProject
+      const globalFile = yield* fs.resolve(join(global.config, "AGENTS.md"))
+      const loaded: { files: InstructionDiscovery.File[] | Instructions.Unavailable } = { files: [] }
+
+      const publish = (update: Watcher.Update) => PubSub.publish(changes, update.path).pipe(Effect.asVoid)
+      const globalUpdates = yield* watcher.subscribe({ path: globalFile, type: "file" })
+      yield* globalUpdates.pipe(Stream.runForEach(publish), Effect.forkScoped({ startImmediately: true }))
+      if (project) {
+        const projectUpdates = yield* watcher.subscribe({ path: stop, type: "directory" })
+        yield* projectUpdates.pipe(
+          Stream.filter((update) => FSUtil.contains(stop, update.path) && update.path.endsWith(`${sep}AGENTS.md`)),
+          Stream.runForEach(publish),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+      }
+
+      const read = Effect.fn("ConfigInstructionPlugin.read")(function* (path: string, required: boolean) {
+        const content = yield* fs.readFileStringSafe(path)
+        if (content !== undefined) return new InstructionDiscovery.File({ path: AbsolutePath.make(path), content })
+        yield* Effect.logDebug("instruction file skipped", { path, reason: "missing" })
+        if (required) return Instructions.unavailable
+      })
+
+      const globalSource = Effect.fn("ConfigInstructionPlugin.globalSource")(function* () {
+        const file = yield* read(globalFile, false)
+        return file instanceof InstructionDiscovery.File ? [file] : []
+      })
+
+      const projectSource = Effect.fn("ConfigInstructionPlugin.projectSource")(function* () {
+        if (!project) return []
+        const discovered = new Set(
+          yield* Effect.forEach(yield* fs.up({ targets: ["AGENTS.md"], start, stop }), fs.resolve),
+        )
+        const files = yield* Effect.forEach(discovered, (path) => read(path, true), { concurrency: "unbounded" })
+        if (files.some((file) => file === Instructions.unavailable)) return Instructions.unavailable
+        return files.filter((file): file is InstructionDiscovery.File => file !== undefined)
+      })
+
+      const isolate = <A, E, R>(source: string, effect: Effect.Effect<A, E, R>) =>
+        effect.pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to load instruction source", { source, cause }).pipe(
+              Effect.as(Instructions.unavailable),
+            ),
+          ),
+        )
+
+      const refresh = Effect.fn("ConfigInstructionPlugin.refresh")(function* (file?: string) {
+        yield* lock.withPermit(
+          Effect.gen(function* () {
+            const sources = yield* Effect.all({
+              global: isolate("global", globalSource()),
+              project: isolate("project", projectSource()),
+            })
+            loaded.files =
+              Array.isArray(sources.global) && Array.isArray(sources.project)
+                ? [...sources.global, ...sources.project]
+                : Instructions.unavailable
+            if (!file) return
+            yield* Effect.logInfo("instructions rescanned", {
+              file,
+              instructions: Array.isArray(loaded.files) ? loaded.files.map((item) => item.path) : "unavailable",
+            })
+          }),
+        )
+      })
+
+      yield* Stream.fromPubSub(changes).pipe(
+        Stream.runForEach((file) => refresh(file).pipe(Effect.andThen(discovery.reload()))),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      yield* refresh()
+      yield* discovery.transform((draft) => {
+        if (!Array.isArray(loaded.files)) {
+          draft.unavailable()
+          return
+        }
+        for (const file of loaded.files) draft.add(file)
+      })
+    }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to activate instruction source", { cause }).pipe(
+          Effect.andThen(discovery.transform((draft) => draft.unavailable())),
+          Effect.asVoid,
+        ),
+      ),
+    )
+  }),
+})

--- a/packages/core/src/config/plugin/instruction.ts
+++ b/packages/core/src/config/plugin/instruction.ts
@@ -3,13 +3,17 @@ export * as ConfigInstructionPlugin from "./instruction"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
-import { isAbsolute, join, relative, sep } from "path"
+import { dirname, join } from "path"
 import { Effect, PubSub, Semaphore, Stream } from "effect"
 import { Watcher } from "../../filesystem/watcher"
 import { InstructionDiscovery } from "../../instruction-discovery"
 import { Instructions } from "../../instructions/index"
 import { Location } from "../../location"
 import { AbsolutePath } from "../../schema"
+
+type Loaded =
+  | { readonly type: "available"; readonly files: InstructionDiscovery.File[] }
+  | { readonly type: "unavailable" }
 
 export const Plugin = define({
   id: "opencode.config.instruction",
@@ -24,35 +28,29 @@ export const Plugin = define({
       const lock = Semaphore.makeUnsafe(1)
       const start = yield* fs.resolve(location.directory)
       const stop = yield* fs.resolve(location.project.directory)
-      const fromProject = relative(stop, start)
-      const insideProject =
-        fromProject === "" || (fromProject !== ".." && !fromProject.startsWith(`..${sep}`) && !isAbsolute(fromProject))
-      const project = discovery.project && insideProject
+      const project = discovery.project && FSUtil.contains(stop, start)
       const globalFile = yield* fs.resolve(join(global.config, "AGENTS.md"))
-      const loaded: { files: InstructionDiscovery.File[] | Instructions.Unavailable } = { files: [] }
+      const loaded: { current: Loaded } = { current: { type: "available", files: [] } }
 
       const publish = (update: Watcher.Update) => PubSub.publish(changes, update.path).pipe(Effect.asVoid)
-      const globalUpdates = yield* watcher.subscribe({ path: globalFile, type: "file" })
-      yield* globalUpdates.pipe(Stream.runForEach(publish), Effect.forkScoped({ startImmediately: true }))
-      if (project) {
-        const projectUpdates = yield* watcher.subscribe({ path: stop, type: "directory" })
-        yield* projectUpdates.pipe(
-          Stream.filter((update) => FSUtil.contains(stop, update.path) && update.path.endsWith(`${sep}AGENTS.md`)),
-          Stream.runForEach(publish),
-          Effect.forkScoped({ startImmediately: true }),
-        )
+      const candidates = [
+        globalFile,
+        ...(project ? ancestorDirectories(start, stop).map((directory) => join(directory, "AGENTS.md")) : []),
+      ]
+      for (const path of new Set(candidates)) {
+        const updates = yield* watcher.subscribe({ path, type: "file" })
+        yield* updates.pipe(Stream.runForEach(publish), Effect.forkScoped({ startImmediately: true }))
       }
 
-      const read = Effect.fn("ConfigInstructionPlugin.read")(function* (path: string, required: boolean) {
+      const read = Effect.fn("ConfigInstructionPlugin.read")(function* (path: string) {
         const content = yield* fs.readFileStringSafe(path)
         if (content !== undefined) return new InstructionDiscovery.File({ path: AbsolutePath.make(path), content })
-        yield* Effect.logDebug("instruction file skipped", { path, reason: "missing" })
-        if (required) return Instructions.unavailable
+        yield* Effect.logDebug("instruction file skipped", { path, reason: "unavailable" })
       })
 
       const globalSource = Effect.fn("ConfigInstructionPlugin.globalSource")(function* () {
-        const file = yield* read(globalFile, false)
-        return file instanceof InstructionDiscovery.File ? [file] : []
+        const file = yield* read(globalFile)
+        return file ? [file] : []
       })
 
       const projectSource = Effect.fn("ConfigInstructionPlugin.projectSource")(function* () {
@@ -60,8 +58,8 @@ export const Plugin = define({
         const discovered = new Set(
           yield* Effect.forEach(yield* fs.up({ targets: ["AGENTS.md"], start, stop }), fs.resolve),
         )
-        const files = yield* Effect.forEach(discovered, (path) => read(path, true), { concurrency: "unbounded" })
-        if (files.some((file) => file === Instructions.unavailable)) return Instructions.unavailable
+        const files = yield* Effect.forEach(discovered, read, { concurrency: "unbounded" })
+        if (files.some((file) => file === undefined)) return Instructions.unavailable
         return files.filter((file): file is InstructionDiscovery.File => file !== undefined)
       })
 
@@ -81,14 +79,15 @@ export const Plugin = define({
               global: isolate("global", globalSource()),
               project: isolate("project", projectSource()),
             })
-            loaded.files =
+            loaded.current =
               Array.isArray(sources.global) && Array.isArray(sources.project)
-                ? [...sources.global, ...sources.project]
-                : Instructions.unavailable
+                ? { type: "available", files: [...sources.global, ...sources.project] }
+                : { type: "unavailable" }
             if (!file) return
             yield* Effect.logInfo("instructions rescanned", {
               file,
-              instructions: Array.isArray(loaded.files) ? loaded.files.map((item) => item.path) : "unavailable",
+              instructions:
+                loaded.current.type === "available" ? loaded.current.files.map((item) => item.path) : "unavailable",
             })
           }),
         )
@@ -100,11 +99,11 @@ export const Plugin = define({
       )
       yield* refresh()
       yield* discovery.transform((draft) => {
-        if (!Array.isArray(loaded.files)) {
+        if (loaded.current.type === "unavailable") {
           draft.unavailable()
           return
         }
-        for (const file of loaded.files) draft.add(file)
+        for (const file of loaded.current.files) draft.add(file)
       })
     }).pipe(
       Effect.catchCause((cause) =>
@@ -116,3 +115,8 @@ export const Plugin = define({
     )
   }),
 })
+
+function ancestorDirectories(start: string, stop: string): string[] {
+  if (start === stop) return [start]
+  return [start, ...ancestorDirectories(dirname(start), stop)]
+}

--- a/packages/core/src/config/plugin/instruction.ts
+++ b/packages/core/src/config/plugin/instruction.ts
@@ -84,7 +84,7 @@ export const Plugin = define({
                 ? { type: "available", files: [...sources.global, ...sources.project] }
                 : { type: "unavailable" }
             if (!file) return
-            yield* Effect.logInfo("instructions rescanned", {
+            yield* Effect.logDebug("instructions rescanned", {
               file,
               instructions:
                 loaded.current.type === "available" ? loaded.current.files.map((item) => item.path) : "unavailable",

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -1,15 +1,13 @@
 export * as InstructionDiscovery from "./instruction-discovery"
 
-import { Array, Context, Effect, Layer, Schema } from "effect"
-import { isAbsolute, join, relative, sep } from "path"
-import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Global } from "@opencode-ai/util/global"
-import { Location } from "./location"
-import { AbsolutePath } from "./schema"
-import { Instructions } from "./instructions/index"
+import { Context, Effect, Layer, Schema, Types } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Bus } from "./bus"
+import { Instructions } from "./instructions/index"
+import { AbsolutePath } from "./schema"
+import { State } from "./state"
 
-class File extends Schema.Class<File>("InstructionDiscovery.File")({
+export class File extends Schema.Class<File>("InstructionDiscovery.File")({
   path: AbsolutePath,
   content: Schema.String,
 }) {}
@@ -17,7 +15,26 @@ class File extends Schema.Class<File>("InstructionDiscovery.File")({
 const Files = Schema.Array(File)
 const key = Instructions.Key.make("core/instructions")
 
-export interface Interface {
+export const Event = {
+  Updated: Bus.ephemeral({ type: "instruction-discovery.updated", schema: {} }),
+}
+
+export type Data = {
+  files: Map<AbsolutePath, Types.DeepMutable<File>>
+  available: boolean
+}
+
+export type Draft = {
+  list: () => readonly Types.DeepMutable<File>[]
+  add: (file: File) => void
+  update: (path: string, update: (file: Types.DeepMutable<File>) => void) => void
+  remove: (path: string) => void
+  unavailable: () => void
+}
+
+export interface Interface extends State.Transformable<Draft> {
+  readonly project: boolean
+  readonly list: () => Effect.Effect<File[] | Instructions.Unavailable>
   readonly load: () => Effect.Effect<Instructions.List>
 }
 
@@ -32,9 +49,26 @@ export const layer = (options?: Options) =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
-      const fs = yield* FSUtil.Service
-      const global = yield* Global.Service
-      const location = yield* Location.Service
+      const bus = yield* Bus.Service
+      const state = State.create<Data, Draft>({
+        name: "instruction-discovery",
+        initial: () => ({ files: new Map(), available: true }),
+        draft: (draft) => ({
+          list: () => Array.from(draft.files.values()),
+          add: (file) => draft.files.set(file.path, new File(file) as Types.DeepMutable<File>),
+          update: (path, update) => {
+            const current = draft.files.get(AbsolutePath.make(path))
+            if (!current) return
+            update(current)
+            current.path = AbsolutePath.make(path)
+          },
+          remove: (path) => draft.files.delete(AbsolutePath.make(path)),
+          unavailable: () => {
+            draft.available = false
+          },
+        }),
+        finalize: () => bus.publish(Event.Updated, {}).pipe(Effect.asVoid),
+      })
 
       const source = (value: ReadonlyArray<File> | Instructions.Unavailable | Instructions.Removed) =>
         Instructions.make<ReadonlyArray<File>>({
@@ -49,52 +83,22 @@ export const layer = (options?: Options) =>
           },
         })
 
-      const observe = Effect.fn("InstructionDiscovery.observe")(function* () {
-        const start = yield* fs.resolve(location.directory)
-        const stop = yield* fs.resolve(location.project.directory)
-        const fromProject = relative(stop, start)
-        const insideProject =
-          fromProject === "" ||
-          (fromProject !== ".." && !fromProject.startsWith(`..${sep}`) && !isAbsolute(fromProject))
-        const discovered = new Set(
-          yield* Effect.forEach(
-            options?.project === false || !insideProject
-              ? []
-              : yield* fs.up({
-                  targets: ["AGENTS.md"],
-                  start,
-                  stop,
-                }),
-            fs.resolve,
-          ),
-        )
-        const paths = Array.dedupe([yield* fs.resolve(join(global.config, "AGENTS.md")), ...discovered])
-        const files = yield* Effect.forEach(
-          paths,
-          (path) =>
-            fs
-              .readFileStringSafe(path)
-              .pipe(
-                Effect.map((content) =>
-                  content === undefined ? undefined : new File({ path: AbsolutePath.make(path), content }),
-                ),
-              ),
-          { concurrency: "unbounded" },
-        )
-        if (files.some((file, index) => file === undefined && discovered.has(paths[index])))
-          return Instructions.unavailable
-        return files.filter((file): file is File => file !== undefined)
+      const list = Effect.fn("InstructionDiscovery.list")(function* () {
+        const current = state.get()
+        if (!current.available) return Instructions.unavailable
+        return Array.from(current.files.values())
       })
 
       return Service.of({
-        load: () =>
-          observe().pipe(
-            Effect.map((files) =>
-              Array.isArray(files) && files.length === 0 ? source(Instructions.removed) : source(files),
-            ),
-            Effect.catch(() => Effect.succeed(source(Instructions.unavailable))),
-            Effect.catchDefect(() => Effect.succeed(source(Instructions.unavailable))),
-          ),
+        project: options?.project !== false,
+        transform: state.transform,
+        reload: state.reload,
+        list,
+        load: Effect.fn("InstructionDiscovery.load")(function* () {
+          const files = yield* list()
+          if (!Array.isArray(files)) return source(files)
+          return source(files.length === 0 ? Instructions.removed : files)
+        }),
       })
     }),
   )
@@ -103,7 +107,7 @@ export function configured(options?: Options) {
   return makeLocationNode({
     service: Service,
     layer: layer(options),
-    deps: [FSUtil.node, Global.node, Location.node],
+    deps: [Bus.node],
   })
 }
 

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -26,6 +26,8 @@ export type Data = {
 
 export type Draft = {
   list: () => readonly Types.DeepMutable<File>[]
+  // Map insertion order is render order: config adds global then nearest-to-farthest project files;
+  // sibling contributors interleave by transform registration order.
   add: (file: File) => void
   update: (path: string, update: (file: Types.DeepMutable<File>) => void) => void
   remove: (path: string) => void
@@ -33,6 +35,8 @@ export type Draft = {
 }
 
 export interface Interface extends State.Transformable<Draft> {
+  // Discovery policy lives here because internal plugins have no per-composition options channel.
+  // Move it into plugin config once plugins can consume their own options.
   readonly project: boolean
   readonly list: () => Effect.Effect<File[] | Instructions.Unavailable>
   readonly load: () => Effect.Effect<Instructions.List>

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -12,6 +12,7 @@ import { Config } from "../config"
 import { Credential } from "../credential"
 import { ConfigAgentPlugin } from "../config/plugin/agent"
 import { ConfigCommandPlugin } from "../config/plugin/command"
+import { ConfigInstructionPlugin } from "../config/plugin/instruction"
 import { ConfigProviderPlugin } from "../config/plugin/provider"
 import { ConfigPolicyPlugin } from "../config/plugin/policy"
 import { ConfigReferencePlugin } from "../config/plugin/reference"
@@ -26,6 +27,7 @@ import { FileSystem } from "../filesystem"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { Image } from "../image"
+import { InstructionDiscovery } from "../instruction-discovery"
 import { Integration } from "../integration"
 import { KV } from "../kv"
 import { Location } from "../location"
@@ -83,6 +85,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const global = yield* Global.Service
   const http = yield* HttpClient.HttpClient
   const image = yield* Image.Service
+  const instructionDiscovery = yield* InstructionDiscovery.Service
   const integration = yield* Integration.Service
   const kv = yield* KV.Service
   const location = yield* Location.Service
@@ -118,6 +121,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Global.Service, global),
     Context.make(HttpClient.HttpClient, http),
     Context.make(Image.Service, image),
+    Context.make(InstructionDiscovery.Service, instructionDiscovery),
     Context.make(Integration.Service, integration),
     Context.make(KV.Service, kv),
     Context.make(Location.Service, location),
@@ -160,6 +164,7 @@ export const requirements = LayerNode.group([
   Global.node,
   httpClient,
   Image.node,
+  InstructionDiscovery.node,
   Integration.node,
   KV.node,
   Location.node,
@@ -209,6 +214,7 @@ const pre = [
 ] as const satisfies readonly InternalPlugin[]
 
 const post = [
+  ConfigInstructionPlugin.Plugin,
   ConfigReferencePlugin.Plugin,
   ConfigAgentPlugin.Plugin,
   ConfigCommandPlugin.Plugin,

--- a/packages/core/test/fixture/global.ts
+++ b/packages/core/test/fixture/global.ts
@@ -1,0 +1,27 @@
+import path from "path"
+import { Global } from "@opencode-ai/util/global"
+import { Effect, Layer } from "effect"
+import { tmpdir } from "./tmpdir"
+
+export const tempGlobalLayer = Layer.unwrap(
+  Effect.acquireRelease(
+    Effect.promise(() => tmpdir()),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ).pipe(
+    Effect.map((tmp) => {
+      const data = path.join(tmp.path, "data")
+      const cache = path.join(tmp.path, "cache")
+      return Global.layerWith({
+        home: path.join(tmp.path, "home"),
+        data,
+        cache,
+        config: path.join(tmp.path, "config"),
+        state: path.join(tmp.path, "state"),
+        tmp: path.join(tmp.path, "tmp"),
+        bin: path.join(cache, "bin"),
+        log: path.join(data, "log"),
+        repos: path.join(data, "repos"),
+      })
+    }),
+  ),
+)

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -386,7 +386,8 @@ describe("ConfigInstructionPlugin.Plugin", () => {
         ),
       )
 
-      expect(observed.values).toEqual([{ targets: ["AGENTS.md"], start: "/repo", stop: "/repo" }])
+      const repo = path.resolve("/repo")
+      expect(observed.values).toEqual([{ targets: ["AGENTS.md"], start: repo, stop: repo }])
     }),
   )
 })

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Deferred, Effect, Fiber, Layer, Stream } from "effect"
 import fs from "fs/promises"
-import os from "os"
 import path from "path"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Bus } from "@opencode-ai/core/bus"
@@ -14,6 +13,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { tempGlobalLayer } from "./fixture/global"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
 import { readInitial, readUpdate, state } from "./lib/instructions"
@@ -23,7 +23,7 @@ import { host } from "./plugin/host"
 const it = testEffect(Layer.empty)
 
 const instructionLayer = (input: {
-  config: string
+  config?: string
   locationServiceLayer: Layer.Layer<Location.Service>
   filesystemLayer?: Layer.Layer<FSUtil.Service>
   project?: boolean
@@ -34,7 +34,7 @@ const instructionLayer = (input: {
       LayerNode.group([InstructionDiscovery.node, Bus.node, FSUtil.node, Global.node, Location.node, Watcher.node]),
       [
         [InstructionDiscovery.node, InstructionDiscovery.configured({ project: input.project })],
-        [Global.node, Global.layerWith({ config: input.config })],
+        [Global.node, input.config ? Global.layerWith({ config: input.config }) : tempGlobalLayer],
         [Location.node, input.locationServiceLayer],
         [Watcher.node, watcher],
         ...(input.filesystemLayer ? [[FSUtil.node, input.filesystemLayer] as const] : []),
@@ -279,7 +279,6 @@ describe("ConfigInstructionPlugin.Plugin", () => {
     }).pipe(
       Effect.provide(
         instructionLayer({
-          config: path.join(os.tmpdir(), "opencode-instruction-failure"),
           filesystemLayer: failingFS,
           locationServiceLayer: Layer.succeed(
             Location.Service,
@@ -315,7 +314,6 @@ describe("ConfigInstructionPlugin.Plugin", () => {
     }).pipe(
       Effect.provide(
         instructionLayer({
-          config: path.join(os.tmpdir(), "opencode-instruction-race"),
           filesystemLayer: racingFS,
           locationServiceLayer: Layer.succeed(
             Location.Service,
@@ -344,7 +342,6 @@ describe("ConfigInstructionPlugin.Plugin", () => {
       yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
             filesystemLayer: observingFS,
             locationServiceLayer: Layer.succeed(
               Location.Service,
@@ -358,7 +355,6 @@ describe("ConfigInstructionPlugin.Plugin", () => {
       yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
             filesystemLayer: observingFS,
             project: false,
             locationServiceLayer: Layer.succeed(
@@ -371,7 +367,6 @@ describe("ConfigInstructionPlugin.Plugin", () => {
       yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
             filesystemLayer: observingFS,
             locationServiceLayer: Layer.succeed(
               Location.Service,

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -132,7 +132,9 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           const watcher = yield* Watcher.Test
           expect(yield* watcher.subscriptions()).toEqual([
             { path: globalFile, type: "file" },
-            { path: project, type: "directory" },
+            { path: packageFile, type: "file" },
+            { path: path.join(project, "packages", "AGENTS.md"), type: "file" },
+            { path: projectFile, type: "file" },
           ])
           const initialized = yield* readInitial(yield* discovery.load())
           expect(initialized.text).toBe(
@@ -210,6 +212,50 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           ),
         ),
       ),
+    ),
+  )
+
+  it.live("discovers a newly created instruction file in an intermediate directory", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        const project = path.join(tmp.path, "project")
+        const intermediate = path.join(project, "packages", "AGENTS.md")
+        const directory = path.join(project, "packages", "core")
+        const projectFile = path.join(project, "AGENTS.md")
+        return Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))
+          yield* Effect.promise(() => fs.writeFile(projectFile, "project"))
+          const discovery = yield* start()
+          expect((yield* readInitial(yield* discovery.load())).text).toBe(`Instructions from: ${projectFile}\nproject`)
+
+          yield* Effect.promise(() => fs.writeFile(intermediate, "intermediate"))
+          yield* emitAndWait({ type: "create", path: intermediate })
+
+          expect((yield* readInitial(yield* discovery.load())).text).toBe(
+            [`Instructions from: ${intermediate}\nintermediate`, `Instructions from: ${projectFile}\nproject`].join(
+              "\n\n",
+            ),
+          )
+        }).pipe(
+          Effect.provide(
+            instructionLayer({
+              config: path.join(tmp.path, "global"),
+              locationServiceLayer: Layer.succeed(
+                Location.Service,
+                Location.Service.of(
+                  location(
+                    { directory: AbsolutePath.make(directory) },
+                    { projectDirectory: AbsolutePath.make(project) },
+                  ),
+                ),
+              ),
+            }),
+          ),
+        )
+      }),
     ),
   )
 

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -1,51 +1,124 @@
 import { describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
+import { Deferred, Effect, Fiber, Layer, Stream } from "effect"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Global } from "@opencode-ai/util/global"
+import { Bus } from "@opencode-ai/core/bus"
+import { ConfigInstructionPlugin } from "@opencode-ai/core/config/plugin/instruction"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
+import { Instructions } from "@opencode-ai/core/instructions"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Global } from "@opencode-ai/util/global"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
-import { testEffect } from "./lib/effect"
 import { readInitial, readUpdate, state } from "./lib/instructions"
+import { testEffect } from "./lib/effect"
+import { host } from "./plugin/host"
 
 const it = testEffect(Layer.empty)
-const testConfig = path.join(os.tmpdir(), "opencode-instruction-discovery-test")
 
 const instructionLayer = (input: {
   config: string
   locationServiceLayer: Layer.Layer<Location.Service>
   filesystemLayer?: Layer.Layer<FSUtil.Service>
   project?: boolean
-}) =>
-  AppNodeBuilder.build(InstructionDiscovery.node, [
-    [InstructionDiscovery.node, InstructionDiscovery.configured({ project: input.project })],
-    [Global.node, Global.layerWith({ config: input.config })],
-    [Location.node, input.locationServiceLayer],
-    ...(input.filesystemLayer ? [[FSUtil.node, input.filesystemLayer] as const] : []),
-  ])
+}) => {
+  const watcher = Watcher.testLayer
+  return Layer.mergeAll(
+    AppNodeBuilder.build(
+      LayerNode.group([InstructionDiscovery.node, Bus.node, FSUtil.node, Global.node, Location.node, Watcher.node]),
+      [
+        [InstructionDiscovery.node, InstructionDiscovery.configured({ project: input.project })],
+        [Global.node, Global.layerWith({ config: input.config })],
+        [Location.node, input.locationServiceLayer],
+        [Watcher.node, watcher],
+        ...(input.filesystemLayer ? [[FSUtil.node, input.filesystemLayer] as const] : []),
+      ],
+    ),
+    watcher,
+  )
+}
+
+const start = Effect.fnUntraced(function* () {
+  yield* ConfigInstructionPlugin.Plugin.effect(host())
+  return yield* InstructionDiscovery.Service
+})
+
+const file = (path: string, content: string) =>
+  new InstructionDiscovery.File({ path: AbsolutePath.make(path), content })
+
+function emitAndWait(update: Watcher.Update) {
+  return Effect.gen(function* () {
+    const watcher = yield* Watcher.Test
+    const bus = yield* Bus.Service
+    const updated = yield* Deferred.make<void>()
+    const fiber = yield* bus.subscribe(InstructionDiscovery.Event.Updated).pipe(
+      Stream.runForEach(() => Deferred.succeed(updated, undefined).pipe(Effect.asVoid)),
+      Effect.forkScoped,
+    )
+    yield* Effect.yieldNow
+    yield* watcher.emit(update)
+    yield* Deferred.await(updated).pipe(Effect.timeout("2 seconds"))
+    yield* Fiber.interrupt(fiber)
+  })
+}
 
 describe("InstructionDiscovery", () => {
-  it.live("loads global and upward project AGENTS.md files as one aggregate context", () =>
+  it.effect("stores ordered values with last-write-wins precedence", () =>
+    Effect.gen(function* () {
+      const discovery = yield* InstructionDiscovery.Service
+      yield* discovery.transform((draft) => {
+        draft.add(file("/repo/AGENTS.md", "first"))
+        draft.add(file("/repo/packages/AGENTS.md", "package"))
+        draft.add(file("/repo/AGENTS.md", "last"))
+        draft.update("/repo/packages/AGENTS.md", (current) => {
+          current.content = "updated"
+          current.path = AbsolutePath.make("/ignored")
+        })
+        draft.remove("/missing")
+      })
+
+      expect(yield* discovery.list()).toEqual([
+        file("/repo/AGENTS.md", "last"),
+        file("/repo/packages/AGENTS.md", "updated"),
+      ])
+    }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
+  )
+
+  it.effect("preserves admitted values while the source is unavailable", () =>
+    Effect.gen(function* () {
+      const discovery = yield* InstructionDiscovery.Service
+      yield* discovery.transform((draft) => draft.unavailable())
+      expect(
+        (yield* readUpdate(
+          yield* discovery.load(),
+          state({ "core/instructions": [{ path: "/repo/AGENTS.md", content: "old" }] }),
+        )).changed,
+      ).toBe(false)
+    }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
+  )
+})
+
+describe("ConfigInstructionPlugin.Plugin", () => {
+  it.live("loads global and upward project files and rescans them on change", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ).pipe(
-      Effect.flatMap((tmp) =>
-        Effect.gen(function* () {
-          const global = path.join(tmp.path, "global")
-          const project = path.join(tmp.path, "project")
-          const directory = path.join(project, "packages", "core")
-          const outside = path.join(tmp.path, "AGENTS.md")
-          const globalFile = path.join(global, "AGENTS.md")
-          const projectFile = path.join(project, "AGENTS.md")
-          const packageFile = path.join(directory, "AGENTS.md")
+      Effect.flatMap((tmp) => {
+        const global = path.join(tmp.path, "global")
+        const project = path.join(tmp.path, "project")
+        const directory = path.join(project, "packages", "core")
+        const outside = path.join(tmp.path, "AGENTS.md")
+        const globalFile = path.join(global, "AGENTS.md")
+        const projectFile = path.join(project, "AGENTS.md")
+        const packageFile = path.join(directory, "AGENTS.md")
+        return Effect.gen(function* () {
           yield* Effect.promise(async () => {
             await fs.mkdir(global, { recursive: true })
             await fs.mkdir(directory, { recursive: true })
@@ -55,25 +128,13 @@ describe("InstructionDiscovery", () => {
             await fs.writeFile(packageFile, "package")
           })
 
-          const load = InstructionDiscovery.Service.pipe(
-            Effect.flatMap((service) => service.load()),
-            Effect.provide(
-              instructionLayer({
-                config: global,
-                locationServiceLayer: Layer.succeed(
-                  Location.Service,
-                  Location.Service.of(
-                    location(
-                      { directory: AbsolutePath.make(directory) },
-                      { projectDirectory: AbsolutePath.make(project) },
-                    ),
-                  ),
-                ),
-              }),
-            ),
-          )
-
-          const initialized = yield* readInitial(yield* load)
+          const discovery = yield* start()
+          const watcher = yield* Watcher.Test
+          expect(yield* watcher.subscriptions()).toEqual([
+            { path: globalFile, type: "file" },
+            { path: project, type: "directory" },
+          ])
+          const initialized = yield* readInitial(yield* discovery.load())
           expect(initialized.text).toBe(
             [
               `Instructions from: ${globalFile}\nglobal`,
@@ -84,13 +145,14 @@ describe("InstructionDiscovery", () => {
           expect(initialized.text).not.toContain("outside")
 
           yield* Effect.promise(() => fs.writeFile(packageFile, "changed"))
-          expect((yield* readUpdate(yield* load, initialized)).text).toContain(
+          yield* emitAndWait({ type: "update", path: packageFile })
+          expect((yield* readUpdate(yield* discovery.load(), initialized)).text).toContain(
             `Instructions from: ${packageFile}\nchanged`,
           )
 
           yield* Effect.promise(() => fs.rm(packageFile))
-          const partial = yield* readUpdate(yield* load, initialized)
-          expect(partial.text).toBe(
+          yield* emitAndWait({ type: "delete", path: packageFile })
+          expect((yield* readUpdate(yield* discovery.load(), initialized)).text).toBe(
             [
               "These instructions replace all previously loaded ambient instructions.",
               `Instructions from: ${globalFile}\nglobal`,
@@ -98,12 +160,30 @@ describe("InstructionDiscovery", () => {
             ].join("\n\n"),
           )
 
-          yield* Effect.promise(() => Promise.all([fs.rm(globalFile), fs.rm(projectFile)]))
-          expect((yield* readUpdate(yield* load, initialized)).text).toBe(
+          yield* Effect.promise(() => fs.rm(globalFile))
+          yield* emitAndWait({ type: "delete", path: globalFile })
+          yield* Effect.promise(() => fs.rm(projectFile))
+          yield* emitAndWait({ type: "delete", path: projectFile })
+          expect((yield* readUpdate(yield* discovery.load(), initialized)).text).toBe(
             "Previously loaded instructions no longer apply.",
           )
-        }),
-      ),
+        }).pipe(
+          Effect.provide(
+            instructionLayer({
+              config: global,
+              locationServiceLayer: Layer.succeed(
+                Location.Service,
+                Location.Service.of(
+                  location(
+                    { directory: AbsolutePath.make(directory) },
+                    { projectDirectory: AbsolutePath.make(project) },
+                  ),
+                ),
+              ),
+            }),
+          ),
+        )
+      }),
     ),
   )
 
@@ -116,115 +196,109 @@ describe("InstructionDiscovery", () => {
         Effect.gen(function* () {
           const file = path.join(tmp.path, "AGENTS.md")
           yield* Effect.promise(() => fs.writeFile(file, ""))
-          const context = yield* InstructionDiscovery.Service.pipe(
-            Effect.flatMap((service) => service.load()),
-            Effect.provide(
-              instructionLayer({
-                config: path.join(tmp.path, "global"),
-                locationServiceLayer: Layer.succeed(
-                  Location.Service,
-                  Location.Service.of(location({ directory: AbsolutePath.make(tmp.path) })),
-                ),
-              }),
-            ),
-          )
-
-          expect((yield* readInitial(context)).text).toBe(`Instructions from: ${file}\n`)
-        }),
+          const discovery = yield* start()
+          expect((yield* readInitial(yield* discovery.load())).text).toBe(`Instructions from: ${file}\n`)
+        }).pipe(
+          Effect.provide(
+            instructionLayer({
+              config: path.join(tmp.path, "global"),
+              locationServiceLayer: Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(tmp.path) })),
+              ),
+            }),
+          ),
+        ),
       ),
     ),
   )
 
-  it.effect("preserves admitted instructions while observation is unavailable", () =>
-    Effect.gen(function* () {
-      const failingFS = Layer.effect(
-        FSUtil.Service,
-        FSUtil.Service.pipe(
-          Effect.map((fs) =>
-            FSUtil.Service.of({ ...fs, up: () => Effect.fail(new FSUtil.FileSystemError({ method: "up" })) }),
-          ),
+  it.effect("isolates source failure without failing activation", () => {
+    const failingFS = Layer.effect(
+      FSUtil.Service,
+      FSUtil.Service.pipe(
+        Effect.map((fs) =>
+          FSUtil.Service.of({ ...fs, up: () => Effect.fail(new FSUtil.FileSystemError({ method: "up" })) }),
         ),
-      ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
-      const context = yield* InstructionDiscovery.Service.pipe(
-        Effect.flatMap((service) => service.load()),
-        Effect.provide(
-          instructionLayer({
-            config: testConfig,
-            filesystemLayer: failingFS,
-            locationServiceLayer: Layer.succeed(
-              Location.Service,
-              Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
-            ),
+      ),
+    ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
+    return Effect.gen(function* () {
+      const discovery = yield* start()
+      expect(
+        (yield* readUpdate(
+          yield* discovery.load(),
+          state({ "core/instructions": [{ path: "/repo/AGENTS.md", content: "old" }] }),
+        )).changed,
+      ).toBe(false)
+    }).pipe(
+      Effect.provide(
+        instructionLayer({
+          config: path.join(os.tmpdir(), "opencode-instruction-failure"),
+          filesystemLayer: failingFS,
+          locationServiceLayer: Layer.succeed(
+            Location.Service,
+            Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
+          ),
+        }),
+      ),
+    )
+  })
+
+  it.effect("marks a discovered file that disappears before read as unavailable", () => {
+    const discovered = AbsolutePath.make("/repo/AGENTS.md")
+    const racingFS = Layer.effect(
+      FSUtil.Service,
+      FSUtil.Service.pipe(
+        Effect.map((fs) =>
+          FSUtil.Service.of({
+            ...fs,
+            up: () => Effect.succeed([discovered]),
+            readFileStringSafe: () => Effect.succeed(undefined),
           }),
         ),
-      )
-
+      ),
+    ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
+    return Effect.gen(function* () {
+      const discovery = yield* start()
       expect(
-        (yield* readUpdate(context, state({ "core/instructions": [{ path: "/repo/AGENTS.md", content: "old" }] })))
-          .changed,
+        (yield* readUpdate(
+          yield* discovery.load(),
+          state({ "core/instructions": [{ path: discovered, content: "old" }] }),
+        )).changed,
       ).toBe(false)
-    }),
-  )
-
-  it.effect("preserves admitted instructions when a discovered file disappears before read", () =>
-    Effect.gen(function* () {
-      const file = AbsolutePath.make("/repo/AGENTS.md")
-      const racingFS = Layer.effect(
-        FSUtil.Service,
-        FSUtil.Service.pipe(
-          Effect.map((fs) =>
-            FSUtil.Service.of({
-              ...fs,
-              up: () => Effect.succeed([file]),
-              readFileStringSafe: () => Effect.succeed(undefined),
-            }),
+    }).pipe(
+      Effect.provide(
+        instructionLayer({
+          config: path.join(os.tmpdir(), "opencode-instruction-race"),
+          filesystemLayer: racingFS,
+          locationServiceLayer: Layer.succeed(
+            Location.Service,
+            Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
           ),
-        ),
-      ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
-      const context = yield* InstructionDiscovery.Service.pipe(
-        Effect.flatMap((service) => service.load()),
-        Effect.provide(
-          instructionLayer({
-            config: testConfig,
-            filesystemLayer: racingFS,
-            locationServiceLayer: Layer.succeed(
-              Location.Service,
-              Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
-            ),
-          }),
-        ),
-      )
+        }),
+      ),
+    )
+  })
 
-      expect(
-        (yield* readUpdate(context, state({ "core/instructions": [{ path: file, content: "old" }] }))).changed,
-      ).toBe(false)
-    }),
-  )
-
-  it.effect("canonicalizes upward discovery boundaries", () =>
+  it.effect("canonicalizes boundaries and honors project opt-out", () =>
     Effect.gen(function* () {
-      let observed: { targets: string[]; start: string; stop?: string } | undefined
+      const observed: { values: { targets: string[]; start: string; stop?: string }[] } = { values: [] }
       const observingFS = Layer.effect(
         FSUtil.Service,
         FSUtil.Service.pipe(
           Effect.map((fs) =>
             FSUtil.Service.of({
               ...fs,
-              up: (options) =>
-                Effect.sync(() => {
-                  observed = options
-                  return []
-                }),
+              up: (options) => Effect.sync(() => (observed.values.push(options), [])),
             }),
           ),
         ),
       ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
 
-      yield* InstructionDiscovery.Service.pipe(
-        Effect.flatMap((service) => service.load()),
+      yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: testConfig,
+            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
             filesystemLayer: observingFS,
             locationServiceLayer: Layer.succeed(
               Location.Service,
@@ -235,31 +309,12 @@ describe("InstructionDiscovery", () => {
           }),
         ),
       )
-
-      expect(observed).toEqual({
-        targets: ["AGENTS.md"],
-        start: FSUtil.resolve("/repo"),
-        stop: FSUtil.resolve("/repo"),
-      })
-    }),
-  )
-
-  it.effect("honors the project instruction opt-out", () =>
-    Effect.gen(function* () {
-      let scanned = false
-
-      yield* InstructionDiscovery.Service.pipe(
-        Effect.flatMap((service) => service.load()),
+      yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: testConfig,
+            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
+            filesystemLayer: observingFS,
             project: false,
-            filesystemLayer: Layer.effect(
-              FSUtil.Service,
-              FSUtil.Service.pipe(
-                Effect.map((fs) => FSUtil.Service.of({ ...fs, up: () => Effect.sync(() => ((scanned = true), [])) })),
-              ),
-            ).pipe(Layer.provide(LayerNode.compile(FSUtil.node))),
             locationServiceLayer: Layer.succeed(
               Location.Service,
               Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
@@ -267,25 +322,11 @@ describe("InstructionDiscovery", () => {
           }),
         ),
       )
-
-      expect(scanned).toBe(false)
-    }),
-  )
-
-  it.effect("does not discover project instructions outside the canonical project root", () =>
-    Effect.gen(function* () {
-      let scanned = false
-      yield* InstructionDiscovery.Service.pipe(
-        Effect.flatMap((service) => service.load()),
+      yield* start().pipe(
         Effect.provide(
           instructionLayer({
-            config: testConfig,
-            filesystemLayer: Layer.effect(
-              FSUtil.Service,
-              FSUtil.Service.pipe(
-                Effect.map((fs) => FSUtil.Service.of({ ...fs, up: () => Effect.sync(() => ((scanned = true), [])) })),
-              ),
-            ).pipe(Layer.provide(LayerNode.compile(FSUtil.node))),
+            config: path.join(os.tmpdir(), "opencode-instruction-canonical"),
+            filesystemLayer: observingFS,
             locationServiceLayer: Layer.succeed(
               Location.Service,
               Location.Service.of(
@@ -299,7 +340,7 @@ describe("InstructionDiscovery", () => {
         ),
       )
 
-      expect(scanned).toBe(false)
+      expect(observed.values).toEqual([{ targets: ["AGENTS.md"], start: "/repo", stop: "/repo" }])
     }),
   )
 })

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -99,7 +99,10 @@ const builtins = Layer.mock(InstructionBuiltIns.Service, {
       }),
     ),
 })
-const discovery = Layer.mock(InstructionDiscovery.Service, { load: () => Effect.succeed(Instructions.empty) })
+const discovery = Layer.mock(InstructionDiscovery.Service, {
+  project: true,
+  load: () => Effect.succeed(Instructions.empty),
+})
 const skills = Layer.mock(SkillInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const references = Layer.mock(ReferenceInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const mcp = Layer.mock(McpInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -83,7 +83,10 @@ const models = Layer.mock(SessionRunnerModel.Service)({
     ),
 })
 const systemContext = Layer.mock(InstructionBuiltIns.Service, { load: () => Effect.succeed(Instructions.empty) })
-const instructionContext = Layer.mock(InstructionDiscovery.Service, { load: () => Effect.succeed(Instructions.empty) })
+const instructionContext = Layer.mock(InstructionDiscovery.Service, {
+  project: true,
+  load: () => Effect.succeed(Instructions.empty),
+})
 const skillInstructions = Layer.mock(SkillInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const referenceInstructions = Layer.mock(ReferenceInstructions.Service, {
   load: () => Effect.succeed(Instructions.empty),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -312,7 +312,10 @@ const systemContext = Layer.mock(InstructionBuiltIns.Service, {
       }),
     ),
 })
-const instructionContext = Layer.mock(InstructionDiscovery.Service, { load: () => Effect.succeed(Instructions.empty) })
+const instructionContext = Layer.mock(InstructionDiscovery.Service, {
+  project: true,
+  load: () => Effect.succeed(Instructions.empty),
+})
 const skillInstructions = Layer.mock(SkillInstructions.Service, {
   load: (agent) =>
     Effect.succeed(


### PR DESCRIPTION
## What

Move ambient `AGENTS.md` filesystem acquisition out of `InstructionDiscovery` and into a config-side internal plugin.

`InstructionDiscovery` now stores loaded instruction values in ordered, path-keyed state and exposes draft operations for config-side producers. It keeps the existing `Instructions` source key and rendering semantics used by session prompt admission.

## Why

This continues the ownership direction established by #41618 and #41622: core domain services own values, while config-side modules own filesystem discovery, parsing, canonicalization, and watching.

Previously, `InstructionDiscovery.load()` performed canonicalization, upward scanning, and file reads inside the core service on every selection. That made the prompt-facing service itself filesystem-aware.

## How

- Refactor `packages/core/src/instruction-discovery.ts` into a `State`-backed value service with ordered `list`/`add`/`update`/`remove` drafts and explicit unavailable state.
- Add `packages/core/src/config/plugin/instruction.ts` to canonicalize location/project boundaries, load global and upward-project `AGENTS.md` sources, and derive the finite candidate set from the working directory's ancestor chain.
- Watch every candidate with an exact `type: "file"` subscription. These cheap parent-directory watches detect create/update/delete even when a candidate does not exist yet, avoid recursively watching the project tree, and do not depend on the optional `@parcel/watcher` native binding.
- Re-scan and re-draft values on relevant watcher updates; publish `InstructionDiscovery.Event.Updated` only after committed values are visible.
- Replacing select-time reads adds a bounded staleness window (filesystem-event latency plus the State reload debounce, approximately <=1s): a racing prompt may render pre-edit content once, while the following prompt is guaranteed fresh.
- Isolate global/project source failures with warnings, log skipped missing files at debug level, and degrade activation/setup failures to unavailable state instead of failing plugin activation.
- Register the instruction config plugin with the existing internal post-config plugins so `PluginSupervisor.flush` completes initial acquisition before `SessionContext.select()` reads values.

```mermaid
sequenceDiagram
  participant Config as ConfigInstructionPlugin
  participant FS as FSUtil + Watcher
  participant Values as InstructionDiscovery
  participant Session as SessionContext
  participant Prompt as InstructionState

  Config->>FS: canonicalize, scan, and read AGENTS.md sources
  Config->>Values: transform loaded values
  Values-->>Config: commit, then publish Updated
  FS-->>Config: relevant file update
  Config->>Values: refresh and reload draft
  Session->>Values: load filesystem-free instruction source
  Session->>Prompt: compose and admit instruction values
```

## Testing

- `cd packages/core && bunx tsgo --noEmit`
- `cd packages/core && bun run typecheck`
- `cd packages/core && bun run test test/instruction-discovery.test.ts test/instruction-state.test.ts test/mcp-instructions.test.ts test/reference-instructions.test.ts test/session-instructions.test.ts test/instructions/builtins.test.ts test/instructions/index.test.ts test/codemode/instructions.test.ts test/skill/instructions.test.ts` (60 passed)
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks passed across the workspace)
- `cd packages/core && bun run test` reached 1,632 passed, 16 skipped, and one unrelated environment-dependent failure in `PluginSupervisor config > logs invalid packages and continues loading`; the assertion sees two plugins from the user's global config, and the test reproduces alone.

## Findings

- `InstructionDiscovery` was a stateless location-scoped service whose sole `load()` call canonicalized the working/project boundaries, scanned upward for `AGENTS.md`, canonicalized discovered files, and read content. It had no cache or watcher; every session selection performed fresh acquisition.
- Discovery order was global config `AGENTS.md`, then nearest-to-farthest project files through the canonical project root. Canonical path deduplication prevented the same global/project file from rendering twice.
- A missing global file contributed nothing; a project file disappearing after discovery or any observation failure yielded `Instructions.unavailable`, preserving admitted values. Confirmed zero files yielded `Instructions.removed`.
- `SessionContext.select()` waits for `PluginSupervisor.flush`, then composes built-ins, ambient discovery, code mode, skills, references, MCP guidance, and session entries. `InstructionState` hashes and durably admits those values before request assembly.
- `SessionInstructions` is a separate read-tool path: it loads nested instructions discovered while reading files and publishes durable synthetic messages. This PR deliberately leaves that tool-ground behavior unchanged.
- The template fit because both the config plugin and values service are location-scoped. The main difference from skills is semantic ordering plus unavailable-vs-removed state, which remain explicit in the value service and tests.
