### PR TITLE
fix(core): isolate config plugin tests from ambient user config

### DIFF
--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -8,6 +8,7 @@ import { Catalog } from "@opencode-ai/core/catalog"
 import { ConfigPluginSource } from "@opencode-ai/core/config/plugin/source"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
 import { Bus } from "@opencode-ai/core/bus"
 import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
@@ -20,14 +21,18 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Effect, Fiber, Logger, Stream } from "effect"
 import { Database } from "../../src/database/database"
 import { tmpdir } from "../fixture/tmpdir"
+import { tempGlobalLayer } from "../fixture/global"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node])),
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+  ]),
 )
 const staticIt = testEffect(
   AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
     [ConfigPluginSource.node, ConfigPluginSource.empty],
+    [Global.node, tempGlobalLayer],
   ]),
 )
 

--- a/packages/core/test/fixture/global.ts
+++ b/packages/core/test/fixture/global.ts
@@ -1,0 +1,27 @@
+import path from "path"
+import { Global } from "@opencode-ai/util/global"
+import { Effect, Layer } from "effect"
+import { tmpdir } from "./tmpdir"
+
+export const tempGlobalLayer = Layer.unwrap(
+  Effect.acquireRelease(
+    Effect.promise(() => tmpdir()),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ).pipe(
+    Effect.map((tmp) => {
+      const data = path.join(tmp.path, "data")
+      const cache = path.join(tmp.path, "cache")
+      return Global.layerWith({
+        home: path.join(tmp.path, "home"),
+        data,
+        cache,
+        config: path.join(tmp.path, "config"),
+        state: path.join(tmp.path, "state"),
+        tmp: path.join(tmp.path, "tmp"),
+        bin: path.join(cache, "bin"),
+        log: path.join(data, "log"),
+        repos: path.join(data, "repos"),
+      })
+    }),
+  ),
+)

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -9,6 +9,7 @@ import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
 import { Plugin } from "@opencode-ai/core/plugin"
@@ -21,6 +22,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { tmpdir } from "./fixture/tmpdir"
+import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
 import { toolDefinitions, waitForTool } from "./lib/tool"
 import { Database } from "../src/database/database"
@@ -28,9 +30,15 @@ import { Bus } from "../src/bus"
 import { Reference } from "../src/reference"
 import { Tool } from "../src/tool"
 
-const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, LocationServiceMap.node])))
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+  ]),
+)
 const itWithSdk = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node])),
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+  ]),
 )
 
 describe("LocationServiceMap", () => {

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -33,6 +33,7 @@ import { ShellTool } from "@opencode-ai/core/tool/plugin/shell"
 import { ToolOutput } from "@opencode-ai/core/tool-output"
 import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
+import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
 import { toolIdentity, executeTool, toolDefinitions, waitForTool } from "./lib/tool"
 
@@ -138,6 +139,7 @@ const layer = AppNodeBuilder.build(
   [
     [SessionExecution.node, executionNode],
     [Permission.node, permission],
+    [Global.node, tempGlobalLayer],
   ],
 )
 

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { Money } from "@opencode-ai/schema/money"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Database } from "@opencode-ai/core/database/database"
 import { Bus } from "@opencode-ai/core/bus"
@@ -26,6 +27,7 @@ import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { SubagentTool } from "@opencode-ai/core/tool/plugin/subagent"
 import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
+import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
 import { executeTool, toolIdentity, waitForTool } from "./lib/tool"
 
@@ -100,7 +102,10 @@ const layer = AppNodeBuilder.build(
     PluginRuntime.providerNode,
     LocationServiceMap.node,
   ]),
-  [[SessionExecution.node, executionNode]],
+  [
+    [SessionExecution.node, executionNode],
+    [Global.node, tempGlobalLayer],
+  ],
 )
 
 const it = testEffect(layer)


### PR DESCRIPTION
## What

`packages/core/test/config/plugin.test.ts` read the developer’s real `~/.config/opencode` through the default `Global` service. If that config declared plugins unavailable in the test environment, their load failures were appended to the captured log targets and the exact-list assertion failed spuriously.

**Before:** setting `OPENCODE_CONFIG_DIR` to a config with a nonexistent plugin reproduced an extra ambient target before the two fixture targets.

**After:** every affected graph receives a scoped temporary `Global`, so ambient XDG config and other user paths cannot enter these suites.

## How

- Add a reusable `tempGlobalLayer` fixture that places every `Global` path under a fresh temporary directory and removes it with the test scope.
- Override `Global.node` in both config plugin test graphs.
- Audit sibling core graphs that construct the real `LocationServiceMap`; apply the same isolation to `location-layer.test.ts`, `tool-subagent.test.ts`, and `tool-shell.test.ts`.
- Audit `packages/cli/test`; it has no `AppNodeBuilder.build` suites matching this leak pattern.

## Testing

- `bunx tsgo --noEmit` in `packages/core`
- `bun test test/config/plugin.test.ts` with a clean environment: 13 passed
- The same plugin suite with `OPENCODE_CONFIG_DIR` containing two nonexistent ambient plugins: 13 passed
- `bun test test/location-layer.test.ts test/tool-subagent.test.ts test/tool-shell.test.ts` with a clean environment: 43 passed
- The same sibling suites with the polluted `OPENCODE_CONFIG_DIR`: 43 passed
- Push hook repository typecheck: 33/33 Turbo tasks passed