### PR TITLE
fix(acp): respect default agent variant

### DIFF
--- a/packages/opencode/src/acp/directory.ts
+++ b/packages/opencode/src/acp/directory.ts
@@ -39,6 +39,7 @@ export type Snapshot = {
   readonly defaultModeID: string
   readonly availableCommands: readonly Command.Info[]
   readonly defaultModel?: DefaultModel
+  readonly defaultVariant?: string
 }
 
 export interface LoaderInterface {
@@ -66,6 +67,7 @@ export const build = (input: {
   readonly defaultModeID: string
   readonly commands: readonly Command.Info[]
   readonly defaultModel?: DefaultModel
+  readonly defaultVariant?: string
 }): Snapshot => {
   const modelOptions = Provider.sort(
     Object.values(input.providers).flatMap((provider) =>
@@ -101,6 +103,7 @@ export const build = (input: {
       : (input.modes[0]?.id ?? input.defaultModeID),
     availableCommands: input.commands,
     ...(input.defaultModel ? { defaultModel: input.defaultModel } : {}),
+    ...(input.defaultVariant ? { defaultVariant: input.defaultVariant } : {}),
   }
 }
 
@@ -134,6 +137,12 @@ export const loaderLayer = Layer.effect(
             defaultModeID: defaultAgent.name,
             commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
             ...(defaultModel._tag === "Some" ? { defaultModel: defaultModel.value } : {}),
+            ...(defaultModel._tag === "Some" &&
+            defaultAgent.model?.providerID === defaultModel.value.providerID &&
+            defaultAgent.model.modelID === defaultModel.value.modelID &&
+            defaultAgent.variant
+              ? { defaultVariant: defaultAgent.variant }
+              : {}),
           })
         }).pipe(Effect.provideService(InstanceRef, ctx))
       }),

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -751,6 +751,7 @@ async function loadDirectorySnapshot(sdk: OpencodeClient, directory: string) {
     const defaultModelStarted = performance.now()
     const defaultModel = defaultModelFromConfig(configResponse?.data?.model, providers)
     ACPProfile.duration("acp.directory.defaultModel.resolve", defaultModelStarted, { configured: !!defaultModel })
+    const defaultAgent = agents.find((agent) => agent.mode !== "subagent" && agent.hidden !== true)
     const modes = agents
       .filter((agent) => agent.mode !== "subagent" && agent.hidden !== true)
       .map((agent) => ({
@@ -775,9 +776,15 @@ async function loadDirectorySnapshot(sdk: OpencodeClient, directory: string) {
       directory,
       providers,
       modes,
-      defaultModeID: agents.find((agent) => agent.mode === "primary" && agent.hidden !== true)?.name ?? "build",
+      defaultModeID: defaultAgent?.name ?? "build",
       commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
       ...(defaultModel ? { defaultModel } : {}),
+      ...(defaultModel &&
+      defaultAgent?.model?.providerID === defaultModel.providerID &&
+      defaultAgent.model.modelID === defaultModel.modelID &&
+      defaultAgent.variant
+        ? { defaultVariant: defaultAgent.variant }
+        : {}),
     })
   })
 }
@@ -895,6 +902,13 @@ function sendUsageUpdate(
 function selectVariant(snapshot: Directory.Snapshot, model: Directory.DefaultModel) {
   const variants = Directory.variants(snapshot, model)
   if (!variants) return
+  if (
+    snapshot.defaultModel?.providerID === model.providerID &&
+    snapshot.defaultModel.modelID === model.modelID &&
+    snapshot.defaultVariant &&
+    variants[snapshot.defaultVariant]
+  )
+    return snapshot.defaultVariant
   if (variants.default) return "default"
   return Object.keys(variants)[0]
 }

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -196,6 +196,12 @@ describe("ACP service sessions", () => {
       abort?: (input: { sessionID: string }) => Promise<{ data: boolean }>
       prompt?: (input: unknown) => Promise<{ data: { info: ReturnType<typeof assistantInfo> } }>
       sessionUpdate?: (update: SessionNotification) => Promise<void>
+      configuredModel?: string
+      defaultAgent?: {
+        model: { providerID: ProviderV2.ID; modelID: ModelV2.ID }
+        mode?: "primary" | "all"
+        variant: string
+      }
     },
   ) => {
     const updates: SessionNotification[] = []
@@ -219,13 +225,13 @@ describe("ACP service sessions", () => {
       },
       config: {
         providers: () => Promise.resolve({ data: { providers: [provider], default: { test: modelID } } }),
-        get: () => Promise.resolve({ data: {} }),
+        get: () => Promise.resolve({ data: options?.configuredModel ? { model: options.configuredModel } : {} }),
       },
       app: {
         agents: () =>
           Promise.resolve({
             data: [
-              { name: "build", mode: "primary", permission: [], options: {} },
+              { name: "build", mode: "primary", permission: [], options: {}, ...options?.defaultAgent },
               { name: "plan", mode: "primary", description: "Plan first", permission: [], options: {} },
               { name: "hidden", mode: "primary", hidden: true, permission: [], options: {} },
             ],
@@ -355,6 +361,21 @@ describe("ACP service sessions", () => {
     expect(JSON.stringify(updates[0])).toContain("available_commands_update")
     expect(JSON.stringify(updates[0])).toContain("review-skill")
     expect(mcpAdds).toEqual(["tools"])
+  })
+
+  it("uses the default agent variant for a matching configured model", async () => {
+    const { service } = makeService([], {
+      configuredModel: `${providerID}/${secondModelID}`,
+      defaultAgent: {
+        model: { providerID, modelID: secondModelID },
+        mode: "all",
+        variant: "medium",
+      },
+    })
+    const result = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+    expect(select(result, "model")?.currentValue).toBe(`${providerID}/${secondModelID}`)
+    expect(select(result, "effort")?.currentValue).toBe("medium")
   })
 
   it("loads a session and restores model variant and mode from messages", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #41628

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fresh ACP sessions retained the configured default model but not the matching default agent variant, so initial effort fell back to the first available variant. This carries the variant in the ACP directory snapshot only when the agent and configured models match, then selects it only when that model supports it. It also recognizes visible custom default agents with `mode: "all"`.

### How did you verify your code works?

- `bun test test/acp` (129 pass)
- `bun run typecheck`
- `bunx prettier --check src/acp/directory.ts src/acp/service.ts test/acp/service-session.test.ts`
- Real ACP subprocess: current `dev` selected `none`; this branch selected the configured `medium` variant

### Screenshots / recordings

Not applicable; this changes ACP session initialization without UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR