### PR TITLE
fix(tui): use current session model for context limit display

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -27,7 +27,10 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
 
     const tokens =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    const currentModel = session()?.model
+    const model = currentModel
+      ? props.api.state.provider.find((item) => item.id === currentModel.providerID)?.models[currentModel.id]
+      : props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     return {
       tokens,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,


### PR DESCRIPTION
## Summary
- After switching models mid-session, the sidebar context limit percentage was calculated using the last assistant message's model instead of the currently selected model
- Now uses the session's current model for context limit calculation, falling back to the last assistant message's model when session model is not set

Fixes #35072