### PR TITLE
perf(drizzle): add explicit variance annotations to Effect SQLite types

### DIFF
--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/select.ts
@@ -45,9 +45,9 @@ export type SQLiteEffectSelectPrepare<
 >
 
 export class SQLiteEffectSelectBuilder<
-  TSelection extends SelectedFields | undefined,
-  TRunResult,
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  out TSelection extends SelectedFields | undefined,
+  out TRunResult,
+  out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
   TBuilderMode extends "db" | "qb" = "db",
 > {
   static readonly [entityKind]: string = "SQLiteEffectSelectBuilder"

--- a/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
+++ b/packages/effect-drizzle-sqlite/src/sqlite-core/effect/session.ts
@@ -304,9 +304,9 @@ export class SQLiteEffectPreparedQuery<
 }
 
 export abstract class SQLiteEffectSession<
-  TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
-  TRunResult = unknown,
-  TRelations extends AnyRelations = EmptyRelations,
+  out TEffectHKT extends QueryEffectHKTBase = QueryEffectHKTBase,
+  out TRunResult = unknown,
+  out TRelations extends AnyRelations = EmptyRelations,
 > {
   static readonly [entityKind]: string = "SQLiteEffectSession"
 
@@ -404,9 +404,9 @@ export abstract class SQLiteEffectSession<
 }
 
 export abstract class SQLiteEffectTransaction<
-  TEffectHKT extends QueryEffectHKTBase,
-  TRunResult,
-  TRelations extends AnyRelations = EmptyRelations,
+  out TEffectHKT extends QueryEffectHKTBase,
+  out TRunResult,
+  out TRelations extends AnyRelations = EmptyRelations,
 > extends SQLiteEffectDatabase<TEffectHKT, TRunResult, TRelations> {
   static override readonly [entityKind]: string = "SQLiteEffectTransaction"
 


### PR DESCRIPTION
## Summary
- Add 'out' variance annotations to SQLiteEffectSession, SQLiteEffectTransaction, and SQLiteEffectSelectBuilder
- Avoids ~680ms of recursive variance derivation per typecheck

Fixes #40890