### PR TITLE
fix(tui): deduplicate repeated image attachments

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -59,6 +59,20 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
   return []
 }
 
+const userAttachmentContent = (files: readonly FileAttachment[]) => {
+  const seen = new Map<string, Set<string>>()
+  return files.flatMap((file) => {
+    if (!imageMimes.has(file.mime) || file.source.type !== "inline" || !file.mention?.text)
+      return attachmentContent(file)
+    const metadata = JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text])
+    const matches = seen.get(file.data)
+    if (matches?.has(metadata)) return []
+    if (matches) matches.add(metadata)
+    if (!matches) seen.set(file.data, new Set([metadata]))
+    return attachmentContent(file)
+  })
+}
+
 const decodeToolInput = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 
 const providerMetadata = (
@@ -186,7 +200,7 @@ function toLLMMessage(message: SessionMessage.Info, model: Model.Ref, providerMe
       const content = [
         ...(message.skills ?? []).map((skill) => Message.text(skill.text)),
         ...(message.text === "" ? [] : [Message.text(message.text)]),
-        ...(message.files ?? []).flatMap(attachmentContent),
+        ...userAttachmentContent(message.files ?? []),
       ]
       if (content.length === 0) return []
       return [

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -60,15 +60,20 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
 }
 
 const userAttachmentContent = (files: readonly FileAttachment[]) => {
-  const seen = new Map<string, Set<string>>()
+  const eligible = files.filter(
+    (file) => imageMimes.has(file.mime) && file.source.type === "inline" && file.mention?.text,
+  )
+  if (eligible.length < 2) return files.flatMap(attachmentContent)
+
+  const seen = new Map<string, string[]>()
   return files.flatMap((file) => {
     if (!imageMimes.has(file.mime) || file.source.type !== "inline" || !file.mention?.text)
       return attachmentContent(file)
     const metadata = JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text])
-    const matches = seen.get(file.data)
-    if (matches?.has(metadata)) return []
-    if (matches) matches.add(metadata)
-    if (!matches) seen.set(file.data, new Set([metadata]))
+    const matches = seen.get(metadata)
+    if (matches?.includes(file.data)) return []
+    if (matches) matches.push(file.data)
+    if (!matches) seen.set(metadata, [file.data])
     return attachmentContent(file)
   })
 }

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -373,6 +373,97 @@ Recent work
     ])
   })
 
+  test("deduplicates provider media while preserving durable attachment references", () => {
+    const data = Base64.make("AAECAw==")
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-duplicate-image"),
+          type: "user",
+          text: "[Image 1] [Image 1] [Image 2]",
+          files: [
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+              mention: { start: 0, end: 9, text: "[Image 1]" },
+            }),
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+              mention: { start: 10, end: 19, text: "[Image 1]" },
+            }),
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+              description: "alternate use",
+              mention: { start: 20, end: 29, text: "[Image 2]" },
+            }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "[Image 1] [Image 1] [Image 2]" },
+      { type: "media", mediaType: "image/png", data, filename: "image.png" },
+      {
+        type: "media",
+        mediaType: "image/png",
+        data,
+        filename: "image.png",
+        metadata: { description: "alternate use" },
+      },
+    ])
+  })
+
+  test("preserves provider media with distinct labels or URI sources", () => {
+    const data = Base64.make("AAECAw==")
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-distinct-images"),
+          type: "user",
+          text: "[Image 1] [Image 2]",
+          files: [
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+              mention: { start: 0, end: 9, text: "[Image 1]" },
+            }),
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+              mention: { start: 10, end: 19, text: "[Image 2]" },
+            }),
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "uri", uri: "file:///project/image.png" },
+              name: "image.png",
+              mention: { start: 0, end: 9, text: "[Image 1]" },
+            }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages[0]?.content.filter((part) => part.type === "media")).toHaveLength(3)
+  })
+
   test("replays durable tool media into canonical tool messages without structured base64", () => {
     const messages = toLLMMessages(
       [

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -454,6 +454,12 @@ Recent work
               name: "image.png",
               mention: { start: 0, end: 9, text: "[Image 1]" },
             }),
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "inline" },
+              name: "image.png",
+            }),
           ],
           time: { created },
         }),
@@ -461,7 +467,7 @@ Recent work
       model,
     )
 
-    expect(messages[0]?.content.filter((part) => part.type === "media")).toHaveLength(3)
+    expect(messages[0]?.content.filter((part) => part.type === "media")).toHaveLength(4)
   })
 
   test("replays durable tool media into canonical tool messages without structured base64", () => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -60,7 +60,7 @@ import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
 import { PluginSlot } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
-import { deduplicatePromptFiles, promptAttachmentLabel } from "../../prompt/attachment"
+import { deduplicatePromptImages, promptAttachmentLabel } from "../../prompt/attachment"
 import { DialogImagePreview } from "../dialog-image-preview"
 
 export type PromptProps = {
@@ -332,7 +332,7 @@ export function Prompt(props: PromptProps) {
   }
 
   const imageAttachments = createMemo(() =>
-    (deduplicatePromptFiles(store.prompt.files) ?? []).filter((file) => file.uri.startsWith("data:image/")),
+    (store.prompt.files ?? []).filter((file) => file.uri.startsWith("data:image/")),
   )
   const imagePreviewHeight = createMemo(() => Math.max(4, Math.min(8, Math.floor(dimensions().height / 4))))
   const imagePreviewWidth = createMemo(() => imagePreviewHeight() * 2)
@@ -748,6 +748,11 @@ export function Prompt(props: PromptProps) {
           if (ref.type === "file") {
             const part = draft.prompt.files?.[ref.index]
             if (!part?.mention) continue
+            const duplicate = part.uri.startsWith("data:image/") ? files.findIndex((file) => file.uri === part.uri) : -1
+            if (duplicate >= 0) {
+              newMap.set(extmark.id, { type: "file", index: duplicate })
+              continue
+            }
             part.mention.start = extmark.start
             part.mention.end = extmark.end
             const index = files.length
@@ -1139,7 +1144,7 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
-    const files = deduplicatePromptFiles(store.prompt.files)
+    const files = deduplicatePromptImages(store.prompt.files)
 
     if (store.mode === "shell") {
       move.startSubmit()
@@ -1404,8 +1409,11 @@ export function Prompt(props: PromptProps) {
     setStore(
       produce((draft) => {
         const files = (draft.prompt.files ??= [])
-        const index = files.length
-        files.push(part)
+        const duplicate = file.uri.startsWith("data:image/")
+          ? files.findIndex((attachment) => attachment.uri === file.uri)
+          : -1
+        const index = duplicate >= 0 ? duplicate : files.length
+        if (duplicate < 0) files.push(part)
         draft.extmarkToPart.set(extmarkId, { type: "file", index })
       }),
     )

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -60,6 +60,7 @@ import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
 import { PluginSlot } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
+import { deduplicatePromptFiles, promptAttachmentLabel } from "../../prompt/attachment"
 import { DialogImagePreview } from "../dialog-image-preview"
 
 export type PromptProps = {
@@ -331,7 +332,7 @@ export function Prompt(props: PromptProps) {
   }
 
   const imageAttachments = createMemo(() =>
-    (store.prompt.files ?? []).filter((file) => typeof file.uri === "string" && file.uri.startsWith("data:image/")),
+    (deduplicatePromptFiles(store.prompt.files) ?? []).filter((file) => file.uri.startsWith("data:image/")),
   )
   const imagePreviewHeight = createMemo(() => Math.max(4, Math.min(8, Math.floor(dimensions().height / 4))))
   const imagePreviewWidth = createMemo(() => imagePreviewHeight() * 2)
@@ -1138,6 +1139,7 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
+    const files = deduplicatePromptFiles(store.prompt.files)
 
     if (store.mode === "shell") {
       move.startSubmit()
@@ -1158,7 +1160,7 @@ export function Prompt(props: PromptProps) {
           arguments: slashHead.arguments,
           agent: agent.id,
           model,
-          files: store.prompt.files,
+          files,
           agents: store.prompt.agents,
           skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
           delivery,
@@ -1225,7 +1227,7 @@ export function Prompt(props: PromptProps) {
         .prompt({
           sessionID,
           text: inputText,
-          files: store.prompt.files,
+          files,
           agents: store.prompt.agents,
           skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
           delivery,
@@ -1376,13 +1378,7 @@ export function Prompt(props: PromptProps) {
   function pasteAttachment(file: { filename?: string; uri: string }) {
     const currentOffset = input.cursorOffset
     const extmarkStart = currentOffset
-    const pdf = file.uri.startsWith("data:application/pdf;")
-    const count = pdf
-      ? (store.prompt.files?.filter(
-          (attachment) => typeof attachment.uri === "string" && attachment.uri.startsWith("data:application/pdf;"),
-        ).length ?? 0)
-      : imageAttachments().length
-    const virtualText = pdf ? `[PDF ${count + 1}]` : `[Image ${count + 1}]`
+    const virtualText = promptAttachmentLabel(store.prompt.files, file.uri)
     const extmarkEnd = extmarkStart + virtualText.length
     const textToInsert = virtualText + " "
 

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -60,7 +60,11 @@ import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
 import { PluginSlot } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
-import { deduplicatePromptImages, promptAttachmentLabel } from "../../prompt/attachment"
+import {
+  deduplicatePromptAttachments,
+  isReusablePromptAttachment,
+  promptAttachmentLabel,
+} from "../../prompt/attachment"
 import { DialogImagePreview } from "../dialog-image-preview"
 
 export type PromptProps = {
@@ -748,7 +752,9 @@ export function Prompt(props: PromptProps) {
           if (ref.type === "file") {
             const part = draft.prompt.files?.[ref.index]
             if (!part?.mention) continue
-            const duplicate = part.uri.startsWith("data:image/") ? files.findIndex((file) => file.uri === part.uri) : -1
+            const duplicate = isReusablePromptAttachment(part.uri)
+              ? files.findIndex((file) => file.uri === part.uri)
+              : -1
             if (duplicate >= 0) {
               newMap.set(extmark.id, { type: "file", index: duplicate })
               continue
@@ -1144,7 +1150,7 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
-    const files = deduplicatePromptImages(store.prompt.files)
+    const files = deduplicatePromptAttachments(store.prompt.files)
 
     if (store.mode === "shell") {
       move.startSubmit()
@@ -1409,7 +1415,7 @@ export function Prompt(props: PromptProps) {
     setStore(
       produce((draft) => {
         const files = (draft.prompt.files ??= [])
-        const duplicate = file.uri.startsWith("data:image/")
+        const duplicate = isReusablePromptAttachment(file.uri)
           ? files.findIndex((attachment) => attachment.uri === file.uri)
           : -1
         const index = duplicate >= 0 ? duplicate : files.length

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -61,8 +61,8 @@ import { abbreviateHome } from "../../runtime"
 import { PluginSlot } from "../../plugin/render"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import {
-  deduplicatePromptAttachments,
-  isReusablePromptAttachment,
+  deduplicatePromptImages,
+  preserveMentionlessPromptAttachments,
   promptAttachmentLabel,
 } from "../../prompt/attachment"
 import { DialogImagePreview } from "../dialog-image-preview"
@@ -336,7 +336,7 @@ export function Prompt(props: PromptProps) {
   }
 
   const imageAttachments = createMemo(() =>
-    (store.prompt.files ?? []).filter((file) => file.uri.startsWith("data:image/")),
+    (deduplicatePromptImages(store.prompt.files) ?? []).filter((file) => file.uri.startsWith("data:image/")),
   )
   const imagePreviewHeight = createMemo(() => Math.max(4, Math.min(8, Math.floor(dimensions().height / 4))))
   const imagePreviewWidth = createMemo(() => imagePreviewHeight() * 2)
@@ -752,13 +752,6 @@ export function Prompt(props: PromptProps) {
           if (ref.type === "file") {
             const part = draft.prompt.files?.[ref.index]
             if (!part?.mention) continue
-            const duplicate = isReusablePromptAttachment(part.uri)
-              ? files.findIndex((file) => file.uri === part.uri)
-              : -1
-            if (duplicate >= 0) {
-              newMap.set(extmark.id, { type: "file", index: duplicate })
-              continue
-            }
             part.mention.start = extmark.start
             part.mention.end = extmark.end
             const index = files.length
@@ -795,8 +788,14 @@ export function Prompt(props: PromptProps) {
           newMap.set(extmark.id, { type: "pasted", index })
         }
 
+        const nextFiles = preserveMentionlessPromptAttachments(draft.prompt.files, files)
+
         draft.extmarkToPart = newMap
-        draft.prompt.files = files
+        if (
+          nextFiles.length !== draft.prompt.files?.length ||
+          nextFiles.some((file, index) => file !== draft.prompt.files?.[index])
+        )
+          draft.prompt.files = nextFiles
         draft.prompt.agents = agents
         draft.prompt.skills = skills
         draft.prompt.pasted = pasted
@@ -1150,8 +1149,6 @@ export function Prompt(props: PromptProps) {
 
     // Capture mode before it gets reset
     const currentMode = store.mode
-    const files = deduplicatePromptAttachments(store.prompt.files)
-
     if (store.mode === "shell") {
       move.startSubmit()
       void client.api.session.shell({
@@ -1171,7 +1168,7 @@ export function Prompt(props: PromptProps) {
           arguments: slashHead.arguments,
           agent: agent.id,
           model,
-          files,
+          files: store.prompt.files,
           agents: store.prompt.agents,
           skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
           delivery,
@@ -1238,7 +1235,7 @@ export function Prompt(props: PromptProps) {
         .prompt({
           sessionID,
           text: inputText,
-          files,
+          files: store.prompt.files,
           agents: store.prompt.agents,
           skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
           delivery,
@@ -1389,7 +1386,7 @@ export function Prompt(props: PromptProps) {
   function pasteAttachment(file: { filename?: string; uri: string }) {
     const currentOffset = input.cursorOffset
     const extmarkStart = currentOffset
-    const virtualText = promptAttachmentLabel(store.prompt.files, file.uri)
+    const virtualText = promptAttachmentLabel(store.prompt.files, { uri: file.uri, name: file.filename })
     const extmarkEnd = extmarkStart + virtualText.length
     const textToInsert = virtualText + " "
 
@@ -1415,11 +1412,8 @@ export function Prompt(props: PromptProps) {
     setStore(
       produce((draft) => {
         const files = (draft.prompt.files ??= [])
-        const duplicate = isReusablePromptAttachment(file.uri)
-          ? files.findIndex((attachment) => attachment.uri === file.uri)
-          : -1
-        const index = duplicate >= 0 ? duplicate : files.length
-        if (duplicate < 0) files.push(part)
+        const index = files.length
+        files.push(part)
         draft.extmarkToPart.set(extmarkId, { type: "file", index })
       }),
     )

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -741,6 +741,7 @@ export function Prompt(props: PromptProps) {
     setStore(
       produce((draft) => {
         const newMap = new Map<number, PromptPartRef>()
+        const fileExtmarks = new Map<number, NonNullable<PromptInfo["files"]>[number]>()
         const files: NonNullable<PromptInfo["files"]> = []
         const agents: NonNullable<PromptInfo["agents"]> = []
         const skills: NonNullable<PromptInfo["skills"]> = []
@@ -754,9 +755,8 @@ export function Prompt(props: PromptProps) {
             if (!part?.mention) continue
             part.mention.start = extmark.start
             part.mention.end = extmark.end
-            const index = files.length
             files.push(part)
-            newMap.set(extmark.id, { type: "file", index })
+            fileExtmarks.set(extmark.id, part)
             continue
           }
           if (ref.type === "agent") {
@@ -789,6 +789,11 @@ export function Prompt(props: PromptProps) {
         }
 
         const nextFiles = preserveMentionlessPromptAttachments(draft.prompt.files, files)
+        const fileIndices = new Map(nextFiles.map((file, index) => [file, index]))
+        for (const [extmark, file] of fileExtmarks) {
+          const index = fileIndices.get(file)
+          if (index !== undefined) newMap.set(extmark, { type: "file", index })
+        }
 
         draft.extmarkToPart = newMap
         if (

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -1,29 +1,78 @@
 import type { PromptInput } from "@opencode-ai/schema"
 
 type PromptFile = PromptInput.FileAttachment
+type PromptFileIdentity = Pick<PromptFile, "uri" | "name" | "description">
+type ProjectedFile = Readonly<{
+  data: string
+  mime: string
+  source: { type: string }
+  name?: string
+  description?: string
+  mention?: { text: string }
+}>
 
-export function isReusablePromptAttachment(uri: string) {
-  return uri.startsWith("data:image/") || uri.startsWith("data:application/pdf;")
+function attachmentKind(uri: string) {
+  if (uri.startsWith("data:image/")) return "Image"
+  if (uri.startsWith("data:application/pdf;")) return "PDF"
+  return undefined
 }
 
-export function deduplicatePromptAttachments(files: readonly PromptFile[] | undefined) {
+function attachmentMetadata(file: PromptFileIdentity) {
+  return JSON.stringify([file.name ?? null, file.description ?? null])
+}
+
+export function deduplicatePromptImages(files: readonly PromptFile[] | undefined) {
   if (!files || files.length < 2) return files
-  const seen = new Set<string>()
+  const seen = new Map<string, Set<string>>()
   return files.filter((file) => {
-    if (!isReusablePromptAttachment(file.uri)) return true
-    if (seen.has(file.uri)) return false
-    seen.add(file.uri)
+    if (!file.uri.startsWith("data:image/")) return true
+    const metadata = attachmentMetadata(file)
+    const matches = seen.get(file.uri)
+    if (matches?.has(metadata)) return false
+    if (matches) matches.add(metadata)
+    if (!matches) seen.set(file.uri, new Set([metadata]))
     return true
   })
 }
 
-export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, uri: string) {
-  const pdf = uri.startsWith("data:application/pdf;")
-  const existing = files?.find((file) => file.uri === uri)?.mention?.text
+export function preserveMentionlessPromptAttachments(
+  files: readonly PromptFile[] | undefined,
+  mentioned: PromptFile[],
+) {
+  return [...mentioned, ...(files?.filter((file) => !file.mention) ?? [])]
+}
+
+export function deduplicateVisibleImages<T extends ProjectedFile>(files: readonly T[]) {
+  const seen = new Map<string, Set<string>>()
+  return files.filter((file) => {
+    if (!file.mime.startsWith("image/") || file.source.type !== "inline" || !file.mention?.text) return true
+    const metadata = JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text])
+    const matches = seen.get(file.data)
+    if (matches?.has(metadata)) return false
+    if (matches) matches.add(metadata)
+    if (!matches) seen.set(file.data, new Set([metadata]))
+    return true
+  })
+}
+
+export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, file: PromptFileIdentity) {
+  const kind = attachmentKind(file.uri)
+  if (!kind) throw new Error(`Unsupported inline attachment: ${file.uri}`)
+  const metadata = attachmentMetadata(file)
+  const existing =
+    kind === "Image"
+      ? files?.find(
+          (candidate) =>
+            candidate.uri === file.uri && attachmentMetadata(candidate) === metadata && candidate.mention?.text,
+        )?.mention?.text
+      : undefined
   if (existing) return existing
 
-  const prefix = pdf ? "data:application/pdf;" : "data:image/"
-  const attachments = deduplicatePromptAttachments(files)
-  const count = attachments?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
-  return `[${pdf ? "PDF" : "Image"} ${count + 1}]`
+  const pattern = new RegExp(`^\\[${kind} (\\d+)\\]$`)
+  const count =
+    files?.reduce((highest, candidate) => {
+      const match = candidate.mention?.text.match(pattern)
+      return match ? Math.max(highest, Number(match[1])) : highest
+    }, 0) ?? 0
+  return `[${kind} ${count + 1}]`
 }

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -21,38 +21,56 @@ function attachmentMetadata(file: PromptFileIdentity) {
   return JSON.stringify([file.name ?? null, file.description ?? null])
 }
 
-export function deduplicatePromptImages(files: readonly PromptFile[] | undefined) {
-  if (!files || files.length < 2) return files
-  const seen = new Map<string, Set<string>>()
-  return files.filter((file) => {
-    if (!file.uri.startsWith("data:image/")) return true
-    const metadata = attachmentMetadata(file)
-    const matches = seen.get(file.uri)
-    if (matches?.has(metadata)) return false
-    if (matches) matches.add(metadata)
-    if (!matches) seen.set(file.uri, new Set([metadata]))
+function deduplicateByIdentity<T>(
+  items: readonly T[],
+  identity: (item: T) => { metadata: string; payload: string } | undefined,
+) {
+  const seen = new Map<string, string[]>()
+  return items.filter((item) => {
+    const key = identity(item)
+    if (!key) return true
+    const matches = seen.get(key.metadata)
+    if (matches?.includes(key.payload)) return false
+    if (matches) matches.push(key.payload)
+    if (!matches) seen.set(key.metadata, [key.payload])
     return true
   })
+}
+
+export function deduplicatePromptImages(files: readonly PromptFile[] | undefined) {
+  if (!files || files.length < 2) return files
+  return deduplicateByIdentity(files, (file) =>
+    file.uri.startsWith("data:image/") && file.mention?.text
+      ? {
+          metadata: JSON.stringify([attachmentMetadata(file), file.mention.text]),
+          payload: file.uri,
+        }
+      : undefined,
+  )
 }
 
 export function preserveMentionlessPromptAttachments(
   files: readonly PromptFile[] | undefined,
   mentioned: PromptFile[],
 ) {
-  return [...mentioned, ...(files?.filter((file) => !file.mention) ?? [])]
+  if (!files) return mentioned
+  const tracked = mentioned.values()
+  return files.flatMap((file) => {
+    if (!file.mention?.text) return [file]
+    const next = tracked.next()
+    return next.done ? [] : [next.value]
+  })
 }
 
 export function deduplicateVisibleImages<T extends ProjectedFile>(files: readonly T[]) {
-  const seen = new Map<string, Set<string>>()
-  return files.filter((file) => {
-    if (!file.mime.startsWith("image/") || file.source.type !== "inline" || !file.mention?.text) return true
-    const metadata = JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text])
-    const matches = seen.get(file.data)
-    if (matches?.has(metadata)) return false
-    if (matches) matches.add(metadata)
-    if (!matches) seen.set(file.data, new Set([metadata]))
-    return true
-  })
+  return deduplicateByIdentity(files, (file) =>
+    file.mime.startsWith("image/") && file.source.type === "inline" && file.mention?.text
+      ? {
+          metadata: JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text]),
+          payload: file.data,
+        }
+      : undefined,
+  )
 }
 
 export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, file: PromptFileIdentity) {

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -25,5 +25,5 @@ export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, 
   const prefix = pdf ? "data:application/pdf;" : "data:image/"
   const attachments = deduplicatePromptAttachments(files)
   const count = attachments?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
-  return `${pdf ? "PDF" : "Image"} ${count + 1}`
+  return `[${pdf ? "PDF" : "Image"} ${count + 1}]`
 }

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -2,11 +2,15 @@ import type { PromptInput } from "@opencode-ai/schema"
 
 type PromptFile = PromptInput.FileAttachment
 
-export function deduplicatePromptImages(files: readonly PromptFile[] | undefined) {
+export function isReusablePromptAttachment(uri: string) {
+  return uri.startsWith("data:image/") || uri.startsWith("data:application/pdf;")
+}
+
+export function deduplicatePromptAttachments(files: readonly PromptFile[] | undefined) {
   if (!files || files.length < 2) return files
   const seen = new Set<string>()
   return files.filter((file) => {
-    if (!file.uri.startsWith("data:image/")) return true
+    if (!isReusablePromptAttachment(file.uri)) return true
     if (seen.has(file.uri)) return false
     seen.add(file.uri)
     return true
@@ -15,11 +19,11 @@ export function deduplicatePromptImages(files: readonly PromptFile[] | undefined
 
 export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, uri: string) {
   const pdf = uri.startsWith("data:application/pdf;")
-  const existing = !pdf && files?.find((file) => file.uri === uri)?.mention?.text
+  const existing = files?.find((file) => file.uri === uri)?.mention?.text
   if (existing) return existing
 
   const prefix = pdf ? "data:application/pdf;" : "data:image/"
-  const attachments = pdf ? files : deduplicatePromptImages(files)
+  const attachments = deduplicatePromptAttachments(files)
   const count = attachments?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
-  return `[${pdf ? "PDF" : "Image"} ${count + 1}]`
+  return `${pdf ? "PDF" : "Image"} ${count + 1}`
 }

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -1,0 +1,23 @@
+import type { PromptInfo } from "./history"
+
+type PromptFile = NonNullable<PromptInfo["files"]>[number]
+
+export function deduplicatePromptFiles(files: readonly PromptFile[] | undefined) {
+  if (!files) return undefined
+  const seen = new Set<string>()
+  return files.filter((file) => {
+    if (seen.has(file.uri)) return false
+    seen.add(file.uri)
+    return true
+  })
+}
+
+export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, uri: string) {
+  const pdf = uri.startsWith("data:application/pdf;")
+  const existing = files?.find((file) => file.uri === uri)?.mention?.text
+  if (existing) return existing
+
+  const prefix = pdf ? "data:application/pdf;" : "data:image/"
+  const count = deduplicatePromptFiles(files)?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
+  return `[${pdf ? "PDF" : "Image"} ${count + 1}]`
+}

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -1,11 +1,12 @@
-import type { PromptInfo } from "./history"
+import type { PromptInput } from "@opencode-ai/schema"
 
-type PromptFile = NonNullable<PromptInfo["files"]>[number]
+type PromptFile = PromptInput.FileAttachment
 
-export function deduplicatePromptFiles(files: readonly PromptFile[] | undefined) {
-  if (!files) return undefined
+export function deduplicatePromptImages(files: readonly PromptFile[] | undefined) {
+  if (!files || files.length < 2) return files
   const seen = new Set<string>()
   return files.filter((file) => {
+    if (!file.uri.startsWith("data:image/")) return true
     if (seen.has(file.uri)) return false
     seen.add(file.uri)
     return true
@@ -14,10 +15,11 @@ export function deduplicatePromptFiles(files: readonly PromptFile[] | undefined)
 
 export function promptAttachmentLabel(files: readonly PromptFile[] | undefined, uri: string) {
   const pdf = uri.startsWith("data:application/pdf;")
-  const existing = files?.find((file) => file.uri === uri)?.mention?.text
+  const existing = !pdf && files?.find((file) => file.uri === uri)?.mention?.text
   if (existing) return existing
 
   const prefix = pdf ? "data:application/pdf;" : "data:image/"
-  const count = deduplicatePromptFiles(files)?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
+  const attachments = pdf ? files : deduplicatePromptImages(files)
+  const count = attachments?.filter((file) => file.uri.startsWith(prefix)).length ?? 0
   return `[${pdf ? "PDF" : "Image"} ${count + 1}]`
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -70,6 +70,7 @@ import stripAnsi from "strip-ansi"
 import { usePromptRef } from "../../context/prompt"
 import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
 import { projectedPromptInput } from "../../prompt/codec"
+import { deduplicateVisibleImages } from "../../prompt/attachment"
 import { useEpilogue } from "../../context/epilogue"
 import { normalizePath } from "../../util/path"
 import { PermissionPrompt } from "./permission"
@@ -1899,7 +1900,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
   const ctx = use()
   const data = useData()
   const local = useLocal()
-  const files = createMemo(() => props.message.files ?? [])
+  const files = createMemo(() => deduplicateVisibleImages(props.message.files ?? []))
   const skills = createMemo(() => props.message.skills ?? [])
   const images = createMemo(() =>
     files().flatMap((file) =>

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -9,12 +9,29 @@ import {
 describe("prompt attachments", () => {
   test("deduplicates identical inline images while preserving other attachments", () => {
     const files = [
-      { uri: "data:image/png;base64,AAA", name: "first.png" },
+      {
+        uri: "data:image/png;base64,AAA",
+        name: "first.png",
+        mention: { start: 0, end: 9, text: "[Image 1]" },
+      },
       { uri: "file:///same", name: "first.txt" },
       { uri: "data:application/pdf;base64,CCC", name: "first.pdf" },
-      { uri: "data:image/png;base64,BBB", name: "second.png" },
-      { uri: "data:image/png;base64,AAA", name: "first.png" },
-      { uri: "data:image/png;base64,AAA", name: "first.png", description: "alternate use" },
+      {
+        uri: "data:image/png;base64,BBB",
+        name: "second.png",
+        mention: { start: 10, end: 19, text: "[Image 2]" },
+      },
+      {
+        uri: "data:image/png;base64,AAA",
+        name: "first.png",
+        mention: { start: 20, end: 29, text: "[Image 1]" },
+      },
+      {
+        uri: "data:image/png;base64,AAA",
+        name: "first.png",
+        description: "alternate use",
+        mention: { start: 30, end: 39, text: "[Image 1]" },
+      },
       { uri: "file:///same", name: "second.txt" },
       { uri: "data:application/pdf;base64,CCC", name: "first.pdf" },
     ]
@@ -62,14 +79,27 @@ describe("prompt attachments", () => {
 
   test("preserves mentionless attachments when tracked mentions are synchronized", () => {
     const mentionless = { uri: "data:image/png;base64,AAA" }
+    const emptyMention = {
+      uri: "data:image/png;base64,CCC",
+      mention: { start: 0, end: 0, text: "" },
+    }
     const mentioned = {
       uri: "data:image/png;base64,BBB",
       mention: { start: 0, end: 9, text: "[Image 1]" },
     }
 
-    expect(preserveMentionlessPromptAttachments([mentionless, mentioned], [mentioned])).toEqual([
-      mentioned,
+    const restored = preserveMentionlessPromptAttachments([mentionless, emptyMention, mentioned], [mentioned])
+    expect(restored).toEqual([mentionless, emptyMention, mentioned])
+    expect(restored.indexOf(mentioned)).toBe(2)
+
+    const another = {
+      uri: "data:image/png;base64,DDD",
+      mention: { start: 10, end: 19, text: "[Image 2]" },
+    }
+    expect(preserveMentionlessPromptAttachments([mentioned, mentionless, another], [another, mentioned])).toEqual([
+      another,
       mentionless,
+      mentioned,
     ])
   })
 
@@ -85,5 +115,11 @@ describe("prompt attachments", () => {
 
     expect(deduplicateVisibleImages(files)).toEqual([file])
     expect(files).toHaveLength(2)
+
+    const distinct = [
+      { ...file, mention: { text: "[Image 2]" } },
+      { ...file, mention: undefined },
+    ]
+    expect(deduplicateVisibleImages([file, ...distinct])).toEqual([file, ...distinct])
   })
 })

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, test } from "bun:test"
-import { deduplicatePromptFiles, promptAttachmentLabel } from "../../src/prompt/attachment"
+import { deduplicatePromptImages, promptAttachmentLabel } from "../../src/prompt/attachment"
 
 describe("prompt attachments", () => {
-  test("deduplicates identical attachment data while preserving order", () => {
+  test("deduplicates identical image data while preserving order", () => {
     const files = [
       { uri: "data:image/png;base64,AAA", name: "first.png" },
+      { uri: "file:///same", name: "first.txt" },
       { uri: "data:image/png;base64,BBB", name: "second.png" },
       { uri: "data:image/png;base64,AAA", name: "duplicate.png" },
+      { uri: "file:///same", name: "second.txt" },
     ]
 
-    expect(deduplicatePromptFiles(files)).toEqual(files.slice(0, 2))
-    expect(files).toHaveLength(3)
+    expect(deduplicatePromptImages(files)).toEqual([files[0], files[1], files[2], files[4]])
+    expect(files).toHaveLength(5)
   })
 
   test("reuses labels for identical image data", () => {

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { deduplicatePromptFiles, promptAttachmentLabel } from "../../src/prompt/attachment"
+
+describe("prompt attachments", () => {
+  test("deduplicates identical attachment data while preserving order", () => {
+    const files = [
+      { uri: "data:image/png;base64,AAA", name: "first.png" },
+      { uri: "data:image/png;base64,BBB", name: "second.png" },
+      { uri: "data:image/png;base64,AAA", name: "duplicate.png" },
+    ]
+
+    expect(deduplicatePromptFiles(files)).toEqual(files.slice(0, 2))
+    expect(files).toHaveLength(3)
+  })
+
+  test("reuses labels for identical image data", () => {
+    const first = "data:image/png;base64,AAA"
+    const second = "data:image/png;base64,BBB"
+    const files = [{ uri: first, mention: { start: 0, end: 9, text: "[Image 1]" } }]
+
+    expect(promptAttachmentLabel(files, first)).toBe("[Image 1]")
+    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("[Image 2]")
+  })
+
+  test("numbers PDFs independently from images", () => {
+    const files = [{ uri: "data:image/png;base64,AAA" }]
+
+    expect(promptAttachmentLabel(files, "data:application/pdf;base64,BBB")).toBe("[PDF 1]")
+  })
+})

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -20,18 +20,21 @@ describe("prompt attachments", () => {
   test("reuses labels for identical image data", () => {
     const first = "data:image/png;base64,AAA"
     const second = "data:image/png;base64,BBB"
-    const files = [{ uri: first, mention: { start: 0, end: 7, text: "Image 1" } }]
+    const files = [{ uri: first, mention: { start: 0, end: 9, text: "[Image 1]" } }]
 
-    expect(promptAttachmentLabel(files, first)).toBe("Image 1")
-    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("Image 2")
+    expect(promptAttachmentLabel(files, first)).toBe("[Image 1]")
+    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("[Image 2]")
   })
 
   test("numbers PDFs independently from images", () => {
     const first = "data:application/pdf;base64,BBB"
     const second = "data:application/pdf;base64,CCC"
-    const files = [{ uri: "data:image/png;base64,AAA" }, { uri: first, mention: { start: 10, end: 15, text: "PDF 1" } }]
+    const files = [
+      { uri: "data:image/png;base64,AAA" },
+      { uri: first, mention: { start: 10, end: 17, text: "[PDF 1]" } },
+    ]
 
-    expect(promptAttachmentLabel(files, first)).toBe("PDF 1")
-    expect(promptAttachmentLabel([...files, { ...files[1], mention: undefined }], second)).toBe("PDF 2")
+    expect(promptAttachmentLabel(files, first)).toBe("[PDF 1]")
+    expect(promptAttachmentLabel([...files, { ...files[1], mention: undefined }], second)).toBe("[PDF 2]")
   })
 })

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -1,32 +1,37 @@
 import { describe, expect, test } from "bun:test"
-import { deduplicatePromptImages, promptAttachmentLabel } from "../../src/prompt/attachment"
+import { deduplicatePromptAttachments, promptAttachmentLabel } from "../../src/prompt/attachment"
 
 describe("prompt attachments", () => {
-  test("deduplicates identical image data while preserving order", () => {
+  test("deduplicates identical inline media while preserving other attachments", () => {
     const files = [
       { uri: "data:image/png;base64,AAA", name: "first.png" },
       { uri: "file:///same", name: "first.txt" },
+      { uri: "data:application/pdf;base64,CCC", name: "first.pdf" },
       { uri: "data:image/png;base64,BBB", name: "second.png" },
       { uri: "data:image/png;base64,AAA", name: "duplicate.png" },
       { uri: "file:///same", name: "second.txt" },
+      { uri: "data:application/pdf;base64,CCC", name: "duplicate.pdf" },
     ]
 
-    expect(deduplicatePromptImages(files)).toEqual([files[0], files[1], files[2], files[4]])
-    expect(files).toHaveLength(5)
+    expect(deduplicatePromptAttachments(files)).toEqual([files[0], files[1], files[2], files[3], files[5]])
+    expect(files).toHaveLength(7)
   })
 
   test("reuses labels for identical image data", () => {
     const first = "data:image/png;base64,AAA"
     const second = "data:image/png;base64,BBB"
-    const files = [{ uri: first, mention: { start: 0, end: 9, text: "[Image 1]" } }]
+    const files = [{ uri: first, mention: { start: 0, end: 7, text: "Image 1" } }]
 
-    expect(promptAttachmentLabel(files, first)).toBe("[Image 1]")
-    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("[Image 2]")
+    expect(promptAttachmentLabel(files, first)).toBe("Image 1")
+    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("Image 2")
   })
 
   test("numbers PDFs independently from images", () => {
-    const files = [{ uri: "data:image/png;base64,AAA" }]
+    const first = "data:application/pdf;base64,BBB"
+    const second = "data:application/pdf;base64,CCC"
+    const files = [{ uri: "data:image/png;base64,AAA" }, { uri: first, mention: { start: 10, end: 15, text: "PDF 1" } }]
 
-    expect(promptAttachmentLabel(files, "data:application/pdf;base64,BBB")).toBe("[PDF 1]")
+    expect(promptAttachmentLabel(files, first)).toBe("PDF 1")
+    expect(promptAttachmentLabel([...files, { ...files[1], mention: undefined }], second)).toBe("PDF 2")
   })
 })

--- a/packages/tui/test/prompt/attachment.test.ts
+++ b/packages/tui/test/prompt/attachment.test.ts
@@ -1,20 +1,34 @@
 import { describe, expect, test } from "bun:test"
-import { deduplicatePromptAttachments, promptAttachmentLabel } from "../../src/prompt/attachment"
+import {
+  deduplicatePromptImages,
+  deduplicateVisibleImages,
+  preserveMentionlessPromptAttachments,
+  promptAttachmentLabel,
+} from "../../src/prompt/attachment"
 
 describe("prompt attachments", () => {
-  test("deduplicates identical inline media while preserving other attachments", () => {
+  test("deduplicates identical inline images while preserving other attachments", () => {
     const files = [
       { uri: "data:image/png;base64,AAA", name: "first.png" },
       { uri: "file:///same", name: "first.txt" },
       { uri: "data:application/pdf;base64,CCC", name: "first.pdf" },
       { uri: "data:image/png;base64,BBB", name: "second.png" },
-      { uri: "data:image/png;base64,AAA", name: "duplicate.png" },
+      { uri: "data:image/png;base64,AAA", name: "first.png" },
+      { uri: "data:image/png;base64,AAA", name: "first.png", description: "alternate use" },
       { uri: "file:///same", name: "second.txt" },
-      { uri: "data:application/pdf;base64,CCC", name: "duplicate.pdf" },
+      { uri: "data:application/pdf;base64,CCC", name: "first.pdf" },
     ]
 
-    expect(deduplicatePromptAttachments(files)).toEqual([files[0], files[1], files[2], files[3], files[5]])
-    expect(files).toHaveLength(7)
+    expect(deduplicatePromptImages(files)).toEqual([
+      files[0],
+      files[1],
+      files[2],
+      files[3],
+      files[5],
+      files[6],
+      files[7],
+    ])
+    expect(files).toHaveLength(8)
   })
 
   test("reuses labels for identical image data", () => {
@@ -22,19 +36,54 @@ describe("prompt attachments", () => {
     const second = "data:image/png;base64,BBB"
     const files = [{ uri: first, mention: { start: 0, end: 9, text: "[Image 1]" } }]
 
-    expect(promptAttachmentLabel(files, first)).toBe("[Image 1]")
-    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], second)).toBe("[Image 2]")
+    expect(promptAttachmentLabel(files, { uri: first })).toBe("[Image 1]")
+    expect(promptAttachmentLabel([...files, { ...files[0], mention: undefined }], { uri: second })).toBe("[Image 2]")
+    expect(promptAttachmentLabel([{ uri: first }], { uri: first })).toBe("[Image 1]")
   })
 
   test("numbers PDFs independently from images", () => {
-    const first = "data:application/pdf;base64,BBB"
-    const second = "data:application/pdf;base64,CCC"
-    const files = [
-      { uri: "data:image/png;base64,AAA" },
-      { uri: first, mention: { start: 10, end: 17, text: "[PDF 1]" } },
-    ]
+    const files = [{ uri: "data:image/png;base64,AAA" }]
 
-    expect(promptAttachmentLabel(files, first)).toBe("[PDF 1]")
-    expect(promptAttachmentLabel([...files, { ...files[1], mention: undefined }], second)).toBe("[PDF 2]")
+    expect(promptAttachmentLabel(files, { uri: "data:application/pdf;base64,BBB" })).toBe("[PDF 1]")
+  })
+
+  test("does not reuse a label when attachment metadata differs", () => {
+    const uri = "data:image/png;base64,AAA"
+    const files = [{ uri, name: "one.png", mention: { start: 0, end: 9, text: "[Image 1]" } }]
+
+    expect(promptAttachmentLabel(files, { uri, name: "two.png" })).toBe("[Image 2]")
+  })
+
+  test("does not reuse numbers after an earlier attachment is removed", () => {
+    const files = [{ uri: "data:image/png;base64,BBB", mention: { start: 0, end: 9, text: "[Image 2]" } }]
+
+    expect(promptAttachmentLabel(files, { uri: "data:image/png;base64,CCC" })).toBe("[Image 3]")
+  })
+
+  test("preserves mentionless attachments when tracked mentions are synchronized", () => {
+    const mentionless = { uri: "data:image/png;base64,AAA" }
+    const mentioned = {
+      uri: "data:image/png;base64,BBB",
+      mention: { start: 0, end: 9, text: "[Image 1]" },
+    }
+
+    expect(preserveMentionlessPromptAttachments([mentionless, mentioned], [mentioned])).toEqual([
+      mentioned,
+      mentionless,
+    ])
+  })
+
+  test("deduplicates visible inline image cards without dropping durable references", () => {
+    const file = {
+      data: "AAA",
+      mime: "image/png",
+      source: { type: "inline" },
+      name: "clipboard",
+      mention: { text: "[Image 1]" },
+    }
+    const files = [file, { ...file, mention: { text: "[Image 1]" } }]
+
+    expect(deduplicateVisibleImages(files)).toEqual([file])
+    expect(files).toHaveLength(2)
   })
 })

--- a/packages/tui/test/prompt/history.test.ts
+++ b/packages/tui/test/prompt/history.test.ts
@@ -41,4 +41,21 @@ describe("prompt history", () => {
     const b = entry("describe this", [{ name: "b.png", uri: "data:image/png;base64,BBB" }])
     expect(isDuplicateEntry(a, b)).toBe(false)
   })
+
+  test("preserves duplicate attachment mentions for prompt restoration", () => {
+    const value = entry("[Image 1] [Image 1]", [
+      {
+        name: "clipboard",
+        uri: "data:image/png;base64,AAA",
+        mention: { start: 0, end: 9, text: "[Image 1]" },
+      },
+      {
+        name: "clipboard",
+        uri: "data:image/png;base64,AAA",
+        mention: { start: 10, end: 19, text: "[Image 1]" },
+      },
+    ])
+
+    expect(parsePromptHistory(JSON.stringify(value))).toEqual([value])
+  })
 })


### PR DESCRIPTION
## What

Deduplicate repeated inline images without losing their references. Pasting the same clipboard image twice now renders two `[Image 1]` mentions, one preview and submitted-message card, and one provider image payload.

## Before / After

**Before:** Pasting identical clipboard image data twice created `[Image 1]` and `[Image 2]`, rendered duplicate previews and file cards, and sent duplicate image media to the provider.

**After:** Both mentions remain independently restorable and editable in prompt history, stash, editor, undo, revert, and fork flows. TUI projections show the image once, and provider lowering emits one media part.

## How

- `packages/tui/src/prompt/attachment.ts` defines exact image identity using URI, name, and description for composer labels and previews.
- `packages/tui/src/component/prompt/index.tsx` retains every mention record, including mentionless attachments, while avoiding preview recomputation on mention-only edits.
- `packages/tui/src/routes/session/index.tsx` collapses duplicate visible cards without changing durable message data.
- `packages/core/src/session/runner/to-llm-message.ts` deduplicates only inline images with identical normalized data, MIME, name, description, and mention label. URI-backed, mentionless, differently labeled, or metadata-distinct images remain separate.

## Scope

This compares exact inline image data. It does not perceptually hash separately encoded copies, alter PDF lowering, or deduplicate text files, directories, ranges, names, descriptions, distinct labels, or URI-backed attachments. Durable messages continue to retain one attachment record per mention so every reference can be restored; deduplication applies to TUI projections and provider media lowering.

## Testing

- `bun run test test/prompt` from `packages/tui` (`36` passing)
- `bun run test test/session-runner-message.test.ts` from `packages/core` (`18` passing)
- `bun typecheck` from `packages/tui` and `packages/core`
- `bun turbo typecheck --concurrency=3` via the push hook
- OpenCode Drive end-to-end run against this worktree, asserting that two durable references produce one `data:image/` provider payload and one visible attachment card

## Demo

OpenCode Drive pastes the same PNG twice. The final session contains two `[Image 1]` references, one attachment card, and one provider image payload.

https://github.com/user-attachments/assets/67b59cfa-58b6-4049-b9eb-ace80f2c81d1

## Flow

```mermaid
flowchart LR
  A[Paste image] --> B[Durable Image 1 reference]
  C[Paste identical image] --> D[Second durable Image 1 reference]
  B --> E[One visible preview/card]
  D --> E
  B --> F[Provider lowering]
  D --> F
  F --> G[One image media part]
```
