### PR TITLE
feat(tui): show previous agent in switch notices

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -386,7 +386,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             },
           }))
           break
-        case "session.agent.selected":
+        case "session.agent.selected": {
+          const previous = store.session.info[event.data.sessionID]?.agent
           if (store.session.info[event.data.sessionID])
             setStore("session", "info", event.data.sessionID, "agent", event.data.agent)
           message.update(event.data.sessionID, (draft, index) => {
@@ -394,10 +395,12 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               id: messageIDFromEvent(event.id),
               type: "agent-switched",
               agent: event.data.agent,
+              previous,
               time: { created: event.created },
             })
           })
           break
+        }
         case "session.model.selected":
           if (store.session.info[event.data.sessionID])
             setStore("session", "info", event.data.sessionID, "model", event.data.model)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1652,7 +1652,12 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
   const ctx = use()
   const theme = useTheme()
   const text = () => {
-    if (props.message.type === "agent-switched") return `Switched agent to ${props.message.agent}`
+    if (props.message.type === "agent-switched") {
+      const agent = Locale.titlecase(props.message.agent)
+      if (props.message.previous && props.message.previous !== props.message.agent)
+        return `Switched agent from ${Locale.titlecase(props.message.previous)} to ${agent}`
+      return `Switched agent to ${agent}`
+    }
     if (props.message.type === "model-switched")
       return switchLabel(props.message.model, ctx.models(), props.message.previous)
     return ""


### PR DESCRIPTION
## Summary

- TUI agent switch notices now use the persisted previous agent: `Switched agent from Build to Plan`.
- Live events copy `previous` from the current session agent before applying the new one.

## Test plan

- [x] `packages/tui` agent switch label tests
- [x] `packages/tui` typecheck
- Switch agent mid-session and confirm the notice shows the old and new agent