### PR TITLE
fix(app): enable desktop menu commands in new layout

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -39,6 +39,7 @@ import type { PromptSession } from "@/context/prompt"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
 import { normalizeSessionInfo } from "@/utils/session"
+import { useMenuFallbackCommands } from "./use-menu-fallback-commands"
 
 const legacyTitlebarHeight = 40
 const v2TitlebarHeight = 36
@@ -68,6 +69,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
   const language = useLanguage()
   const settings = useSettings()
   const server = useServer()
+  useMenuFallbackCommands()
   const navigate = useNavigate()
   const location = useLocation()
   const params = useParams()

--- a/packages/app/src/components/use-menu-fallback-commands.ts
+++ b/packages/app/src/components/use-menu-fallback-commands.ts
@@ -1,0 +1,97 @@
+import { useCommand } from "@/context/command"
+import { useLayout } from "@/context/layout"
+import { useLanguage } from "@/context/language"
+import { ServerConnection, useServer } from "@/context/server"
+import { useSettings } from "@/context/settings"
+import { useTabs } from "@/context/tabs"
+import { useDirectoryPicker } from "@/components/directory-picker"
+import { openServerProjects, useGlobal } from "@/context/global"
+import { usePlatform } from "@/context/platform"
+
+/**
+ * Registers fallback command handlers for desktop menu items that may not be
+ * registered on certain pages (e.g. the home page in the new layout).
+ *
+ * The command registry gives the most recent keyed registration precedence.
+ * When the session page mounts, its registration replaces the session
+ * fallback without producing duplicate command IDs. The layout fallback owns
+ * commands that the new shell no longer registers.
+ *
+ * When the session page unmounts (e.g. navigating back to home), its
+ * registration is cleaned up via `onCleanup`, and this fallback automatically
+ * becomes active again.
+ */
+export function useMenuFallbackCommands() {
+  const command = useCommand()
+  const language = useLanguage()
+  const layout = useLayout()
+  const settings = useSettings()
+  const platform = usePlatform()
+  const server = useServer()
+  const global = useGlobal()
+  const tabs = useTabs()
+  const pickDirectory = useDirectoryPicker()
+
+  if (platform.platform !== "desktop" || !settings.general.newLayoutDesigns()) return null
+
+  command.register("session", () => [
+    {
+      id: "session.new",
+      title: language.t("command.session.new"),
+      category: language.t("command.category.session"),
+      keybind: "mod+shift+s",
+      onSelect: () => {
+        const hasTabNew = command.options.some((opt) => opt.id === "tab.new")
+        if (hasTabNew) command.trigger("tab.new")
+      },
+    },
+    {
+      id: "terminal.toggle",
+      title: language.t("command.terminal.toggle"),
+      category: language.t("command.category.view"),
+      keybind: "ctrl+`",
+      onSelect: () => layout.terminal.toggle(),
+    },
+    {
+      id: "fileTree.toggle",
+      title: language.t("command.fileTree.toggle"),
+      category: language.t("command.category.view"),
+      keybind: "mod+\\",
+      onSelect: () => layout.fileTree.toggle(),
+    },
+  ])
+
+  command.register("layout", () => [
+    {
+      id: "project.open",
+      title: language.t("command.project.open"),
+      category: language.t("command.category.project"),
+      keybind: "mod+o",
+      onSelect: () => {
+        const conn = server.current
+        if (!conn) return
+        pickDirectory({
+          server: conn,
+          title: language.t("command.project.open"),
+          multiple: true,
+          onSelect: (result) => {
+            if (!result) return
+            const dirs = Array.isArray(result) ? result : [result]
+            const directory = openServerProjects(global.ensureServerCtx(conn), dirs)
+            if (!directory) return
+            void tabs.newDraft({ server: ServerConnection.key(conn), directory })
+          },
+        })
+      },
+    },
+    {
+      id: "sidebar.toggle",
+      title: language.t("command.sidebar.toggle"),
+      category: language.t("command.category.view"),
+      keybind: "mod+b",
+      onSelect: () => layout.sidebar.toggle(),
+    },
+  ])
+
+  return null
+}

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -155,6 +155,28 @@ function createServerCtx(
 
 export type ServerCtx = ReturnType<typeof createServerCtx>
 
+export function openServerProjects(ctx: ServerCtx, directories: string[]) {
+  const directory = directories[0]
+  if (!directory) return undefined
+
+  directories.forEach((item) => {
+    if (ctx.projects.list().some((project) => project.worktree === item)) return
+    const location = { directory: item }
+    void ctx.sdk.api.file
+      .list({ path: ".", location })
+      .then(async (files) => {
+        if (files.data.length > 0) return ctx.sdk.api.project.current({ location })
+        const result = await ctx.sdk.client.project.initGit({ directory: item })
+        return result.data ?? ctx.sdk.api.project.current({ location })
+      })
+      .then((project) => ctx.sync.child(item, { bootstrap: false })[1]("project", project.id))
+      .catch(() => undefined)
+    ctx.projects.open(item)
+  })
+  ctx.projects.touch(directory)
+  return directory
+}
+
 function isLocalHost(url: string) {
   const host = url.replace(/^https?:\/\//, "").split(":")[0]
   if (host === "localhost" || host === "127.0.0.1") return "local"

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -611,6 +611,22 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       if (sessionTimer !== undefined) window.clearTimeout(sessionTimer)
     })
 
+    // Terminal opened state is global (not per-session). Both layout.terminal
+    // and view().terminal expose the same underlying state.
+    const terminalOpened = createMemo(() => store.terminal?.opened ?? false)
+
+    function setTerminalOpened(next: boolean) {
+      const current = store.terminal
+      if (!current) {
+        setStore("terminal", { height: DEFAULT_TERMINAL_HEIGHT, opened: next })
+        return
+      }
+
+      const value = current.opened ?? false
+      if (value === next) return
+      setStore("terminal", "opened", next)
+    }
+
     return {
       route,
       ready,
@@ -687,8 +703,23 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       },
       terminal: {
         height: createMemo(() => store.terminal.height),
+        opened: terminalOpened,
         resize(height: number) {
           setStore("terminal", "height", height)
+        },
+        open() {
+          setTerminalOpened(true)
+        },
+        close() {
+          setTerminalOpened(false)
+        },
+        toggle() {
+          const current = store.terminal
+          if (!current) {
+            setStore("terminal", { height: DEFAULT_TERMINAL_HEIGHT, opened: true })
+            return
+          }
+          setStore("terminal", "opened", (prev) => !(prev ?? false))
         },
       },
       review: {
@@ -817,21 +848,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           const file = s().reviewFile
           if (typeof file === "string") return file
         })
-        const terminalOpened = createMemo(() => store.terminal?.opened ?? false)
         const reviewPanelOpened = createMemo(() => store.review?.panelOpened ?? DEFAULT_REVIEW_PANEL_OPENED)
         const reviewPanelSource = createMemo(() => (reviewPanelOpened() ? ephemeral.reviewPanelSource : "other"))
-
-        function setTerminalOpened(next: boolean) {
-          const current = store.terminal
-          if (!current) {
-            setStore("terminal", { height: DEFAULT_TERMINAL_HEIGHT, opened: next })
-            return
-          }
-
-          const value = current.opened ?? false
-          if (value === next) return
-          setStore("terminal", "opened", next)
-        }
 
         function setReviewPanelOpened(next: boolean, source: ReviewPanelSource) {
           const nextSource = next ? source : "other"

--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -1,4 +1,4 @@
-import { useGlobal } from "@/context/global"
+import { openServerProjects, useGlobal } from "@/context/global"
 import { type HomeProjectSelection, useLayout } from "@/context/layout"
 import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
@@ -87,24 +87,8 @@ export function createHomeController() {
         setSelection(toggleHomeProjectSelection(selection(), key, directory))
       },
       add: (conn: ServerConnection.Any, directories: string[]) => {
-        const directory = directories[0]
+        const directory = openServerProjects(global.ensureServerCtx(conn), directories)
         if (!directory) return
-        const ctx = global.ensureServerCtx(conn)
-        directories.forEach((item) => {
-          if (ctx.projects.list().some((project) => project.worktree === item)) return
-          const location = { directory: item }
-          void ctx.sdk.api.file
-            .list({ path: ".", location })
-            .then(async (files) => {
-              if (files.data.length > 0) return ctx.sdk.api.project.current({ location })
-              const result = await ctx.sdk.client.project.initGit({ directory: item })
-              return result.data ?? ctx.sdk.api.project.current({ location })
-            })
-            .then((project) => ctx.sync.child(item, { bootstrap: false })[1]("project", project.id))
-            .catch(() => undefined)
-          ctx.projects.open(item)
-        })
-        ctx.projects.touch(directory)
         setSelection({ server: ServerConnection.key(conn), directory })
       },
       openNewSession: () => {


### PR DESCRIPTION
### Issue for this PR

Closes #40898

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the desktop app's new layout, some menu commands were not registered on pages such as Home. The app menu treats missing commands as disabled, so New Session, Open Project, Toggle Sidebar, Toggle Terminal, and Toggle File Tree appeared greyed out.

This adds desktop-only fallback registrations for those commands in the persistent titlebar. The fallbacks use the existing `session` and `layout` registration keys, so page-specific session commands replace them when a session is mounted and the fallbacks return when it unmounts.

The project-opening logic is shared with the Home page so opening a project from the menu follows the same initialization and synchronization path. Terminal visibility is exposed through the global layout state so the fallback can toggle it without requiring a session-scoped view.

The fallbacks are only registered for the desktop app when the new layout is enabled, leaving the legacy layout and web app unchanged.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/app`.
- Ran `bun run test:unit` from `packages/app`: 722 tests passed.
- Verified the staged diff with `git diff --cached --check`.
- Manually verified the affected menu items are enabled and trigger their corresponding actions in the Linux desktop app.

### Screenshots / recordings
<img width="578" height="289" alt="615c49a746cc290718827dfa243821d9" src="https://github.com/user-attachments/assets/213b6da3-50f2-4342-bd5e-b1909b596aed" />
<img width="644" height="427" alt="bd078016ef94fa8e2a28b58c400cb8db" src="https://github.com/user-attachments/assets/14cc9c86-a9fe-41da-8670-2d58f2751157" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR