### PR TITLE
feat(core): extract plan agent into a plugin

### DIFF
--- a/packages/core/src/plugin/agent.ts
+++ b/packages/core/src/plugin/agent.ts
@@ -101,16 +101,6 @@ export const Plugin = define({
         item.permissions.push({ action: "question", resource: "*", effect: "allow" })
       })
 
-      draft.update(Agent.ID.make("plan"), (item) => {
-        item.name = Agent.Name.make("Plan")
-        item.description = "Plan mode. Disallows all edit tools."
-        item.mode = "primary"
-        item.permissions.push(
-          { action: "question", resource: "*", effect: "allow" },
-          { action: "edit", resource: "*", effect: "deny" },
-        )
-      })
-
       draft.update(Agent.ID.make("general"), (item) => {
         item.name = Agent.Name.make("General")
         item.description =

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -60,6 +60,7 @@ import { WellKnown } from "../wellknown"
 import { WriteTool } from "../tool/plugin/write"
 import { AgentPlugin } from "./agent"
 import { CommandPlugin } from "./command"
+import { PlanPlugin } from "./plan"
 import { ModelsDevPlugin } from "./models-dev"
 import { ProviderPlugins } from "./provider"
 import { WebSearchPlugins } from "./websearch"
@@ -192,6 +193,7 @@ export type InternalPlugin = Plugin<Requirements | Scope.Scope>
 const pre = [
   WellKnownPlugin.Plugin,
   AgentPlugin.Plugin,
+  PlanPlugin.Plugin,
   CommandPlugin.Plugin,
   SkillPlugin.Plugin,
   ...SystemPromptPlugin.Plugins,

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -1,0 +1,29 @@
+export * as PlanPlugin from "./plan"
+
+import { ToolFailure } from "@opencode-ai/ai"
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Effect } from "effect"
+import { Agent } from "../agent"
+
+export const Plugin = define({
+  id: "opencode.plan",
+  effect: Effect.fn(function* (ctx) {
+    yield* ctx.agent.transform((draft) => {
+      draft.update(Agent.ID.make("plan"), (item) => {
+        item.name = Agent.Name.make("Plan")
+        item.description = "Plan mode. Disallows all edit tools."
+        item.mode = "primary"
+        item.permissions.push({ action: "question", resource: "*", effect: "allow" })
+      })
+    })
+
+    yield* ctx.tool.hook("execute.before", (event) => {
+      if (event.agent !== Agent.ID.make("plan")) return Effect.void
+      if (event.tool !== "edit" && event.tool !== "write" && event.tool !== "patch") return Effect.void
+      return new ToolFailure({
+        message:
+          "You cannot perform writes while Plan is selected. Do not use edit, write, or patch. Continue planning without modifying files.",
+      })
+    })
+  }),
+})

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -2,14 +2,24 @@ export * as PlanPlugin from "./plan"
 
 import { ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
 import { Agent } from "../agent"
+
+const plan = Agent.ID.make("plan")
+
+const enter = `<system-reminder>
+You are in Plan mode. This is a read-only mode. Do not modify files or take other write actions. Do not delegate work to a subagent that can make edits. Investigate, ask questions, and propose a plan.
+</system-reminder>`
+
+const leave = `<system-reminder>
+You are no longer in Plan mode. The previous read-only restrictions no longer apply. You may edit files and use write tools again.
+</system-reminder>`
 
 export const Plugin = define({
   id: "opencode.plan",
   effect: Effect.fn(function* (ctx) {
     yield* ctx.agent.transform((draft) => {
-      draft.update(Agent.ID.make("plan"), (item) => {
+      draft.update(plan, (item) => {
         item.name = Agent.Name.make("Plan")
         item.description = "Read-only agent for exploring the codebase and planning work before implementation."
         item.mode = "primary"
@@ -18,11 +28,28 @@ export const Plugin = define({
     })
 
     yield* ctx.tool.hook("execute.before", (event) => {
-      if (event.agent !== Agent.ID.make("plan")) return Effect.void
+      if (event.agent !== plan) return Effect.void
       if (event.tool !== "edit" && event.tool !== "write" && event.tool !== "patch") return Effect.void
       return new ToolFailure({
         message: `Cannot use ${event.tool} in Plan mode. You are in a read-only mode and must not modify files.`,
       })
     })
+
+    yield* ctx.event.subscribe().pipe(
+      Stream.filter((event) => event.type === "session.agent.selected"),
+      Stream.runForEach((event) => {
+        if (event.data.agent === event.data.previous) return Effect.void
+        const text = event.data.agent === plan ? enter : event.data.previous === plan ? leave : undefined
+        if (!text) return Effect.void
+        return ctx.session
+          .synthetic({
+            sessionID: event.data.sessionID,
+            text,
+            resume: false,
+          })
+          .pipe(Effect.catch(() => Effect.void))
+      }),
+      Effect.forkScoped({ startImmediately: true }),
+    )
   }),
 })

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -8,11 +8,11 @@ import { Agent } from "../agent"
 const plan = Agent.ID.make("plan")
 
 const enter = `<system-reminder>
-You are in Plan mode. This is a read-only mode. Do not modify files or take other write actions. Do not delegate work to a subagent that can make edits. Investigate, ask questions, and propose a plan.
+You are in Plan mode. This is a READ-ONLY environment. You are not allowed to edit files, and you may not ask a subagent to edit them either.
 </system-reminder>`
 
 const leave = `<system-reminder>
-You are no longer in Plan mode. The previous read-only restrictions no longer apply. You may edit files and use write tools again.
+You are no longer in Plan mode. The previous read-only restrictions no longer apply. You may edit files again.
 </system-reminder>`
 
 export const Plugin = define({

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -8,11 +8,13 @@ import { Agent } from "../agent"
 const plan = Agent.ID.make("plan")
 
 const enter = `<system-reminder>
-You are in Plan mode. This is a READ-ONLY environment. You are not allowed to edit files, and you may not ask a subagent to edit them either.
+You are in Plan mode. You are not allowed to edit or create files, and you may not ask a subagent to do that either.
+
+You are in Plan mode until the user switches agents. Plan mode is not changed by user intent, tone, or imperative language. If the user asks you to change files, do not edit. Tell them they need to switch agents.
 </system-reminder>`
 
 const leave = `<system-reminder>
-You are no longer in Plan mode. The previous read-only restrictions no longer apply. You may edit files again.
+You are NO LONGER in Plan mode. The previous Plan restrictions no longer apply. Any Plan mode instructions from earlier in this conversation are no longer active.
 </system-reminder>`
 
 export const Plugin = define({

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -4,6 +4,7 @@ import { ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Agent } from "../agent"
+import { SessionEvent } from "../session/event"
 
 const plan = Agent.ID.make("plan")
 
@@ -38,16 +39,12 @@ export const Plugin = define({
     })
 
     yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "session.created" || event.type === "session.agent.selected"),
+      Stream.filter(
+        (event): event is SessionEvent.Created | SessionEvent.AgentSelected =>
+          event.type === "session.created" || event.type === "session.agent.selected",
+      ),
       Stream.runForEach((event) => {
-        if (event.type === "session.created" && event.data.agent !== plan) return Effect.void
-        if (event.type === "session.agent.selected" && event.data.agent === event.data.previous) return Effect.void
-        const text =
-          event.type === "session.created" || event.data.agent === plan
-            ? enter
-            : event.data.previous === plan
-              ? leave
-              : undefined
+        const text = reminder(event)
         if (!text) return Effect.void
         return ctx.session
           .synthetic({
@@ -61,3 +58,13 @@ export const Plugin = define({
     )
   }),
 })
+
+function reminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
+  if (event.type === "session.created") {
+    if (event.data.agent !== plan) return
+    return enter
+  }
+  if (event.data.agent === event.data.previous) return
+  if (event.data.agent === plan) return enter
+  if (event.data.previous === plan) return leave
+}

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -38,10 +38,16 @@ export const Plugin = define({
     })
 
     yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "session.agent.selected"),
+      Stream.filter((event) => event.type === "session.created" || event.type === "session.agent.selected"),
       Stream.runForEach((event) => {
-        if (event.data.agent === event.data.previous) return Effect.void
-        const text = event.data.agent === plan ? enter : event.data.previous === plan ? leave : undefined
+        if (event.type === "session.created" && event.data.agent !== plan) return Effect.void
+        if (event.type === "session.agent.selected" && event.data.agent === event.data.previous) return Effect.void
+        const text =
+          event.type === "session.created" || event.data.agent === plan
+            ? enter
+            : event.data.previous === plan
+              ? leave
+              : undefined
         if (!text) return Effect.void
         return ctx.session
           .synthetic({

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -11,7 +11,7 @@ export const Plugin = define({
     yield* ctx.agent.transform((draft) => {
       draft.update(Agent.ID.make("plan"), (item) => {
         item.name = Agent.Name.make("Plan")
-        item.description = "Plan mode. Disallows all edit tools."
+        item.description = "Read-only agent for exploring the codebase and planning work before implementation."
         item.mode = "primary"
         item.permissions.push({ action: "question", resource: "*", effect: "allow" })
       })
@@ -21,8 +21,7 @@ export const Plugin = define({
       if (event.agent !== Agent.ID.make("plan")) return Effect.void
       if (event.tool !== "edit" && event.tool !== "write" && event.tool !== "patch") return Effect.void
       return new ToolFailure({
-        message:
-          "You cannot perform writes while Plan is selected. Do not use edit, write, or patch. Continue planning without modifying files.",
+        message: `Cannot use ${event.tool} in Plan mode. You are in a read-only mode and must not modify files.`,
       })
     })
   }),

--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -165,7 +165,6 @@ describe("Agent", () => {
         "compaction",
         "explore",
         "general",
-        "plan",
         "summary",
         "title",
       ])

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -14379,6 +14379,9 @@
               },
               "agent": {
                 "type": "string"
+              },
+              "previous": {
+                "type": "string"
               }
             },
             "required": ["sessionID", "agent"],

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -14379,6 +14379,9 @@
               },
               "agent": {
                 "type": "string"
+              },
+              "previous": {
+                "type": "string"
               }
             },
             "required": ["sessionID", "agent"],

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -14379,6 +14379,9 @@
               },
               "agent": {
                 "type": "string"
+              },
+              "previous": {
+                "type": "string"
               }
             },
             "required": ["sessionID", "agent"],


### PR DESCRIPTION
## Summary

- Extract the built-in Plan agent from `opencode.agent` into its own internal plugin, `opencode.plan`.
- Stop using `edit * deny`, so edit/write/patch stay in the advertised tool schema.
- Reject those tools from `execute.before` when Plan is selected, returning a `ToolFailure` to the model.
- Inject read-only enter/leave reminders from `session.agent.selected`, using the durable predecessor contract merged in #41771.

## Test plan

- [ ] Switch a session to Plan and confirm edit/write/patch still appear in the tool list
- [ ] Call edit, write, or patch under Plan and confirm the model gets a write-disabled tool error
- [ ] Confirm Build can still edit/write/patch
- [ ] Confirm `plugins: ["-opencode.plan"]` removes the Plan agent