### PR TITLE
feat(plugin): allow tool hooks to fail with tool errors

### DIFF
--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -4,6 +4,7 @@ import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
 import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
+import type { Tool } from "@opencode-ai/schema/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -15,19 +16,22 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-type Callback<Event> = (event: Event) => Effect.Effect<void>
+// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
+type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+
+type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name]>,
+    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name]>
+  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -56,7 +60,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -3,8 +3,7 @@ export * as PluginHooks from "./hooks"
 import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
-import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
-import type { Tool } from "@opencode-ai/schema/tool"
+import type { ToolFailures, ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -16,27 +15,29 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
+
+// Failure channel for each hook event. Only tool execute.before may fail: a Tool.Error rejects the call before it runs.
 interface Failures extends Record<keyof Domains, unknown> {
-  readonly aisdk: never
-  readonly session: never
-  readonly shell: never
-  readonly tool: Tool.Error
+  readonly aisdk: NoFailures<AISDKHooks>
+  readonly session: NoFailures<SessionHooks>
+  readonly shell: NoFailures<ShellHooks>
+  readonly tool: ToolFailures
 }
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
-  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain][Name]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
-  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain][Name]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -65,7 +66,9 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain][typeof name]> = Reflect.apply(callback, undefined, [
+          event,
+        ])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -16,8 +16,13 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
-type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+interface Failures extends Record<keyof Domains, unknown> {
+  readonly aisdk: never
+  readonly session: never
+  readonly shell: never
+  readonly tool: Tool.Error
+}
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
@@ -25,13 +30,13 @@ export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -60,7 +65,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test"
+import { ToolFailure } from "@opencode-ai/ai"
 import { Context, Effect, Exit, Fiber, Schema, Stream } from "effect"
 import { Plugin as EffectPlugin } from "@opencode-ai/plugin/effect"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
@@ -393,6 +394,53 @@ describe("Plugin", () => {
         content: [{ type: "text", text: '{"text":"before-mutated"}' }],
         metadata: { rewritten: true },
       })
+    }),
+  )
+
+  it.effect("rejects tool execution when an execute.before hook fails", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const registry = yield* Tool.Service
+      const executed: unknown[] = []
+
+      const plugin = EffectPlugin.define({
+        id: "tool-hook-reject",
+        effect: (ctx) =>
+          Effect.gen(function* () {
+            yield* ctx.tool
+              .transform((draft) =>
+                draft.add({
+                  name: "echo",
+                  options: { codemode: false },
+                  description: "Echo",
+                  input: Schema.Struct({ text: Schema.String }),
+                  output: Schema.Struct({ text: Schema.String }),
+                  execute: ({ text }) =>
+                    Effect.sync(() => executed.push({ text })).pipe(Effect.as({ output: { text } })),
+                }),
+              )
+              .pipe(Effect.orDie)
+
+            yield* ctx.tool
+              .hook("execute.before", () => new ToolFailure({ message: "write disabled" }))
+              .pipe(Effect.asVoid)
+          }),
+      })
+
+      yield* plugins.activate([versioned(plugin)])
+
+      const toolSet = yield* registry.snapshot()
+      const failure = yield* toolSet
+        .execute({
+          sessionID: Session.ID.make("ses_hook_reject"),
+          agent: Agent.ID.make("build"),
+          messageID: SessionMessage.ID.make("msg_hook_reject"),
+          call: { type: "tool-call", id: "call-hook-reject", name: "echo", input: { text: "original" } },
+        })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ _tag: "Tool.Error", message: "write disabled" })
+      expect(executed).toEqual([])
     }),
   )
 })

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,11 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failures extends Record<keyof Spec, unknown> = Record<keyof Spec, never>> = <
+  Name extends keyof Spec,
+>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failures[Name]>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,9 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -40,5 +40,5 @@ export interface ToolHooks {
 
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks>
+  readonly hook: Hooks<ToolHooks, Tool.Error>
 }

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -38,7 +38,13 @@ export interface ToolHooks {
   )
 }
 
+// Only execute.before may fail: a Tool.Error rejects the call before the tool runs.
+export interface ToolFailures extends Record<keyof ToolHooks, unknown> {
+  readonly "execute.before": Tool.Error
+  readonly "execute.after": never
+}
+
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks, Tool.Error>
+  readonly hook: Hooks<ToolHooks, ToolFailures>
 }


### PR DESCRIPTION
## Summary

- Add a per-event `Failures` map parameter to the shared `Hooks<Spec>` registration type, defaulting every event to `never` so session, shell, and aisdk hooks stay infallible.
- Opt only `tool.execute.before` in: it may fail with `Tool.Error` (e.g. `ToolFailure`) to reject a tool call before it runs. `execute.after` remains infallible — after-hooks observe and mutate results but cannot convert outcomes into failures.
- Type `PluginHooks.register`/`trigger` with the same per-event failure lookup instead of casting the error channel away; the tool `execute.before` trigger honestly carries `Tool.Error`, which `executeTool` already has in its error channel and the runner already converts into a model-visible failed tool result via the existing `catchTag("Tool.Error")`.

Promise-flavor plugins need no changes: a throw from a Promise hook becomes a defect in the tool fiber, and runner settlement already closes a defected call as a failed tool result the model can read (`classifyToolExits` in `runner/llm.ts`). This PR only adds the typed rejection channel for Effect plugins.

This is the mechanism half of the Plan-agent-as-plugin change, extracted so the error channel is scoped precisely to the one event where rejection is meaningful.

## Test plan

- [x] `bun typecheck` in `packages/plugin` and `packages/core`
- [x] New test: an Effect `execute.before` hook failing with `ToolFailure` rejects execution with `Tool.Error` and the tool never runs
- [x] Existing plugin hook tests still pass