### PR TITLE
Fixes #37650

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -89,7 +89,7 @@ const layer = Layer.effect(
         sessionID: request.sessionID,
         permission: request.permission,
         patterns: request.patterns,
-        metadata: request.metadata,
+        metadata: Object.fromEntries(Object.entries(request.metadata).filter(([, value]) => value !== undefined)),
         always: request.always,
         tool: request.tool,
       }

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -31,7 +31,7 @@ export const GlobTool = Tool.define(
             always: ["*"],
             metadata: {
               pattern: params.pattern,
-              path: params.path,
+              ...(params.path !== undefined && { path: params.path }),
             },
           })
 

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -42,8 +42,8 @@ export const GrepTool = Tool.define(
             always: ["*"],
             metadata: {
               pattern: params.pattern,
-              path: params.path,
-              include: params.include,
+              ...(params.path !== undefined && { path: params.path }),
+              ...(params.include !== undefined && { include: params.include }),
             },
           })
 

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -1,7 +1,7 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { test, expect } from "bun:test"
 import os from "os"
-import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Permission } from "../../src/permission"
@@ -1172,3 +1172,61 @@ it.instance(
     }),
   { git: true },
 )
+
+it.instance(
+  "ask - omits undefined metadata fields for glob and grep permission requests and successfully encodes permission list",
+  () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("session_meta_test")
+
+      yield* ask({
+        id: PermissionV1.ID.make("per_glob_1"),
+        sessionID,
+        permission: "glob",
+        patterns: ["**/*.txt"],
+        metadata: { pattern: "**/*.txt", path: undefined },
+        always: ["*"],
+        ruleset: [{ permission: "glob", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      yield* ask({
+        id: PermissionV1.ID.make("per_grep_1"),
+        sessionID,
+        permission: "grep",
+        patterns: ["needle"],
+        metadata: { pattern: "needle", path: undefined, include: undefined },
+        always: ["*"],
+        ruleset: [{ permission: "grep", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      yield* ask({
+        id: PermissionV1.ID.make("per_grep_2"),
+        sessionID,
+        permission: "grep",
+        patterns: ["needle"],
+        metadata: { pattern: "needle", path: "src", include: "*.ts" },
+        always: ["*"],
+        ruleset: [{ permission: "grep", pattern: "*", action: "ask" }],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(3)
+      expect(pending).toHaveLength(3)
+
+      const globReq = pending.find((r) => r.id === "per_glob_1")!
+      expect(globReq.metadata).toEqual({ pattern: "**/*.txt" })
+      expect("path" in globReq.metadata).toBe(false)
+
+      const grepReq = pending.find((r) => r.id === "per_grep_1")!
+      expect(grepReq.metadata).toEqual({ pattern: "needle" })
+      expect("path" in grepReq.metadata).toBe(false)
+      expect("include" in grepReq.metadata).toBe(false)
+
+      const grepWithOptsReq = pending.find((r) => r.id === "per_grep_2")!
+      expect(grepWithOptsReq.metadata).toEqual({ pattern: "needle", path: "src", include: "*.ts" })
+
+      const encoded = yield* Schema.encode(Schema.Array(PermissionV1.Request))(pending)
+      expect(encoded).toHaveLength(3)
+    }),
+  { git: true },
+)
+

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -129,4 +129,30 @@ describe("tool.glob", () => {
       }
     }),
   )
+
+  it.instance("permission metadata omits optional path when not provided", () =>
+    Effect.gen(function* () {
+      yield* TestInstance
+      const askData = asks()
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      yield* glob.execute({ pattern: "*.ts" }, askData.next)
+      expect(askData.items).toHaveLength(1)
+      expect(askData.items[0].metadata).toEqual({ pattern: "*.ts" })
+      expect("path" in askData.items[0].metadata).toBe(false)
+    }),
+  )
+
+  it.instance("permission metadata includes path when provided", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const askData = asks()
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      yield* glob.execute({ pattern: "*.ts", path: test.directory }, askData.next)
+      expect(askData.items).toHaveLength(1)
+      expect(askData.items[0].metadata).toEqual({ pattern: "*.ts", path: test.directory })
+    }),
+  )
 })
+

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -41,6 +41,20 @@ const ctx = {
   ask: () => Effect.void,
 }
 
+const asks = () => {
+  const items: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+  return {
+    items,
+    next: {
+      ...ctx,
+      ask: (req: Omit<PermissionV1.Request, "id" | "sessionID" | "tool">) =>
+        Effect.sync(() => {
+          items.push(req)
+        }),
+    } satisfies Tool.Context,
+  }
+}
+
 const root = path.join(__dirname, "../..")
 const full = (p: string) => (process.platform === "win32" ? Filesystem.normalizePath(p) : p)
 
@@ -220,4 +234,31 @@ describe("tool.grep", () => {
       expect(requests.find((req) => req.permission === "external_directory")).toBeUndefined()
     }),
   )
+
+  it.instance("permission metadata omits optional path and include when not provided", () =>
+    Effect.gen(function* () {
+      yield* TestInstance
+      const askData = asks()
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      yield* grep.execute({ pattern: "needle" }, askData.next)
+      expect(askData.items).toHaveLength(1)
+      expect(askData.items[0].metadata).toEqual({ pattern: "needle" })
+      expect("path" in askData.items[0].metadata).toBe(false)
+      expect("include" in askData.items[0].metadata).toBe(false)
+    }),
+  )
+
+  it.instance("permission metadata includes path and include when provided", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const askData = asks()
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      yield* grep.execute({ pattern: "needle", path: test.directory, include: "*.ts" }, askData.next)
+      expect(askData.items).toHaveLength(1)
+      expect(askData.items[0].metadata).toEqual({ pattern: "needle", path: test.directory, include: "*.ts" })
+    }),
+  )
 })
+


### PR DESCRIPTION
### Issue for this PR
tools: optional search metadata breaks pending permission listing
 #37650

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When executing `glob` and `grep` tools without optional parameters, `params.path` and `params.include` are `undefined`. Previously, these were passed directly into the permission request `metadata` object (e.g., `{ pattern: "...", path: undefined, include: undefined }`), leaving keys with `undefined` values that can cause schema encoding or serialization issues.

This PR fixes the issue by:
1. Conditionally adding `path` and `include` to permission request `metadata` only when defined in `GlobTool` (`packages/opencode/src/tool/glob.ts`) and `GrepTool` (`packages/opencode/src/tool/grep.ts`).
2. Filtering out any `undefined` metadata values in `Permission.ask` (`packages/opencode/src/permission/index.ts`) before building the permission request object.

### How did you verify your code works?

Added unit tests to verify permission request metadata construction and schema encoding:
- `packages/opencode/test/permission/next.test.ts`: Verified permission requests omit `undefined` metadata properties and encode properly with `Schema.encode(Schema.Array(PermissionV1.Request))`.
- `packages/opencode/test/tool/glob.test.ts`: Verified `GlobTool` omits `path` key when not supplied and includes it when provided.
- `packages/opencode/test/tool/grep.test.ts`: Verified `GrepTool` omits `path` and `include` keys when not supplied and includes them when provided.

### Screenshots / recordings

_N/A (No UI changes)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
