### PR TITLE
fix(core): normalize copilot reasoning usage

### DIFF
--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -356,6 +356,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         cachedTokens: number | undefined
       }
       totalTokens: number | undefined
+      raw: NonNullable<z.infer<typeof openaiCompatibleTokenUsageSchema>> | undefined
     } = {
       completionTokens: undefined,
       completionTokensDetails: {
@@ -368,6 +369,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         cachedTokens: undefined,
       },
       totalTokens: undefined,
+      raw: undefined,
     }
     let isFirstChunk = true
     const providerOptionsName = this.providerOptionsName
@@ -422,6 +424,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             }
 
             if (value.usage != null) {
+              usage.raw = value.usage
               const {
                 prompt_tokens,
                 total_tokens,
@@ -703,11 +706,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                   text: undefined,
                   reasoning: usage.completionTokensDetails.reasoningTokens,
                 },
-                raw: {
-                  prompt_tokens: usage.promptTokens ?? null,
-                  completion_tokens: usage.completionTokens ?? null,
-                  total_tokens: usage.totalTokens ?? null,
-                },
+                raw: usage.raw,
               },
               providerMetadata,
             })

--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -285,9 +285,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
           cacheWrite: undefined,
         },
         outputTokens: {
-          total: responseBody.usage?.completion_tokens ?? undefined,
+          ...outputUsage(responseBody.usage),
           text: undefined,
-          reasoning: responseBody.usage?.completion_tokens_details?.reasoning_tokens ?? undefined,
         },
         raw: responseBody.usage ?? undefined,
       },
@@ -425,18 +424,16 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             if (value.usage != null) {
               const {
                 prompt_tokens,
-                completion_tokens,
                 total_tokens,
                 prompt_tokens_details,
                 completion_tokens_details,
               } = value.usage
 
               usage.promptTokens = prompt_tokens ?? undefined
-              usage.completionTokens = completion_tokens ?? undefined
+              const output = outputUsage(value.usage)
+              usage.completionTokens = output.total
+              usage.completionTokensDetails.reasoningTokens = output.reasoning
               usage.totalTokens = total_tokens ?? undefined
-              if (completion_tokens_details?.reasoning_tokens != null) {
-                usage.completionTokensDetails.reasoningTokens = completion_tokens_details?.reasoning_tokens
-              }
               if (completion_tokens_details?.accepted_prediction_tokens != null) {
                 usage.completionTokensDetails.acceptedPredictionTokens =
                   completion_tokens_details?.accepted_prediction_tokens
@@ -727,6 +724,7 @@ const openaiCompatibleTokenUsageSchema = z
   .object({
     prompt_tokens: z.number().nullish(),
     completion_tokens: z.number().nullish(),
+    reasoning_tokens: z.number().nullish(),
     total_tokens: z.number().nullish(),
     prompt_tokens_details: z
       .object({
@@ -742,6 +740,17 @@ const openaiCompatibleTokenUsageSchema = z
       .nullish(),
   })
   .nullish()
+
+function outputUsage(usage: z.infer<typeof openaiCompatibleTokenUsageSchema>) {
+  const nested = usage?.completion_tokens_details?.reasoning_tokens
+  return {
+    total:
+      usage?.completion_tokens == null
+        ? undefined
+        : usage.completion_tokens + (nested == null ? (usage.reasoning_tokens ?? 0) : 0),
+    reasoning: nested ?? usage?.reasoning_tokens ?? undefined,
+  }
+}
 
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency

--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -356,7 +356,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         cachedTokens: number | undefined
       }
       totalTokens: number | undefined
-      raw: NonNullable<z.infer<typeof openaiCompatibleTokenUsageSchema>> | undefined
+      rawCompletionTokens: number | undefined
     } = {
       completionTokens: undefined,
       completionTokensDetails: {
@@ -369,7 +369,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         cachedTokens: undefined,
       },
       totalTokens: undefined,
-      raw: undefined,
+      rawCompletionTokens: undefined,
     }
     let isFirstChunk = true
     const providerOptionsName = this.providerOptionsName
@@ -424,15 +424,16 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
             }
 
             if (value.usage != null) {
-              usage.raw = value.usage
               const {
                 prompt_tokens,
+                completion_tokens,
                 total_tokens,
                 prompt_tokens_details,
                 completion_tokens_details,
               } = value.usage
 
               usage.promptTokens = prompt_tokens ?? undefined
+              usage.rawCompletionTokens = completion_tokens ?? undefined
               const output = outputUsage(value.usage)
               usage.completionTokens = output.total
               usage.completionTokensDetails.reasoningTokens = output.reasoning
@@ -706,7 +707,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
                   text: undefined,
                   reasoning: usage.completionTokensDetails.reasoningTokens,
                 },
-                raw: usage.raw,
+                raw: {
+                  prompt_tokens: usage.promptTokens ?? null,
+                  completion_tokens: usage.rawCompletionTokens ?? null,
+                  total_tokens: usage.totalTokens ?? null,
+                },
               },
               providerMetadata,
             })

--- a/packages/core/test/github-copilot/copilot-chat-model.test.ts
+++ b/packages/core/test/github-copilot/copilot-chat-model.test.ts
@@ -205,12 +205,6 @@ describe("doStream", () => {
       usage: {
         inputTokens: { total: 19581 },
         outputTokens: { total: 187, reasoning: 134 },
-        raw: {
-          prompt_tokens: 19581,
-          completion_tokens: 53,
-          reasoning_tokens: 134,
-          total_tokens: 19768,
-        },
       },
     })
   })

--- a/packages/core/test/github-copilot/copilot-chat-model.test.ts
+++ b/packages/core/test/github-copilot/copilot-chat-model.test.ts
@@ -24,6 +24,11 @@ const FIXTURES = {
     `data: [DONE]`,
   ],
 
+  nestedReasoningUsage: [
+    `data: {"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1677652288,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"completion_tokens":187,"completion_tokens_details":{"reasoning_tokens":134},"prompt_tokens":100,"total_tokens":287}}`,
+    `data: [DONE]`,
+  ],
+
   reasoningWithToolCalls: [
     `data: {"choices":[{"index":0,"delta":{"content":null,"role":"assistant","reasoning_text":"**Understanding Dayzee's Purpose**\\n\\nI'm starting to get a better handle on \`dayzee\`.\\n\\n"}}],"created":1764940861,"id":"OdwyabKMI9yel7oPlbzgwQM","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"gemini-3-pro-preview"}`,
     `data: {"choices":[{"index":0,"delta":{"content":null,"role":"assistant","reasoning_text":"**Assessing Dayzee's Functionality**\\n\\nI've reviewed the files.\\n\\n"}}],"created":1764940862,"id":"OdwyabKMI9yel7oPlbzgwQM","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"gemini-3-pro-preview"}`,
@@ -91,6 +96,18 @@ function createMockFetch(chunks: string[]) {
   })
 }
 
+function createMockGenerateFetch() {
+  return mock(async () =>
+    Response.json({
+      id: "chatcmpl-generate",
+      created: 1677652288,
+      model: "gemini-test",
+      choices: [{ message: { role: "assistant", content: "Hello" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 100, completion_tokens: 53, reasoning_tokens: 134, total_tokens: 287 },
+    }),
+  )
+}
+
 function createModel(fetchFn: ReturnType<typeof mock>) {
   return new OpenAICompatibleChatLanguageModel("test-model", {
     provider: "copilot.chat",
@@ -99,6 +116,20 @@ function createModel(fetchFn: ReturnType<typeof mock>) {
     fetch: fetchFn as any,
   })
 }
+
+describe("doGenerate", () => {
+  test("should include top-level reasoning tokens in output usage", async () => {
+    const result = await createModel(createMockGenerateFetch()).doGenerate({
+      prompt: TEST_PROMPT,
+      includeRawChunks: false,
+    })
+
+    expect(result.usage).toMatchObject({
+      inputTokens: { total: 100 },
+      outputTokens: { total: 187, reasoning: 134 },
+    })
+  })
+})
 
 describe("doStream", () => {
   test("should stream text deltas", async () => {
@@ -204,7 +235,20 @@ describe("doStream", () => {
       finishReason: { unified: "tool-calls" },
       usage: {
         inputTokens: { total: 19581 },
-        outputTokens: { total: 53 },
+        outputTokens: { total: 187, reasoning: 134 },
+      },
+    })
+  })
+
+  test("should not add nested reasoning tokens to inclusive completion tokens", async () => {
+    const model = createModel(createMockFetch(FIXTURES.nestedReasoningUsage))
+    const { stream } = await model.doStream({ prompt: TEST_PROMPT, includeRawChunks: false })
+    const finish = (await convertReadableStreamToArray(stream)).find((part) => part.type === "finish")
+
+    expect(finish).toMatchObject({
+      usage: {
+        inputTokens: { total: 100 },
+        outputTokens: { total: 187, reasoning: 134 },
       },
     })
   })
@@ -259,7 +303,7 @@ describe("doStream", () => {
       finishReason: { unified: "stop" },
       usage: {
         inputTokens: { total: 5778 },
-        outputTokens: { total: 59 },
+        outputTokens: { total: 154, reasoning: 95 },
       },
       providerMetadata: {
         copilot: {
@@ -391,7 +435,7 @@ describe("doStream", () => {
       finishReason: { unified: "tool-calls" },
       usage: {
         inputTokens: { total: 3767 },
-        outputTokens: { total: 19 },
+        outputTokens: { total: 30, reasoning: 11 },
       },
     })
   })

--- a/packages/core/test/github-copilot/copilot-chat-model.test.ts
+++ b/packages/core/test/github-copilot/copilot-chat-model.test.ts
@@ -24,11 +24,6 @@ const FIXTURES = {
     `data: [DONE]`,
   ],
 
-  nestedReasoningUsage: [
-    `data: {"id":"chatcmpl-usage","object":"chat.completion.chunk","created":1677652288,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"usage":{"completion_tokens":187,"completion_tokens_details":{"reasoning_tokens":134},"prompt_tokens":100,"total_tokens":287}}`,
-    `data: [DONE]`,
-  ],
-
   reasoningWithToolCalls: [
     `data: {"choices":[{"index":0,"delta":{"content":null,"role":"assistant","reasoning_text":"**Understanding Dayzee's Purpose**\\n\\nI'm starting to get a better handle on \`dayzee\`.\\n\\n"}}],"created":1764940861,"id":"OdwyabKMI9yel7oPlbzgwQM","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"gemini-3-pro-preview"}`,
     `data: {"choices":[{"index":0,"delta":{"content":null,"role":"assistant","reasoning_text":"**Assessing Dayzee's Functionality**\\n\\nI've reviewed the files.\\n\\n"}}],"created":1764940862,"id":"OdwyabKMI9yel7oPlbzgwQM","usage":{"completion_tokens":0,"prompt_tokens":0,"prompt_tokens_details":{"cached_tokens":0},"total_tokens":0,"reasoning_tokens":0},"model":"gemini-3-pro-preview"}`,
@@ -96,18 +91,6 @@ function createMockFetch(chunks: string[]) {
   })
 }
 
-function createMockGenerateFetch() {
-  return mock(async () =>
-    Response.json({
-      id: "chatcmpl-generate",
-      created: 1677652288,
-      model: "gemini-test",
-      choices: [{ message: { role: "assistant", content: "Hello" }, finish_reason: "stop" }],
-      usage: { prompt_tokens: 100, completion_tokens: 53, reasoning_tokens: 134, total_tokens: 287 },
-    }),
-  )
-}
-
 function createModel(fetchFn: ReturnType<typeof mock>) {
   return new OpenAICompatibleChatLanguageModel("test-model", {
     provider: "copilot.chat",
@@ -116,20 +99,6 @@ function createModel(fetchFn: ReturnType<typeof mock>) {
     fetch: fetchFn as any,
   })
 }
-
-describe("doGenerate", () => {
-  test("should include top-level reasoning tokens in output usage", async () => {
-    const result = await createModel(createMockGenerateFetch()).doGenerate({
-      prompt: TEST_PROMPT,
-      includeRawChunks: false,
-    })
-
-    expect(result.usage).toMatchObject({
-      inputTokens: { total: 100 },
-      outputTokens: { total: 187, reasoning: 134 },
-    })
-  })
-})
 
 describe("doStream", () => {
   test("should stream text deltas", async () => {
@@ -235,19 +204,6 @@ describe("doStream", () => {
       finishReason: { unified: "tool-calls" },
       usage: {
         inputTokens: { total: 19581 },
-        outputTokens: { total: 187, reasoning: 134 },
-      },
-    })
-  })
-
-  test("should not add nested reasoning tokens to inclusive completion tokens", async () => {
-    const model = createModel(createMockFetch(FIXTURES.nestedReasoningUsage))
-    const { stream } = await model.doStream({ prompt: TEST_PROMPT, includeRawChunks: false })
-    const finish = (await convertReadableStreamToArray(stream)).find((part) => part.type === "finish")
-
-    expect(finish).toMatchObject({
-      usage: {
-        inputTokens: { total: 100 },
         outputTokens: { total: 187, reasoning: 134 },
       },
     })

--- a/packages/core/test/github-copilot/copilot-chat-model.test.ts
+++ b/packages/core/test/github-copilot/copilot-chat-model.test.ts
@@ -205,6 +205,12 @@ describe("doStream", () => {
       usage: {
         inputTokens: { total: 19581 },
         outputTokens: { total: 187, reasoning: 134 },
+        raw: {
+          prompt_tokens: 19581,
+          completion_tokens: 53,
+          reasoning_tokens: 134,
+          total_tokens: 19768,
+        },
       },
     })
   })


### PR DESCRIPTION
## Summary
- accept Copilot Chat responses that report reasoning tokens at the top level
- include top-level reasoning in the normalized inclusive output token total while preserving standard nested OpenAI semantics
- retain the existing streamed raw completion-token value
- assert normalized usage against the existing observed Copilot Gemini stream fixtures

## Testing
- `bun test test/github-copilot/copilot-chat-model.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`
- targeted oxlint: no errors; pre-existing warnings remain
- monorepo pre-push typecheck is currently blocked by unrelated missing clipboard exports from the installed `@opentui/core` in `packages/tui`