### PR TITLE
refactor(plugin): colocate hook failure specs

### DIFF
--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -4,6 +4,7 @@ import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
 import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
+import type { Tool } from "@opencode-ai/schema/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -15,19 +16,22 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-type Callback<Event> = (event: Event) => Effect.Effect<void>
+// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
+type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+
+type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name]>,
+    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name]>
+  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -56,7 +60,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -1,8 +1,8 @@
 export * as PluginHooks from "./hooks"
 
-import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
-import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
-import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
+import type { AISDKFailures, AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
+import type { SessionFailures, SessionHooks } from "@opencode-ai/plugin/effect/session"
+import type { ShellFailures, ShellHooks } from "@opencode-ai/plugin/effect/shell"
 import type { ToolFailures, ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -15,13 +15,11 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
-
-// Failure channel for each hook event. Only tool execute.before may fail: a Tool.Error rejects the call before it runs.
+// Each domain declares its own failure spec next to its hooks; this map only mirrors Domains.
 interface Failures extends Record<keyof Domains, unknown> {
-  readonly aisdk: NoFailures<AISDKHooks>
-  readonly session: NoFailures<SessionHooks>
-  readonly shell: NoFailures<ShellHooks>
+  readonly aisdk: AISDKFailures
+  readonly session: SessionFailures
+  readonly shell: ShellFailures
   readonly tool: ToolFailures
 }
 

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -3,8 +3,7 @@ export * as PluginHooks from "./hooks"
 import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
-import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
-import type { Tool } from "@opencode-ai/schema/tool"
+import type { ToolFailures, ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -16,27 +15,29 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
+
+// Failure channel for each hook event. Only tool execute.before may fail: a Tool.Error rejects the call before it runs.
 interface Failures extends Record<keyof Domains, unknown> {
-  readonly aisdk: never
-  readonly session: never
-  readonly shell: never
-  readonly tool: Tool.Error
+  readonly aisdk: NoFailures<AISDKHooks>
+  readonly session: NoFailures<SessionHooks>
+  readonly shell: NoFailures<ShellHooks>
+  readonly tool: ToolFailures
 }
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
-  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain][Name]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
-  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain][Name]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -65,7 +66,9 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain][typeof name]> = Reflect.apply(callback, undefined, [
+          event,
+        ])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -16,8 +16,13 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
-type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+interface Failures extends Record<keyof Domains, unknown> {
+  readonly aisdk: never
+  readonly session: never
+  readonly shell: never
+  readonly tool: Tool.Error
+}
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
@@ -25,13 +30,13 @@ export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -60,7 +65,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test"
+import { ToolFailure } from "@opencode-ai/ai"
 import { Context, Effect, Exit, Fiber, Schema, Stream } from "effect"
 import { Plugin as EffectPlugin } from "@opencode-ai/plugin/effect"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
@@ -393,6 +394,53 @@ describe("Plugin", () => {
         content: [{ type: "text", text: '{"text":"before-mutated"}' }],
         metadata: { rewritten: true },
       })
+    }),
+  )
+
+  it.effect("rejects tool execution when an execute.before hook fails", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const registry = yield* Tool.Service
+      const executed: unknown[] = []
+
+      const plugin = EffectPlugin.define({
+        id: "tool-hook-reject",
+        effect: (ctx) =>
+          Effect.gen(function* () {
+            yield* ctx.tool
+              .transform((draft) =>
+                draft.add({
+                  name: "echo",
+                  options: { codemode: false },
+                  description: "Echo",
+                  input: Schema.Struct({ text: Schema.String }),
+                  output: Schema.Struct({ text: Schema.String }),
+                  execute: ({ text }) =>
+                    Effect.sync(() => executed.push({ text })).pipe(Effect.as({ output: { text } })),
+                }),
+              )
+              .pipe(Effect.orDie)
+
+            yield* ctx.tool
+              .hook("execute.before", () => new ToolFailure({ message: "write disabled" }))
+              .pipe(Effect.asVoid)
+          }),
+      })
+
+      yield* plugins.activate([versioned(plugin)])
+
+      const toolSet = yield* registry.snapshot()
+      const failure = yield* toolSet
+        .execute({
+          sessionID: Session.ID.make("ses_hook_reject"),
+          agent: Agent.ID.make("build"),
+          messageID: SessionMessage.ID.make("msg_hook_reject"),
+          call: { type: "tool-call", id: "call-hook-reject", name: "echo", input: { text: "original" } },
+        })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ _tag: "Tool.Error", message: "write disabled" })
+      expect(executed).toEqual([])
     }),
   )
 })

--- a/packages/plugin/src/effect/aisdk.ts
+++ b/packages/plugin/src/effect/aisdk.ts
@@ -1,6 +1,6 @@
 import type { LanguageModelV3 } from "@ai-sdk/provider"
 import type { Model } from "@opencode-ai/schema/model"
-import type { Hooks } from "./registration.js"
+import type { Hooks, NoFailures } from "./registration.js"
 
 export interface AISDKHooks {
   sdk: {
@@ -17,6 +17,8 @@ export interface AISDKHooks {
   }
 }
 
+export type AISDKFailures = NoFailures<AISDKHooks>
+
 export interface AISDKDomain {
-  readonly hook: Hooks<AISDKHooks>
+  readonly hook: Hooks<AISDKHooks, AISDKFailures>
 }

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,6 +4,8 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
+export type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
+
 export type Hooks<Spec, Failures extends Record<keyof Spec, unknown> = Record<keyof Spec, never>> = <
   Name extends keyof Spec,
 >(

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,11 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failures extends Record<keyof Spec, unknown> = Record<keyof Spec, never>> = <
+  Name extends keyof Spec,
+>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failures[Name]>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,9 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -4,7 +4,7 @@ import type { Agent } from "@opencode-ai/schema/agent"
 import type { Model } from "@opencode-ai/schema/model"
 import type { Session } from "@opencode-ai/schema/session"
 import type { JsonSchema } from "effect"
-import type { Hooks } from "./registration.js"
+import type { Hooks, NoFailures } from "./registration.js"
 
 export interface SessionContext {
   readonly sessionID: Session.ID
@@ -36,9 +36,11 @@ export interface SessionHooks {
   readonly "http.response": SessionHttpResponse
 }
 
+export type SessionFailures = NoFailures<SessionHooks>
+
 export type SessionDomain = Pick<
   SessionApi<unknown>,
   "create" | "get" | "prompt" | "generate" | "command" | "synthetic" | "interrupt" | "rename" | "wait"
 > & {
-  readonly hook: Hooks<SessionHooks>
+  readonly hook: Hooks<SessionHooks, SessionFailures>
 }

--- a/packages/plugin/src/effect/shell.ts
+++ b/packages/plugin/src/effect/shell.ts
@@ -1,4 +1,4 @@
-import type { Hooks } from "./registration.js"
+import type { Hooks, NoFailures } from "./registration.js"
 
 export interface ShellCreateBefore {
   command: string
@@ -12,6 +12,8 @@ export interface ShellHooks {
   readonly "create.before": ShellCreateBefore
 }
 
+export type ShellFailures = NoFailures<ShellHooks>
+
 export interface ShellDomain {
-  readonly hook: Hooks<ShellHooks>
+  readonly hook: Hooks<ShellHooks, ShellFailures>
 }

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -40,5 +40,5 @@ export interface ToolHooks {
 
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks>
+  readonly hook: Hooks<ToolHooks, Tool.Error>
 }

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -38,7 +38,13 @@ export interface ToolHooks {
   )
 }
 
+// Only execute.before may fail: a Tool.Error rejects the call before the tool runs.
+export interface ToolFailures extends Record<keyof ToolHooks, unknown> {
+  readonly "execute.before": Tool.Error
+  readonly "execute.after": never
+}
+
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks, Tool.Error>
+  readonly hook: Hooks<ToolHooks, ToolFailures>
 }


### PR DESCRIPTION
## Summary

Alternative shape A for #41668, stacked on it for comparison — merge at most one of the alternatives.

- Move each domain's failure declaration next to its hook spec: `SessionFailures`, `ShellFailures`, and `AISDKFailures` are declared in their own modules as `NoFailures<...>` (exported from `registration.ts`), alongside the existing `ToolFailures`.
- Each domain interface now passes its own failures explicitly: `hook: Hooks<SessionHooks, SessionFailures>` etc.
- Core's `Failures` map becomes pure wiring that mirrors `Domains`, referencing the co-located specs instead of declaring failure semantics itself.

Trade-off: the can-this-fail decision lives at the hook site, at the cost of three exported types that exist only to say "cannot fail".

## Test plan

- [x] `bun typecheck` in `packages/plugin` and `packages/core`
- [x] Plugin hook tests pass unchanged