### PR TITLE
refactor(plugin): embed hook failures in event specs

### DIFF
--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -4,6 +4,7 @@ import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
 import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
+import type { Tool } from "@opencode-ai/schema/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -15,19 +16,22 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-type Callback<Event> = (event: Event) => Effect.Effect<void>
+// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
+type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+
+type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name]>,
+    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name]>
+  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -56,7 +60,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -3,8 +3,7 @@ export * as PluginHooks from "./hooks"
 import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
-import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
-import type { Tool } from "@opencode-ai/schema/tool"
+import type { ToolFailures, ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -16,27 +15,29 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
+
+// Failure channel for each hook event. Only tool execute.before may fail: a Tool.Error rejects the call before it runs.
 interface Failures extends Record<keyof Domains, unknown> {
-  readonly aisdk: never
-  readonly session: never
-  readonly shell: never
-  readonly tool: Tool.Error
+  readonly aisdk: NoFailures<AISDKHooks>
+  readonly session: NoFailures<SessionHooks>
+  readonly shell: NoFailures<ShellHooks>
+  readonly tool: ToolFailures
 }
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
-  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain][Name]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
-  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
+  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain][Name]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -65,7 +66,9 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain][typeof name]> = Reflect.apply(callback, undefined, [
+          event,
+        ])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -16,8 +16,13 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-// Only tool hooks may fail; a Tool.Error from execute.before rejects the call before it runs.
-type Failure<Domain extends keyof Domains> = Domain extends "tool" ? Tool.Error : never
+// Failure channel for each hook domain. A Tool.Error from execute.before rejects the call before it runs.
+interface Failures extends Record<keyof Domains, unknown> {
+  readonly aisdk: never
+  readonly session: never
+  readonly shell: never
+  readonly tool: Tool.Error
+}
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
@@ -25,13 +30,13 @@ export interface Interface {
   readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failure<Domain>>,
+    callback: Callback<Domains[Domain][Name], Failures[Domain]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
   readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
     event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failure<Domain>>
+  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -60,7 +65,7 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failure<typeof domain>> = Reflect.apply(callback, undefined, [event])
+        const result: Effect.Effect<void, Failures[typeof domain]> = Reflect.apply(callback, undefined, [event])
         yield* result
       }
       return event

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -3,7 +3,8 @@ export * as PluginHooks from "./hooks"
 import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
 import type { ShellHooks } from "@opencode-ai/plugin/effect/shell"
-import type { ToolFailures, ToolHooks } from "@opencode-ai/plugin/effect/tool"
+import type { HookSpec } from "@opencode-ai/plugin/effect/registration"
+import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Context, Effect, Layer, Scope } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { State } from "../state"
@@ -15,29 +16,23 @@ export interface Domains {
   readonly tool: ToolHooks
 }
 
-type NoFailures<Spec> = { readonly [Name in keyof Spec]: never }
-
-// Failure channel for each hook event. Only tool execute.before may fail: a Tool.Error rejects the call before it runs.
-interface Failures extends Record<keyof Domains, unknown> {
-  readonly aisdk: NoFailures<AISDKHooks>
-  readonly session: NoFailures<SessionHooks>
-  readonly shell: NoFailures<ShellHooks>
-  readonly tool: ToolFailures
-}
+// Each hook event carries its own failure channel in its spec. The HookSpec intersection
+// only tells the checker that generic lookups have event and failure keys.
+type Spec<Domain extends keyof Domains, Name extends keyof Domains[Domain]> = Domains[Domain][Name] & HookSpec
 
 type Callback<Event, Error> = (event: Event) => Effect.Effect<void, Error>
 
 export interface Interface {
-  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
+  readonly register: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    callback: Callback<Domains[Domain][Name], Failures[Domain][Name]>,
+    callback: Callback<Spec<Domain, Name>["event"], Spec<Domain, Name>["failure"]>,
   ) => Effect.Effect<State.Registration, never, Scope.Scope>
-  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain] & keyof Failures[Domain]>(
+  readonly trigger: <Domain extends keyof Domains, Name extends keyof Domains[Domain]>(
     domain: Domain,
     name: Name,
-    event: Domains[Domain][Name],
-  ) => Effect.Effect<Domains[Domain][Name], Failures[Domain][Name]>
+    event: Spec<Domain, Name>["event"],
+  ) => Effect.Effect<Spec<Domain, Name>["event"], Spec<Domain, Name>["failure"]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/PluginHooks") {}
@@ -66,9 +61,11 @@ const layer = Layer.effect(
 
     const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
-        const result: Effect.Effect<void, Failures[typeof domain][typeof name]> = Reflect.apply(callback, undefined, [
-          event,
-        ])
+        const result: Effect.Effect<void, Spec<typeof domain, typeof name>["failure"]> = Reflect.apply(
+          callback,
+          undefined,
+          [event],
+        )
         yield* result
       }
       return event

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -88,7 +88,7 @@ const layer = Layer.effect(
       input: unknown,
       context: Tool.Context,
     ) {
-      const beforeEvent: PluginHooks.Domains["tool"]["execute.before"] = {
+      const beforeEvent: PluginHooks.Domains["tool"]["execute.before"]["event"] = {
         tool: name,
         sessionID: context.sessionID,
         agent: context.agent,
@@ -110,7 +110,7 @@ const layer = Layer.effect(
         input: beforeEvent.input,
       }
       if ("failure" in execution) {
-        const afterEvent: PluginHooks.Domains["tool"]["execute.after"] = {
+        const afterEvent: PluginHooks.Domains["tool"]["execute.after"]["event"] = {
           ...base,
           status: "error",
           error: execution.failure,
@@ -118,7 +118,7 @@ const layer = Layer.effect(
         yield* hooks.trigger("tool", "execute.after", afterEvent)
         return yield* afterEvent.error
       }
-      const afterEvent: PluginHooks.Domains["tool"]["execute.after"] = {
+      const afterEvent: PluginHooks.Domains["tool"]["execute.after"]["event"] = {
         ...base,
         status: "completed",
         result: {

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from "bun:test"
+import { ToolFailure } from "@opencode-ai/ai"
 import { Context, Effect, Exit, Fiber, Schema, Stream } from "effect"
 import { Plugin as EffectPlugin } from "@opencode-ai/plugin/effect"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
@@ -393,6 +394,53 @@ describe("Plugin", () => {
         content: [{ type: "text", text: '{"text":"before-mutated"}' }],
         metadata: { rewritten: true },
       })
+    }),
+  )
+
+  it.effect("rejects tool execution when an execute.before hook fails", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const registry = yield* Tool.Service
+      const executed: unknown[] = []
+
+      const plugin = EffectPlugin.define({
+        id: "tool-hook-reject",
+        effect: (ctx) =>
+          Effect.gen(function* () {
+            yield* ctx.tool
+              .transform((draft) =>
+                draft.add({
+                  name: "echo",
+                  options: { codemode: false },
+                  description: "Echo",
+                  input: Schema.Struct({ text: Schema.String }),
+                  output: Schema.Struct({ text: Schema.String }),
+                  execute: ({ text }) =>
+                    Effect.sync(() => executed.push({ text })).pipe(Effect.as({ output: { text } })),
+                }),
+              )
+              .pipe(Effect.orDie)
+
+            yield* ctx.tool
+              .hook("execute.before", () => new ToolFailure({ message: "write disabled" }))
+              .pipe(Effect.asVoid)
+          }),
+      })
+
+      yield* plugins.activate([versioned(plugin)])
+
+      const toolSet = yield* registry.snapshot()
+      const failure = yield* toolSet
+        .execute({
+          sessionID: Session.ID.make("ses_hook_reject"),
+          agent: Agent.ID.make("build"),
+          messageID: SessionMessage.ID.make("msg_hook_reject"),
+          call: { type: "tool-call", id: "call-hook-reject", name: "echo", input: { text: "original" } },
+        })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ _tag: "Tool.Error", message: "write disabled" })
+      expect(executed).toEqual([])
     }),
   )
 })

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -207,7 +207,7 @@ describe("fromPromise", () => {
           },
         }),
       ).effect(host)
-      const event: SessionHooks["context"] = {
+      const event: SessionHooks["context"]["event"] = {
         sessionID: Session.ID.make("ses_promise_session_context"),
         agent: Agent.ID.make("build"),
         model: Model.Ref.make({ providerID: Provider.ID.make("test"), id: Model.ID.make("model") }),

--- a/packages/core/test/plugin/system-prompt.test.ts
+++ b/packages/core/test/plugin/system-prompt.test.ts
@@ -25,7 +25,7 @@ const makeHost = Effect.gen(function* () {
   return yield* PluginHost.make(plugins)
 })
 
-const context = (id: string, system = fallback): SessionHooks["context"] => ({
+const context = (id: string, system = fallback): SessionHooks["context"]["event"] => ({
   sessionID: Session.ID.make("ses_system_prompt"),
   agent: Agent.ID.make("build"),
   model: Model.Ref.make({ providerID: Provider.ID.make("test"), id: Model.ID.make(id) }),

--- a/packages/plugin/src/effect/aisdk.ts
+++ b/packages/plugin/src/effect/aisdk.ts
@@ -4,16 +4,22 @@ import type { Hooks } from "./registration.js"
 
 export interface AISDKHooks {
   sdk: {
-    readonly model: Model.Info
-    readonly package: string
-    readonly options: Record<string, any>
-    sdk?: any
+    readonly event: {
+      readonly model: Model.Info
+      readonly package: string
+      readonly options: Record<string, any>
+      sdk?: any
+    }
+    readonly failure: never
   }
   language: {
-    readonly model: Model.Info
-    readonly sdk: any
-    readonly options: Record<string, any>
-    language?: LanguageModelV3
+    readonly event: {
+      readonly model: Model.Info
+      readonly sdk: any
+      readonly options: Record<string, any>
+      language?: LanguageModelV3
+    }
+    readonly failure: never
   }
 }
 

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,11 +4,15 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec, Failures extends Record<keyof Spec, unknown> = Record<keyof Spec, never>> = <
-  Name extends keyof Spec,
->(
+// Every hook event declares its own failure channel next to its payload; most events cannot fail.
+export interface HookSpec {
+  readonly event: unknown
+  readonly failure: unknown
+}
+
+export type Hooks<Spec extends Record<keyof Spec, HookSpec>> = <Name extends keyof Spec>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void, Failures[Name]>,
+  callback: (input: Spec[Name]["event"]) => Effect.Effect<void, Spec[Name]["failure"]>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,11 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failures extends Record<keyof Spec, unknown> = Record<keyof Spec, never>> = <
+  Name extends keyof Spec,
+>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failures[Name]>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/registration.ts
+++ b/packages/plugin/src/effect/registration.ts
@@ -4,9 +4,9 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
-export type Hooks<Spec> = <Name extends keyof Spec>(
+export type Hooks<Spec, Failure = never> = <Name extends keyof Spec>(
   name: Name,
-  callback: (input: Spec[Name]) => Effect.Effect<void>,
+  callback: (input: Spec[Name]) => Effect.Effect<void, Failure>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Effect.Effect<Registration, never, Scope.Scope>

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -31,9 +31,9 @@ export interface SessionHttpResponse {
 }
 
 export interface SessionHooks {
-  readonly context: SessionContext
-  readonly "http.request": SessionHttpRequest
-  readonly "http.response": SessionHttpResponse
+  readonly context: { readonly event: SessionContext; readonly failure: never }
+  readonly "http.request": { readonly event: SessionHttpRequest; readonly failure: never }
+  readonly "http.response": { readonly event: SessionHttpResponse; readonly failure: never }
 }
 
 export type SessionDomain = Pick<

--- a/packages/plugin/src/effect/shell.ts
+++ b/packages/plugin/src/effect/shell.ts
@@ -9,7 +9,7 @@ export interface ShellCreateBefore {
 }
 
 export interface ShellHooks {
-  readonly "create.before": ShellCreateBefore
+  readonly "create.before": { readonly event: ShellCreateBefore; readonly failure: never }
 }
 
 export interface ShellDomain {

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -12,39 +12,40 @@ export interface ToolDraft {
 
 export interface ToolHooks {
   readonly "execute.before": {
-    readonly tool: string
-    readonly sessionID: Session.ID
-    readonly agent: Agent.ID
-    readonly messageID: SessionMessage.ID
-    readonly id: Tool.CallID
-    input: unknown
+    readonly event: {
+      readonly tool: string
+      readonly sessionID: Session.ID
+      readonly agent: Agent.ID
+      readonly messageID: SessionMessage.ID
+      readonly id: Tool.CallID
+      input: unknown
+    }
+    // Failing rejects the call before the tool runs.
+    readonly failure: Tool.Error
   }
   readonly "execute.after": {
-    readonly tool: string
-    readonly sessionID: Session.ID
-    readonly agent: Agent.ID
-    readonly messageID: SessionMessage.ID
-    readonly id: Tool.CallID
-    readonly input: unknown
-  } & (
-    | {
-        readonly status: "completed"
-        result: Tool.Result
-      }
-    | {
-        readonly status: "error"
-        error: Tool.Error
-      }
-  )
-}
-
-// Only execute.before may fail: a Tool.Error rejects the call before the tool runs.
-export interface ToolFailures extends Record<keyof ToolHooks, unknown> {
-  readonly "execute.before": Tool.Error
-  readonly "execute.after": never
+    readonly event: {
+      readonly tool: string
+      readonly sessionID: Session.ID
+      readonly agent: Agent.ID
+      readonly messageID: SessionMessage.ID
+      readonly id: Tool.CallID
+      readonly input: unknown
+    } & (
+      | {
+          readonly status: "completed"
+          result: Tool.Result
+        }
+      | {
+          readonly status: "error"
+          error: Tool.Error
+        }
+    )
+    readonly failure: never
+  }
 }
 
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks, ToolFailures>
+  readonly hook: Hooks<ToolHooks>
 }

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -40,5 +40,5 @@ export interface ToolHooks {
 
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks>
+  readonly hook: Hooks<ToolHooks, Tool.Error>
 }

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -38,7 +38,13 @@ export interface ToolHooks {
   )
 }
 
+// Only execute.before may fail: a Tool.Error rejects the call before the tool runs.
+export interface ToolFailures extends Record<keyof ToolHooks, unknown> {
+  readonly "execute.before": Tool.Error
+  readonly "execute.after": never
+}
+
 export interface ToolDomain {
   readonly transform: Transform<ToolDraft>
-  readonly hook: Hooks<ToolHooks, Tool.Error>
+  readonly hook: Hooks<ToolHooks, ToolFailures>
 }

--- a/packages/plugin/src/promise/aisdk.ts
+++ b/packages/plugin/src/promise/aisdk.ts
@@ -4,16 +4,22 @@ import type { Hooks } from "./registration.js"
 
 export interface AISDKHooks {
   sdk: {
-    readonly model: Model.Info
-    readonly package: string
-    readonly options: Record<string, any>
-    sdk?: any
+    readonly event: {
+      readonly model: Model.Info
+      readonly package: string
+      readonly options: Record<string, any>
+      sdk?: any
+    }
+    readonly failure: never
   }
   language: {
-    readonly model: Model.Info
-    readonly sdk: any
-    readonly options: Record<string, any>
-    language?: LanguageModelV3
+    readonly event: {
+      readonly model: Model.Info
+      readonly sdk: any
+      readonly options: Record<string, any>
+      language?: LanguageModelV3
+    }
+    readonly failure: never
   }
 }
 

--- a/packages/plugin/src/promise/registration.ts
+++ b/packages/plugin/src/promise/registration.ts
@@ -2,9 +2,16 @@ export interface Registration {
   readonly dispose: () => Promise<void>
 }
 
-export type Hooks<Spec> = <Name extends keyof Spec>(
+// Mirrors the Effect flavor's HookSpec; Promise hooks signal failure by throwing, so the
+// declared failure channel documents which throws are meaningful rather than typing them.
+export interface HookSpec {
+  readonly event: unknown
+  readonly failure: unknown
+}
+
+export type Hooks<Spec extends Record<keyof Spec, HookSpec>> = <Name extends keyof Spec>(
   name: Name,
-  callback: (input: Spec[Name]) => Promise<void> | void,
+  callback: (input: Spec[Name]["event"]) => Promise<void> | void,
 ) => Promise<Registration>
 
 export type Transform<Input> = (callback: (input: Input) => void) => Promise<Registration>

--- a/packages/plugin/src/promise/session.ts
+++ b/packages/plugin/src/promise/session.ts
@@ -31,9 +31,9 @@ export interface SessionHttpResponse {
 }
 
 export interface SessionHooks {
-  readonly context: SessionContext
-  readonly "http.request": SessionHttpRequest
-  readonly "http.response": SessionHttpResponse
+  readonly context: { readonly event: SessionContext; readonly failure: never }
+  readonly "http.request": { readonly event: SessionHttpRequest; readonly failure: never }
+  readonly "http.response": { readonly event: SessionHttpResponse; readonly failure: never }
 }
 
 export type SessionDomain = Pick<

--- a/packages/plugin/src/promise/shell.ts
+++ b/packages/plugin/src/promise/shell.ts
@@ -9,7 +9,7 @@ export interface ShellCreateBefore {
 }
 
 export interface ShellHooks {
-  readonly "create.before": ShellCreateBefore
+  readonly "create.before": { readonly event: ShellCreateBefore; readonly failure: never }
 }
 
 export interface ShellDomain {

--- a/packages/plugin/src/promise/tool.ts
+++ b/packages/plugin/src/promise/tool.ts
@@ -29,30 +29,37 @@ interface ToolDraft {
 
 interface ToolHooks {
   readonly "execute.before": {
-    readonly tool: string
-    readonly sessionID: Session.ID
-    readonly agent: Agent.ID
-    readonly messageID: SessionMessage.ID
-    readonly id: Tool.CallID
-    input: unknown
+    readonly event: {
+      readonly tool: string
+      readonly sessionID: Session.ID
+      readonly agent: Agent.ID
+      readonly messageID: SessionMessage.ID
+      readonly id: Tool.CallID
+      input: unknown
+    }
+    // Throwing rejects the call before the tool runs.
+    readonly failure: Tool.Error
   }
   readonly "execute.after": {
-    readonly tool: string
-    readonly sessionID: Session.ID
-    readonly agent: Agent.ID
-    readonly messageID: SessionMessage.ID
-    readonly id: Tool.CallID
-    readonly input: unknown
-  } & (
-    | {
-        readonly status: "completed"
-        result: Tool.Result
-      }
-    | {
-        readonly status: "error"
-        error: Tool.Error
-      }
-  )
+    readonly event: {
+      readonly tool: string
+      readonly sessionID: Session.ID
+      readonly agent: Agent.ID
+      readonly messageID: SessionMessage.ID
+      readonly id: Tool.CallID
+      readonly input: unknown
+    } & (
+      | {
+          readonly status: "completed"
+          result: Tool.Result
+        }
+      | {
+          readonly status: "error"
+          error: Tool.Error
+        }
+    )
+    readonly failure: never
+  }
 }
 
 export interface ToolDomain {


### PR DESCRIPTION
## Summary

Alternative shape B for #41668, stacked on it for comparison — merge at most one of the alternatives (see also #41679).

- Every hook spec entry becomes `{ event; failure }` (`HookSpec`), so each event declares its own failure channel exactly where the event is defined. `tool.execute.before` declares `failure: Tool.Error`; every other event declares `failure: never`.
- The central `Failures` map in core and the `ToolFailures` type are deleted entirely; `Hooks<Spec>` goes back to one type parameter, and core's `register`/`trigger` read `event`/`failure` straight off `Domains[Domain][Name]` (via a `& HookSpec` intersection so generic lookups typecheck).
- Both flavors restructured: the Promise specs mirror the wrapped shape so the `fromPromise` adapter keeps unifying without casts. Promise hooks still signal failure by throwing; their `failure` entries are documentation of which throws are meaningful.

Trade-off: maximal co-location and no central failure declaration at all, at the cost of restructuring every hook spec in both flavors and a dead `failure: never` field on events that can never fail.

## Test plan

- [x] `bun typecheck` in `packages/plugin` and `packages/core`
- [x] Full `packages/core` test suite passes (1638 pass, 0 fail)
- [x] `packages/plugin` tests pass