### PR TITLE
fix(opencode): refresh task resume permissions

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -436,6 +436,11 @@ export interface Interface {
     model: NonNullable<Info["model"]>
     time: number
   }) => Effect.Effect<void>
+  readonly setAgentPermission: (input: {
+    sessionID: SessionID
+    agent: string
+    permission: PermissionV1.Ruleset
+  }) => Effect.Effect<void>
   readonly setPermission: (input: { sessionID: SessionID; permission: PermissionV1.Ruleset }) => Effect.Effect<void>
   readonly setRevert: (input: {
     sessionID: SessionID
@@ -777,6 +782,18 @@ const layer: Layer.Layer<
       }).pipe(Effect.orDie)
     })
 
+    const setAgentPermission = Effect.fn("Session.setAgentPermission")(function* (input: {
+      sessionID: SessionID
+      agent: string
+      permission: PermissionV1.Ruleset
+    }) {
+      yield* patch(input.sessionID, {
+        agent: input.agent,
+        permission: [...input.permission],
+        time: { updated: Date.now() },
+      }).pipe(Effect.orDie)
+    })
+
     const setPermission = Effect.fn("Session.setPermission")(function* (input: {
       sessionID: SessionID
       permission: PermissionV1.Ruleset
@@ -916,6 +933,7 @@ const layer: Layer.Layer<
       setArchived,
       setMetadata,
       setAgentModel,
+      setAgentPermission,
       setPermission,
       setRevert,
       clearRevert,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -78,6 +78,13 @@ function renderOutput(input: {
   ].join("\n")
 }
 
+function samePermissionRule(
+  left: { permission: string; pattern: string; action: string },
+  right: { permission: string; pattern: string; action: string },
+) {
+  return left.permission === right.permission && left.pattern === right.pattern && left.action === right.action
+}
+
 export const TaskTool = Tool.define(
   id,
   Effect.gen(function* () {
@@ -136,39 +143,27 @@ export const TaskTool = Tool.define(
       const session = params.task_id
         ? yield* sessions.get(SessionID.make(params.task_id)).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
-      const childPermission = deriveSubagentSessionPermission({
-        parentSessionPermission: parent.permission ?? [],
-        subagent: next,
-      })
-      const childToolDenies = [
-        ...(next.permission.some((rule) => rule.permission === "todowrite")
-          ? []
-          : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
-        ...(next.permission.some((rule) => rule.permission === id)
-          ? []
-          : [{ permission: id, pattern: "*" as const, action: "deny" as const }]),
-        ...(cfg.experimental?.primary_tools?.map((permission) => ({
-          permission,
-          pattern: "*" as const,
-          action: "deny" as const,
-        })) ?? []),
-      ]
+      const childSessionPermission = (subagent: Agent.Info, parentPermission = parent.permission ?? []) => {
+        const inherited = deriveSubagentSessionPermission({
+          parentSessionPermission: parentPermission,
+          subagent,
+        })
+        const toolDenies =
+          cfg.experimental?.primary_tools?.map((permission) => ({
+            permission,
+            pattern: "*" as const,
+            action: "deny" as const,
+          })) ?? []
+        return [...inherited, ...toolDenies.filter((deny) => !inherited.some((rule) => samePermissionRule(rule, deny)))]
+      }
+      const childPermission = childSessionPermission(next)
       const nextSession =
         session ??
         (yield* sessions.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${next.name} subagent)`,
           agent: next.name,
-          permission: [
-            ...childPermission,
-            ...childToolDenies.filter(
-              (deny) =>
-                !childPermission.some(
-                  (rule) =>
-                    rule.permission === deny.permission && rule.pattern === deny.pattern && rule.action === deny.action,
-                ),
-            ),
-          ],
+          permission: childPermission,
         }))
 
       const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
@@ -199,6 +194,27 @@ export const TaskTool = Tool.define(
 
       const runTask = Effect.fn("TaskTool.runTask")(function* () {
         const parts = yield* ops.resolvePromptParts(params.prompt)
+        const current = yield* sessions.get(nextSession.id)
+        if (current.parentID === ctx.sessionID && current.agent !== next.name) {
+          const currentParent = yield* sessions.get(ctx.sessionID)
+          const currentParentPermission = currentParent.permission ?? []
+          const previous = current.agent ? yield* agent.get(current.agent) : undefined
+          const preserved = [...(current.permission ?? [])]
+          for (const rule of previous ? childSessionPermission(previous, currentParentPermission) : []) {
+            // Remove one derived copy so an identical session-specific rule remains.
+            const index = preserved.findIndex((item) => samePermissionRule(item, rule))
+            if (index !== -1) preserved.splice(index, 1)
+          }
+          const nextPermission = childSessionPermission(next, currentParentPermission)
+          yield* sessions.setAgentPermission({
+            sessionID: nextSession.id,
+            agent: next.name,
+            permission: [
+              ...preserved.filter((rule) => !nextPermission.some((item) => samePermissionRule(item, rule))),
+              ...nextPermission,
+            ],
+          })
+        }
         const result = yield* ops.prompt({
           messageID: MessageID.ascending(),
           sessionID: nextSession.id,

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -255,6 +255,88 @@ describe("tool.task", () => {
     }),
   )
 
+  it.instance(
+    "execute refreshes derived permissions when resuming with a different subagent type",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        yield* sessions.setPermission({
+          sessionID: chat.id,
+          permission: [{ permission: "bash", pattern: "*", action: "deny" }],
+        })
+        const child = yield* sessions.create({
+          parentID: chat.id,
+          title: "General child",
+          agent: "general",
+          permission: [
+            { permission: "bash", pattern: "*", action: "deny" },
+            { permission: "task", pattern: "*", action: "deny" },
+            { permission: "webfetch", pattern: "*", action: "deny" },
+          ],
+        })
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const context = {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: stubOps({ onPrompt: (input) => (seen = input) }) },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        }
+        const resume = (subagent_type: string) =>
+          def.execute(
+            {
+              description: "continue bug",
+              prompt: "continue investigating",
+              subagent_type,
+              task_id: child.id,
+            },
+            context,
+          )
+
+        const result = yield* resume("reviewer")
+
+        expect(result.metadata.sessionId).toBe(child.id)
+        expect(seen?.agent).toBe("reviewer")
+        expect(yield* sessions.get(child.id)).toMatchObject({
+          agent: "reviewer",
+          permission: [
+            { permission: "webfetch", pattern: "*", action: "deny" },
+            { permission: "bash", pattern: "*", action: "deny" },
+            { permission: "todowrite", pattern: "*", action: "deny" },
+          ],
+        })
+
+        yield* resume("general")
+
+        expect(yield* sessions.get(child.id)).toMatchObject({
+          agent: "general",
+          permission: [
+            { permission: "webfetch", pattern: "*", action: "deny" },
+            { permission: "bash", pattern: "*", action: "deny" },
+            { permission: "task", pattern: "*", action: "deny" },
+          ],
+        })
+      }),
+    {
+      config: {
+        agent: {
+          reviewer: {
+            mode: "subagent",
+            permission: {
+              task: "allow",
+            },
+          },
+        },
+      },
+    },
+  )
+
   it.instance("execute asks by default and skips checks when bypassed", () =>
     Effect.gen(function* () {
       const { chat, assistant } = yield* seed()
@@ -743,6 +825,112 @@ describe("tool.task", () => {
       expect(notification.parts[0]?.type).toBe("text")
       if (notification.parts[0]?.type === "text") expect(notification.parts[0].text).toContain("second done")
     }),
+  )
+
+  background.instance(
+    "queued resumes refresh permissions from the latest subagent type",
+    () =>
+      Effect.gen(function* () {
+        const jobs = yield* BackgroundJob.Service
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        const firstStarted = defer<void>()
+        const firstDone = defer<void>()
+        const secondStarted = defer<void>()
+        const secondDone = defer<void>()
+        const thirdStarted = defer<void>()
+        const seen: Session.Info[] = []
+        const promptOps: TaskPromptOps = {
+          ...stubOps(),
+          prompt: (input) => {
+            if (input.sessionID === chat.id) return Effect.succeed(reply(input, "injected"))
+            return Effect.gen(function* () {
+              seen.push(yield* sessions.get(input.sessionID).pipe(Effect.orDie))
+              if (seen.length === 1) {
+                firstStarted.resolve()
+                yield* Effect.promise(() => firstDone.promise)
+              } else if (seen.length === 2) {
+                secondStarted.resolve()
+                yield* Effect.promise(() => secondDone.promise)
+              } else {
+                thirdStarted.resolve()
+              }
+              return reply(input, `run ${seen.length}`)
+            })
+          },
+        }
+        const context = {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        }
+
+        const started = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "start investigation",
+            subagent_type: "general",
+            background: true,
+          },
+          context,
+        )
+        yield* Effect.promise(() => firstStarted.promise)
+
+        yield* def.execute(
+          {
+            description: "review findings",
+            prompt: "review the current findings",
+            subagent_type: "reviewer",
+            task_id: started.metadata.sessionId,
+          },
+          context,
+        )
+        yield* def.execute(
+          {
+            description: "continue investigation",
+            prompt: "continue the investigation",
+            subagent_type: "general",
+            task_id: started.metadata.sessionId,
+          },
+          context,
+        )
+
+        firstDone.resolve()
+        yield* Effect.promise(() => secondStarted.promise)
+        expect(seen[1]).toMatchObject({
+          agent: "reviewer",
+          permission: [{ permission: "todowrite", pattern: "*", action: "deny" }],
+        })
+
+        secondDone.resolve()
+        yield* Effect.promise(() => thirdStarted.promise)
+        expect(seen[2]).toMatchObject({
+          agent: "general",
+          permission: [{ permission: "task", pattern: "*", action: "deny" }],
+        })
+
+        const waited = yield* jobs.wait({ id: started.metadata.sessionId, timeout: 2_000 })
+        expect(waited.info?.status).toBe("completed")
+      }),
+    {
+      config: {
+        agent: {
+          reviewer: {
+            mode: "subagent",
+            permission: {
+              task: "allow",
+            },
+          },
+        },
+      },
+    },
   )
 
   background.instance("background tasks complete through the background job service", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #41681

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a queued `task_id` resume starts under a different subagent, atomically refresh its stored agent and Task-owned permission rules before prompting it. Rules derived for the previous agent are replaced, while current parent ceilings and child-specific restrictions are preserved.

Permission rules do not currently carry provenance, so the refresh removes one matching old-derived copy and conservatively keeps unmatched or duplicate restrictions.

### How did you verify your code works?

- Added red/green coverage for sequential and queued agent switches.
- `bun test test/tool/task.test.ts` (22 pass)
- `bun test test/agent/plan-mode-subagent-bypass.test.ts` (5 pass)
- `tsgo --noEmit` in `packages/opencode`
- Prettier check and targeted oxlint (0 errors)

### Screenshots / recordings

Not applicable (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
