### PR TITLE
fix(session): make retry cap and backoffDelay configurable per provider

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -1,7 +1,7 @@
 export * as ConfigProviderV1 from "./provider"
 
 import { Schema } from "effect"
-import { PositiveInt } from "../../schema"
+import { NonNegativeInt, PositiveInt } from "../../schema"
 
 export const ModelStatus = Schema.Literals(["alpha", "beta", "deprecated", "active"])
 
@@ -117,6 +117,14 @@ export const Info = Schema.Struct({
         chunkTimeout: Schema.optional(PositiveInt).annotate({
           description:
             "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+        }),
+        retry: Schema.optional(NonNegativeInt).annotate({
+          description:
+            "Maximum number of retries for retryable API errors from this provider (default 5). Set to 0 to disable retries.",
+        }),
+        backoffDelay: Schema.optional(PositiveInt).annotate({
+          description:
+            "Initial delay in milliseconds for exponential backoff between retries (default 2000). Ignored when the provider responds with retry-after headers.",
         }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1739,6 +1739,9 @@ const layer = Layer.effect(
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
+        // consumed by the session retry policy, not the provider SDK
+        delete options["retry"]
+        delete options["backoffDelay"]
 
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -18,7 +18,7 @@ import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
-import type { Provider } from "@/provider/provider"
+import { Provider } from "@/provider/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { isRecord } from "@/util/record"
@@ -86,6 +86,7 @@ const layer = Layer.effect(
     const snapshot = yield* Snapshot.Service
     const agents = yield* Agent.Service
     const llm = yield* LLM.Service
+    const provider = yield* Provider.Service
     const permission = yield* Permission.Service
     const plugin = yield* Plugin.Service
     const summary = yield* SessionSummary.Service
@@ -632,6 +633,10 @@ const layer = Layer.effect(
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
 
+        const options = (yield* provider.getProvider(input.model.providerID))?.options ?? {}
+        const retryOption = (key: "retry" | "backoffDelay") =>
+          typeof options[key] === "number" ? options[key] : undefined
+
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
             ctx.currentText = undefined
@@ -660,6 +665,8 @@ const layer = Layer.effect(
             Effect.retry(
               SessionRetry.policy({
                 provider: input.model.providerID,
+                retry: retryOption("retry"),
+                backoffDelay: retryOption("backoffDelay"),
                 parse,
                 set: (info) => {
                   return status.set(ctx.sessionID, {
@@ -705,6 +712,7 @@ export const node = LayerNode.make({
     Snapshot.node,
     Agent.node,
     LLM.node,
+    Provider.node,
     Permission.node,
     Plugin.node,
     SessionSummary.node,

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -43,7 +43,7 @@ function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
 
-export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random()) {
+export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random(), backoffDelay?: number) {
   if (error) {
     const headers = error.data.responseHeaders
     if (headers) {
@@ -69,15 +69,15 @@ export function delay(attempt: number, error?: SessionV1.APIError, random = Math
         }
       }
 
-      return cap(exponential(attempt, random))
+      return cap(exponential(attempt, random, backoffDelay))
     }
   }
 
-  return cap(Math.min(exponential(attempt, random), RETRY_MAX_DELAY_NO_HEADERS))
+  return cap(Math.min(exponential(attempt, random, backoffDelay), RETRY_MAX_DELAY_NO_HEADERS))
 }
 
-function exponential(attempt: number, random: number) {
-  const base = RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
+function exponential(attempt: number, random: number, backoffDelay?: number) {
+  const base = (backoffDelay ?? RETRY_INITIAL_DELAY) * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
   return Math.ceil(base + base * RETRY_JITTER_FACTOR * random)
 }
 
@@ -181,6 +181,8 @@ function parseJSON(value: unknown) {
 
 export function policy(opts: {
   provider: string
+  retry?: number
+  backoffDelay?: number
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
 }) {
@@ -189,9 +191,14 @@ export function policy(opts: {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
-      if (meta.attempt > RETRY_MAX_RETRIES) return Cause.done(meta.attempt)
+      if (meta.attempt > (opts.retry ?? RETRY_MAX_RETRIES)) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
-        const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
+        const wait = delay(
+          meta.attempt,
+          SessionV1.APIError.isInstance(error) ? error : undefined,
+          undefined,
+          opts.backoffDelay,
+        )
         const now = yield* Clock.currentTimeMillis
         yield* opts.set({
           attempt: meta.attempt,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -94,6 +94,17 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(1, error)).toBe(SessionRetry.RETRY_MAX_DELAY)
   })
 
+  test("uses configured backoffDelay as the initial delay", () => {
+    const error = apiError()
+    const delays = Array.from({ length: 6 }, (_, index) => SessionRetry.delay(index + 1, error, 0, 1000))
+    expect(delays).toStrictEqual([1000, 2000, 4000, 8000, 16000, 30000])
+  })
+
+  test("prefers retry-after headers over configured backoffDelay", () => {
+    const error = apiError({ "retry-after-ms": "1500" })
+    expect(SessionRetry.delay(1, error, 0, 5000)).toBe(1500)
+  })
+
   it.instance("policy updates retry status and increments attempts", () =>
     Effect.gen(function* () {
       const sessionID = SessionID.make("session-retry-test")
@@ -144,6 +155,73 @@ describe("session.retry.delay", () => {
       )
 
       expect(attempts).toStrictEqual([1, 2, 3, 4, 5])
+    }),
+  )
+
+  it.instance("policy stops after the configured retry limit", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("session-retry-limit-test")
+      const error = apiError({ "retry-after-ms": "0" })
+      const status = yield* SessionStatus.Service
+
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          retry: 1,
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: (info) =>
+            status.set(sessionID, {
+              type: "retry",
+              attempt: info.attempt,
+              message: info.message,
+              next: info.next,
+            }),
+        }),
+      )
+      yield* step(error)
+      const second = yield* step(error).pipe(Effect.exit)
+
+      expect(second._tag).toBe("Failure")
+      expect(yield* status.get(sessionID)).toMatchObject({
+        type: "retry",
+        attempt: 1,
+        message: "boom",
+      })
+    }),
+  )
+
+  it.instance("policy retry option can raise the attempt limit", () =>
+    Effect.gen(function* () {
+      const error = apiError({ "retry-after-ms": "0" })
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          retry: SessionRetry.RETRY_MAX_RETRIES + 2,
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: () => Effect.void,
+        }),
+      )
+      for (let attempt = 1; attempt <= SessionRetry.RETRY_MAX_RETRIES + 2; attempt++) {
+        yield* step(error)
+      }
+      const exhausted = yield* step(error).pipe(Effect.exit)
+      expect(exhausted._tag).toBe("Failure")
+    }),
+  )
+
+  it.instance("policy with retry 0 never retries", () =>
+    Effect.gen(function* () {
+      const error = apiError({ "retry-after-ms": "0" })
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          retry: 0,
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: () => Effect.void,
+        }),
+      )
+      const result = yield* step(error).pipe(Effect.exit)
+      expect(result._tag).toBe("Failure")
     }),
   )
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1755,7 +1755,9 @@ export type ProviderConfig = {
      */
     headerTimeout?: number | false
     chunkTimeout?: number
-    [key: string]: unknown | string | boolean | number | false | number | false | number | undefined
+    retry?: number
+    backoffDelay?: number
+    [key: string]: unknown | string | boolean | number | false | number | false | number | number | undefined
   }
   models?: {
     [key: string]: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20784,6 +20784,14 @@
               "chunkTimeout": {
                 "type": "integer",
                 "exclusiveMinimum": 0
+              },
+              "retry": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "backoffDelay": {
+                "type": "integer",
+                "exclusiveMinimum": 0
               }
             },
             "additionalProperties": {}

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -374,7 +374,7 @@ You can configure the providers and models you want to use in your OpenCode conf
 
 The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
 
-Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
+Provider options can include `timeout`, `chunkTimeout`, `retry`, `backoffDelay`, and `setCacheKey`:
 
 ```json title="opencode.json"
 {
@@ -384,6 +384,8 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
       "options": {
         "timeout": 600000,
         "chunkTimeout": 30000,
+        "retry": 3,
+        "backoffDelay": 1000,
         "setCacheKey": true
       }
     }
@@ -393,6 +395,8 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
 - `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted.
+- `retry` - Maximum number of retries for retryable API errors like rate limits or server errors (default: 5). Set to `0` to disable retries.
+- `backoffDelay` - Initial delay in milliseconds for exponential backoff between retries (default: 2000). Ignored when the provider responds with `retry-after` headers.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).


### PR DESCRIPTION
### Issue for this PR

Closes #21960

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Follow-up to #41939, which added the fixed `RETRY_MAX_RETRIES = 5` cap. That default is right for most cases, but the retry budget users want differs per provider (an aggressive retry loop against a rate-limited Bedrock account makes things worse; a flaky self-hosted proxy may need more than 5). This PR makes the cap and the initial backoff configurable per provider:

```json
{
  "provider": {
    "amazon-bedrock": {
      "options": { "retry": 3, "backoffDelay": 1000 }
    }
  }
}
```

- `retry` — max attempts (default 5 from #41939, `0` disables retries)
- `backoffDelay` — initial backoff in ms (default 2000); provider `retry-after` headers still take precedence, and the jitter from #41939 is preserved

Both options are stripped before SDK construction (like `chunkTimeout`) so they never reach the provider client.

### How did you verify your code works?

- Rebased on current `dev` (keeps the #41939 jitter + cap behavior and its tests intact).
- New unit tests in `test/session/retry.test.ts`: `retry` raises/lowers the cap; `retry: 0` never retries; `backoffDelay` changes the backoff progression; `retry-after` headers still win. `bun test test/session/retry.test.ts` → 59 pass.
- `bun run typecheck` clean in `packages/core` and `packages/opencode`.
- Regenerated SDK types via `./script/generate.ts`.

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
