### PR TITLE
fix: normalize Windows backslash paths in file watcher to fix tree refresh

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -15,10 +15,10 @@ describe("file path helpers", () => {
 
   test("normalizes Windows absolute paths with mixed separators", () => {
     const path = createPathHelpers(() => "C:\\repo")
-    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src\\app.ts")
+    expect(path.normalize("C:\\repo\\src\\app.ts")).toBe("src/app.ts")
     expect(path.normalize("C:/repo/src/app.ts")).toBe("src/app.ts")
     expect(path.normalize("file://C:/repo/src/app.ts")).toBe("src/app.ts")
-    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src\\app.ts")
+    expect(path.normalize("c:\\repo\\src\\app.ts")).toBe("src/app.ts")
   })
 
   test("normalizes Windows directory separators", () => {

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -127,6 +127,9 @@ export function createPathHelpers(scope: () => string) {
     if (path.startsWith("/") || path.startsWith("\\")) {
       path = path.slice(1)
     }
+    if (windows) {
+      path = path.replace(/\\/g, "/")
+    }
     return path
   }
 

--- a/packages/app/src/context/file/watcher.ts
+++ b/packages/app/src/context/file/watcher.ts
@@ -24,7 +24,7 @@ export function invalidateFromWatcher(event: WatcherEvent, ops: WatcherOps) {
   if (!rawPath) return
   if (!kind) return
 
-  const path = ops.normalize(rawPath)
+  const path = ops.normalize(rawPath).replace(/\\/g, "/")
   if (!path) return
   if (path.startsWith(".git/")) return
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -957,7 +957,7 @@ export default function Page() {
         ? (details.properties as Record<string, unknown>)
         : undefined
     const file = typeof props?.file === "string" ? props.file : undefined
-    if (!file || file.startsWith(".git/")) return
+    if (!file || file.replace(/\\/g, "/").startsWith(".git/")) return
     refreshVcs()
   })
   onCleanup(stopVcs)


### PR DESCRIPTION
File tree and file viewer do not auto-refresh after AI edits on Windows because `path.normalize()` preserved backslashes while tree-store and watcher's `split('/')` expected forward slashes, causing path lookup mismatches and preventing directory refresh.

### Changes

- **`path.ts`** — `normalize()` now converts backslashes to forward slashes on Windows, consistent with `normalizeDir()` and `encodeFilePath()` which already do this
- **`watcher.ts`** — adds defensive `.replace(/\\/g, "/")` after normalization as a safety net
- **`session.tsx`** — normalize path separators in VCS watcher `.git/` filter so Windows backslash paths don't bypass the guard
- **`path.test.ts`** — updated Windows path normalization test expectations from `src\\app.ts` to `src/app.ts`

### Verification

- Tested the normalize and watcher invalidate logic in isolation with Bun
- Existing test suite expectations updated to match new behavior

Fixes #38125