### PR TITLE
fix(app): fallback blob ID generation for non-secure HTTP contexts

### DIFF
--- a/packages/app/src/utils/draft-store.ts
+++ b/packages/app/src/utils/draft-store.ts
@@ -22,10 +22,13 @@ function blobUrl(id: string, blob: Blob) {
 }
 
 async function blobID(blob: Blob) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-  return id
+  if (globalThis.crypto?.subtle) {
+    const id = Array.from(new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("")
+    return id
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36)
 }
 
 export async function createBlobReference(blob: Blob): Promise<BlobReference> {


### PR DESCRIPTION
### Issue for this PR

Closes #41706

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an issue where pasting an image in a non-secure HTTP context (e.g. over a remote server IP) causes a crash. The `blobID` function was using `crypto.subtle.digest`, but the Web Crypto API spec makes `crypto.subtle` undefined in non-secure contexts. 

This PR updates `blobID` to check if `globalThis.crypto?.subtle` is available. If it's not, it falls back to a non-cryptographic random string for the ID, allowing images to paste normally.

### How did you verify your code works?

Verified that the `globalThis.crypto?.subtle` check successfully prevents the `TypeError` and falls back correctly when accessed over plain HTTP.

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
