### PR TITLE
fix(tui): prevent sidebar selection copy bleed

### DIFF
--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -5,9 +5,20 @@ import { useTheme } from "../../context/theme"
 import { useTuiConfig } from "../../config"
 import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { usePluginRuntime } from "../../plugin/runtime"
+import type { Renderable } from "@opentui/core"
 
 import { getScrollAcceleration } from "../../util/scroll"
 import { WorkspaceLabel } from "../../component/workspace-label"
+
+export function disableSelectionSubtree(root: Renderable) {
+  root.selectable = false
+  const stack = [...root.getChildren()]
+  while (stack.length > 0) {
+    const node = stack.pop()!
+    node.selectable = false
+    stack.push(...node.getChildren())
+  }
+}
 
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const pluginRuntime = usePluginRuntime()
@@ -26,6 +37,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   return (
     <Show when={session()}>
       <box
+        renderBefore={function () {
+          disableSelectionSubtree(this)
+        }}
         backgroundColor={theme.backgroundPanel}
         width={42}
         height="100%"

--- a/packages/tui/test/util/sidebar-selection.test.ts
+++ b/packages/tui/test/util/sidebar-selection.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import type { Renderable } from "@opentui/core"
+import { disableSelectionSubtree } from "../../src/routes/session/sidebar"
+
+type MockRenderable = {
+  selectable: boolean
+  children: MockRenderable[]
+  getChildren: () => MockRenderable[]
+}
+
+function mockRenderable(children: MockRenderable[] = []): MockRenderable {
+  return {
+    selectable: true,
+    children,
+    getChildren() {
+      return this.children
+    },
+  }
+}
+
+function asRenderable(node: MockRenderable) {
+  return node as unknown as Renderable
+}
+
+test("disableSelectionSubtree disables selection for all descendants", () => {
+  const leaf = mockRenderable()
+  const nested = mockRenderable([leaf])
+  const sibling = mockRenderable()
+  const root = mockRenderable([nested, sibling])
+
+  disableSelectionSubtree(asRenderable(root))
+
+  expect(root.selectable).toBe(false)
+  expect(nested.selectable).toBe(false)
+  expect(leaf.selectable).toBe(false)
+  expect(sibling.selectable).toBe(false)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41692

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a TUI text-selection bug where selecting conversation text could also include the right Context sidebar text in clipboard output.

Changes in this PR:
- Mark the sidebar subtree as non-selectable in the session sidebar implementation.
- Add a regression test to verify the subtree is recursively non-selectable.

Why this works:
- OpenTUI selection can traverse selectable siblings during drag.
- Making the sidebar subtree non-selectable removes sidebar text from selection candidates, so copied selection stays scoped to intended content.

### How did you verify your code works?

- Ran: ./script/bun-docker.sh run --cwd packages/tui test test/util/sidebar-selection.test.ts
- Ran: ./script/bun-docker.sh run --cwd packages/tui typecheck
- Manual behavior check in TUI: selecting conversation text no longer copies Context sidebar text.

### Screenshots / recordings
<img width="1140" height="195" alt="Screenshot 2026-08-11 123209" src="https://github.com/user-attachments/assets/5a40a4a2-cc65-44c5-bf92-7174f586b5a0" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
