### PR TITLE
docs: add docker bun contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,40 @@ https://github.com/anomalyco/models.dev
   bun dev
   ```
 
+### Running Bun via Docker (no local Bun required)
+
+If `bun` is not available on your machine, you can run Bun in Docker:
+
+```bash
+script/bun-docker.sh --version
+script/bun-docker.sh install
+```
+
+On first run this script builds a local image (`opencode-bun:1.3.14-1`) with
+`python3`, `make`, `g++`, and `git` so native package installs work.
+
+Run package-scoped checks the same way:
+
+```bash
+script/bun-docker.sh run --cwd packages/tui test
+script/bun-docker.sh run --cwd packages/tui typecheck
+```
+
+For a single regression test file:
+
+```bash
+script/bun-docker.sh run --cwd packages/tui test test/util/sidebar-selection.test.ts
+```
+
+To run the OpenCode terminal UI (TUI) itself with Docker Bun:
+
+```bash
+script/bun-docker.sh run dev .
+```
+
+This starts the same interactive terminal experience as `bun dev .`, but without
+requiring Bun on your host machine.
+
 ### Running against a different directory
 
 By default, `bun dev` runs OpenCode in the `packages/opencode` directory. To run it against a different directory or repository:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,9 @@ script/bun-docker.sh --version
 script/bun-docker.sh install
 ```
 
-On first run this script builds a local image (`opencode-bun:1.3.14-1`) with
-`python3`, `make`, `g++`, and `git` so native package installs work.
+On first run this script builds a local image (`opencode-bun:<bun-version>-build`)
+using the Bun version from `package.json` (`packageManager`), with `python3`,
+`make`, `g++`, and `git` so native package installs work.
 
 Run package-scoped checks the same way:
 

--- a/script/bun-docker.sh
+++ b/script/bun-docker.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "" ]]; then
+  cat <<'EOF'
+Run Bun commands in Docker when Bun is not installed locally.
+
+Usage:
+  script/bun-docker.sh <bun-args...>
+
+Examples:
+  script/bun-docker.sh --version
+  script/bun-docker.sh install
+  script/bun-docker.sh run --cwd packages/tui test
+  script/bun-docker.sh run --cwd packages/tui typecheck
+EOF
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+UID_GID="$(id -u):$(id -g)"
+LOCAL_IMAGE="opencode-bun:1.3.14-1"
+
+TTY_ARGS=()
+if [[ -t 0 && -t 1 ]]; then
+  TTY_ARGS=("-it")
+fi
+
+if ! docker image inspect "$LOCAL_IMAGE" >/dev/null 2>&1; then
+  docker build -t "$LOCAL_IMAGE" -f - "$ROOT" <<'EOF'
+FROM oven/bun:1.3.14
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 make g++ git \
+  && rm -rf /var/lib/apt/lists/*
+EOF
+fi
+
+exec docker run --rm "${TTY_ARGS[@]}" \
+  --user "$UID_GID" \
+  -e HOME=/tmp \
+  -v "$ROOT:/workspaces/opencode" \
+  -w /workspaces/opencode \
+  "$LOCAL_IMAGE" bun "$@"

--- a/script/bun-docker.sh
+++ b/script/bun-docker.sh
@@ -19,7 +19,14 @@ fi
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 UID_GID="$(id -u):$(id -g)"
-LOCAL_IMAGE="opencode-bun:1.3.14-1"
+BUN_VERSION="$(sed -nE 's/.*"packageManager"[[:space:]]*:[[:space:]]*"bun@([^"]+)".*/\1/p' "$ROOT/package.json" | head -n1)"
+if [[ "$BUN_VERSION" == "" ]]; then
+  echo "Unable to determine Bun version from package.json packageManager field." >&2
+  exit 1
+fi
+
+LOCAL_IMAGE="opencode-bun:${BUN_VERSION}-build"
+BASE_IMAGE="oven/bun:${BUN_VERSION}"
 
 TTY_ARGS=()
 if [[ -t 0 && -t 1 ]]; then
@@ -27,8 +34,8 @@ if [[ -t 0 && -t 1 ]]; then
 fi
 
 if ! docker image inspect "$LOCAL_IMAGE" >/dev/null 2>&1; then
-  docker build -t "$LOCAL_IMAGE" -f - "$ROOT" <<'EOF'
-FROM oven/bun:1.3.14
+  docker build -t "$LOCAL_IMAGE" -f - "$ROOT" <<EOF
+FROM ${BASE_IMAGE}
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ git \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Issue for this PR

Closes #41715

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a Docker-based Bun workflow for contributors who cannot run Bun natively.

Changes:
- Adds `script/bun-docker.sh` to run Bun commands in a pinned Docker image.
- Derives the Bun version from `package.json` (`packageManager`) so the helper image always tracks the repo's Bun version.
- Builds a local helper image with `python3`, `make`, `g++`, and `git` so native dependency installs work.
- Documents usage in `CONTRIBUTING.md` for install, typecheck, tests, and launching the TUI.

Why this works:
- Contributors can execute the same Bun commands without host Bun installation.
- The image version stays aligned with the repo's declared Bun version.
- Added build dependencies fix native package install failures encountered with the base image alone.

### How did you verify your code works?

- Ran: `./script/bun-docker.sh --version`
- Ran: `./script/bun-docker.sh install`
- Ran: `./script/bun-docker.sh run dev .`

### Screenshots / recordings

N/A (workflow/documentation change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._