### PR TITLE
fix(core): preserve unsupported image attachments as text instead of dropping them

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -64,6 +64,20 @@ const directoryAttachment = (file: FileAttachment): ContentPart => ({
   },
 })
 
+const unsupportedImageAttachment = (file: FileAttachment): ContentPart => ({
+  type: "text",
+  text: `\n\nAttached image with unsupported format (${file.mime}): ${
+    attachmentLocation(file) ?? file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")
+  } — content not included because model providers do not support this format`,
+  metadata: {
+    attachment: {
+      source: file.source,
+      name: file.name,
+      description: file.description,
+    },
+  },
+})
+
 const attachmentContent = (file: FileAttachment): ContentPart[] => {
   if (file.mime === "text/plain") return [textAttachment(file)]
   if (file.mime === "application/x-directory") return [directoryAttachment(file)]
@@ -71,6 +85,7 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
     const location = attachmentLocation(file)
     return [...(location === undefined ? [] : [Message.text(`Attached file: ${location}`)]), media(file)]
   }
+  if (file.mime.startsWith("image/")) return [unsupportedImageAttachment(file)]
   return []
 }
 

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -472,6 +472,38 @@ Recent work
     ])
   })
 
+  test("preserves unsupported image formats as text attachments instead of dropping them", () => {
+    const data = Base64.make("AAECAw==")
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-avif-image"),
+          type: "user",
+          text: "Inspect this image",
+          files: [
+            FileAttachment.make({ data, mime: "image/avif", source: { type: "inline" }, name: "image.avif" }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "Inspect this image" },
+      {
+        type: "text",
+        text: "\n\nAttached image with unsupported format (image/avif): image.avif — content not included because model providers do not support this format",
+        metadata: {
+          attachment: {
+            source: { type: "inline" },
+            name: "image.avif",
+          },
+        },
+      },
+    ])
+  })
+
   test("does not add attachment location text for non-local provider media", () => {
     const data = Base64.make("AAECAw==")
     const messages = toLLMMessages(


### PR DESCRIPTION
### Issue for this PR

Closes #41722

### Type of change

- [x] Bug fix

### What does this PR do?

In V2, `to-llm-message.ts` only lowers `image/png|jpeg|gif|webp` attachments to provider media; any other image mime (e.g. `image/avif`, `image/tiff`) returned `[]` from `attachmentContent`, silently dropping the attachment. The TUI file picker accepts `.avif` and inserts an `[Image N]` mention, so the model saw the label but never the content (or a notice that it was dropped).

This PR lowers unsupported image formats to a descriptive text attachment (mime + name + reason) instead of dropping them, so the model is aware the user attached an image it cannot view and can respond appropriately instead of referencing a nonexistent image.

### How did you verify your code works?

- Added a regression test in `packages/core/test/session-runner-message.test.ts` covering an `image/avif` attachment
- `bun test test/session-runner-message.test.ts` — 19 pass
- `bun typecheck` (packages/core) — clean

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR