### PR TITLE
fix(opencode): omit unsafe delete diffs

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -14,6 +14,17 @@ import DESCRIPTION from "./apply_patch.txt"
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { Format } from "../format"
 import * as Bom from "@/util/bom"
+import { isBinaryFile } from "@/util/binary"
+
+const MAX_DELETE_DIFF_BYTES = 1024 * 1024
+
+function omittedDeleteDiff(filePath: string, size: number) {
+  return [
+    `Index: ${filePath}`,
+    "===================================================================",
+    `Binary or oversized file deleted (${size} bytes; content diff omitted)`,
+  ].join("\n")
+}
 
 export const Parameters = Schema.Struct({
   patchText: Schema.String.annotate({ description: "The full patch text that describes all changes to be made" }),
@@ -159,23 +170,28 @@ export const ApplyPatchTool = Tool.define(
           }
 
           case "delete": {
-            const source = yield* Bom.readFile(afs, filePath).pipe(
-              Effect.catch((error) =>
-                Effect.fail(
-                  new Error(
-                    `apply_patch verification failed: ${error instanceof Error ? error.message : String(error)}`,
-                  ),
-                ),
-              ),
-            )
-            const contentToDelete = source.text
-            const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+            const stat = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (!stat || stat.type === "Directory") {
+              return yield* Effect.fail(
+                new Error(`apply_patch verification failed: Failed to read file to delete: ${filePath}`),
+              )
+            }
+            const size = Number(stat.size)
+            const knownBinary = isBinaryFile(filePath, new Uint8Array())
+            const bytes = !knownBinary && size <= MAX_DELETE_DIFF_BYTES ? yield* afs.readFile(filePath) : undefined
+            const omit = knownBinary || size > MAX_DELETE_DIFF_BYTES || isBinaryFile(filePath, bytes ?? new Uint8Array())
+            const source = omit
+              ? { bom: false, text: "" }
+              : Bom.split(new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes))
+            const deleteDiff = omit
+              ? omittedDeleteDiff(filePath, size)
+              : trimDiff(createTwoFilesPatch(filePath, filePath, source.text, ""))
 
-            const deletions = contentToDelete.split("\n").length
+            const deletions = omit ? 0 : source.text.split("\n").length
 
             fileChanges.push({
               filePath,
-              oldContent: contentToDelete,
+              oldContent: source.text,
               newContent: "",
               type: "delete",
               diff: deleteDiff,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -9,6 +9,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isPdfAttachment, sniffAttachmentMime } from "@/util/media"
+import { isBinaryFile } from "@/util/binary"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -178,53 +179,6 @@ export const ReadTool = Tool.define<
 
       return { raw, count: flags.count, cut: flags.cut, more: flags.more, offset: opts.offset }
     })
-
-    const isBinaryFile = (filepath: string, bytes: Uint8Array) => {
-      const ext = path.extname(filepath).toLowerCase()
-      switch (ext) {
-        case ".zip":
-        case ".tar":
-        case ".gz":
-        case ".exe":
-        case ".dll":
-        case ".so":
-        case ".class":
-        case ".jar":
-        case ".war":
-        case ".7z":
-        case ".doc":
-        case ".docx":
-        case ".xls":
-        case ".xlsx":
-        case ".ppt":
-        case ".pptx":
-        case ".odt":
-        case ".ods":
-        case ".odp":
-        case ".bin":
-        case ".dat":
-        case ".obj":
-        case ".o":
-        case ".a":
-        case ".lib":
-        case ".wasm":
-        case ".pyc":
-        case ".pyo":
-          return true
-      }
-
-      if (bytes.length === 0) return false
-
-      let nonPrintableCount = 0
-      for (let i = 0; i < bytes.length; i++) {
-        if (bytes[i] === 0) return true
-        if (bytes[i] < 9 || (bytes[i] > 13 && bytes[i] < 32)) {
-          nonPrintableCount++
-        }
-      }
-
-      return nonPrintableCount / bytes.length > 0.3
-    }
 
     const run = Effect.fn("ReadTool.execute")(function* (
       params: Schema.Schema.Type<typeof Parameters>,

--- a/packages/opencode/src/util/binary.ts
+++ b/packages/opencode/src/util/binary.ts
@@ -1,0 +1,45 @@
+import path from "path"
+
+const extensions = new Set([
+  ".zip",
+  ".tar",
+  ".gz",
+  ".exe",
+  ".dll",
+  ".so",
+  ".class",
+  ".jar",
+  ".war",
+  ".7z",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  ".odt",
+  ".ods",
+  ".odp",
+  ".bin",
+  ".dat",
+  ".obj",
+  ".o",
+  ".a",
+  ".lib",
+  ".wasm",
+  ".pyc",
+  ".pyo",
+])
+
+export function isBinaryFile(filepath: string, bytes: Uint8Array) {
+  if (extensions.has(path.extname(filepath).toLowerCase())) return true
+  if (bytes.length === 0) return false
+
+  let nonPrintableCount = 0
+  for (const byte of bytes) {
+    if (byte === 0) return true
+    if (byte < 9 || (byte > 13 && byte < 32)) nonPrintableCount++
+  }
+
+  return nonPrintableCount / bytes.length > 0.3
+}

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -74,6 +74,7 @@ const makeCtx = () => {
 
 const readText = (filepath: string) => Effect.promise(() => fs.readFile(filepath, "utf-8"))
 const writeText = (filepath: string, content: string) => Effect.promise(() => fs.writeFile(filepath, content, "utf-8"))
+const writeBytes = (filepath: string, content: Uint8Array) => Effect.promise(() => fs.writeFile(filepath, content))
 const makeDir = (dir: string) => Effect.promise(() => fs.mkdir(dir, { recursive: true }))
 
 const expectFailure = <A, E, R>(effect: Effect.Effect<A, E, R>, message?: string) =>
@@ -343,6 +344,48 @@ describe("tool.apply_patch freeform", () => {
       const patchText = "*** Begin Patch\n*** Delete File: dir\n*** End Patch"
 
       yield* expectFailure(execute({ patchText }, ctx))
+    }),
+  )
+
+  it.instance("deletes binary files without embedding their contents in metadata", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "archive.zip")
+      const content = new Uint8Array(128 * 1024)
+      content.set([0x50, 0x4b, 0x03, 0x04])
+      yield* writeBytes(target, content)
+
+      const result = yield* execute(
+        { patchText: "*** Begin Patch\n*** Delete File: archive.zip\n*** End Patch" },
+        ctx,
+      )
+
+      expect(result.metadata.diff.length).toBeLessThan(1024)
+      expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.diff.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      yield* expectReadFailure(target)
+    }),
+  )
+
+  it.instance("deletes oversized text files without embedding their contents in metadata", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "large.txt")
+      yield* writeText(target, "x".repeat(1024 * 1024 + 1))
+
+      const result = yield* execute(
+        { patchText: "*** Begin Patch\n*** Delete File: large.txt\n*** End Patch" },
+        ctx,
+      )
+
+      expect(result.metadata.diff.length).toBeLessThan(1024)
+      expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.diff.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      yield* expectReadFailure(target)
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #41733

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` previously read every deleted file as UTF-8 and generated a full unified diff. For binary or very large files, that could duplicate hundreds of megabytes in session metadata and crash the Desktop sidecar.

This change reuses the read tool's binary detection and omits content diffs for binary files and files larger than 1 MiB. The delete still succeeds, but metadata contains a short marker instead of the file contents.

### How did you verify your code works?

- `bun test test/tool/apply_patch.test.ts --timeout 30000 --only-failures` (29 passed)
- `bun test test/tool/read.test.ts --timeout 30000 --only-failures` (40 passed)
- `bun typecheck` from `packages/opencode`
- Root `bun typecheck` (30 packages passed)

The new regression cases cover both binary and oversized text deletions and assert that neither result nor permission metadata embeds the contents.

### Screenshots / recordings

Not applicable; this is a core tool metadata fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
