### PR TITLE
fix(core): models.dev catalog population must survive KV cache write failures

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Layer, Option, Schedule, Schema, Semaphore } from "effect"
+import { Cause, Context, Duration, Effect, Layer, Option, Schedule, Schema, Semaphore } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ModelsDev } from "@opencode-ai/schema/models-dev"
 import { Money } from "@opencode-ai/schema/money"
@@ -612,7 +612,16 @@ export const layer = (options?: Options) =>
       const fetchAndWrite = Effect.fn("ModelsDev.fetchAndWrite")(function* () {
         const text = yield* fetchApi()
         const catalog = (yield* Schema.decodeUnknownEffect(CatalogJson)(text)) as Record<string, SourceProvider>
-        yield* kv.set(key, { updatedAt: Date.now(), body: text })
+        // Best-effort: a cache-write failure must never kill catalog
+        // population. The payload has outgrown some KV backends' per-value
+        // limits (Durable Object SQLite caps values at 2 MB and api.json
+        // passed it in Aug 2026); a boot without a cache hit just refetches.
+        yield* kv.set(key, { updatedAt: Date.now(), body: text }).pipe(
+          Effect.catchCauseIf(
+            (cause) => !Cause.hasInterruptsOnly(cause),
+            (cause) => Effect.logWarning("Failed to cache models.dev catalog", { cause }),
+          ),
+        )
         return catalog
       })
 

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -185,6 +185,15 @@ const buildLayer = (state: Ref.Ref<MockState>, cache: MockCache, options: Models
     ]),
   )
 
+// Mirrors production KV backends whose writes die as defects (e.g. Durable
+// Object SQLite rejecting values over its 2 MB cap with EffectDrizzleQueryError).
+const makeFailingWriteKV = (cache: MockCache) =>
+  Layer.mock(KV.Service, {
+    get: (key) => Effect.sync(() => cache.values.get(key)),
+    set: () => Effect.die(new Error("Failed query: insert into \"kv\"")),
+    remove: (key) => Effect.sync(() => cache.values.delete(key)).pipe(Effect.asVoid),
+  })
+
 const makeCache = (): MockCache => ({ values: new Map() })
 
 const writeCacheText = (cache: MockCache, text: string, updatedAt = Date.now()) =>
@@ -243,6 +252,25 @@ describe("ModelsDev Service", () => {
       const result = yield* ModelsDev.Service.use((s) => s.get()).pipe(Effect.provide(context))
       expect(result).toEqual(fixture2Snapshot)
       expect(cache.values.get(cacheKey)).toMatchObject({ body: JSON.stringify(fixture2) })
+      const final = yield* Ref.get(state)
+      expect(final.calls.length).toBe(1)
+    }),
+  )
+
+  it.live("get() still populates the catalog when the KV cache write fails", () =>
+    Effect.gen(function* () {
+      const cache = makeCache()
+      const state = yield* Ref.make({ ...initialState, body: JSON.stringify(fixture2) })
+      const layer = Layer.fresh(
+        AppNodeBuilder.build(ModelsDev.node, [
+          [ModelsDev.node, ModelsDev.configured({ fetch: true })],
+          [LayerNodePlatform.httpClient, Layer.succeed(HttpClient.HttpClient, makeMockClient(state))],
+          [KV.node, makeFailingWriteKV(cache)],
+        ]),
+      )
+      const result = yield* ModelsDev.Service.use((s) => s.get()).pipe(Effect.provide(layer))
+      expect(result).toEqual(fixture2Snapshot)
+      expect(cache.values.has(cacheKey)).toBe(false)
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBe(1)
     }),


### PR DESCRIPTION
## What

Make the models.dev KV cache write in `fetchAndWrite` best-effort: a failed `kv.set` now logs a warning instead of killing catalog population.

## Why

models.dev `api.json` is now ~3.6 MB, past the 2 MB per-value cap of Durable Object SQLite (the workerd embedding's KV backend). `kv.set` dies there with `EffectDrizzleQueryError: Failed query: insert into "kv" ...`, and since `populate` pipes through `Effect.orDie`, one failed cache insert empties the entire model catalog — every session fails with `ModelUnavailable`. Observed live in production today; the failure began when api.json crossed the size cap. The catalog was already fetched and decoded by the time the write fails, so dying is pure loss.

## How

Wrap `kv.set` with `Effect.catchCauseIf` on non-interrupt causes (`!Cause.hasInterruptsOnly`) and `Effect.logWarning`. Interrupts still propagate.

## Testing

- New regression test: `get() still populates the catalog when the KV cache write fails` — KV stub whose `set` dies (mirroring the real defect) while fetch succeeds; asserts the catalog is returned instead of dying.
- Existing `test/models.test.ts` suite passes (12/12); `bun turbo typecheck --filter=@opencode-ai/core` clean.

## Follow-up consideration

With an oversized payload the 5-minute refresh loop refetches every cycle since the cache write never lands. A compression or payload-trimming follow-up could restore caching, but correctness first.