### PR TITLE
fix(desktop): only pin @opencode-ai/plugin version for production releases

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -20,6 +20,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -11,7 +11,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { existsSync } from "fs"
 import { Account } from "@/account/account"
 import { isRecord } from "@/util/record"
@@ -440,7 +440,7 @@ const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version: InstallationChannel === "latest" ? InstallationVersion : undefined,
                 },
               ],
             })

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -16,7 +16,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CurrentWorkingDirectory } from "./tui-cwd"
 import { ConfigPlugin } from "@/config/plugin"
 import { TuiKeybind } from "@opencode-ai/tui/config/keybind"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { Filesystem } from "@/util/filesystem"
 import { ConfigVariable } from "@/config/variable"
@@ -239,7 +239,7 @@ const layer = Layer.effect(
             add: [
               {
                 name: "@opencode-ai/plugin",
-                version: InstallationLocal ? undefined : InstallationVersion,
+                version: InstallationChannel === "latest" ? InstallationVersion : undefined,
               },
             ],
           })


### PR DESCRIPTION
## Problem
Non-production builds (dev branches, local source, beta) fail the background npm install of @opencode-ai/plugin because they try to install a preview version (e.g. 0.0.0-fix-branch-20260811) that doesn't exist on npm.

## Root Cause
config.ts and tui.ts use InstallationLocal ? undefined : InstallationVersion. InstallationLocal is only true when OPENCODE_CHANNEL is "local" or undefined (running raw source). When built via build-node.ts, OPENCODE_CHANNEL is baked in from Script.channel — which returns the git branch name for non-release builds. So InstallationLocal is false, and it tries @opencode-ai/plugin@{preview-version} → 404 from npm.

## Fix
Change the condition to only pin the exact version when InstallationChannel === "latest" (production releases). All other builds install @opencode-ai/plugin@latest from npm.

## Changes
- packages/opencode/src/config/config.ts — import InstallationChannel instead of InstallationLocal; condition changed
- packages/opencode/src/config/tui.ts — identical change