### PR TITLE
docs: add opencode-plugin-peers to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-plugin-peers](https://github.com/jkrandom-sudo/opencode-plugin-peers)                    | Claude Code-style cross-session messaging and durable local handoffs between OpenCode sessions     |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #41747

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-plugin-peers` to the ecosystem plugin table. The plugin provides Claude Code-style cross-session messaging and durable local handoffs between independent OpenCode sessions.

### How did you verify your code works?

Confirmed the branch is one commit ahead of `dev` with a one-line change to `packages/web/src/content/docs/ecosystem.mdx`. The linked repository is public and documents installation, supported versions, security behavior, and the current v0.2.2 release.

### Screenshots / recordings

Not applicable; this is a documentation-only table entry.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR