### PR TITLE
feat(tui): render structured mentions inline

### DIFF
--- a/packages/tui/src/prompt/user-message-mention.ts
+++ b/packages/tui/src/prompt/user-message-mention.ts
@@ -1,0 +1,57 @@
+import type { PromptMention } from "@opencode-ai/schema"
+import { displaySlice, promptOffsetWidth } from "./display"
+
+export type UserMessageMention = {
+  key: string
+  type: "file" | "agent" | "skill"
+  mention?: PromptMention
+}
+
+export type UserMessageMentionSegment = {
+  text: string
+  type?: UserMessageMention["type"]
+}
+
+export function renderUserMessageMentions(text: string, mentions: readonly UserMessageMention[]) {
+  const candidates = mentions.flatMap((item) => {
+    const mention = item.mention
+    if (!mention?.text || mention.start < 0 || mention.end <= mention.start) return []
+    if (mention.end > promptOffsetWidth(text)) return []
+    if (!isDisplayRange(text, mention.start, mention.end)) return []
+    if (displaySlice(text, mention.start, mention.end) !== mention.text) return []
+    return [{ ...item, start: mention.start, end: mention.end }]
+  })
+
+  const valid = candidates
+    .filter((item) => !candidates.some((other) => other.key !== item.key && overlaps(item, other)))
+    .sort((left, right) => left.start - right.start || left.end - right.end || left.key.localeCompare(right.key))
+
+  const segments: UserMessageMentionSegment[] = []
+  const inline = new Set<string>()
+  let cursor = 0
+
+  for (const item of valid) {
+    if (item.start < cursor) continue
+    const before = displaySlice(text, cursor, item.start)
+    if (before) segments.push({ text: before })
+    segments.push({ text: item.mention!.text, type: item.type })
+    inline.add(item.key)
+    cursor = item.end
+  }
+
+  const remainder = displaySlice(text, cursor)
+  if (remainder) segments.push({ text: remainder })
+  if (segments.length === 0 && text) segments.push({ text })
+
+  return { segments, inline }
+}
+
+function overlaps(left: { start: number; end: number }, right: { start: number; end: number }) {
+  return left.start < right.end && left.end > right.start
+}
+
+function isDisplayRange(text: string, start: number, end: number) {
+  return (
+    promptOffsetWidth(displaySlice(text, 0, start)) === start && promptOffsetWidth(displaySlice(text, 0, end)) === end
+  )
+}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -71,6 +71,7 @@ import { usePromptRef } from "../../context/prompt"
 import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
 import { projectedPromptInput } from "../../prompt/codec"
 import { deduplicateVisibleImages } from "../../prompt/attachment"
+import { renderUserMessageMentions } from "../../prompt/user-message-mention"
 import { useEpilogue } from "../../context/epilogue"
 import { normalizePath } from "../../util/path"
 import { PermissionPrompt } from "./permission"
@@ -1915,10 +1916,28 @@ function UserMessage(props: { message: SessionMessageUser }) {
   const ctx = use()
   const data = useData()
   const local = useLocal()
-  const files = createMemo(() => deduplicateVisibleImages(props.message.files ?? []))
+  const files = createMemo(() => props.message.files ?? [])
   const skills = createMemo(() => props.message.skills ?? [])
+  const agents = createMemo(() => props.message.agents ?? [])
+  const mentions = createMemo(() =>
+    renderUserMessageMentions(props.message.text, [
+      ...files().map((file, index) => ({ key: `file:${index}`, type: "file" as const, mention: file.mention })),
+      ...agents().map((agent, index) => ({ key: `agent:${index}`, type: "agent" as const, mention: agent.mention })),
+      ...skills().map((skill, index) => ({ key: `skill:${index}`, type: "skill" as const, mention: skill.mention })),
+    ]),
+  )
+  const visibleFiles = createMemo(() => deduplicateVisibleImages(files().map((file, index) => ({ ...file, index }))))
+  const fileBadges = createMemo(() =>
+    visibleFiles().filter((file) => !file.mime.startsWith("image/") && !mentions().inline.has(`file:${file.index}`)),
+  )
+  const agentBadges = createMemo(() => agents().filter((_, index) => !mentions().inline.has(`agent:${index}`)))
+  const skillBadges = createMemo(() => skills().filter((_, index) => !mentions().inline.has(`skill:${index}`)))
+  const bodyVisible = createMemo(
+    () =>
+      !!props.message.text.trim() || fileBadges().length > 0 || agentBadges().length > 0 || skillBadges().length > 0,
+  )
   const images = createMemo(() =>
-    files().flatMap((file) =>
+    visibleFiles().flatMap((file) =>
       file.mime.startsWith("image/") ? [{ uri: `data:${file.mime};base64,${file.data}` }] : [],
     ),
   )
@@ -1937,103 +1956,119 @@ function UserMessage(props: { message: SessionMessageUser }) {
   }
 
   return (
-    <Show when={props.message.text.trim() || files().length || skills().length}>
+    <Show when={props.message.text.trim() || files().length || agents().length || skills().length}>
       <box
         border={["left"]}
         borderColor={delivery() ? theme.border.default : color()}
         customBorderChars={SplitBorder.customBorderChars}
       >
         <SessionImages images={images()} paddingLeft={2} />
-        <box
-          onMouseOver={() => {
-            setHover(true)
-          }}
-          onMouseOut={() => {
-            setHover(false)
-          }}
-          onMouseUp={() => {
-            if (renderer.getSelection()?.getSelectedText()) return
-            if (delivery() === "steer") {
+        <Show when={bodyVisible()}>
+          <box
+            onMouseOver={() => {
+              setHover(true)
+            }}
+            onMouseOut={() => {
+              setHover(false)
+            }}
+            onMouseUp={() => {
+              if (renderer.getSelection()?.getSelectedText()) return
+              if (delivery() === "steer") {
+                dialog.replace(() => (
+                  <DialogSelect
+                    title="Pending steer"
+                    options={[
+                      { title: "Move to queue", value: "queue" as const },
+                      { title: "Delete", value: "cancel" as const },
+                    ]}
+                    onSelect={(option) => {
+                      void updatePendingSteer(option.value)
+                    }}
+                  />
+                ))
+                return
+              }
               dialog.replace(() => (
-                <DialogSelect
-                  title="Pending steer"
-                  options={[
-                    { title: "Move to queue", value: "queue" as const },
-                    { title: "Delete", value: "cancel" as const },
-                  ]}
-                  onSelect={(option) => {
-                    void updatePendingSteer(option.value)
-                  }}
+                <DialogMessage
+                  messageID={props.message.id}
+                  sessionID={ctx.sessionID}
+                  setPrompt={(value) => promptRef.current?.set(value)}
                 />
               ))
-              return
-            }
-            dialog.replace(() => (
-              <DialogMessage
-                messageID={props.message.id}
-                sessionID={ctx.sessionID}
-                setPrompt={(value) => promptRef.current?.set(value)}
-              />
-            ))
-          }}
-          paddingTop={1}
-          paddingBottom={1}
-          paddingLeft={2}
-          backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
-          flexShrink={0}
-        >
-          <text fg={theme.text.default}>{props.message.text}</text>
-          <Show when={skills().length}>
-            <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
-              <For each={skills()}>
-                {(skill) => (
-                  <text fg={theme.text.default}>
-                    <span
-                      style={{
-                        bg: theme.hue.accent[mode() === "light" ? 700 : 200],
-                        fg: theme.background.default,
-                        bold: true,
-                      }}
-                    >
-                      {" skill "}
-                    </span>
-                    <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>
-                      {` ${skill.name} `}
-                    </span>
-                  </text>
+            }}
+            paddingTop={1}
+            paddingBottom={1}
+            paddingLeft={2}
+            backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
+            flexShrink={0}
+          >
+            <text fg={theme.text.default}>
+              <For each={mentions().segments}>
+                {(segment) => (
+                  <span
+                    style={
+                      segment.type
+                        ? {
+                            fg:
+                              segment.type === "file"
+                                ? theme.text.feedback.warning.default
+                                : (segment.type === "agent"
+                                    ? theme.categorical[0]
+                                    : (theme.categorical[1] ?? theme.categorical[0]))[mode() === "light" ? 700 : 200],
+                            bold: true,
+                          }
+                        : undefined
+                    }
+                  >
+                    {segment.text}
+                  </span>
                 )}
               </For>
-            </box>
-          </Show>
-          <Show when={files().length}>
-            <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
-              <For each={files()}>
-                {(file) => {
-                  const label = file.mime === "application/x-directory" ? "dir" : "file"
-                  return (
-                    <text fg={theme.text.default}>
-                      <span
-                        style={{
-                          bg: theme.hue.accent[mode() === "light" ? 700 : 200],
-                          fg: theme.background.default,
-                          bold: true,
-                        }}
-                      >
-                        {` ${label} `}
-                      </span>
-                      <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>
-                        {" "}
-                        {file.name ?? (file.source.type === "uri" ? file.source.uri : "attachment")}{" "}
-                      </span>
-                    </text>
-                  )
-                }}
-              </For>
-            </box>
-          </Show>
-        </box>
+            </text>
+            <Show when={skillBadges().length}>
+              <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
+                <For each={skillBadges()}>{(skill) => <UserMentionBadge type="skill" name={skill.name} />}</For>
+              </box>
+            </Show>
+            <Show when={agentBadges().length}>
+              <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
+                <For each={agentBadges()}>{(agent) => <UserMentionBadge type="agent" name={agent.name} />}</For>
+              </box>
+            </Show>
+            <Show when={fileBadges().length}>
+              <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
+                <For each={fileBadges()}>
+                  {(file) => (
+                    <UserMentionBadge
+                      type={file.mime === "application/x-directory" ? "dir" : "file"}
+                      name={file.name ?? (file.source.type === "uri" ? file.source.uri : "attachment")}
+                    />
+                  )}
+                </For>
+              </box>
+            </Show>
+          </box>
+        </Show>
       </box>
     </Show>
+  )
+}
+
+function UserMentionBadge(props: { type: "agent" | "dir" | "file" | "skill"; name: string }) {
+  const theme = useTheme("elevated")
+  const mode = useThemes().mode
+  const color = () =>
+    props.type === "agent"
+      ? theme.categorical[0][mode() === "light" ? 700 : 200]
+      : props.type === "skill"
+        ? (theme.categorical[1] ?? theme.categorical[0])[mode() === "light" ? 700 : 200]
+        : theme.hue.accent[mode() === "light" ? 700 : 200]
+
+  return (
+    <text fg={theme.text.default}>
+      <span style={{ bg: color(), fg: theme.background.default, bold: true }}>{` ${props.type} `}</span>
+      <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>{` ${props.name} `}</span>
+    </text>
   )
 }
 

--- a/packages/tui/test/prompt/user-message-mention.test.ts
+++ b/packages/tui/test/prompt/user-message-mention.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test"
+import { renderUserMessageMentions } from "../../src/prompt/user-message-mention"
+
+test("renders valid file, agent, and skill mentions in order", () => {
+  const result = renderUserMessageMentions("请检查 @src/app.ts 并使用 @build /effect", [
+    { key: "file:0", type: "file", mention: { start: 7, end: 18, text: "@src/app.ts" } },
+    { key: "agent:0", type: "agent", mention: { start: 26, end: 32, text: "@build" } },
+    { key: "skill:0", type: "skill", mention: { start: 33, end: 40, text: "/effect" } },
+  ])
+
+  expect(result.segments).toEqual([
+    { text: "请检查 " },
+    { text: "@src/app.ts", type: "file" },
+    { text: " 并使用 " },
+    { text: "@build", type: "agent" },
+    { text: " " },
+    { text: "/effect", type: "skill" },
+  ])
+  expect([...result.inline]).toEqual(["file:0", "agent:0", "skill:0"])
+})
+
+test("falls back when ranges are stale, out of bounds, or overlapping", () => {
+  const result = renderUserMessageMentions("看 @one 和 @two", [
+    { key: "stale", type: "file", mention: { start: 3, end: 7, text: "@bad" } },
+    { key: "overlap-a", type: "agent", mention: { start: 3, end: 7, text: "@one" } },
+    { key: "overlap-b", type: "skill", mention: { start: 5, end: 8, text: "ne " } },
+    { key: "out-of-bounds", type: "file", mention: { start: 100, end: 105, text: "@two" } },
+  ])
+
+  expect(result.segments).toEqual([{ text: "看 @one 和 @two" }])
+  expect([...result.inline]).toEqual([])
+})
+
+test("uses terminal display width for Unicode ranges", () => {
+  const text = "中文 @file"
+  const result = renderUserMessageMentions(text, [
+    { key: "file:0", type: "file", mention: { start: 5, end: 10, text: "@file" } },
+  ])
+
+  expect(result.segments).toEqual([{ text: "中文 " }, { text: "@file", type: "file" }])
+})
+
+test("falls back when a range splits a wide character", () => {
+  const result = renderUserMessageMentions("中文", [
+    { key: "file:0", type: "file", mention: { start: 0, end: 1, text: "中" } },
+  ])
+
+  expect(result.segments).toEqual([{ text: "中文" }])
+  expect([...result.inline]).toEqual([])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41197

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The V2 TUI rendered user-message text plainly, then showed files and skills as separate badges; agent mentions were not rendered. This adds a shared renderer that verifies every persisted display-width range against the text before styling file, agent, and skill mentions inline. Invalid, overlapping, or partial-wide-character ranges remain as badges, while image attachments keep their preview.

### How did you verify your code works?

- `bun run test` in `packages/tui`: 631 passed, 5 skipped.
- `bun typecheck` in `packages/tui`.
- Pre-push `bun turbo typecheck --concurrency=3`: 33 packages passed.
- Prettier and `git diff --check`.

### Screenshots / recordings

Not included. This changes terminal text styling; focused tests cover valid mixed mentions, Unicode display widths, stale ranges, and overlap fallback.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR