### PR TITLE
refactor(core): reuse plugin directory names

### DIFF
--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -153,10 +153,12 @@ const scan = Effect.fn("ConfigPluginSource.scan")(function* (
   })
 })
 
+const sourceDirectories = ["plugin", "plugins"] as const
+
 function discoverDirectory(fs: FSUtil.Interface, directory: string) {
   return Effect.gen(function* () {
     const files = yield* fs
-      .scan("{plugin,plugins}/*.{ts,js}", {
+      .scan(`{${sourceDirectories.join(",")}}/*.{ts,js}`, {
         cwd: directory,
         absolute: true,
         include: "file",
@@ -167,8 +169,6 @@ function discoverDirectory(fs: FSUtil.Interface, directory: string) {
     return files.sort().map((target): Operation => ({ type: "add", target, options: {} }))
   })
 }
-
-const sourceDirectories = ["plugin", "plugins"] as const
 
 function isPluginSource(entries: readonly Entry[], file: string) {
   return entries.some(


### PR DESCRIPTION
## What
Uses one definition for the supported `plugin` and `plugins` directory names.

## How
Builds the discovery glob from the same tuple used to recognize plugin source paths.

## Testing
- `bun run test test/config/plugin.test.ts` in `packages/core`
- `bun typecheck` in `packages/core`