### PR TITLE
refactor(core): defer database global lookup

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -42,10 +42,10 @@ const databaseLayer = Layer.effect(
 export function layer(options: Options = { path: ":memory:" }) {
   return Layer.unwrap(
     Effect.gen(function* () {
-      const global = yield* Global.Service
       const provide = (filename: string) => databaseLayer.pipe(Layer.provide(sqliteLayer({ filename })))
       const filename = options.path ?? ":memory:"
       if (filename === ":memory:" || isAbsolute(filename)) return provide(filename)
+      const global = yield* Global.Service
       return provide(join(global.data, filename))
     }),
   )


### PR DESCRIPTION
## What
Avoids acquiring `Global.Service` when a database already has a complete path.

## How
Returns memory and absolute-path layers before reading the global data directory. Relative database paths continue to resolve under global data.

## Testing
- `bun typecheck` in `packages/core`
- repository-wide typecheck from the push hook