### PR TITLE
refactor: simplify attachment identity tracking

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -65,15 +65,15 @@ const userAttachmentContent = (files: readonly FileAttachment[]) => {
   )
   if (eligible.length < 2) return files.flatMap(attachmentContent)
 
-  const seen = new Map<string, string[]>()
+  const seen = new Map<string, Set<string>>()
   return files.flatMap((file) => {
     if (!imageMimes.has(file.mime) || file.source.type !== "inline" || !file.mention?.text)
       return attachmentContent(file)
     const metadata = JSON.stringify([file.mime, file.name ?? null, file.description ?? null, file.mention.text])
-    const matches = seen.get(metadata)
-    if (matches?.includes(file.data)) return []
-    if (matches) matches.push(file.data)
-    if (!matches) seen.set(metadata, [file.data])
+    const payloads = seen.get(metadata) ?? new Set<string>()
+    if (payloads.has(file.data)) return []
+    payloads.add(file.data)
+    seen.set(metadata, payloads)
     return attachmentContent(file)
   })
 }

--- a/packages/tui/src/prompt/attachment.ts
+++ b/packages/tui/src/prompt/attachment.ts
@@ -25,14 +25,14 @@ function deduplicateByIdentity<T>(
   items: readonly T[],
   identity: (item: T) => { metadata: string; payload: string } | undefined,
 ) {
-  const seen = new Map<string, string[]>()
+  const seen = new Map<string, Set<string>>()
   return items.filter((item) => {
     const key = identity(item)
     if (!key) return true
-    const matches = seen.get(key.metadata)
-    if (matches?.includes(key.payload)) return false
-    if (matches) matches.push(key.payload)
-    if (!matches) seen.set(key.metadata, [key.payload])
+    const payloads = seen.get(key.metadata) ?? new Set<string>()
+    if (payloads.has(key.payload)) return false
+    payloads.add(key.payload)
+    seen.set(key.metadata, payloads)
     return true
   })
 }
@@ -42,7 +42,7 @@ export function deduplicatePromptImages(files: readonly PromptFile[] | undefined
   return deduplicateByIdentity(files, (file) =>
     file.uri.startsWith("data:image/") && file.mention?.text
       ? {
-          metadata: JSON.stringify([attachmentMetadata(file), file.mention.text]),
+          metadata: JSON.stringify([file.name ?? null, file.description ?? null, file.mention.text]),
           payload: file.uri,
         }
       : undefined,


### PR DESCRIPTION
## What
Simplifies duplicate attachment identity tracking without changing deduplication behavior.

## How
- stores seen payloads in `Set<string>` values instead of arrays
- constructs prompt image metadata in one JSON encoding step
- keeps the TUI and model-message implementations local to their packages

## Testing
- `bun run test test/prompt/attachment.test.ts` in `packages/tui`
- `bun typecheck` in `packages/tui`
- `bun run test test/session-runner-message.test.ts` in `packages/core`
- `bun typecheck` in `packages/core`