### PR TITLE
refactor(tui): simplify marquee reset

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -62,13 +62,9 @@ function createMarquee(hovered: () => string | undefined, animations: () => bool
   const leading = createAnimatable({ opacity: 0 }, { enabled: animations, transition: tween({ duration: 0.25 }) })
 
   createEffect(() => {
-    if (!hovered()) {
-      setOffset(0)
-      leading.jump({ opacity: 0 })
-      return
-    }
     setOffset(0)
     leading.jump({ opacity: 0 })
+    if (!hovered()) return
     let interval: ReturnType<typeof setInterval> | undefined
     const delay = setTimeout(() => {
       setOffset(1)


### PR DESCRIPTION
## What
Removes duplicated marquee reset statements while preserving hover behavior.

## How
Resets the offset and leading fade once before returning for an unhovered tab.

## Testing
- `bun typecheck` in `packages/tui`