### PR TITLE
docs: refine agent contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,161 +1,55 @@
-- To regenerate the legacy JavaScript SDK, run `./packages/sdk/js/script/build.ts`.
-- After changing the public Protocol or Server `HttpApi`, run `bun run generate` from `packages/client`. Do not edit `src/generated` or `src/generated-effect` directly.
-- Keep runtime dependencies directed from Schema to Core and Protocol, then from Core and Protocol to Server. Client runtime code may depend on Schema and Protocol but never Core or Server; `sdk-next` composes Client, Core, and Server.
-- The default branch in this repo is `dev`.
-- Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
+# Repository Guidance
 
-## Branch Names
+## Scope
 
-Use a short branch name of at most three words, separated by hyphens. Do not use slashes or type prefixes such as `feat/` or `fix/`.
+- The default branch is `dev`; use `dev` or `origin/dev` for diffs because a local `main` may not exist.
+- Follow the nearest `AGENTS.md` for the files you change. More specific nested guidance takes precedence over this file.
+- Read [CONTRIBUTING.md](./CONTRIBUTING.md) before implementing or opening a PR.
 
-Examples: `session-recovery`, `fix-scroll-state`, `regenerate-sdk`.
+## Setup
 
-## Commits and PR Titles
+- Use the Bun version pinned by the root `package.json` `packageManager` field (currently `bun@1.3.14`).
+- Run `bun install` from the repository root.
 
-Use conventional commit-style messages and PR titles: `type(scope): summary`.
+## Contribution Gates
 
-Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`. Scopes are optional; use the affected package or area when helpful, e.g. `core`, `opencode`, `tui`, `app`, `desktop`, `sdk`, or `plugin`.
+- Get core-team design approval before implementing UI or core product features.
+- Every PR must link an existing GitHub issue. Keep PRs focused and explain verification for logic changes.
+- Include before-and-after screenshots or video for UI changes.
+- Use short branch names of at most three hyphen-separated words, without slash or type prefixes.
+- Use conventional commit and PR titles: `type(scope): summary`. Valid types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`.
 
-Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributing guide`, `chore(sdk): regenerate types`.
+## Validation
 
-## Style Guide
+- Run tests from the owning package, never the repository root; the root `test` script intentionally fails. Use that package's `test` script (`bun run test`) when it exists, or `bun test <relative-test-path>` for a focused test.
+- Run package typechecks with `bun run typecheck` from the owning package. Run repository-wide checks from the root with `bun run lint` and `bun run typecheck`; do not invoke `tsc` directly.
 
-### General Principles
+## Generated Code
 
-- Keep things in one function unless composable or reusable
-- Do not extract single-use helpers preemptively. Inline the logic at the call site unless the helper is reused, hides a genuinely complex boundary, or has a clear independent name that improves the caller.
-- Avoid `try`/`catch` where possible
-- Avoid using the `any` type
-- Use Bun APIs when possible, like `Bun.file()`
-- Rely on type inference when possible; avoid explicit type annotations or interfaces unless necessary for exports or clarity
-- Prefer functional array methods (flatMap, filter, map) over for loops; use type guards on filter to maintain type inference downstream
-- In `src/config`, follow the existing self-export pattern at the top of the file (for example `export * as ConfigAgent from "./agent"`) when adding a new config module.
-- In Effect generators, bind services to named variables before calling methods. Do not use nested service yields such as `yield* (yield* Foo.Service).bar()`.
+- After changing the public Protocol or Server `HttpApi`, run `bun run generate` from `packages/client`. The script owns `packages/client/src/generated` and `packages/client/src/generated-effect`; never edit those directories directly.
+- Run `./script/generate.ts` from the root for the repository-wide legacy JavaScript SDK and OpenAPI generation pipeline. Run `./packages/sdk/js/script/build.ts` only when regenerating that SDK alone.
+- Commit generated output when its source contract changes, and verify the resulting diff.
 
-Reduce total variable count by inlining when a value is only used once.
+## Architecture
 
-```ts
-// Good
-const journal = await Bun.file(path.join(dir, "journal.json")).json()
+- Keep runtime dependencies directed from Schema to Core and Protocol, then from Core and Protocol to Server. Client runtime code may depend on Schema and Protocol, never Core or Server; `sdk-next` composes Client, Core, and Server.
 
-// Bad
-const journalPath = path.join(dir, "journal.json")
-const journal = await Bun.file(journalPath).json()
-```
+## Style
 
-### Destructuring
-
-Avoid unnecessary destructuring. Use dot notation to preserve context.
-
-```ts
-// Good
-obj.a
-obj.b
-
-// Bad
-const { a, b } = obj
-```
-
-### Imports
-
-- Never alias imports. Do not use `import { foo as bar } from "..."` or renamed imports like `resolve as pathResolve`.
-- Never use star imports. Do not use `import * as Foo from "..."` or `import type * as Foo from "..."`.
-- If a namespace-style value is needed, import the module's own exported namespace by name, for example `import { Project } from "@opencode-ai/core/project"`, then reference `Project.ID`.
-- Prefer dynamic imports for heavy modules that are only needed in selected code paths, especially in startup-sensitive entrypoints. Destructure dynamic import bindings near the top of the narrowest scope that needs them so they read like normal imports. Avoid inline chains such as `await import("./module").then((mod) => mod.value())` or `(await import("./module")).value()`. Keep branch-specific imports inside the branch that needs them to preserve lazy loading.
-
-### Variables
-
-Prefer `const` over `let`. Use ternaries or early returns instead of reassignment.
-
-```ts
-// Good
-const foo = condition ? 1 : 2
-
-// Bad
-let foo
-if (condition) foo = 1
-else foo = 2
-```
-
-### Control Flow
-
-Avoid `else` statements. Prefer early returns.
-
-```ts
-// Good
-function foo() {
-  if (condition) return 1
-  return 2
-}
-
-// Bad
-function foo() {
-  if (condition) return 1
-  else return 2
-}
-```
-
-### Complex Logic
-
-When a function has several validation branches or supporting details, make the main function read as the happy path and move supporting details into small helpers below it.
-
-```ts
-// Good
-export function loadThing(input: unknown) {
-  const config = requireConfig(input)
-  const metadata = readMetadata(input)
-  return createThing({ config, metadata })
-}
-
-function requireConfig(input: unknown) {
-  ...
-}
-```
-
-- Keep helpers close to the code they support, below the main export when that improves readability.
-- Do not over-abstract simple expressions into many single-use helpers; extract only when it names a real concept like `requireConfig` or `readMetadata`.
-- Do not return `Effect` from helpers unless they actually perform effectful work. Synchronous parsing, validation, and option building should stay synchronous.
-- Prefer Effect schema helpers such as `Schema.UnknownFromJsonString` and `Schema.decodeUnknownOption` over manual `JSON.parse` wrapped in `Effect.try` when parsing untrusted JSON strings.
-- Add comments for non-obvious constraints and surprising behavior, not for obvious assignments or control flow.
-
-### Schema Definitions (Drizzle)
-
-Use snake_case for field names so column names don't need to be redefined as strings.
-
-```ts
-// Good
-const table = sqliteTable("session", {
-  id: text().primaryKey(),
-  project_id: text().notNull(),
-  created_at: integer().notNull(),
-})
-
-// Bad
-const table = sqliteTable("session", {
-  id: text("id").primaryKey(),
-  projectID: text("project_id").notNull(),
-  createdAt: integer("created_at").notNull(),
-})
-```
-
-## Testing
-
-- Avoid mocks as much as possible, you shouldn't be using globalThis.\* at all unless it's the only option.
-- Test actual implementation, do not duplicate logic into tests
-- Tests cannot run from repo root (guard: `do-not-run-tests-from-root`); run from package dirs like `packages/opencode`.
-
-## Type Checking
-
-- Always run `bun typecheck` from package directories (e.g., `packages/opencode`), never `tsc` directly.
+- Keep code in one function unless extraction creates reuse, composition, or a clear complex boundary.
+- Prefer `const`, early returns, dot access, functional array methods, Bun APIs, and inferred types. Avoid `any`, unnecessary destructuring, `else`, and `try`/`catch` where practical.
+- Never alias or star-import modules. Import an exported namespace by name when namespace-style access is needed.
+- Keep heavy dynamic imports inside the narrow branch that needs them.
+- In Effect generators, bind services to named variables before calling methods; do not nest service yields.
+- Keep synchronous parsing and validation synchronous. Prefer Effect schema decoders over manual `JSON.parse` wrapped in `Effect.try`.
+- Use snake_case Drizzle fields so column names do not need string overrides.
+- Test actual behavior with minimal mocking; do not duplicate implementation logic in tests.
 
 ## V2 Session Core
 
-- Keep durable prompt admission separate from model execution. `SessionV2.prompt(...)` admits one durable `session_input` row before scheduling advisory `SessionExecution.wake(sessionID)` unless `resume: false` requests admit-only behavior. The serialized runner promotes admitted inputs into visible user messages at safe boundaries.
-- Reusing a Session ID adopts the existing Session. Reusing a prompt message ID reconciles an exact retry only when Session, prompt, and delivery mode match; conflicting reuse fails. Historical projected prompts lazily synthesize promoted inbox records during exact retry.
-- Keep `SessionExecution` process-global and Session-ID based. Its local implementation owns the process-local Session coordinator and discovers placement through `SessionStore` plus `LocationServiceMap.get(session.location)` only when a drain starts; no layer should take a Session ID. V2 interruption targets the active process-local ownership chain for that Session; idle or missing interruption is a no-op.
-- Keep `SessionRunner`, model resolution, tool registry, permissions, and filesystem Location-scoped. Omitted `Location.workspaceID` means implicit-local placement; explicit workspace identity remains reserved for future placement semantics.
-- Preserve one explicit `llm.stream(request)` call per provider turn and reload projected history before durable continuation. Do not bridge through legacy `SessionPrompt.loop(...)` or delegate orchestration to an in-memory tool loop.
-- Keep local Session drains process-local until clustering is implemented. `SessionRunCoordinator` joins explicit same-Session resumes, coalesces prompt wakeups, and allows different Sessions to run concurrently. Advisory wakes drain eligible durable inbox rows only; post-crash continuation recovery requires a separate explicit design before it may retry provider work. A drain has no durable identity or transcript boundary.
-- Keep delivery vocabulary explicit. Prompts steer by default and promote at the next safe provider-turn boundary while the current drain requires continuation. An explicit `queue` input remains pending until the Session would otherwise become idle; promote one queued input at that boundary, then reevaluate continuation before promoting another. Promoting any new user input resets the selected agent's provider-turn allowance; a batch of steers resets it once.
-- Keep EventV2 replay owner claims separate from clustered Session execution ownership.
-- Keep the System Context algebra, registry, and built-ins in `src/system-context`; keep Context Source producers with their observed domains, and keep Session History selection plus Context Epoch persistence Session-owned.
+Read [specs/v2/session.md](./specs/v2/session.md) before changing V2 Session behavior. Preserve these safety invariants:
+
+- Durable prompt admission stays separate from model execution. Do not route V2 orchestration through legacy `SessionPrompt.loop(...)` or an in-memory tool loop.
+- `SessionExecution` remains process-global and Session-ID based; runners, models, tools, permissions, and filesystems remain Location-scoped. No layer takes a Session ID.
+- Issue exactly one explicit `llm.stream(request)` per provider turn and reload projected history before durable continuation.
+- Wakes are advisory and must not retry ambiguous provider work after a crash. Event replay ownership remains separate from clustered Session execution ownership.


### PR DESCRIPTION
### Issue for this PR

Closes #41761

Internal tracking: [OTP-4183](https://glints.atlassian.net/browse/OTP-4183)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Makes root agent guidance concise and actionable. It points detailed V2 Session behavior to the existing spec and clarifies setup, validation, contribution gates, nested guidance precedence, and generation ownership.

### How did you verify your code works?

Ran Prettier 3.6.2 against `AGENTS.md`, `git diff --check`, and checked every referenced file, executable, package script, and pinned Bun version.

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR