### PR TITLE
fix(util): defer module-scope randomness and import.meta path derivation

### DIFF
--- a/packages/util/src/npm-config.ts
+++ b/packages/util/src/npm-config.ts
@@ -7,13 +7,13 @@ import Config from "@npmcli/config"
 import { definitions, flatten, nerfDarts, shorthands } from "@npmcli/config/lib/definitions/index.js"
 import { Effect } from "effect"
 
-const npmPath = fileURLToPath(new URL("..", import.meta.url))
-
 export const load = (dir: string) =>
   Effect.tryPromise({
     try: async () => {
       const config = new Config({
-        npmPath,
+        // Resolved per call: on workerd import.meta.url is undefined and building
+        // this URL at module scope fails startup validation; npm config never runs there.
+        npmPath: fileURLToPath(new URL("..", import.meta.url)),
         cwd: dir,
         env: { ...process.env },
         argv: [process.execPath, process.execPath, "--prefix", dir],

--- a/packages/util/src/observability.ts
+++ b/packages/util/src/observability.ts
@@ -1,6 +1,6 @@
 export * as Observability from "./observability.js"
 
-import { NodeFileSystem } from "@effect/platform-node"
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
 import { LayerNode } from "./effect/layer-node.js"
 import { Effect, Layer, Logger, References, Schema } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
@@ -50,4 +50,10 @@ export function layer(
   ).pipe(Layer.catchCause(() => local))
 }
 
-export const node = LayerNode.make({ name: "observability", layer: layer(), deps: [] })
+// Layer.suspend: constructing the loggers eagerly at module scope performs
+// I/O (file logger, run id) that workerd forbids in global scope.
+export const node = LayerNode.make({
+  name: "observability",
+  layer: Layer.suspend(() => layer()),
+  deps: [],
+})

--- a/packages/util/src/observability/logging.ts
+++ b/packages/util/src/observability/logging.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { Global } from "../global.js"
 import { runID } from "./shared.js"
 
-function formatter(id: string = runID) {
+function formatter(id: string = runID()) {
   return Logger.map(Logger.formatStructured, (output) => {
     const messages = Array.isArray(output.message) ? output.message : [output.message]
     return [
@@ -51,7 +51,7 @@ export function file(local = true, channel = "local") {
   return path.join(Global.Path.log, `opencode-${channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.log`)
 }
 
-export function fileLogger(target = file(), id: string = runID) {
+export function fileLogger(target = file(), id: string = runID()) {
   // Do not set batchWindow to 0; it causes high idle CPU usage.
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem

--- a/packages/util/src/observability/otlp.ts
+++ b/packages/util/src/observability/otlp.ts
@@ -54,8 +54,8 @@ export function resource(app: App = { client: "opencode", version: "unknown", ch
       ...resourceAttributes(),
       "deployment.environment.name": app.channel,
       "opencode.client": app.client,
-      "opencode.run": runID,
-      "service.instance.id": runID,
+      "opencode.run": runID(),
+      "service.instance.id": runID(),
     },
   }
 }

--- a/packages/util/src/observability/shared.ts
+++ b/packages/util/src/observability/shared.ts
@@ -1,1 +1,8 @@
-export const runID = crypto.randomUUID().slice(0, 8)
+// Lazy: workerd forbids generating random values in global scope, so the id
+// materializes on first call (inside a handler) and stays stable afterwards.
+let generated: string | undefined
+
+export function runID(): string {
+  generated ??= crypto.randomUUID().slice(0, 8)
+  return generated
+}


### PR DESCRIPTION
## What

Follow-up to the import-purity train (#41619, "route Global path consumers through the service" family). Cloudflare workerd validates bundles by evaluating the module graph in global scope, where async I/O, timers, and random-value generation are forbidden, and where `import.meta.url` is undefined. Deploying an embedded opencode server surfaced two remaining module-scope violations plus one eagerly-constructed layer. This PR defers all three to first use.

Behavior-preserving on node/bun: `runID` is still stable for the lifetime of the process — it just materializes on first call instead of at import time.

## Before / After

**Before**: importing `@opencode-ai/core` (transitively `@opencode-ai/util`) under workerd fails startup validation:
- `observability/shared.ts` calls `crypto.randomUUID()` at module scope → "random values forbidden in global scope".
- `npm-config.ts` constructs `new URL("..", import.meta.url)` at module scope → throws, since `import.meta.url` is undefined on workerd.
- `observability.ts` constructs the logging layer eagerly via `layer()` at module scope (file-logger I/O, run id), and its barrel import of `@effect/platform-node` eagerly pulls in the undici HttpClient.

**After**: the module graph evaluates cleanly in global scope. Randomness, path derivation, and layer construction all happen on first use inside a handler.

## How

- `packages/util/src/observability/shared.ts` — `runID` becomes a lazily-memoized function (`generated ??= crypto.randomUUID().slice(0, 8)`).
- `packages/util/src/observability/logging.ts`, `packages/util/src/observability/otlp.ts` — call sites updated `runID` → `runID()`. These are the only consumers repo-wide.
- `packages/util/src/observability.ts` — `node` layer wrapped in `Layer.suspend(() => layer())`; `NodeFileSystem` import narrowed to the `@effect/platform-node/NodeFileSystem` subpath so the barrel's eager undici HttpClient import stays out of the graph.
- `packages/util/src/npm-config.ts` — `npmPath` becomes a thunk evaluated inside `load` (npm config is never used on workerd).

## Scope

Planned follow-up (not in this PR): a CI guard that evaluates the core module graph under workerd conditions, so future module-scope purity violations fail at PR time instead of at deploy.

## Testing

- `bun turbo typecheck --filter=@opencode-ai/util --filter=@opencode-ai/core` — clean (full 33-package typecheck also ran green on push).
- `packages/util`: `bun run test` — 7 pass.
- `packages/core`: `bun run test test/effect/observability.test.ts` — 6 pass.
- Validated live in production on a workerd embedding of the opencode server: the bundle passes workerd's global-scope validator and `runID` remains stable per isolate.
