### PR TITLE
fix(tui): stop retrying unavailable audio

### DIFF
--- a/packages/tui/src/audio.ts
+++ b/packages/tui/src/audio.ts
@@ -38,7 +38,12 @@ export function loadSoundFile(file: string) {
 export function play(sound: AudioSound, options?: AudioPlayOptions) {
   const current = getAudio()
   if (!current) return null
-  if (!current.isStarted() && !current.start()) return null
+  if (!current.isStarted() && !current.start()) {
+    current.dispose()
+    audio = null
+    sounds.clear()
+    return null
+  }
   return current.play(sound, options)
 }
 

--- a/packages/tui/test/audio.test.ts
+++ b/packages/tui/test/audio.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, expect, mock, test } from "bun:test"
+
+afterEach(() => {
+  mock.restore()
+})
+
+test("does not retry audio startup after the playback device is unavailable", async () => {
+  let starts = 0
+  let disposes = 0
+  let plays = 0
+  const engine = {
+    on() {},
+    isStarted() {
+      return false
+    },
+    start() {
+      starts++
+      return false
+    },
+    play() {
+      plays++
+      return 1
+    },
+    dispose() {
+      disposes++
+    },
+  }
+
+  mock.module("@opentui/core", () => ({
+    Audio: {
+      create() {
+        return engine
+      },
+    },
+  }))
+
+  const audio = await import("../src/audio")
+  audio.play(1)
+  audio.play(1)
+
+  expect(starts).toBe(1)
+  expect(disposes).toBe(1)
+  expect(plays).toBe(0)
+
+  audio.dispose()
+  audio.play(1)
+  audio.play(1)
+
+  expect(starts).toBe(2)
+  expect(disposes).toBe(2)
+  expect(plays).toBe(0)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41763

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops retrying TUI audio startup after the playback device is unavailable. The failed native engine is disposed, cached sounds are cleared, and audio remains disabled until the next TUI lifecycle.

This prevents each later attention sound from re-running native ALSA device discovery and writing another diagnostics block over the terminal.

The remaining first native diagnostics block is tracked upstream in anomalyco/opentui#1358.

### How did you verify your code works?

- `bun test test/audio.test.ts` in `packages/tui`
- `bun test` in `packages/tui` — 194 passed, 1 skipped
- The regression test verifies one startup attempt per TUI lifecycle and confirms `dispose()` allows a fresh lifecycle to try again.
- Linux ARM64 container with `libasound2` and no `/dev/snd`: three playback attempts produced 105 ALSA stderr lines and three startup errors before the fix, versus 35 lines and one startup error after it.

Local `bun typecheck` is currently blocked by existing Buffer/Node type incompatibilities in unchanged files and dependencies, including `@ff-labs/fff-bun`, `packages/core`, and the existing `packages/tui/src/audio.ts` event typing. GitHub CI will run the required typecheck in the repository environment.

### Screenshots / recordings

Not included. The Linux reproduction confirms that the change prevents repeated native ALSA stderr blocks. The first native startup attempt can still emit one diagnostics block.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


