### PR TITLE
refactor(core): compact question tool schema

### DIFF
--- a/packages/core/src/tool/plugin/question.ts
+++ b/packages/core/src/tool/plugin/question.ts
@@ -21,7 +21,9 @@ Usage notes:
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label`
 
 export const Input = Schema.Struct({
-  questions: Schema.NonEmptyArray(Question.Prompt).annotate({ description: "Questions to ask" }),
+  questions: Schema.Array(Question.Prompt)
+    .check(Schema.isNonEmpty())
+    .annotate({ description: "Questions to ask" }),
 })
 
 export const Output = Schema.Struct({

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -91,6 +91,7 @@ const it = testEffect(
 describe("QuestionTool", () => {
   it.effect("emits one item schema for the nonempty questions array", () =>
     Effect.gen(function* () {
+      captured = undefined
       const registry = yield* Tool.Service
       const definition = (yield* toolDefinitions(registry)).find((tool) => tool.name === QuestionTool.name)
 
@@ -98,6 +99,17 @@ describe("QuestionTool", () => {
       expect(definition?.inputSchema).toHaveProperty("properties.questions.minItems", 1)
       expect(definition?.inputSchema).toHaveProperty("properties.questions.items")
       expect(definition?.inputSchema).not.toHaveProperty("properties.questions.prefixItems")
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-question-empty", name: QuestionTool.name, input: { questions: [] } },
+        }),
+      ).toMatchObject({
+        status: "error",
+        error: { type: "tool.execution", message: expect.stringContaining("Invalid tool input") },
+      })
+      expect(capturedInput()).toBeUndefined()
     }),
   )
 

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -89,6 +89,18 @@ const it = testEffect(
 )
 
 describe("QuestionTool", () => {
+  it.effect("emits one item schema for the nonempty questions array", () =>
+    Effect.gen(function* () {
+      const registry = yield* Tool.Service
+      const definition = (yield* toolDefinitions(registry)).find((tool) => tool.name === QuestionTool.name)
+
+      expect(definition?.inputSchema).toHaveProperty("properties.questions.type", "array")
+      expect(definition?.inputSchema).toHaveProperty("properties.questions.minItems", 1)
+      expect(definition?.inputSchema).toHaveProperty("properties.questions.items")
+      expect(definition?.inputSchema).not.toHaveProperty("properties.questions.prefixItems")
+    }),
+  )
+
   it.effect("omits a catalog-denied question and enforces its leaf permission", () =>
     Effect.gen(function* () {
       captured = undefined


### PR DESCRIPTION
## What

Serialize the `question` tool's nonempty `questions` array without duplicating the complete question item schema.

## Before / After

**Before**

`Schema.NonEmptyArray(Question.Prompt)` produced both `prefixItems` and `items`, each containing the same `Question.Prompt` object:

```json
{
  "questions": {
    "type": "array",
    "prefixItems": [{ "...": "Question.Prompt" }],
    "minItems": 1,
    "items": { "...": "Question.Prompt" }
  }
}
```

Serialized input schema: **1,355 characters**.

**After**

```json
{
  "questions": {
    "minItems": 1,
    "description": "Questions to ask",
    "type": "array",
    "items": { "...": "Question.Prompt" }
  }
}
```

Serialized input schema: **754 characters**, removing 601 characters while retaining `minItems: 1` validation.

## How

`packages/core/src/tool/plugin/question.ts` now models the field as `Schema.Array(Question.Prompt).check(Schema.isNonEmpty())`. The tool remains named `question`, and its execution through `Form.Service` is unchanged.

A regression assertion verifies the model-facing JSON schema contains one `items` schema and no `prefixItems`.

## Scope

No tool names, form behavior, question fields, answer handling, or permission behavior change.

## Testing

- `bun run test` from `packages/core`: 1,641 passed, 16 skipped
- `bun typecheck` from `packages/core`
- Repository pre-push typecheck: 33 tasks passed
