### PR TITLE
refactor(core): trim model tool guidance

### DIFF
--- a/packages/core/src/codemode/instructions.ts
+++ b/packages/core/src/codemode/instructions.ts
@@ -20,7 +20,7 @@ Use \`search\` to discover exact paths and signatures for additional tools:
 
 export function render(catalog: CodeModeCatalog.Summary) {
   if (catalog.total === 0)
-    return "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool."
+    return "`execute` can call only tools listed in the Code Mode catalog. None are currently available; wait for a catalog update before calling it."
 
   const tools = catalog.namespaces.flatMap((namespace) => {
     const count = namespace.count === 1 ? "1 tool" : `${namespace.count} tools`

--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -33,12 +33,11 @@ type CollectedFiles = {
 
 // Invariant model-facing guidance; the changing tool catalog is delivered through Instructions.
 const description = [
-  "Run JavaScript in a confined Code Mode runtime to orchestrate tool calls and compose their results.",
-  "Imports, direct filesystem access, and timers are unavailable. Do not use `fetch`; all external access goes through `tools`.",
-  "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by `search`. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
-  'Call tools through `tools` using only exact paths and signatures from the catalog. Do not infer or normalize tool names; preserve bracket notation such as `tools.<namespace>["tool-name"](input)`.',
-  "Prefer an explicit `return`; if omitted, the final top-level expression becomes the result.",
-  "Await every call whose completion matters; pending calls are interrupted when execution ends. Run independent calls concurrently with `Promise.all`.",
+  "Run JavaScript in a confined Code Mode runtime to call catalog tools and compose their results.",
+  "Use only exact `tools` paths and signatures listed in Code Mode instructions or returned by `search`; other tools are unavailable.",
+  "Imports, direct filesystem access, timers, and `fetch` are unavailable.",
+  "Await every call whose completion matters, using `Promise.all` for independent calls.",
+  "Return a value explicitly; otherwise the final top-level expression is returned.",
 ].join("\n")
 
 export const create = (

--- a/packages/core/src/tool/plugin/edit.ts
+++ b/packages/core/src/tool/plugin/edit.ts
@@ -123,7 +123,7 @@ export const Plugin = {
           name,
           options: { codemode: false, permission: "edit" },
           description:
-            "Edit the contents of a file by finding and replacing exact text. When editing text from Read output, preserve the exact indentation (tabs or spaces) and omit the line-number prefix, such as `1: `. Never include the prefix in oldString or newString. The edit fails if oldString is not found. By default, oldString must identify a UNIQUE location. Multiple matches FAIL unless replaceAll is true. Add more surrounding context to disambiguate, or set replaceAll to true to replace every occurrence. Use replaceAll when the change should apply to every occurrence, such as renaming a variable.",
+            "Edit a file by replacing exact text. When using Read output, preserve indentation and omit line-number prefixes such as `1: `. oldString must be unique unless replaceAll is true; add surrounding context to disambiguate it.",
           input: Input,
           output: Output,
           execute: (input, context) => {

--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -38,8 +38,6 @@ const description = (shell?: string) =>
     "Prefer dedicated tools over shell commands when possible.",
     "When output is large, the full result is saved to a file and a truncated preview is returned.",
     "Rely on automatic truncation unless filtering the output is more useful.",
-    "Commands accept an optional timeout, background commands have no timeout by default.",
-    "Background commands return immediately, and you will be notified when they complete.",
   ].join(" ")
 
 export const Input = Schema.Struct({

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -37,9 +37,6 @@ export const Output = Schema.Struct({
 export const description = [
   "Spawns an agent in a child session to work on the specified task.",
   "Include all relevant context and instructions in the prompt because the child starts with fresh context.",
-  "Foreground (default) runs the subagent to completion and returns its final response.",
-  "Background mode (background=true) launches it asynchronously and returns immediately; you are notified when it finishes.",
-  "Use background only for independent work that can run while you continue elsewhere.",
 ].join("\n")
 
 export const Plugin = {

--- a/packages/core/test/codemode/catalog.test.ts
+++ b/packages/core/test/codemode/catalog.test.ts
@@ -140,7 +140,7 @@ describe("CodeModeInstructions.render", () => {
 
   test("renders only the no-tools notice for an empty catalog", () => {
     expect(render([])).toBe(
-      "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
+      "`execute` can call only tools listed in the Code Mode catalog. None are currently available; wait for a catalog update before calling it.",
     )
   })
 })

--- a/packages/core/test/codemode/instructions.test.ts
+++ b/packages/core/test/codemode/instructions.test.ts
@@ -26,7 +26,7 @@ describe("CodeModeInstructions", () => {
     Effect.gen(function* () {
       const initialized = yield* readInitial(CodeModeInstructions.make([]))
       expect(initialized.text).toBe(
-        "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
+        "`execute` can call only tools listed in the Code Mode catalog. None are currently available; wait for a catalog update before calling it.",
       )
 
       const added = yield* readUpdate(CodeModeInstructions.make([echo]), initialized)
@@ -36,7 +36,7 @@ describe("CodeModeInstructions", () => {
       expect(yield* readUpdate(CodeModeInstructions.make([]), { values: added.values })).toMatchObject({
         text:
           "The Code Mode tool catalog has changed. This catalog supersedes the previous Code Mode tool catalog.\n\n" +
-          "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
+          "`execute` can call only tools listed in the Code Mode catalog. None are currently available; wait for a catalog update before calling it.",
       })
     }),
   )

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -138,7 +138,11 @@ describe("EditTool", () => {
           Effect.andThen(
             withTool(tmp.path, (registry) =>
               Effect.gen(function* () {
-                expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["edit", "execute"])
+                const definitions = yield* toolDefinitions(registry)
+                expect(definitions.map((tool) => tool.name)).toEqual(["edit", "execute"])
+                expect(definitions.find((tool) => tool.name === "edit")?.description).toBe(
+                  "Edit a file by replacing exact text. When using Read output, preserve indentation and omit line-number prefixes such as `1: `. oldString must be unique unless replaceAll is true; add surrounding context to disambiguate it.",
+                )
                 expect(
                   (yield* toolDefinitions(registry, [{ action: "edit", resource: "*", effect: "deny" }])).map(
                     (tool) => tool.name,

--- a/packages/core/test/tool-execute.test.ts
+++ b/packages/core/test/tool-execute.test.ts
@@ -22,12 +22,11 @@ const createCodeMode = (tools: ReadonlyMap<string, Info>) =>
 test("execute describes invariant Code Mode behavior", () => {
   expect(createCodeMode(new Map()).description).toBe(
     [
-      "Run JavaScript in a confined Code Mode runtime to orchestrate tool calls and compose their results.",
-      "Imports, direct filesystem access, and timers are unavailable. Do not use `fetch`; all external access goes through `tools`.",
-      "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by `search`. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
-      'Call tools through `tools` using only exact paths and signatures from the catalog. Do not infer or normalize tool names; preserve bracket notation such as `tools.<namespace>["tool-name"](input)`.',
-      "Prefer an explicit `return`; if omitted, the final top-level expression becomes the result.",
-      "Await every call whose completion matters; pending calls are interrupted when execution ends. Run independent calls concurrently with `Promise.all`.",
+      "Run JavaScript in a confined Code Mode runtime to call catalog tools and compose their results.",
+      "Use only exact `tools` paths and signatures listed in Code Mode instructions or returned by `search`; other tools are unavailable.",
+      "Imports, direct filesystem access, timers, and `fetch` are unavailable.",
+      "Await every call whose completion matters, using `Promise.all` for independent calls.",
+      "Return a value explicitly; otherwise the final top-level expression is returned.",
     ].join("\n"),
   )
 })

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -212,6 +212,8 @@ describe("ShellTool", () => {
             const definitions = yield* toolDefinitions(registry)
             const definition = definitions.find((tool) => tool.name === "shell")
             expect(definition?.description).toStartWith("Execute a shell command and return its output.")
+            expect(definition?.description).not.toContain("background")
+            expect(definition?.inputSchema).toHaveProperty("properties.background.description")
             expect(definition?.inputSchema).not.toHaveProperty("properties.timeout.maximum")
             // Code Mode receives the declared output schema, including the command output text.
             expect(definition?.outputSchema).toHaveProperty("properties.output")

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -151,7 +151,9 @@ describe("SubagentTool", () => {
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
           yield* waitForTool(registry, SubagentTool.name)
-          expect((yield* registry.snapshot()).definitions.map((tool) => tool.name)).toContain(SubagentTool.name)
+          const definition = (yield* registry.snapshot()).definitions.find((tool) => tool.name === SubagentTool.name)
+          expect(definition?.description).not.toContain("Background mode")
+          expect(definition?.inputSchema).toHaveProperty("properties.background.description")
           expect(
             yield* executeTool(registry, {
               sessionID: parent.id,


### PR DESCRIPTION
## What

Remove repeated model-facing guidance from `edit`, `shell`, `subagent`, and `execute` while keeping each behavioral rule in one authoritative place.

## Before / After

| Surface | Before | After | Removed |
|---|---:|---:|---:|
| `edit` description | 589 chars | 222 chars | 367 |
| `shell` description | 532 chars | 362 chars | 170 |
| `subagent` description | 1,139 chars | 849 chars | 290 |
| `execute` description | 913 chars | 465 chars | 448 |
| Empty Code Mode guidance | 166 chars | 137 chars | 29 |
| **Total** | **3,339 chars** | **2,035 chars** | **1,304** |

**Before**

The `shell` and `subagent` descriptions repeated timeout/background behavior already attached to their input fields. `edit` restated exact-match and uniqueness behavior several ways. `execute` repeated catalog restrictions in multiple sentences.

The empty Code Mode instruction said:

```text
No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.
```

**After**

Field-specific timeout and background behavior lives on the corresponding schema fields. The compact `execute` description sent to the model is:

```text
Run JavaScript in a confined Code Mode runtime to call catalog tools and compose their results.
Use only exact `tools` paths and signatures listed in Code Mode instructions or returned by `search`; other tools are unavailable.
Imports, direct filesystem access, timers, and `fetch` are unavailable.
Await every call whose completion matters, using `Promise.all` for independent calls.
Return a value explicitly; otherwise the final top-level expression is returned.
```

The empty catalog instruction is:

```text
`execute` can call only tools listed in the Code Mode catalog. None are currently available; wait for a catalog update before calling it.
```

## How

The change edits only model-facing descriptions and their exact-text assertions. `execute` remains present when the catalog is empty, preserving the stable tool prefix when Code Mode tools are added later.

## Scope

No tool names, input schemas, execution behavior, permission behavior, background semantics, or Code Mode availability change.

## Testing

- `bun run test` from `packages/core`: 1,640 passed, 16 skipped
- Focused tool and Code Mode suites after rebase: 64 passed
- `bun typecheck` from `packages/core`
- Repository pre-push typecheck: 33 tasks passed
