### PR TITLE
feat(tui): add content-aware session widths

### DIFF
--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -1,5 +1,6 @@
 import {
   TextRenderable,
+  BoxRenderable,
   RenderableEvents,
   createMarkdownCodeBlockRenderer,
   parseColor,
@@ -33,6 +34,7 @@ interface PreparedDiagram {
   readonly source: string
   readonly text: StyledText
   readonly height: number
+  readonly width: number
 }
 
 export interface MermaidMarkdownRendererOptions {
@@ -55,16 +57,23 @@ function color(value: ColorInput | undefined): RGBA | undefined {
   return value === undefined ? undefined : parseColor(value)
 }
 
-class StaticDiagramRenderable extends TextRenderable {
+class StaticDiagramRenderable extends BoxRenderable {
   constructor(ctx: RenderContext, prepared: PreparedDiagram) {
     super(ctx, {
-      content: prepared.text,
       width: "100%",
+      alignItems: "center",
+      flexShrink: 0,
+      marginTop: 1,
+    })
+    const diagram = new TextRenderable(ctx, {
+      content: prepared.text,
+      width: prepared.width,
+      maxWidth: "100%",
       height: prepared.height,
       wrapMode: "none",
       selectable: false,
-      marginTop: 1,
     })
+    this.add(diagram)
     let dragX: number | undefined
     this.onMouseDown = (event: MouseEvent) => {
       if (event.button !== 0) return
@@ -79,7 +88,7 @@ class StaticDiagramRenderable extends TextRenderable {
       if (dragX === undefined) return
       const dx = event.x - dragX
       dragX = event.x
-      if (dx) this.scrollX -= dx
+      if (dx) diagram.scrollX -= dx
     }
     this.onMouseDragEnd = (event: MouseEvent) => {
       dragX = undefined
@@ -121,6 +130,7 @@ function prepareDiagram(kind: DiagramKind, source: string, options: MermaidMarkd
           }),
         ),
         height: size.height,
+        width: size.width,
       }
     }
     case "sequence": {
@@ -144,6 +154,7 @@ function prepareDiagram(kind: DiagramKind, source: string, options: MermaidMarkd
           }),
         ),
         height: size.height,
+        width: size.width,
       }
     }
     case "state": {
@@ -168,6 +179,7 @@ function prepareDiagram(kind: DiagramKind, source: string, options: MermaidMarkd
           }),
         ),
         height: size.height,
+        width: size.width,
       }
     }
   }

--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -61,7 +61,7 @@ class StaticDiagramRenderable extends BoxRenderable {
   constructor(ctx: RenderContext, prepared: PreparedDiagram) {
     super(ctx, {
       width: "100%",
-      alignItems: "center",
+      alignItems: "flex-start",
       flexShrink: 0,
       marginTop: 1,
     })

--- a/packages/merman/src/test/markdown.test.ts
+++ b/packages/merman/src/test/markdown.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, beforeAll, expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { CodeRenderable, MarkdownRenderable, RGBA, SyntaxStyle, TreeSitterClient } from "@opentui/core"
+import { CodeRenderable, MarkdownRenderable, RGBA, SyntaxStyle, TextRenderable, TreeSitterClient } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { createMermaidMarkdownRenderer } from "../markdown.js"
 
@@ -76,6 +76,31 @@ flowchart LR
   expect(frame).toContain("Done")
   expect(frame).not.toContain("flowchart LR")
   expect(markdown.getChildren()[0]?.marginTop).toBe(1)
+})
+
+test("centers a Mermaid diagram narrower than its canvas", async () => {
+  const testRenderer = await createTestRenderer({ width: 80, height: 14 })
+  renderer = testRenderer.renderer
+  const markdown = new MarkdownRenderable(renderer, {
+    id: "markdown-centered-mermaid",
+    content: `\`\`\`mermaid
+flowchart LR
+  A[Start] --> B[Done]
+\`\`\``,
+    syntaxStyle,
+    treeSitterClient,
+    renderNode: createMermaidMarkdownRenderer(renderer),
+  })
+
+  renderer.root.add(markdown)
+  await renderMarkdown(markdown, testRenderer.renderOnce)
+
+  const line = testRenderer
+    .captureCharFrame()
+    .split("\n")
+    .find((value) => value.includes("Start"))
+  if (!line) throw new Error("Expected the rendered diagram")
+  expect(line.indexOf("Start")).toBeGreaterThan(10)
 })
 
 test("recognizes normalized Mermaid fence info strings", async () => {
@@ -235,17 +260,19 @@ sequenceDiagram
   renderer.root.add(markdown)
   await renderMarkdown(markdown, testRenderer.renderOnce)
 
-  const diagram = markdown.getChildren()[0] as CodeRenderable
+  const wrapper = markdown.getChildren()[0]
+  if (!wrapper) throw new Error("Expected the rendered diagram wrapper")
+  const diagram = wrapper.getChildren()[0] as TextRenderable
   expect(diagram.scrollWidth).toBeGreaterThan(diagram.width)
   expect(diagram.scrollX).toBe(0)
 
-  await testRenderer.mockMouse.drag(diagram.x + 20, diagram.y + 2, diagram.x + 5, diagram.y + 2)
+  await testRenderer.mockMouse.drag(wrapper.x + 20, wrapper.y + 2, wrapper.x + 5, wrapper.y + 2)
   await testRenderer.renderOnce()
   expect(diagram.scrollX).toBeGreaterThan(0)
   expect(diagram.hasSelection()).toBe(false)
 
   diagram.scrollX = 0
-  await testRenderer.mockMouse.scroll(diagram.x + 20, diagram.y + 2, "right")
+  await testRenderer.mockMouse.scroll(wrapper.x + 20, wrapper.y + 2, "right")
   await testRenderer.renderOnce()
   expect(diagram.scrollX).toBeGreaterThan(0)
 })

--- a/packages/merman/src/test/markdown.test.ts
+++ b/packages/merman/src/test/markdown.test.ts
@@ -78,7 +78,7 @@ flowchart LR
   expect(markdown.getChildren()[0]?.marginTop).toBe(1)
 })
 
-test("centers a Mermaid diagram narrower than its canvas", async () => {
+test("leaves Mermaid alignment to its containing layout", async () => {
   const testRenderer = await createTestRenderer({ width: 80, height: 14 })
   renderer = testRenderer.renderer
   const markdown = new MarkdownRenderable(renderer, {
@@ -100,7 +100,7 @@ flowchart LR
     .split("\n")
     .find((value) => value.includes("Start"))
   if (!line) throw new Error("Expected the rendered diagram")
-  expect(line.indexOf("Start")).toBeGreaterThan(10)
+  expect(line.indexOf("Start")).toBeLessThan(10)
 })
 
 test("recognizes normalized Mermaid fence info strings", async () => {

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -61,6 +61,15 @@ export const settings: Setting[] = [
     keywords: ["scroll bar"],
   },
   {
+    title: "Max width",
+    category: "Session",
+    path: ["session", "max_width"],
+    default: "auto",
+    values: ["auto", 80, 100, 120],
+    labels: ["auto", "80 columns", "100 columns", "120 columns"],
+    keywords: ["transcript", "composer", "centered", "reading width"],
+  },
+  {
     title: "Thinking",
     category: "Session",
     path: ["session", "thinking"],

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -61,13 +61,13 @@ export const settings: Setting[] = [
     keywords: ["scroll bar"],
   },
   {
-    title: "Max width",
+    title: "Reading width",
     category: "Session",
     path: ["session", "max_width"],
     default: "auto",
-    values: ["auto", 80, 100, 120],
-    labels: ["auto", "80 columns", "100 columns", "120 columns"],
-    keywords: ["transcript", "composer", "centered", "reading width"],
+    values: ["auto", 66, 72, 80],
+    labels: ["auto", "66 columns", "72 columns", "80 columns"],
+    keywords: ["transcript", "composer", "centered", "max width", "prose"],
   },
   {
     title: "Thinking",

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -125,6 +125,11 @@ export const Info = Schema.Struct({
         description: "Session sidebar visibility; 'auto' shows it when space permits",
       }),
       scrollbar: Schema.optional(Schema.Boolean).annotate({ description: "Show the session transcript scrollbar" }),
+      max_width: Schema.optional(
+        Schema.Union([Schema.Int.check(Schema.isGreaterThan(4)), Schema.Literal("auto")]),
+      ).annotate({
+        description: "Session transcript and composer max width, or 'auto' to use the available width",
+      }),
       thinking: Schema.optional(Schema.Literals(["show", "hide"])).annotate({
         description: "Show or hide model reasoning by default",
       }),

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -128,7 +128,7 @@ export const Info = Schema.Struct({
       max_width: Schema.optional(
         Schema.Union([Schema.Int.check(Schema.isGreaterThan(4)), Schema.Literal("auto")]),
       ).annotate({
-        description: "Session transcript and composer max width, or 'auto' to use the available width",
+        description: "Session prose and composer max width, or 'auto' to use the available width",
       }),
       thinking: Schema.optional(Schema.Literals(["show", "hide"])).annotate({
         description: "Show or hide model reasoning by default",

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -68,7 +68,7 @@ import { errorMessage } from "../../util/error"
 import { useToast } from "../../ui/toast"
 import stripAnsi from "strip-ansi"
 import { usePromptRef } from "../../context/prompt"
-import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
+import { sessionContentWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
 import { projectedPromptInput } from "../../prompt/codec"
 import { deduplicateVisibleImages } from "../../prompt/attachment"
 import { useEpilogue } from "../../context/epilogue"
@@ -225,6 +225,7 @@ export function Session() {
   const thinkingMode = createMemo<ThinkingMode>(() => config.session?.thinking ?? "hide")
   const showThinking = createMemo(() => true)
   const showScrollbar = createMemo(() => config.session?.scrollbar ?? false)
+  const maxWidth = createMemo(() => config.session?.max_width ?? "auto")
   const markdownMode = createMemo(() => config.session?.markdown ?? "rendered")
   const diffWrapMode = createMemo(() => config.diffs?.wrap ?? "word")
   const groupExploration = createMemo(() => config.session?.grouping !== "none")
@@ -243,7 +244,7 @@ export function Session() {
     if (sidebar() === "auto" && wide()) return true
     return false
   })
-  const contentWidth = createMemo(() => availableWidth() - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => sessionContentWidth(availableWidth(), sidebarVisible(), maxWidth()))
   const models = createMemo(() => data.location.model.list(location()) ?? [])
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(config))
@@ -1037,103 +1038,107 @@ export function Session() {
       }}
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
-        <box
-          flexGrow={1}
-          minHeight={0}
-          paddingBottom={1}
-          paddingLeft={dimensions().width < 44 ? 1 : 2}
-          paddingRight={dimensions().width < 44 ? 1 : 2}
-          gap={1}
-        >
-          <Show when={session()}>
-            <scrollbox
-              ref={(r) => (scroll = r)}
-              viewportOptions={{
-                paddingRight: showScrollbar() ? 1 : 0,
-              }}
-              verticalScrollbarOptions={{
-                paddingLeft: 1,
-                visible: showScrollbar(),
-                trackOptions: {
-                  backgroundColor: theme.raise(theme.background.surface.offset),
-                  foregroundColor: theme.border.default,
-                },
-              }}
-              stickyScroll={!navigationMessage()}
-              stickyStart="bottom"
-              flexGrow={1}
-              scrollAcceleration={scrollAcceleration()}
-            >
-              <For each={visibleRows()}>
-                {(row, index) => (
-                  <SessionRowView
-                    row={row}
-                    message={(messageID) => data.session.message.get(route.sessionID, messageID)}
-                    boundaryID={boundaries()[index() + hidden()]}
+        <box flexGrow={1} minHeight={0} alignItems="center">
+          <box
+            width="100%"
+            maxWidth={maxWidth() === "auto" ? undefined : maxWidth()}
+            flexGrow={1}
+            minHeight={0}
+            paddingBottom={1}
+            paddingLeft={dimensions().width < 44 ? 1 : 2}
+            paddingRight={dimensions().width < 44 ? 1 : 2}
+            gap={1}
+          >
+            <Show when={session()}>
+              <scrollbox
+                ref={(r) => (scroll = r)}
+                viewportOptions={{
+                  paddingRight: showScrollbar() ? 1 : 0,
+                }}
+                verticalScrollbarOptions={{
+                  paddingLeft: 1,
+                  visible: showScrollbar(),
+                  trackOptions: {
+                    backgroundColor: theme.raise(theme.background.surface.offset),
+                    foregroundColor: theme.border.default,
+                  },
+                }}
+                stickyScroll={!navigationMessage()}
+                stickyStart="bottom"
+                flexGrow={1}
+                scrollAcceleration={scrollAcceleration()}
+              >
+                <For each={visibleRows()}>
+                  {(row, index) => (
+                    <SessionRowView
+                      row={row}
+                      message={(messageID) => data.session.message.get(route.sessionID, messageID)}
+                      boundaryID={boundaries()[index() + hidden()]}
+                    />
+                  )}
+                </For>
+                <BackgroundToolHint messages={messages()} />
+                <Show when={session()?.revert?.messageID}>
+                  <RevertMessage
+                    count={messagesFromRevert().filter((message) => message.type === "user").length}
+                    files={session()!.revert!.files ?? []}
                   />
-                )}
-              </For>
-              <BackgroundToolHint messages={messages()} />
-              <Show when={session()?.revert?.messageID}>
-                <RevertMessage
-                  count={messagesFromRevert().filter((message) => message.type === "user").length}
-                  files={session()!.revert!.files ?? []}
+                </Show>
+                <Show when={navigationSlack()}>
+                  {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
+                </Show>
+              </scrollbox>
+              <box flexShrink={0}>
+                <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
+                  <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
+                </Show>
+                <PluginSlot name="session.composer.top" input={{ sessionID: route.sessionID }} mode="all" />
+                <Composer
+                  sessionID={route.sessionID}
+                  open={composer.open || (!!session()?.parentID && forms().length === 0)}
+                  defaultTab={composer.tab ?? (session()?.parentID ? "subagents" : undefined)}
+                  onClose={() => setComposer("open", false)}
                 />
-              </Show>
-              <Show when={navigationSlack()}>
-                {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
-              </Show>
-            </scrollbox>
-            <box flexShrink={0}>
-              <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
-                <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
-              </Show>
-              <PluginSlot name="session.composer.top" input={{ sessionID: route.sessionID }} mode="all" />
-              <Composer
-                sessionID={route.sessionID}
-                open={composer.open || (!!session()?.parentID && forms().length === 0)}
-                defaultTab={composer.tab ?? (session()?.parentID ? "subagents" : undefined)}
-                onClose={() => setComposer("open", false)}
-              />
-              <Switch>
-                <Match when={composer.open || (!!session()?.parentID && forms().length === 0)}>{null}</Match>
-                <Match when={promptedPermissions().length > 0}>
-                  <Show when={promptedPermissions()[0]?.id} keyed>
-                    {(_) => {
-                      const request = promptedPermissions()[0]
-                      return request ? (
-                        <PermissionPrompt request={request} directory={session()?.location.directory} />
-                      ) : null
-                    }}
-                  </Show>
-                </Match>
-                <Match when={forms().length > 0}>
-                  <Show when={forms()[0]?.id} keyed>
-                    {(_) => {
-                      const form = forms()[0]
-                      return form ? <FormPrompt form={form} /> : null
-                    }}
-                  </Show>
-                </Match>
-                <Match when={!disabled()}>
-                  <Prompt
-                    visible={true}
-                    ref={bind}
-                    disabled={false}
-                    onSubmit={() => {
-                      toBottom()
-                    }}
-                    onEmptySubmit={async () => {
-                      const next = queuedPrompts()[0]
-                      if (!next) return false
-                      return mutatePending("steer", next.id)
-                    }}
-                    sessionID={route.sessionID}
-                  />
-                </Match>
-              </Switch>
-            </box>
-          </Show>
+                <Switch>
+                  <Match when={composer.open || (!!session()?.parentID && forms().length === 0)}>{null}</Match>
+                  <Match when={promptedPermissions().length > 0}>
+                    <Show when={promptedPermissions()[0]?.id} keyed>
+                      {(_) => {
+                        const request = promptedPermissions()[0]
+                        return request ? (
+                          <PermissionPrompt request={request} directory={session()?.location.directory} />
+                        ) : null
+                      }}
+                    </Show>
+                  </Match>
+                  <Match when={forms().length > 0}>
+                    <Show when={forms()[0]?.id} keyed>
+                      {(_) => {
+                        const form = forms()[0]
+                        return form ? <FormPrompt form={form} /> : null
+                      }}
+                    </Show>
+                  </Match>
+                  <Match when={!disabled()}>
+                    <Prompt
+                      visible={true}
+                      ref={bind}
+                      disabled={false}
+                      onSubmit={() => {
+                        toBottom()
+                      }}
+                      onEmptySubmit={async () => {
+                        const next = queuedPrompts()[0]
+                        if (!next) return false
+                        return mutatePending("steer", next.id)
+                      }}
+                      sessionID={route.sessionID}
+                    />
+                  </Match>
+                </Switch>
+              </box>
+            </Show>
+          </box>
         </box>
         <Show when={sidebarVisible()}>
           <Switch>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2240,41 +2240,53 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
   const theme = useTheme()
   const { currentSyntax: syntax } = useThemes()
   const plugins = usePlugin()
-  const segments = createMemo(() => markdownLanes(props.part.text.trim()))
+  const constrained = () => (ctx.config.session?.max_width ?? "auto") !== "auto"
+
+  function Content(input: { content: string }) {
+    return (
+      <box paddingLeft={3} flexShrink={0}>
+        <markdown
+          syntaxStyle={syntax()}
+          streaming={true}
+          internalBlockMode="top-level"
+          content={input.content.trim()}
+          tableOptions={{ style: "grid" }}
+          conceal={ctx.markdownMode() === "rendered"}
+          fg={theme.markdown.text}
+          bg={theme.background.default}
+          renderNode={plugins.markdown()}
+        />
+      </box>
+    )
+  }
+
   return (
     <Show when={props.part.text.trim()}>
-      <Index each={segments()}>
-        {(segment, index) => {
-          const content = (
-            <box paddingLeft={3} flexShrink={0}>
-              <markdown
-                syntaxStyle={syntax()}
-                streaming={true}
-                internalBlockMode="top-level"
-                content={segment().content.trim()}
-                tableOptions={{ style: "grid" }}
-                conceal={ctx.markdownMode() === "rendered"}
-                fg={theme.markdown.text}
-                bg={theme.background.default}
-                renderNode={plugins.markdown()}
-              />
-            </box>
-          )
-          return (
-            <box width="100%" marginTop={markdownLaneMarginTop(index, segment().width)} flexShrink={0}>
-              <Switch>
-                <Match when={segment().width === "wide"}>{content}</Match>
-                <Match when={segment().width === "code"}>
-                  <SessionContentLane width="code">{content}</SessionContentLane>
-                </Match>
-                <Match when={segment().width === "readable"}>
-                  <SessionContentLane width="readable">{content}</SessionContentLane>
-                </Match>
-              </Switch>
-            </box>
-          )
-        }}
-      </Index>
+      <Switch>
+        <Match when={!constrained()}>
+          <Content content={props.part.text} />
+        </Match>
+        <Match when={constrained()}>
+          <Index each={markdownLanes(props.part.text.trim())}>
+            {(segment, index) => {
+              const content = <Content content={segment().content} />
+              return (
+                <box width="100%" marginTop={markdownLaneMarginTop(index, segment().width)} flexShrink={0}>
+                  <Switch>
+                    <Match when={segment().width === "wide"}>{content}</Match>
+                    <Match when={segment().width === "code"}>
+                      <SessionContentLane width="code">{content}</SessionContentLane>
+                    </Match>
+                    <Match when={segment().width === "readable"}>
+                      <SessionContentLane width="readable">{content}</SessionContentLane>
+                    </Match>
+                  </Switch>
+                </box>
+              )
+            }}
+          </Index>
+        </Match>
+      </Switch>
     </Show>
   )
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -108,7 +108,7 @@ import { createSingleFlight } from "../../util/single-flight"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import { generateThinkingSyntax } from "./thinking-syntax"
 import { createDelayedPresence } from "../../util/delayed-presence"
-import { markdownLanes } from "./markdown-lanes"
+import { markdownLaneMarginTop, markdownLanes } from "./markdown-lanes"
 
 addDefaultParsers(parsers.parsers)
 
@@ -2244,7 +2244,7 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
   return (
     <Show when={props.part.text.trim()}>
       <Index each={segments()}>
-        {(segment) => {
+        {(segment, index) => {
           const content = (
             <box paddingLeft={3} flexShrink={0}>
               <markdown
@@ -2261,15 +2261,17 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
             </box>
           )
           return (
-            <Switch>
-              <Match when={segment().width === "wide"}>{content}</Match>
-              <Match when={segment().width === "code"}>
-                <SessionContentLane width="code">{content}</SessionContentLane>
-              </Match>
-              <Match when={segment().width === "readable"}>
-                <SessionContentLane width="readable">{content}</SessionContentLane>
-              </Match>
-            </Switch>
+            <box width="100%" marginTop={markdownLaneMarginTop(index, segment().width)} flexShrink={0}>
+              <Switch>
+                <Match when={segment().width === "wide"}>{content}</Match>
+                <Match when={segment().width === "code"}>
+                  <SessionContentLane width="code">{content}</SessionContentLane>
+                </Match>
+                <Match when={segment().width === "readable"}>
+                  <SessionContentLane width="readable">{content}</SessionContentLane>
+                </Match>
+              </Switch>
+            </box>
           )
         }}
       </Index>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -68,7 +68,7 @@ import { errorMessage } from "../../util/error"
 import { useToast } from "../../ui/toast"
 import stripAnsi from "strip-ansi"
 import { usePromptRef } from "../../context/prompt"
-import { sessionContentWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
+import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
 import { projectedPromptInput } from "../../prompt/codec"
 import { deduplicateVisibleImages } from "../../prompt/attachment"
 import { useEpilogue } from "../../context/epilogue"
@@ -108,12 +108,15 @@ import { createSingleFlight } from "../../util/single-flight"
 import type { SessionPending } from "@opencode-ai/schema/session-pending"
 import { generateThinkingSyntax } from "./thinking-syntax"
 import { createDelayedPresence } from "../../util/delayed-presence"
+import { markdownLanes } from "./markdown-lanes"
 
 addDefaultParsers(parsers.parsers)
 
 // Exclude temporary bottom space when measuring the real transcript height.
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const BACKGROUND_TOOL_HINT_DELAY = 1_000
+// The assistant inset leaves 85 columns for code, matching common documentation guidance.
+const SESSION_CODE_LANE_WIDTH = 88
 
 // Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
 // The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
@@ -225,7 +228,6 @@ export function Session() {
   const thinkingMode = createMemo<ThinkingMode>(() => config.session?.thinking ?? "hide")
   const showThinking = createMemo(() => true)
   const showScrollbar = createMemo(() => config.session?.scrollbar ?? false)
-  const maxWidth = createMemo(() => config.session?.max_width ?? "auto")
   const markdownMode = createMemo(() => config.session?.markdown ?? "rendered")
   const diffWrapMode = createMemo(() => config.diffs?.wrap ?? "word")
   const groupExploration = createMemo(() => config.session?.grouping !== "none")
@@ -244,7 +246,7 @@ export function Session() {
     if (sidebar() === "auto" && wide()) return true
     return false
   })
-  const contentWidth = createMemo(() => sessionContentWidth(availableWidth(), sidebarVisible(), maxWidth()))
+  const contentWidth = createMemo(() => availableWidth() - (sidebarVisible() ? 42 : 0) - 4)
   const models = createMemo(() => data.location.model.list(location()) ?? [])
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(config))
@@ -1038,56 +1040,54 @@ export function Session() {
       }}
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
-        <box flexGrow={1} minHeight={0} alignItems="center">
-          <box
-            width="100%"
-            maxWidth={maxWidth() === "auto" ? undefined : maxWidth()}
-            flexGrow={1}
-            minHeight={0}
-            paddingBottom={1}
-            paddingLeft={dimensions().width < 44 ? 1 : 2}
-            paddingRight={dimensions().width < 44 ? 1 : 2}
-            gap={1}
-          >
-            <Show when={session()}>
-              <scrollbox
-                ref={(r) => (scroll = r)}
-                viewportOptions={{
-                  paddingRight: showScrollbar() ? 1 : 0,
-                }}
-                verticalScrollbarOptions={{
-                  paddingLeft: 1,
-                  visible: showScrollbar(),
-                  trackOptions: {
-                    backgroundColor: theme.raise(theme.background.surface.offset),
-                    foregroundColor: theme.border.default,
-                  },
-                }}
-                stickyScroll={!navigationMessage()}
-                stickyStart="bottom"
-                flexGrow={1}
-                scrollAcceleration={scrollAcceleration()}
-              >
-                <For each={visibleRows()}>
-                  {(row, index) => (
-                    <SessionRowView
-                      row={row}
-                      message={(messageID) => data.session.message.get(route.sessionID, messageID)}
-                      boundaryID={boundaries()[index() + hidden()]}
-                    />
-                  )}
-                </For>
-                <BackgroundToolHint messages={messages()} />
-                <Show when={session()?.revert?.messageID}>
-                  <RevertMessage
-                    count={messagesFromRevert().filter((message) => message.type === "user").length}
-                    files={session()!.revert!.files ?? []}
+        <box
+          flexGrow={1}
+          minHeight={0}
+          paddingBottom={1}
+          paddingLeft={dimensions().width < 44 ? 1 : 2}
+          paddingRight={dimensions().width < 44 ? 1 : 2}
+          gap={1}
+        >
+          <Show when={session()}>
+            <scrollbox
+              ref={(r) => (scroll = r)}
+              viewportOptions={{
+                paddingRight: showScrollbar() ? 1 : 0,
+              }}
+              verticalScrollbarOptions={{
+                paddingLeft: 1,
+                visible: showScrollbar(),
+                trackOptions: {
+                  backgroundColor: theme.raise(theme.background.surface.offset),
+                  foregroundColor: theme.border.default,
+                },
+              }}
+              stickyScroll={!navigationMessage()}
+              stickyStart="bottom"
+              flexGrow={1}
+              scrollAcceleration={scrollAcceleration()}
+            >
+              <For each={visibleRows()}>
+                {(row, index) => (
+                  <SessionRowView
+                    row={row}
+                    message={(messageID) => data.session.message.get(route.sessionID, messageID)}
+                    boundaryID={boundaries()[index() + hidden()]}
                   />
-                </Show>
-                <Show when={navigationSlack()}>
-                  {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
-                </Show>
-              </scrollbox>
+                )}
+              </For>
+              <BackgroundToolHint messages={messages()} />
+              <Show when={session()?.revert?.messageID}>
+                <RevertMessage
+                  count={messagesFromRevert().filter((message) => message.type === "user").length}
+                  files={session()!.revert!.files ?? []}
+                />
+              </Show>
+              <Show when={navigationSlack()}>
+                {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
+              </Show>
+            </scrollbox>
+            <SessionContentLane width="readable">
               <box flexShrink={0}>
                 <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                   <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
@@ -1137,8 +1137,8 @@ export function Session() {
                   </Match>
                 </Switch>
               </box>
-            </Show>
-          </box>
+            </SessionContentLane>
+          </Show>
         </box>
         <Show when={sidebarVisible()}>
           <Switch>
@@ -1204,7 +1204,9 @@ function SessionRowView(props: SessionRowViewProps) {
             <Show when={props.message(row().messageID)}>
               {(message) => (
                 <Show when={message().type === "assistant"}>
-                  <AssistantFooter message={message() as SessionMessageAssistant} />
+                  <SessionContentLane width="readable">
+                    <AssistantFooter message={message() as SessionMessageAssistant} />
+                  </SessionContentLane>
                 </Show>
               )}
             </Show>
@@ -1216,6 +1218,22 @@ function SessionRowView(props: SessionRowViewProps) {
           )}
         </Match>
       </Switch>
+    </box>
+  )
+}
+
+function SessionContentLane(props: { children: JSX.Element; width: "readable" | "code" }) {
+  const ctx = use()
+  const maxWidth = createMemo(() => {
+    const readable = ctx.config.session?.max_width ?? "auto"
+    if (readable === "auto" || props.width === "readable") return readable
+    return Math.max(readable, SESSION_CODE_LANE_WIDTH)
+  })
+  return (
+    <box width="100%" alignItems="center" flexShrink={0}>
+      <box width="100%" maxWidth={maxWidth() === "auto" ? undefined : maxWidth()} flexShrink={0}>
+        {props.children}
+      </box>
     </box>
   )
 }
@@ -1943,79 +1961,56 @@ function UserMessage(props: { message: SessionMessageUser }) {
 
   return (
     <Show when={props.message.text.trim() || files().length || skills().length}>
-      <box
-        border={["left"]}
-        borderColor={delivery() ? theme.border.default : color()}
-        customBorderChars={SplitBorder.customBorderChars}
-      >
-        <SessionImages images={images()} paddingLeft={2} />
+      <SessionContentLane width="readable">
         <box
-          onMouseOver={() => {
-            setHover(true)
-          }}
-          onMouseOut={() => {
-            setHover(false)
-          }}
-          onMouseUp={() => {
-            if (renderer.getSelection()?.getSelectedText()) return
-            if (delivery() === "steer") {
+          border={["left"]}
+          borderColor={delivery() ? theme.border.default : color()}
+          customBorderChars={SplitBorder.customBorderChars}
+        >
+          <SessionImages images={images()} paddingLeft={2} />
+          <box
+            onMouseOver={() => {
+              setHover(true)
+            }}
+            onMouseOut={() => {
+              setHover(false)
+            }}
+            onMouseUp={() => {
+              if (renderer.getSelection()?.getSelectedText()) return
+              if (delivery() === "steer") {
+                dialog.replace(() => (
+                  <DialogSelect
+                    title="Pending steer"
+                    options={[
+                      { title: "Move to queue", value: "queue" as const },
+                      { title: "Delete", value: "cancel" as const },
+                    ]}
+                    onSelect={(option) => {
+                      void updatePendingSteer(option.value)
+                    }}
+                  />
+                ))
+                return
+              }
               dialog.replace(() => (
-                <DialogSelect
-                  title="Pending steer"
-                  options={[
-                    { title: "Move to queue", value: "queue" as const },
-                    { title: "Delete", value: "cancel" as const },
-                  ]}
-                  onSelect={(option) => {
-                    void updatePendingSteer(option.value)
-                  }}
+                <DialogMessage
+                  messageID={props.message.id}
+                  sessionID={ctx.sessionID}
+                  setPrompt={(value) => promptRef.current?.set(value)}
                 />
               ))
-              return
-            }
-            dialog.replace(() => (
-              <DialogMessage
-                messageID={props.message.id}
-                sessionID={ctx.sessionID}
-                setPrompt={(value) => promptRef.current?.set(value)}
-              />
-            ))
-          }}
-          paddingTop={1}
-          paddingBottom={1}
-          paddingLeft={2}
-          backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
-          flexShrink={0}
-        >
-          <text fg={theme.text.default}>{props.message.text}</text>
-          <Show when={skills().length}>
-            <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
-              <For each={skills()}>
-                {(skill) => (
-                  <text fg={theme.text.default}>
-                    <span
-                      style={{
-                        bg: theme.hue.accent[mode() === "light" ? 700 : 200],
-                        fg: theme.background.default,
-                        bold: true,
-                      }}
-                    >
-                      {" skill "}
-                    </span>
-                    <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>
-                      {` ${skill.name} `}
-                    </span>
-                  </text>
-                )}
-              </For>
-            </box>
-          </Show>
-          <Show when={files().length}>
-            <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
-              <For each={files()}>
-                {(file) => {
-                  const label = file.mime === "application/x-directory" ? "dir" : "file"
-                  return (
+            }}
+            paddingTop={1}
+            paddingBottom={1}
+            paddingLeft={2}
+            backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
+            flexShrink={0}
+          >
+            <text fg={theme.text.default}>{props.message.text}</text>
+            <Show when={skills().length}>
+              <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
+                <For each={skills()}>
+                  {(skill) => (
                     <text fg={theme.text.default}>
                       <span
                         style={{
@@ -2024,20 +2019,45 @@ function UserMessage(props: { message: SessionMessageUser }) {
                           bold: true,
                         }}
                       >
-                        {` ${label} `}
+                        {" skill "}
                       </span>
                       <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>
-                        {" "}
-                        {file.name ?? (file.source.type === "uri" ? file.source.uri : "attachment")}{" "}
+                        {` ${skill.name} `}
                       </span>
                     </text>
-                  )
-                }}
-              </For>
-            </box>
-          </Show>
+                  )}
+                </For>
+              </box>
+            </Show>
+            <Show when={files().length}>
+              <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
+                <For each={files()}>
+                  {(file) => {
+                    const label = file.mime === "application/x-directory" ? "dir" : "file"
+                    return (
+                      <text fg={theme.text.default}>
+                        <span
+                          style={{
+                            bg: theme.hue.accent[mode() === "light" ? 700 : 200],
+                            fg: theme.background.default,
+                            bold: true,
+                          }}
+                        >
+                          {` ${label} `}
+                        </span>
+                        <span style={{ bg: theme.raise(theme.background.default), fg: theme.text.subdued }}>
+                          {" "}
+                          {file.name ?? (file.source.type === "uri" ? file.source.uri : "attachment")}{" "}
+                        </span>
+                      </text>
+                    )
+                  }}
+                </For>
+              </box>
+            </Show>
+          </box>
         </box>
-      </box>
+      </SessionContentLane>
     </Show>
   )
 }
@@ -2220,21 +2240,39 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
   const theme = useTheme()
   const { currentSyntax: syntax } = useThemes()
   const plugins = usePlugin()
+  const segments = createMemo(() => markdownLanes(props.part.text.trim()))
   return (
     <Show when={props.part.text.trim()}>
-      <box paddingLeft={3} flexShrink={0}>
-        <markdown
-          syntaxStyle={syntax()}
-          streaming={true}
-          internalBlockMode="top-level"
-          content={props.part.text.trim()}
-          tableOptions={{ style: "grid" }}
-          conceal={ctx.markdownMode() === "rendered"}
-          fg={theme.markdown.text}
-          bg={theme.background.default}
-          renderNode={plugins.markdown()}
-        />
-      </box>
+      <Index each={segments()}>
+        {(segment) => {
+          const content = (
+            <box paddingLeft={3} flexShrink={0}>
+              <markdown
+                syntaxStyle={syntax()}
+                streaming={true}
+                internalBlockMode="top-level"
+                content={segment().content.trim()}
+                tableOptions={{ style: "grid" }}
+                conceal={ctx.markdownMode() === "rendered"}
+                fg={theme.markdown.text}
+                bg={theme.background.default}
+                renderNode={plugins.markdown()}
+              />
+            </box>
+          )
+          return (
+            <Switch>
+              <Match when={segment().width === "wide"}>{content}</Match>
+              <Match when={segment().width === "code"}>
+                <SessionContentLane width="code">{content}</SessionContentLane>
+              </Match>
+              <Match when={segment().width === "readable"}>
+                <SessionContentLane width="readable">{content}</SessionContentLane>
+              </Match>
+            </Switch>
+          )
+        }}
+      </Index>
     </Show>
   )
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -68,7 +68,7 @@ import { errorMessage } from "../../util/error"
 import { useToast } from "../../ui/toast"
 import stripAnsi from "strip-ansi"
 import { usePromptRef } from "../../context/prompt"
-import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
+import { sessionLaneLayout, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
 import { projectedPromptInput } from "../../prompt/codec"
 import { deduplicateVisibleImages } from "../../prompt/attachment"
 import { useEpilogue } from "../../context/epilogue"
@@ -115,9 +115,6 @@ addDefaultParsers(parsers.parsers)
 // Exclude temporary bottom space when measuring the real transcript height.
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const BACKGROUND_TOOL_HINT_DELAY = 1_000
-// The assistant inset leaves 85 columns for code, matching common documentation guidance.
-const SESSION_TECHNICAL_LANE_WIDTH = 88
-
 // Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
 // The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
 // in a few hundred milliseconds without a perceptible pause.
@@ -1238,17 +1235,35 @@ function SessionRowView(props: SessionRowViewProps) {
 
 function SessionContentLane(props: { children: JSX.Element; width: "readable" | "technical" }) {
   const ctx = use()
-  const maxWidth = createMemo(() => {
-    const readable = ctx.config.session?.max_width ?? "auto"
-    if (readable === "auto" || props.width === "readable") return readable
-    return Math.max(readable, SESSION_TECHNICAL_LANE_WIDTH)
+  const readable = () => ctx.config.session?.max_width ?? "auto"
+  const layout = createMemo(() => {
+    const width = readable()
+    return width === "auto" ? undefined : sessionLaneLayout(ctx.width, width)
   })
   return (
-    <Show when={maxWidth() !== "auto"} fallback={props.children}>
-      <box width="100%" alignItems="center" flexShrink={0}>
-        <box width="100%" maxWidth={maxWidth() === "auto" ? undefined : maxWidth()} flexShrink={0}>
-          {props.children}
+    <Show when={layout()} fallback={props.children}>
+      {(value) => (
+        <box width="100%" paddingLeft={value().inset} flexShrink={0}>
+          <box width={value()[props.width]} flexShrink={0}>
+            {props.children}
+          </box>
         </box>
+      )}
+    </Show>
+  )
+}
+
+function SessionBreakoutLane(props: { children: JSX.Element }) {
+  const ctx = use()
+  const readable = () => ctx.config.session?.max_width ?? "auto"
+  const inset = createMemo(() => {
+    const width = readable()
+    return width === "auto" ? undefined : sessionLaneLayout(ctx.width, width).inset
+  })
+  return (
+    <Show when={inset() !== undefined} fallback={props.children}>
+      <box width="100%" paddingLeft={inset()} flexShrink={0}>
+        {props.children}
       </box>
     </Show>
   )
@@ -2306,7 +2321,9 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
               return (
                 <box width="100%" marginTop={markdownLaneMarginTop(index, segment().width)} flexShrink={0}>
                   <Switch>
-                    <Match when={segment().width === "full"}>{content}</Match>
+                    <Match when={segment().width === "full"}>
+                      <SessionBreakoutLane>{content}</SessionBreakoutLane>
+                    </Match>
                     <Match when={segment().width === "technical"}>
                       <SessionContentLane width="technical">{content}</SessionContentLane>
                     </Match>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -116,7 +116,7 @@ addDefaultParsers(parsers.parsers)
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const BACKGROUND_TOOL_HINT_DELAY = 1_000
 // The assistant inset leaves 85 columns for code, matching common documentation guidance.
-const SESSION_CODE_LANE_WIDTH = 88
+const SESSION_TECHNICAL_LANE_WIDTH = 88
 
 // Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
 // The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
@@ -1181,22 +1181,30 @@ function SessionRowView(props: SessionRowViewProps) {
           )}
         </Match>
         <Match when={props.row.type === "compaction-queued"}>
-          <CompactionQueued />
+          <SessionContentLane width="readable">
+            <CompactionQueued />
+          </SessionContentLane>
         </Match>
         <Match when={props.row.type === "part" ? props.row : undefined}>
           {(row) => <SessionPartView partRef={row().ref} message={props.message} />}
         </Match>
         <Match when={props.row.type === "group" && props.row.kind === "reasoning" ? props.row : undefined}>
-          {(row) => <SessionReasoningGroupView refs={row().refs} completed={row().completed} message={props.message} />}
+          {(row) => (
+            <SessionContentLane width="readable">
+              <SessionReasoningGroupView refs={row().refs} completed={row().completed} message={props.message} />
+            </SessionContentLane>
+          )}
         </Match>
         <Match when={props.row.type === "group" && props.row.kind === "exploration" ? props.row : undefined}>
           {(row) => (
-            <SessionGroupView
-              refs={row().refs}
-              pending={row().pending}
-              completed={row().completed}
-              message={props.message}
-            />
+            <SessionContentLane width="readable">
+              <SessionGroupView
+                refs={row().refs}
+                pending={row().pending}
+                completed={row().completed}
+                message={props.message}
+              />
+            </SessionContentLane>
           )}
         </Match>
         <Match when={props.row.type === "assistant-footer" ? props.row : undefined}>
@@ -1214,7 +1222,13 @@ function SessionRowView(props: SessionRowViewProps) {
         </Match>
         <Match when={props.row.type === "turn-usage" ? props.row : undefined}>
           {(row) => (
-            <TurnTokenUsage messageIDs={row().messageIDs} previousCache={row().previousCache} message={props.message} />
+            <SessionContentLane width="technical">
+              <TurnTokenUsage
+                messageIDs={row().messageIDs}
+                previousCache={row().previousCache}
+                message={props.message}
+              />
+            </SessionContentLane>
           )}
         </Match>
       </Switch>
@@ -1222,19 +1236,21 @@ function SessionRowView(props: SessionRowViewProps) {
   )
 }
 
-function SessionContentLane(props: { children: JSX.Element; width: "readable" | "code" }) {
+function SessionContentLane(props: { children: JSX.Element; width: "readable" | "technical" }) {
   const ctx = use()
   const maxWidth = createMemo(() => {
     const readable = ctx.config.session?.max_width ?? "auto"
     if (readable === "auto" || props.width === "readable") return readable
-    return Math.max(readable, SESSION_CODE_LANE_WIDTH)
+    return Math.max(readable, SESSION_TECHNICAL_LANE_WIDTH)
   })
   return (
-    <box width="100%" alignItems="center" flexShrink={0}>
-      <box width="100%" maxWidth={maxWidth() === "auto" ? undefined : maxWidth()} flexShrink={0}>
-        {props.children}
+    <Show when={maxWidth() !== "auto"} fallback={props.children}>
+      <box width="100%" alignItems="center" flexShrink={0}>
+        <box width="100%" maxWidth={maxWidth() === "auto" ? undefined : maxWidth()} flexShrink={0}>
+          {props.children}
+        </box>
       </box>
-    </box>
+    </Show>
   )
 }
 
@@ -1400,20 +1416,35 @@ function SessionMessageView(props: { message: SessionMessageInfo }) {
         <UserMessage message={props.message as SessionMessageUser} />
       </Match>
       <Match when={props.message.type === "shell"}>
-        <ShellMessage message={props.message as Extract<SessionMessageInfo, { type: "shell" }>} />
+        <SessionContentLane width="technical">
+          <ShellMessage message={props.message as Extract<SessionMessageInfo, { type: "shell" }>} />
+        </SessionContentLane>
       </Match>
       <Match when={props.message.type === "agent-switched" || props.message.type === "model-switched"}>
-        <SessionSwitchMessageV2 message={props.message} />
+        <SessionContentLane width="readable">
+          <SessionSwitchMessageV2 message={props.message} />
+        </SessionContentLane>
       </Match>
       <Match
         when={props.message.type === "system" || props.message.type === "synthetic" || props.message.type === "skill"}
       >
-        <Show when={props.message.type === "skill"} fallback={<SessionNoticeMessageV2 message={props.message} />}>
-          <SessionSkillMessage message={props.message as Extract<SessionMessageInfo, { type: "skill" }>} />
+        <Show
+          when={props.message.type === "skill"}
+          fallback={
+            <SessionContentLane width="readable">
+              <SessionNoticeMessageV2 message={props.message} />
+            </SessionContentLane>
+          }
+        >
+          <SessionContentLane width="readable">
+            <SessionSkillMessage message={props.message as Extract<SessionMessageInfo, { type: "skill" }>} />
+          </SessionContentLane>
         </Show>
       </Match>
       <Match when={props.message.type === "compaction"}>
-        <CompactionMessage message={props.message as Extract<SessionMessageInfo, { type: "compaction" }>} />
+        <SessionContentLane width="readable">
+          <CompactionMessage message={props.message as Extract<SessionMessageInfo, { type: "compaction" }>} />
+        </SessionContentLane>
       </Match>
     </Switch>
   )
@@ -1434,11 +1465,13 @@ function SessionPartView(props: { partRef: PartRef; message: (messageID: string)
             <TextPart part={item() as SessionMessageAssistantText} last={false} />
           </Match>
           <Match when={item().type === "reasoning"}>
-            <ReasoningPart
-              part={item() as SessionMessageAssistantReasoning}
-              message={message() as SessionMessageAssistant}
-              last={false}
-            />
+            <SessionContentLane width="readable">
+              <ReasoningPart
+                part={item() as SessionMessageAssistantReasoning}
+                message={message() as SessionMessageAssistant}
+                last={false}
+              />
+            </SessionContentLane>
           </Match>
           <Match when={item().type === "tool"}>
             <ToolPart part={item() as SessionMessageAssistantTool} />
@@ -2273,9 +2306,9 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
               return (
                 <box width="100%" marginTop={markdownLaneMarginTop(index, segment().width)} flexShrink={0}>
                   <Switch>
-                    <Match when={segment().width === "wide"}>{content}</Match>
-                    <Match when={segment().width === "code"}>
-                      <SessionContentLane width="code">{content}</SessionContentLane>
+                    <Match when={segment().width === "full"}>{content}</Match>
+                    <Match when={segment().width === "technical"}>
+                      <SessionContentLane width="technical">{content}</SessionContentLane>
                     </Match>
                     <Match when={segment().width === "readable"}>
                       <SessionContentLane width="readable">{content}</SessionContentLane>
@@ -2295,6 +2328,7 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
 
 function ToolPart(props: { part: SessionMessageAssistantTool; images?: boolean }) {
   const display = createMemo(() => toolDisplay(props.part.name))
+  const width = createMemo(() => toolLane(props.part.name))
 
   const toolprops = {
     get metadata() {
@@ -2364,10 +2398,12 @@ function ToolPart(props: { part: SessionMessageAssistantTool; images?: boolean }
     </Switch>
   )
   return [
-    content,
-    <Show when={props.images !== false}>
-      <ToolImages parts={[props.part]} />
-    </Show>,
+    <SessionContentLane width={width()}>{content}</SessionContentLane>,
+    <SessionContentLane width="readable">
+      <Show when={props.images !== false}>
+        <ToolImages parts={[props.part]} />
+      </Show>
+    </SessionContentLane>,
   ]
 }
 
@@ -3201,7 +3237,7 @@ function Edit(props: ToolProps) {
     const diffView = ctx.config.diffs?.view
     if (diffView === "unified") return "unified"
     if (diffView === "split") return "split"
-    // Default to "auto" behavior
+    if ((ctx.config.session?.max_width ?? "auto") !== "auto") return "unified"
     return ctx.width > 120 ? "split" : "unified"
   })
 
@@ -3279,6 +3315,7 @@ function ApplyPatch(props: ToolProps) {
   const view = createMemo(() => {
     if (ctx.config.diffs?.view === "unified") return "unified"
     if (ctx.config.diffs?.view === "split") return "split"
+    if ((ctx.config.session?.max_width ?? "auto") !== "auto") return "unified"
     return ctx.width > 120 ? "split" : "unified"
   })
 
@@ -3464,9 +3501,15 @@ const toolDisplays = new Set([
   "skill",
 ])
 
+const technicalToolDisplays = new Set(["shell", "write", "edit", "execute", "patch", "generic"])
+
 export function toolDisplay(tool: string) {
   const normalized = canonicalToolName(tool)
   return toolDisplays.has(normalized) ? normalized : "generic"
+}
+
+export function toolLane(tool: string): "readable" | "technical" {
+  return technicalToolDisplays.has(toolDisplay(tool)) ? "technical" : "readable"
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/tui/src/routes/session/markdown-lanes.ts
+++ b/packages/tui/src/routes/session/markdown-lanes.ts
@@ -38,3 +38,8 @@ export function markdownLanes(content: string): MarkdownLane[] {
 
   return result
 }
+
+export function markdownLaneMarginTop(index: number, width: MarkdownLane["width"]) {
+  if (index === 0 || width === "wide") return 0
+  return 1
+}

--- a/packages/tui/src/routes/session/markdown-lanes.ts
+++ b/packages/tui/src/routes/session/markdown-lanes.ts
@@ -1,0 +1,40 @@
+export type MarkdownLane = {
+  content: string
+  width: "readable" | "code" | "wide"
+}
+
+export function markdownLanes(content: string): MarkdownLane[] {
+  const result: MarkdownLane[] = []
+  let fence: { marker: "`" | "~"; length: number } | undefined
+
+  for (const line of content.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? []) {
+    const opening = fence ? undefined : line.match(/^ {0,3}(`{3,}|~{3,})([^\n]*)/)
+    const marker = opening?.[1]
+    if (marker) fence = { marker: marker.startsWith("`") ? "`" : "~", length: marker.length }
+
+    const width = opening
+      ? opening[2]?.trim().split(/\s/, 1)[0]?.toLowerCase() === "mermaid"
+        ? "wide"
+        : "code"
+      : fence
+        ? (result.at(-1)?.width ?? "code")
+        : "readable"
+    const previous = result.at(-1)
+    if (previous?.width === width) previous.content += line
+    else result.push({ content: line, width })
+
+    if (!fence) continue
+    const currentFence = fence
+    const trimmed = line.trim()
+    if (
+      !opening &&
+      (line.match(/^ */)?.[0].length ?? 0) <= 3 &&
+      trimmed.length >= currentFence.length &&
+      [...trimmed].every((character) => character === currentFence.marker)
+    ) {
+      fence = undefined
+    }
+  }
+
+  return result
+}

--- a/packages/tui/src/routes/session/markdown-lanes.ts
+++ b/packages/tui/src/routes/session/markdown-lanes.ts
@@ -1,29 +1,38 @@
 export type MarkdownLane = {
   content: string
-  width: "readable" | "code" | "wide"
+  width: "readable" | "technical" | "full"
 }
 
 export function markdownLanes(content: string): MarkdownLane[] {
   const result: MarkdownLane[] = []
   let fence: { marker: "`" | "~"; length: number } | undefined
+  let table = false
+  const lines = content.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? []
 
-  for (const line of content.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? []) {
+  for (const [index, line] of lines.entries()) {
     const opening = fence ? undefined : line.match(/^ {0,3}(`{3,}|~{3,})([^\n]*)/)
     const marker = opening?.[1]
+    const tableOpening = !opening && !fence && isTableRow(line) && isTableDelimiter(lines[index + 1])
     if (marker) fence = { marker: marker.startsWith("`") ? "`" : "~", length: marker.length }
+    if (tableOpening) table = true
 
     const width = opening
       ? opening[2]?.trim().split(/\s/, 1)[0]?.toLowerCase() === "mermaid"
-        ? "wide"
-        : "code"
+        ? "full"
+        : "technical"
       : fence
-        ? (result.at(-1)?.width ?? "code")
-        : "readable"
+        ? (result.at(-1)?.width ?? "technical")
+        : table
+          ? "technical"
+          : "readable"
     const previous = result.at(-1)
     if (previous?.width === width) previous.content += line
     else result.push({ content: line, width })
 
-    if (!fence) continue
+    if (!fence) {
+      if (table && !isTableRow(lines[index + 1])) table = false
+      continue
+    }
     const currentFence = fence
     const trimmed = line.trim()
     if (
@@ -39,7 +48,18 @@ export function markdownLanes(content: string): MarkdownLane[] {
   return result
 }
 
+function isTableRow(line: string | undefined) {
+  return Boolean(line?.trim() && line.includes("|"))
+}
+
+function isTableDelimiter(line: string | undefined) {
+  if (!line) return false
+  const value = line.trim().replace(/^\||\|$/g, "")
+  const cells = value.split("|")
+  return cells.length > 1 && cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()))
+}
+
 export function markdownLaneMarginTop(index: number, width: MarkdownLane["width"]) {
-  if (index === 0 || width === "wide") return 0
+  if (index === 0 || width === "full") return 0
   return 1
 }

--- a/packages/tui/src/ui/layout.ts
+++ b/packages/tui/src/ui/layout.ts
@@ -1,6 +1,16 @@
 export const SESSION_SIDEBAR_WIDTH = 42
+export const SESSION_TECHNICAL_LANE_WIDTH = 88
 const SESSION_CONTENT_MIN_WIDTH = 44
 
 export function sessionTabsFitVertically(total: number) {
   return total >= SESSION_SIDEBAR_WIDTH + SESSION_CONTENT_MIN_WIDTH
+}
+
+export function sessionLaneLayout(available: number, readable: number) {
+  const technical = Math.min(available, Math.max(readable, SESSION_TECHNICAL_LANE_WIDTH))
+  return {
+    inset: Math.max(0, Math.floor((available - technical) / 2)),
+    readable: Math.min(readable, technical),
+    technical,
+  }
 }

--- a/packages/tui/src/ui/layout.ts
+++ b/packages/tui/src/ui/layout.ts
@@ -1,6 +1,13 @@
 export const SESSION_SIDEBAR_WIDTH = 42
 const SESSION_CONTENT_MIN_WIDTH = 44
+const SESSION_CONTENT_PADDING = 4
 
 export function sessionTabsFitVertically(total: number) {
   return total >= SESSION_SIDEBAR_WIDTH + SESSION_CONTENT_MIN_WIDTH
+}
+
+export function sessionContentWidth(total: number, sidebar: boolean, maxWidth: number | "auto" = "auto") {
+  const available = total - (sidebar ? SESSION_SIDEBAR_WIDTH : 0) - SESSION_CONTENT_PADDING
+  if (maxWidth === "auto") return available
+  return Math.max(1, Math.min(available, maxWidth - SESSION_CONTENT_PADDING))
 }

--- a/packages/tui/src/ui/layout.ts
+++ b/packages/tui/src/ui/layout.ts
@@ -6,10 +6,13 @@ export function sessionTabsFitVertically(total: number) {
   return total >= SESSION_SIDEBAR_WIDTH + SESSION_CONTENT_MIN_WIDTH
 }
 
+// The shared spine centers the prose measure; the technical rail shares its
+// leading edge and extends rightward, clamped so it still fits the canvas.
 export function sessionLaneLayout(available: number, readable: number) {
   const technical = Math.min(available, Math.max(readable, SESSION_TECHNICAL_LANE_WIDTH))
+  const centered = Math.floor((available - Math.min(readable, technical)) / 2)
   return {
-    inset: Math.max(0, Math.floor((available - technical) / 2)),
+    inset: Math.max(0, Math.min(centered, available - technical)),
     readable: Math.min(readable, technical),
     technical,
   }

--- a/packages/tui/src/ui/layout.ts
+++ b/packages/tui/src/ui/layout.ts
@@ -1,13 +1,6 @@
 export const SESSION_SIDEBAR_WIDTH = 42
 const SESSION_CONTENT_MIN_WIDTH = 44
-const SESSION_CONTENT_PADDING = 4
 
 export function sessionTabsFitVertically(total: number) {
   return total >= SESSION_SIDEBAR_WIDTH + SESSION_CONTENT_MIN_WIDTH
-}
-
-export function sessionContentWidth(total: number, sidebar: boolean, maxWidth: number | "auto" = "auto") {
-  const available = total - (sidebar ? SESSION_SIDEBAR_WIDTH : 0) - SESSION_CONTENT_PADDING
-  if (maxWidth === "auto") return available
-  return Math.max(1, Math.min(available, maxWidth - SESSION_CONTENT_PADDING))
 }

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -10,6 +10,7 @@ import {
   parseQuestionAnswers,
   parseQuestions,
   toolDisplay,
+  toolLane,
 } from "../../../src/routes/session"
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined
@@ -131,6 +132,11 @@ describe("TUI inline tool wrapping", () => {
     expect(toolDisplay("apply_patch")).toBe("patch")
     expect(toolDisplay("patch")).toBe("patch")
     expect(toolDisplay("plugin_tool")).toBe("generic")
+    expect(toolLane("glob")).toBe("readable")
+    expect(toolLane("webfetch")).toBe("readable")
+    expect(toolLane("shell")).toBe("technical")
+    expect(toolLane("apply_patch")).toBe("technical")
+    expect(toolLane("plugin_tool")).toBe("technical")
   })
 
   test("replaces pending copy when a tool fails before completion", async () => {

--- a/packages/tui/test/cli/tui/markdown-lanes.test.ts
+++ b/packages/tui/test/cli/tui/markdown-lanes.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { markdownLanes } from "../../../src/routes/session/markdown-lanes"
+import { markdownLaneMarginTop, markdownLanes } from "../../../src/routes/session/markdown-lanes"
 
 test("keeps prose in the readable lane", () => {
   expect(markdownLanes("Before\n\nAfter")).toEqual([{ content: "Before\n\nAfter", width: "readable" }])
@@ -46,4 +46,11 @@ test("gives ordinary fenced code an intermediate lane", () => {
   expect(markdownLanes("```ts\nexport const value = true\n```")).toEqual([
     { content: "```ts\nexport const value = true\n```", width: "code" },
   ])
+})
+
+test("restores spacing between separately rendered blocks", () => {
+  expect(markdownLaneMarginTop(0, "readable")).toBe(0)
+  expect(markdownLaneMarginTop(1, "code")).toBe(1)
+  expect(markdownLaneMarginTop(2, "readable")).toBe(1)
+  expect(markdownLaneMarginTop(1, "wide")).toBe(0)
 })

--- a/packages/tui/test/cli/tui/markdown-lanes.test.ts
+++ b/packages/tui/test/cli/tui/markdown-lanes.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { markdownLanes } from "../../../src/routes/session/markdown-lanes"
+
+test("keeps prose in the readable lane", () => {
+  expect(markdownLanes("Before\n\nAfter")).toEqual([{ content: "Before\n\nAfter", width: "readable" }])
+})
+
+test("moves fenced blocks into the wide lane", () => {
+  expect(
+    markdownLanes(`Before
+
+\`\`\`mermaid
+flowchart LR
+  A --> B
+\`\`\`
+
+After`),
+  ).toEqual([
+    { content: "Before\n\n", width: "readable" },
+    { content: "```mermaid\nflowchart LR\n  A --> B\n```\n", width: "wide" },
+    { content: "\nAfter", width: "readable" },
+  ])
+})
+
+test("keeps an incomplete streaming fence wide", () => {
+  expect(markdownLanes("Before\n```mermaid\nflowchart LR\n  A -->")).toEqual([
+    { content: "Before\n", width: "readable" },
+    { content: "```mermaid\nflowchart LR\n  A -->", width: "wide" },
+  ])
+})
+
+test("supports tilde fences and longer closing fences", () => {
+  expect(markdownLanes("~~~ts\nconst value = 1\n~~~~\nAfter")).toEqual([
+    { content: "~~~ts\nconst value = 1\n~~~~\n", width: "code" },
+    { content: "After", width: "readable" },
+  ])
+})
+
+test("does not close a fence indented as code", () => {
+  expect(markdownLanes("```ts\n    ```\nstill code")).toEqual([
+    { content: "```ts\n    ```\nstill code", width: "code" },
+  ])
+})
+
+test("gives ordinary fenced code an intermediate lane", () => {
+  expect(markdownLanes("```ts\nexport const value = true\n```")).toEqual([
+    { content: "```ts\nexport const value = true\n```", width: "code" },
+  ])
+})

--- a/packages/tui/test/cli/tui/markdown-lanes.test.ts
+++ b/packages/tui/test/cli/tui/markdown-lanes.test.ts
@@ -5,7 +5,7 @@ test("keeps prose in the readable lane", () => {
   expect(markdownLanes("Before\n\nAfter")).toEqual([{ content: "Before\n\nAfter", width: "readable" }])
 })
 
-test("moves fenced blocks into the wide lane", () => {
+test("moves Mermaid fences into the full lane", () => {
   expect(
     markdownLanes(`Before
 
@@ -17,40 +17,52 @@ flowchart LR
 After`),
   ).toEqual([
     { content: "Before\n\n", width: "readable" },
-    { content: "```mermaid\nflowchart LR\n  A --> B\n```\n", width: "wide" },
+    { content: "```mermaid\nflowchart LR\n  A --> B\n```\n", width: "full" },
     { content: "\nAfter", width: "readable" },
   ])
 })
 
-test("keeps an incomplete streaming fence wide", () => {
+test("keeps an incomplete streaming Mermaid fence full width", () => {
   expect(markdownLanes("Before\n```mermaid\nflowchart LR\n  A -->")).toEqual([
     { content: "Before\n", width: "readable" },
-    { content: "```mermaid\nflowchart LR\n  A -->", width: "wide" },
+    { content: "```mermaid\nflowchart LR\n  A -->", width: "full" },
   ])
 })
 
 test("supports tilde fences and longer closing fences", () => {
   expect(markdownLanes("~~~ts\nconst value = 1\n~~~~\nAfter")).toEqual([
-    { content: "~~~ts\nconst value = 1\n~~~~\n", width: "code" },
+    { content: "~~~ts\nconst value = 1\n~~~~\n", width: "technical" },
     { content: "After", width: "readable" },
   ])
 })
 
 test("does not close a fence indented as code", () => {
   expect(markdownLanes("```ts\n    ```\nstill code")).toEqual([
-    { content: "```ts\n    ```\nstill code", width: "code" },
+    { content: "```ts\n    ```\nstill code", width: "technical" },
   ])
 })
 
 test("gives ordinary fenced code an intermediate lane", () => {
   expect(markdownLanes("```ts\nexport const value = true\n```")).toEqual([
-    { content: "```ts\nexport const value = true\n```", width: "code" },
+    { content: "```ts\nexport const value = true\n```", width: "technical" },
   ])
+})
+
+test("gives Markdown tables the technical lane", () => {
+  expect(markdownLanes("Before\n\n| Name | Value |\n| --- | ---: |\n| Width | 88 |\n\nAfter")).toEqual([
+    { content: "Before\n\n", width: "readable" },
+    { content: "| Name | Value |\n| --- | ---: |\n| Width | 88 |\n", width: "technical" },
+    { content: "\nAfter", width: "readable" },
+  ])
+})
+
+test("does not treat ordinary pipe characters as a table", () => {
+  expect(markdownLanes("Use foo | bar in prose.")).toEqual([{ content: "Use foo | bar in prose.", width: "readable" }])
 })
 
 test("restores spacing between separately rendered blocks", () => {
   expect(markdownLaneMarginTop(0, "readable")).toBe(0)
-  expect(markdownLaneMarginTop(1, "code")).toBe(1)
+  expect(markdownLaneMarginTop(1, "technical")).toBe(1)
   expect(markdownLaneMarginTop(2, "readable")).toBe(1)
-  expect(markdownLaneMarginTop(1, "wide")).toBe(0)
+  expect(markdownLaneMarginTop(1, "full")).toBe(0)
 })

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -27,6 +27,15 @@ test("validates the session tabs setting", () => {
   expect(decode({ session: { image_preview: true } })).toEqual({ session: { image_preview: true } })
 })
 
+test("validates the session max width setting", () => {
+  const decode = Schema.decodeUnknownSync(Info)
+
+  expect(decode({ session: { max_width: "auto" } })).toEqual({ session: { max_width: "auto" } })
+  expect(decode({ session: { max_width: 100 } })).toEqual({ session: { max_width: 100 } })
+  expect(() => decode({ session: { max_width: 4 } })).toThrow()
+  expect(() => decode({ session: { max_width: 100.5 } })).toThrow()
+})
+
 test("resolves nested config and keybind defaults", () => {
   const config = resolve(
     {
@@ -51,6 +60,13 @@ test("shows resolved tab defaults in settings", () => {
   expect(settings.find((setting) => setting.path.join(".") === "tabs.enabled")?.default).toBe(true)
   expect(settings.find((setting) => setting.path.join(".") === "tabs.scope")?.default).toBe("cwd")
   expect(settings.find((setting) => setting.path.join(".") === "tabs.layout")?.default).toBe("horizontal")
+})
+
+test("shows session max width presets in settings", () => {
+  const setting = settings.find((setting) => setting.path.join(".") === "session.max_width")
+
+  expect(setting?.default).toBe("auto")
+  expect(setting?.values).toEqual(["auto", 80, 100, 120])
 })
 
 test("provides config and its host interface", async () => {

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -62,11 +62,11 @@ test("shows resolved tab defaults in settings", () => {
   expect(settings.find((setting) => setting.path.join(".") === "tabs.layout")?.default).toBe("horizontal")
 })
 
-test("shows session max width presets in settings", () => {
+test("shows session reading width presets in settings", () => {
   const setting = settings.find((setting) => setting.path.join(".") === "session.max_width")
 
   expect(setting?.default).toBe("auto")
-  expect(setting?.values).toEqual(["auto", 80, 100, 120])
+  expect(setting?.values).toEqual(["auto", 66, 72, 80])
 })
 
 test("provides config and its host interface", async () => {

--- a/packages/tui/test/ui/layout.test.ts
+++ b/packages/tui/test/ui/layout.test.ts
@@ -1,8 +1,18 @@
 import { expect, test } from "bun:test"
-import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../src/ui/layout"
+import { sessionContentWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../src/ui/layout"
 
 test("vertical tabs match the session sidebar and preserve compact content width", () => {
   expect(SESSION_SIDEBAR_WIDTH).toBe(42)
   expect(sessionTabsFitVertically(86)).toBe(true)
   expect(sessionTabsFitVertically(85)).toBe(false)
+})
+
+test("session content uses available width by default", () => {
+  expect(sessionContentWidth(160, false)).toBe(156)
+  expect(sessionContentWidth(160, true)).toBe(114)
+})
+
+test("session content caps wide sessions and preserves narrow sessions", () => {
+  expect(sessionContentWidth(160, false, 100)).toBe(96)
+  expect(sessionContentWidth(80, false, 100)).toBe(76)
 })

--- a/packages/tui/test/ui/layout.test.ts
+++ b/packages/tui/test/ui/layout.test.ts
@@ -1,18 +1,8 @@
 import { expect, test } from "bun:test"
-import { sessionContentWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../src/ui/layout"
+import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../src/ui/layout"
 
 test("vertical tabs match the session sidebar and preserve compact content width", () => {
   expect(SESSION_SIDEBAR_WIDTH).toBe(42)
   expect(sessionTabsFitVertically(86)).toBe(true)
   expect(sessionTabsFitVertically(85)).toBe(false)
-})
-
-test("session content uses available width by default", () => {
-  expect(sessionContentWidth(160, false)).toBe(156)
-  expect(sessionContentWidth(160, true)).toBe(114)
-})
-
-test("session content caps wide sessions and preserves narrow sessions", () => {
-  expect(sessionContentWidth(160, false, 100)).toBe(96)
-  expect(sessionContentWidth(80, false, 100)).toBe(76)
 })

--- a/packages/tui/test/ui/layout.test.ts
+++ b/packages/tui/test/ui/layout.test.ts
@@ -1,8 +1,20 @@
 import { expect, test } from "bun:test"
-import { sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "../../src/ui/layout"
+import {
+  sessionLaneLayout,
+  sessionTabsFitVertically,
+  SESSION_SIDEBAR_WIDTH,
+  SESSION_TECHNICAL_LANE_WIDTH,
+} from "../../src/ui/layout"
 
 test("vertical tabs match the session sidebar and preserve compact content width", () => {
   expect(SESSION_SIDEBAR_WIDTH).toBe(42)
   expect(sessionTabsFitVertically(86)).toBe(true)
   expect(sessionTabsFitVertically(85)).toBe(false)
+})
+
+test("session lanes share one leading edge", () => {
+  expect(SESSION_TECHNICAL_LANE_WIDTH).toBe(88)
+  expect(sessionLaneLayout(156, 66)).toEqual({ inset: 34, readable: 66, technical: 88 })
+  expect(sessionLaneLayout(80, 66)).toEqual({ inset: 0, readable: 66, technical: 80 })
+  expect(sessionLaneLayout(60, 66)).toEqual({ inset: 0, readable: 60, technical: 60 })
 })

--- a/packages/tui/test/ui/layout.test.ts
+++ b/packages/tui/test/ui/layout.test.ts
@@ -12,9 +12,12 @@ test("vertical tabs match the session sidebar and preserve compact content width
   expect(sessionTabsFitVertically(85)).toBe(false)
 })
 
-test("session lanes share one leading edge", () => {
+test("session lanes center the prose measure on one leading edge", () => {
   expect(SESSION_TECHNICAL_LANE_WIDTH).toBe(88)
-  expect(sessionLaneLayout(156, 66)).toEqual({ inset: 34, readable: 66, technical: 88 })
+  // Wide canvas: prose is truly centered, technical extends rightward.
+  expect(sessionLaneLayout(156, 66)).toEqual({ inset: 45, readable: 66, technical: 88 })
+  // Centering the prose would push the technical rail past the canvas; clamp.
+  expect(sessionLaneLayout(100, 66)).toEqual({ inset: 12, readable: 66, technical: 88 })
   expect(sessionLaneLayout(80, 66)).toEqual({ inset: 0, readable: 66, technical: 80 })
   expect(sessionLaneLayout(60, 66)).toEqual({ inset: 0, readable: 60, technical: 60 })
 })


### PR DESCRIPTION
## What

Adds opt-in, content-aware reading widths for V2 TUI sessions. Wide terminals no longer require one compromise width for every kind of content:

- One centered 88-column document rail establishes a shared leading spine.
- Prose, user messages, tool/status rows, summaries, errors, and the composer use the first configured reading-width columns of that rail.
- Code, tables, shell/JSON output, and unified diffs extend rightward through the technical rail.
- Mermaid diagrams keep their intrinsic width and can break out rightward into the remaining canvas.

`session.max_width` accepts `"auto"` or a numeric reading width. `/settings` exposes 66, 72, and 80-column presets based on established typography guidance: [Bringhurst's 45–75 character range](https://webtypography.net/2.1.2), [Baymard's 50–75 range](https://baymard.com/blog/line-length-readability), and [Google's 80-column code guidance](https://developers.google.com/style/code-samples).

## How

- `packages/tui/src/config/index.tsx` defines and validates `session.max_width`.
- `packages/tui/src/component/dialog-config.tsx` exposes the reading-width presets.
- `packages/tui/src/routes/session/index.tsx` centers one technical rail and aligns every narrower or wider transcript block to its leading spine.
- `packages/tui/src/routes/session/markdown-lanes.ts` separates prose, tables, ordinary fences, and Mermaid fences without disrupting streamed Markdown rendering.
- `packages/merman/src/markdown.ts` preserves intrinsic diagram width and horizontal drag/scroll while leaving alignment to the transcript grid.

```mermaid
flowchart LR
  A[Session content] --> B{Content kind}
  B -->|Prose, tools, status| C[Reading measure on shared spine]
  B -->|Code, tables, shell, JSON, diffs| D[88-column technical rail]
  B -->|Mermaid| E[Intrinsic width or rightward breakout]
```

## Scope

This remains opt-in. Existing configurations retain the original render path through the `auto` default: no lane scan, segmentation, or layout wrappers. Explicit split-diff configuration is preserved; otherwise constrained sessions use unified diffs in the technical lane.

## Testing

- `bun run test` in `packages/tui`: 639 passed, 5 skipped
- `bun run test` in `packages/merman`: 286 passed
- `bun typecheck` in `packages/tui`
- Pre-push workspace typecheck: 33 packages passed
- OpenCode Drive run at 160 columns exercised every lane across prose, tools, an error, shell output, a diff, a table, TypeScript, JSON, and Mermaid

## Demo

Simulated OpenCode Drive session showing the shared leading spine across prose, tools, status, error, shell output, unified diff, table, TypeScript, and JSON, followed by both an intrinsic-width Mermaid diagram and a wider rightward breakout:

https://github.com/user-attachments/assets/8ebd5a9f-f52e-433d-ac53-dddeb92f83e4
