### PR TITLE
fix(acp): avoid implicit model variant

### DIFF
--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -422,8 +422,7 @@ async function loadCatalog(client: OpenCodeClient, cwd: string): Promise<Catalog
         defaultModel: {
           providerID: defaultModel.providerID,
           id: defaultModel.id,
-          variant:
-            defaultModel.variants.find((variant) => variant.id === "default")?.id ?? defaultModel.variants[0]?.id,
+          variant: defaultModel.variants.find((variant) => variant.id === "default")?.id,
         },
         modes: agents.map((agent) => ({ id: agent.id, name: agent.name, description: agent.description })),
         defaultModeID: defaultAgent.id,

--- a/packages/cli/test/acp/service-lifecycle.test.ts
+++ b/packages/cli/test/acp/service-lifecycle.test.ts
@@ -3,6 +3,38 @@ import type { SessionConfigOption } from "@agentclientprotocol/sdk"
 import { makeACPFixture, makeSession, secondModel } from "./service-fixture"
 
 describe("acp service lifecycle", () => {
+  test("does not persist the first catalog variant when no explicit default exists", async () => {
+    const model = { ...secondModel, variants: [{ id: "none" }, { id: "high" }] }
+    await using fixture = makeACPFixture({
+      models: [model],
+      defaultModel: model,
+      fetch(request) {
+        if (request.method === "POST" && request.path === "/api/session") {
+          return Response.json({
+            data: makeSession("ses_default_variant", {
+              model: { providerID: model.providerID, id: model.id },
+            }),
+          })
+        }
+        return undefined
+      },
+    })
+
+    const created = await fixture.service.newSession({ cwd: "/workspace", mcpServers: [] })
+
+    expect(fixture.requests).toContainEqual({
+      method: "POST",
+      path: "/api/session",
+      query: {},
+      body: {
+        location: { directory: "/workspace" },
+        agent: "build",
+        model: { providerID: "test", id: "second-model" },
+      },
+    })
+    expect(currentValue(created, "effort")).toBe("none")
+  })
+
   test("loads and forks with paginated replay while resume does not replay", async () => {
     await using fixture = makeACPFixture({
       fetch(request) {


### PR DESCRIPTION
## What

Stop ACP session creation from selecting and persisting the first model catalog variant when the model does not declare an explicit `default` variant.

Closes #41323

## Before / After

**Before:** When an ACP client created a session for a model whose catalog variants began with `none` but contained no `default`, ACP sent `variant: "none"` in the session model. Zen then forwarded that unsolicited reasoning effort to an upstream endpoint that rejects `none`, so every prompt failed with HTTP 400 before model execution.

**After:** ACP leaves the session model variant undefined unless the catalog explicitly declares `default`. The effort config option still lists the catalog variants and displays the first available choice when no variant has been selected, preserving the existing ACP control surface without persisting that display fallback.

## How

- `packages/cli/src/acp/service.ts` now resolves only an explicitly declared `default` variant for the default model reference.
- `packages/cli/test/acp/service-lifecycle.test.ts` verifies that a catalog beginning with `none` produces a session-create request with no variant while the effort control continues to display `none`.

## Scope

This does not alter models.dev catalog metadata, remap provider-specific effort names, or change explicitly selected/default variants. It only removes ACP's implicit first-variant persistence during session creation.

## Testing

- `bun run test test/acp/service-lifecycle.test.ts` (5 passed)
- `bun run test test/acp/service.test.ts test/acp/service-directory.test.ts test/acp/service-lifecycle.test.ts test/acp/service-usage.test.ts test/acp/config-option.test.ts test/acp/config-options.subprocess.test.ts` (29 passed)
- `bun typecheck` from `packages/cli` (passed)
- Push hook workspace typecheck (33 packages passed)
- `bun run test test/acp` (93 passed, 1 unrelated failure: `test/acp/command.test.ts` parses malformed subprocess NDJSON; reproduced in isolation)
