### PR TITLE
fix(server): await models before listing

### DIFF
--- a/packages/server/src/handlers/model.ts
+++ b/packages/server/src/handlers/model.ts
@@ -12,6 +12,19 @@ export const ModelHandler = HttpApiBuilder.group(Api, "server.model", (handlers)
       .handle(
         "model.list",
         Effect.fn(function* () {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush.pipe(
+            Effect.timeoutOrElse({
+              duration: "5 seconds",
+              orElse: () =>
+                Effect.fail(
+                  new ServiceUnavailableError({
+                    message: "Model catalog initialization timed out",
+                    service: "model.catalog",
+                  }),
+                ),
+            }),
+          )
           const catalog = yield* Catalog.Service
           return yield* response(catalog.model.available())
         }),

--- a/packages/server/test/model.test.ts
+++ b/packages/server/test/model.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { ServerProcess } from "../src/process"
+
+it.live("waits for plugin initialization before listing models", () =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => tmpdir("opencode-model-endpoint-")),
+    (tmp) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() =>
+          fs.writeFile(
+            path.join(tmp.path, "opencode.json"),
+            JSON.stringify({
+              providers: {
+                custom: {
+                  package: "aisdk:@ai-sdk/openai-compatible",
+                  settings: { apiKey: "secret" },
+                  models: { chat: {} },
+                },
+              },
+            }),
+          ),
+        )
+        const server = yield* ServerProcess.start<never, never>({
+          hostname: "127.0.0.1",
+          port: 0,
+          password: "secret",
+          app: { version: "test-version" },
+          database: { path: ":memory:" },
+          config: { directory: tmp.path },
+          fs: { filewatcher: false },
+        })
+        const url = new URL("/api/model", HttpServer.formatAddress(server.address))
+        url.searchParams.set("location[directory]", tmp.path)
+        const response = yield* Effect.promise(() =>
+          fetch(url, { headers: { authorization: `Basic ${btoa("opencode:secret")}` } }),
+        )
+
+        expect(response.status).toBe(200)
+        const body: unknown = yield* Effect.promise(() => response.json())
+        if (!isRecord(body) || !Array.isArray(body["data"])) throw new Error("Expected a model list response")
+        expect(
+          body["data"].some((model) => isRecord(model) && model["providerID"] === "custom" && model["id"] === "chat"),
+        ).toBeTrue()
+      }),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ),
+)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## What

Make the first `model.list` request against a newly started server wait for model-providing plugins to finish initializing. This restores `opencode models --standalone` output on cold start instead of silently returning no models.

Closes #41071

## Before / After

**Before:** A standalone server became HTTP-ready while `PluginSupervisor` was still activating the initial plugin generation. An immediate `model.list` request read the empty `Catalog`, returned HTTP 200 with `data: []`, and the CLI printed nothing before exiting 0.

**After:** `model.list` waits for `PluginSupervisor.flush` before reading the catalog, matching the existing `model.default` readiness boundary. If initialization does not settle within five seconds, the endpoint returns the existing model-catalog service-unavailable error rather than a successful empty response.

## How

- `packages/server/src/handlers/model.ts` applies the existing bounded model-catalog initialization wait to `model.list`.
- `packages/server/test/model.test.ts` starts a fresh server with a configured custom model and immediately requests `/api/model`, asserting that the cold-start response includes that model.

## Scope

- No CLI output or exit-code behavior changes are needed; the fix is at the server model-list consistency boundary.
- No protocol or generated-client surfaces change.
- Provider loading and plugin supervision behavior are unchanged.

## Testing

- `bun run test test/model.test.ts --rerun-each 3` from `packages/server` (3 passes)
- `bun run test` from `packages/server` (18 passes, 11 skips)
- `bun typecheck` from `packages/server`
- Push hook: `bun turbo typecheck --concurrency=3` (33 successful tasks)
- `bunx prettier --check src/handlers/model.ts test/model.test.ts` from `packages/server`

The regression test was also run before the handler change and reproduced the bug as HTTP 200 with `{ "data": [] }`.
