### PR TITLE
fix(core): discover local plugin packages

### DIFF
--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -4,7 +4,7 @@ import { Directory, Document, type Entry } from "@opencode-ai/schema/config"
 import { ConfigPlugin } from "@opencode-ai/schema/config/plugin"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Effect, Layer, Option, PubSub, Schema, Scope, Stream } from "effect"
+import { Context, Effect, Layer, Option, Predicate, PubSub, Schema, Scope, Stream } from "effect"
 import path from "path"
 import { fileURLToPath } from "url"
 import { Config } from "../../config"
@@ -163,29 +163,30 @@ const decodePackage = Schema.decodeUnknownOption(Package)
 
 function discoverDirectory(fs: FSUtil.Interface, directory: string) {
   return Effect.gen(function* () {
-    const files = yield* fs
-      .scan(`{${sourceDirectories.join(",")}}/*.{ts,js}`, {
-        cwd: directory,
-        absolute: true,
-        include: "file",
-        dot: true,
-        symlink: true,
-      })
-      .pipe(Effect.orElseSucceed(() => []))
-    const children = yield* fs
-      .scan(`{${sourceDirectories.join(",")}}/*`, {
-        cwd: directory,
-        absolute: true,
-        include: "all",
-        dot: true,
-        symlink: true,
-      })
-      .pipe(Effect.orElseSucceed(() => []))
-    const directories = yield* Effect.filter(children.sort(), fs.isDir)
-    const packages = yield* Effect.forEach(directories, (child) => discoverPackage(fs, child))
-    return [...files.sort(), ...packages.filter((target): target is string => typeof target === "string")].map(
-      (target): Operation => ({ type: "add", target, options: {} }),
-    )
+    const children = (yield* Effect.forEach(sourceDirectories, (source) =>
+      fs.readDirectoryEntries(path.join(directory, source)).pipe(
+        Effect.orElseSucceed(() => []),
+        Effect.map((entries) =>
+          entries.map((entry) => ({ ...entry, target: path.join(directory, source, entry.name) })),
+        ),
+      ),
+    ))
+      .flat()
+      .sort((a, b) => a.target.localeCompare(b.target))
+    const targets = yield* Effect.forEach(children, (entry) => discoverChild(fs, entry))
+    return targets.flatMap(Option.toArray).map((target): Operation => ({ type: "add", target, options: {} }))
+  })
+}
+
+function discoverChild(fs: FSUtil.Interface, entry: FSUtil.DirEntry & { target: string }) {
+  return Effect.gen(function* () {
+    const source = entry.target.endsWith(".ts") || entry.target.endsWith(".js")
+    if (entry.type === "file" && source) return Option.some(entry.target)
+    if (entry.type === "directory") return yield* discoverPackage(fs, entry.target)
+    if (entry.type !== "symlink") return Option.none<string>()
+    if (source && (yield* fs.isFile(entry.target))) return Option.some(entry.target)
+    if (yield* fs.isDir(entry.target)) return yield* discoverPackage(fs, entry.target)
+    return Option.none<string>()
   })
 }
 
@@ -195,15 +196,15 @@ function discoverPackage(fs: FSUtil.Interface, directory: string) {
       .readJson(path.join(directory, "package.json"))
       .pipe(Effect.map(decodePackage), Effect.orElseSucceed(Option.none))
     const configured = Option.isSome(manifest)
-      ? [manifest.value.exports, manifest.value.module, manifest.value.main].filter(
-          (entry): entry is string => typeof entry === "string",
-        )
+      ? [manifest.value.exports, manifest.value.module, manifest.value.main].filter(Predicate.isString)
       : []
-    const target = yield* Effect.findFirst(
-      [...configured, "index.ts", "index.js"].map((entry) => path.resolve(directory, entry)),
+    return yield* Effect.findFirst(
+      [...configured, "index.ts", "index.js"]
+        .filter((entry) => !path.isAbsolute(entry))
+        .map((entry) => path.resolve(directory, entry))
+        .filter((entry) => FSUtil.contains(directory, entry)),
       fs.isFile,
     )
-    return Option.getOrUndefined(target)
   })
 }
 

--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -4,7 +4,7 @@ import { Directory, Document, type Entry } from "@opencode-ai/schema/config"
 import { ConfigPlugin } from "@opencode-ai/schema/config/plugin"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Effect, Layer, Option, PubSub, Scope, Stream } from "effect"
+import { Context, Effect, Layer, Option, PubSub, Schema, Scope, Stream } from "effect"
 import path from "path"
 import { fileURLToPath } from "url"
 import { Config } from "../../config"
@@ -154,6 +154,12 @@ const scan = Effect.fn("ConfigPluginSource.scan")(function* (
 })
 
 const sourceDirectories = ["plugin", "plugins"] as const
+const Package = Schema.Struct({
+  exports: Schema.optional(Schema.Unknown),
+  module: Schema.optional(Schema.Unknown),
+  main: Schema.optional(Schema.Unknown),
+})
+const decodePackage = Schema.decodeUnknownOption(Package)
 
 function discoverDirectory(fs: FSUtil.Interface, directory: string) {
   return Effect.gen(function* () {
@@ -166,7 +172,38 @@ function discoverDirectory(fs: FSUtil.Interface, directory: string) {
         symlink: true,
       })
       .pipe(Effect.orElseSucceed(() => []))
-    return files.sort().map((target): Operation => ({ type: "add", target, options: {} }))
+    const children = yield* fs
+      .scan(`{${sourceDirectories.join(",")}}/*`, {
+        cwd: directory,
+        absolute: true,
+        include: "all",
+        dot: true,
+        symlink: true,
+      })
+      .pipe(Effect.orElseSucceed(() => []))
+    const directories = yield* Effect.filter(children.sort(), fs.isDir)
+    const packages = yield* Effect.forEach(directories, (child) => discoverPackage(fs, child))
+    return [...files.sort(), ...packages.filter((target): target is string => typeof target === "string")].map(
+      (target): Operation => ({ type: "add", target, options: {} }),
+    )
+  })
+}
+
+function discoverPackage(fs: FSUtil.Interface, directory: string) {
+  return Effect.gen(function* () {
+    const manifest = yield* fs
+      .readJson(path.join(directory, "package.json"))
+      .pipe(Effect.map(decodePackage), Effect.orElseSucceed(Option.none))
+    const configured = Option.isSome(manifest)
+      ? [manifest.value.exports, manifest.value.module, manifest.value.main].filter(
+          (entry): entry is string => typeof entry === "string",
+        )
+      : []
+    const target = yield* Effect.findFirst(
+      [...configured, "index.ts", "index.js"].map((entry) => path.resolve(directory, entry)),
+      fs.isFile,
+    )
+    return Option.getOrUndefined(target)
   })
 }
 

--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -172,7 +172,7 @@ function discoverDirectory(fs: FSUtil.Interface, directory: string) {
       ),
     ))
       .flat()
-      .sort((a, b) => a.target.localeCompare(b.target))
+      .sort((a, b) => (a.target < b.target ? -1 : a.target > b.target ? 1 : 0))
     const targets = yield* Effect.forEach(children, (entry) => discoverChild(fs, entry))
     return targets.flatMap(Option.toArray).map((target): Operation => ({ type: "add", target, options: {} }))
   })
@@ -192,6 +192,7 @@ function discoverChild(fs: FSUtil.Interface, entry: FSUtil.DirEntry & { target: 
 
 function discoverPackage(fs: FSUtil.Interface, directory: string) {
   return Effect.gen(function* () {
+    const root = yield* fs.resolve(directory)
     const manifest = yield* fs
       .readJson(path.join(directory, "package.json"))
       .pipe(Effect.map(decodePackage), Effect.orElseSucceed(Option.none))
@@ -203,7 +204,16 @@ function discoverPackage(fs: FSUtil.Interface, directory: string) {
         .filter((entry) => !path.isAbsolute(entry))
         .map((entry) => path.resolve(directory, entry))
         .filter((entry) => FSUtil.contains(directory, entry)),
-      fs.isFile,
+      (entry) =>
+        fs
+          .isFile(entry)
+          .pipe(
+            Effect.flatMap((exists) =>
+              exists
+                ? fs.resolve(entry).pipe(Effect.map((resolved) => FSUtil.contains(root, resolved)))
+                : Effect.succeed(false),
+            ),
+          ),
     )
   })
 }

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -168,65 +168,60 @@ describe("PluginSupervisor config", () => {
     ),
   )
 
-  it.live("loads auto-discovered plugin packages from package metadata", () =>
-    withLocation(
-      undefined,
-      Effect.gen(function* () {
-        yield* ready()
-        const plugins = yield* Plugin.Service
-        expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("package-metadata")
-      }),
-      false,
-      async (directory) => {
-        const plugin = path.join(directory, ".opencode", "plugins", "package-metadata")
-        await fs.mkdir(plugin, { recursive: true })
-        await fs.writeFile(path.join(plugin, "package.json"), JSON.stringify({ exports: "./entry.ts" }))
-        await fs.writeFile(path.join(plugin, "entry.ts"), discoveredPlugin("package-metadata"))
-      },
-    ),
-  )
-
-  it.live("loads auto-discovered plugin packages from index fallback", () =>
-    withLocation(
-      undefined,
-      Effect.gen(function* () {
-        yield* ready()
-        const plugins = yield* Plugin.Service
-        expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("index-fallback")
-      }),
-      false,
-      async (directory) => {
-        const plugin = path.join(directory, ".opencode", "plugins", "index-fallback")
-        await fs.mkdir(plugin, { recursive: true })
-        await fs.writeFile(path.join(plugin, "index.js"), discoveredPlugin("index-fallback"))
-      },
-    ),
-  )
-
-  it.live("prefers package metadata over index fallback", () =>
+  it.live("loads auto-discovered plugin package entrypoints in order", () =>
     withLocation(
       undefined,
       Effect.gen(function* () {
         yield* ready()
         const plugins = yield* Plugin.Service
         const ids = (yield* plugins.list()).map((plugin) => String(plugin.id))
-        expect(ids).toContain("metadata-precedence")
-        expect(ids).not.toContain("module-collision")
-        expect(ids).not.toContain("main-collision")
-        expect(ids).not.toContain("index-collision")
+        expect(ids).toContain("package-exports")
+        expect(ids).toContain("package-module")
+        expect(ids).toContain("package-main")
+        expect(ids).toContain("package-index")
       }),
       false,
       async (directory) => {
-        const plugin = path.join(directory, ".opencode", "plugins", "collision")
-        await fs.mkdir(plugin, { recursive: true })
-        await fs.writeFile(
-          path.join(plugin, "package.json"),
-          JSON.stringify({ exports: "./entry.js", module: "./module.js", main: "./main.js" }),
+        await Promise.all([
+          writeDiscoveredPackage(directory, "exports", { exports: "./entry.ts" }, { "entry.ts": "package-exports" }),
+          writeDiscoveredPackage(
+            directory,
+            "module",
+            { exports: "./missing.js", module: "./entry.js" },
+            { "entry.js": "package-module" },
+          ),
+          writeDiscoveredPackage(
+            directory,
+            "main",
+            { exports: { import: "./missing.js" }, module: "./missing.js", main: "./entry.js" },
+            { "entry.js": "package-main" },
+          ),
+          writeDiscoveredPackage(directory, "index", undefined, { "index.js": "package-index" }),
+        ])
+      },
+    ),
+  )
+
+  it.live("keeps auto-discovered package entrypoints inside the package directory", () =>
+    withLocation(
+      undefined,
+      Effect.gen(function* () {
+        yield* ready()
+        const plugins = yield* Plugin.Service
+        const ids = (yield* plugins.list()).map((plugin) => String(plugin.id))
+        expect(ids).toContain("contained-fallback")
+        expect(ids).not.toContain("escaped-entrypoint")
+      }),
+      false,
+      async (directory) => {
+        await fs.mkdir(path.join(directory, ".opencode"), { recursive: true })
+        await fs.writeFile(path.join(directory, ".opencode", "escape.js"), discoveredPlugin("escaped-entrypoint"))
+        await writeDiscoveredPackage(
+          directory,
+          "contained",
+          { exports: "../../escape.js" },
+          { "index.js": "contained-fallback" },
         )
-        await fs.writeFile(path.join(plugin, "entry.js"), discoveredPlugin("metadata-precedence"))
-        await fs.writeFile(path.join(plugin, "module.js"), discoveredPlugin("module-collision"))
-        await fs.writeFile(path.join(plugin, "main.js"), discoveredPlugin("main-collision"))
-        await fs.writeFile(path.join(plugin, "index.js"), discoveredPlugin("index-collision"))
       },
     ),
   )
@@ -455,4 +450,18 @@ export default Plugin.define({
 
 function discoveredPlugin(id: string) {
   return `export default { id: ${JSON.stringify(id)}, setup() {} }`
+}
+
+async function writeDiscoveredPackage(
+  directory: string,
+  name: string,
+  manifest: Record<string, unknown> | undefined,
+  files: Record<string, string>,
+) {
+  const plugin = path.join(directory, ".opencode", "plugins", name)
+  await fs.mkdir(plugin, { recursive: true })
+  await Promise.all([
+    ...(manifest ? [fs.writeFile(path.join(plugin, "package.json"), JSON.stringify(manifest))] : []),
+    ...Object.entries(files).map(([file, id]) => fs.writeFile(path.join(plugin, file), discoveredPlugin(id))),
+  ])
 }

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -168,6 +168,69 @@ describe("PluginSupervisor config", () => {
     ),
   )
 
+  it.live("loads auto-discovered plugin packages from package metadata", () =>
+    withLocation(
+      undefined,
+      Effect.gen(function* () {
+        yield* ready()
+        const plugins = yield* Plugin.Service
+        expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("package-metadata")
+      }),
+      false,
+      async (directory) => {
+        const plugin = path.join(directory, ".opencode", "plugins", "package-metadata")
+        await fs.mkdir(plugin, { recursive: true })
+        await fs.writeFile(path.join(plugin, "package.json"), JSON.stringify({ exports: "./entry.ts" }))
+        await fs.writeFile(path.join(plugin, "entry.ts"), discoveredPlugin("package-metadata"))
+      },
+    ),
+  )
+
+  it.live("loads auto-discovered plugin packages from index fallback", () =>
+    withLocation(
+      undefined,
+      Effect.gen(function* () {
+        yield* ready()
+        const plugins = yield* Plugin.Service
+        expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("index-fallback")
+      }),
+      false,
+      async (directory) => {
+        const plugin = path.join(directory, ".opencode", "plugins", "index-fallback")
+        await fs.mkdir(plugin, { recursive: true })
+        await fs.writeFile(path.join(plugin, "index.js"), discoveredPlugin("index-fallback"))
+      },
+    ),
+  )
+
+  it.live("prefers package metadata over index fallback", () =>
+    withLocation(
+      undefined,
+      Effect.gen(function* () {
+        yield* ready()
+        const plugins = yield* Plugin.Service
+        const ids = (yield* plugins.list()).map((plugin) => String(plugin.id))
+        expect(ids).toContain("metadata-precedence")
+        expect(ids).not.toContain("module-collision")
+        expect(ids).not.toContain("main-collision")
+        expect(ids).not.toContain("index-collision")
+      }),
+      false,
+      async (directory) => {
+        const plugin = path.join(directory, ".opencode", "plugins", "collision")
+        await fs.mkdir(plugin, { recursive: true })
+        await fs.writeFile(
+          path.join(plugin, "package.json"),
+          JSON.stringify({ exports: "./entry.js", module: "./module.js", main: "./main.js" }),
+        )
+        await fs.writeFile(path.join(plugin, "entry.js"), discoveredPlugin("metadata-precedence"))
+        await fs.writeFile(path.join(plugin, "module.js"), discoveredPlugin("module-collision"))
+        await fs.writeFile(path.join(plugin, "main.js"), discoveredPlugin("main-collision"))
+        await fs.writeFile(path.join(plugin, "index.js"), discoveredPlugin("index-collision"))
+      },
+    ),
+  )
+
   staticIt.live("uses only internal and SDK plugins when the static source is wired", () =>
     Effect.gen(function* () {
       const sdk = yield* SdkPlugins.Service
@@ -388,4 +451,8 @@ export default Plugin.define({
   },
 })
 `
+}
+
+function discoveredPlugin(id: string) {
+  return `export default { id: ${JSON.stringify(id)}, setup() {} }`
 }

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -210,6 +210,7 @@ describe("PluginSupervisor config", () => {
         const plugins = yield* Plugin.Service
         const ids = (yield* plugins.list()).map((plugin) => String(plugin.id))
         expect(ids).toContain("contained-fallback")
+        expect(ids).toContain("symlink-fallback")
         expect(ids).not.toContain("escaped-entrypoint")
       }),
       false,
@@ -221,6 +222,16 @@ describe("PluginSupervisor config", () => {
           "contained",
           { exports: "../../escape.js" },
           { "index.js": "contained-fallback" },
+        )
+        await writeDiscoveredPackage(
+          directory,
+          "symlink",
+          { exports: "./entry.js" },
+          { "index.js": "symlink-fallback" },
+        )
+        await fs.symlink(
+          path.join(directory, ".opencode", "escape.js"),
+          path.join(directory, ".opencode", "plugins", "symlink", "entry.js"),
         )
       },
     ),


### PR DESCRIPTION
Closes #41530

## What

Discover local plugin packages placed as immediate child directories under `.opencode/plugin/` or `.opencode/plugins/`, matching the documented V2 local discovery behavior.

## Before / After

**Before:** OpenCode scanned only direct `.ts` and `.js` children. A directory such as `.opencode/plugins/reviewer/` was silently skipped even when `package.json` exposed `"exports": "./entry.ts"` or the directory contained `index.ts` / `index.js`.

**After:** OpenCode enumerates each discovery directory once and loads immediate child packages in deterministic code-unit order. It resolves the first existing contained entrypoint from string `exports`, `module`, `main`, `index.ts`, then `index.js`, while preserving direct-file and symlink discovery.

## How

- `packages/core/src/config/plugin/source.ts` uses `FSUtil.readDirectoryEntries` to classify immediate files, directories, and symlinks without overlapping globs.
- Package metadata is schema-decoded, candidate entrypoints must remain inside their package directory after real-path resolution, and the first existing candidate wins.
- `packages/core/test/config/plugin.test.ts` covers string `exports`, fallback through missing `exports` to `module`, fallback through missing `module` to `main`, `index.js`, lexical traversal rejection, and symlink escape rejection.

## Scope

- Does not recursively walk package contents or discover nested plugin packages.
- Does not add conditional/object `exports` or extensionless Node resolution; the documented and reported case is a string path to an existing entrypoint.
- Does not change explicit plugin configuration or npm package installation.

## Testing

- `bun run test test/config/plugin.test.ts` from `packages/core` (15 passed)
- `bun typecheck` from `packages/core`
- `bunx prettier --check packages/core/src/config/plugin/source.ts packages/core/test/config/plugin.test.ts`
- `git diff --check`
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks passed)
- Exact issue reproduction: started the worktree V2 server with isolated `OPENCODE_CONFIG_DIR`, queried `/api/plugin`, and observed both `repro.direct-file` and `repro.directory-package` after catalog initialization