### PR TITLE
fix(core): resolve Bedrock region templates

### DIFF
--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -254,7 +254,14 @@ function prepareRuntimeModel(model: Info, credential: Credential.Value | undefin
     if (credential?.type === "key" && credential.metadata !== undefined)
       draft.body = Provider.mergeOverlay(draft.body, credential.metadata)
     if (typeof draft.settings?.baseURL !== "string") return
+    const bedrockRegion =
+      Provider.isAISDK(draft.package) &&
+      Provider.packageName(draft.package) === "@ai-sdk/amazon-bedrock/mantle" &&
+      typeof draft.settings.region === "string"
+        ? draft.settings.region
+        : undefined
     draft.settings.baseURL = draft.settings.baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
+      if (name === "AWS_REGION" && bedrockRegion) return bedrockRegion
       return process.env[name] ?? placeholder
     })
   })

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -152,6 +152,28 @@ describe("ModelResolver", () => {
     }),
   )
 
+  it.effect("resolves the Bedrock Mantle catalog endpoint from the configured region", () =>
+    withEnv({ AWS_REGION: undefined }, () =>
+      Effect.gen(function* () {
+        const resolved = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
+            providerID: Provider.ID.amazonBedrock,
+            modelID: "openai.gpt-oss-120b",
+            settings: {
+              region: "us-west-2",
+              baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+            },
+          }),
+        )
+
+        expect(resolved.route).toMatchObject({
+          id: "bedrock-mantle-responses",
+          endpoint: { baseURL: "https://bedrock-mantle.us-west-2.api.aws/openai/v1" },
+        })
+      }),
+    ),
+  )
+
   it.effect("uses the API modelID instead of the catalog ID for native OpenAI routes", () =>
     Effect.gen(function* () {
       const catalog = model(Provider.aisdk("@ai-sdk/openai"), {


### PR DESCRIPTION
## What

Resolve Bedrock Mantle catalog endpoints containing `${AWS_REGION}` from the provider's configured `settings.region`, even when `AWS_REGION` is absent from the process environment.

Closes #40075

## Before / After

**Before:** A Bedrock config with `settings.region: "us-west-2"` and the catalog URL `https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1` failed during model resolution when `AWS_REGION` was unset. The generic unresolved-variable guard raised `UnresolvedProviderVariablesError` before the merged native Mantle route could construct or use its regional endpoint.

**After:** The known Bedrock Mantle `AWS_REGION` placeholder resolves from configured `settings.region` first. The native Responses/Chat provider receives `https://bedrock-mantle.us-west-2.api.aws/openai/v1`, with its endpoint and signing region aligned.

## How

- `packages/core/src/model-resolver.ts` recognizes only the Bedrock Mantle package and only the `AWS_REGION` placeholder, preferring configured region before the existing environment substitution pass.
- `packages/core/test/model-resolver.test.ts` covers the integrated catalog-to-native-provider path with configured region, no `AWS_REGION`, and the literal catalog template.
- The regression failed before the fix with `AWS_REGION is required to resolve the provider endpoint`.

## Scope

- Generic environment-template substitution semantics are unchanged for other packages and placeholders.
- Native Mantle routing remains in place; this does not revive the obsolete provider-plugin seam used by #40076.
- Credential provider callbacks are not projected into native serialized settings.
- This does not address the other templated catalog URLs mentioned in #40075.

## Testing

- `cd packages/core && bun run test test/model-resolver.test.ts test/aisdk-native.test.ts` (42 pass)
- `cd packages/core && bun typecheck`
- `cd packages/ai && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3` (33 tasks pass)
- `cd packages/ai && bun run test test/provider/bedrock-mantle.test.ts test/provider/bedrock-converse.test.ts test/provider-package.test.ts` (60 pass, 1 pre-existing failure in the unchanged `supports bearer authentication and custom base URLs` test, which receives an empty recorded response)
- `cd packages/core && bunx prettier --check src/model-resolver.ts test/model-resolver.test.ts`
