### PR TITLE
fix(app): use dedicated file manager icon on Linux

### DIFF
--- a/packages/app/src/components/session/open-in-app.tsx
+++ b/packages/app/src/components/session/open-in-app.tsx
@@ -104,7 +104,7 @@ export function detectOpenAppOS(platform: ReturnType<typeof usePlatform>): OpenA
 export function openAppFileManager(os: OpenAppOS) {
   if (os === "macos") return { label: "session.header.open.finder", icon: "finder" as const }
   if (os === "windows") return { label: "session.header.open.fileExplorer", icon: "file-explorer" as const }
-  return { label: "session.header.open.fileManager", icon: "finder" as const }
+  return { label: "session.header.open.fileManager", icon: "file-manager" as const }
 }
 
 export function openAppsForOS(os: OpenAppOS) {

--- a/packages/app/src/utils/file-manager.ts
+++ b/packages/app/src/utils/file-manager.ts
@@ -6,7 +6,7 @@ export function fileManagerApp(os: FileManagerOS): {
     | "session.header.reveal.finder"
     | "session.header.reveal.fileExplorer"
     | "session.header.reveal.containingFolder"
-  icon: "finder" | "file-explorer"
+  icon: "finder" | "file-explorer" | "file-manager"
 } {
   if (os === "macos")
     return { label: "session.header.open.finder", actionLabel: "session.header.reveal.finder", icon: "finder" }
@@ -19,6 +19,6 @@ export function fileManagerApp(os: FileManagerOS): {
   return {
     label: "session.header.open.fileManager",
     actionLabel: "session.header.reveal.containingFolder",
-    icon: "finder",
+    icon: "file-manager",
   }
 }

--- a/packages/ui/src/assets/icons/app/file-manager.svg
+++ b/packages/ui/src/assets/icons/app/file-manager.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+</svg>

--- a/packages/ui/src/components/app-icon.tsx
+++ b/packages/ui/src/components/app-icon.tsx
@@ -6,6 +6,7 @@ import androidStudio from "../assets/icons/app/android-studio.svg"
 import antigravity from "../assets/icons/app/antigravity.svg"
 import cursor from "../assets/icons/app/cursor.svg"
 import fileExplorer from "../assets/icons/app/file-explorer.svg"
+import fileManager from "../assets/icons/app/file-manager.svg"
 import finder from "../assets/icons/app/finder.png"
 import ghostty from "../assets/icons/app/ghostty.svg"
 import iterm2 from "../assets/icons/app/iterm2.svg"
@@ -24,6 +25,7 @@ const icons = {
   cursor,
   zed,
   "file-explorer": fileExplorer,
+  "file-manager": fileManager,
   finder,
   terminal,
   iterm2,

--- a/packages/ui/src/components/app-icons/types.ts
+++ b/packages/ui/src/components/app-icons/types.ts
@@ -5,6 +5,7 @@ export const iconNames = [
   "cursor",
   "zed",
   "file-explorer",
+  "file-manager",
   "finder",
   "terminal",
   "iterm2",


### PR DESCRIPTION
### Issue for this PR

Closes #12615

Replaces #12616 (the previous attempt was auto-closed after 60 days without updates).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Linux the "file manager" button in the session header and the V2 side panel showed the macOS Finder icon. There was no Linux-specific icon registered, so the Linux branch fell back to `finder`.

This PR adds a `file-manager` icon (Heroicons folder) to the app icon set and uses it for the Linux branch in both render paths (`utils/file-manager.ts` for the V1 header, `open-in-app.tsx` for the V2 side panel). The logic is the same as #12616, adapted to the current codebase.

### How did you verify your code works?

- `bun run --cwd packages/ui typecheck` passes
- `bun run --cwd packages/app typecheck` passes

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

Screenshot of the issue is in #12615 (the icon shown there is the exact behavior this PR fixes). The change is a single icon swap, so the before state is visible in the linked issue.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
