### PR TITLE
fix(console): preserve assistant content arrays

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -152,6 +152,13 @@ export function fromOpenaiRequest(body: any): CommonRequest {
       const c = (m as any).content
       const out: any = { role: "assistant" }
       if (typeof c === "string" && c.length > 0) out.content = c
+      if (Array.isArray(c)) {
+        const text = c
+          .filter((p: any) => p && p.type === "output_text" && typeof p.text === "string")
+          .map((p: any) => p.text)
+          .join("")
+        if (text.length > 0) out.content = text
+      }
       if (Array.isArray((m as any).tool_calls)) out.tool_calls = (m as any).tool_calls
       msgs.push(out)
       continue

--- a/packages/console/app/test/providerRequest.test.ts
+++ b/packages/console/app/test/providerRequest.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { fromOpenaiRequest } from "../src/routes/zen/util/provider/openai"
+
+describe("provider request conversion", () => {
+  test("preserves array-form OpenAI assistant content", () => {
+    expect(
+      fromOpenaiRequest({
+        model: "gpt-5",
+        input: [
+          {
+            role: "assistant",
+            content: [
+              { type: "output_text", text: "hello" },
+              { type: "output_text", text: " world" },
+            ],
+          },
+          { role: "user", content: "continue" },
+        ],
+      }).messages,
+    ).toEqual([
+      { role: "assistant", content: "hello world" },
+      { role: "user", content: "continue" },
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41766

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI Responses API assistant messages may provide content as an array of output_text parts. fromOpenaiRequest only preserved string content, so array-form messages were forwarded without content and rejected.

This change joins the output_text parts into assistant content while preserving existing tool calls. It also adds regression coverage for multi-part assistant content.

### How did you verify your code works?

- Added a regression test confirming that multiple output_text parts become hello world.
- Ran bun test test/providerRequest.test.ts from packages/console/app.
- Ran bun typecheck from packages/console/app.
- Passed the pre-push repository typecheck across 30 packages.

### Screenshots / recordings

Not applicable; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR