### PR TITLE
refactor(core): reuse plugin source discovery

### DIFF
--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -117,7 +117,7 @@ function parse(input: ConfigPlugin.Plugin): Operation {
   return { type: "remove", target: input.slice(1) }
 }
 
-export const scan = Effect.fn("ConfigPluginSource.scan")(function* (
+const scan = Effect.fn("ConfigPluginSource.scan")(function* (
   fs: FSUtil.Interface,
   location: Location.Interface,
   entries: readonly Entry[],

--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -117,7 +117,7 @@ function parse(input: ConfigPlugin.Plugin): Operation {
   return { type: "remove", target: input.slice(1) }
 }
 
-const scan = Effect.fn("ConfigPluginSource.scan")(function* (
+export const scan = Effect.fn("ConfigPluginSource.scan")(function* (
   fs: FSUtil.Interface,
   location: Location.Interface,
   entries: readonly Entry[],

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -17,6 +17,7 @@ import { ConfigProviderPlugin } from "../config/plugin/provider"
 import { ConfigPolicyPlugin } from "../config/plugin/policy"
 import { ConfigReferencePlugin } from "../config/plugin/reference"
 import { ConfigSkillPlugin } from "../config/plugin/skill"
+import { ConfigPluginSource } from "../config/plugin/source"
 import { ConfigWebSearchPlugin } from "../config/plugin/websearch"
 import { Bus } from "../bus"
 import { Environment } from "../environment"
@@ -76,6 +77,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const command = yield* Command.Service
   const config = yield* Config.Service
   const credential = yield* Credential.Service
+  const pluginSources = yield* ConfigPluginSource.Service
   const bus = yield* Bus.Service
   const environment = yield* Environment.Service
   const mutation = yield* FileMutation.Service
@@ -112,6 +114,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Command.Service, command),
     Context.make(Config.Service, config),
     Context.make(Credential.Service, credential),
+    Context.make(ConfigPluginSource.Service, pluginSources),
     Context.make(Bus.Service, bus),
     Context.make(Environment.Service, environment),
     Context.make(FileMutation.Service, mutation),
@@ -155,6 +158,7 @@ export const requirements = LayerNode.group([
   Command.node,
   Config.node,
   Credential.node,
+  ConfigPluginSource.node,
   Bus.node,
   Environment.node,
   FileMutation.node,

--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -6,10 +6,7 @@ import { define, type Context } from "@opencode-ai/plugin/effect/plugin"
 import { Effect } from "effect"
 import { AbsolutePath } from "../schema"
 import { Skill } from "../skill"
-import { Config } from "../config"
 import { ConfigPluginSource } from "../config/plugin/source"
-import { Location } from "../location"
-import { FSUtil } from "@opencode-ai/util/fs-util"
 import os from "os"
 import opencodeContent from "./skill/opencode.md" with { type: "text" }
 import reportContent from "./skill/report.md" with { type: "text" }
@@ -71,10 +68,8 @@ const reportContentWithDiagnostics = Effect.fn("SkillPlugin.reportContentWithDia
 })
 
 const configuredPlugins = Effect.fn("SkillPlugin.configuredPlugins")(function* () {
-  const config = yield* Config.Service
-  const fs = yield* FSUtil.Service
-  const location = yield* Location.Service
-  return (yield* ConfigPluginSource.scan(fs, location, yield* config.entries()))
+  const sources = yield* ConfigPluginSource.Service
+  return (yield* sources.operations())
     .map((operation) => (operation.type === "remove" ? `-${operation.target}` : operation.target))
     .toSorted()
 })

--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -7,11 +7,10 @@ import { Effect } from "effect"
 import { AbsolutePath } from "../schema"
 import { Skill } from "../skill"
 import { Config } from "../config"
+import { ConfigPluginSource } from "../config/plugin/source"
 import { Location } from "../location"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import os from "os"
-import path from "path"
-import { fileURLToPath } from "url"
 import opencodeContent from "./skill/opencode.md" with { type: "text" }
 import reportContent from "./skill/report.md" with { type: "text" }
 
@@ -75,29 +74,9 @@ const configuredPlugins = Effect.fn("SkillPlugin.configuredPlugins")(function* (
   const config = yield* Config.Service
   const fs = yield* FSUtil.Service
   const location = yield* Location.Service
-  return yield* Effect.forEach(yield* config.entries(), (entry) => {
-    if (entry.type === "document") {
-      const directory = entry.path ? path.dirname(entry.path) : location.directory
-      return Effect.succeed(
-        (entry.info.plugins ?? []).map((item) => {
-          const ref = typeof item === "string" ? { package: item } : item
-          if (ref.package.startsWith("file://")) return fileURLToPath(ref.package)
-          if (ref.package.startsWith("./") || ref.package.startsWith("../")) return path.resolve(directory, ref.package)
-          return ref.package
-        }),
-      )
-    }
-    if (entry.type !== "directory") return Effect.succeed([])
-    return fs
-      .scan("{plugin,plugins}/*.{ts,js}", {
-        cwd: entry.path,
-        absolute: true,
-        include: "file",
-        dot: true,
-        symlink: true,
-      })
-      .pipe(Effect.orElseSucceed(() => []))
-  }).pipe(Effect.map((items) => items.flat().toSorted()))
+  return (yield* ConfigPluginSource.scan(fs, location, yield* config.entries()))
+    .map((operation) => (operation.type === "remove" ? `-${operation.target}` : operation.target))
+    .toSorted()
 })
 
 function terminal() {

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -1,23 +1,18 @@
-import fs from "fs/promises"
-import path from "path"
-import { pathToFileURL } from "url"
 import { describe, expect } from "bun:test"
-import { NodeFileSystem } from "@effect/platform-node"
-import { Directory, Document, Info } from "@opencode-ai/schema/config"
-import { Config } from "@opencode-ai/core/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Location } from "@opencode-ai/core/location"
-import { Effect, Schema, Stream } from "effect"
+import { ConfigPluginSource } from "@opencode-ai/core/config/plugin/source"
+import { Effect, Layer, Stream } from "effect"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
-import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Skill } from "@opencode-ai/core/skill"
-import { location } from "../fixture/location"
-import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 import { host } from "./host"
 
 const it = testEffect(AppNodeBuilder.build(Skill.node))
+const sources = (operations: readonly ConfigPluginSource.Operation[] = []) =>
+  Layer.succeed(
+    ConfigPluginSource.Service,
+    ConfigPluginSource.Service.of({ operations: () => Effect.succeed(operations), changes: () => Stream.never }),
+  )
 
 describe("SkillPlugin.Plugin", () => {
   it.effect("registers built-in skills", () =>
@@ -32,15 +27,7 @@ describe("SkillPlugin.Plugin", () => {
             reload: skill.reload,
           },
         }),
-      ).pipe(
-        Effect.provide(Config.testLayer()),
-        Effect.provideService(
-          Location.Service,
-          Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
-        ),
-        Effect.provide(AppNodeBuilder.build(FSUtil.node)),
-        Effect.provide(NodeFileSystem.layer),
-      )
+      ).pipe(Effect.provide(sources()))
       const skills = yield* skill.list()
       const report = skills.find((item) => item.id === "report")
 
@@ -65,67 +52,28 @@ describe("SkillPlugin.Plugin", () => {
   )
 
   it.effect("reports canonical configured plugin sources with existing labels and ordering", () =>
-    Effect.acquireRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ).pipe(
-      Effect.tap((tmp) =>
-        Effect.promise(async () => {
-          await fs.mkdir(path.join(tmp.path, "plugin"), { recursive: true })
-          await fs.writeFile(path.join(tmp.path, "plugin", "discovered.ts"), "")
+    Effect.gen(function* () {
+      const skill = yield* Skill.Service
+      yield* SkillPlugin.Plugin.effect(
+        host({
+          skill: {
+            list: () => Effect.die("unused skill.list"),
+            transform: skill.transform,
+            reload: skill.reload,
+          },
         }),
+      )
+      const report = (yield* skill.list()).find((item) => item.id === "report")
+      expect(report?.content).toContain("- Active plugins: -disabled, local.ts, package-plugin, package-plugin")
+    }).pipe(
+      Effect.provide(
+        sources([
+          { type: "add", target: "package-plugin", options: {} },
+          { type: "remove", target: "disabled" },
+          { type: "add", target: "local.ts", options: {}, mtime: 1 },
+          { type: "add", target: "package-plugin", options: { enabled: true } },
+        ]),
       ),
-      Effect.flatMap((tmp) => {
-        const config = path.join(tmp.path, "config", "opencode.json")
-        const external = path.join(tmp.path, "external.ts")
-        const labels = [
-          "-disabled",
-          path.join(tmp.path, "config", "relative.ts"),
-          path.join(tmp.path, "plugin", "discovered.ts"),
-          external,
-          "package-plugin",
-          "package-plugin",
-        ].toSorted()
-        return Effect.gen(function* () {
-          const skill = yield* Skill.Service
-          yield* SkillPlugin.Plugin.effect(
-            host({
-              skill: {
-                list: () => Effect.die("unused skill.list"),
-                transform: skill.transform,
-                reload: skill.reload,
-              },
-            }),
-          )
-          const report = (yield* skill.list()).find((item) => item.id === "report")
-          expect(report?.content).toContain(`- Active plugins: ${labels.join(", ")}`)
-        }).pipe(
-          Effect.provide(
-            Config.testLayer([
-              new Document({
-                type: "document",
-                path: config,
-                info: Schema.decodeUnknownSync(Info)({
-                  plugins: [
-                    "./relative.ts",
-                    "package-plugin",
-                    { package: "package-plugin", options: { enabled: true } },
-                    pathToFileURL(external).href,
-                    "-disabled",
-                  ],
-                }),
-              }),
-              new Directory({ type: "directory", path: AbsolutePath.make(tmp.path) }),
-            ]),
-          ),
-          Effect.provideService(
-            Location.Service,
-            Location.Service.of(location({ directory: AbsolutePath.make(tmp.path) })),
-          ),
-          Effect.provide(AppNodeBuilder.build(FSUtil.node)),
-          Effect.provide(NodeFileSystem.layer),
-        )
-      }),
     ),
   )
 })

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -1,14 +1,19 @@
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
 import { describe, expect } from "bun:test"
 import { NodeFileSystem } from "@effect/platform-node"
+import { Directory, Document, Info } from "@opencode-ai/schema/config"
 import { Config } from "@opencode-ai/core/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Location } from "@opencode-ai/core/location"
-import { Effect, Stream } from "effect"
+import { Effect, Schema, Stream } from "effect"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Skill } from "@opencode-ai/core/skill"
 import { location } from "../fixture/location"
+import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 import { host } from "./host"
 
@@ -57,5 +62,70 @@ describe("SkillPlugin.Plugin", () => {
       expect(report?.content).toContain("- opencode version: 1.2.3")
       expect(report?.content).toContain("- install/channel: beta")
     }),
+  )
+
+  it.effect("reports canonical configured plugin sources with existing labels and ordering", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.tap((tmp) =>
+        Effect.promise(async () => {
+          await fs.mkdir(path.join(tmp.path, "plugin"), { recursive: true })
+          await fs.writeFile(path.join(tmp.path, "plugin", "discovered.ts"), "")
+        }),
+      ),
+      Effect.flatMap((tmp) => {
+        const config = path.join(tmp.path, "config", "opencode.json")
+        const external = path.join(tmp.path, "external.ts")
+        const labels = [
+          "-disabled",
+          path.join(tmp.path, "config", "relative.ts"),
+          path.join(tmp.path, "plugin", "discovered.ts"),
+          external,
+          "package-plugin",
+          "package-plugin",
+        ].toSorted()
+        return Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          yield* SkillPlugin.Plugin.effect(
+            host({
+              skill: {
+                list: () => Effect.die("unused skill.list"),
+                transform: skill.transform,
+                reload: skill.reload,
+              },
+            }),
+          )
+          const report = (yield* skill.list()).find((item) => item.id === "report")
+          expect(report?.content).toContain(`- Active plugins: ${labels.join(", ")}`)
+        }).pipe(
+          Effect.provide(
+            Config.testLayer([
+              new Document({
+                type: "document",
+                path: config,
+                info: Schema.decodeUnknownSync(Info)({
+                  plugins: [
+                    "./relative.ts",
+                    "package-plugin",
+                    { package: "package-plugin", options: { enabled: true } },
+                    pathToFileURL(external).href,
+                    "-disabled",
+                  ],
+                }),
+              }),
+              new Directory({ type: "directory", path: AbsolutePath.make(tmp.path) }),
+            ]),
+          ),
+          Effect.provideService(
+            Location.Service,
+            Location.Service.of(location({ directory: AbsolutePath.make(tmp.path) })),
+          ),
+          Effect.provide(AppNodeBuilder.build(FSUtil.node)),
+          Effect.provide(NodeFileSystem.layer),
+        )
+      }),
+    ),
   )
 })


### PR DESCRIPTION
## What

Reuse the config plugin source scanner when rendering the built-in report skill instead of maintaining a second implementation of plugin parsing, path resolution, and directory discovery.

## How

- Export the existing `ConfigPluginSource.scan` operation.
- Map canonical add/remove operations back to the report skill labels.
- Preserve sorting, removals, duplicate entries, relative paths, file URLs, and `{plugin,plugins}` auto-discovery.

## Scope

This only consolidates configured plugin discovery. It does not change plugin activation or report formatting.

## Testing

- `bun run test test/plugin/skill.test.ts`
- `bun run test test/config/plugin.test.ts`
- `bun typecheck` from `packages/core`
- Repository push hook typecheck across affected packages
- `bunx prettier --check src/config/plugin/source.ts src/plugin/skill.ts test/plugin/skill.test.ts`
- `git diff --check`