### PR TITLE
refactor(core): centralize project upsert

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -2,7 +2,7 @@ export * as Project from "./project"
 
 import { Context, Effect, Layer, Schema } from "effect"
 import { ChildProcess } from "effect/unstable/process"
-import { asc, desc, isNotNull, isNull, ne, or } from "drizzle-orm"
+import { asc, desc } from "drizzle-orm"
 import path from "path"
 import { AbsolutePath } from "./schema"
 import { Database } from "./database/database"
@@ -13,7 +13,7 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Hash } from "@opencode-ai/util/hash"
 import { ProjectDirectories } from "./project/directories"
 import { ProjectSchema } from "./project/schema"
-import { ProjectTable } from "./project/sql"
+import { ProjectTable, upsertProject } from "./project/sql"
 
 export const ID = ProjectSchema.ID
 export type ID = ProjectSchema.ID
@@ -98,19 +98,7 @@ const layer = Layer.effect(
       yield* db
         .transaction((tx) =>
           Effect.gen(function* () {
-            const vcs = project.vcs?.type
-            yield* tx
-              .insert(ProjectTable)
-              .values({ id: project.id, worktree: project.canonical, vcs, sandboxes: [] })
-              .onConflictDoUpdate({
-                target: ProjectTable.id,
-                set: { worktree: project.canonical, vcs: vcs ?? null },
-                setWhere: or(
-                  ne(ProjectTable.worktree, project.canonical),
-                  vcs ? or(isNull(ProjectTable.vcs), ne(ProjectTable.vcs, vcs)) : isNotNull(ProjectTable.vcs),
-                ),
-              })
-              .run()
+            yield* upsertProject(tx, project)
             if (!project.vcs) return
             yield* projectDirectories.create({ projectID: project.id, directory: project.canonical }, tx)
             if (project.directory === project.canonical) return

--- a/packages/core/src/project/sql.ts
+++ b/packages/core/src/project/sql.ts
@@ -1,7 +1,13 @@
+import type { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
+import { isNotNull, isNull, ne, or } from "drizzle-orm"
 import { sqliteTable, text, integer, primaryKey } from "drizzle-orm/sqlite-core"
 import { absoluteArrayColumn, absoluteColumn } from "../database/path"
 import { Timestamps } from "../database/schema.sql"
+import type { AbsolutePath } from "../schema"
 import { ProjectSchema } from "./schema"
+
+type DatabaseClient = EffectDrizzleSqlite.EffectSQLiteDatabase
+type Transaction = Parameters<Parameters<DatabaseClient["transaction"]>[0]>[0]
 
 export const ProjectTable = sqliteTable("project", {
   id: text().$type<ProjectSchema.ID>().primaryKey(),
@@ -33,3 +39,22 @@ export const ProjectDirectoryTable = sqliteTable(
   },
   (table) => [primaryKey({ columns: [table.project_id, table.directory] })],
 )
+
+export function upsertProject(
+  db: DatabaseClient | Transaction,
+  project: { readonly id: ProjectSchema.ID; readonly canonical: AbsolutePath; readonly vcs?: ProjectSchema.Vcs },
+) {
+  const vcs = project.vcs?.type
+  return db
+    .insert(ProjectTable)
+    .values({ id: project.id, worktree: project.canonical, vcs, sandboxes: [] })
+    .onConflictDoUpdate({
+      target: ProjectTable.id,
+      set: { worktree: project.canonical, vcs: vcs ?? null },
+      setWhere: or(
+        ne(ProjectTable.worktree, project.canonical),
+        vcs ? or(isNull(ProjectTable.vcs), ne(ProjectTable.vcs, vcs)) : isNotNull(ProjectTable.vcs),
+      ),
+    })
+    .run()
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,7 +3,7 @@ export * from "./session/schema"
 
 import { Effect, Layer, Schema, Context, Stream, Scope } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
-import { and, asc, desc, eq, gt, isNotNull, isNull, like, lt, ne, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { Project } from "./project"
 import { Workspace } from "./workspace"
 import { Model } from "./model"
@@ -21,7 +21,7 @@ import { Agent } from "./agent"
 import { Money } from "@opencode-ai/schema/money"
 import { App } from "./app"
 import { Slug } from "./util/slug"
-import { ProjectTable } from "./project/sql"
+import { upsertProject } from "./project/sql"
 import path from "path"
 import { fromRow } from "./session/info"
 import { SessionRunner } from "./session/runner/index"
@@ -309,22 +309,7 @@ const layer = Layer.effect(
     const shellLocks = KeyedMutex.makeUnsafe<SessionSchema.ID>()
     const decodeMessage = Schema.decodeUnknownEffect(SessionMessage.Info)
     const isDurableSessionEvent = Schema.is(SessionEvent.Durable)
-    const persistProject = (project: Project.Resolved) => {
-      const vcs = project.vcs?.type
-      return db
-        .insert(ProjectTable)
-        .values({ id: project.id, worktree: project.canonical, vcs, sandboxes: [] })
-        .onConflictDoUpdate({
-          target: ProjectTable.id,
-          set: { worktree: project.canonical, vcs: vcs ?? null },
-          setWhere: or(
-            ne(ProjectTable.worktree, project.canonical),
-            vcs ? or(isNull(ProjectTable.vcs), ne(ProjectTable.vcs, vcs)) : isNotNull(ProjectTable.vcs),
-          ),
-        })
-        .run()
-        .pipe(Effect.orDie)
-    }
+    const persistProject = (project: Project.Resolved) => upsertProject(db, project).pipe(Effect.orDie)
     const decode = (row: typeof SessionMessageTable.$inferSelect) =>
       decodeMessage({ ...row.data, id: row.id, type: row.type }).pipe(
         Effect.mapError(

--- a/packages/core/src/session/transfer.ts
+++ b/packages/core/src/session/transfer.ts
@@ -3,7 +3,7 @@ export * as SessionTransfer from "./transfer"
 import { SessionTransfer } from "@opencode-ai/schema/session-transfer"
 import { Tool } from "@opencode-ai/schema/tool"
 import { Skill } from "@opencode-ai/schema/skill"
-import { eq, isNotNull, isNull, ne, or } from "drizzle-orm"
+import { eq } from "drizzle-orm"
 import { Context, DateTime, Effect, Layer, Schema } from "effect"
 import path from "path"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
@@ -12,7 +12,7 @@ import { Bus } from "../bus"
 import { Database } from "../database/database"
 import { Location } from "../location"
 import { Project } from "../project"
-import { ProjectTable } from "../project/sql"
+import { upsertProject } from "../project/sql"
 import { AbsolutePath, RelativePath } from "../schema"
 import { Session } from "../session"
 import { Slug } from "../util/slug"
@@ -49,22 +49,7 @@ const layer = Layer.effect(
     const sessions = yield* Session.Service
     const encodeMessage = Schema.encodeSync(SessionMessage.Info)
 
-    const persistProject = (project: Project.Resolved) => {
-      const vcs = project.vcs?.type
-      return db
-        .insert(ProjectTable)
-        .values({ id: project.id, worktree: project.canonical, vcs, sandboxes: [] })
-        .onConflictDoUpdate({
-          target: ProjectTable.id,
-          set: { worktree: project.canonical, vcs: vcs ?? null },
-          setWhere: or(
-            ne(ProjectTable.worktree, project.canonical),
-            vcs ? or(isNull(ProjectTable.vcs), ne(ProjectTable.vcs, vcs)) : isNotNull(ProjectTable.vcs),
-          ),
-        })
-        .run()
-        .pipe(Effect.orDie)
-    }
+    const persistProject = (project: Project.Resolved) => upsertProject(db, project).pipe(Effect.orDie)
 
     return Service.of({
       export: Effect.fn("SessionTransfer.export")(function* (input) {


### PR DESCRIPTION
## What

Centralize project persistence that was duplicated across project resolution, session creation and movement, and session transfer import.

## How

- Add a transaction-compatible `upsertProject` operation beside the project SQL schema.
- Reuse it from `project.ts`, `session.ts`, and `session/transfer.ts`.
- Preserve worktree, VCS conflict conditions, sandbox initialization, transaction scope, and existing defect boundaries.

## Scope

This changes only the shared upsert implementation. Project resolution and session behavior remain unchanged.

## Testing

- `bun run test test/project.test.ts test/session-create.test.ts` from `packages/core` (45 passed, 1 skipped)
- `bun typecheck` from `packages/core`
- Repository push hook typecheck across affected packages
- `git diff --check`