### PR TITLE
refactor(core): share AI SDK provider factory

### DIFF
--- a/packages/core/src/plugin/provider/alibaba.ts
+++ b/packages/core/src/plugin/provider/alibaba.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const AlibabaPlugin = createProviderPlugin({
   id: "opencode.provider.alibaba",
   package: "@ai-sdk/alibaba",
-  load: async () => {
+  load: async (options) => {
     const { createAlibaba } = await import("@ai-sdk/alibaba")
-    return (options) => createAlibaba(options)
+    return createAlibaba(options)
   },
 })

--- a/packages/core/src/plugin/provider/alibaba.ts
+++ b/packages/core/src/plugin/provider/alibaba.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const AlibabaPlugin = define({
+export const AlibabaPlugin = createProviderPlugin({
   id: "opencode.provider.alibaba",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/alibaba") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/alibaba"))
-        evt.sdk = mod.createAlibaba(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/alibaba",
+  load: async () => {
+    const { createAlibaba } = await import("@ai-sdk/alibaba")
+    return (options) => createAlibaba(options)
+  },
 })

--- a/packages/core/src/plugin/provider/cohere.ts
+++ b/packages/core/src/plugin/provider/cohere.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const CoherePlugin = define({
+export const CoherePlugin = createProviderPlugin({
   id: "opencode.provider.cohere",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/cohere") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/cohere"))
-        evt.sdk = mod.createCohere(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/cohere",
+  load: async () => {
+    const { createCohere } = await import("@ai-sdk/cohere")
+    return (options) => createCohere(options)
+  },
 })

--- a/packages/core/src/plugin/provider/cohere.ts
+++ b/packages/core/src/plugin/provider/cohere.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const CoherePlugin = createProviderPlugin({
   id: "opencode.provider.cohere",
   package: "@ai-sdk/cohere",
-  load: async () => {
+  load: async (options) => {
     const { createCohere } = await import("@ai-sdk/cohere")
-    return (options) => createCohere(options)
+    return createCohere(options)
   },
 })

--- a/packages/core/src/plugin/provider/deepinfra.ts
+++ b/packages/core/src/plugin/provider/deepinfra.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const DeepInfraPlugin = define({
+export const DeepInfraPlugin = createProviderPlugin({
   id: "opencode.provider.deepinfra",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/deepinfra") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/deepinfra"))
-        evt.sdk = mod.createDeepInfra(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/deepinfra",
+  load: async () => {
+    const { createDeepInfra } = await import("@ai-sdk/deepinfra")
+    return (options) => createDeepInfra(options)
+  },
 })

--- a/packages/core/src/plugin/provider/deepinfra.ts
+++ b/packages/core/src/plugin/provider/deepinfra.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const DeepInfraPlugin = createProviderPlugin({
   id: "opencode.provider.deepinfra",
   package: "@ai-sdk/deepinfra",
-  load: async () => {
+  load: async (options) => {
     const { createDeepInfra } = await import("@ai-sdk/deepinfra")
-    return (options) => createDeepInfra(options)
+    return createDeepInfra(options)
   },
 })

--- a/packages/core/src/plugin/provider/factory.ts
+++ b/packages/core/src/plugin/provider/factory.ts
@@ -1,0 +1,23 @@
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import type { AISDKHooks } from "@opencode-ai/plugin/effect/aisdk"
+import { Effect } from "effect"
+
+export function createProviderPlugin(input: {
+  readonly id: string
+  readonly package: string
+  readonly load: () => Promise<(options: AISDKHooks["sdk"]["options"]) => unknown>
+}) {
+  return define({
+    id: input.id,
+    effect: Effect.fn(function* (ctx) {
+      yield* ctx.aisdk.hook(
+        "sdk",
+        Effect.fn(function* (evt) {
+          if (evt.package !== input.package) return
+          const create = yield* Effect.promise(input.load)
+          evt.sdk = create(evt.options)
+        }),
+      )
+    }),
+  })
+}

--- a/packages/core/src/plugin/provider/factory.ts
+++ b/packages/core/src/plugin/provider/factory.ts
@@ -5,7 +5,7 @@ import { Effect } from "effect"
 export function createProviderPlugin(input: {
   readonly id: string
   readonly package: string
-  readonly load: () => Promise<(options: AISDKHooks["sdk"]["options"]) => unknown>
+  readonly load: (options: AISDKHooks["sdk"]["options"]) => Promise<unknown>
 }) {
   return define({
     id: input.id,
@@ -14,8 +14,7 @@ export function createProviderPlugin(input: {
         "sdk",
         Effect.fn(function* (evt) {
           if (evt.package !== input.package) return
-          const create = yield* Effect.promise(input.load)
-          evt.sdk = create(evt.options)
+          evt.sdk = yield* Effect.promise(() => input.load(evt.options))
         }),
       )
     }),

--- a/packages/core/src/plugin/provider/gateway.ts
+++ b/packages/core/src/plugin/provider/gateway.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const GatewayPlugin = define({
+export const GatewayPlugin = createProviderPlugin({
   id: "opencode.provider.gateway",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/gateway") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/gateway"))
-        evt.sdk = mod.createGateway(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/gateway",
+  load: async () => {
+    const { createGateway } = await import("@ai-sdk/gateway")
+    return (options) => createGateway(options)
+  },
 })

--- a/packages/core/src/plugin/provider/gateway.ts
+++ b/packages/core/src/plugin/provider/gateway.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const GatewayPlugin = createProviderPlugin({
   id: "opencode.provider.gateway",
   package: "@ai-sdk/gateway",
-  load: async () => {
+  load: async (options) => {
     const { createGateway } = await import("@ai-sdk/gateway")
-    return (options) => createGateway(options)
+    return createGateway(options)
   },
 })

--- a/packages/core/src/plugin/provider/groq.ts
+++ b/packages/core/src/plugin/provider/groq.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const GroqPlugin = createProviderPlugin({
   id: "opencode.provider.groq",
   package: "@ai-sdk/groq",
-  load: async () => {
+  load: async (options) => {
     const { createGroq } = await import("@ai-sdk/groq")
-    return (options) => createGroq(options)
+    return createGroq(options)
   },
 })

--- a/packages/core/src/plugin/provider/groq.ts
+++ b/packages/core/src/plugin/provider/groq.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const GroqPlugin = define({
+export const GroqPlugin = createProviderPlugin({
   id: "opencode.provider.groq",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/groq") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/groq"))
-        evt.sdk = mod.createGroq(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/groq",
+  load: async () => {
+    const { createGroq } = await import("@ai-sdk/groq")
+    return (options) => createGroq(options)
+  },
 })

--- a/packages/core/src/plugin/provider/mistral.ts
+++ b/packages/core/src/plugin/provider/mistral.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const MistralPlugin = define({
+export const MistralPlugin = createProviderPlugin({
   id: "opencode.provider.mistral",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/mistral") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/mistral"))
-        evt.sdk = mod.createMistral(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/mistral",
+  load: async () => {
+    const { createMistral } = await import("@ai-sdk/mistral")
+    return (options) => createMistral(options)
+  },
 })

--- a/packages/core/src/plugin/provider/mistral.ts
+++ b/packages/core/src/plugin/provider/mistral.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const MistralPlugin = createProviderPlugin({
   id: "opencode.provider.mistral",
   package: "@ai-sdk/mistral",
-  load: async () => {
+  load: async (options) => {
     const { createMistral } = await import("@ai-sdk/mistral")
-    return (options) => createMistral(options)
+    return createMistral(options)
   },
 })

--- a/packages/core/src/plugin/provider/perplexity.ts
+++ b/packages/core/src/plugin/provider/perplexity.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const PerplexityPlugin = define({
+export const PerplexityPlugin = createProviderPlugin({
   id: "opencode.provider.perplexity",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/perplexity") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/perplexity"))
-        evt.sdk = mod.createPerplexity(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/perplexity",
+  load: async () => {
+    const { createPerplexity } = await import("@ai-sdk/perplexity")
+    return (options) => createPerplexity(options)
+  },
 })

--- a/packages/core/src/plugin/provider/perplexity.ts
+++ b/packages/core/src/plugin/provider/perplexity.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const PerplexityPlugin = createProviderPlugin({
   id: "opencode.provider.perplexity",
   package: "@ai-sdk/perplexity",
-  load: async () => {
+  load: async (options) => {
     const { createPerplexity } = await import("@ai-sdk/perplexity")
-    return (options) => createPerplexity(options)
+    return createPerplexity(options)
   },
 })

--- a/packages/core/src/plugin/provider/togetherai.ts
+++ b/packages/core/src/plugin/provider/togetherai.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const TogetherAIPlugin = createProviderPlugin({
   id: "opencode.provider.togetherai",
   package: "@ai-sdk/togetherai",
-  load: async () => {
+  load: async (options) => {
     const { createTogetherAI } = await import("@ai-sdk/togetherai")
-    return (options) => createTogetherAI(options)
+    return createTogetherAI(options)
   },
 })

--- a/packages/core/src/plugin/provider/togetherai.ts
+++ b/packages/core/src/plugin/provider/togetherai.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const TogetherAIPlugin = define({
+export const TogetherAIPlugin = createProviderPlugin({
   id: "opencode.provider.togetherai",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "@ai-sdk/togetherai") return
-        const mod = yield* Effect.promise(() => import("@ai-sdk/togetherai"))
-        evt.sdk = mod.createTogetherAI(evt.options)
-      }),
-    )
-  }),
+  package: "@ai-sdk/togetherai",
+  load: async () => {
+    const { createTogetherAI } = await import("@ai-sdk/togetherai")
+    return (options) => createTogetherAI(options)
+  },
 })

--- a/packages/core/src/plugin/provider/venice.ts
+++ b/packages/core/src/plugin/provider/venice.ts
@@ -1,16 +1,10 @@
-import { Effect } from "effect"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { createProviderPlugin } from "./factory"
 
-export const VenicePlugin = define({
+export const VenicePlugin = createProviderPlugin({
   id: "opencode.provider.venice",
-  effect: Effect.fn(function* (ctx) {
-    yield* ctx.aisdk.hook(
-      "sdk",
-      Effect.fn(function* (evt) {
-        if (evt.package !== "venice-ai-sdk-provider") return
-        const mod = yield* Effect.promise(() => import("venice-ai-sdk-provider"))
-        evt.sdk = mod.createVenice(evt.options)
-      }),
-    )
-  }),
+  package: "venice-ai-sdk-provider",
+  load: async () => {
+    const { createVenice } = await import("venice-ai-sdk-provider")
+    return (options) => createVenice(options)
+  },
 })

--- a/packages/core/src/plugin/provider/venice.ts
+++ b/packages/core/src/plugin/provider/venice.ts
@@ -3,8 +3,8 @@ import { createProviderPlugin } from "./factory"
 export const VenicePlugin = createProviderPlugin({
   id: "opencode.provider.venice",
   package: "venice-ai-sdk-provider",
-  load: async () => {
+  load: async (options) => {
     const { createVenice } = await import("venice-ai-sdk-provider")
-    return (options) => createVenice(options)
+    return createVenice(options)
   },
 })


### PR DESCRIPTION
## What

Replace nine copies of the same AI SDK provider plugin wiring with one private provider factory.

## How

- Add `createProviderPlugin` for exact package matching and SDK hook registration.
- Keep each provider module responsible for its plugin ID, package name, lazy dynamic import, and provider constructor.
- Preserve all existing named plugin exports.

## Scope

This covers only the nine providers with identical SDK-hook behavior. Providers with additional configuration or hooks remain explicit.

## Testing

- `bun run test test/plugin/provider-factory.test.ts` from `packages/core` (9 passed)
- `bun typecheck` from `packages/core`
- Repository push hook typecheck across affected packages
- `git diff --check`