### PR TITLE
fix(llm): surface attached image filename in model context

### DIFF
--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -430,6 +430,8 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
           continue
         }
         if (part.type === "media") {
+          const caption = ProviderShared.mediaCaption(part)
+          if (caption !== undefined) content.push({ type: "text", text: caption })
           content.push(yield* lowerImage(part))
           continue
         }

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -220,6 +220,10 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
       for (const part of message.content) {
         if (!ProviderShared.supportsContent(part, ["text", "media"]))
           return yield* ProviderShared.unsupportedContent("Gemini", "user", ["text", "media"])
+        if (part.type === "media") {
+          const caption = ProviderShared.mediaCaption(part)
+          if (caption !== undefined) parts.push({ text: caption })
+        }
         parts.push(yield* lowerUserPart(part))
       }
       contents.push({ role: "user", parts })

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -218,6 +218,8 @@ const lowerUserMessage = Effect.fn("OpenAIChat.lowerUserMessage")(function* (mes
       continue
     }
     if (part.type === "media") {
+      const caption = ProviderShared.mediaCaption(part)
+      if (caption !== undefined) content.push({ type: "text", text: caption })
       content.push(yield* lowerMedia(part))
       continue
     }

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -308,14 +308,16 @@ const hostedToolItemID = (part: ToolResultPart) => {
 const lowerUserContent = Effect.fn("OpenAIResponses.lowerUserContent")(function* (
   part: LLMRequest["messages"][number]["content"][number],
 ) {
-  if (part.type === "text") return { type: "input_text" as const, text: part.text }
+  if (part.type === "text") return [{ type: "input_text" as const, text: part.text }]
   if (part.type === "media") {
     const media = yield* ProviderShared.validateMedia(
       "OpenAI Responses",
       part,
       new Set<string>(ProviderShared.IMAGE_MIMES),
     )
-    return { type: "input_image" as const, image_url: media.dataUrl }
+    const image = { type: "input_image" as const, image_url: media.dataUrl }
+    const caption = ProviderShared.mediaCaption(part)
+    return caption === undefined ? [image] : [{ type: "input_text" as const, text: caption }, image]
   }
   return yield* ProviderShared.unsupportedContent("OpenAI Responses", "user", ["text", "media"])
 })
@@ -363,7 +365,10 @@ const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (requ
     }
 
     if (message.role === "user") {
-      input.push({ role: "user", content: yield* Effect.forEach(message.content, lowerUserContent) })
+      input.push({
+        role: "user",
+        content: (yield* Effect.forEach(message.content, lowerUserContent)).flat(),
+      })
       continue
     }
 

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -171,6 +171,15 @@ export interface ValidatedMedia {
   readonly bytes: Uint8Array
 }
 
+/**
+ * Caption text exposing a media part's original filename to the model. The
+ * filename survives attachment ingestion (TUI -> core -> MediaPart.filename)
+ * but provider wire formats have no native field for it, so it is surfaced as
+ * a text part alongside the media content.
+ */
+export const mediaCaption = (part: MediaPart): string | undefined =>
+  part.filename === undefined || part.filename === "" ? undefined : `[Image: ${part.filename}]`
+
 export const validateMedia = Effect.fn("ProviderShared.validateMedia")(function* (
   route: string,
   part: MediaPart,

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -82,6 +82,33 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
+  it.effect("surfaces the original filename alongside image media", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<AnthropicMessages.AnthropicMessagesBody>(
+        LLM.request({
+          model,
+          messages: [
+            Message.user([
+              { type: "media", mediaType: "image/png", data: "AAECAw==", filename: "IMG_3480.JPG" },
+              { type: "media", mediaType: "image/jpeg", data: "data:image/jpeg;base64,/9j/" },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "[Image: IMG_3480.JPG]" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "AAECAw==" } },
+            { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "/9j/" } },
+          ],
+        },
+      ])
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text for unsupported Anthropic models", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<AnthropicMessages.AnthropicMessagesBody>(

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -182,6 +182,33 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("surfaces the original filename alongside image media", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<Gemini.GeminiBody>(
+        LLM.request({
+          model,
+          messages: [
+            Message.user([
+              { type: "media", mediaType: "image/png", data: "AAECAw==", filename: "IMG_3480.JPG" },
+              { type: "media", mediaType: "image/jpeg", data: "data:image/jpeg;base64,/9j/" },
+            ]),
+          ],
+        }),
+      )
+      expect(prepared.body.contents).toEqual([
+        {
+          role: "user",
+          parts: [
+            { text: "[Image: IMG_3480.JPG]" },
+            { inlineData: { mimeType: "image/png", data: "AAECAw==" } },
+            { inlineData: { mimeType: "image/jpeg", data: "/9j/" } },
+          ],
+        },
+      ])
+    }),
+  )
+
+
   for (const [name, media] of [
     ["mismatched data URL MIME", { mediaType: "image/png", data: "data:image/jpeg;base64,/9j/" }],
     ["malformed base64", { mediaType: "image/png", data: "%%%=" }],

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -462,6 +462,35 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("surfaces the original filename alongside image media", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          id: "req_media_named",
+          model,
+          messages: [
+            Message.user([
+              { type: "media", mediaType: "image/png", data: "AAECAw==", filename: "IMG_3480.JPG" },
+              { type: "media", mediaType: "image/jpeg", data: "data:image/jpeg;base64,/9j/" },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "[Image: IMG_3480.JPG]" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,AAECAw==" } },
+            { type: "image_url", image_url: { url: "data:image/jpeg;base64,/9j/" } },
+          ],
+        },
+      ])
+    }),
+  )
+
+
   it.effect("lowers reasoning-only assistant history", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1315,6 +1315,35 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("surfaces the original filename alongside image media", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.request({
+          id: "req_media_named",
+          model,
+          messages: [
+            Message.user([
+              { type: "media", mediaType: "image/png", data: "AAECAw==", filename: "IMG_3480.JPG" },
+              { type: "media", mediaType: "image/jpeg", data: "data:image/jpeg;base64,/9j/" },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "[Image: IMG_3480.JPG]" },
+            { type: "input_image", image_url: "data:image/png;base64,AAECAw==" },
+            { type: "input_image", image_url: "data:image/jpeg;base64,/9j/" },
+          ],
+        },
+      ])
+    }),
+  )
+
+
   it.effect("rejects unsupported user media content", () =>
     Effect.gen(function* () {
       const error = yield* LLMClient.prepare(


### PR DESCRIPTION
## Summary

When a user attaches an image in the TUI, the attachment chip shows the original filename (e.g. `IMG_3480.JPG`), and the filename survives all the way into `MediaPart.filename` — but every provider lowering drops it before building the request. The model receives only the image content, so it cannot identify or reference the attached file.

This PR emits the filename as a caption text part alongside the image in the user message for the four image-capable protocols:

- OpenAI Chat (`openai-chat`)
- OpenAI Responses (`openai-responses`)
- Anthropic Messages (`anthropic-messages`)
- Gemini (`gemini`)

Bedrock Converse already preserves `filename` for document blocks, so it is left unchanged.

## Changes

- `packages/llm/src/protocols/shared.ts`: new `mediaCaption(part)` helper producing `[Image: <filename>]` when a filename is present.
- Each protocol's user-content lowering now prepends that caption text before the image content.
- Added prepare-layer tests for all four protocols asserting the caption appears alongside the image.

## Test plan

- `bun test` in `packages/llm`: 302 pass, 0 fail.
- `tsgo --noEmit` in `packages/llm`: clean.

Fixes #41454