### PR TITLE
core: write-ahead execution claims replace shutdown-hook suspension

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,8 +1,10 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "15060ec5-05f7-4b86-b2a5-9108609432b3",
-  "prevIds": ["1551a157-8959-4ba9-a52b-4ea3b7b28cae"],
+  "id": "00924d88-1842-4d71-ac74-5682ddc47e1c",
+  "prevIds": [
+    "15060ec5-05f7-4b86-b2a5-9108609432b3"
+  ],
   "ddl": [
     {
       "name": "account_state",
@@ -1303,6 +1305,16 @@
       "table": "session_v2"
     },
     {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "resume_attempts",
+      "entityType": "columns",
+      "table": "session_v2"
+    },
+    {
       "type": "text",
       "notNull": false,
       "autoincrement": false,
@@ -1353,9 +1365,13 @@
       "table": "workspace"
     },
     {
-      "columns": ["active_account_id"],
+      "columns": [
+        "active_account_id"
+      ],
       "tableTo": "account",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "SET NULL",
       "nameExplicit": false,
@@ -1364,9 +1380,13 @@
       "table": "account_state"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "tableTo": "event_sequence",
-      "columnsTo": ["aggregate_id"],
+      "columnsTo": [
+        "aggregate_id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1375,9 +1395,13 @@
       "table": "event"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1386,9 +1410,13 @@
       "table": "permission"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1397,9 +1425,13 @@
       "table": "project_directory"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session_v2",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1408,9 +1440,13 @@
       "table": "instruction_entry"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session_v2",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1419,9 +1455,13 @@
       "table": "instruction_state"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session_v2",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1430,9 +1470,13 @@
       "table": "session_message"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session_v2",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1441,9 +1485,13 @@
       "table": "session_pending"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1452,119 +1500,156 @@
       "table": "session_v2"
     },
     {
-      "columns": ["email", "url"],
+      "columns": [
+        "email",
+        "url"
+      ],
       "nameExplicit": false,
       "name": "control_account_pk",
       "entityType": "pks",
       "table": "control_account"
     },
     {
-      "columns": ["project_id", "directory"],
+      "columns": [
+        "project_id",
+        "directory"
+      ],
       "nameExplicit": false,
       "name": "project_directory_pk",
       "entityType": "pks",
       "table": "project_directory"
     },
     {
-      "columns": ["session_id", "key"],
+      "columns": [
+        "session_id",
+        "key"
+      ],
       "nameExplicit": false,
       "name": "instruction_entry_pk",
       "entityType": "pks",
       "table": "instruction_entry"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_state_pk",
       "table": "account_state",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_pk",
       "table": "account",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "credential_pk",
       "table": "credential",
       "entityType": "pks"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "nameExplicit": false,
       "name": "event_sequence_pk",
       "table": "event_sequence",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "event_pk",
       "table": "event",
       "entityType": "pks"
     },
     {
-      "columns": ["key"],
+      "columns": [
+        "key"
+      ],
       "nameExplicit": false,
       "name": "kv_pk",
       "table": "kv",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "permission_pk",
       "table": "permission",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "project_pk",
       "table": "project",
       "entityType": "pks"
     },
     {
-      "columns": ["hash"],
+      "columns": [
+        "hash"
+      ],
       "nameExplicit": false,
       "name": "instruction_blob_pk",
       "table": "instruction_blob",
       "entityType": "pks"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "nameExplicit": false,
       "name": "instruction_state_pk",
       "table": "instruction_state",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_message_pk",
       "table": "session_message",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_pending_pk",
       "table": "session_pending",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_v2_pk",
       "table": "session_v2",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "workspace_pk",
       "table": "workspace",

--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -2,9 +2,7 @@
   "version": "7",
   "dialect": "sqlite",
   "id": "00924d88-1842-4d71-ac74-5682ddc47e1c",
-  "prevIds": [
-    "15060ec5-05f7-4b86-b2a5-9108609432b3"
-  ],
+  "prevIds": ["15060ec5-05f7-4b86-b2a5-9108609432b3"],
   "ddl": [
     {
       "name": "account_state",
@@ -1365,13 +1363,9 @@
       "table": "workspace"
     },
     {
-      "columns": [
-        "active_account_id"
-      ],
+      "columns": ["active_account_id"],
       "tableTo": "account",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "SET NULL",
       "nameExplicit": false,
@@ -1380,13 +1374,9 @@
       "table": "account_state"
     },
     {
-      "columns": [
-        "aggregate_id"
-      ],
+      "columns": ["aggregate_id"],
       "tableTo": "event_sequence",
-      "columnsTo": [
-        "aggregate_id"
-      ],
+      "columnsTo": ["aggregate_id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1395,13 +1385,9 @@
       "table": "event"
     },
     {
-      "columns": [
-        "project_id"
-      ],
+      "columns": ["project_id"],
       "tableTo": "project",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1410,13 +1396,9 @@
       "table": "permission"
     },
     {
-      "columns": [
-        "project_id"
-      ],
+      "columns": ["project_id"],
       "tableTo": "project",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1425,13 +1407,9 @@
       "table": "project_directory"
     },
     {
-      "columns": [
-        "session_id"
-      ],
+      "columns": ["session_id"],
       "tableTo": "session_v2",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1440,13 +1418,9 @@
       "table": "instruction_entry"
     },
     {
-      "columns": [
-        "session_id"
-      ],
+      "columns": ["session_id"],
       "tableTo": "session_v2",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1455,13 +1429,9 @@
       "table": "instruction_state"
     },
     {
-      "columns": [
-        "session_id"
-      ],
+      "columns": ["session_id"],
       "tableTo": "session_v2",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1470,13 +1440,9 @@
       "table": "session_message"
     },
     {
-      "columns": [
-        "session_id"
-      ],
+      "columns": ["session_id"],
       "tableTo": "session_v2",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1485,13 +1451,9 @@
       "table": "session_pending"
     },
     {
-      "columns": [
-        "project_id"
-      ],
+      "columns": ["project_id"],
       "tableTo": "project",
-      "columnsTo": [
-        "id"
-      ],
+      "columnsTo": ["id"],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1500,156 +1462,119 @@
       "table": "session_v2"
     },
     {
-      "columns": [
-        "email",
-        "url"
-      ],
+      "columns": ["email", "url"],
       "nameExplicit": false,
       "name": "control_account_pk",
       "entityType": "pks",
       "table": "control_account"
     },
     {
-      "columns": [
-        "project_id",
-        "directory"
-      ],
+      "columns": ["project_id", "directory"],
       "nameExplicit": false,
       "name": "project_directory_pk",
       "entityType": "pks",
       "table": "project_directory"
     },
     {
-      "columns": [
-        "session_id",
-        "key"
-      ],
+      "columns": ["session_id", "key"],
       "nameExplicit": false,
       "name": "instruction_entry_pk",
       "entityType": "pks",
       "table": "instruction_entry"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "account_state_pk",
       "table": "account_state",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "account_pk",
       "table": "account",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "credential_pk",
       "table": "credential",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "aggregate_id"
-      ],
+      "columns": ["aggregate_id"],
       "nameExplicit": false,
       "name": "event_sequence_pk",
       "table": "event_sequence",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "event_pk",
       "table": "event",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "key"
-      ],
+      "columns": ["key"],
       "nameExplicit": false,
       "name": "kv_pk",
       "table": "kv",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "permission_pk",
       "table": "permission",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "project_pk",
       "table": "project",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "hash"
-      ],
+      "columns": ["hash"],
       "nameExplicit": false,
       "name": "instruction_blob_pk",
       "table": "instruction_blob",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "session_id"
-      ],
+      "columns": ["session_id"],
       "nameExplicit": false,
       "name": "instruction_state_pk",
       "table": "instruction_state",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "session_message_pk",
       "table": "session_message",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "session_pending_pk",
       "table": "session_pending",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "session_v2_pk",
       "table": "session_v2",
       "entityType": "pks"
     },
     {
-      "columns": [
-        "id"
-      ],
+      "columns": ["id"],
       "nameExplicit": false,
       "name": "workspace_pk",
       "table": "workspace",

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -40,6 +40,7 @@ import m37 from "./migration/20260622202450_simplify_session_input"
 import m38 from "./migration/20260804233008_loose_psylocke"
 import m39 from "./migration/20260805200742_import_legacy_credentials"
 import m40 from "./migration/20260808023530_workspace_domain"
+import m41 from "./migration/20260811161259_execution_claim_attempts"
 
 export const migrations = [
   m00,
@@ -83,4 +84,5 @@ export const migrations = [
   m38,
   m39,
   m40,
+  m41,
 ] satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260811161259_execution_claim_attempts.ts
+++ b/packages/core/src/database/migration/20260811161259_execution_claim_attempts.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+const migration: DatabaseMigration.Migration = {
+  id: "20260811161259_execution_claim_attempts",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`ALTER TABLE \`session_v2\` ADD \`resume_attempts\` integer DEFAULT 0 NOT NULL;`)
+    })
+  },
+}
+
+export default migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -200,6 +200,7 @@ const schema: Omit<DatabaseMigration.Migration, "id"> = {
           \`time_compacting\` integer,
           \`time_archived\` integer,
           \`time_suspended\` integer,
+          \`resume_attempts\` integer DEFAULT 0 NOT NULL,
           CONSTRAINT \`fk_session_v2_project_id_project_id_fk\` FOREIGN KEY (\`project_id\`) REFERENCES \`project\`(\`id\`) ON DELETE CASCADE
         );
       `)

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -56,16 +56,22 @@ export const layer = Layer.effect(
         ),
         Effect.asVoid,
       )
-    // Starting or finishing on its own clears stale suspension; interruption preserves it because
-    // managed-server teardown suspends active Sessions immediately before interrupting their drains.
-    const clearSuspensionOnCommit = (sessionID: SessionSchema.ID) => ({
-      commit: () => Effect.asVoid(store.consumeSuspended(sessionID)),
+    // Write-ahead claim: starting records the durable intent that a turn is in flight, in the same
+    // transaction as the started event. Terminals release it — except shutdown interruption, which
+    // preserves the claim so the next server start resumes the turn. A claim that survives with no
+    // terminal is the signature of a process that died without teardown (crash, SIGKILL, eviction);
+    // recovery is a property of the database, never of a shutdown hook that may not run.
+    const claimOnCommit = (sessionID: SessionSchema.ID) => ({
+      commit: () => store.claim(sessionID),
+    })
+    const releaseOnCommit = (sessionID: SessionSchema.ID) => ({
+      commit: () => store.release(sessionID),
     })
     const coordinator = yield* SessionRunCoordinator.make<SessionSchema.ID, SessionRunner.RunError, InterruptReason>({
       started: (sessionID) =>
         reportLifecycle(
           sessionID,
-          bus.publish(SessionEvent.Execution.Started, { sessionID }, clearSuspensionOnCommit(sessionID)),
+          bus.publish(SessionEvent.Execution.Started, { sessionID }, claimOnCommit(sessionID)),
         ),
       drain: Effect.fnUntraced(function* (sessionID: SessionSchema.ID, force) {
         const session = yield* store.get(sessionID)
@@ -86,11 +92,17 @@ export const layer = Layer.effect(
           Effect.gen(function* () {
             const outcome = terminal(exit, reason)
             if (outcome.type === "succeeded") {
-              yield* bus.publish(SessionEvent.Execution.Succeeded, { sessionID }, clearSuspensionOnCommit(sessionID))
+              yield* bus.publish(SessionEvent.Execution.Succeeded, { sessionID }, releaseOnCommit(sessionID))
               return
             }
             if (outcome.type === "interrupted") {
-              yield* bus.publish(SessionEvent.Execution.Interrupted, { sessionID, reason: outcome.reason })
+              // A user cancel (or a superseding execution) releases the claim: the turn must not
+              // resurrect at the next boot. Shutdown interruption keeps it for restart continuity.
+              yield* bus.publish(
+                SessionEvent.Execution.Interrupted,
+                { sessionID, reason: outcome.reason },
+                outcome.reason === "shutdown" ? undefined : releaseOnCommit(sessionID),
+              )
               return
             }
             yield* bus.publish(
@@ -99,7 +111,7 @@ export const layer = Layer.effect(
                 sessionID,
                 error: outcome.error,
               },
-              clearSuspensionOnCommit(sessionID),
+              releaseOnCommit(sessionID),
             )
           }),
         ),

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -5,61 +5,136 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "../../bus"
 import { SessionEvent } from "../event"
 import { SessionExecution } from "../execution"
+import { SessionSchema } from "../schema"
 import { SessionStore } from "../store"
 
 const CONTINUE_AFTER_SERVER_RESTART =
   "The server restarted while you were working. Continue from where you left off without repeating completed work."
 
+export interface Options {
+  /**
+   * Times a single turn may be resumed before it is terminalized instead.
+   * The counter is durable and only a terminal event resets it, so a turn
+   * that keeps dying cannot crash-loop across restarts. Turns that complete
+   * never accumulate: the budget is per-turn, not per-session.
+   */
+  readonly maxAttempts?: number
+  /**
+   * Claims whose aggregate saw a durable event more recently than this are
+   * deferred: another process may still be draining the turn (managed-server
+   * handoff overlap). Deferred claims are re-checked once after
+   * `redriveDelayMs` and otherwise left for the next start.
+   */
+  readonly graceMs?: number
+  readonly redriveDelayMs?: number
+}
+
+const DEFAULT_MAX_ATTEMPTS = 10
+const DEFAULT_GRACE_MS = 15_000
+const DEFAULT_REDRIVE_DELAY_MS = 20_000
+
 export interface Interface {
   /**
-   * Marks every execution active in this process for resumption by the next server start.
-   * Call once new work has stopped arriving and before teardown interrupts the drains.
+   * Resumes Sessions whose execution claim was never released — turns orphaned
+   * by a process that died without teardown, or interrupted by a graceful
+   * shutdown (which preserves the claim on purpose). Each claim is consumed
+   * atomically, so a Session resumes at most once per sweep.
    */
-  readonly suspendActiveSessions: Effect.Effect<void>
-  /** Resumes suspended Sessions. Each suspension is consumed atomically, so a Session resumes at most once. */
   readonly resumeSuspendedSessions: Effect.Effect<void>
 }
 
 /**
- * Restart continuity actions for the managed server. The service is inert until called: only the
- * managed server invokes it, so default, embedded, and stdio servers never suspend or auto-resume.
+ * Recovery for orphaned executions. Claims are written at turn start by
+ * SessionExecution, so this sweep needs no cooperation from the previous
+ * process: crash, SIGKILL, isolate eviction, and graceful restart all leave
+ * the same durable signature. The service is inert until called — the managed
+ * server invokes it at boot; embedders that can die without teardown call it
+ * from their own start-up.
  */
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRestart") {}
 
-export const layer = Layer.effect(
-  Service,
-  Effect.gen(function* () {
-    const store = yield* SessionStore.Service
-    const execution = yield* SessionExecution.Service
-    const bus = yield* Bus.Service
-    return Service.of({
-      suspendActiveSessions: Effect.gen(function* () {
-        yield* store.suspend(yield* execution.active)
-      }),
-      resumeSuspendedSessions: Effect.gen(function* () {
-        const sessions = yield* store.listSuspended()
-        yield* Effect.forEach(
-          sessions,
+export const layer = (options?: Options) =>
+  Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const store = yield* SessionStore.Service
+      const execution = yield* SessionExecution.Service
+      const bus = yield* Bus.Service
+      const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+      const graceMs = options?.graceMs ?? DEFAULT_GRACE_MS
+      const redriveDelayMs = options?.redriveDelayMs ?? DEFAULT_REDRIVE_DELAY_MS
+
+      /** Claims with message activity inside the grace window may belong to a live drain elsewhere. */
+      const settled = Effect.fnUntraced(function* (sessionID: SessionSchema.ID) {
+        const lastActivityAt = yield* store.lastActivityAt(sessionID)
+        return lastActivityAt === undefined || Date.now() - lastActivityAt >= graceMs
+      })
+
+      const resumeOne = Effect.fnUntraced(function* (sessionID: SessionSchema.ID) {
+        // Durable before the resume runs, so a crash inside the resumed turn is
+        // counted by the next sweep and the budget cannot be dodged.
+        const attempts = yield* store.countResume(sessionID)
+        if (attempts > maxAttempts) {
+          // Terminalize instead: the release hook clears the claim and resets the
+          // counter atomically with the terminal event.
+          yield* bus.publish(
+            SessionEvent.Execution.Failed,
+            {
+              sessionID,
+              error: {
+                type: "aborted",
+                message: "Execution was interrupted repeatedly and will not be resumed automatically.",
+              },
+            },
+            { commit: () => store.release(sessionID) },
+          )
+          return
+        }
+        if (!(yield* store.consumeSuspended(sessionID))) return
+        yield* bus.publish(SessionEvent.Synthetic, {
+          sessionID,
+          text: CONTINUE_AFTER_SERVER_RESTART,
+          description: "Continuing after restart",
+        })
+        // Drain failures are already logged and durably recorded by the execution layer.
+        yield* Effect.ignore(execution.resume(sessionID))
+      })
+
+      const sweep = (sessionIDs: ReadonlyArray<SessionSchema.ID>) =>
+        Effect.forEach(
+          sessionIDs,
           (sessionID) =>
             Effect.gen(function* () {
-              if (!(yield* store.consumeSuspended(sessionID))) return
-              yield* bus.publish(SessionEvent.Synthetic, {
-                sessionID,
-                text: CONTINUE_AFTER_SERVER_RESTART,
-                description: "Continuing after restart",
-              })
-              // Drain failures are already logged and durably recorded by the execution layer.
-              yield* Effect.ignore(execution.resume(sessionID))
+              if (yield* settled(sessionID)) return yield* resumeOne(sessionID)
+              return sessionID
             }),
-          { concurrency: "unbounded", discard: true },
-        )
-      }),
-    })
-  }),
-)
+          { concurrency: "unbounded" },
+        ).pipe(Effect.map((results) => results.filter((result) => result !== undefined)))
 
-export const node = makeGlobalNode({
-  service: Service,
-  layer,
-  deps: [SessionStore.node, SessionExecution.node, Bus.node],
-})
+      return Service.of({
+        resumeSuspendedSessions: Effect.gen(function* () {
+          // Sessions already draining in this process keep their claim; resuming
+          // them would only inject a stray continuation into a live turn.
+          const active = yield* execution.active
+          const claimed = (yield* store.listSuspended()).filter((sessionID) => !active.has(sessionID))
+          const deferred = yield* sweep(claimed)
+          if (deferred.length === 0) return
+          // One redrive covers the managed-server handoff overlap: the previous
+          // server's drains are interrupted moments after this one boots. Claims
+          // still active after the delay wait for the next start.
+          yield* Effect.sleep(redriveDelayMs)
+          const activeNow = yield* execution.active
+          yield* sweep(deferred.filter((sessionID) => !activeNow.has(sessionID)))
+        }),
+      })
+    }),
+  )
+
+export const configured = (options?: Options) =>
+  makeGlobalNode({
+    service: Service,
+    layer: layer(options),
+    deps: [SessionStore.node, SessionExecution.node, Bus.node],
+  })
+
+export const node = configured()

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -19,26 +19,17 @@ export interface Options {
    * never accumulate: the budget is per-turn, not per-session.
    */
   readonly maxAttempts?: number
-  /**
-   * Claims whose aggregate saw a durable event more recently than this are
-   * deferred: another process may still be draining the turn (managed-server
-   * handoff overlap). Deferred claims are re-checked once after
-   * `redriveDelayMs` and otherwise left for the next start.
-   */
-  readonly graceMs?: number
-  readonly redriveDelayMs?: number
 }
 
 const DEFAULT_MAX_ATTEMPTS = 10
-const DEFAULT_GRACE_MS = 15_000
-const DEFAULT_REDRIVE_DELAY_MS = 20_000
 
 export interface Interface {
   /**
    * Resumes Sessions whose execution claim was never released — turns orphaned
    * by a process that died without teardown, or interrupted by a graceful
-   * shutdown (which preserves the claim on purpose). Each claim is consumed
-   * atomically, so a Session resumes at most once per sweep.
+   * shutdown (which preserves the claim on purpose). The claim is never
+   * cleared here: only a terminal event releases it, so a death anywhere in
+   * the resume path leaves the same orphaned claim for the next boot.
    */
   readonly resumeSuspendedSessions: Effect.Effect<void>
 }
@@ -47,9 +38,15 @@ export interface Interface {
  * Recovery for orphaned executions. Claims are written at turn start by
  * SessionExecution, so this sweep needs no cooperation from the previous
  * process: crash, SIGKILL, isolate eviction, and graceful restart all leave
- * the same durable signature. The service is inert until called — the managed
- * server invokes it at boot; embedders that can die without teardown call it
- * from their own start-up.
+ * the same durable signature.
+ *
+ * The sweep assumes every orphaned claim's owner is dead. The managed-server
+ * protocol guarantees this: a successor is only spawned after the previous
+ * process is confirmed dead (client service `kill`/`evict` poll the PID), the
+ * registration lock admits one managed server at a time, and unregistered
+ * servers sharing the database never sweep. The service is inert until called
+ * — the managed server invokes it at boot; embedders that can die without
+ * teardown call it from their own start-up.
  */
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRestart") {}
 
@@ -60,15 +57,8 @@ export const layer = (options?: Options) =>
       const store = yield* SessionStore.Service
       const execution = yield* SessionExecution.Service
       const bus = yield* Bus.Service
+      const scope = yield* Effect.scope
       const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
-      const graceMs = options?.graceMs ?? DEFAULT_GRACE_MS
-      const redriveDelayMs = options?.redriveDelayMs ?? DEFAULT_REDRIVE_DELAY_MS
-
-      /** Claims with message activity inside the grace window may belong to a live drain elsewhere. */
-      const settled = Effect.fnUntraced(function* (sessionID: SessionSchema.ID) {
-        const lastActivityAt = yield* store.lastActivityAt(sessionID)
-        return lastActivityAt === undefined || Date.now() - lastActivityAt >= graceMs
-      })
 
       const resumeOne = Effect.fnUntraced(function* (sessionID: SessionSchema.ID) {
         // Durable before the resume runs, so a crash inside the resumed turn is
@@ -90,41 +80,24 @@ export const layer = (options?: Options) =>
           )
           return
         }
-        if (!(yield* store.consumeSuspended(sessionID))) return
         yield* bus.publish(SessionEvent.Synthetic, {
           sessionID,
           text: CONTINUE_AFTER_SERVER_RESTART,
           description: "Continuing after restart",
         })
-        // Drain failures are already logged and durably recorded by the execution layer.
-        yield* Effect.ignore(execution.resume(sessionID))
+        // Forked into the service scope so boot never waits on resumed turns;
+        // resuming an already-live Session joins its execution. Drain failures
+        // are logged and durably recorded by the execution layer.
+        yield* execution.resume(sessionID).pipe(Effect.ignore, Effect.forkIn(scope))
       })
-
-      const sweep = (sessionIDs: ReadonlyArray<SessionSchema.ID>) =>
-        Effect.forEach(
-          sessionIDs,
-          (sessionID) =>
-            Effect.gen(function* () {
-              if (yield* settled(sessionID)) return yield* resumeOne(sessionID)
-              return sessionID
-            }),
-          { concurrency: "unbounded" },
-        ).pipe(Effect.map((results) => results.filter((result) => result !== undefined)))
 
       return Service.of({
         resumeSuspendedSessions: Effect.gen(function* () {
+          const active = yield* execution.active
           // Sessions already draining in this process keep their claim; resuming
           // them would only inject a stray continuation into a live turn.
-          const active = yield* execution.active
-          const claimed = (yield* store.listSuspended()).filter((sessionID) => !active.has(sessionID))
-          const deferred = yield* sweep(claimed)
-          if (deferred.length === 0) return
-          // One redrive covers the managed-server handoff overlap: the previous
-          // server's drains are interrupted moments after this one boots. Claims
-          // still active after the delay wait for the next start.
-          yield* Effect.sleep(redriveDelayMs)
-          const activeNow = yield* execution.active
-          yield* sweep(deferred.filter((sessionID) => !activeNow.has(sessionID)))
+          const orphaned = (yield* store.listSuspended()).filter((sessionID) => !active.has(sessionID))
+          yield* Effect.forEach(orphaned, resumeOne, { concurrency: "unbounded", discard: true })
         }),
       })
     }),

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -11,6 +11,11 @@ import { SessionStore } from "../store"
 const CONTINUE_AFTER_SERVER_RESTART =
   "The server restarted while you were working. Continue from where you left off without repeating completed work."
 
+const RESUME_EXHAUSTED = {
+  type: "aborted",
+  message: "Execution was interrupted repeatedly and will not be resumed automatically.",
+} as const
+
 export interface Options {
   /**
    * Times a single turn may be resumed before it is terminalized instead.
@@ -45,8 +50,8 @@ export interface Interface {
  * process is confirmed dead (client service `kill`/`evict` poll the PID), the
  * registration lock admits one managed server at a time, and unregistered
  * servers sharing the database never sweep. The service is inert until called
- * — the managed server invokes it at boot; embedders that can die without
- * teardown call it from their own start-up.
+ * — the managed server invokes it at boot; embedders may call it from their
+ * own start-up.
  */
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRestart") {}
 
@@ -64,18 +69,13 @@ export const layer = (options?: Options) =>
         // Durable before the resume runs, so a crash inside the resumed turn is
         // counted by the next sweep and the budget cannot be dodged.
         const attempts = yield* store.countResume(sessionID)
+        if (attempts === undefined) return // the Session was deleted since listing
         if (attempts > maxAttempts) {
           // Terminalize instead: the release hook clears the claim and resets the
           // counter atomically with the terminal event.
           yield* bus.publish(
             SessionEvent.Execution.Failed,
-            {
-              sessionID,
-              error: {
-                type: "aborted",
-                message: "Execution was interrupted repeatedly and will not be resumed automatically.",
-              },
-            },
+            { sessionID, error: RESUME_EXHAUSTED },
             { commit: () => store.release(sessionID) },
           )
           return
@@ -93,6 +93,11 @@ export const layer = (options?: Options) =>
 
       return Service.of({
         resumeSuspendedSessions: Effect.gen(function* () {
+          // Child claims never drive recovery (children are not resumed), so a
+          // dead child's claim is noise no terminal will ever release. Clearing
+          // is safe even against a live child: claims are recovery markers, not
+          // locks, and children are excluded from that recovery.
+          yield* store.releaseChildClaims
           const active = yield* execution.active
           // Sessions already draining in this process keep their claim; resuming
           // them would only inject a stray continuation into a live turn.
@@ -103,11 +108,8 @@ export const layer = (options?: Options) =>
     }),
   )
 
-export const configured = (options?: Options) =>
-  makeGlobalNode({
-    service: Service,
-    layer: layer(options),
-    deps: [SessionStore.node, SessionExecution.node, Bus.node],
-  })
-
-export const node = configured()
+export const node = makeGlobalNode({
+  service: Service,
+  layer: layer(),
+  deps: [SessionStore.node, SessionExecution.node, Bus.node],
+})

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -59,6 +59,7 @@ export const SessionTable = sqliteTable(
     time_compacting: integer(),
     time_archived: integer(),
     time_suspended: integer(),
+    resume_attempts: integer().notNull().default(0),
   },
   (table) => [
     index("session_v2_project_idx").on(table.project_id),

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -58,6 +58,7 @@ export const SessionTable = sqliteTable(
     ...Timestamps,
     time_compacting: integer(),
     time_archived: integer(),
+    /** The execution claim timestamp (historical column name; see SessionStore.claim). */
     time_suspended: integer(),
     resume_attempts: integer().notNull().default(0),
   },

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -1,6 +1,6 @@
 export * as SessionStore from "./store"
 
-import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm"
+import { and, eq, isNotNull, isNull, sql } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
@@ -18,9 +18,25 @@ export interface Interface {
     messageID: SessionMessage.ID,
   ) => Effect.Effect<{ readonly sessionID: Session.ID; readonly message: SessionMessage.Info } | undefined>
   readonly listSuspended: () => Effect.Effect<ReadonlyArray<Session.ID>>
-  /** Clears suspension, reporting whether this caller consumed it. At most one concurrent caller receives true. */
+  /** Clears the claim, reporting whether this caller consumed it. At most one concurrent caller receives true. */
   readonly consumeSuspended: (sessionID: Session.ID) => Effect.Effect<boolean>
-  readonly suspend: (sessionIDs: Iterable<Session.ID>) => Effect.Effect<void>
+  /**
+   * Records the execution claim: the durable write-ahead intent that a turn is
+   * (or was) in flight. Set when execution starts; a claim that survives to the
+   * next boot is the signature of a process that died without teardown.
+   */
+  readonly claim: (sessionID: Session.ID) => Effect.Effect<void>
+  /** Releases the claim and resets resume accounting. Terminal events call this on commit. */
+  readonly release: (sessionID: Session.ID) => Effect.Effect<void>
+  /** Durably counts one more resume of an orphaned claim, returning the new total. */
+  readonly countResume: (sessionID: Session.ID) => Effect.Effect<number>
+  /**
+   * When the Session's messages last changed, or undefined for an empty
+   * Session. Message rows update as a live drain streams, so recent activity
+   * suggests another process may still own the turn. Event persistence is
+   * opt-in, so this deliberately reads messages, not the event log.
+   */
+  readonly lastActivityAt: (sessionID: Session.ID) => Effect.Effect<number | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStore") {}
@@ -75,16 +91,42 @@ const layer = Layer.effect(
             .pipe(Effect.orDie)) !== undefined
         )
       }),
-      suspend: Effect.fn("SessionStore.suspend")(function* (sessionIDs) {
-        const ids = Array.from(sessionIDs)
-        if (ids.length === 0) return
-        // The null guard preserves the original suspension time if a Session is somehow suspended twice.
+      claim: Effect.fn("SessionStore.claim")(function* (sessionID) {
+        // The null guard preserves the original claim time if a claimed Session drains again
+        // before the sweep saw it (a user prompt beat the recovery to the wake-up).
         yield* db
           .update(SessionTable)
           .set({ time_suspended: Date.now() })
-          .where(and(inArray(SessionTable.id, ids), isNull(SessionTable.time_suspended)))
+          .where(and(eq(SessionTable.id, sessionID), isNull(SessionTable.time_suspended)))
           .run()
           .pipe(Effect.orDie)
+      }),
+      release: Effect.fn("SessionStore.release")(function* (sessionID) {
+        yield* db
+          .update(SessionTable)
+          .set({ time_suspended: null, resume_attempts: 0 })
+          .where(eq(SessionTable.id, sessionID))
+          .run()
+          .pipe(Effect.orDie)
+      }),
+      countResume: Effect.fn("SessionStore.countResume")(function* (sessionID) {
+        const row = yield* db
+          .update(SessionTable)
+          .set({ resume_attempts: sql`${SessionTable.resume_attempts} + 1` })
+          .where(eq(SessionTable.id, sessionID))
+          .returning({ attempts: SessionTable.resume_attempts })
+          .get()
+          .pipe(Effect.orDie)
+        return row?.attempts ?? 0
+      }),
+      lastActivityAt: Effect.fn("SessionStore.lastActivityAt")(function* (sessionID) {
+        const row = yield* db
+          .select({ updatedAt: sql<number | null>`max(${SessionMessageTable.time_updated})` })
+          .from(SessionMessageTable)
+          .where(eq(SessionMessageTable.session_id, sessionID))
+          .get()
+          .pipe(Effect.orDie)
+        return row?.updatedAt ?? undefined
       }),
     })
   }),

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -26,13 +26,23 @@ export interface Interface {
   /**
    * Records the execution claim: the durable write-ahead intent that a turn is
    * (or was) in flight. Set when execution starts; a claim that survives to the
-   * next boot is the signature of a process that died without teardown.
+   * next boot marks a turn that never completed — its process crashed or shut
+   * down mid-turn.
    */
   readonly claim: (sessionID: Session.ID) => Effect.Effect<void>
   /** Releases the claim and resets resume accounting. Terminal events call this on commit. */
   readonly release: (sessionID: Session.ID) => Effect.Effect<void>
-  /** Durably counts one more resume of an orphaned claim, returning the new total. */
-  readonly countResume: (sessionID: Session.ID) => Effect.Effect<number>
+  /**
+   * Clears orphaned child (subagent) claims. Children are never resumed
+   * independently, so a dead child's claim is noise no terminal will ever
+   * release.
+   */
+  readonly releaseChildClaims: Effect.Effect<void>
+  /**
+   * Durably counts one more resume of an orphaned claim, returning the new
+   * total — or undefined when the Session no longer exists.
+   */
+  readonly countResume: (sessionID: Session.ID) => Effect.Effect<number | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStore") {}
@@ -77,11 +87,13 @@ const layer = Layer.effect(
           )
       }),
       claim: Effect.fn("SessionStore.claim")(function* (sessionID) {
-        // The null guard preserves the original claim time if a claimed Session drains again
-        // before the sweep saw it (a user prompt beat the recovery to the wake-up).
+        // The null guard makes re-claiming a still-claimed Session a zero-row
+        // no-op (a resumed turn re-claims through the same started hook).
+        // Claim bookkeeping never counts as user activity: time_updated is
+        // pinned so session ordering only moves on real changes.
         yield* db
           .update(SessionTable)
-          .set({ time_suspended: Date.now() })
+          .set({ time_suspended: Date.now(), time_updated: sql`${SessionTable.time_updated}` })
           .where(and(eq(SessionTable.id, sessionID), isNull(SessionTable.time_suspended)))
           .run()
           .pipe(Effect.orDie)
@@ -89,20 +101,29 @@ const layer = Layer.effect(
       release: Effect.fn("SessionStore.release")(function* (sessionID) {
         yield* db
           .update(SessionTable)
-          .set({ time_suspended: null, resume_attempts: 0 })
+          .set({ time_suspended: null, resume_attempts: 0, time_updated: sql`${SessionTable.time_updated}` })
           .where(eq(SessionTable.id, sessionID))
           .run()
           .pipe(Effect.orDie)
       }),
+      releaseChildClaims: db
+        .update(SessionTable)
+        .set({ time_suspended: null, resume_attempts: 0, time_updated: sql`${SessionTable.time_updated}` })
+        .where(and(isNotNull(SessionTable.time_suspended), isNotNull(SessionTable.parent_id)))
+        .run()
+        .pipe(Effect.orDie, Effect.asVoid, Effect.withSpan("SessionStore.releaseChildClaims")),
       countResume: Effect.fn("SessionStore.countResume")(function* (sessionID) {
         const row = yield* db
           .update(SessionTable)
-          .set({ resume_attempts: sql`${SessionTable.resume_attempts} + 1` })
+          .set({
+            resume_attempts: sql`${SessionTable.resume_attempts} + 1`,
+            time_updated: sql`${SessionTable.time_updated}`,
+          })
           .where(eq(SessionTable.id, sessionID))
           .returning({ attempts: SessionTable.resume_attempts })
           .get()
           .pipe(Effect.orDie)
-        return row?.attempts ?? 0
+        return row?.attempts
       }),
     })
   }),

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -17,9 +17,12 @@ export interface Interface {
   readonly message: (
     messageID: SessionMessage.ID,
   ) => Effect.Effect<{ readonly sessionID: Session.ID; readonly message: SessionMessage.Info } | undefined>
+  /**
+   * Top-level Sessions holding an execution claim. Child (subagent) Sessions
+   * are excluded: a resumed parent re-runs its tool call and spawns fresh
+   * children, so resuming orphaned children would duplicate their work.
+   */
   readonly listSuspended: () => Effect.Effect<ReadonlyArray<Session.ID>>
-  /** Clears the claim, reporting whether this caller consumed it. At most one concurrent caller receives true. */
-  readonly consumeSuspended: (sessionID: Session.ID) => Effect.Effect<boolean>
   /**
    * Records the execution claim: the durable write-ahead intent that a turn is
    * (or was) in flight. Set when execution starts; a claim that survives to the
@@ -30,13 +33,6 @@ export interface Interface {
   readonly release: (sessionID: Session.ID) => Effect.Effect<void>
   /** Durably counts one more resume of an orphaned claim, returning the new total. */
   readonly countResume: (sessionID: Session.ID) => Effect.Effect<number>
-  /**
-   * When the Session's messages last changed, or undefined for an empty
-   * Session. Message rows update as a live drain streams, so recent activity
-   * suggests another process may still own the turn. Event persistence is
-   * opt-in, so this deliberately reads messages, not the event log.
-   */
-  readonly lastActivityAt: (sessionID: Session.ID) => Effect.Effect<number | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStore") {}
@@ -73,23 +69,12 @@ const layer = Layer.effect(
         return yield* db
           .select({ sessionID: SessionTable.id })
           .from(SessionTable)
-          .where(isNotNull(SessionTable.time_suspended))
+          .where(and(isNotNull(SessionTable.time_suspended), isNull(SessionTable.parent_id)))
           .all()
           .pipe(
             Effect.orDie,
             Effect.map((rows) => rows.map((row) => row.sessionID)),
           )
-      }),
-      consumeSuspended: Effect.fn("SessionStore.consumeSuspended")(function* (sessionID) {
-        return (
-          (yield* db
-            .update(SessionTable)
-            .set({ time_suspended: null })
-            .where(and(eq(SessionTable.id, sessionID), isNotNull(SessionTable.time_suspended)))
-            .returning({ sessionID: SessionTable.id })
-            .get()
-            .pipe(Effect.orDie)) !== undefined
-        )
       }),
       claim: Effect.fn("SessionStore.claim")(function* (sessionID) {
         // The null guard preserves the original claim time if a claimed Session drains again
@@ -118,15 +103,6 @@ const layer = Layer.effect(
           .get()
           .pipe(Effect.orDie)
         return row?.attempts ?? 0
-      }),
-      lastActivityAt: Effect.fn("SessionStore.lastActivityAt")(function* (sessionID) {
-        const row = yield* db
-          .select({ updatedAt: sql<number | null>`max(${SessionMessageTable.time_updated})` })
-          .from(SessionMessageTable)
-          .where(eq(SessionMessageTable.session_id, sessionID))
-          .get()
-          .pipe(Effect.orDie)
-        return row?.updatedAt ?? undefined
       }),
     })
   }),

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -14,10 +14,12 @@ import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { UserInterruptedError } from "@opencode-ai/core/session/error"
 import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionRunner } from "@opencode-ai/core/session/runner"
-import { SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
-import { Context, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Scope } from "effect"
+import { Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Schema, Scope } from "effect"
+import { eq } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SessionStore.node])))
@@ -49,7 +51,7 @@ describe("SessionExecution lifecycle", () => {
     })
   })
 
-  it.effect("atomically consumes each suspension at most once", () =>
+  it.effect("atomically consumes each claim at most once", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
       const store = yield* SessionStore.Service
@@ -60,47 +62,73 @@ describe("SessionExecution lifecycle", () => {
       expect(yield* store.consumeSuspended(first)).toBe(true)
       expect(yield* store.consumeSuspended(first)).toBe(false)
       expect(yield* store.consumeSuspended(second)).toBe(true)
-      expect(yield* suspensions(database)).toEqual({ [first]: false, [second]: false })
+      expect(yield* claims(database)).toEqual({ [first]: false, [second]: false })
     }),
   )
 
-  it.effect("suspension survives teardown interruption and clears when a drain finishes on its own", () =>
+  it.effect("claims at execution start, releases on completion, and preserves through teardown", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
-      const interrupted = Session.ID.make("ses_suspend_interrupted")
-      const completed = Session.ID.make("ses_suspend_completed")
+      const interrupted = Session.ID.make("ses_claim_interrupted")
+      const completed = Session.ID.make("ses_claim_completed")
       yield* seedSessions(database, [interrupted, completed])
 
-      const draining = yield* Deferred.make<void>()
+      // Each drain signals once it runs; the claim commits before the drain starts.
+      const running = new Map(
+        [interrupted, completed].map((id) => [id, Deferred.makeUnsafe<void>()] as const),
+      )
       const release = yield* Deferred.make<void>()
       const scope = yield* Scope.make()
       const context = yield* buildExecution(scope, ({ sessionID }) =>
-        sessionID === completed
-          ? Deferred.await(release)
-          : Deferred.succeed(draining, undefined).pipe(Effect.andThen(Effect.never)),
+        Deferred.succeed(running.get(sessionID)!, undefined).pipe(
+          Effect.andThen(sessionID === completed ? Deferred.await(release) : Effect.never),
+        ),
       )
       const execution = Context.get(context, SessionExecution.Service)
-      const restart = Context.get(context, SessionRestart.Service)
       yield* execution.resume(interrupted).pipe(Effect.forkScoped)
       const completing = yield* execution.resume(completed).pipe(Effect.forkIn(scope))
-      yield* Deferred.await(draining)
+      yield* Effect.forEach(running.values(), Deferred.await, { discard: true })
 
-      yield* restart.suspendActiveSessions
-      expect(yield* suspensions(database)).toEqual({ [interrupted]: true, [completed]: true })
+      // The write-ahead claim exists WHILE the turns run — no shutdown hook involved.
+      expect(yield* claims(database)).toEqual({ [interrupted]: true, [completed]: true })
 
-      // A drain that finishes on its own after suspension clears its stale suspension.
+      // A drain that finishes on its own releases its claim.
       yield* Deferred.succeed(release, undefined)
       yield* Fiber.join(completing)
       yield* execution.awaitIdle(completed)
-      expect((yield* suspensions(database))[completed]).toBe(false)
+      expect((yield* claims(database))[completed]).toBe(false)
 
-      // Teardown interruption preserves suspension for the next server start.
+      // Teardown interruption (graceful twin of an unclean death) preserves the claim
+      // for the next server start.
       yield* Scope.close(scope, Exit.void)
-      expect((yield* suspensions(database))[interrupted]).toBe(true)
+      expect((yield* claims(database))[interrupted]).toBe(true)
     }),
   )
 
-  it.effect("starts every suspended execution without waiting for earlier drains to finish", () =>
+  it.effect("a user interrupt releases the claim so the turn never resurrects", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_claim_user_cancel")
+      yield* seedSessions(database, [sessionID])
+
+      const draining = yield* Deferred.make<void>()
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, () =>
+        Deferred.succeed(draining, undefined).pipe(Effect.andThen(Effect.never)),
+      )
+      const execution = Context.get(context, SessionExecution.Service)
+      yield* execution.resume(sessionID).pipe(Effect.forkScoped)
+      yield* Deferred.await(draining)
+      expect((yield* claims(database))[sessionID]).toBe(true)
+
+      yield* execution.interrupt(sessionID)
+      yield* execution.awaitIdle(sessionID)
+      expect((yield* claims(database))[sessionID]).toBe(false)
+    }),
+  )
+
+  it.effect("starts every claimed execution without waiting for earlier drains to finish", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
       const sessionIDs = Array.from({ length: 5 }, (_, index) => Session.ID.make(`ses_resume_concurrent_${index}`))
@@ -125,7 +153,7 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
-  it.effect("resumes each suspended Session at most once", () =>
+  it.effect("resumes each claimed Session at most once", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
       const bus = yield* Bus.Service
@@ -151,7 +179,9 @@ describe("SessionExecution lifecycle", () => {
           description: "Continuing after restart",
         })),
       )
-      expect(yield* suspensions(database)).toEqual({ [first]: false, [second]: false })
+      // Drains completed naturally, so claims are released and counters reset.
+      expect(yield* claims(database)).toEqual({ [first]: false, [second]: false })
+      expect(yield* attempts(database, first)).toBe(0)
 
       yield* restart.resumeSuspendedSessions
       expect(drained.length).toBe(2)
@@ -159,12 +189,87 @@ describe("SessionExecution lifecycle", () => {
       yield* Scope.close(scope, Exit.void)
     }),
   )
+
+  it.effect("terminalizes a turn that exhausts its resume budget instead of crash-looping", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const sessionID = Session.ID.make("ses_resume_exhausted")
+      // A claim from a dead process, already resumed twice without completing.
+      yield* seedSessions(database, [sessionID], { time_suspended: Date.now(), resume_attempts: 2 })
+
+      const drained: string[] = []
+      const failures: SessionEvent.Execution.Failed[] = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(
+        scope,
+        ({ sessionID: id }) => Effect.sync(() => void drained.push(id)),
+        { maxAttempts: 2 },
+      )
+      const restart = Context.get(context, SessionRestart.Service)
+      yield* bus.project(SessionEvent.Execution.Failed, (event) => Effect.sync(() => void failures.push(event)))
+
+      yield* restart.resumeSuspendedSessions
+      expect(drained).toEqual([])
+      expect(failures.map((event) => event.data.error.type)).toEqual(["aborted"])
+      // The terminal released the claim and reset the counter atomically.
+      expect(yield* claims(database)).toEqual({ [sessionID]: false })
+      expect(yield* attempts(database, sessionID)).toBe(0)
+    }),
+  )
+
+  it.effect("counts every resume durably before the turn runs", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_resume_counted")
+      yield* seedSessions(database, [sessionID], { time_suspended: Date.now() })
+
+      const draining = yield* Deferred.make<void>()
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      // The drain never terminalizes (mirrors a process that will die mid-turn).
+      const context = yield* buildExecution(scope, () =>
+        Deferred.succeed(draining, undefined).pipe(Effect.andThen(Effect.never)),
+      )
+      const restart = Context.get(context, SessionRestart.Service)
+      yield* restart.resumeSuspendedSessions.pipe(Effect.forkIn(scope))
+      yield* Deferred.await(draining)
+
+      expect(yield* attempts(database, sessionID)).toBe(1)
+    }),
+  )
+
+  it.live("defers claims whose Session has recent message activity", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_resume_deferred")
+      yield* seedSessions(database, [sessionID], { time_suspended: Date.now() })
+      // Fresh message activity: another process may still be draining this turn.
+      yield* seedMessage(database, sessionID, Date.now())
+
+      const drained: string[] = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(
+        scope,
+        ({ sessionID: id }) => Effect.sync(() => void drained.push(id)),
+        { graceMs: 60_000, redriveDelayMs: 0 },
+      )
+      const restart = Context.get(context, SessionRestart.Service)
+
+      yield* restart.resumeSuspendedSessions
+      expect(drained).toEqual([])
+      // The claim survives for the next start.
+      expect((yield* claims(database))[sessionID]).toBe(true)
+    }),
+  )
 })
 
 function seedSessions(
   database: Database.Service["Service"],
   sessionIDs: ReadonlyArray<Session.ID>,
-  values: { time_suspended?: number } = {},
+  values: { time_suspended?: number; resume_attempts?: number } = {},
 ) {
   return Effect.gen(function* () {
     yield* database.db
@@ -190,19 +295,50 @@ function seedSessions(
   })
 }
 
-function suspensions(database: Database.Service["Service"]) {
+function seedMessage(database: Database.Service["Service"], sessionID: Session.ID, timeUpdated: number) {
+  const id = SessionMessage.ID.create()
+  const { id: _, type, ...data } = Schema.encodeSync(SessionMessage.Info)({
+    id,
+    type: "synthetic",
+    text: "live turn output",
+    time: { created: DateTime.makeUnsafe(timeUpdated) },
+  })
   return database.db
-    .select({ id: SessionTable.id, suspended: SessionTable.time_suspended })
+    .insert(SessionMessageTable)
+    .values({ id, session_id: sessionID, type, seq: 0, time_created: timeUpdated, time_updated: timeUpdated, data })
+    .run()
+    .pipe(Effect.orDie)
+}
+
+function claims(database: Database.Service["Service"]) {
+  return database.db
+    .select({ id: SessionTable.id, claimed: SessionTable.time_suspended })
     .from(SessionTable)
     .all()
     .pipe(
       Effect.orDie,
-      Effect.map((rows) => Object.fromEntries(rows.map((row) => [row.id, row.suspended !== null]))),
+      Effect.map((rows) => Object.fromEntries(rows.map((row) => [row.id, row.claimed !== null]))),
+    )
+}
+
+function attempts(database: Database.Service["Service"], sessionID: Session.ID) {
+  return database.db
+    .select({ attempts: SessionTable.resume_attempts })
+    .from(SessionTable)
+    .where(eq(SessionTable.id, sessionID))
+    .get()
+    .pipe(
+      Effect.orDie,
+      Effect.map((row) => row?.attempts ?? -1),
     )
 }
 
 /** Builds the local execution layer plus the restart actions against the test harness services. */
-function buildExecution(scope: Scope.Closeable, drain: SessionRunner.Interface["drain"]) {
+function buildExecution(
+  scope: Scope.Closeable,
+  drain: SessionRunner.Interface["drain"],
+  options?: SessionRestart.Options,
+) {
   return Effect.gen(function* () {
     const database = yield* Database.Service
     const bus = yield* Bus.Service
@@ -218,7 +354,7 @@ function buildExecution(scope: Scope.Closeable, drain: SessionRunner.Interface["
       ),
     )
     return yield* Layer.buildWithScope(
-      SessionRestart.layer.pipe(
+      SessionRestart.layer({ graceMs: 0, redriveDelayMs: 0, ...options }).pipe(
         Layer.provideMerge(SessionExecution.layer),
         Layer.provide(Layer.succeed(Database.Service, database)),
         Layer.provide(Layer.succeed(Bus.Service, bus)),

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -14,11 +14,10 @@ import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { UserInterruptedError } from "@opencode-ai/core/session/error"
 import { SessionEvent } from "@opencode-ai/core/session/event"
-import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionRunner } from "@opencode-ai/core/session/runner"
-import { SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
-import { Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Schema, Scope } from "effect"
+import { Context, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Scope } from "effect"
 import { eq } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
 
@@ -51,18 +50,20 @@ describe("SessionExecution lifecycle", () => {
     })
   })
 
-  it.effect("atomically consumes each claim at most once", () =>
+  it.effect("the sweep only lists claimed top-level Sessions", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
       const store = yield* SessionStore.Service
-      const first = Session.ID.make("ses_recover_first")
-      const second = Session.ID.make("ses_recover_second")
-      yield* seedSessions(database, [first, second], { time_suspended: Date.now() })
+      const parent = Session.ID.make("ses_recover_parent")
+      const child = Session.ID.make("ses_recover_child")
+      const idle = Session.ID.make("ses_recover_idle")
+      yield* seedSessions(database, [parent], { time_suspended: Date.now() })
+      yield* seedSessions(database, [idle])
+      // An orphaned child is never resumed: the resumed parent re-runs its
+      // tool call and spawns a fresh child instead.
+      yield* seedSessions(database, [child], { time_suspended: Date.now(), parent_id: parent })
 
-      expect(yield* store.consumeSuspended(first)).toBe(true)
-      expect(yield* store.consumeSuspended(first)).toBe(false)
-      expect(yield* store.consumeSuspended(second)).toBe(true)
-      expect(yield* claims(database)).toEqual({ [first]: false, [second]: false })
+      expect(yield* store.listSuspended()).toEqual([parent])
     }),
   )
 
@@ -162,14 +163,22 @@ describe("SessionExecution lifecycle", () => {
       yield* seedSessions(database, [first, second], { time_suspended: Date.now() })
 
       const drained: string[] = []
+      const bothDraining = yield* Deferred.make<void>()
       const continued: SessionEvent.Synthetic[] = []
       const scope = yield* Scope.make()
-      const context = yield* buildExecution(scope, ({ sessionID }) => Effect.sync(() => void drained.push(sessionID)))
+      const context = yield* buildExecution(scope, ({ sessionID }) =>
+        Effect.sync(() => {
+          drained.push(sessionID)
+          if (drained.length === 2) Deferred.doneUnsafe(bothDraining, Effect.void)
+        }),
+      )
       const execution = Context.get(context, SessionExecution.Service)
       const restart = Context.get(context, SessionRestart.Service)
       yield* bus.project(SessionEvent.Synthetic, (event) => Effect.sync(() => void continued.push(event)))
 
+      // The sweep forks resumed drains, so completion is observed through the executions.
       yield* restart.resumeSuspendedSessions
+      yield* Deferred.await(bothDraining)
       yield* Effect.forEach([first, second], execution.awaitIdle, { discard: true })
       expect(drained.toSorted()).toEqual([first, second])
       expect(continued.map((event) => event.data).toSorted((a, b) => a.sessionID.localeCompare(b.sessionID))).toEqual(
@@ -219,7 +228,7 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
-  it.effect("counts every resume durably before the turn runs", () =>
+  it.effect("counts every resume durably and never consumes the claim it recovers", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
       const sessionID = Session.ID.make("ses_resume_counted")
@@ -236,45 +245,60 @@ describe("SessionExecution lifecycle", () => {
       yield* restart.resumeSuspendedSessions.pipe(Effect.forkIn(scope))
       yield* Deferred.await(draining)
 
+      // The attempt is durable before the drain runs, and the claim is held
+      // throughout: a crash anywhere in the resume path leaves both intact.
+      expect(yield* attempts(database, sessionID)).toBe(1)
+      expect((yield* claims(database))[sessionID]).toBe(true)
+
+      // Teardown (a graceful shutdown's interrupt) preserves both, so the next
+      // boot counts attempt 2 against the same turn.
+      yield* Scope.close(scope, Exit.void)
+      expect((yield* claims(database))[sessionID]).toBe(true)
       expect(yield* attempts(database, sessionID)).toBe(1)
     }),
   )
 
-  it.live("defers claims whose Session has recent message activity", () =>
+  it.effect("the sweep leaves Sessions already draining in this process untouched", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
-      const sessionID = Session.ID.make("ses_resume_deferred")
-      yield* seedSessions(database, [sessionID], { time_suspended: Date.now() })
-      // Fresh message activity: another process may still be draining this turn.
-      yield* seedMessage(database, sessionID, Date.now())
+      const bus = yield* Bus.Service
+      const sessionID = Session.ID.make("ses_resume_local_active")
+      yield* seedSessions(database, [sessionID])
 
-      const drained: string[] = []
+      const draining = yield* Deferred.make<void>()
+      const continued: SessionEvent.Synthetic[] = []
       const scope = yield* Scope.make()
       yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* buildExecution(
-        scope,
-        ({ sessionID: id }) => Effect.sync(() => void drained.push(id)),
-        { graceMs: 60_000, redriveDelayMs: 0 },
+      const context = yield* buildExecution(scope, () =>
+        Deferred.succeed(draining, undefined).pipe(Effect.andThen(Effect.never)),
       )
+      const execution = Context.get(context, SessionExecution.Service)
       const restart = Context.get(context, SessionRestart.Service)
+      yield* bus.project(SessionEvent.Synthetic, (event) => Effect.sync(() => void continued.push(event)))
 
+      // A live local turn holds a claim; the sweep must not count, continue, or terminalize it.
+      yield* execution.resume(sessionID).pipe(Effect.forkScoped)
+      yield* Deferred.await(draining)
       yield* restart.resumeSuspendedSessions
-      expect(drained).toEqual([])
-      // The claim survives for the next start.
+
+      expect(continued).toEqual([])
+      expect(yield* attempts(database, sessionID)).toBe(0)
       expect((yield* claims(database))[sessionID]).toBe(true)
     }),
   )
+
 })
 
 function seedSessions(
   database: Database.Service["Service"],
   sessionIDs: ReadonlyArray<Session.ID>,
-  values: { time_suspended?: number; resume_attempts?: number } = {},
+  values: { time_suspended?: number; resume_attempts?: number; parent_id?: Session.ID } = {},
 ) {
   return Effect.gen(function* () {
     yield* database.db
       .insert(ProjectTable)
       .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+      .onConflictDoNothing()
       .run()
       .pipe(Effect.orDie)
     yield* database.db
@@ -293,21 +317,6 @@ function seedSessions(
       .run()
       .pipe(Effect.orDie)
   })
-}
-
-function seedMessage(database: Database.Service["Service"], sessionID: Session.ID, timeUpdated: number) {
-  const id = SessionMessage.ID.create()
-  const { id: _, type, ...data } = Schema.encodeSync(SessionMessage.Info)({
-    id,
-    type: "synthetic",
-    text: "live turn output",
-    time: { created: DateTime.makeUnsafe(timeUpdated) },
-  })
-  return database.db
-    .insert(SessionMessageTable)
-    .values({ id, session_id: sessionID, type, seq: 0, time_created: timeUpdated, time_updated: timeUpdated, data })
-    .run()
-    .pipe(Effect.orDie)
 }
 
 function claims(database: Database.Service["Service"]) {
@@ -354,7 +363,7 @@ function buildExecution(
       ),
     )
     return yield* Layer.buildWithScope(
-      SessionRestart.layer({ graceMs: 0, redriveDelayMs: 0, ...options }).pipe(
+      SessionRestart.layer(options).pipe(
         Layer.provideMerge(SessionExecution.layer),
         Layer.provide(Layer.succeed(Database.Service, database)),
         Layer.provide(Layer.succeed(Bus.Service, bus)),

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -64,6 +64,10 @@ describe("SessionExecution lifecycle", () => {
       yield* seedSessions(database, [child], { time_suspended: Date.now(), parent_id: parent })
 
       expect(yield* store.listSuspended()).toEqual([parent])
+
+      // The sweep clears orphaned child claims outright; parents keep theirs.
+      yield* store.releaseChildClaims
+      expect(yield* claims(database)).toEqual({ [parent]: true, [child]: false, [idle]: false })
     }),
   )
 
@@ -75,20 +79,20 @@ describe("SessionExecution lifecycle", () => {
       yield* seedSessions(database, [interrupted, completed])
 
       // Each drain signals once it runs; the claim commits before the drain starts.
-      const running = new Map(
-        [interrupted, completed].map((id) => [id, Deferred.makeUnsafe<void>()] as const),
-      )
+      const interruptedRunning = yield* Deferred.make<void>()
+      const completedRunning = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
       const scope = yield* Scope.make()
       const context = yield* buildExecution(scope, ({ sessionID }) =>
-        Deferred.succeed(running.get(sessionID)!, undefined).pipe(
-          Effect.andThen(sessionID === completed ? Deferred.await(release) : Effect.never),
-        ),
+        sessionID === completed
+          ? Deferred.succeed(completedRunning, undefined).pipe(Effect.andThen(Deferred.await(release)))
+          : Deferred.succeed(interruptedRunning, undefined).pipe(Effect.andThen(Effect.never)),
       )
       const execution = Context.get(context, SessionExecution.Service)
       yield* execution.resume(interrupted).pipe(Effect.forkScoped)
       const completing = yield* execution.resume(completed).pipe(Effect.forkIn(scope))
-      yield* Effect.forEach(running.values(), Deferred.await, { discard: true })
+      yield* Deferred.await(interruptedRunning)
+      yield* Deferred.await(completedRunning)
 
       // The write-ahead claim exists WHILE the turns run — no shutdown hook involved.
       expect(yield* claims(database)).toEqual({ [interrupted]: true, [completed]: true })
@@ -286,13 +290,12 @@ describe("SessionExecution lifecycle", () => {
       expect((yield* claims(database))[sessionID]).toBe(true)
     }),
   )
-
 })
 
 function seedSessions(
   database: Database.Service["Service"],
   sessionIDs: ReadonlyArray<Session.ID>,
-  values: { time_suspended?: number; resume_attempts?: number; parent_id?: Session.ID } = {},
+  values: Partial<Pick<typeof SessionTable.$inferInsert, "time_suspended" | "resume_attempts" | "parent_id">> = {},
 ) {
   return Effect.gen(function* () {
     yield* database.db
@@ -338,7 +341,7 @@ function attempts(database: Database.Service["Service"], sessionID: Session.ID) 
     .get()
     .pipe(
       Effect.orDie,
-      Effect.map((row) => row?.attempts ?? -1),
+      Effect.map((row) => row?.attempts),
     )
 }
 

--- a/packages/core/test/v1-migration.test.ts
+++ b/packages/core/test/v1-migration.test.ts
@@ -63,6 +63,7 @@ const session = (
   time_compacting: 3,
   time_archived: null,
   time_suspended: null,
+  resume_attempts: 0,
   ...overrides,
 })
 

--- a/packages/server/src/process.ts
+++ b/packages/server/src/process.ts
@@ -247,12 +247,10 @@ function unavailable(status: Status.State) {
 }
 
 /**
- * The managed server owns restart continuity: it resumes Sessions the previous server suspended and
- * suspends its own active Sessions on graceful shutdown. Suspension runs while the drains are still
- * alive: connections close first, this finalizer runs next, and Session execution teardown follows.
+ * The managed server owns restart continuity: at boot it resumes Sessions whose execution claim was
+ * never released. Claims are written when execution starts (see SessionExecution), so recovery covers
+ * graceful restarts and unclean deaths alike — no shutdown hook participates.
  */
 const installRestartContinuity = Effect.fnUntraced(function* (restart: SessionRestart.Interface) {
   yield* Effect.forkScoped(restart.resumeSuspendedSessions)
-  // Registered after the fork so suspension observes still-running resumed drains during teardown.
-  yield* Effect.addFinalizer(() => restart.suspendActiveSessions)
 })


### PR DESCRIPTION
## What

Restart continuity for in-flight turns currently depends on a graceful-shutdown finalizer: `suspendActiveSessions` marks active Sessions moments before the process exits, and the next boot resumes whatever was marked. Any death without teardown — crash, SIGKILL, OOM, isolate eviction — skips the finalizer and silently loses the turn. For embedders whose runtime evicts mid-turn as steady state (workerd Durable Objects), that is the common case, not the edge case.

This PR inverts when the durable mark is written. The **claim** is recorded when execution *starts*, in the same transaction as the `Execution.Started` event, and terminals *release* it on commit. Recovery becomes a property of the database: a claim with no terminal is the signature of a dead process, regardless of how it died. No shutdown hook participates in correctness anymore.

## Before / After

**Before:** a turn is draining when the process dies uncleanly. The shutdown finalizer never runs, so `time_suspended` is never set. The next server boots, `resumeSuspendedSessions` finds nothing, and the turn is gone — the user's session sits idle with a half-finished assistant message and no continuation. Only graceful `SIGINT`/`SIGTERM` restarts recovered.

Separately, a user-cancelled turn could resurrect: `Execution.Interrupted` never cleared suspension, so a cancel that raced a shutdown left the suspension mark in place and the next boot resumed a turn the user had explicitly killed.

**After:** the claim exists *while* the turn runs. Crash, SIGKILL, eviction, and graceful restart all leave the same durable state, and the next boot resumes the turn with a synthetic continuation. A user interrupt (or a superseding execution) releases the claim on commit, so a cancelled turn can never resurrect. A turn that keeps dying without completing exhausts a durable resume budget (default 10) and is terminalized with `Execution.Failed` instead of crash-looping forever.

## How

**`packages/core/src/session/execution.ts`** — `clearSuspensionOnCommit` becomes a `claimOnCommit` / `releaseOnCommit` pair. `Started` claims; `Succeeded` and `Failed` release; `Interrupted` releases for `user` and `superseded` reasons but deliberately preserves the claim for `shutdown`, so a graceful restart looks identical to an unclean death.

**`packages/core/src/session/store.ts`** — `store.suspend` (bulk, shutdown-time) and `consumeSuspended` are deleted. New primitives: `claim` (null-guarded so re-claims are zero-write no-ops), `release` (clears claim + resets the attempt counter), `countResume` (durable increment; reports a deleted Session as `undefined` so the sweep skips it), `releaseChildClaims`. All claim bookkeeping pins `time_updated` (the `applyUsage` precedent) so it never counts as user activity for session ordering. `listSuspended` returns only top-level Sessions, and the sweep clears orphaned child claims outright: children are never resumed independently — a resumed parent re-runs its tool call and spawns fresh children.

**`packages/core/src/session/execution/restart.ts`** — the sweep resumes orphaned claims without ever clearing them: only terminal events release a claim, so a death anywhere in the resume path leaves the same orphaned claim for the next boot. Per claim: skip if locally active → durably count the attempt *before* resuming (a crash inside the resumed turn cannot dodge the budget) → terminalize past `maxAttempts` → otherwise publish the synthetic continuation and resume, forked so boot never waits on resumed turns (resuming an already-live Session joins its execution). `suspendActiveSessions` is gone from the interface.

The sweep assumes every orphaned claim's owner is dead. The managed-server protocol guarantees this: `kill`/`evict` in the client service confirm the previous PID is gone before a contender is spawned, the registration lock admits one managed server at a time, and unregistered servers sharing the database never sweep.

**`packages/server/src/process.ts`** — the shutdown finalizer is deleted. Boot-time `resumeSuspendedSessions` is the whole contract.

**Schema** — one column, `session_v2.resume_attempts integer not null default 0` (`sql.ts`, generated migration `20260811161259_execution_claim_attempts`). `time_suspended` is reinterpreted as the claim timestamp; no rename, no data migration — an existing suspension from an old server reads as an orphaned claim and resumes exactly as before.

## Flow

```mermaid
sequenceDiagram
    participant U as User
    participant E as SessionExecution
    participant DB as SQLite
    participant R as SessionRestart (next boot)

    U->>E: prompt
    E->>DB: Execution.Started + claim (one tx)
    Note over E: drain runs, claim held
    alt completes / fails / user interrupt
        E->>DB: terminal event + release (one tx)
    else process dies (crash, eviction) or shutdown interrupt
        Note over DB: claim survives, no terminal
        R->>DB: sweep finds orphaned claim
        alt attempts exhausted
            R->>DB: Execution.Failed + release
        else
            R->>DB: count attempt (claim untouched)
            R->>E: synthetic continuation + resume (forked)
        end
    end
```

## Scope

Deliberately not covered here:

- **Cross-process session fencing** — servers that share a database without registering (`--standalone` alongside the managed server) have no fencing for *any* concurrent session operation today; the sweep inherits that, it does not create it. If shared-database multi-server becomes real, the principled fix is an owner ID + liveness check on the claim, for the whole class at once.
- **Tool re-execution on replay** — a resumed turn may re-run a tool whose first invocation completed but never recorded. Cloudflare's Agents SDK ships the same hole; `settleStaleToolCalls` bounds the damage.
- **Progress-based attempt reset** — dropped for simplicity in favor of a higher budget. If it returns, it should be a `progress: true` flag on event *definitions*, not event-name string matching.

## Testing

- `packages/core`: full suite — 1645 pass / 0 fail (172 files).
- `packages/server`: 17 pass / 0 fail.
- `bun turbo typecheck --filter=@opencode-ai/core --filter=@opencode-ai/server` clean; `oxlint` clean on changed files.
- Lifecycle coverage in `test/session-execution.test.ts`: claim exists while the drain runs and survives teardown interruption; natural completion releases; user interrupt releases (no resurrection); the sweep leaves locally-active Sessions untouched; the sweep never consumes the claim it recovers (attempt counted durably before the turn runs, claim intact through a second teardown); budget exhaustion terminalizes with `Execution.Failed` and resets the counter; child Sessions are excluded from the sweep.
