### PR TITLE
feat: Opviera CLI phase 1 — gateway-locked fork of opencode

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -1,33 +1,55 @@
 name: "Setup Git Committer"
-description: "Create app token and configure git user"
+description: "Resolve a push token and configure the git user"
 inputs:
-  opencode-app-id:
-    description: "OpenCode GitHub App ID"
-    required: true
-  opencode-app-secret:
-    description: "OpenCode GitHub App private key"
-    required: true
+  opviera-app-id:
+    description: "Opviera GitHub App ID (optional — falls back to GITHUB_TOKEN when unset)"
+    required: false
+    default: ""
+  opviera-app-secret:
+    description: "Opviera GitHub App private key (optional — falls back to GITHUB_TOKEN when unset)"
+    required: false
+    default: ""
+  github-token:
+    description: "Fallback token used when no GitHub App credentials are supplied"
+    required: false
+    default: ${{ github.token }}
 outputs:
   token:
-    description: "GitHub App token"
-    value: ${{ steps.apptoken.outputs.token }}
+    description: "Token to authenticate pushes and gh CLI calls"
+    value: ${{ steps.resolve.outputs.token }}
   app-slug:
-    description: "GitHub App slug"
-    value: ${{ steps.apptoken.outputs.app-slug }}
+    description: "Committer slug (the app's slug, or github-actions)"
+    value: ${{ steps.resolve.outputs.slug }}
 runs:
   using: "composite"
   steps:
+    # A GitHub App is optional. Supplying one gives commits a Virstack identity and lets pushes
+    # bypass branch protection that excludes GITHUB_TOKEN; without it the workflow still runs on the
+    # built-in token, which this repo's workflows already grant `contents: write`.
     - name: Create app token
       id: apptoken
+      if: inputs.opviera-app-id != ''
       uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
       with:
-        app-id: ${{ inputs.opencode-app-id }}
-        private-key: ${{ inputs.opencode-app-secret }}
+        app-id: ${{ inputs.opviera-app-id }}
+        private-key: ${{ inputs.opviera-app-secret }}
         owner: ${{ github.repository_owner }}
+
+    - name: Resolve committer identity
+      id: resolve
+      run: |
+        if [ -n "${{ inputs.opviera-app-id }}" ]; then
+          echo "token=${{ steps.apptoken.outputs.token }}" >> "$GITHUB_OUTPUT"
+          echo "slug=${{ steps.apptoken.outputs.app-slug }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "token=${{ inputs.github-token }}" >> "$GITHUB_OUTPUT"
+          echo "slug=github-actions" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
 
     - name: Configure git user
       run: |
-        slug="${{ steps.apptoken.outputs.app-slug }}"
+        slug="${{ steps.resolve.outputs.slug }}"
         git config --global user.name "${slug}[bot]"
         git config --global user.email "${slug}[bot]@users.noreply.github.com"
       shell: bash
@@ -39,5 +61,5 @@ runs:
 
     - name: Configure git remote
       run: |
-        git remote set-url origin https://x-access-token:${{ steps.apptoken.outputs.token }}@github.com/${{ github.repository }}
+        git remote set-url origin https://x-access-token:${{ steps.resolve.outputs.token }}@github.com/${{ github.repository }}
       shell: bash

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -24,8 +24,8 @@ jobs:
         id: setup-git-committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Install OpenCode
         run: bun i -g opencode-ai

--- a/.github/workflows/docs-locale-sync.yml
+++ b/.github/workflows/docs-locale-sync.yml
@@ -29,8 +29,8 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Compute changed English docs
         id: changes

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,8 +22,8 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Generate
         run: ./script/generate.ts

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Setup git committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Pull latest changes
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
       - ci
       - dev
       - beta
-      - fix/npm-native-binary-install
       - snapshot-*
   workflow_dispatch:
     inputs:
@@ -34,7 +33,7 @@ permissions:
 jobs:
   version:
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: github.repository == 'anomalyco/opencode'
+    if: github.repository == 'virstack/opviera-cli'
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -46,22 +45,17 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
-
-      - name: Install OpenCode
-        if: inputs.bump || inputs.version
-        run: bun i -g opencode-ai
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - id: version
         run: |
           ./script/version.ts
         env:
           GH_TOKEN: ${{ steps.committer.outputs.token }}
-          OPENCODE_BUMP: ${{ inputs.bump }}
-          OPENCODE_VERSION: ${{ inputs.version }}
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GH_REPO: ${{ (github.ref_name == 'beta' && 'anomalyco/opencode-beta') || github.repository }}
+          OPVIERA_BUMP: ${{ inputs.bump }}
+          OPVIERA_VERSION: ${{ inputs.version }}
+          GH_REPO: ${{ github.repository }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       release: ${{ steps.version.outputs.release }}
@@ -71,7 +65,7 @@ jobs:
   build-cli:
     needs: version
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: github.repository == 'anomalyco/opencode'
+    if: github.repository == 'virstack/opviera-cli'
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -83,8 +77,8 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Build
         id: build
@@ -92,8 +86,8 @@ jobs:
           ./packages/opencode/script/build.ts ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
           ./packages/cli/script/build.ts ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
         env:
-          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
-          OPENCODE_RELEASE: ${{ needs.version.outputs.release }}
+          OPVIERA_VERSION: ${{ needs.version.outputs.version }}
+          OPVIERA_RELEASE: ${{ needs.version.outputs.release }}
           GH_REPO: ${{ needs.version.outputs.repo }}
           GH_TOKEN: ${{ steps.committer.outputs.token }}
 
@@ -122,7 +116,9 @@ jobs:
       - build-cli
       - version
     runs-on: blacksmith-4vcpu-windows-2025
-    if: github.repository == 'anomalyco/opencode'
+    # Off until Virstack has Azure Trusted Signing credentials. Set the repository variable
+    # ENABLE_CODE_SIGNING=true to turn it on — `publish` tolerates this job being skipped.
+    if: github.repository == 'virstack/opviera-cli' && vars.ENABLE_CODE_SIGNING == 'true'
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -142,8 +138,8 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Azure login
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -220,7 +216,9 @@ jobs:
   build-electron:
     needs:
       - version
-    if: github.repository == 'anomalyco/opencode'
+    # Opviera ships no desktop app yet; this also needs Apple notarization credentials.
+    # Set the repository variable ENABLE_DESKTOP_BUILD=true to turn it on.
+    if: github.repository == 'virstack/opviera-cli' && vars.ENABLE_DESKTOP_BUILD == 'true'
     continue-on-error: false
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -306,15 +304,15 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Prepare
         run: bun ./scripts/prepare.ts
         working-directory: packages/desktop
         env:
-          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
-          OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
+          OPVIERA_VERSION: ${{ needs.version.outputs.version }}
+          OPVIERA_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
           RUST_TARGET: ${{ matrix.settings.target }}
 
       - name: Build
@@ -322,8 +320,8 @@ jobs:
         working-directory: packages/desktop
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
-          OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
+          OPVIERA_VERSION: ${{ needs.version.outputs.version }}
+          OPVIERA_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.WEB_SENTRY_PROJECT }}
@@ -338,7 +336,7 @@ jobs:
         working-directory: packages/desktop
         timeout-minutes: 60
         env:
-          OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
+          OPVIERA_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
           GH_TOKEN: ${{ steps.committer.outputs.token }}
           CSC_KEYCHAIN: build.keychain
           APPLE_API_KEY: ${{ runner.temp }}/apple-api-key.p8
@@ -351,7 +349,7 @@ jobs:
         working-directory: packages/desktop
         timeout-minutes: 60
         env:
-          OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
+          OPVIERA_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
 
       - name: Create macOS .app.tar.gz
         if: runner.os == 'macOS' && needs.version.outputs.release
@@ -443,6 +441,8 @@ jobs:
           path: packages/opencode/dist
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        # Only produced when sign-cli-windows runs; unsigned binaries come from opencode-cli-windows.
+        if: vars.ENABLE_CODE_SIGNING == 'true'
         with:
           name: opencode-cli-signed-windows
           path: packages/opencode/dist
@@ -469,8 +469,8 @@ jobs:
         id: committer
         uses: ./.github/actions/setup-git-committer
         with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+          opviera-app-id: ${{ vars.OPVIERA_APP_ID }}
+          opviera-app-secret: ${{ secrets.OPVIERA_APP_SECRET }}
 
       - name: Cache apt packages (AUR)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -506,8 +506,8 @@ jobs:
 
       - run: ./script/publish.ts
         env:
-          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
-          OPENCODE_RELEASE: ${{ needs.version.outputs.release }}
+          OPVIERA_VERSION: ${{ needs.version.outputs.version }}
+          OPVIERA_RELEASE: ${{ needs.version.outputs.release }}
           AUR_KEY: ${{ secrets.AUR_KEY }}
           GITHUB_TOKEN: ${{ steps.committer.outputs.token }}
           GH_REPO: ${{ needs.version.outputs.repo }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,9 @@
 MIT License
 
+Opviera CLI is a derivative work of opencode (https://github.com/anomalyco/opencode).
+The upstream copyright notice below is retained as the MIT licence requires.
+
+Copyright (c) 2026 Virstack
 Copyright (c) 2025 opencode
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,129 +1,52 @@
-<p align="center">
-  <a href="https://opencode.ai">
-    <picture>
-      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
-      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
-    </picture>
-  </a>
-</p>
-<p align="center">The open source AI coding agent.</p>
-<p align="center">
-  <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
-  <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
-  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
-</p>
+# Opviera CLI
 
-<p align="center">
-  <a href="README.md">English</a> |
-  <a href="README.zh.md">简体中文</a> |
-  <a href="README.zht.md">繁體中文</a> |
-  <a href="README.ko.md">한국어</a> |
-  <a href="README.de.md">Deutsch</a> |
-  <a href="README.es.md">Español</a> |
-  <a href="README.fr.md">Français</a> |
-  <a href="README.it.md">Italiano</a> |
-  <a href="README.da.md">Dansk</a> |
-  <a href="README.ja.md">日本語</a> |
-  <a href="README.pl.md">Polski</a> |
-  <a href="README.ru.md">Русский</a> |
-  <a href="README.bs.md">Bosanski</a> |
-  <a href="README.ar.md">العربية</a> |
-  <a href="README.no.md">Norsk</a> |
-  <a href="README.br.md">Português (Brasil)</a> |
-  <a href="README.th.md">ไทย</a> |
-  <a href="README.tr.md">Türkçe</a> |
-  <a href="README.uk.md">Українська</a> |
-  <a href="README.bn.md">বাংলা</a> |
-  <a href="README.gr.md">Ελληνικά</a> |
-  <a href="README.vi.md">Tiếng Việt</a>
-</p>
+An agentic coding tool for your terminal, wired to the Opviera platform.
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+Opviera CLI runs against your organisation's Opviera gateway and nothing else. Your administrator
+issues you an API key; the CLI validates it, scopes your work to a project, and every request is
+metered against your organisation's quotas and budgets. There is no separate model subscription to
+manage and no way to route work somewhere unbilled.
 
----
+## Getting started
 
-### Installation
+1. Get an Opviera API key (`vsk_…`) and your project name from your administrator.
+2. Run `opviera` in your project directory.
+3. Enter the project name and your key when prompted. The key is validated against the gateway
+   before the agent starts, and stored in `~/.local/share/opviera/auth.json` with `0600`
+   permissions so you only do this once.
 
-```bash
-# YOLO
-curl -fsSL https://opencode.ai/install | bash
-
-# Package managers
-npm i -g opencode-ai@latest        # or bun/pnpm/yarn
-scoop install opencode             # Windows
-choco install opencode             # Windows
-brew install anomalyco/tap/opencode # macOS and Linux (recommended, always up to date)
-brew install opencode              # macOS and Linux (official brew formula, updated less)
-sudo pacman -S opencode            # Arch Linux (Stable)
-paru -S opencode-bin               # Arch Linux (Latest from AUR)
-mise use -g opencode               # Any OS
-nix run nixpkgs#opencode           # or github:anomalyco/opencode for latest dev branch
+```
+$ opviera
 ```
 
-> [!TIP]
-> Remove versions older than 0.1.x before installing.
+### Non-interactive use
 
-### Desktop App (BETA)
+For CI and containers, set the credential in the environment instead. It is validated exactly the
+same way — this supplies the key, it does not skip the check.
 
-OpenCode is also available as a desktop application. Download directly from the [releases page](https://github.com/anomalyco/opencode/releases) or [opencode.ai/download](https://opencode.ai/download).
-
-| Platform              | Download                           |
-| --------------------- | ---------------------------------- |
-| macOS (Apple Silicon) | `opencode-desktop-mac-arm64.dmg`   |
-| macOS (Intel)         | `opencode-desktop-mac-x64.dmg`     |
-| Windows               | `opencode-desktop-windows-x64.exe` |
-| Linux                 | `.deb`, `.rpm`, or `.AppImage`     |
-
-```bash
-# macOS (Homebrew)
-brew install --cask opencode-desktop
-# Windows (Scoop)
-scoop bucket add extras; scoop install extras/opencode-desktop
+```
+export OPVIERA_API_KEY=vsk_…
+export OPVIERA_PROJECT_ID=your-project   # required if your key's policy restricts projects
 ```
 
-#### Installation Directory
+### Self-hosted gateways
 
-The install script respects the following priority order for the installation path:
+`OPVIERA_GATEWAY_URL` points the CLI at a different Opviera deployment (include the `/gateway`
+mount, e.g. `https://gateway.example.com/gateway`). It selects which Opviera gateway to use; it is
+not a way to reach a non-Opviera provider.
 
-1. `$OPENCODE_INSTALL_DIR` - Custom installation directory
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification compliant path
-3. `$HOME/bin` - Standard user binary directory (if it exists or can be created)
-4. `$HOME/.opencode/bin` - Default fallback
+## Configuration
 
-```bash
-# Examples
-OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
-```
+Project configuration lives in `opviera.json` (or `opviera.jsonc`) in your project directory, with
+global defaults in `~/.config/opviera/`.
 
-### Agents
+## Credits
 
-OpenCode includes two built-in agents you can switch between with the `Tab` key.
+Opviera CLI is built on [opencode](https://github.com/anomalyco/opencode), an open-source AI coding
+agent, used under the MIT licence. It is an independent derivative work: it is not affiliated with,
+endorsed by, or supported by the opencode project. Please report Opviera issues to Virstack, not
+upstream.
 
-- **build** - Default, full-access agent for development work
-- **plan** - Read-only agent for analysis and code exploration
-  - Denies file edits by default
-  - Asks permission before running bash commands
-  - Ideal for exploring unfamiliar codebases or planning changes
+## Licence
 
-Also included is a **general** subagent for complex searches and multistep tasks.
-This is used internally and can be invoked using `@general` in messages.
-
-Learn more about [agents](https://opencode.ai/docs/agents).
-
-### Documentation
-
-For more info on how to configure OpenCode, [**head over to our docs**](https://opencode.ai/docs).
-
-### Contributing
-
-If you're interested in contributing to OpenCode, please read our [contributing docs](./CONTRIBUTING.md) before submitting a pull request.
-
-### Building on OpenCode
-
-If you are working on a project that's related to OpenCode and is using "opencode" as part of its name, for example "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in any way.
-
----
-
-**Join our community** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)
+MIT — see [LICENSE](./LICENSE), which retains the upstream opencode copyright notice.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,149 @@
+# Releasing Opviera CLI
+
+How a release gets from this repo to `curl -fsSL https://opviera.ai/install | bash`.
+
+The install script (`./install`, served at `opviera.ai/install`) downloads a per-platform binary from
+this repo's **GitHub Releases**. So the chain is: build binaries → attach them to a release → serve
+the install script. Nothing else is involved — there is no npm package and no CDN.
+
+## Prerequisites
+
+- `bun` (version pinned by `packageManager` in the root `package.json`)
+- `gh` CLI, authenticated with write access to `virstack/opviera-cli`
+- The repo must stay **public** — the installer calls `api.github.com/.../releases/latest`
+  unauthenticated. Making it private breaks the one-liner for everyone.
+
+## One-time setup
+
+### 1. Release workflow — already pointed at this repo ✅
+
+`.github/workflows/publish.yml` has been updated: the repo guards target `virstack/opviera-cli`,
+`GH_REPO` uses this repository, release inputs are `OPVIERA_BUMP` / `OPVIERA_VERSION` /
+`OPVIERA_RELEASE` / `OPVIERA_CHANNEL`, and the step that installed upstream's CLI into CI (with
+their API key, to AI-generate release notes) is gone — changelog generation is now best-effort and
+falls back to "No notable changes".
+
+Two jobs are **off by default**, gated on repository variables so no YAML edit is needed to enable
+them later:
+
+| Job | Enable with | Needs |
+|---|---|---|
+| `sign-cli-windows` | `ENABLE_CODE_SIGNING=true` | Azure Trusted Signing credentials |
+| `build-electron` | `ENABLE_DESKTOP_BUILD=true` | Apple notarization + Sentry; no desktop app yet |
+
+`publish` runs with `always() && !failure()`, so it proceeds while those are skipped, and the
+signed-Windows artifact download is gated on the same variable.
+
+**No secrets are required to cut a release.** `setup-git-committer` uses the built-in `GITHUB_TOKEN`
+by default (every workflow that calls it already grants `contents: write`), committing as
+`github-actions[bot]`.
+
+A GitHub App is optional. Set repository variable `OPVIERA_APP_ID` and secret `OPVIERA_APP_SECRET`
+and the action switches to it automatically — worth doing if you want commits under a Virstack
+identity, or if branch protection excludes `GITHUB_TOKEN` (its pushes cannot bypass required
+reviews).
+
+### 2. Serve the install script
+
+Serve `./install` from this repo at `https://opviera.ai/install`. The one hard requirement is that
+it returns the **raw script body as `text/plain`** — if the host answers with an HTML shell or a 404
+page, `curl … | bash` executes that HTML.
+
+nginx:
+
+```nginx
+location = /install {
+    alias /var/www/opviera/install;
+    default_type text/plain;
+    add_header Cache-Control "no-store";
+}
+```
+
+Alternatively serve it from the gateway backend beside the existing `/config/:client` scripts in
+`ScriptService`, which gives you the same per-IP rate limiting.
+
+## Cutting a release
+
+### 3. Build the binaries
+
+Release inputs are `OPVIERA_VERSION`, `OPVIERA_CHANNEL`, `OPVIERA_BUMP`, `OPVIERA_RELEASE`. (The old
+`OPENCODE_*` names still work as a fallback, so a half-updated pipeline doesn't silently build the
+wrong thing.)
+
+Host platform only, to sanity-check the pipeline:
+
+```bash
+cd packages/opencode
+OPVIERA_VERSION=0.1.0 bun run script/build.ts --single
+# → dist/opviera-darwin-arm64/bin/opviera
+```
+
+All 12 targets (what a real release ships — linux/darwin/win32 × x64/arm64, plus baseline and musl
+variants):
+
+```bash
+OPVIERA_VERSION=0.1.0 bun run script/build.ts
+```
+
+> `OPVIERA_VERSION` is **required** for a release build. Upstream derived the next version from
+> `opencode-ai` on npm; that is disabled, because it would inherit opencode's version lineage and
+> publish our first release as something like `v1.18.17`. Preview builds off a non-`latest` branch
+> still auto-version as `0.0.0-<branch>-<timestamp>`.
+
+### 4. Publish
+
+The tag must exist before `build.ts` uploads to it. `OPVIERA_RELEASE=1` is what makes the build
+package the binaries (tar.gz for linux, zip elsewhere) and run `gh release upload`.
+
+```bash
+gh release create v0.1.0 --repo virstack/opviera-cli --title "v0.1.0" --notes "First release"
+
+cd packages/opencode
+GH_REPO=virstack/opviera-cli OPVIERA_RELEASE=1 OPVIERA_VERSION=0.1.0 bun run script/build.ts
+```
+
+Assets land as `opviera-<os>-<arch>[-baseline][-musl].{zip,tar.gz}` — exactly the names the install
+script derives from `$APP-$target$archive_ext`. If these ever stop matching, the installer 404s.
+
+### 5. Code signing (before you announce the URL)
+
+Unsigned binaries are quarantined: macOS reports *"cannot be opened because the developer cannot be
+verified"*, and Windows SmartScreen warns. Upstream's pipeline does Apple notarization and Azure
+Trusted Signing; both need Virstack certificates. Until then, expect users to hit Gatekeeper.
+
+## Verifying
+
+```bash
+curl -fsSL https://opviera.ai/install | head -5    # must be shell, not HTML
+curl -fsSL https://opviera.ai/install | bash
+opviera --version
+```
+
+The installer puts the binary in `~/.opviera/bin` and appends that to `PATH` in the user's shell rc
+(`--no-modify-path` opts out). Other flags: `--version <v>` to pin a version, `--binary <path>` to
+install from a local build — useful for testing the installer without publishing:
+
+```bash
+./install --binary packages/opencode/dist/opviera-darwin-arm64/bin/opviera --no-modify-path
+```
+
+## First run
+
+Installing does not sign the user in. In their project directory:
+
+```bash
+cd ~/my-project
+opviera
+```
+
+They are prompted for a project name and an Opviera API key (`vsk_…`). On success the key is stored
+in `~/.local/share/opviera/auth.json` (mode `0600`) and an `opviera.json` is written into that
+project folder with the gateway URL, project id and permitted models — no credential, so it is safe
+to commit.
+
+For CI, supply the credential instead of prompting; it is validated identically:
+
+```bash
+export OPVIERA_API_KEY=vsk_…
+export OPVIERA_PROJECT_ID=your-project   # required if the key's policy restricts projects
+```

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-APP=opencode
+APP=opviera
 
 MUTED='\033[0;2m'
 RED='\033[0;31m'
@@ -9,7 +9,7 @@ NC='\033[0m' # No Color
 
 usage() {
     cat <<EOF
-OpenCode Installer
+Opviera Installer
 
 Usage: install.sh [options]
 
@@ -20,9 +20,9 @@ Options:
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
-    curl -fsSL https://opencode.ai/install | bash
-    curl -fsSL https://opencode.ai/install | bash -s -- --version 1.0.180
-    ./install --binary /path/to/opencode
+    curl -fsSL https://opviera.ai/install | bash
+    curl -fsSL https://opviera.ai/install | bash -s -- --version 1.0.180
+    ./install --binary /path/to/opviera
 EOF
 }
 
@@ -65,7 +65,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-INSTALL_DIR=$HOME/.opencode/bin
+INSTALL_DIR=$HOME/.opviera/bin
 mkdir -p "$INSTALL_DIR"
 
 # If --binary is provided, skip all download/detection logic
@@ -181,8 +181,8 @@ else
     fi
 
     if [ -z "$requested_version" ]; then
-        url="https://github.com/anomalyco/opencode/releases/latest/download/$filename"
-        specific_version=$(curl -s https://api.github.com/repos/anomalyco/opencode/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+        url="https://github.com/virstack/opviera-cli/releases/latest/download/$filename"
+        specific_version=$(curl -s https://api.github.com/repos/virstack/opviera-cli/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
 
         if [[ $? -ne 0 || -z "$specific_version" ]]; then
             echo -e "${RED}Failed to fetch version information${NC}"
@@ -191,14 +191,14 @@ else
     else
         # Strip leading 'v' if present
         requested_version="${requested_version#v}"
-        url="https://github.com/anomalyco/opencode/releases/download/v${requested_version}/$filename"
+        url="https://github.com/virstack/opviera-cli/releases/download/v${requested_version}/$filename"
         specific_version=$requested_version
 
         # Verify the release exists before downloading
-        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/anomalyco/opencode/releases/tag/v${requested_version}")
+        http_status=$(curl -sI -o /dev/null -w "%{http_code}" "https://github.com/virstack/opviera-cli/releases/tag/v${requested_version}")
         if [ "$http_status" = "404" ]; then
             echo -e "${RED}Error: Release v${requested_version} not found${NC}"
-            echo -e "${MUTED}Available releases: https://github.com/anomalyco/opencode/releases${NC}"
+            echo -e "${MUTED}Available releases: https://github.com/virstack/opviera-cli/releases${NC}"
             exit 1
         fi
     fi
@@ -219,11 +219,11 @@ print_message() {
 }
 
 check_version() {
-    if command -v opencode >/dev/null 2>&1; then
-        opencode_path=$(which opencode)
+    if command -v opviera >/dev/null 2>&1; then
+        opviera_path=$(which opviera)
 
         ## Check the installed version
-        installed_version=$(opencode --version 2>/dev/null || echo "")
+        installed_version=$(opviera --version 2>/dev/null || echo "")
 
         if [[ "$installed_version" != "$specific_version" ]]; then
             print_message info "${MUTED}Installed version: ${NC}$installed_version."
@@ -275,7 +275,7 @@ download_with_progress() {
     fi
 
     local tmp_dir=${TMPDIR:-/tmp}
-    local basename="${tmp_dir}/opencode_install_$$"
+    local basename="${tmp_dir}/opviera_install_$$"
     local tracefile="${basename}.trace"
 
     rm -f "$tracefile"
@@ -325,8 +325,8 @@ download_with_progress() {
 }
 
 download_and_install() {
-    print_message info "\n${MUTED}Installing ${NC}opencode ${MUTED}version: ${NC}$specific_version"
-    local tmp_dir="${TMPDIR:-/tmp}/opencode_install_$$"
+    print_message info "\n${MUTED}Installing ${NC}opviera ${MUTED}version: ${NC}$specific_version"
+    local tmp_dir="${TMPDIR:-/tmp}/opviera_install_$$"
     mkdir -p "$tmp_dir"
 
     if [[ "$os" == "windows" ]] || ! [ -t 2 ] || ! download_with_progress "$url" "$tmp_dir/$filename"; then
@@ -340,15 +340,15 @@ download_and_install() {
         unzip -q "$tmp_dir/$filename" -d "$tmp_dir"
     fi
 
-    mv "$tmp_dir/opencode" "$INSTALL_DIR"
-    chmod 755 "${INSTALL_DIR}/opencode"
+    mv "$tmp_dir/opviera" "$INSTALL_DIR"
+    chmod 755 "${INSTALL_DIR}/opviera"
     rm -rf "$tmp_dir"
 }
 
 install_from_binary() {
-    print_message info "\n${MUTED}Installing ${NC}opencode ${MUTED}from: ${NC}$binary_path"
-    cp "$binary_path" "${INSTALL_DIR}/opencode"
-    chmod 755 "${INSTALL_DIR}/opencode"
+    print_message info "\n${MUTED}Installing ${NC}opviera ${MUTED}from: ${NC}$binary_path"
+    cp "$binary_path" "${INSTALL_DIR}/opviera"
+    chmod 755 "${INSTALL_DIR}/opviera"
 }
 
 if [ -n "$binary_path" ]; then
@@ -366,9 +366,9 @@ add_to_path() {
     if grep -Fxq "$command" "$config_file"; then
         print_message info "Command already exists in $config_file, skipping write."
     elif [[ -w $config_file ]]; then
-        echo -e "\n# opencode" >> "$config_file"
+        echo -e "\n# opviera" >> "$config_file"
         echo "$command" >> "$config_file"
-        print_message info "${MUTED}Successfully added ${NC}opencode ${MUTED}to \$PATH in ${NC}$config_file"
+        print_message info "${MUTED}Successfully added ${NC}opviera ${MUTED}to \$PATH in ${NC}$config_file"
     else
         print_message warning "Manually add the directory to $config_file (or similar):"
         print_message info "  $command"
@@ -444,17 +444,17 @@ if [ -n "${GITHUB_ACTIONS-}" ] && [ "${GITHUB_ACTIONS}" == "true" ]; then
 fi
 
 echo -e ""
-echo -e "${MUTED}                    ${NC}             ▄     "
-echo -e "${MUTED}█▀▀█ █▀▀█ █▀▀█ █▀▀▄ ${NC}█▀▀▀ █▀▀█ █▀▀█ █▀▀█"
-echo -e "${MUTED}█░░█ █░░█ █▀▀▀ █░░█ ${NC}█░░░ █░░█ █░░█ █▀▀▀"
-echo -e "${MUTED}▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ${NC}▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀"
+echo -e "${MUTED}               ${NC}░▄░              "
+echo -e "${MUTED}█▀▀█ █▀▀█ █░░█ ${NC}░█░ █▀▀▀ █▀▀▄ ▄▀▀█"
+echo -e "${MUTED}█░░█ █░░█ █░░█ ${NC}░█░ █▀▀▀ █░░░ █▄▄█"
+echo -e "${MUTED}▀▀▀▀ █▀▀▀ ▀▄▄▀ ${NC}░▀░ ▀▀▀▀ ▀░░░ ▀░░▀"
 echo -e ""
 echo -e ""
-echo -e "${MUTED}OpenCode includes free models, to start:${NC}"
+echo -e "${MUTED}Sign in with your Opviera API key to start:${NC}"
 echo -e ""
 echo -e "cd <project>  ${MUTED}# Open directory${NC}"
-echo -e "opencode      ${MUTED}# Run command${NC}"
+echo -e "opviera      ${MUTED}# Run command${NC}"
 echo -e ""
-echo -e "${MUTED}For more information visit ${NC}https://opencode.ai/docs"
+echo -e "${MUTED}For more information visit ${NC}https://opviera.ai/docs"
 echo -e ""
 echo -e ""

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -139,7 +139,10 @@ const layer = Layer.effect(
     const global = yield* Global.Service
     const location = yield* Location.Service
     const policy = yield* Policy.Service
-    const names = ["opencode.json", "opencode.jsonc"]
+    // Opviera's names are ADDITIVE, listed first so they win. The upstream names stay readable:
+    // removing them breaks schema generation, v1 migration and managed-settings paths that key off
+    // `opencode.json` by literal name.
+    const names = ["opviera.json", "opviera.jsonc", "opencode.json", "opencode.jsonc"]
     const decodeOptions = { errors: "all", onExcessProperty: "ignore", propertyOrder: "original" } as const
     const decodeInfo = Schema.decodeUnknownOption(Info, decodeOptions)
     const decodeV1Info = Schema.decodeUnknownOption(ConfigV1.Info, decodeOptions)

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -47,8 +47,8 @@ export function path() {
   }
   if (
     ["latest", "beta", "prod"].includes(InstallationChannel) ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
+    Flag.env("OPENCODE_DISABLE_CHANNEL_DB") === "1" ||
+    Flag.env("OPENCODE_DISABLE_CHANNEL_DB") === "true"
   )
     return join(Global.Path.data, "opencode.db")
   return join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -1,52 +1,88 @@
 import { Config } from "effect"
 
+/**
+ * Every flag is addressable as `OPVIERA_*`, with the upstream `OPENCODE_*` name still honoured as
+ * a fallback.
+ *
+ * Aliasing rather than renaming is deliberate: these names are read via bare `process.env` across
+ * many files and hardcoded throughout the test suite, so a hard rename is the same class of change
+ * as the config-filename rename that broke ~120 tests. The keys below stay `OPENCODE_*` for that
+ * reason — they are internal identifiers, and only the ENV VAR a user types is brand-visible.
+ *
+ * Non-prefixed keys (`OTEL_*`) pass through untouched: they are OpenTelemetry standard names, not
+ * ours to rebrand.
+ */
+export function envName(key: string) {
+  return key.startsWith("OPENCODE_") ? `OPVIERA_${key.slice("OPENCODE_".length)}` : key
+}
+
+export function env(key: string) {
+  return process.env[envName(key)] ?? process.env[key]
+}
+
 export function truthy(key: string) {
-  const value = process.env[key]?.toLowerCase()
+  const value = env(key)?.toLowerCase()
   return value === "true" || value === "1"
 }
 
-const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
-const fff = process.env["OPENCODE_DISABLE_FFF"]
+const copy = env("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT")
+const fff = env("OPENCODE_DISABLE_FFF")
 
 function enabledByExperimental(key: string) {
-  return process.env[key] === undefined ? truthy("OPENCODE_EXPERIMENTAL") : truthy(key)
+  return env(key) === undefined ? truthy("OPENCODE_EXPERIMENTAL") : truthy(key)
+}
+
+/** Effect Config equivalent of the alias: prefer the Opviera name, fall back to upstream. */
+function boolConfig(key: string) {
+  return Config.boolean(envName(key)).pipe(
+    Config.orElse(() => Config.boolean(key)),
+    Config.withDefault(false),
+  )
 }
 
 export const Flag = {
+  /**
+   * Read an aliased env var by its upstream key: `OPVIERA_X` wins, `OPENCODE_X` is the fallback.
+   * Exposed here so the handful of call sites that read env directly (logging, websearch, auth
+   * content) get the same aliasing as the flags below without importing a second symbol.
+   */
+  env,
+
   OTEL_EXPORTER_OTLP_ENDPOINT: process.env["OTEL_EXPORTER_OTLP_ENDPOINT"],
   OTEL_EXPORTER_OTLP_HEADERS: process.env["OTEL_EXPORTER_OTLP_HEADERS"],
 
   OPENCODE_AUTO_HEAP_SNAPSHOT: truthy("OPENCODE_AUTO_HEAP_SNAPSHOT"),
-  OPENCODE_GIT_BASH_PATH: process.env["OPENCODE_GIT_BASH_PATH"],
-  OPENCODE_CONFIG: process.env["OPENCODE_CONFIG"],
-  OPENCODE_CONFIG_CONTENT: process.env["OPENCODE_CONFIG_CONTENT"],
-  OPENCODE_DISABLE_AUTOUPDATE: truthy("OPENCODE_DISABLE_AUTOUPDATE"),
+  OPENCODE_GIT_BASH_PATH: env("OPENCODE_GIT_BASH_PATH"),
+  OPENCODE_CONFIG: env("OPENCODE_CONFIG"),
+  OPENCODE_CONFIG_CONTENT: env("OPENCODE_CONFIG_CONTENT"),
+  // Always on. The upstream updater checks opencode.ai, npm, Homebrew, Chocolatey, Scoop and the
+  // GitHub releases API one second after the TUI starts — none of which distribute Opviera.
+  OPENCODE_DISABLE_AUTOUPDATE: true,
   OPENCODE_ALWAYS_NOTIFY_UPDATE: truthy("OPENCODE_ALWAYS_NOTIFY_UPDATE"),
   OPENCODE_DISABLE_PRUNE: truthy("OPENCODE_DISABLE_PRUNE"),
   OPENCODE_DISABLE_TERMINAL_TITLE: truthy("OPENCODE_DISABLE_TERMINAL_TITLE"),
   OPENCODE_SHOW_TTFD: truthy("OPENCODE_SHOW_TTFD"),
   OPENCODE_DISABLE_AUTOCOMPACT: truthy("OPENCODE_DISABLE_AUTOCOMPACT"),
-  OPENCODE_DISABLE_MODELS_FETCH: truthy("OPENCODE_DISABLE_MODELS_FETCH"),
+  // Always on. Opviera's catalog is provisioned from the gateway's own model list, so it reflects
+  // the key's policy exactly. Letting models.opencode.ai repopulate the catalog would reintroduce
+  // providers this build deliberately removed.
+  OPENCODE_DISABLE_MODELS_FETCH: true,
   OPENCODE_DISABLE_MOUSE: truthy("OPENCODE_DISABLE_MOUSE"),
-  OPENCODE_FAKE_VCS: process.env["OPENCODE_FAKE_VCS"],
-  OPENCODE_SERVER_PASSWORD: process.env["OPENCODE_SERVER_PASSWORD"],
-  OPENCODE_SERVER_USERNAME: process.env["OPENCODE_SERVER_USERNAME"],
+  OPENCODE_FAKE_VCS: env("OPENCODE_FAKE_VCS"),
+  OPENCODE_SERVER_PASSWORD: env("OPENCODE_SERVER_PASSWORD"),
+  OPENCODE_SERVER_USERNAME: env("OPENCODE_SERVER_USERNAME"),
   OPENCODE_DISABLE_FFF: fff === undefined ? process.platform === "win32" : truthy("OPENCODE_DISABLE_FFF"),
 
   // Experimental
-  OPENCODE_EXPERIMENTAL_FILEWATCHER: Config.boolean("OPENCODE_EXPERIMENTAL_FILEWATCHER").pipe(
-    Config.withDefault(false),
-  ),
-  OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: Config.boolean("OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER").pipe(
-    Config.withDefault(false),
-  ),
+  OPENCODE_EXPERIMENTAL_FILEWATCHER: boolConfig("OPENCODE_EXPERIMENTAL_FILEWATCHER"),
+  OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: boolConfig("OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER"),
   OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT:
     copy === undefined ? process.platform === "win32" : truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
-  OPENCODE_MODELS_URL: process.env["OPENCODE_MODELS_URL"],
-  OPENCODE_MODELS_PATH: process.env["OPENCODE_MODELS_PATH"],
-  OPENCODE_DB: process.env["OPENCODE_DB"],
+  OPENCODE_MODELS_URL: env("OPENCODE_MODELS_URL"),
+  OPENCODE_MODELS_PATH: env("OPENCODE_MODELS_PATH"),
+  OPENCODE_DB: env("OPENCODE_DB"),
 
-  OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
+  OPENCODE_WORKSPACE_ID: env("OPENCODE_WORKSPACE_ID"),
   OPENCODE_EXPERIMENTAL_WORKSPACES: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),
 
   // Evaluated at access time (not module load) because tests, the CLI, and
@@ -58,21 +94,21 @@ export const Flag = {
     return enabledByExperimental("OPENCODE_EXPERIMENTAL_REFERENCES")
   },
   get OPENCODE_TUI_CONFIG() {
-    return process.env["OPENCODE_TUI_CONFIG"]
+    return env("OPENCODE_TUI_CONFIG")
   },
   get OPENCODE_CONFIG_DIR() {
-    return process.env["OPENCODE_CONFIG_DIR"]
+    return env("OPENCODE_CONFIG_DIR")
   },
   get OPENCODE_PURE() {
     return truthy("OPENCODE_PURE")
   },
   get OPENCODE_PERMISSION() {
-    return process.env["OPENCODE_PERMISSION"]
+    return env("OPENCODE_PERMISSION")
   },
   get OPENCODE_PLUGIN_META_FILE() {
-    return process.env["OPENCODE_PLUGIN_META_FILE"]
+    return env("OPENCODE_PLUGIN_META_FILE")
   },
   get OPENCODE_CLIENT() {
-    return process.env["OPENCODE_CLIENT"] ?? "cli"
+    return env("OPENCODE_CLIENT") ?? "cli"
   },
 }

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -7,7 +7,10 @@ import { Flock } from "./util/flock"
 import { Flag } from "./flag/flag"
 import { makeGlobalNode } from "./effect/app-node"
 
-const app = "opencode"
+// Names every XDG directory the CLI owns (~/.config/opviera, ~/.local/share/opviera, …). This must
+// differ from upstream opencode: sharing those directories would mean sharing auth.json, the model
+// cache and session state with a genuine opencode install on the same machine.
+const app = "opviera"
 const data = path.join(xdgData!, app)
 const cache = path.join(xdgCache!, app)
 const config = path.join(xdgConfig!, app)

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -20,7 +20,7 @@ const InterleavedField = Schema.Union([
   Schema.String,
 ])
 
-const USER_AGENT = `opencode/${InstallationChannel}/${InstallationVersion}/${Flag.OPENCODE_CLIENT}`
+const USER_AGENT = `opviera/${InstallationChannel}/${InstallationVersion}/${Flag.OPENCODE_CLIENT}`
 
 const CostTier = Schema.Struct({
   input: Schema.Finite,

--- a/packages/core/src/observability/logging.ts
+++ b/packages/core/src/observability/logging.ts
@@ -1,3 +1,4 @@
+import { Flag } from "../flag/flag"
 import { Formatter, Logger, type LogLevel } from "effect"
 import path from "path"
 import { Global } from "../global"
@@ -54,7 +55,7 @@ export function fileLogger(file = path.join(Global.Path.log, "opencode.log"), id
 const stderrLogger = Logger.make((options) => process.stderr.write(formatter().log(options) + "\n"))
 
 export function minimumLogLevel() {
-  const value = process.env.OPENCODE_LOG_LEVEL?.toUpperCase()
+  const value = Flag.env("OPENCODE_LOG_LEVEL")?.toUpperCase()
   const levels = {
     DEBUG: "Debug",
     INFO: "Info",
@@ -65,7 +66,7 @@ export function minimumLogLevel() {
 }
 
 export function loggers() {
-  return process.env.OPENCODE_PRINT_LOGS === "1" ? [fileLogger(), stderrLogger] : [fileLogger()]
+  return Flag.env("OPENCODE_PRINT_LOGS") === "1" ? [fileLogger(), stderrLogger] : [fileLogger()]
 }
 
 export * as Logging from "./logging"

--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -1,71 +1,19 @@
-import { AlibabaPlugin } from "./provider/alibaba"
-import { AmazonBedrockPlugin } from "./provider/amazon-bedrock"
 import { AnthropicPlugin } from "./provider/anthropic"
-import { AzureCognitiveServicesPlugin, AzurePlugin } from "./provider/azure"
-import { CerebrasPlugin } from "./provider/cerebras"
-import { CloudflareAIGatewayPlugin } from "./provider/cloudflare-ai-gateway"
-import { CloudflareWorkersAIPlugin } from "./provider/cloudflare-workers-ai"
-import { CoherePlugin } from "./provider/cohere"
-import { DeepInfraPlugin } from "./provider/deepinfra"
-import { DynamicProviderPlugin } from "./provider/dynamic"
-import { GatewayPlugin } from "./provider/gateway"
-import { GithubCopilotPlugin } from "./provider/github-copilot"
-import { GitLabPlugin } from "./provider/gitlab"
-import { GooglePlugin } from "./provider/google"
-import { GoogleVertexAnthropicPlugin, GoogleVertexPlugin } from "./provider/google-vertex"
-import { GroqPlugin } from "./provider/groq"
-import { KiloPlugin } from "./provider/kilo"
-import { LLMGatewayPlugin } from "./provider/llmgateway"
-import { MistralPlugin } from "./provider/mistral"
-import { NvidiaPlugin } from "./provider/nvidia"
-import { OpenAIPlugin } from "./provider/openai"
-import { SnowflakeCortexPlugin } from "./provider/snowflake-cortex"
-import { OpenAICompatiblePlugin } from "./provider/openai-compatible"
-import { OpencodePlugin } from "./provider/opencode"
-import { OpenRouterPlugin } from "./provider/openrouter"
-import { PerplexityPlugin } from "./provider/perplexity"
-import { SapAICorePlugin } from "./provider/sap-ai-core"
-import { TogetherAIPlugin } from "./provider/togetherai"
-import { VercelPlugin } from "./provider/vercel"
-import { VenicePlugin } from "./provider/venice"
-import { XAIPlugin } from "./provider/xai"
-import { ZenmuxPlugin } from "./provider/zenmux"
 import type { PluginInternal } from "./internal"
 import type { Scope } from "effect"
 
-export const ProviderPlugins: PluginInternal.Plugin<PluginInternal.Requirements | Scope.Scope>[] = [
-  AlibabaPlugin,
-  AmazonBedrockPlugin,
-  AnthropicPlugin,
-  AzureCognitiveServicesPlugin,
-  AzurePlugin,
-  CerebrasPlugin,
-  CloudflareAIGatewayPlugin,
-  CloudflareWorkersAIPlugin,
-  CoherePlugin,
-  DeepInfraPlugin,
-  GatewayPlugin,
-  GithubCopilotPlugin,
-  GitLabPlugin,
-  GooglePlugin,
-  GoogleVertexAnthropicPlugin,
-  GoogleVertexPlugin,
-  GroqPlugin,
-  KiloPlugin,
-  LLMGatewayPlugin,
-  MistralPlugin,
-  NvidiaPlugin,
-  OpencodePlugin,
-  SnowflakeCortexPlugin,
-  OpenAICompatiblePlugin,
-  OpenAIPlugin,
-  OpenRouterPlugin,
-  PerplexityPlugin,
-  SapAICorePlugin,
-  TogetherAIPlugin,
-  VercelPlugin,
-  VenicePlugin,
-  XAIPlugin,
-  ZenmuxPlugin,
-  DynamicProviderPlugin,
-]
+/**
+ * Opviera ships exactly one provider integration.
+ *
+ * Upstream opencode registers ~30 here (OpenAI, Bedrock, Vertex, OpenRouter, Copilot, …). They are
+ * removed rather than merely disabled: a config allow-list can be edited, but a plugin that is not
+ * compiled into the binary cannot be re-enabled by any config file, env var, or flag.
+ *
+ * `AnthropicPlugin` stays because it is the SDK factory for `@ai-sdk/anthropic`, which is the wire
+ * protocol the Opviera gateway speaks — it does not by itself grant access to Anthropic. Reaching
+ * Anthropic directly would need a `baseURL` pointing there, and `enabled_providers` plus the
+ * provisioned config pin that to the gateway.
+ *
+ * If you re-add a provider here, you have unlocked the CLI. That is the whole control.
+ */
+export const ProviderPlugins: PluginInternal.Plugin<PluginInternal.Requirements | Scope.Scope>[] = [AnthropicPlugin]

--- a/packages/core/src/tool/websearch.ts
+++ b/packages/core/src/tool/websearch.ts
@@ -5,7 +5,7 @@ import { Context, Duration, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { makeLocationNode } from "../effect/app-node"
 import { LayerNodePlatform } from "../effect/app-node-platform"
-import { truthy } from "../flag/flag"
+import { truthy, Flag } from "../flag/flag"
 import { InstallationVersion } from "../installation/version"
 import { PositiveInt } from "../schema"
 import { PermissionV2 } from "../permission"
@@ -70,18 +70,16 @@ export interface Config {
 export class ConfigService extends Context.Service<ConfigService, Config>()("@opencode/v2/WebSearchConfig") {}
 
 /** Isolates the retained product environment contract from the generic tool implementation. */
-export const defaultConfigLayer = Layer.sync(ConfigService, () =>
-  ConfigService.of({
-    provider:
-      process.env.OPENCODE_WEBSEARCH_PROVIDER === "exa" || process.env.OPENCODE_WEBSEARCH_PROVIDER === "parallel"
-        ? process.env.OPENCODE_WEBSEARCH_PROVIDER
-        : undefined,
+export const defaultConfigLayer = Layer.sync(ConfigService, () => {
+  const searchProvider = Flag.env("OPENCODE_WEBSEARCH_PROVIDER")
+  return ConfigService.of({
+    provider: searchProvider === "exa" || searchProvider === "parallel" ? searchProvider : undefined,
     enableExa: truthy("OPENCODE_EXPERIMENTAL") || truthy("OPENCODE_ENABLE_EXA") || truthy("OPENCODE_EXPERIMENTAL_EXA"),
     enableParallel: truthy("OPENCODE_ENABLE_PARALLEL") || truthy("OPENCODE_EXPERIMENTAL_PARALLEL"),
     exaApiKey: process.env.EXA_API_KEY,
     parallelApiKey: process.env.PARALLEL_API_KEY,
-  }),
-)
+  })
+})
 
 export const configNode = makeLocationNode({ service: ConfigService, layer: defaultConfigLayer, deps: [] })
 
@@ -237,7 +235,7 @@ const layer = Layer.effectDiscard(
                         // V2 invocation context does not safely expose the model yet.
                       },
                       {
-                        "User-Agent": `opencode/${InstallationVersion}`,
+                        "User-Agent": `opviera/${InstallationVersion}`,
                         ...(config.parallelApiKey ? { Authorization: `Bearer ${config.parallelApiKey}` } : {}),
                       },
                     )

--- a/packages/opencode/bin/opviera
+++ b/packages/opencode/bin/opviera
@@ -49,7 +49,7 @@ const scriptPath = fs.realpathSync(__filename)
 const scriptDir = path.dirname(scriptPath)
 
 //
-const cached = path.join(scriptDir, ".opencode")
+const cached = path.join(scriptDir, ".opviera")
 
 const platformMap = {
   darwin: "darwin",
@@ -70,8 +70,8 @@ let arch = archMap[os.arch()]
 if (!arch) {
   arch = os.arch()
 }
-const base = "opencode-" + platform + "-" + arch
-const binary = platform === "windows" ? "opencode.exe" : "opencode"
+const base = "opviera-" + platform + "-" + arch
+const binary = platform === "windows" ? "opviera.exe" : "opviera"
 
 function supportsAvx2() {
   if (arch !== "x64") return false
@@ -189,7 +189,7 @@ function findBinary(startDir) {
 const resolved = envPath || (fs.existsSync(cached) ? cached : findBinary(scriptDir))
 if (!resolved) {
   console.error(
-    "It seems that your package manager failed to install the right version of the opencode CLI for your platform. You can try manually installing " +
+    "It seems that your package manager failed to install the right version of the Opviera CLI for your platform. You can try manually installing " +
       names.map((n) => `\"${n}\"`).join(" or ") +
       " package",
   )

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "version": "1.18.16",
-  "name": "opencode",
+  "name": "opviera",
   "type": "module",
   "license": "MIT",
   "private": true,
@@ -16,7 +16,7 @@
     "dev:temporary": "bun run --conditions=browser ./src/temporary.ts"
   },
   "bin": {
-    "opencode": "./bin/opencode"
+    "opviera": "./bin/opviera"
   },
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -175,8 +175,8 @@ for (const item of targets) {
       autoloadTsconfig: true,
       autoloadPackageJson: true,
       target: name.replace(pkg.name, "bun") as any,
-      outfile: `dist/${name}/bin/opencode`,
-      execArgv: [`--user-agent=opencode/${Script.version}`, "--use-system-ca", "--"],
+      outfile: `dist/${name}/bin/opviera`,
+      execArgv: [`--user-agent=opviera/${Script.version}`, "--use-system-ca", "--"],
       windows: {},
     },
     files: {
@@ -203,7 +203,7 @@ for (const item of targets) {
 
   // Smoke test: only run if binary is for current platform
   if (item.os === process.platform && item.arch === process.arch && !item.abi) {
-    const binaryPath = `dist/${name}/bin/opencode`
+    const binaryPath = `dist/${name}/bin/opviera`
     console.log(`Running smoke test: ${binaryPath} --version`)
     try {
       const versionOutput = await $`${binaryPath} --version`.text()

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -1,3 +1,4 @@
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import path from "path"
 import { Effect, Layer, Record, Result, Schema, Context } from "effect"
@@ -56,9 +57,10 @@ const layer = Layer.effect(
     const decode = Schema.decodeUnknownOption(Info)
 
     const all = Effect.fn("Auth.all")(function* () {
-      if (process.env.OPENCODE_AUTH_CONTENT) {
+      const injected = Flag.env("OPENCODE_AUTH_CONTENT")
+      if (injected) {
         try {
-          return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
+          return JSON.parse(injected)
         } catch (err) {}
       }
 

--- a/packages/opencode/src/cli/cmd/account-opviera.ts
+++ b/packages/opencode/src/cli/cmd/account-opviera.ts
@@ -1,0 +1,31 @@
+import { cmd } from "./cmd"
+import { UI } from "../ui"
+import * as Credential from "../opviera/credential"
+
+/**
+ * `opviera login` / `opviera logout`.
+ *
+ * Login re-runs the SAME gate the TUI runs at startup rather than reimplementing the prompts, so
+ * there is one sign-in flow and one place to change it.
+ */
+export const LoginCommand = cmd({
+  command: "login",
+  describe: "sign in to Opviera with an API key",
+  async handler() {
+    // Discard any stored key first, otherwise the gate would validate it and skip the prompts —
+    // which is the opposite of what someone typing `login` wants.
+    await Credential.clear()
+    const { ensureAuthenticated } = await import("../opviera/gate")
+    await ensureAuthenticated()
+  },
+})
+
+export const LogoutCommand = cmd({
+  command: "logout",
+  describe: "remove the stored Opviera API key",
+  async handler() {
+    const existing = await Credential.read()
+    await Credential.clear()
+    UI.println(existing ? "Signed out of Opviera." : "You are not signed in.")
+  },
+})

--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -6,7 +6,7 @@ import { ServerAuth } from "@/server/auth"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
-  describe: "attach to a running opencode server",
+  describe: "attach to a running Opviera server",
   builder: (yargs) =>
     yargs
       .positional("url", {

--- a/packages/opencode/src/cli/cmd/pr.ts
+++ b/packages/opencode/src/cli/cmd/pr.ts
@@ -7,7 +7,7 @@ import { Process } from "@/util/process"
 
 export const PrCommand = effectCmd({
   command: "pr <number>",
-  describe: "fetch and checkout a GitHub PR branch, then run opencode",
+  describe: "fetch and checkout a GitHub PR branch, then run Opviera",
   builder: (yargs) =>
     yargs.positional("number", {
       type: "number",

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -304,7 +304,7 @@ export const ProvidersLoginCommand = effectCmd({
   builder: (yargs: Argv) =>
     yargs
       .positional("url", {
-        describe: "opencode auth provider",
+        describe: "Opviera auth provider",
         type: "string",
       })
       .option("provider", {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -125,7 +125,7 @@ async function toolError(part: ToolPart) {
 
 export const RunCommand = effectCmd({
   command: "run [message..]",
-  describe: "run opencode with a message",
+  describe: "run Opviera with a message",
   // --attach connects to a remote server (no local instance needed); the
   // default path runs an in-process server and needs the project instance.
   instance: (args) => !args.attach,
@@ -189,7 +189,7 @@ export const RunCommand = effectCmd({
       })
       .option("attach", {
         type: "string",
-        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
+        describe: "attach to a running Opviera server (e.g., http://localhost:4096)",
       })
       .option("password", {
         alias: ["p"],

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -6,7 +6,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 export const ServeCommand = effectCmd({
   command: "serve",
   builder: (yargs) => withNetworkOptions(yargs),
-  describe: "starts a headless opencode server",
+  describe: "starts a headless Opviera server",
   // Server loads instances per-request via x-opencode-directory header — no
   // need for an ambient project InstanceContext at startup.
   instance: false,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -71,12 +71,12 @@ export function resolveThreadDirectory(project?: string, envPWD = process.env.PW
 
 export const TuiThreadCommand = cmd({
   command: "$0 [project]",
-  describe: "start opencode tui",
+  describe: "start Opviera tui",
   builder: (yargs) =>
     withNetworkOptions(yargs)
       .positional("project", {
         type: "string",
-        describe: "path to start opencode in",
+        describe: "path to start Opviera in",
       })
       .option("model", {
         type: "string",
@@ -206,6 +206,11 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+
+      // Opviera is a single-platform CLI: no gateway credential, no agent. Runs here — main
+      // thread, TTY still attached, before the worker or any instance exists.
+      const { ensureAuthenticated } = await import("../opviera/gate")
+      await ensureAuthenticated()
 
       const worker = new Worker(file, {
         env: Object.fromEntries(

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -24,7 +24,7 @@ interface RemovalTargets {
 
 export const UninstallCommand = {
   command: "uninstall",
-  describe: "uninstall opencode and remove all related files",
+  describe: "uninstall Opviera and remove all related files",
   builder: (yargs: Argv) =>
     yargs
       .option("keep-config", {

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -6,7 +6,7 @@ import { InstallationVersion } from "@opencode-ai/core/installation/version"
 
 export const UpgradeCommand = {
   command: "upgrade [target]",
-  describe: "upgrade opencode to the latest or a specific version",
+  describe: "upgrade Opviera to the latest or a specific version",
   builder: (yargs: Argv) => {
     return yargs
       .positional("target", {

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -31,7 +31,7 @@ function getNetworkIPs() {
 export const WebCommand = effectCmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
-  describe: "start opencode server and open web interface",
+  describe: "start Opviera server and open web interface",
   // Server loads instances per-request via x-opencode-directory header — no
   // ambient project InstanceContext needed at startup.
   instance: false,

--- a/packages/opencode/src/cli/opviera/client.ts
+++ b/packages/opencode/src/cli/opviera/client.ts
@@ -1,0 +1,112 @@
+import { gatewayUrl } from "./config"
+
+export interface WhoAmIProject {
+  identifier: string
+  name: string
+}
+
+export interface WhoAmIModel {
+  id: string
+  displayName: string
+  provider: string
+  supportsThinking: boolean
+}
+
+export interface WhoAmI {
+  user: { id: string; name: string | null }
+  organization: { id: string; name: string | null }
+  key: { prefix: string; upstream: string }
+  boundProjectId: string | null
+  projectRequired: boolean
+  projects: WhoAmIProject[]
+  models: WhoAmIModel[]
+  forcedModel: string | null
+}
+
+/**
+ * A gateway rejection, already reduced to something worth showing a user.
+ *
+ * `retryable` distinguishes "your key is wrong, ask again" from "your key is fine but the account
+ * is not usable" — the gate re-prompts on the former and exits on the latter, because re-typing a
+ * suspended account's key a second time helps nobody.
+ */
+export class GatewayError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly retryable: boolean,
+    readonly requestId?: string,
+  ) {
+    super(message)
+    this.name = "GatewayError"
+  }
+}
+
+/**
+ * Validate a key and fetch everything the CLI needs to start: the projects it may use, the models
+ * its policy permits, and whether the key is already bound to a project.
+ *
+ * Free on the gateway — no quota, no usage event — and deliberately served above the billing gate,
+ * so a valid key on a non-billing-active org still authenticates and we can say exactly that.
+ */
+export async function whoami(apiKey: string, signal?: AbortSignal): Promise<WhoAmI> {
+  const url = `${gatewayUrl()}/v1/whoami`
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      headers: { "x-api-key": apiKey, accept: "application/json" },
+      signal,
+    })
+  } catch {
+    throw new GatewayError(
+      `Could not reach the Opviera gateway at ${url}. Check your connection, then try again.`,
+      0,
+      false,
+    )
+  }
+
+  const requestId = response.headers.get("request-id") ?? undefined
+
+  if (response.ok) {
+    try {
+      return (await response.json()) as WhoAmI
+    } catch {
+      throw new GatewayError("The gateway returned a malformed response.", response.status, false, requestId)
+    }
+  }
+
+  const message = await errorMessage(response)
+
+  // 401 means the key itself is wrong — worth asking for another one.
+  if (response.status === 401) {
+    throw new GatewayError(message, 401, true, requestId)
+  }
+  // 403 means the key authenticated but the account state blocks it: suspended user, paused key,
+  // no policy, or inactive billing. Every one of those messages ends in "contact your
+  // administrator", so re-prompting would only invite the user to hunt for a key that cannot exist.
+  if (response.status === 403) {
+    throw new GatewayError(message, 403, false, requestId)
+  }
+  if (response.status === 404) {
+    throw new GatewayError(
+      `The gateway at ${gatewayUrl()} does not support this CLI (no /v1/whoami). It may need upgrading.`,
+      404,
+      false,
+      requestId,
+    )
+  }
+  throw new GatewayError(message, response.status, false, requestId)
+}
+
+/** Gateway errors are Anthropic-shaped: `{ type: "error", error: { type, message } }`. */
+async function errorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: { message?: string } }
+    const message = body?.error?.message
+    if (typeof message === "string" && message.length > 0) return message
+  } catch {
+    // fall through to the generic message below
+  }
+  return `The gateway rejected the request (HTTP ${response.status}).`
+}

--- a/packages/opencode/src/cli/opviera/config.ts
+++ b/packages/opencode/src/cli/opviera/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Opviera platform constants.
+ *
+ * This CLI talks to exactly one place: the Opviera gateway. The base URL is compiled in and
+ * overridable only by an env var, which exists for development and self-hosted deployments — it is
+ * NOT a general "point me at any provider" switch. Everything else about provider selection is
+ * removed elsewhere in the build (see the provider lock).
+ */
+
+/** Provider id used in the catalog, the config file, and as the auth.json key. */
+export const PROVIDER_ID = "opviera"
+
+export const DEFAULT_GATEWAY_URL = "https://gateway.opviera.com/gateway"
+
+/**
+ * Base URL including the `/gateway` mount — the Anthropic SDK appends `/v1`, so the wire path
+ * ends up `<base>/v1/messages`, matching how the platform's own config recipes are built.
+ */
+export function gatewayUrl(): string {
+  const raw = process.env["OPVIERA_GATEWAY_URL"]?.trim()
+  return stripTrailingSlash(raw && raw.length > 0 ? raw : DEFAULT_GATEWAY_URL)
+}
+
+export function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "")
+}
+
+/**
+ * Keys are `vsk_` + 40 hex characters. Checked client-side purely to give instant feedback on an
+ * obvious paste error; the gateway is always the authority (it applies the identical rule before
+ * any database lookup).
+ */
+const KEY_PATTERN = /^vsk_[0-9a-f]{40}$/
+
+export function looksLikeApiKey(value: string): boolean {
+  return KEY_PATTERN.test(value.trim())
+}

--- a/packages/opencode/src/cli/opviera/credential.ts
+++ b/packages/opencode/src/cli/opviera/credential.ts
@@ -1,0 +1,73 @@
+import fs from "fs/promises"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { PROVIDER_ID } from "./config"
+
+/**
+ * Reads and writes the SAME `auth.json` the Effect-based `Auth` service owns, in the same
+ * `{ type: "api", key, metadata }` shape and the same 0600 mode.
+ *
+ * Deliberately plain fs rather than the Auth service: the startup gate runs in the CLI's main
+ * thread before any Effect runtime or instance exists, and standing one up purely to read one
+ * record would invert that ordering. The record stays fully readable by the Auth service.
+ */
+
+const file = path.join(Global.Path.data, "auth.json")
+
+export interface Credential {
+  key: string
+  projectId: string | null
+  projectName: string | null
+  gatewayUrl: string
+}
+
+interface ApiRecord {
+  type: "api"
+  key: string
+  metadata?: Record<string, string>
+}
+
+async function readAll(): Promise<Record<string, unknown>> {
+  try {
+    const raw = await fs.readFile(file, "utf8")
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    // Missing or unreadable auth.json simply means "not logged in".
+    return {}
+  }
+}
+
+export async function read(): Promise<Credential | undefined> {
+  const record = (await readAll())[PROVIDER_ID] as ApiRecord | undefined
+  if (!record || record.type !== "api" || typeof record.key !== "string" || record.key.length === 0) return undefined
+  const metadata = record.metadata ?? {}
+  return {
+    key: record.key,
+    projectId: metadata["projectId"] || null,
+    projectName: metadata["projectName"] || null,
+    gatewayUrl: metadata["gatewayUrl"] ?? "",
+  }
+}
+
+export async function write(credential: Credential): Promise<void> {
+  const data = await readAll()
+  const metadata: Record<string, string> = { gatewayUrl: credential.gatewayUrl }
+  if (credential.projectId) metadata["projectId"] = credential.projectId
+  if (credential.projectName) metadata["projectName"] = credential.projectName
+
+  const record: ApiRecord = { type: "api", key: credential.key, metadata }
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  await fs.writeFile(file, JSON.stringify({ ...data, [PROVIDER_ID]: record }, null, 2), { mode: 0o600 })
+  // writeFile only applies `mode` when it creates the file, so an existing file keeps its old
+  // permissions unless we set them explicitly.
+  await fs.chmod(file, 0o600).catch(() => {})
+}
+
+export async function clear(): Promise<void> {
+  const data = await readAll()
+  if (!(PROVIDER_ID in data)) return
+  delete data[PROVIDER_ID]
+  await fs.writeFile(file, JSON.stringify(data, null, 2), { mode: 0o600 })
+  await fs.chmod(file, 0o600).catch(() => {})
+}

--- a/packages/opencode/src/cli/opviera/gate.ts
+++ b/packages/opencode/src/cli/opviera/gate.ts
@@ -1,0 +1,194 @@
+import * as prompts from "@clack/prompts"
+import { UI } from "@/cli/ui"
+import { gatewayUrl, looksLikeApiKey } from "./config"
+import { whoami, GatewayError, type WhoAmI } from "./client"
+import * as Credential from "./credential"
+import { provision } from "./provision"
+
+/**
+ * The startup gate. Opviera is a single-platform CLI: there is no agent to enter until a gateway
+ * key has been accepted, so this runs before the TUI worker is spawned, in the main thread, while
+ * a real TTY is still attached.
+ *
+ * Returns the validated credential plus the whoami payload, which the caller uses to build the
+ * model catalog — so the models offered are exactly the ones the key's policy permits.
+ */
+export interface Session {
+  credential: Credential.Credential
+  identity: WhoAmI
+}
+
+/** Ctrl-C at any prompt. */
+function cancelled(): never {
+  prompts.cancel("Sign-in cancelled.")
+  process.exit(1)
+}
+
+function describe(identity: WhoAmI, projectName: string | null): string {
+  const org = identity.organization.name ?? "your organization"
+  const who = identity.user.name ? `${identity.user.name} · ` : ""
+  return projectName ? `${who}${org} · ${projectName}` : `${who}${org}`
+}
+
+export async function ensureAuthenticated(): Promise<Session> {
+  // Non-interactive hatch for CI and containers. Validated exactly like a typed key — it is a
+  // different way to supply the credential, not a way to skip the check.
+  const envKey = process.env["OPVIERA_API_KEY"]?.trim()
+  if (envKey) {
+    const identity = await validateOrExit(envKey)
+    const project = resolveProject(identity, process.env["OPVIERA_PROJECT_ID"]?.trim() ?? "")
+    if (!project && identity.projectRequired) {
+      UI.error("OPVIERA_PROJECT_ID is required for this API key. Set it to one of: " + projectList(identity))
+      process.exit(1)
+    }
+    const credential = {
+      key: envKey,
+      projectId: project?.identifier ?? null,
+      projectName: project?.name ?? null,
+      gatewayUrl: gatewayUrl(),
+    }
+    await provision(identity, credential.projectId)
+    return { credential, identity }
+  }
+
+  const stored = await Credential.read()
+  if (stored) {
+    const identity = await revalidate(stored.key)
+    if (identity) {
+      // Re-provisioned on every start so a policy change (models added or revoked) takes effect
+      // without the user having to sign in again.
+      await provision(identity, stored.projectId)
+      return { credential: stored, identity }
+    }
+    // A stored key that no longer works falls through to the prompts below rather than failing —
+    // rotating a key should not require finding the credential file.
+  }
+
+  if (!process.stdin.isTTY) {
+    UI.error("Opviera needs an API key. Set OPVIERA_API_KEY, or run `opviera` in a terminal to sign in.")
+    process.exit(1)
+  }
+
+  UI.logo()
+  prompts.intro("Sign in to Opviera")
+
+  const typedProject = await prompts.text({
+    message: "Project name",
+    placeholder: "the project this work belongs to",
+  })
+  if (prompts.isCancel(typedProject)) cancelled()
+
+  let identity: WhoAmI | undefined
+  let key = ""
+  // Only the key is re-prompted on failure: the project name was fine, and re-typing it after a
+  // mistyped key is busywork.
+  while (!identity) {
+    const entered = await prompts.password({
+      message: "API key",
+      validate: (value) =>
+        looksLikeApiKey(value ?? "") ? undefined : "That does not look like an Opviera key (expected vsk_…).",
+    })
+    if (prompts.isCancel(entered)) cancelled()
+    key = entered.trim()
+
+    const spin = prompts.spinner()
+    spin.start("Validating")
+    try {
+      identity = await whoami(key)
+      spin.stop("Key accepted")
+    } catch (error) {
+      const failure = error instanceof GatewayError ? error : undefined
+      spin.stop(failure?.message ?? "Validation failed", 1)
+      if (!failure?.retryable) {
+        if (failure?.requestId) prompts.log.info(`Request id: ${failure.requestId}`)
+        process.exit(1)
+      }
+    }
+  }
+
+  const project = resolveProject(identity, typedProject)
+  const chosen = project ?? (await chooseProject(identity, typedProject))
+
+  if (identity.boundProjectId) {
+    prompts.log.info(`This key is bound to "${chosen?.name ?? identity.boundProjectId}" — using it.`)
+  }
+
+  const credential: Credential.Credential = {
+    key,
+    projectId: chosen?.identifier ?? null,
+    projectName: chosen?.name ?? null,
+    gatewayUrl: gatewayUrl(),
+  }
+  await Credential.write(credential)
+  await provision(identity, credential.projectId)
+
+  prompts.outro(describe(identity, credential.projectName))
+  return { credential, identity }
+}
+
+/**
+ * Match what the user typed against the projects the key may actually use.
+ *
+ * A project's identity on the gateway is its slug `identifier` ("Acme Web" → `acme-web`), which a
+ * user has no reason to know — so either the name or the identifier is accepted, case-insensitively.
+ */
+export function resolveProject(identity: WhoAmI, typed: string): { identifier: string; name: string } | undefined {
+  // A bound key decides server-side; whatever was typed is irrelevant.
+  if (identity.boundProjectId) {
+    const known = identity.projects.find((p) => p.identifier === identity.boundProjectId)
+    return known ?? { identifier: identity.boundProjectId, name: identity.boundProjectId }
+  }
+  const needle = typed.trim().toLowerCase()
+  if (!needle) return undefined
+  return identity.projects.find(
+    (p) => p.identifier.toLowerCase() === needle || p.name.trim().toLowerCase() === needle,
+  )
+}
+
+/** No match: show the real list rather than rejecting what the user typed. */
+async function chooseProject(
+  identity: WhoAmI,
+  typed: string,
+): Promise<{ identifier: string; name: string } | undefined> {
+  if (identity.projects.length === 0) {
+    if (identity.projectRequired) {
+      UI.error("This API key requires a project, but none are available to it. Contact your administrator.")
+      process.exit(1)
+    }
+    return undefined
+  }
+
+  if (typed.trim()) prompts.log.warn(`No project named "${typed.trim()}".`)
+
+  const options = identity.projects.map((p) => ({ value: p.identifier, label: p.name, hint: p.identifier }))
+  const picked = await prompts.select({
+    message: identity.projectRequired ? "Choose your project" : "Choose your project (optional)",
+    options: identity.projectRequired ? options : [...options, { value: "", label: "None", hint: "skip" }],
+  })
+  if (prompts.isCancel(picked)) cancelled()
+  return identity.projects.find((p) => p.identifier === picked)
+}
+
+function projectList(identity: WhoAmI): string {
+  return identity.projects.map((p) => p.identifier).join(", ") || "(none available)"
+}
+
+async function validateOrExit(key: string): Promise<WhoAmI> {
+  return await whoami(key).catch((error: unknown) => {
+    UI.error(error instanceof Error ? error.message : "Could not validate the Opviera API key.")
+    return process.exit(1)
+  })
+}
+
+/** Stored-credential check: a hard failure exits, a bad key returns undefined so we re-prompt. */
+async function revalidate(key: string): Promise<WhoAmI | undefined> {
+  try {
+    return await whoami(key)
+  } catch (error) {
+    if (error instanceof GatewayError && !error.retryable) {
+      UI.error(error.message)
+      process.exit(1)
+    }
+    return undefined
+  }
+}

--- a/packages/opencode/src/cli/opviera/provision.ts
+++ b/packages/opencode/src/cli/opviera/provision.ts
@@ -1,0 +1,88 @@
+import fs from "fs/promises"
+import path from "path"
+import { PROVIDER_ID, gatewayUrl } from "./config"
+import type { WhoAmI } from "./client"
+
+/**
+ * Writes the Opviera provider into the opened project's config after a key validates.
+ *
+ * The catalog has no "create a provider" hook — providers come from models.dev or from config — so
+ * the provider is materialised here from the whoami payload. Two consequences worth keeping:
+ *
+ *  - The model list IS the policy. Models come from the gateway, so a model the key may not use
+ *    never appears in the picker; there is nothing to keep in sync by hand.
+ *  - `enabled_providers` is pinned to Opviera alone, which is what makes every other provider
+ *    unreachable even if one is declared in a project's own config file.
+ *
+ * The API KEY IS DELIBERATELY NOT WRITTEN HERE. It lives in auth.json at 0600; this file is
+ * ordinary config that a user may well paste into a support ticket.
+ */
+
+/**
+ * Written into the DIRECTORY THE USER OPENED, not a global config dir, so each project carries its
+ * own gateway settings and project id — open the CLI somewhere else and it provisions there.
+ *
+ * `opviera.json` is read because both config loaders now list it ahead of the upstream names.
+ *
+ * Safe to commit: it holds the gateway URL, project id and permitted model list, and deliberately
+ * no credential (see below).
+ */
+function configPath(): string {
+  return path.join(process.cwd(), "opviera.json")
+}
+
+interface ProviderModel {
+  name: string
+}
+
+export async function provision(identity: WhoAmI, projectId: string | null): Promise<string> {
+  const headers: Record<string, string> = {
+    // Tags gateway usage as coming from this CLI. Kept as the value the platform already
+    // recognises so usage attribution works without a server-side change.
+    "x-clawgate-client": "opencode",
+  }
+  // A bound key carries its project server-side and projectCheck ignores the header entirely.
+  if (projectId && !identity.boundProjectId) headers["x-project-id"] = projectId
+
+  const models: Record<string, ProviderModel> = {}
+  for (const model of identity.models) {
+    models[model.id] = { name: model.displayName }
+  }
+
+  const existing = await read()
+  const next = {
+    ...existing,
+    // Only Opviera. Declared here rather than left to chance: opencode treats an absent
+    // enabled_providers as "allow everything".
+    enabled_providers: [PROVIDER_ID],
+    provider: {
+      ...(existing["provider"] as Record<string, unknown> | undefined),
+      [PROVIDER_ID]: {
+        name: "Opviera",
+        npm: "@ai-sdk/anthropic",
+        // Lets the provider pick the key up from the environment in CI, where nothing is written
+        // to auth.json. Interactive runs resolve it from auth.json under the same provider id.
+        env: ["OPVIERA_API_KEY"],
+        options: {
+          // The Anthropic SDK appends the resource path, so this is the `/v1` root.
+          baseURL: `${gatewayUrl()}/v1`,
+          headers,
+        },
+        models,
+      },
+    },
+  }
+
+  const file = configPath()
+  await fs.writeFile(file, JSON.stringify(next, null, 2) + "\n")
+  return file
+}
+
+async function read(): Promise<Record<string, unknown>> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(configPath(), "utf8"))
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    return {}
+  }
+}

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -2,11 +2,14 @@ import { EOL } from "os"
 import { Schema } from "effect"
 import { logo as glyphs } from "./logo"
 
+// The non-TTY wordmark. A SECOND, independent copy of the brand art (the shaded one lives in
+// packages/tui/src/logo.ts) — it contains no "opviera" substring, so a grep-driven rename will
+// miss it. Keep the two in sync by hand.
 const wordmark = [
-  `⠀                                ▄     `,
-  `█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█`,
-  `█  █ █  █ █▀▀▀ █  █ █    █  █ █  █ █▀▀▀`,
-  `▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`,
+  `⠀                ▄                 `,
+  `█▀▀█ █▀▀█ █  █   █  █▀▀█ █▀▀▄ ▄▀▀█`,
+  `█  █ █  █ █  █   █  █▀▀▀ █    █▄▄█`,
+  `▀▀▀▀ █▀▀▀ ▀▄▄▀   ▀  ▀▀▀▀ ▀    ▀▀▀▀`,
 ]
 
 export class CancelledError extends Schema.TaggedErrorClass<CancelledError>()("UICancelledError", {}) {}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -404,8 +404,13 @@ const layer = Layer.effect(
         }
 
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-          for (const file of yield* ConfigPaths.files("opencode", ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
-            yield* merge(file, yield* loadFile(file, authEnv), "local")
+          // Both base names are walked. `opviera` is loaded LAST so it wins on conflict, while the
+          // upstream name keeps working for anyone who already has one — removing it breaks
+          // schema generation, v1 migration and managed-settings paths that key off it literally.
+          for (const name of ["opencode", "opviera"]) {
+            for (const file of yield* ConfigPaths.files(name, ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
+              yield* merge(file, yield* loadFile(file, authEnv), "local")
+            }
           }
         }
 
@@ -465,9 +470,10 @@ const layer = Layer.effect(
           yield* mergePluginOrigins(dir, list)
         }
 
-        if (process.env.OPENCODE_CONFIG_CONTENT) {
+        const inlineConfig = Flag.env("OPENCODE_CONFIG_CONTENT")
+        if (inlineConfig) {
           const source = "OPENCODE_CONFIG_CONTENT"
-          const next = yield* loadConfig(process.env.OPENCODE_CONFIG_CONTENT, {
+          const next = yield* loadConfig(inlineConfig, {
             dir: ctx.directory,
             source,
           })

--- a/packages/opencode/src/ide/index.ts
+++ b/packages/opencode/src/ide/index.ts
@@ -1,3 +1,4 @@
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Schema } from "effect"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Process } from "@/util/process"
@@ -30,7 +31,7 @@ export function ide() {
 }
 
 export function alreadyInstalled() {
-  return process.env["OPENCODE_CALLER"] === "vscode" || process.env["OPENCODE_CALLER"] === "vscode-insiders"
+  return Flag.env("OPENCODE_CALLER") === "vscode" || Flag.env("OPENCODE_CALLER") === "vscode-insiders"
 }
 
 export async function install(ide: (typeof SUPPORTED_IDES)[number]["name"]) {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -2,6 +2,7 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
 import { GenerateCommand } from "./cli/cmd/generate"
+import { LoginCommand, LogoutCommand } from "./cli/cmd/account-opviera"
 import { ConsoleCommand } from "./cli/cmd/account"
 import { ProvidersCommand } from "./cli/cmd/providers"
 import { AgentCommand } from "./cli/cmd/agent"
@@ -34,7 +35,7 @@ const args = hideBin(process.argv)
 
 function show(out: string) {
   const text = out.trimStart()
-  if (!text.startsWith("opencode ")) {
+  if (!text.startsWith("opviera ")) {
     process.stderr.write(UI.logo() + EOL + EOL)
     process.stderr.write(text + EOL)
     return
@@ -44,7 +45,7 @@ function show(out: string) {
 
 const cli = yargs(args)
   .parserConfiguration({ "populate--": true })
-  .scriptName("opencode")
+  .scriptName("opviera")
   .wrap(100)
   .help("help", "show help")
   .alias("help", "h")
@@ -86,6 +87,8 @@ const cli = yargs(args)
   .command(GenerateCommand)
   .command(DebugCommand)
   .command(ConsoleCommand)
+  .command(LoginCommand)
+  .command(LogoutCommand)
   .command(ProvidersCommand)
   .command(AgentCommand)
   .command(UpgradeCommand)

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -39,7 +39,7 @@ export const Info = Schema.Struct({
 export type Info = Schema.Schema.Type<typeof Info>
 
 export function userAgent(client = "cli") {
-  return `opencode/${InstallationChannel}/${InstallationVersion}/${client}`
+  return `opviera/${InstallationChannel}/${InstallationVersion}/${client}`
 }
 
 export const USER_AGENT = userAgent()

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -618,7 +618,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       const directory = yield* InstanceState.directory
 
       const aiGatewayHeaders = {
-        "User-Agent": `opencode/${InstallationVersion} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
+        "User-Agent": `opviera/${InstallationVersion} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
         "anthropic-beta": "context-1m-2025-08-07",
         ...providerConfig?.options?.aiGatewayHeaders,
       }
@@ -751,7 +751,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         options: {
           apiKey,
           headers: {
-            "User-Agent": `opencode/${InstallationVersion} cloudflare-workers-ai (${os.platform()} ${os.release()}; ${os.arch()})`,
+            "User-Agent": `opviera/${InstallationVersion} cloudflare-workers-ai (${os.platform()} ${os.release()}; ${os.arch()})`,
           },
         },
         async getModel(sdk: any, modelID: string) {
@@ -819,7 +819,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         skipCache: input.options?.skipCache,
         collectLog: input.options?.collectLog,
         headers: {
-          "User-Agent": `opencode/${InstallationVersion} cloudflare-ai-gateway (${os.platform()} ${os.release()}; ${os.arch()})`,
+          "User-Agent": `opviera/${InstallationVersion} cloudflare-ai-gateway (${os.platform()} ${os.release()}; ${os.arch()})`,
         },
       }
 

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -15,7 +15,10 @@ import { jsonSchema, tool as aiTool, type ModelMessage, type Tool } from "ai"
 import type { Plugin } from "@/plugin"
 import { mergeDeep } from "remeda"
 
-const USER_AGENT = `opencode/${InstallationVersion}`
+// Sent on every model request. The AI SDK appends its own
+// `ai-sdk/provider-utils/… runtime/bun/…` suffix, so this is the brand-visible prefix the gateway
+// (and anything else on the wire) sees.
+const USER_AGENT = `opviera/${InstallationVersion}`
 
 type PrepareInput = {
   readonly user: SessionV1.User

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -52,7 +52,7 @@ export function webSearchModelName(extra: Tool.Context["extra"]) {
 }
 
 function parallelAuthHeaders() {
-  const headers = { "User-Agent": `opencode/${InstallationVersion}` }
+  const headers = { "User-Agent": `opviera/${InstallationVersion}` }
   if (!process.env.PARALLEL_API_KEY) return headers
   return { ...headers, Authorization: `Bearer ${process.env.PARALLEL_API_KEY}` }
 }

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode acp --help 1`] = `
-"opencode acp
+"opviera acp
 
 start ACP (Agent Client Protocol) server
 
@@ -22,16 +22,16 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode mcp --help 1`] = `
-"opencode mcp
+"opviera mcp
 
 manage MCP (Model Context Protocol) servers
 
 Commands:
-  opencode mcp add [name]     add an MCP server
-  opencode mcp list           list MCP servers and their status                        [aliases: ls]
-  opencode mcp auth [name]    authenticate with an OAuth-enabled MCP server
-  opencode mcp logout [name]  remove OAuth credentials for an MCP server
-  opencode mcp debug <name>   debug OAuth connection for an MCP server
+  opviera mcp add [name]     add an MCP server
+  opviera mcp list           list MCP servers and their status                         [aliases: ls]
+  opviera mcp auth [name]    authenticate with an OAuth-enabled MCP server
+  opviera mcp logout [name]  remove OAuth credentials for an MCP server
+  opviera mcp debug <name>   debug OAuth connection for an MCP server
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -42,9 +42,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode attach --help 1`] = `
-"opencode attach <url>
+"opviera attach <url>
 
-attach to a running opencode server
+attach to a running Opviera server
 
 Positionals:
   url  http://localhost:4096                                                     [string] [required]
@@ -68,9 +68,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode run --help 1`] = `
-"opencode run [message..]
+"opviera run [message..]
 
-run opencode with a message
+run Opviera with a message
 
 Positionals:
   message  message to send                                                     [array] [default: []]
@@ -92,7 +92,7 @@ Options:
                                           [string] [choices: "default", "json"] [default: "default"]
   -f, --file         file(s) to attach to message                                            [array]
       --title        title for the session (uses truncated prompt if no value provided)     [string]
-      --attach       attach to a running opencode server (e.g., http://localhost:4096)      [string]
+      --attach       attach to a running Opviera server (e.g., http://localhost:4096)       [string]
   -p, --password     basic auth password (defaults to OPENCODE_SERVER_PASSWORD)             [string]
   -u, --username     basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')
                                                                                             [string]
@@ -108,24 +108,24 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode debug --help 1`] = `
-"opencode debug
+"opviera debug
 
 debugging and troubleshooting tools
 
 Commands:
-  opencode debug config        show resolved configuration
-  opencode debug lsp           LSP debugging utilities
-  opencode debug rg            ripgrep debugging utilities
-  opencode debug file          file system debugging utilities
-  opencode debug scrap         list all known projects
-  opencode debug skill         list all available skills
-  opencode debug snapshot      snapshot debugging utilities
-  opencode debug startup       print startup timing
-  opencode debug agent <name>  show agent configuration details
-  opencode debug v2            debug v2 catalog and built-in plugins
-  opencode debug info          show debug information
-  opencode debug paths         show global paths (data, config, cache, state)
-  opencode debug wait          wait indefinitely (for debugging)
+  opviera debug config        show resolved configuration
+  opviera debug lsp           LSP debugging utilities
+  opviera debug rg            ripgrep debugging utilities
+  opviera debug file          file system debugging utilities
+  opviera debug scrap         list all known projects
+  opviera debug skill         list all available skills
+  opviera debug snapshot      snapshot debugging utilities
+  opviera debug startup       print startup timing
+  opviera debug agent <name>  show agent configuration details
+  opviera debug v2            debug v2 catalog and built-in plugins
+  opviera debug info          show debug information
+  opviera debug paths         show global paths (data, config, cache, state)
+  opviera debug wait          wait indefinitely (for debugging)
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -136,14 +136,14 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode providers --help 1`] = `
-"opencode providers
+"opviera providers
 
 manage AI providers and credentials
 
 Commands:
-  opencode providers list               list providers and credentials                 [aliases: ls]
-  opencode providers login [url]        log in to a provider
-  opencode providers logout [provider]  log out from a configured provider
+  opviera providers list               list providers and credentials                  [aliases: ls]
+  opviera providers login [url]        log in to a provider
+  opviera providers logout [provider]  log out from a configured provider
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -154,13 +154,13 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode agent --help 1`] = `
-"opencode agent
+"opviera agent
 
 manage agents
 
 Commands:
-  opencode agent create  create a new agent
-  opencode agent list    list all available agents
+  opviera agent create  create a new agent
+  opviera agent list    list all available agents
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -171,9 +171,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode upgrade --help 1`] = `
-"opencode upgrade [target]
+"opviera upgrade [target]
 
-upgrade opencode to the latest or a specific version
+upgrade Opviera to the latest or a specific version
 
 Positionals:
   target  version to upgrade to, for ex '0.1.48' or 'v0.1.48'                               [string]
@@ -189,9 +189,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode uninstall --help 1`] = `
-"opencode uninstall
+"opviera uninstall
 
-uninstall opencode and remove all related files
+uninstall Opviera and remove all related files
 
 Options:
   -h, --help         show help                                                             [boolean]
@@ -206,9 +206,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode serve --help 1`] = `
-"opencode serve
+"opviera serve
 
-starts a headless opencode server
+starts a headless Opviera server
 
 Options:
   -h, --help         show help                                                             [boolean]
@@ -226,9 +226,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode web --help 1`] = `
-"opencode web
+"opviera web
 
-start opencode server and open web interface
+start Opviera server and open web interface
 
 Options:
   -h, --help         show help                                                             [boolean]
@@ -246,7 +246,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode models --help 1`] = `
-"opencode models [provider]
+"opviera models [provider]
 
 list all available models
 
@@ -264,7 +264,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode stats --help 1`] = `
-"opencode stats
+"opviera stats
 
 show token usage and cost statistics
 
@@ -282,7 +282,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode export --help 1`] = `
-"opencode export [sessionID]
+"opviera export [sessionID]
 
 export session data as JSON
 
@@ -299,7 +299,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode import --help 1`] = `
-"opencode import <file>
+"opviera import <file>
 
 import session data from JSON file or URL
 
@@ -315,13 +315,13 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode github --help 1`] = `
-"opencode github
+"opviera github
 
 manage GitHub agent
 
 Commands:
-  opencode github install  install the GitHub agent
-  opencode github run      run the GitHub agent
+  opviera github install  install the GitHub agent
+  opviera github run      run the GitHub agent
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -332,9 +332,9 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode pr --help 1`] = `
-"opencode pr <number>
+"opviera pr <number>
 
-fetch and checkout a GitHub PR branch, then run opencode
+fetch and checkout a GitHub PR branch, then run Opviera
 
 Positionals:
   number  PR number to checkout                                                  [number] [required]
@@ -348,13 +348,13 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode session --help 1`] = `
-"opencode session
+"opviera session
 
 manage sessions
 
 Commands:
-  opencode session list                list sessions
-  opencode session delete <sessionID>  delete a session
+  opviera session list                list sessions
+  opviera session delete <sessionID>  delete a session
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -365,7 +365,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode plugin --help 1`] = `
-"opencode plugin <module>
+"opviera plugin <module>
 
 install plugin and update config
 
@@ -383,13 +383,13 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode db --help 1`] = `
-"opencode db
+"opviera db
 
 database tools
 
 Commands:
-  opencode db [query]     open an interactive sqlite3 shell or run a query                 [default]
-  opencode db path        print the database path
+  opviera db [query]     open an interactive sqlite3 shell or run a query                  [default]
+  opviera db path        print the database path
 
 Positionals:
   query  SQL query to execute                                                               [string]
@@ -404,7 +404,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode mcp list --help 1`] = `
-"opencode mcp list
+"opviera mcp list
 
 list MCP servers and their status
 
@@ -417,7 +417,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode mcp add --help 1`] = `
-"opencode mcp add [name]
+"opviera mcp add [name]
 
 add an MCP server
 
@@ -436,12 +436,12 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode mcp auth --help 1`] = `
-"opencode mcp auth [name]
+"opviera mcp auth [name]
 
 authenticate with an OAuth-enabled MCP server
 
 Commands:
-  opencode mcp auth list  list OAuth-capable MCP servers and their auth status         [aliases: ls]
+  opviera mcp auth list  list OAuth-capable MCP servers and their auth status          [aliases: ls]
 
 Positionals:
   name  name of the MCP server                                                              [string]
@@ -455,7 +455,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode mcp logout --help 1`] = `
-"opencode mcp logout [name]
+"opviera mcp logout [name]
 
 remove OAuth credentials for an MCP server
 
@@ -471,7 +471,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode providers list --help 1`] = `
-"opencode providers list
+"opviera providers list
 
 list providers and credentials
 
@@ -484,12 +484,12 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode providers login --help 1`] = `
-"opencode providers login [url]
+"opviera providers login [url]
 
 log in to a provider
 
 Positionals:
-  url  opencode auth provider                                                               [string]
+  url  Opviera auth provider                                                                [string]
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -502,7 +502,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode providers logout --help 1`] = `
-"opencode providers logout [provider]
+"opviera providers logout [provider]
 
 log out from a configured provider
 
@@ -518,7 +518,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode agent create --help 1`] = `
-"opencode agent create
+"opviera agent create
 
 create a new agent
 
@@ -538,7 +538,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode agent list --help 1`] = `
-"opencode agent list
+"opviera agent list
 
 list all available agents
 
@@ -551,7 +551,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode session list --help 1`] = `
-"opencode session list
+"opviera session list
 
 list sessions
 
@@ -566,7 +566,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode session delete --help 1`] = `
-"opencode session delete <sessionID>
+"opviera session delete <sessionID>
 
 delete a session
 
@@ -582,7 +582,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode github install --help 1`] = `
-"opencode github install
+"opviera github install
 
 install the GitHub agent
 
@@ -595,7 +595,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode github run --help 1`] = `
-"opencode github run
+"opviera github run
 
 run the GitHub agent
 
@@ -610,7 +610,7 @@ Options:
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode db path --help 1`] = `
-"opencode db path
+"opviera db path
 
 print the database path
 

--- a/packages/opencode/test/cli/mcp-add.test.ts
+++ b/packages/opencode/test/cli/mcp-add.test.ts
@@ -22,7 +22,7 @@ describe("opencode mcp add (non-interactive subprocess)", () => {
         opencode.expectExit(result, 0)
 
         const config = yield* Effect.promise(() =>
-          Bun.file(path.join(home, ".config", "opencode", "opencode.json")).json(),
+          Bun.file(path.join(home, ".config", "opviera", "opencode.json")).json(),
         )
         expect(config.mcp.github).toEqual({
           type: "remote",
@@ -58,7 +58,7 @@ describe("opencode mcp add (non-interactive subprocess)", () => {
         opencode.expectExit(result, 0)
 
         const config = yield* Effect.promise(() =>
-          Bun.file(path.join(home, ".config", "opencode", "opencode.json")).json(),
+          Bun.file(path.join(home, ".config", "opviera", "opencode.json")).json(),
         )
         expect(config.mcp.local).toEqual({
           type: "local",

--- a/packages/opencode/test/cli/opviera.test.ts
+++ b/packages/opencode/test/cli/opviera.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { resolveProject } from "@/cli/opviera/gate"
+import { whoami, GatewayError } from "@/cli/opviera/client"
+import { looksLikeApiKey, gatewayUrl, DEFAULT_GATEWAY_URL } from "@/cli/opviera/config"
+import type { WhoAmI } from "@/cli/opviera/client"
+
+const identity = (over: Partial<WhoAmI> = {}): WhoAmI => ({
+  user: { id: "u1", name: "Ada" },
+  organization: { id: "o1", name: "Virstack" },
+  key: { prefix: "vsk_abc12345", upstream: "bedrock" },
+  boundProjectId: null,
+  projectRequired: false,
+  projects: [
+    { identifier: "acme-web", name: "Acme Web" },
+    { identifier: "acme-web-2", name: "Acme Web" },
+  ],
+  models: [],
+  forcedModel: null,
+  ...over,
+})
+
+describe("api key format", () => {
+  test("accepts a real key shape and rejects near-misses", () => {
+    const valid = "vsk_" + "a".repeat(40)
+    expect(looksLikeApiKey(valid)).toBe(true)
+    expect(looksLikeApiKey(" " + valid + " ")).toBe(true)
+    expect(looksLikeApiKey("vsk_" + "a".repeat(39))).toBe(false)
+    expect(looksLikeApiKey("vsk_" + "z".repeat(40))).toBe(false)
+    expect(looksLikeApiKey("sk-ant-abc")).toBe(false)
+    expect(looksLikeApiKey("")).toBe(false)
+  })
+})
+
+describe("project resolution", () => {
+  // A user types the name they know; the gateway only ever accepts the slug.
+  test("resolves by human name, case-insensitively", () => {
+    expect(resolveProject(identity(), "acme web")?.identifier).toBe("acme-web")
+    expect(resolveProject(identity(), "  ACME WEB  ")?.identifier).toBe("acme-web")
+  })
+
+  test("resolves by identifier too", () => {
+    expect(resolveProject(identity(), "acme-web-2")?.identifier).toBe("acme-web-2")
+  })
+
+  test("returns nothing for an unknown or empty name, so the caller can offer the list", () => {
+    expect(resolveProject(identity(), "typo")).toBeUndefined()
+    expect(resolveProject(identity(), "")).toBeUndefined()
+  })
+
+  // A bound key's project is decided server-side; projectCheck ignores whatever the client sends.
+  test("a bound key overrides whatever was typed", () => {
+    const bound = identity({ boundProjectId: "acme-web-2" })
+    expect(resolveProject(bound, "acme web")?.identifier).toBe("acme-web-2")
+    expect(resolveProject(bound, "")?.identifier).toBe("acme-web-2")
+  })
+
+  test("a bound key not present in the visible list still resolves", () => {
+    const bound = identity({ boundProjectId: "hidden", projects: [] })
+    expect(resolveProject(bound, "")?.identifier).toBe("hidden")
+  })
+})
+
+describe("gateway client", () => {
+  const realFetch = globalThis.fetch
+  afterEach(() => {
+    globalThis.fetch = realFetch
+  })
+
+  const respond = (status: number, body: unknown, headers: Record<string, string> = {}) => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json", ...headers },
+      })) as unknown as typeof fetch
+  }
+
+  const anthropicError = (message: string) => ({ type: "error", error: { type: "permission_error", message } })
+
+  test("returns the payload on success", async () => {
+    respond(200, identity())
+    const result = await whoami("vsk_test")
+    expect(result.organization.name).toBe("Virstack")
+    expect(result.projects).toHaveLength(2)
+  })
+
+  test("calls /v1/whoami on the configured gateway with x-api-key", async () => {
+    const seen: { url?: string; key?: string | null } = {}
+    globalThis.fetch = (async (...args: unknown[]) => {
+      seen.url = String(args[0])
+      seen.key = new Headers((args[1] as RequestInit | undefined)?.headers).get("x-api-key")
+      return new Response(JSON.stringify(identity()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as unknown as typeof fetch
+    await whoami("vsk_secret")
+    expect(seen.url).toBe(`${DEFAULT_GATEWAY_URL}/v1/whoami`)
+    expect(seen.key).toBe("vsk_secret")
+  })
+
+  // A bad key is worth asking again for; a dead account is not.
+  test("marks a 401 retryable so the CLI re-prompts", async () => {
+    respond(401, anthropicError("Invalid or revoked API key."))
+    const error = (await whoami("vsk_bad").catch((e) => e)) as GatewayError
+    expect(error).toBeInstanceOf(GatewayError)
+    expect(error.retryable).toBe(true)
+    expect(error.message).toMatch(/invalid or revoked/i)
+  })
+
+  test("marks a suspended account non-retryable", async () => {
+    respond(403, anthropicError("Your account is suspended. Contact your administrator."))
+    const error = (await whoami("vsk_x").catch((e) => e)) as GatewayError
+    expect(error.retryable).toBe(false)
+  })
+
+  // The reason /whoami is mounted above the billing gate: the key is valid, the org is not paying.
+  test("surfaces inactive billing verbatim and does not re-prompt", async () => {
+    respond(403, anthropicError("Billing is not active for this organization."))
+    const error = (await whoami("vsk_x").catch((e) => e)) as GatewayError
+    expect(error.retryable).toBe(false)
+    expect(error.message).toMatch(/billing is not active/i)
+  })
+
+  test("explains an outdated gateway on 404", async () => {
+    respond(404, {})
+    const error = (await whoami("vsk_x").catch((e) => e)) as GatewayError
+    expect(error.message).toMatch(/does not support this CLI/i)
+  })
+
+  test("carries the request id through for support", async () => {
+    respond(401, anthropicError("Invalid or revoked API key."), { "request-id": "req_123" })
+    const error = (await whoami("vsk_x").catch((e) => e)) as GatewayError
+    expect(error.requestId).toBe("req_123")
+  })
+
+  test("reports an unreachable gateway rather than throwing a raw network error", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed")
+    }) as unknown as typeof fetch
+    const error = (await whoami("vsk_x").catch((e) => e)) as GatewayError
+    expect(error).toBeInstanceOf(GatewayError)
+    expect(error.message).toMatch(/could not reach/i)
+    expect(error.retryable).toBe(false)
+  })
+})
+
+describe("gateway url", () => {
+  test("defaults to the Opviera platform and strips a trailing slash", () => {
+    expect(gatewayUrl()).toBe(DEFAULT_GATEWAY_URL)
+    process.env["OPVIERA_GATEWAY_URL"] = "http://localhost:3000/gateway/"
+    expect(gatewayUrl()).toBe("http://localhost:3000/gateway")
+    delete process.env["OPVIERA_GATEWAY_URL"]
+  })
+})

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -17,11 +17,16 @@ if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
   throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`)
 }
 
+// Release inputs are OPVIERA_*. The upstream OPENCODE_* names are still accepted as a fallback so
+// an existing pipeline or a half-updated shell keeps working rather than silently building the
+// wrong version.
+const pick = (name: string) => process.env[`OPVIERA_${name}`] ?? process.env[`OPENCODE_${name}`]
+
 const env = {
-  OPENCODE_CHANNEL: process.env["OPENCODE_CHANNEL"],
-  OPENCODE_BUMP: process.env["OPENCODE_BUMP"],
-  OPENCODE_VERSION: process.env["OPENCODE_VERSION"],
-  OPENCODE_RELEASE: process.env["OPENCODE_RELEASE"],
+  OPENCODE_CHANNEL: pick("CHANNEL"),
+  OPENCODE_BUMP: pick("BUMP"),
+  OPENCODE_VERSION: pick("VERSION"),
+  OPENCODE_RELEASE: pick("RELEASE"),
 }
 const CHANNEL = await (async () => {
   if (env.OPENCODE_CHANNEL) return env.OPENCODE_CHANNEL
@@ -34,17 +39,13 @@ const IS_PREVIEW = CHANNEL !== "latest"
 const VERSION = await (async () => {
   if (env.OPENCODE_VERSION) return env.OPENCODE_VERSION
   if (IS_PREVIEW) return `0.0.0-${CHANNEL}-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
-  const version = await fetch("https://registry.npmjs.org/opencode-ai/latest")
-    .then((res) => {
-      if (!res.ok) throw new Error(res.statusText)
-      return res.json()
-    })
-    .then((data: any) => data.version)
-  const [major, minor, patch] = version.split(".").map((x: string) => Number(x) || 0)
-  const t = env.OPENCODE_BUMP?.toLowerCase()
-  if (t === "major") return `${major + 1}.0.0`
-  if (t === "minor") return `${major}.${minor + 1}.0`
-  return `${major}.${minor}.${patch + 1}`
+  // Upstream derived the next release version from `opencode-ai` on npm. Opviera must never do
+  // that — it would inherit opencode's version lineage and publish, say, v1.18.17 as our first
+  // release. Until an `opviera` npm package exists to bump from, a real release states its version.
+  throw new Error(
+    "OPVIERA_VERSION is required for a release build (e.g. OPVIERA_VERSION=0.1.0). " +
+      "Preview builds off a non-`latest` channel get an automatic 0.0.0-<channel>-<timestamp> version.",
+  )
 })()
 
 const bot = ["actions-user", "opencode", "opencode-agent[bot]"]

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -454,14 +454,14 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     if (!terminalTitleEnabled() || Flag.OPENCODE_DISABLE_TERMINAL_TITLE) return
 
     if (route.data.type === "home") {
-      renderer.setTerminalTitle("OpenCode")
+      renderer.setTerminalTitle("Opviera")
       return
     }
 
     if (route.data.type === "session") {
       const session = sync.session.get(route.data.sessionID)
       if (!session || isDefaultTitle(session.title)) {
-        renderer.setTerminalTitle("OpenCode")
+        renderer.setTerminalTitle("Opviera")
         return
       }
 
@@ -1070,7 +1070,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     await DialogAlert.show(
       dialog,
       "Update Complete",
-      `Successfully updated to OpenCode v${result.data.version}. Please restart the application.`,
+      `Successfully updated to Opviera v${result.data.version}. Please restart the application.`,
     )
 
     void exit()

--- a/packages/tui/src/logo.ts
+++ b/packages/tui/src/logo.ts
@@ -1,6 +1,13 @@
+/**
+ * The Opviera wordmark, split into two halves that are rendered in different shades.
+ *
+ * `marks` below are shading control characters, not glyphs: `_` and `~` render as blank shaded
+ * cells and `^` as a shaded upper bar. Keep every row in a half the same width or the halves
+ * will not line up.
+ */
 export const logo = {
-  left: ["                   ", "█▀▀█ █▀▀█ █▀▀█ █▀▀▄", "█__█ █__█ █^^^ █__█", "▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀~~▀"],
-  right: ["             ▄     ", "█▀▀▀ █▀▀█ █▀▀█ █▀▀█", "█___ █__█ █__█ █^^^", "▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀"],
+  left: ["              ", "█▀▀█ █▀▀█ █__█", "█__█ █__█ █__█", "▀▀▀▀ █▀▀▀ ▀▄▄▀"],
+  right: ["  ▄                ", "  █  █▀▀█ █▀▀▄ ▄▀▀█", "  █  █^^^ █___ █▄▄█", "  ▀  ▀▀▀▀ ▀___ ▀▀▀▀"],
 }
 
 export const go = {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,7 +36,7 @@
     "vscode-languageserver-types": "3.17.5"
   },
   "devDependencies": {
-    "opencode": "workspace:*",
+    "opviera": "workspace:*",
     "@types/node": "catalog:",
     "@astrojs/check": "0.9.6",
     "typescript": "catalog:"

--- a/script/version.ts
+++ b/script/version.ts
@@ -7,7 +7,10 @@ const output = [`version=${Script.version}`]
 const sha = process.env.GITHUB_SHA ?? (await $`git rev-parse HEAD`.text()).trim()
 
 if (!Script.preview) {
-  await $`bun script/changelog.ts --to ${sha}`.cwd(process.cwd())
+  // Best-effort: changelog.ts AI-generates release notes by shelling out to a coding agent. That is
+  // no longer installed in CI (it was upstream's own CLI, and needed their API key), so a failure
+  // here must not abort the release — the notes fall back to "No notable changes" below.
+  await $`bun script/changelog.ts --to ${sha}`.cwd(process.cwd()).nothrow()
   const file = `${process.cwd()}/UPCOMING_CHANGELOG.md`
   const body = await Bun.file(file)
     .text()

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "dependsOn": [],
       "outputs": ["dist/**"]
     },
-    "opencode#test": {
+    "opviera#test": {
       "dependsOn": ["^build"],
       "outputs": [],
       "passThroughEnv": ["*"]


### PR DESCRIPTION
Rebrands this fork as Opviera CLI and locks it to the Opviera (Clawgate) gateway, so the binary cannot reach any other model provider.

Startup gate (packages/opencode/src/cli/opviera/):
- `opviera` shows the wordmark, prompts for a project name and API key, and validates both against GET /gateway/v1/whoami before the agent starts.
- A bad key re-prompts only the key; an unknown project falls back to a picker over the projects the key may actually use; a project-bound key skips the prompt entirely, mirroring the gateway's projectCheck.
- Credentials land in auth.json (0600) in the shape the existing Effect Auth service already reads. OPVIERA_API_KEY is the non-interactive path and is validated identically. Adds `opviera login` / `opviera logout`.

Provider lock:
- packages/core/src/plugin/provider.ts registers ONE provider plugin, down from ~30. A config allow-list can be edited; a plugin that is not compiled in cannot be re-enabled by any file, flag or env var.
- The provider is provisioned into the opened project's opviera.json from the whoami payload, so the model list IS the key's policy and is refreshed on every start. The file carries no credential and is safe to commit.
- models.dev fetching and the auto-updater are hardcoded off; the updater otherwise contacts six external hosts one second after the TUI starts.

Branding: both independent wordmark copies, binary name, ~/.config/opviera, terminal title, user agent, install script, LICENSE (upstream MIT notice retained) and README.

Release pipeline: publish.yml targets virstack/opviera-cli; release inputs are OPVIERA_* (OPENCODE_* still honoured as a fallback); the signing and desktop jobs are gated behind repository variables; the step that installed upstream's CLI into CI, using their API key, is removed and changelog generation is now best-effort. setup-git-committer falls back to GITHUB_TOKEN, so a release needs no secrets. A release build now requires an explicit OPVIERA_VERSION rather than deriving one from opencode's npm package.

Runtime flags are addressable as OPVIERA_*, with OPENCODE_* kept as a fallback.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
