### PR TITLE
feat(plugin): add session stopping hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1125,6 +1125,31 @@ const layer = Layer.effect(
                 callID: orphan.callID,
               })
             }
+            const stopping = yield* plugin.trigger("experimental.session.stopping", { sessionID }, { context: [] })
+            if (stopping.context.length > 0) {
+              const continueMsg = yield* sessions.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID,
+                time: { created: Date.now() },
+                agent: lastUser.agent,
+                model: lastUser.model,
+              })
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: continueMsg.id,
+                sessionID,
+                type: "text",
+                text: stopping.context.join("\n\n"),
+                metadata: { session_stopping: true },
+                synthetic: true,
+                time: {
+                  start: Date.now(),
+                  end: Date.now(),
+                },
+              })
+              continue
+            }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
             break
           }

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -7,6 +7,9 @@ import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { reply } from "../../lib/llm-server"
 import { cliIt } from "../../lib/cli-process"
+import { testProviderConfig } from "../../lib/test-provider"
+
+const disposePlugin = new URL("../../fixture/dispose-plugin.ts", import.meta.url).href
 
 describe("opencode run (non-interactive subprocess)", () => {
   // Happy path: prompt completes, output reaches stdout, process exits 0.
@@ -19,6 +22,33 @@ describe("opencode run (non-interactive subprocess)", () => {
         const result = yield* opencode.run("say hi")
         opencode.expectExit(result, 0)
         expect(result.stdout).toBe("hello from the test llm\n")
+      }),
+    60_000,
+  )
+
+  cliIt.concurrent(
+    "awaits external plugin dispose before the run process exits",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const marker = `${home}/plugin-disposed`
+        yield* llm.text("done")
+        const config = {
+          ...testProviderConfig(llm.url),
+          plugin: [disposePlugin],
+        }
+
+        const result = yield* opencode.run("finish and dispose", {
+          env: {
+            OPENCODE_PURE: "false",
+            OPENCODE_DISABLE_DEFAULT_PLUGINS: "true",
+            OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+            OPENCODE_TEST_PLUGIN_DISPOSE_MARKER: marker,
+          },
+        })
+
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toBe("done\n")
+        expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(true)
       }),
     60_000,
   )

--- a/packages/opencode/test/fixture/dispose-plugin.ts
+++ b/packages/opencode/test/fixture/dispose-plugin.ts
@@ -1,0 +1,7 @@
+export default async () => ({
+  dispose: async () => {
+    const marker = process.env.OPENCODE_TEST_PLUGIN_DISPOSE_MARKER
+    if (!marker) throw new Error("OPENCODE_TEST_PLUGIN_DISPOSE_MARKER is required")
+    await Bun.write(marker, "disposed")
+  },
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -208,20 +208,41 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking"
+  plugin?: Layer.Layer<Plugin.Service>
+}) {
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
     [MCP.node, makeMcp(input?.mcpInstructions)],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
+  if (input?.plugin) {
+    const withPlugin = [...replacements, [Plugin.node, input.plugin] as const] as const
+    if (input.processor === "blocking") {
+      return LayerNode.compile(promptRoot, [
+        ...withPlugin,
+        [SessionProcessor.node, blockingProcessor] as const,
+      ] as const)
+    }
+    return LayerNode.compile(promptRoot, withPlugin)
+  }
   if (input?.processor === "blocking") {
-    return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, blockingProcessor]])
+    return LayerNode.compile(promptRoot, [
+      ...replacements,
+      [SessionProcessor.node, blockingProcessor] as const,
+    ] as const)
   }
   return LayerNode.compile(promptRoot, replacements)
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking"
+  plugin?: Layer.Layer<Plugin.Service>
+}) {
   const root = LayerNode.group([promptRoot, testLLMServerNode])
   const replacements = [
     [SessionSummary.node, summary],
@@ -229,13 +250,24 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
     [MCP.node, makeMcp(input?.mcpInstructions)],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
+  if (input?.plugin) {
+    const withPlugin = [...replacements, [Plugin.node, input.plugin] as const] as const
+    if (input.processor === "blocking") {
+      return LayerNode.compile(root, [...withPlugin, [SessionProcessor.node, blockingProcessor] as const] as const)
+    }
+    return LayerNode.compile(root, withPlugin)
+  }
   if (input?.processor === "blocking") {
-    return LayerNode.compile(root, [...replacements, [SessionProcessor.node, blockingProcessor]])
+    return LayerNode.compile(root, [...replacements, [SessionProcessor.node, blockingProcessor] as const] as const)
   }
   return LayerNode.compile(root, replacements)
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking"
+  plugin?: Layer.Layer<Plugin.Service>
+}) {
   return makePrompt(input)
 }
 
@@ -442,6 +474,30 @@ const boot = Effect.fn("test.boot")(function* (input?: { title?: string }) {
   return { prompt, run, sessions, chat }
 })
 
+function sessionStoppingPlugin(outputs: readonly (readonly string[] | Error)[]) {
+  const state = {
+    calls: 0,
+    assistantPersisted: [] as boolean[],
+  }
+  const layer = Layer.mock(Plugin.Service)({
+    trigger: (<Name extends string, Input, Output>(name: Name, input: Input, output: Output) => {
+      if (name !== "experimental.session.stopping") return Effect.succeed(output)
+      return Effect.gen(function* () {
+        const messages = yield* Session.use.messages({ sessionID: (input as { sessionID: SessionID }).sessionID })
+        const last = messages.at(-1)
+        state.assistantPersisted.push(last?.info.role === "assistant" && last.info.finish === "stop")
+        const next = outputs[state.calls++] ?? []
+        if (next instanceof Error) return yield* Effect.die(next)
+        ;(output as { context: string[] }).context.push(...next)
+        return output
+      })
+    }) as Plugin.Interface["trigger"],
+    list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+  return { layer, state }
+}
+
 // Loop semantics
 
 noLLMServer.instance(
@@ -551,6 +607,94 @@ it.instance("loop calls LLM and returns assistant message", () =>
     const parts = result.parts.filter((p) => p.type === "text")
     expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
     expect(yield* llm.hits).toHaveLength(1)
+  }),
+)
+
+const stoppingEmpty = sessionStoppingPlugin([[]])
+const stoppingEmptyIt = testEffect(makeHttp({ plugin: stoppingEmpty.layer }))
+
+stoppingEmptyIt.instance("session stopping without context leaves the completed assistant turn terminal", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* user(chat.id, "hello")
+    yield* llm.text("finished")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+
+    expect(result.info.role).toBe("assistant")
+    expect(stoppingEmpty.state.calls).toBe(1)
+    expect(stoppingEmpty.state.assistantPersisted).toEqual([true])
+    expect(messages.map((message) => message.info.role)).toEqual(["user", "assistant"])
+    expect(messages.flatMap((message) => message.parts).some((part) => part.type === "text" && part.synthetic)).toBe(
+      false,
+    )
+    expect(yield* llm.hits).toHaveLength(1)
+  }),
+)
+
+const stoppingContinue = sessionStoppingPlugin([["first instruction", "second instruction"], []])
+const stoppingContinueIt = testEffect(makeHttp({ plugin: stoppingContinue.layer }))
+
+stoppingContinueIt.instance("session stopping persists ordered hidden context and continues the loop", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* user(chat.id, "hello")
+    yield* llm.text("first answer")
+    yield* llm.text("second answer")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+    const hidden = messages[2]?.parts.find((part) => part.type === "text")
+    const requests = yield* llm.inputs
+
+    expect(result.parts.some((part) => part.type === "text" && part.text === "second answer")).toBe(true)
+    expect(stoppingContinue.state.calls).toBe(2)
+    expect(stoppingContinue.state.assistantPersisted).toEqual([true, true])
+    expect(messages.map((message) => message.info.role)).toEqual(["user", "assistant", "user", "assistant"])
+    expect(hidden).toMatchObject({
+      type: "text",
+      text: "first instruction\n\nsecond instruction",
+      synthetic: true,
+      metadata: { session_stopping: true },
+    })
+    expect(requests).toHaveLength(2)
+    const continuationRequest = JSON.stringify(requests[1])
+    expect(continuationRequest.indexOf("first instruction")).toBeLessThan(
+      continuationRequest.indexOf("second instruction"),
+    )
+  }),
+)
+
+const stoppingFailure = sessionStoppingPlugin([new Error("stopping hook failed")])
+const stoppingFailureIt = testEffect(makeHttp({ plugin: stoppingFailure.layer }))
+
+stoppingFailureIt.instance("session stopping hook failure fails the loop after preserving the assistant turn", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* user(chat.id, "hello")
+    yield* llm.text("finished before failure")
+
+    const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toMatchObject({ message: "stopping hook failed" })
+    expect(stoppingFailure.state.calls).toBe(1)
+    expect(stoppingFailure.state.assistantPersisted).toEqual([true])
+    expect(messages.map((message) => message.info.role)).toEqual(["user", "assistant"])
+    expect(messages.at(-1)?.parts).toContainEqual(
+      expect.objectContaining({ type: "text", text: "finished before failure" }),
+    )
   }),
 )
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -307,6 +307,12 @@ export interface Hooks {
     output: { context: string[]; prompt?: string },
   ) => Promise<void>
   /**
+   * Called after an assistant turn is persisted and immediately before the
+   * session would become idle. Adding context keeps the session running by
+   * creating a hidden synthetic user turn containing that context.
+   */
+  "experimental.session.stopping"?: (input: { sessionID: string }, output: { context: string[] }) => Promise<void>
+  /**
    * Called after compaction succeeds and before a synthetic user
    * auto-continue message is added.
    *


### PR DESCRIPTION
### Issue for this PR

Closes #16626

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a plugin hook before a completed session goes idle. Plugins can append ordered context, which OpenCode persists as a hidden synthetic user turn before continuing the same loop. With no returned context, the existing terminal path is unchanged. Hook failures also leave the completed assistant response intact.

### How did you verify your code works?

- `bun test test/session/prompt.test.ts --timeout 30000`
- `bun test test/cli/run/run-process.test.ts --timeout 30000 -t "awaits external plugin dispose"`
- `bun typecheck` in `packages/plugin` and `packages/opencode`
- full monorepo typecheck from the pre-push hook

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR