### PR TITLE
core: age cap on execution-claim resume

### DIFF
--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -16,6 +16,11 @@ const RESUME_EXHAUSTED = {
   message: "Execution was interrupted repeatedly and will not be resumed automatically.",
 } as const
 
+const RESUME_STALE = {
+  type: "aborted",
+  message: "Execution was interrupted too long ago to resume automatically.",
+} as const
+
 export interface Options {
   /**
    * Times a single turn may be resumed before it is terminalized instead.
@@ -24,9 +29,20 @@ export interface Options {
    * never accumulate: the budget is per-turn, not per-session.
    */
   readonly maxAttempts?: number
+  /**
+   * Claims whose turn showed no sign of life for longer than this are
+   * terminalized instead of resumed. Staleness is measured from the turn's
+   * last durable message activity (falling back to the claim time), NOT from
+   * when the turn started — a long healthy turn interrupted mid-stream is
+   * seconds stale at the next boot. The cap exists for the other case: a
+   * server that died mid-turn and boots hours later should not surprise the
+   * user by silently continuing a turn they have moved past.
+   */
+  readonly maxAgeMs?: number
 }
 
 const DEFAULT_MAX_ATTEMPTS = 10
+const DEFAULT_MAX_AGE_MS = 10 * 60 * 1000
 
 export interface Interface {
   /**
@@ -64,20 +80,33 @@ export const layer = (options?: Options) =>
       const bus = yield* Bus.Service
       const scope = yield* Effect.scope
       const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+      const maxAgeMs = options?.maxAgeMs ?? DEFAULT_MAX_AGE_MS
 
-      const resumeOne = Effect.fnUntraced(function* (sessionID: SessionSchema.ID) {
+      const terminalize = (sessionID: SessionSchema.ID, error: typeof RESUME_EXHAUSTED | typeof RESUME_STALE) =>
+        // The release hook clears the claim and resets the counter atomically
+        // with the terminal event.
+        bus.publish(SessionEvent.Execution.Failed, { sessionID, error }, { commit: () => store.release(sessionID) })
+
+      const resumeOne = Effect.fnUntraced(function* (claim: {
+        readonly sessionID: SessionSchema.ID
+        readonly claimedAt: number
+      }) {
+        const { sessionID, claimedAt } = claim
         // Durable before the resume runs, so a crash inside the resumed turn is
         // counted by the next sweep and the budget cannot be dodged.
         const attempts = yield* store.countResume(sessionID)
         if (attempts === undefined) return // the Session was deleted since listing
         if (attempts > maxAttempts) {
-          // Terminalize instead: the release hook clears the claim and resets the
-          // counter atomically with the terminal event.
-          yield* bus.publish(
-            SessionEvent.Execution.Failed,
-            { sessionID, error: RESUME_EXHAUSTED },
-            { commit: () => store.release(sessionID) },
-          )
+          yield* terminalize(sessionID, RESUME_EXHAUSTED)
+          return
+        }
+        // Staleness runs on the wall clock claims are written with (Date.now in
+        // the store), measured from the turn's last durable sign of life — not
+        // from when it started, so long healthy turns are not penalized.
+        const lastActivity = yield* store.lastActivityAt(sessionID)
+        const lastAlive = Math.max(claimedAt, lastActivity ?? 0)
+        if (Date.now() - lastAlive > maxAgeMs) {
+          yield* terminalize(sessionID, RESUME_STALE)
           return
         }
         yield* bus.publish(SessionEvent.Synthetic, {
@@ -101,7 +130,7 @@ export const layer = (options?: Options) =>
           const active = yield* execution.active
           // Sessions already draining in this process keep their claim; resuming
           // them would only inject a stray continuation into a live turn.
-          const orphaned = (yield* store.listSuspended()).filter((sessionID) => !active.has(sessionID))
+          const orphaned = (yield* store.listSuspended()).filter((claim) => !active.has(claim.sessionID))
           yield* Effect.forEach(orphaned, resumeOne, { concurrency: "unbounded", discard: true })
         }),
       })

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -18,11 +18,14 @@ export interface Interface {
     messageID: SessionMessage.ID,
   ) => Effect.Effect<{ readonly sessionID: Session.ID; readonly message: SessionMessage.Info } | undefined>
   /**
-   * Top-level Sessions holding an execution claim. Child (subagent) Sessions
-   * are excluded: a resumed parent re-runs its tool call and spawns fresh
-   * children, so resuming orphaned children would duplicate their work.
+   * Top-level Sessions holding an execution claim, with when each claim was
+   * written. Child (subagent) Sessions are excluded: a resumed parent re-runs
+   * its tool call and spawns fresh children, so resuming orphaned children
+   * would duplicate their work.
    */
-  readonly listSuspended: () => Effect.Effect<ReadonlyArray<Session.ID>>
+  readonly listSuspended: () => Effect.Effect<
+    ReadonlyArray<{ readonly sessionID: Session.ID; readonly claimedAt: number }>
+  >
   /**
    * Records the execution claim: the durable write-ahead intent that a turn is
    * (or was) in flight. Set when execution starts; a claim that survives to the
@@ -34,8 +37,8 @@ export interface Interface {
   readonly release: (sessionID: Session.ID) => Effect.Effect<void>
   /**
    * Clears orphaned child (subagent) claims. Children are never resumed
-   * independently, so a dead child's claim is noise no terminal will ever
-   * release.
+   * independently, so no terminal is otherwise coming to release a dead
+   * child's claim.
    */
   readonly releaseChildClaims: Effect.Effect<void>
   /**
@@ -43,6 +46,14 @@ export interface Interface {
    * total — or undefined when the Session no longer exists.
    */
   readonly countResume: (sessionID: Session.ID) => Effect.Effect<number | undefined>
+  /**
+   * When the Session's messages last changed, or undefined for an empty
+   * Session. Message rows update at durable part boundaries as a drain runs
+   * (streaming deltas are ephemeral), so this is the coarse "last sign of
+   * life" clock behind the resume staleness policy. Event persistence is
+   * opt-in, so this deliberately reads messages, not the event log.
+   */
+  readonly lastActivityAt: (sessionID: Session.ID) => Effect.Effect<number | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionStore") {}
@@ -77,13 +88,13 @@ const layer = Layer.effect(
       }),
       listSuspended: Effect.fn("SessionStore.listSuspended")(function* () {
         return yield* db
-          .select({ sessionID: SessionTable.id })
+          .select({ sessionID: SessionTable.id, claimedAt: SessionTable.time_suspended })
           .from(SessionTable)
           .where(and(isNotNull(SessionTable.time_suspended), isNull(SessionTable.parent_id)))
           .all()
           .pipe(
             Effect.orDie,
-            Effect.map((rows) => rows.map((row) => row.sessionID)),
+            Effect.map((rows) => rows.map((row) => ({ sessionID: row.sessionID, claimedAt: row.claimedAt ?? 0 }))),
           )
       }),
       claim: Effect.fn("SessionStore.claim")(function* (sessionID) {
@@ -124,6 +135,15 @@ const layer = Layer.effect(
           .get()
           .pipe(Effect.orDie)
         return row?.attempts
+      }),
+      lastActivityAt: Effect.fn("SessionStore.lastActivityAt")(function* (sessionID) {
+        const row = yield* db
+          .select({ updatedAt: sql<number | null>`max(${SessionMessageTable.time_updated})` })
+          .from(SessionMessageTable)
+          .where(eq(SessionMessageTable.session_id, sessionID))
+          .get()
+          .pipe(Effect.orDie)
+        return row?.updatedAt ?? undefined
       }),
     })
   }),

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -10,6 +10,8 @@ import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { SessionMessageTable } from "@opencode-ai/core/session/sql"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { UserInterruptedError } from "@opencode-ai/core/session/error"
@@ -17,7 +19,7 @@ import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionRunner } from "@opencode-ai/core/session/runner"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
-import { Context, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Scope } from "effect"
+import { Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Schema, Scope } from "effect"
 import { eq } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
 
@@ -63,7 +65,7 @@ describe("SessionExecution lifecycle", () => {
       // tool call and spawns a fresh child instead.
       yield* seedSessions(database, [child], { time_suspended: Date.now(), parent_id: parent })
 
-      expect(yield* store.listSuspended()).toEqual([parent])
+      expect((yield* store.listSuspended()).map((claim) => claim.sessionID)).toEqual([parent])
 
       // The sweep clears orphaned child claims outright; parents keep theirs.
       yield* store.releaseChildClaims
@@ -262,6 +264,62 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
+  it.effect("terminalizes a stale claim instead of resuming a turn the user has moved past", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const sessionID = Session.ID.make("ses_resume_stale")
+      // A claim from a process that died an hour ago, with no message activity since.
+      yield* seedSessions(database, [sessionID], { time_suspended: Date.now() - 60 * 60 * 1000 })
+
+      const drained: string[] = []
+      const failures: SessionEvent.Execution.Failed[] = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(
+        scope,
+        ({ sessionID: id }) => Effect.sync(() => void drained.push(id)),
+        { maxAgeMs: 10 * 60 * 1000 },
+      )
+      const restart = Context.get(context, SessionRestart.Service)
+      yield* bus.project(SessionEvent.Execution.Failed, (event) => Effect.sync(() => void failures.push(event)))
+
+      yield* restart.resumeSuspendedSessions
+      expect(drained).toEqual([])
+      expect(failures.map((event) => event.data.error)).toEqual([
+        { type: "aborted", message: "Execution was interrupted too long ago to resume automatically." },
+      ])
+      // The terminal released the claim and reset the counter atomically.
+      expect(yield* claims(database)).toEqual({ [sessionID]: false })
+      expect(yield* attempts(database, sessionID)).toBe(0)
+    }),
+  )
+
+  it.effect("staleness follows the turn's last durable activity, not when it started", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_resume_long_turn")
+      // A long-running turn: claimed an hour ago, but it was still writing
+      // durable message activity moments before the process died.
+      yield* seedSessions(database, [sessionID], { time_suspended: Date.now() - 60 * 60 * 1000 })
+      yield* seedMessage(database, sessionID, Date.now())
+
+      const draining = yield* Deferred.make<void>()
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, () => Deferred.succeed(draining, undefined), {
+        maxAgeMs: 10 * 60 * 1000,
+      })
+      const execution = Context.get(context, SessionExecution.Service)
+      const restart = Context.get(context, SessionRestart.Service)
+
+      yield* restart.resumeSuspendedSessions
+      yield* Deferred.await(draining)
+      yield* execution.awaitIdle(sessionID)
+      expect((yield* claims(database))[sessionID]).toBe(false)
+    }),
+  )
+
   it.effect("the sweep leaves Sessions already draining in this process untouched", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
@@ -320,6 +378,26 @@ function seedSessions(
       .run()
       .pipe(Effect.orDie)
   })
+}
+
+/** Seeds one durable message row whose time_updated is the Session's "last sign of life". */
+function seedMessage(database: Database.Service["Service"], sessionID: Session.ID, updatedAt: number) {
+  const id = SessionMessage.ID.make(`msg_${sessionID}`)
+  const {
+    id: _,
+    type,
+    ...data
+  } = Schema.encodeSync(SessionMessage.Info)({
+    id,
+    type: "synthetic",
+    text: "durable activity",
+    time: { created: DateTime.makeUnsafe(updatedAt) },
+  })
+  return database.db
+    .insert(SessionMessageTable)
+    .values({ id, session_id: sessionID, type, seq: 0, time_created: updatedAt, time_updated: updatedAt, data })
+    .run()
+    .pipe(Effect.orDie)
 }
 
 function claims(database: Database.Service["Service"]) {


### PR DESCRIPTION
Follow-up to #41800.

## What

The restart sweep now refuses to resume a claim whose turn showed no sign of life for longer than `maxAgeMs` (default 10 minutes). Stale claims are terminalized through the same visible path as budget exhaustion: an `Execution.Failed` with "Execution was interrupted too long ago to resume automatically", the claim released and the counter reset atomically with the terminal, partial output preserved.

## Why

#41800 resumed every orphaned claim regardless of age. The cases the mechanism was built for — managed upgrade, crash + respawn, isolate eviction — all reboot within seconds-to-minutes of the death. But a server that died mid-turn and boots hours or days later would silently continue a turn the user has long moved past: surprise token spend and a zombie continuation. Cloudflare's agents SDK hit exactly this in production (cloudflare/agents#1324 — stale continuations jamming agents behind new user messages); their documented recipe is an age guard.

## The clock

Staleness is **not** measured from when the turn started — our agent turns legitimately run for hours, and a 2-hour turn interrupted mid-stream by a deploy is healthy. It is measured from the turn's last durable sign of life:

```
staleness = now − max(claimedAt, lastActivityAt ?? 0)
```

- `lastActivityAt` = the session's newest message `time_updated`. Message rows update at durable part boundaries as a drain runs, so this ticks throughout a healthy turn. It deliberately reads messages, not the event log — event persistence is opt-in.
- `claimedAt` is the floor for turns that died before producing any durable activity.
- Both sides run on the wall clock the store writes claims with (`Date.now`).

Comparison points: Cloudflare's chat recovery recipe is ~2 minutes on the *turn-start* clock (would kill our long turns); their raw fiber recovery discards orphans after 24 h. Ours is 10 minutes on the activity clock — more generous on a more honest clock — and `maxAgeMs` is an `Options` field for embedders with long-silent workloads.

## Known trade-off

A turn that was *silent* for >10 minutes inside one tool call (a monster build) and then crossed a crash reads stale and is skipped. The failure is gentle — visible terminal, partials preserved, one re-prompt — and the asymmetry favors skipping: a wrongly-skipped resume costs a re-prompt; a wrongly-taken resume costs surprise tokens and a zombie continuation.

## Also in this PR

- `listSuspended` returns `{ sessionID, claimedAt }` (the sweep needs the claim time).
- `SessionStore.lastActivityAt` — new read, documented as the staleness clock.
- `releaseChildClaims` doc fix: a dead child's claim *can* be released by a terminal if the user prompts the child session directly; the accurate statement is that no terminal is otherwise coming.

## Testing

Two new tests in `session-execution.test.ts` (12 total, all green):

- a claim from an hour-dead process with no message activity terminalizes with the stale message, claim released, counter reset — and the drain never runs;
- a claim from an hour-long turn with message activity moments before death resumes normally (the activity clock, not the start clock, decides).

Full core suite 1669 pass; repo typecheck clean; touched files lint 0/0.
