### PR TITLE
fix(core): normalize provider endpoint templates

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -68,13 +68,7 @@ export function map(input: MapInput): Mapping | undefined {
 function mapBedrockMantle(input: MapInput): Mapping | undefined {
   const settings = input.settings
   const chat = input.modelID === "openai.gpt-oss-safeguard-20b" || input.modelID === "openai.gpt-oss-safeguard-120b"
-  const credentials = isRecord(settings.credentials) ? settings.credentials : undefined
-  const region =
-    typeof settings.region === "string"
-      ? settings.region
-      : typeof credentials?.region === "string"
-        ? credentials.region
-        : undefined
+  const region = bedrockRegion(settings)
   const baseURL =
     typeof settings.baseURL === "string" && region !== undefined
       ? settings.baseURL.replaceAll("${AWS_REGION}", region)
@@ -168,12 +162,7 @@ function mapBedrockRequest(input: MapInput): Pick<Mapping, "headers" | "body"> {
 
 function mapBedrockCredentials(settings: Readonly<Record<string, unknown>>) {
   const credentials = isRecord(settings.credentials) ? settings.credentials : settings
-  const region =
-    typeof settings.region === "string"
-      ? settings.region
-      : typeof credentials.region === "string"
-        ? credentials.region
-        : undefined
+  const region = bedrockRegion(settings)
   if (
     region === undefined ||
     typeof credentials.accessKeyId !== "string" ||
@@ -186,6 +175,15 @@ function mapBedrockCredentials(settings: Readonly<Record<string, unknown>>) {
     secretAccessKey: credentials.secretAccessKey,
     ...(typeof credentials.sessionToken === "string" ? { sessionToken: credentials.sessionToken } : {}),
   }
+}
+
+function bedrockRegion(settings: Readonly<Record<string, unknown>>) {
+  const credentials = isRecord(settings.credentials) ? settings.credentials : settings
+  return typeof settings.region === "string"
+    ? settings.region
+    : typeof credentials.region === "string"
+      ? credentials.region
+      : undefined
 }
 
 function mapOpenAIOptions(settings: Readonly<Record<string, unknown>>) {

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -26,7 +26,7 @@ export function map(input: MapInput): Mapping | undefined {
         ...mapBedrockRequest(input),
       }
     case "@ai-sdk/amazon-bedrock/mantle":
-      return mapBedrockMantle(input)
+      return mapBedrockMantle(input, baseSettings)
     case "@ai-sdk/azure":
       return {
         package: `@opencode-ai/ai/providers/azure/${input.settings.useCompletionUrls === true ? "chat" : "responses"}`,
@@ -65,18 +65,13 @@ export function map(input: MapInput): Mapping | undefined {
   }
 }
 
-function mapBedrockMantle(input: MapInput): Mapping | undefined {
+function mapBedrockMantle(input: MapInput, baseSettings: Readonly<Record<string, unknown>>): Mapping | undefined {
   const settings = input.settings
   const chat = input.modelID === "openai.gpt-oss-safeguard-20b" || input.modelID === "openai.gpt-oss-safeguard-120b"
-  const region = bedrockRegion(settings)
-  const baseURL =
-    typeof settings.baseURL === "string" && region !== undefined
-      ? settings.baseURL.replaceAll("${AWS_REGION}", region)
-      : settings.baseURL
   return {
     package: `@opencode-ai/ai/providers/amazon-bedrock/mantle/${chat ? "chat" : "responses"}`,
     settings: {
-      ...mapBedrockSettings(settings, typeof baseURL === "string" ? { baseURL } : {}),
+      ...mapBedrockSettings(settings, baseSettings),
       ...mapOpenAIOptions(settings),
     },
     ...(isStringRecord(settings.headers) ? { headers: settings.headers } : {}),
@@ -93,9 +88,13 @@ function mapBedrockSettings(
       : typeof settings.bearerToken === "string"
         ? settings.bearerToken
         : undefined
-  const credentials = mapBedrockCredentials(settings)
+  const region = bedrockRegion(settings)
+  const credentials = mapBedrockCredentials(settings, region)
   return {
     ...baseSettings,
+    ...(typeof baseSettings.baseURL === "string" && region !== undefined
+      ? { baseURL: baseSettings.baseURL.replaceAll("${AWS_REGION}", region) }
+      : {}),
     ...(typeof settings.baseURL !== "string" && typeof settings.endpoint === "string"
       ? { baseURL: settings.endpoint }
       : {}),
@@ -160,9 +159,8 @@ function mapBedrockRequest(input: MapInput): Pick<Mapping, "headers" | "body"> {
   }
 }
 
-function mapBedrockCredentials(settings: Readonly<Record<string, unknown>>) {
+function mapBedrockCredentials(settings: Readonly<Record<string, unknown>>, region: string | undefined) {
   const credentials = isRecord(settings.credentials) ? settings.credentials : settings
-  const region = bedrockRegion(settings)
   if (
     region === undefined ||
     typeof credentials.accessKeyId !== "string" ||

--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -26,7 +26,7 @@ export function map(input: MapInput): Mapping | undefined {
         ...mapBedrockRequest(input),
       }
     case "@ai-sdk/amazon-bedrock/mantle":
-      return mapBedrockMantle(input, baseSettings)
+      return mapBedrockMantle(input)
     case "@ai-sdk/azure":
       return {
         package: `@opencode-ai/ai/providers/azure/${input.settings.useCompletionUrls === true ? "chat" : "responses"}`,
@@ -65,13 +65,24 @@ export function map(input: MapInput): Mapping | undefined {
   }
 }
 
-function mapBedrockMantle(input: MapInput, baseSettings: Readonly<Record<string, unknown>>): Mapping | undefined {
+function mapBedrockMantle(input: MapInput): Mapping | undefined {
   const settings = input.settings
   const chat = input.modelID === "openai.gpt-oss-safeguard-20b" || input.modelID === "openai.gpt-oss-safeguard-120b"
+  const credentials = isRecord(settings.credentials) ? settings.credentials : undefined
+  const region =
+    typeof settings.region === "string"
+      ? settings.region
+      : typeof credentials?.region === "string"
+        ? credentials.region
+        : undefined
+  const baseURL =
+    typeof settings.baseURL === "string" && region !== undefined
+      ? settings.baseURL.replaceAll("${AWS_REGION}", region)
+      : settings.baseURL
   return {
     package: `@opencode-ai/ai/providers/amazon-bedrock/mantle/${chat ? "chat" : "responses"}`,
     settings: {
-      ...mapBedrockSettings(settings, baseSettings),
+      ...mapBedrockSettings(settings, typeof baseURL === "string" ? { baseURL } : {}),
       ...mapOpenAIOptions(settings),
     },
     ...(isStringRecord(settings.headers) ? { headers: settings.headers } : {}),

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -163,36 +163,37 @@ export const fromCatalogModel = (
     Effect.flatMap((resolved) => validateProviderVariables(model, resolved)),
   )
 
-const resolveCatalogModel = (model: Info, credential?: Credential.Value, dependencies?: Dependencies) => {
+const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(function* (
+  model: Info,
+  credential?: Credential.Value,
+  dependencies?: Dependencies,
+) {
   const resolved = prepareRuntimeModel(model, credential)
   const packageName = Provider.packageName(resolved.package)
   const key = apiKey(resolved, credential)
   const configuration = credential?.type === "key" ? credential.configuration : undefined
 
   if (Provider.isAISDK(resolved.package) && packageName === "@ai-sdk/openai") {
-    return Effect.succeed(
-      withDefaults(resolved, OpenAIResponses.route)
-        .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
-        .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
-    )
+    const runtime = yield* prepareProviderModel(resolved)
+    return withDefaults(runtime, OpenAIResponses.route)
+      .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
+      .model({ id: runtime.modelID ?? runtime.id, compatibility: runtime.compatibility })
   }
   if (Provider.isAISDK(resolved.package) && packageName === "@ai-sdk/anthropic") {
-    return Effect.succeed(
-      withDefaults(resolved, AnthropicMessages.route)
-        .with({ auth: key === undefined ? Auth.none : Auth.header("x-api-key", key) })
-        .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
-    )
+    const runtime = yield* prepareProviderModel(resolved)
+    return withDefaults(runtime, AnthropicMessages.route)
+      .with({ auth: key === undefined ? Auth.none : Auth.header("x-api-key", key) })
+      .model({ id: runtime.modelID ?? runtime.id, compatibility: runtime.compatibility })
   }
   if (
     Provider.isAISDK(resolved.package) &&
     packageName === "@ai-sdk/openai-compatible" &&
     typeof resolved.settings?.baseURL === "string"
   ) {
-    return Effect.succeed(
-      withDefaults(resolved, OpenAICompatibleChat.route)
-        .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
-        .model({ id: resolved.modelID ?? resolved.id, compatibility: resolved.compatibility }),
-    )
+    const runtime = yield* prepareProviderModel(resolved)
+    return withDefaults(runtime, OpenAICompatibleChat.route)
+      .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
+      .model({ id: runtime.modelID ?? runtime.id, compatibility: runtime.compatibility })
   }
   const configured = { ...resolved.settings, ...credential?.metadata, ...configuration }
   const mapping = Provider.isAISDK(resolved.package)
@@ -204,48 +205,48 @@ const resolveCatalogModel = (model: Info, credential?: Credential.Value, depende
     : undefined
   const native = mapping?.package ?? resolved.package
   if (Provider.isAISDK(resolved.package) && !mapping) {
-    const loadAISDK = dependencies?.loadAISDK
-    if (!loadAISDK) return Effect.fail(unsupported(resolved))
-    const runtime = produce(resolved, (draft) => {
-      draft.settings = Provider.mergeOverlay(draft.settings, {
+    const settings = yield* prepareProviderSettings(
+      resolved,
+      Provider.mergeOverlay(resolved.settings, {
         ...nativeCredentialSettings(resolved.package ?? "", credential),
         ...credential?.metadata,
         ...configuration,
-      })
-    })
-    return prepareOpaqueAISDKModel(resolved, runtime).pipe(
-      Effect.flatMap((runtime) => loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))),
+      }) ?? {},
     )
+    const loadAISDK = dependencies?.loadAISDK
+    if (!loadAISDK) return yield* unsupported(resolved)
+    const runtime = produce(resolved, (draft) => {
+      draft.settings = settings
+    })
+    return yield* loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))
   }
-  if (!native) return Effect.fail(unsupported(resolved))
+  if (!native) return yield* unsupported(resolved)
 
   const specifier = native
-  return Effect.gen(function* () {
-    const module = yield* (dependencies?.loadPackage ?? Provider.loadPackage)(specifier).pipe(
-      Effect.mapError(() => unsupported(resolved)),
-    )
-    const mapped = mapping?.settings ?? configured
-    const settings = {
-      ...(credential ? withoutNativeAuthSettings(mapped) : mapped),
-      ...nativeCredentialSettings(specifier, credential),
-      headers: Provider.mergeHeaders(mapping?.headers, resolved.headers),
-      body: Provider.mergeOverlay(mapping?.body, resolved.body),
-      limits: { context: resolved.limit.context, input: resolved.limit.input, output: resolved.limit.output },
-    }
-    return yield* Effect.try({
-      try: () => {
-        const runtime = module.model(resolved.modelID ?? resolved.id, settings)
-        return LanguageModel.update(runtime, {
-          provider: resolved.providerID,
-          compatibility: resolved.compatibility
-            ? Object.assign({}, runtime.compatibility, resolved.compatibility)
-            : runtime.compatibility,
-        })
-      },
-      catch: () => unsupported(resolved),
-    })
+  const mapped = yield* prepareProviderSettings(resolved, mapping?.settings ?? configured)
+  const module = yield* (dependencies?.loadPackage ?? Provider.loadPackage)(specifier).pipe(
+    Effect.mapError(() => unsupported(resolved)),
+  )
+  const settings = {
+    ...(credential ? withoutNativeAuthSettings(mapped) : mapped),
+    ...nativeCredentialSettings(specifier, credential),
+    headers: Provider.mergeHeaders(mapping?.headers, resolved.headers),
+    body: Provider.mergeOverlay(mapping?.body, resolved.body),
+    limits: { context: resolved.limit.context, input: resolved.limit.input, output: resolved.limit.output },
+  }
+  return yield* Effect.try({
+    try: () => {
+      const runtime = module.model(resolved.modelID ?? resolved.id, settings)
+      return LanguageModel.update(runtime, {
+        provider: resolved.providerID,
+        compatibility: resolved.compatibility
+          ? Object.assign({}, runtime.compatibility, resolved.compatibility)
+          : runtime.compatibility,
+      })
+    },
+    catch: () => unsupported(resolved),
   })
-}
+})
 
 function prepareRuntimeModel(model: Info, credential: Credential.Value | undefined) {
   return produce(model, (draft) => {
@@ -261,42 +262,58 @@ function validateProviderVariables(
 ): Effect.Effect<LanguageModel, UnresolvedProviderVariablesError> {
   const baseURL = resolved.route.endpoint.baseURL
   if (typeof baseURL !== "string") return Effect.succeed(resolved)
-  const prepared = resolveProviderURL(baseURL)
-  const failure = unresolvedProviderVariables(model, prepared)
-  if (failure) return Effect.fail(failure)
-  if (prepared === baseURL) return Effect.succeed(resolved)
-  return Effect.succeed(
-    LanguageModel.update(resolved, {
-      route: resolved.route.with({ endpoint: { baseURL: prepared } }),
+  return prepareProviderURL(model, baseURL).pipe(
+    Effect.map((prepared) =>
+      prepared === baseURL
+        ? resolved
+        : LanguageModel.update(resolved, {
+            route: resolved.route.with({ endpoint: { baseURL: prepared } }),
+          }),
+    ),
+  )
+}
+
+function prepareProviderModel(model: Info): Effect.Effect<Info, UnresolvedProviderVariablesError> {
+  if (!model.settings) return Effect.succeed(model)
+  return prepareProviderSettings(model, model.settings).pipe(
+    Effect.map((settings) =>
+      settings === model.settings
+        ? model
+        : produce(model, (draft) => {
+            draft.settings = settings
+          }),
+    ),
+  )
+}
+
+function prepareProviderSettings(
+  model: Info,
+  settings: Readonly<Record<string, unknown>>,
+): Effect.Effect<Readonly<Record<string, unknown>>, UnresolvedProviderVariablesError> {
+  const baseURL = settings.baseURL
+  if (typeof baseURL !== "string") return Effect.succeed(settings)
+  return prepareProviderURL(model, baseURL).pipe(
+    Effect.map((prepared) => (prepared === baseURL ? settings : { ...settings, baseURL: prepared })),
+  )
+}
+
+function prepareProviderURL(model: Info, baseURL: string): Effect.Effect<string, UnresolvedProviderVariablesError> {
+  if (!baseURL.includes("${")) return Effect.succeed(baseURL)
+  const variables = new Set<string>()
+  const prepared = baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
+    const value = process.env[name]
+    if (value !== undefined) return value
+    variables.add(name)
+    return placeholder
+  })
+  if (variables.size === 0) return Effect.succeed(prepared)
+  return Effect.fail(
+    new UnresolvedProviderVariablesError({
+      providerID: model.providerID,
+      modelID: model.id,
+      variables: Array.from(variables),
     }),
   )
-}
-
-function prepareOpaqueAISDKModel(model: Info, runtime: Info): Effect.Effect<Info, UnresolvedProviderVariablesError> {
-  const baseURL = runtime.settings?.baseURL
-  if (typeof baseURL !== "string") return Effect.succeed(runtime)
-  const prepared = resolveProviderURL(baseURL)
-  const failure = unresolvedProviderVariables(model, prepared)
-  if (failure) return Effect.fail(failure)
-  return Effect.succeed(
-    produce(runtime, (draft) => {
-      if (draft.settings) draft.settings.baseURL = prepared
-    }),
-  )
-}
-
-const providerVariablePattern = /\$\{([^}]+)\}/g
-
-function resolveProviderURL(baseURL: string) {
-  return baseURL.replace(providerVariablePattern, (placeholder, name: string) => process.env[name] ?? placeholder)
-}
-
-function unresolvedProviderVariables(model: Info, baseURL: string) {
-  const variables = Array.from(baseURL.matchAll(providerVariablePattern), (match) => match[1]).filter(
-    (name, index, names) => names.indexOf(name) === index,
-  )
-  if (variables.length === 0) return
-  return new UnresolvedProviderVariablesError({ providerID: model.providerID, modelID: model.id, variables })
 }
 
 const nativeCredentialSettings = (specifier: string, credential: Credential.Value | undefined) => {

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -158,17 +158,13 @@ export const fromCatalogModel = (
   model: Info,
   credential?: Credential.Value,
   dependencies?: Dependencies,
-): Effect.Effect<LanguageModel, UnsupportedPackageError | UnresolvedProviderVariablesError> => {
-  const prepared = prepareRuntimeModel(model, credential)
-  if (prepared.unresolved.length > 0)
-    return Effect.fail(
-      new UnresolvedProviderVariablesError({
-        providerID: model.providerID,
-        modelID: model.id,
-        variables: prepared.unresolved,
-      }),
-    )
-  const resolved = prepared.model
+): Effect.Effect<LanguageModel, UnsupportedPackageError | UnresolvedProviderVariablesError> =>
+  resolveCatalogModel(model, credential, dependencies).pipe(
+    Effect.flatMap((resolved) => validateProviderVariables(model, resolved)),
+  )
+
+const resolveCatalogModel = (model: Info, credential?: Credential.Value, dependencies?: Dependencies) => {
+  const resolved = prepareRuntimeModel(model, credential)
   const packageName = Provider.packageName(resolved.package)
   const key = apiKey(resolved, credential)
   const configuration = credential?.type === "key" ? credential.configuration : undefined
@@ -208,7 +204,8 @@ export const fromCatalogModel = (
     : undefined
   const native = mapping?.package ?? resolved.package
   if (Provider.isAISDK(resolved.package) && !mapping) {
-    if (!dependencies?.loadAISDK) return Effect.fail(unsupported(resolved))
+    const loadAISDK = dependencies?.loadAISDK
+    if (!loadAISDK) return Effect.fail(unsupported(resolved))
     const runtime = produce(resolved, (draft) => {
       draft.settings = Provider.mergeOverlay(draft.settings, {
         ...nativeCredentialSettings(resolved.package ?? "", credential),
@@ -216,7 +213,9 @@ export const fromCatalogModel = (
         ...configuration,
       })
     })
-    return dependencies.loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))
+    return prepareOpaqueAISDKModel(resolved, runtime).pipe(
+      Effect.flatMap((runtime) => loadAISDK(runtime).pipe(Effect.mapError(() => unsupported(resolved)))),
+    )
   }
   if (!native) return Effect.fail(unsupported(resolved))
 
@@ -249,23 +248,55 @@ export const fromCatalogModel = (
 }
 
 function prepareRuntimeModel(model: Info, credential: Credential.Value | undefined) {
-  const prepared = produce(model, (draft) => {
+  return produce(model, (draft) => {
     if (draft.settings?.apiKey === "") delete draft.settings.apiKey
     if (credential?.type === "key" && credential.metadata !== undefined)
       draft.body = Provider.mergeOverlay(draft.body, credential.metadata)
-    if (typeof draft.settings?.baseURL !== "string") return
-    draft.settings.baseURL = draft.settings.baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
-      return process.env[name] ?? placeholder
-    })
   })
-  const baseURL = prepared.settings?.baseURL
-  const unresolved =
-    typeof baseURL === "string"
-      ? Array.from(baseURL.matchAll(/\$\{([^}]+)\}/g), (match) => match[1]).filter(
-          (name, index, names) => names.indexOf(name) === index,
-        )
-      : []
-  return { model: prepared, unresolved }
+}
+
+function validateProviderVariables(
+  model: Info,
+  resolved: LanguageModel,
+): Effect.Effect<LanguageModel, UnresolvedProviderVariablesError> {
+  const baseURL = resolved.route.endpoint.baseURL
+  if (typeof baseURL !== "string") return Effect.succeed(resolved)
+  const prepared = resolveProviderURL(baseURL)
+  const failure = unresolvedProviderVariables(model, prepared)
+  if (failure) return Effect.fail(failure)
+  if (prepared === baseURL) return Effect.succeed(resolved)
+  return Effect.succeed(
+    LanguageModel.update(resolved, {
+      route: resolved.route.with({ endpoint: { baseURL: prepared } }),
+    }),
+  )
+}
+
+function prepareOpaqueAISDKModel(model: Info, runtime: Info): Effect.Effect<Info, UnresolvedProviderVariablesError> {
+  const baseURL = runtime.settings?.baseURL
+  if (typeof baseURL !== "string") return Effect.succeed(runtime)
+  const prepared = resolveProviderURL(baseURL)
+  const failure = unresolvedProviderVariables(model, prepared)
+  if (failure) return Effect.fail(failure)
+  return Effect.succeed(
+    produce(runtime, (draft) => {
+      if (draft.settings) draft.settings.baseURL = prepared
+    }),
+  )
+}
+
+const providerVariablePattern = /\$\{([^}]+)\}/g
+
+function resolveProviderURL(baseURL: string) {
+  return baseURL.replace(providerVariablePattern, (placeholder, name: string) => process.env[name] ?? placeholder)
+}
+
+function unresolvedProviderVariables(model: Info, baseURL: string) {
+  const variables = Array.from(baseURL.matchAll(providerVariablePattern), (match) => match[1]).filter(
+    (name, index, names) => names.indexOf(name) === index,
+  )
+  if (variables.length === 0) return
+  return new UnresolvedProviderVariablesError({ providerID: model.providerID, modelID: model.id, variables })
 }
 
 const nativeCredentialSettings = (specifier: string, credential: Credential.Value | undefined) => {

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -205,6 +205,8 @@ const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(funct
     : undefined
   const native = mapping?.package ?? resolved.package
   if (Provider.isAISDK(resolved.package) && !mapping) {
+    const loadAISDK = dependencies?.loadAISDK
+    if (!loadAISDK) return yield* unsupported(resolved)
     const settings = yield* prepareProviderSettings(
       resolved,
       Provider.mergeOverlay(resolved.settings, {
@@ -213,8 +215,6 @@ const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(funct
         ...configuration,
       }) ?? {},
     )
-    const loadAISDK = dependencies?.loadAISDK
-    if (!loadAISDK) return yield* unsupported(resolved)
     const runtime = produce(resolved, (draft) => {
       draft.settings = settings
     })
@@ -249,6 +249,7 @@ const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(funct
 })
 
 function prepareRuntimeModel(model: Info, credential: Credential.Value | undefined) {
+  if (model.settings?.apiKey !== "" && (credential?.type !== "key" || credential.metadata === undefined)) return model
   return produce(model, (draft) => {
     if (draft.settings?.apiKey === "") delete draft.settings.apiKey
     if (credential?.type === "key" && credential.metadata !== undefined)
@@ -262,15 +263,8 @@ function validateProviderVariables(
 ): Effect.Effect<LanguageModel, UnresolvedProviderVariablesError> {
   const baseURL = resolved.route.endpoint.baseURL
   if (typeof baseURL !== "string") return Effect.succeed(resolved)
-  return prepareProviderURL(model, baseURL).pipe(
-    Effect.map((prepared) =>
-      prepared === baseURL
-        ? resolved
-        : LanguageModel.update(resolved, {
-            route: resolved.route.with({ endpoint: { baseURL: prepared } }),
-          }),
-    ),
-  )
+  const failure = unresolvedProviderVariables(model, baseURL)
+  return failure ? Effect.fail(failure) : Effect.succeed(resolved)
 }
 
 function prepareProviderModel(model: Info): Effect.Effect<Info, UnresolvedProviderVariablesError> {
@@ -299,21 +293,19 @@ function prepareProviderSettings(
 
 function prepareProviderURL(model: Info, baseURL: string): Effect.Effect<string, UnresolvedProviderVariablesError> {
   if (!baseURL.includes("${")) return Effect.succeed(baseURL)
-  const variables = new Set<string>()
-  const prepared = baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => {
-    const value = process.env[name]
-    if (value !== undefined) return value
-    variables.add(name)
-    return placeholder
+  const prepared = baseURL.replace(/\$\{([^}]+)\}/g, (placeholder, name: string) => process.env[name] ?? placeholder)
+  const failure = unresolvedProviderVariables(model, prepared)
+  return failure ? Effect.fail(failure) : Effect.succeed(prepared)
+}
+
+function unresolvedProviderVariables(model: Info, baseURL: string) {
+  const variables = new Set(Array.from(baseURL.matchAll(/\$\{([^}]+)\}/g), (match) => match[1]))
+  if (variables.size === 0) return
+  return new UnresolvedProviderVariablesError({
+    providerID: model.providerID,
+    modelID: model.id,
+    variables: Array.from(variables),
   })
-  if (variables.size === 0) return Effect.succeed(prepared)
-  return Effect.fail(
-    new UnresolvedProviderVariablesError({
-      providerID: model.providerID,
-      modelID: model.id,
-      variables: Array.from(variables),
-    }),
-  )
 }
 
 const nativeCredentialSettings = (specifier: string, credential: Credential.Value | undefined) => {

--- a/packages/core/test/aisdk-native.test.ts
+++ b/packages/core/test/aisdk-native.test.ts
@@ -123,6 +123,16 @@ describe("AISDKNative", () => {
     expect(map("@ai-sdk/amazon-bedrock/mantle", settings, "openai.gpt-oss-safeguard-20b")?.package).toBe(
       "@opencode-ai/ai/providers/amazon-bedrock/mantle/chat",
     )
+    expect(
+      map(
+        "@ai-sdk/amazon-bedrock/mantle",
+        {
+          region: "us-west-2",
+          baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+        },
+        "openai.gpt-5.5",
+      ),
+    ).toMatchObject({ settings: { baseURL: "https://bedrock-mantle.us-west-2.api.aws/openai/v1" } })
   })
 
   test("maps static Bedrock Mantle credentials without leaking connection options", () => {
@@ -134,8 +144,9 @@ describe("AISDKNative", () => {
             accessKeyId: "key",
             secretAccessKey: "secret",
             sessionToken: "session",
+            region: "eu-west-1",
           },
-          region: "eu-west-1",
+          baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
           profile: "ignored",
           credentialProvider: "ignored",
           fetch: "ignored",
@@ -152,7 +163,7 @@ describe("AISDKNative", () => {
           sessionToken: "session",
           region: "eu-west-1",
         },
-        region: "eu-west-1",
+        baseURL: "https://bedrock-mantle.eu-west-1.api.aws/v1",
         providerOptions: { openai: { store: false } },
       },
     })

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -900,6 +900,25 @@ describe("ModelResolver", () => {
     ),
   )
 
+  it.effect("rejects placeholders introduced by environment expansion before loading providers", () =>
+    withEnv({ PROVIDER_HOST: "${MISSING_HOST}", MISSING_HOST: undefined }, () =>
+      Effect.gen(function* () {
+        const failure = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/mistral"), {
+            settings: { baseURL: "https://${PROVIDER_HOST}/v1" },
+          }),
+          undefined,
+          { loadAISDK: () => Effect.die("AI SDK loader should not be called") },
+        ).pipe(Effect.flip)
+
+        expect(failure).toMatchObject({
+          _tag: "SessionRunnerModel.UnresolvedProviderVariablesError",
+          variables: ["MISSING_HOST"],
+        })
+      }),
+    ),
+  )
+
   it.effect("rejects unresolved variables before loading native provider packages", () =>
     withEnv({ REQUIRED_HOST: undefined }, () =>
       Effect.gen(function* () {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -123,6 +123,24 @@ describe("ModelResolver", () => {
     }),
   )
 
+  it.effect("resolves environment templates before native providers inspect endpoints", () =>
+    withEnv({ AZURE_HOST: "resource.openai.azure.com" }, () =>
+      Effect.gen(function* () {
+        const resolved = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/azure"), {
+            providerID: Provider.ID.azure,
+            settings: { baseURL: "https://${AZURE_HOST}/openai" },
+          }),
+        )
+
+        expect(resolved.route.endpoint).toMatchObject({
+          baseURL: "https://resource.openai.azure.com/openai/v1",
+          query: { "api-version": "v1" },
+        })
+      }),
+    ),
+  )
+
   it.effect("maps Bedrock Mantle models to native Responses and safeguards to Chat", () =>
     Effect.gen(function* () {
       const credential = Credential.Key.make({ type: "key", key: "secret" })
@@ -872,6 +890,25 @@ describe("ModelResolver", () => {
           }),
           undefined,
           { loadAISDK: () => Effect.die("AI SDK loader should not be called") },
+        ).pipe(Effect.flip)
+
+        expect(failure).toMatchObject({
+          _tag: "SessionRunnerModel.UnresolvedProviderVariablesError",
+          variables: ["REQUIRED_HOST"],
+        })
+      }),
+    ),
+  )
+
+  it.effect("rejects unresolved variables before loading native provider packages", () =>
+    withEnv({ REQUIRED_HOST: undefined }, () =>
+      Effect.gen(function* () {
+        const failure = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/google"), {
+            settings: { baseURL: "https://${REQUIRED_HOST}/v1" },
+          }),
+          undefined,
+          { loadPackage: () => Effect.die("Native package loader should not be called") },
         ).pipe(Effect.flip)
 
         expect(failure).toMatchObject({

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -152,6 +152,46 @@ describe("ModelResolver", () => {
     }),
   )
 
+  it.effect("resolves Bedrock Mantle catalog endpoints from the configured region", () =>
+    withEnv({ AWS_REGION: undefined }, () =>
+      Effect.gen(function* () {
+        const catalog = model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
+          providerID: Provider.ID.amazonBedrock,
+          modelID: "openai.gpt-5.5",
+          settings: {
+            region: "us-west-2",
+            baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          },
+        })
+        const resolved = yield* ModelResolver.fromCatalogModel(catalog)
+
+        expect(resolved.route).toMatchObject({
+          id: "bedrock-mantle-responses",
+          endpoint: { baseURL: "https://bedrock-mantle.us-west-2.api.aws/openai/v1" },
+        })
+        expect(catalog.settings?.baseURL).toBe("https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1")
+      }),
+    ),
+  )
+
+  it.effect("prefers the configured Mantle region over the environment", () =>
+    withEnv({ AWS_REGION: "us-east-1" }, () =>
+      Effect.gen(function* () {
+        const resolved = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/amazon-bedrock/mantle"), {
+            modelID: "openai.gpt-5.5",
+            settings: {
+              region: "us-west-2",
+              baseURL: "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+            },
+          }),
+        )
+
+        expect(resolved.route.endpoint.baseURL).toBe("https://bedrock-mantle.us-west-2.api.aws/openai/v1")
+      }),
+    ),
+  )
+
   it.effect("uses the API modelID instead of the catalog ID for native OpenAI routes", () =>
     Effect.gen(function* () {
       const catalog = model(Provider.aisdk("@ai-sdk/openai"), {
@@ -265,7 +305,7 @@ describe("ModelResolver", () => {
     ),
   )
 
-  it.effect("rejects unresolved provider URL variables before route construction", () =>
+  it.effect("rejects unresolved variables in constructed provider routes", () =>
     withEnv({ REQUIRED_HOST: undefined }, () =>
       Effect.gen(function* () {
         const failure = yield* ModelResolver.fromCatalogModel(
@@ -821,6 +861,25 @@ describe("ModelResolver", () => {
 
       expect(resolved).toMatchObject({ id: "mistral-api-model", provider: "test-provider" })
     }),
+  )
+
+  it.effect("rejects unresolved variables before loading opaque AISDK packages", () =>
+    withEnv({ REQUIRED_HOST: undefined }, () =>
+      Effect.gen(function* () {
+        const failure = yield* ModelResolver.fromCatalogModel(
+          model(Provider.aisdk("@ai-sdk/mistral"), {
+            settings: { baseURL: "https://${REQUIRED_HOST}/v1" },
+          }),
+          undefined,
+          { loadAISDK: () => Effect.die("AI SDK loader should not be called") },
+        ).pipe(Effect.flip)
+
+        expect(failure).toMatchObject({
+          _tag: "SessionRunnerModel.UnresolvedProviderVariablesError",
+          variables: ["REQUIRED_HOST"],
+        })
+      }),
+    ),
   )
 
   it.effect("rejects AISDK packages without an available loader", () =>


### PR DESCRIPTION
## What

Resolve Bedrock Mantle catalog endpoints from the provider's configured region without teaching the generic model resolver about Bedrock.

This is the adapter-based alternative to #41786 and closes #40075.

## Before / After

**Before:** models.dev supplies Mantle endpoints such as `https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1`. With `settings.region: "us-west-2"` and no `AWS_REGION`, `ModelResolver` rejected the intermediate catalog settings before the native Mantle adapter or provider could interpret them.

The regression test failed before the fix with:

```text
Cannot initialize amazon-bedrock/test-model: AWS_REGION is required to resolve the provider endpoint
```

**After:** `AISDKNative` translates the known Mantle placeholder from the effective configured or credential region, preserving model-specific `/v1` and `/openai/v1` paths. Generic environment expansion and unresolved-variable validation then run on the effective mapped settings before provider loading. Explicit provider configuration therefore wins over the process environment while providers still construct routes from concrete URLs.

## How

- `packages/core/src/aisdk-native.ts` resolves only the Mantle `AWS_REGION` placeholder while translating the AI SDK catalog package into the native AI package.
- `packages/core/src/model-resolver.ts` maps provider-specific settings first, then performs one-pass generic environment expansion and validation before loading or constructing the provider.
- Constructed routes receive a final unresolved-variable invariant check for provider-generated endpoints.
- Opaque third-party AI SDK packages use the same preparation before their loader runs because their wrapper route does not expose the provider's effective endpoint.
- `packages/ai` is unchanged; the native Mantle provider continues receiving a concrete `baseURL` and region.

## Scope

- Generic `${ENV}` behavior remains unchanged for other providers.
- Unknown unresolved variables still fail with `UnresolvedProviderVariablesError`.
- This does not add a generalized provider preparation hook or address unrelated models.dev templates.

## Testing

- Before-fix reproduction: `cd packages/core && bun run test test/model-resolver.test.ts` failed with unresolved `AWS_REGION`.
- `cd packages/core && bun run test test/model-resolver.test.ts test/aisdk-native.test.ts` (47 pass)
- `cd packages/core && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3` (33 successful)

## Flow

```mermaid
flowchart LR
  A[Catalog model and config] --> B[AI SDK native adapter]
  B -->|Mantle template plus region| C[Effective provider settings]
  C --> D[Generic environment expansion]
  D --> E{Variables unresolved?}
  E -->|Yes| F[UnresolvedProviderVariablesError]
  E -->|No| G[Provider constructs route]
  G --> H[Final endpoint invariant]
  H --> I[LanguageModel]
```