### PR TITLE
fix: log plugin load failures to stderr

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -135,6 +135,7 @@ const layer = Layer.effect(
         const bridge = yield* EffectBridge.make()
 
         function publishPluginError(message: string) {
+          process.stderr.write(`[plugin] ${message}\n`)
           bridge.fork(events.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() }))
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #41817

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugin load errors are only published as a `Session.Event.Error` in `publishPluginError` (`packages/opencode/src/plugin/index.ts`). The desktop renderer does not consume that event, so a plugin that fails to load in the desktop app is invisible: the entry appears in the plugin list, nothing is logged, and no tools register. Example: plugins importing `bun:sqlite` on the Node plugin host (see #41817).

Change: `publishPluginError` also writes the message to stderr, which the desktop sidecar pipes into the server log, so failures are diagnosable.

The `bun:sqlite` shim itself is tracked separately in #41817.

### How did you verify your code works?

Could not run the desktop build locally (no Node/pnpm toolchain in the environment). The change is a one-line addition to the existing error path, using the Node `process.stderr` API; the existing event publish is untouched.

### Screenshots / recordings

N/A (no UI change).

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR