### PR TITLE
test(core): await shell tool registration

### DIFF
--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -27,6 +27,7 @@ import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { Permission } from "@opencode-ai/core/permission"
 import { PluginRuntime } from "@opencode-ai/core/plugin/runtime"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Shell } from "@opencode-ai/core/shell"
 import { Shell as ShellSchema } from "@opencode-ai/schema/shell"
 import { ShellTool } from "@opencode-ai/core/tool/plugin/shell"
@@ -35,7 +36,7 @@ import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
-import { toolIdentity, executeTool, toolDefinitions, waitForTool } from "./lib/tool"
+import { toolIdentity, executeTool, toolDefinitions } from "./lib/tool"
 
 const sessionID = Session.ID.make("ses_shell_tool_test")
 const sessionModel = Model.Ref.make({ id: Model.ID.make("test"), providerID: Provider.ID.make("test") })
@@ -195,8 +196,8 @@ const withSession = <A, E, R>(directory: string, body: (registry: Tool.Interface
     const locations = yield* LocationServiceMap.Service
     const locationLayer = locations.get(location)
     return yield* Effect.gen(function* () {
+      yield* (yield* PluginSupervisor.Service).flush
       const registry = yield* Tool.Service
-      yield* waitForTool(registry, ShellTool.name)
       return yield* body(registry)
     }).pipe(Effect.provide(locationLayer), Effect.ensuring(locations.invalidate(location)))
   })


### PR DESCRIPTION
## What

Make the live ShellTool tests wait for the Location plugin generation to finish through the existing PluginSupervisor readiness barrier.

## Before / After

**Before:** The tests polled the tool registry up to 1,000 times with one-millisecond sleeps. Under CI contention, Linux could exhaust that polling budget before shell registration, while Windows could spend the full five-second Bun test timeout in startup.

**After:** The tests await PluginSupervisor.flush, which completes when initial plugin activation and startup updates have settled, before reading the tool registry.

## How

- `packages/core/test/tool-shell.test.ts` obtains the Location-scoped PluginSupervisor and awaits `flush`.
- Removes the timing-budget-based `waitForTool` call from the shared shell test setup.

## Scope

Test synchronization only. This does not change ShellTool execution, plugin startup, or global test timeouts.

## Testing

- `bun run test test/tool-shell.test.ts`
- Historically failing scenarios repeated 20 times: 60/60 passed
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages