### PR TITLE
refactor(core): unify fff runtime adapters

### DIFF
--- a/packages/core/src/filesystem/fff.bun.ts
+++ b/packages/core/src/filesystem/fff.bun.ts
@@ -1,102 +1,15 @@
-import {
-  FileFinder,
-  type DirItem,
-  type DirSearchResult,
-  type FileItem,
-  type InitOptions,
-  type MixedItem,
-  type MixedSearchResult,
-  type SearchResult,
-} from "@ff-labs/fff-bun"
+import { FileFinder } from "@ff-labs/fff-bun"
+import { bind } from "./fff"
+
+export type { Directory, DirSearch, File, Init, Mixed, MixedSearch, Picker, Result, Search } from "./fff"
 
 declare global {
   const FFF_LIBC: "gnu" | "musl"
 }
 
-export type Result<T> = { ok: true; value: T } | { ok: false; error: string }
+const adapter = bind(FileFinder)
 
-export type Init = InitOptions
-
-export interface Search {
-  items: FileItem[]
-  scores: SearchResult["scores"]
-  totalMatched: number
-  totalFiles: number
-}
-
-export interface DirSearch {
-  items: DirItem[]
-  scores: DirSearchResult["scores"]
-  totalMatched: number
-  totalDirs: number
-}
-
-export interface MixedSearch {
-  items: MixedItem[]
-  scores: MixedSearchResult["scores"]
-  totalMatched: number
-  totalFiles: number
-  totalDirs: number
-}
-
-export type File = FileItem
-export type Directory = DirItem
-export type Mixed = MixedItem
-export interface Picker {
-  destroy(): void
-  isScanning(): boolean
-  waitForScan(timeoutMs?: number): Promise<Result<boolean>>
-  refreshGitStatus(): Result<number>
-  fileSearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<Search>
-  directorySearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<DirSearch>
-  mixedSearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<MixedSearch>
-  trackQuery(query: string, file: string): Result<boolean>
-  getHistoricalQuery(offset: number): Result<string | null>
-}
-
-export function available() {
-  return FileFinder.isAvailable()
-}
-
-export function create(opts: Init): Result<Picker> {
-  const made = FileFinder.create(opts)
-  if (!made.ok) return made
-  const pick = made.value
-  return {
-    ok: true,
-    value: {
-      destroy: () => pick.destroy(),
-      isScanning: () => pick.isScanning(),
-      waitForScan: (timeoutMs) => pick.waitForScan(timeoutMs),
-      refreshGitStatus: () => pick.refreshGitStatus(),
-      fileSearch: (query, next) => pick.fileSearch(query, next),
-      directorySearch: (query, next) => pick.directorySearch(query, next),
-      mixedSearch: (query, next) => pick.mixedSearch(query, next),
-      trackQuery: (query, file) => pick.trackQuery(query, file),
-      getHistoricalQuery: (offset) => pick.getHistoricalQuery(offset),
-    },
-  }
-}
+export const available = adapter.available
+export const create = adapter.create
 
 export * as Fff from "./fff.bun"

--- a/packages/core/src/filesystem/fff.node.ts
+++ b/packages/core/src/filesystem/fff.node.ts
@@ -1,100 +1,12 @@
-import type {
-  DirItem,
-  DirSearchResult,
-  FileItem,
-  InitOptions,
-  MixedItem,
-  MixedSearchResult,
-  SearchResult,
-} from "@ff-labs/fff-node"
+import { bind } from "./fff"
+
+export type { Directory, DirSearch, File, Init, Mixed, MixedSearch, Picker, Result, Search } from "./fff"
 
 const { FileFinder } = await import("@ff-labs/fff-node").catch(() => ({ FileFinder: undefined }))
 
-export type Result<T> = { ok: true; value: T } | { ok: false; error: string }
+const adapter = bind(FileFinder, "fff unavailable on node runtime")
 
-export type Init = InitOptions
-
-export interface Search {
-  items: FileItem[]
-  scores: SearchResult["scores"]
-  totalMatched: number
-  totalFiles: number
-}
-
-export interface DirSearch {
-  items: DirItem[]
-  scores: DirSearchResult["scores"]
-  totalMatched: number
-  totalDirs: number
-}
-
-export interface MixedSearch {
-  items: MixedItem[]
-  scores: MixedSearchResult["scores"]
-  totalMatched: number
-  totalFiles: number
-  totalDirs: number
-}
-
-export type File = FileItem
-export type Directory = DirItem
-export type Mixed = MixedItem
-export interface Picker {
-  destroy(): void
-  isScanning(): boolean
-  waitForScan(timeoutMs?: number): Promise<Result<boolean>>
-  refreshGitStatus(): Result<number>
-  fileSearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<Search>
-  directorySearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<DirSearch>
-  mixedSearch(
-    query: string,
-    opts?: {
-      currentFile?: string
-      pageIndex?: number
-      pageSize?: number
-    },
-  ): Result<MixedSearch>
-  trackQuery(query: string, file: string): Result<boolean>
-  getHistoricalQuery(offset: number): Result<string | null>
-}
-
-export function available() {
-  return FileFinder?.isAvailable() ?? false
-}
-
-export function create(opts: Init): Result<Picker> {
-  if (!FileFinder) return { ok: false, error: "fff unavailable on node runtime" }
-  const made = FileFinder.create(opts)
-  if (!made.ok) return made
-  const pick = made.value
-  return {
-    ok: true,
-    value: {
-      destroy: () => pick.destroy(),
-      isScanning: () => pick.isScanning(),
-      waitForScan: (timeoutMs) => pick.waitForScan(timeoutMs),
-      refreshGitStatus: () => pick.refreshGitStatus(),
-      fileSearch: (query, next) => pick.fileSearch(query, next),
-      directorySearch: (query, next) => pick.directorySearch(query, next),
-      mixedSearch: (query, next) => pick.mixedSearch(query, next),
-      trackQuery: (query, file) => pick.trackQuery(query, file),
-      getHistoricalQuery: (offset) => pick.getHistoricalQuery(offset),
-    },
-  }
-}
+export const available = adapter.available
+export const create = adapter.create
 
 export * as Fff from "./fff.node"

--- a/packages/core/src/filesystem/fff.ts
+++ b/packages/core/src/filesystem/fff.ts
@@ -1,0 +1,66 @@
+export type Result<T> = { ok: true; value: T } | { ok: false; error: string }
+
+export interface Init {
+  basePath: string
+  aiMode?: boolean
+  disableMmapCache?: boolean
+  disableContentIndexing?: boolean
+}
+
+export interface SearchOptions {
+  currentFile?: string
+  pageIndex?: number
+  pageSize?: number
+}
+
+export interface File {
+  relativePath: string
+}
+
+export interface Directory {
+  relativePath: string
+}
+
+export type Mixed = { type: "file"; item: File } | { type: "directory"; item: Directory }
+
+export interface Score {
+  total: number
+}
+
+export interface Search {
+  items: File[]
+  scores: Score[]
+}
+
+export interface DirSearch {
+  items: Directory[]
+  scores: Score[]
+}
+
+export interface MixedSearch {
+  items: Mixed[]
+  scores: Score[]
+}
+
+export interface Picker {
+  destroy(): void
+  fileSearch(query: string, options?: SearchOptions): Result<Search>
+  directorySearch(query: string, options?: SearchOptions): Result<DirSearch>
+  mixedSearch(query: string, options?: SearchOptions): Result<MixedSearch>
+}
+
+export interface Backend {
+  isAvailable(): boolean
+  create(options: Init): Result<Picker>
+}
+
+export function bind(backend: Backend | undefined, unavailable = "fff unavailable") {
+  return {
+    available: () => backend?.isAvailable() ?? false,
+    create: (options: Init): Result<Picker> =>
+      backend?.create(options) ?? {
+        ok: false,
+        error: unavailable,
+      },
+  }
+}


### PR DESCRIPTION
## What

Replace the duplicated Bun and Node FFF contracts and forwarding adapters with one Core-owned structural boundary. This removes 109 net lines while keeping runtime loading behavior separate.

## How

- Adds `packages/core/src/filesystem/fff.ts` with the initialization and search surface Core actually consumes.
- Binds the Bun backend directly to the shared contract.
- Preserves the Node optional dynamic import and its existing unavailable error.
- Removes forwarding wrappers and unused upstream API surface from both runtime adapters.

## Scope

This does not change filesystem search selection, scoring, FFF initialization options used by Core, or the ripgrep fallback. It does not add new FFF operations.

## Testing

- `bun run test test/filesystem/search.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages
- Prettier and `git diff --check`