### PR TITLE
docs: add Lumify MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,24 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Lumify
+
+Add the [Lumify](https://lumify.ai) MCP server for sports schedules, live scores, odds, betting splits, and AI bet confidence.
+
+```json title="opencode.json" {4-11}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "lumify": {
+      "type": "remote",
+      "url": "https://lumify.ai/mcp",
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer {env:LUMIFY_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #41822

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a Lumify example under the MCP docs Examples section, next to Sentry/Context7/Grep. Same remote + API-key pattern as Context7, with `oauth: false` since Lumify doesn’t use OAuth.

### How did you verify your code works?

Matched the existing example MDX patterns in `mcp-servers.mdx`. Config shape matches OpenCode’s documented remote + `oauth: false` + headers pattern. Live server: https://lumify.ai/mcp

### Screenshots / recordings

_N/A — docs only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR