### PR TITLE
test(core): speed up shell tool suite

### DIFF
--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -2,18 +2,21 @@ import fs from "fs/promises"
 import { realpathSync } from "node:fs"
 import os from "os"
 import path from "path"
-import { describe, expect, setDefaultTimeout } from "bun:test"
-import { DateTime, Deferred, Duration, Effect, Fiber, Layer, Scope, Stream } from "effect"
+import { describe, expect } from "bun:test"
+import { Deferred, Duration, Effect, Fiber, Layer, Scope, Stream } from "effect"
 import { Money } from "@opencode-ai/schema/money"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { makeGlobalNode, makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { filesystem } from "@opencode-ai/util/effect/app-node-platform"
 import { Database } from "@opencode-ai/core/database/database"
 import { Bus } from "@opencode-ai/core/bus"
+import { Config } from "@opencode-ai/core/config"
+import { Environment } from "@opencode-ai/core/environment"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { Location } from "@opencode-ai/core/location"
+import { LocationMutation } from "@opencode-ai/core/location-mutation"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
@@ -36,7 +39,7 @@ import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
-import { toolIdentity, executeTool, toolDefinitions } from "./lib/tool"
+import { toolIdentity, executeTool, registerToolPlugin, toolDefinitions } from "./lib/tool"
 
 const sessionID = Session.ID.make("ses_shell_tool_test")
 const sessionModel = Model.Ref.make({ id: Model.ID.make("test"), providerID: Provider.ID.make("test") })
@@ -124,30 +127,42 @@ const executionNode = makeGlobalNode({
   deps: [Bus.node, SessionStore.node],
 })
 
-const layer = AppNodeBuilder.build(
-  LayerNode.group([
-    Database.node,
-    Bus.node,
-    Job.node,
-    Session.node,
-    SessionExecution.node,
-    PluginRuntime.providerNode,
-    LocationServiceMap.node,
-    filesystem,
-    FSUtil.node,
-    Global.node,
-  ]),
-  [
-    [SessionExecution.node, executionNode],
-    [Permission.node, permission],
-    [Global.node, tempGlobalLayer],
+const shellPluginSupervisor = makeLocationNode({
+  service: PluginSupervisor.Service,
+  layer: Layer.effect(
+    PluginSupervisor.Service,
+    registerToolPlugin(ShellTool.Plugin).pipe(Effect.as(PluginSupervisor.Service.of({ flush: Effect.void }))),
+  ),
+  deps: [
+    Config.node,
+    Environment.node,
+    LocationMutation.node,
+    Permission.node,
+    PluginRuntime.node,
+    Shell.node,
+    Tool.node,
   ],
-)
+})
 
-const it = testEffect(layer)
-
-// Each test boots a complete Location and plugin runtime before exercising a real shell.
-setDefaultTimeout(15_000)
+const nodes = LayerNode.group([
+  Database.node,
+  Bus.node,
+  Job.node,
+  Session.node,
+  SessionExecution.node,
+  PluginRuntime.providerNode,
+  LocationServiceMap.node,
+  filesystem,
+  FSUtil.node,
+  Global.node,
+])
+const replacements = [
+  [SessionExecution.node, executionNode],
+  [Permission.node, permission],
+  [Global.node, tempGlobalLayer],
+] satisfies LayerNode.Replacements
+const productionIt = testEffect(AppNodeBuilder.build(nodes, replacements))
+const it = testEffect(AppNodeBuilder.build(nodes, [...replacements, [PluginSupervisor.node, shellPluginSupervisor]]))
 
 const call = (input: typeof ShellTool.Input.Type, id = "call-shell") => ({
   sessionID,
@@ -168,9 +183,6 @@ const idleCommand = isWindows ? "Start-Sleep -Seconds 60" : "sleep 60"
 const timeoutOutputCommand = isWindows
   ? "[Console]::Out.Write('before timeout'); Start-Sleep -Seconds 60"
   : "printf 'before timeout'; sleep 60"
-const steadyProgressCommand = isWindows
-  ? "[Console]::Out.Write('steady'); Start-Sleep -Milliseconds 3400"
-  : "printf steady; sleep 3.4"
 const bodyExitCommand = isWindows
   ? "[Console]::Out.Write('body'); Start-Sleep -Milliseconds 100; exit 7"
   : "printf body && exit 7"
@@ -206,42 +218,49 @@ const withSession = <A, E, R>(directory: string, body: (registry: Tool.Interface
   })
 
 describe("ShellTool", () => {
-  it.live("registers and returns real successful output from the active Location", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        return withSession(tmp.path, (registry) =>
-          Effect.gen(function* () {
-            const definitions = yield* toolDefinitions(registry)
-            const definition = definitions.find((tool) => tool.name === "shell")
-            expect(definition?.description).toStartWith("Execute a shell command and return its output.")
-            expect(definition?.inputSchema).not.toHaveProperty("properties.timeout.maximum")
-            // Code Mode receives the declared output schema, including the command output text.
-            expect(definition?.outputSchema).toHaveProperty("properties.output")
-            expect(
-              (yield* toolDefinitions(registry, [{ action: "shell", resource: "*", effect: "deny" }])).map(
-                (tool) => tool.name,
-              ),
-            ).not.toContain("shell")
+  productionIt.live(
+    "registers and returns real successful output from the active Location",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withSession(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const definitions = yield* toolDefinitions(registry)
+              const definition = definitions.find((tool) => tool.name === "shell")
+              expect(definition?.description).toStartWith("Execute a shell command and return its output.")
+              expect(definition?.inputSchema).not.toHaveProperty("properties.timeout.maximum")
+              // Code Mode receives the declared output schema, including the command output text.
+              expect(definition?.outputSchema).toHaveProperty("properties.output")
+              expect(
+                (yield* toolDefinitions(registry, [{ action: "shell", resource: "*", effect: "deny" }])).map(
+                  (tool) => tool.name,
+                ),
+              ).not.toContain("shell")
 
-            const settled = yield* executeTool(registry, call({ command: helloCommand }))
-            expect(settled.status).toBe("completed")
-            expect(settled.metadata).toMatchObject({ exit: 0, truncated: false })
-            expect(settled.content?.[0]).toEqual({ type: "text", text: "hello" })
-            expect(settled.content?.[1]).toMatchObject({
-              type: "text",
-              text: expect.stringContaining("Command exited with code 0."),
-            })
-            expect(assertions).toMatchObject([
-              { sessionID, action: "shell", resources: [isWindows ? "Start-Sleep -Milliseconds 100" : helloCommand] },
-            ])
-            expect(assertions[0]?.save).toEqual([isWindows ? "Start-Sleep *" : "printf *"])
-          }),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
-    ),
+              const settled = yield* executeTool(registry, call({ command: helloCommand }))
+              expect(settled.status).toBe("completed")
+              expect(settled.metadata).toMatchObject({ exit: 0, truncated: false })
+              expect(settled.content?.[0]).toEqual({ type: "text", text: "hello" })
+              expect(settled.content?.[1]).toMatchObject({
+                type: "text",
+                text: expect.stringContaining("Command exited with code 0."),
+              })
+              expect(assertions).toMatchObject([
+                {
+                  sessionID,
+                  action: "shell",
+                  resources: [isWindows ? "Start-Sleep -Milliseconds 100" : helloCommand],
+                },
+              ])
+              expect(assertions[0]?.save).toEqual([isWindows ? "Start-Sleep *" : "printf *"])
+            }),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 15_000 },
   )
 
   it.live("resolves a relative workdir from the active Location", () =>
@@ -580,7 +599,7 @@ describe("ShellTool", () => {
   )
 
   it.live(
-    "does not repeat shell ID progress",
+    "reports shell ID progress once",
     () =>
       Effect.acquireUseRelease(
         Effect.promise(() => tmpdir()),
@@ -590,7 +609,7 @@ describe("ShellTool", () => {
             Effect.gen(function* () {
               const updates: Tool.Metadata[] = []
               yield* executeTool(registry, {
-                ...call({ command: steadyProgressCommand }, "call-steady-progress"),
+                ...call({ command: helloCommand }, "call-shell-id-progress"),
                 progress: (update) => Effect.sync(() => updates.push(update)),
               })
               expect(updates).toHaveLength(1)

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises"
 import { realpathSync } from "node:fs"
 import os from "os"
 import path from "path"
-import { describe, expect } from "bun:test"
+import { describe, expect, setDefaultTimeout } from "bun:test"
 import { DateTime, Deferred, Duration, Effect, Fiber, Layer, Scope, Stream } from "effect"
 import { Money } from "@opencode-ai/schema/money"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -145,6 +145,9 @@ const layer = AppNodeBuilder.build(
 )
 
 const it = testEffect(layer)
+
+// Each test boots a complete Location and plugin runtime before exercising a real shell.
+setDefaultTimeout(15_000)
 
 const call = (input: typeof ShellTool.Input.Type, id = "call-shell") => ({
   sessionID,


### PR DESCRIPTION
## What

Cuts the live `ShellTool` suite's median runtime from 9.33 seconds to 1.36 seconds, about 85%, while retaining real shell execution and one full production plugin-discovery integration case.

## Before / After

**Before:** All 19 behavioral cases cold-booted the complete Location plugin graph. Each boot waited for the real supervisor debounce and activated every unrelated built-in plugin. One progress test also kept its process alive for 3.4 seconds to cross an output-polling cadence that no longer exists.

**After:** One case still exercises the complete production discovery path. The remaining cases register the real `ShellTool.Plugin` directly into the real Tool registry, following the focused harness used by other built-in tool suites. The shell-ID progress case uses an immediate real command because production now emits that update exactly once after shell creation.

## How

- Adds a focused Location-scoped `PluginSupervisor` test node that registers only `ShellTool.Plugin` and exposes an already-settled `flush`.
- Keeps the registration/schema/filtering integration case on the production `PluginSupervisor` graph with its existing realistic 15-second Windows allowance.
- Runs all behavioral cases against real Tool, Shell, Permission, Job, Session, and PluginRuntime services.
- Removes the stale 3.4-second progress fixture and renames the assertion to describe the current contract.
- Removes an unused `DateTime` import.

## Scope

This changes test construction only. It does not change shell behavior, production plugin startup, shared test helpers, or assertions. Broader Core test-harness optimization should be benchmarked suite by suite because sharing mutable runtimes can weaken isolation.

## Testing

- Baseline benchmark: 1 warmup + 7 measured runs, median 9.33s, range 8.96-9.63s
- Immediate-command experiment: median 5.96s, range 5.46-6.69s
- Focused-registration result: median 1.36s, range 1.30-1.43s
- `bun run test test/tool-shell.test.ts --rerun-each 4` from `packages/core`: 76 passed
- Benchmark run: 152 passed across 8 suite runs
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages
- `bun run lint packages/core/test/tool-shell.test.ts`
- Prettier and `git diff --check`
