### PR TITLE
fix(core): default #sqlite resolution to the node driver

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
       "workerd": "./src/database/sqlite.workerd.ts",
       "bun": "./src/database/sqlite.bun.ts",
       "node": "./src/database/sqlite.node.ts",
-      "default": "./src/database/sqlite.bun.ts"
+      "default": "./src/database/sqlite.node.ts"
     },
     "#pty": {
       "bun": "./src/pty/pty.bun.ts",

--- a/packages/core/test/sqlite-bundle.test.ts
+++ b/packages/core/test/sqlite-bundle.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import type { BunPlugin } from "bun"
+import { join } from "path"
+
+// Pins the #sqlite subpath-import condition gate: bundling database.ts for a
+// non-Bun runtime must never reach the static `import "bun:sqlite"` in
+// sqlite.bun.ts, which crashes workerd (and any other non-Bun bundle) at
+// module load. Bare imports are externalized so only core-relative modules —
+// including the #sqlite resolution under test — end up in the bundle.
+const externalizeBare: BunPlugin = {
+  name: "externalize-bare",
+  setup(build) {
+    build.onResolve({ filter: /^[^.#/]/ }, (args) => ({ path: args.path, external: true }))
+  },
+}
+
+const bundle = async (conditions: Array<string>) => {
+  const result = await Bun.build({
+    // join over URL.pathname: on Windows the latter yields "/C:/..." which
+    // module resolution rejects.
+    entrypoints: [join(import.meta.dir, "../src/database/database.ts")],
+    target: "browser",
+    conditions,
+    plugins: [externalizeBare],
+    throw: false,
+  })
+  expect(result.logs).toEqual([])
+  expect(result.success).toBe(true)
+  return result.outputs[0].text()
+}
+
+// Skipped on Windows: Bun.build inside `bun test` reliably panics Bun 1.3.14
+// there ("Internal assertion failure", twice in a row on CI, always at this
+// file). The assertions pin platform-independent package.json condition
+// resolution, so Linux coverage loses nothing.
+describe.skipIf(process.platform === "win32")("sqlite bundle conditions", () => {
+  test("workerd conditions select the Durable Object driver and never bun:sqlite", async () => {
+    const output = await bundle(["workerd"])
+    expect(output).not.toContain("bun:sqlite")
+    expect(output).not.toContain("node:sqlite")
+    expect(output).toContain("SqliteWorkerd")
+  })
+
+  test("default conditions fall back to node:sqlite, not bun:sqlite", async () => {
+    const output = await bundle([])
+    expect(output).not.toContain("bun:sqlite")
+    expect(output).toContain("SqliteNode")
+  })
+})


### PR DESCRIPTION
## What

Repoints the `default` condition of the `#sqlite` subpath import from `sqlite.bun.ts` to `sqlite.node.ts`, and adds a bundling smoke test that pins `bun:sqlite` out of non-Bun bundles of `database.ts`.

## Why

`sqlite.bun.ts` has a static `import { Database } from "bun:sqlite"`. Any non-Bun bundle that resolves `#sqlite` to it crashes at module load on the unresolvable `bun:sqlite` specifier — downstream workerd embedders currently carry wrangler alias/stubs to work around this.

#41659 added the `workerd` condition (so wrangler's `["workerd", "worker", "browser"]` set resolves to `sqlite.workerd.ts`), but `default` still pointed at the bun variant: any bundler without the `bun`, `node`, or `workerd` condition (browser-target esbuild/Bun.build, or a workerd toolchain that drops the condition) selected `sqlite.bun.ts` and shipped the crash. Reproduced at v2 head: a browser-conditions `Bun.build` of `database.ts` bundles `SqliteBun` and the `bun:sqlite` specifier.

## How

- `packages/core/package.json`: `#sqlite` now maps `workerd` → workerd driver, `bun` → `bun:sqlite` driver, `node`/`default` → the `node:sqlite` driver. Bun and Node runtimes match their own conditions first, so their resolution is unchanged; only the fallback moves off the Bun-only module.
- `packages/core/test/sqlite-bundle.test.ts`: builds `database.ts` with `Bun.build`, externalizing bare imports so only core-relative modules (including the `#sqlite` resolution) are bundled, and asserts:
  - `conditions: ["workerd"]` selects the Durable Object driver with no `bun:sqlite` or `node:sqlite` in the output
  - default (browser) conditions fall back to `SqliteNode`, never `bun:sqlite`

The dynamic `import("bun:sqlite")` in `v1-migration.ts` is lazy and unaffected; it does not appear in either bundle.

## Scope

`packages/core` only: one condition-map line plus a new test file.

## Testing

- `packages/core`: `bun run typecheck` clean; `bun test` green (1666 pass, 0 fail) including the new bundle test
- Repo root: `bun run typecheck` clean (33/33 tasks)
- `bunx oxlint` on touched files: 0 errors, 0 warnings