### PR TITLE
test(core): speed up subagent tool suite

### DIFF
--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect } from "bun:test"
-import { DateTime, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Effect, Fiber, Layer, Schema, Stream } from "effect"
 import path from "path"
 import { Money } from "@opencode-ai/schema/money"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Global } from "@opencode-ai/util/global"
-import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { makeGlobalNode, makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Database } from "@opencode-ai/core/database/database"
 import { Bus } from "@opencode-ai/core/bus"
+import { Config } from "@opencode-ai/core/config"
 import { Location } from "@opencode-ai/core/location"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
@@ -24,12 +25,13 @@ import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { PluginRuntime } from "@opencode-ai/core/plugin/runtime"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
+import { Permission } from "@opencode-ai/core/permission"
 import { SubagentTool } from "@opencode-ai/core/tool/plugin/subagent"
 import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
-import { executeTool, toolIdentity, waitForTool } from "./lib/tool"
+import { executeTool, registerToolPlugin, toolIdentity } from "./lib/tool"
 
 const childText = "child final response"
 const childModel = Model.Ref.make({ id: Model.ID.make("child"), providerID: Provider.ID.make("test") })
@@ -92,23 +94,30 @@ const executionNode = makeGlobalNode({
   deps: [Bus.node, SessionStore.node],
 })
 
-const layer = AppNodeBuilder.build(
-  LayerNode.group([
-    Database.node,
-    Bus.node,
-    Job.node,
-    Session.node,
-    SessionExecution.node,
-    PluginRuntime.providerNode,
-    LocationServiceMap.node,
-  ]),
-  [
-    [SessionExecution.node, executionNode],
-    [Global.node, tempGlobalLayer],
-  ],
-)
+const subagentPluginSupervisor = makeLocationNode({
+  service: PluginSupervisor.Service,
+  layer: Layer.effect(
+    PluginSupervisor.Service,
+    registerToolPlugin(SubagentTool.Plugin).pipe(Effect.as(PluginSupervisor.Service.of({ flush: Effect.void }))),
+  ),
+  deps: [Agent.node, Config.node, Permission.node, PluginRuntime.node, Tool.node],
+})
 
-const it = testEffect(layer)
+const nodes = LayerNode.group([
+  Database.node,
+  Bus.node,
+  Job.node,
+  Session.node,
+  SessionExecution.node,
+  PluginRuntime.providerNode,
+  LocationServiceMap.node,
+])
+const replacements = [
+  [SessionExecution.node, executionNode],
+  [Global.node, tempGlobalLayer],
+] satisfies LayerNode.Replacements
+const productionIt = testEffect(AppNodeBuilder.build(nodes, replacements))
+const it = testEffect(AppNodeBuilder.build(nodes, [...replacements, [PluginSupervisor.node, subagentPluginSupervisor]]))
 
 const withSubagent = (location: Location.Ref) =>
   Effect.gen(function* () {
@@ -136,7 +145,7 @@ const withSubagent = (location: Location.Ref) =>
   })
 
 describe("SubagentTool", () => {
-  it.live("registers globally while resolving agents from the caller location", () =>
+  productionIt.live("registers globally while resolving agents from the caller location", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
@@ -150,7 +159,6 @@ describe("SubagentTool", () => {
 
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
           expect((yield* registry.snapshot()).definitions.map((tool) => tool.name)).toContain(SubagentTool.name)
           expect(
             yield* executeTool(registry, {
@@ -186,7 +194,6 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
 
           expect(
             yield* executeTool(registry, {
@@ -229,7 +236,6 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
 
           const settled = yield* executeTool(registry, {
             sessionID: parent.id,
@@ -270,7 +276,6 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
           const progress: Tool.Metadata[] = []
 
           const settled = yield* executeTool(registry, {
@@ -333,7 +338,6 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
 
           expect(
             yield* executeTool(registry, {
@@ -371,7 +375,6 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          yield* waitForTool(registry, SubagentTool.name)
           const bus = yield* Bus.Service
           const admitted = yield* bus.subscribe(SessionEvent.InputAdmitted).pipe(
             Stream.filter((event) => event.data.sessionID === parent.id && event.data.input.type === "synthetic"),


### PR DESCRIPTION
## What

Cuts the `SubagentTool` suite's measured median runtime from 2.11 seconds to 0.61 seconds, about 71%, while preserving real Session, Job, Agent, Config, Permission, Tool, and PluginRuntime behavior.

## Before / After

**Before:** All six cases cold-booted the complete production Location plugin graph, waited for supervisor discovery, and then polled for the Subagent tool even though `PluginSupervisor.flush` already guarantees settled registration.

**After:** One case retains the complete production discovery path. The five behavioral cases register the real `SubagentTool.Plugin` directly into the real Tool registry through a focused Location-scoped supervisor. Registration is complete when the focused layer is acquired, so redundant `waitForTool` polling is removed.

## How

- Adds a focused `PluginSupervisor` test node with the exact services acquired by `SubagentTool.Plugin`.
- Keeps the global registration/caller-location case on the production plugin graph.
- Runs depth policy, configured depth, foreground execution, failure, and background notification cases through focused real registration.
- Removes an unused `DateTime` import.

## Scope

This changes test construction only. It does not change subagent behavior, production plugin startup, shared test helpers, or assertions. The focused host intentionally stubs the session context hook; the production case retains full PluginHost wiring.

## Testing

- Baseline: 1 warmup + 7 measured runs, median 2.11s; noisy range 1.87-5.72s
- Focused result: 1 warmup + 7 measured runs, median 0.61s, range 0.50-0.75s
- Benchmark: 48 passed across 8 suite runs
- `bun run test test/tool-subagent.test.ts --rerun-each 4`: 24 passed
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages
- Oxlint, Prettier, and `git diff --check`
