### PR TITLE
test(core): narrow effect flock harness

### DIFF
--- a/packages/core/test/fixture/effect-flock-worker.ts
+++ b/packages/core/test/fixture/effect-flock-worker.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import os from "os"
 import { Effect } from "effect"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { EffectFlock } from "@opencode-ai/util/effect-flock"
 import { Global } from "@opencode-ai/util/global"
 
@@ -30,7 +30,7 @@ const testGlobal = Global.layerWith({
   log: os.tmpdir(),
 })
 
-const testLayer = AppNodeBuilder.build(EffectFlock.node, [[Global.node, testGlobal]])
+const testLayer = LayerNode.compile(EffectFlock.node, [[Global.node, testGlobal]])
 
 async function job() {
   if (msg.ready) await fs.writeFile(msg.ready, String(process.pid))

--- a/packages/core/test/util/effect-flock.test.ts
+++ b/packages/core/test/util/effect-flock.test.ts
@@ -5,7 +5,6 @@ import path from "path"
 import os from "os"
 import { Cause, Effect, Exit } from "effect"
 import { testEffect } from "../lib/effect"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { EffectFlock } from "@opencode-ai/util/effect-flock"
 import { Global } from "@opencode-ai/util/global"
@@ -110,7 +109,7 @@ const testGlobal = Global.layerWith({
   log: os.tmpdir(),
 })
 
-const testLayer = AppNodeBuilder.build(EffectFlock.node, [[Global.node, testGlobal]])
+const testLayer = LayerNode.compile(EffectFlock.node, [[Global.node, testGlobal]])
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
## What

Cuts the EffectFlock suite's measured median runtime from 6.45 seconds to 3.64 seconds, about 44%, by avoiding an unrelated Core Location import graph in every lock worker.

## Before / After

**Before:** The EffectFlock test and worker used `AppNodeBuilder`, whose eager import of Core Location services loaded the complete application graph into the parent process and each of 16 contention workers. EffectFlock itself only depends on `Global` and `FSUtil`.

**After:** Both boundaries compile `EffectFlock.node` directly with `LayerNode.compile`. Dependency provisioning remains explicit and identical, without importing Location services.

## How

- Replaces `AppNodeBuilder.build` with `LayerNode.compile` in `effect-flock.test.ts`.
- Applies the same focused construction in `effect-flock-worker.ts`, where repeated process startup makes the import graph especially expensive.
- Leaves worker count, lock timings, production code, and assertions unchanged.

## Scope

This is a test-harness import-boundary change only. It does not reduce contention coverage or alter EffectFlock behavior. Reducing the 16-worker stress count is a separate coverage tradeoff and is intentionally excluded.

## Testing

- Audit baseline: median 6.45s, range 5.82-8.58s
- Focused result: 1 warmup + 7 measured runs, median 3.64s, range 3.44-5.41s
- Benchmark: 96 passed across 8 suite runs
- Focused suite: 12 passed
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages
- Oxlint, Prettier, and `git diff --check`
