### PR TITLE
fix(tui): only apply vcs branch and session events for the local directory

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -283,6 +283,11 @@ export const {
           break
         }
         case "session.updated": {
+          // The TUI subscribes to the control-plane global event stream, so
+          // events from every attached workspace arrive here. Only sessions
+          // that belong to this TUI's directory may enter the local session
+          // list; everything else is foreign state from another workspace.
+          if (event.properties.info.directory !== project.instance.directory()) break
           const result = search(store.session, event.properties.info.id, (s) => s.id)
           if (result.found) {
             setStore("session", result.index, reconcile(event.properties.info))
@@ -437,7 +442,11 @@ export const {
         }
 
         case "vcs.branch.updated": {
-          if (workspace === project.workspace.current()) {
+          // Global event stream: the branch belongs to whichever directory
+          // published it. Only apply it when it matches this TUI's own
+          // instance directory, otherwise every attached TUI would display
+          // the most recently switched branch of any workspace.
+          if (directory === project.instance.directory() && workspace === project.workspace.current()) {
             setStore("vcs", { branch: event.properties.branch })
           }
           break

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -1,18 +1,40 @@
 /** @jsxImportSource @opentui/solid */
 import { describe, expect, test } from "bun:test"
 import { tmpdir } from "../../../fixture/fixture"
-import { mount, wait } from "./sync-fixture"
-import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+import { directory, mount, wait } from "./sync-fixture"
+import type { GlobalEvent, Session } from "@opencode-ai/sdk/v2"
 
-function branchEvent(branch: string, workspace?: string): GlobalEvent {
+function branchEvent(branch: string, opts?: { workspace?: string; directory?: string }): GlobalEvent {
   return {
-    directory: "/tmp/other",
+    directory: opts?.directory ?? "/tmp/other",
     project: "proj_test",
-    workspace,
+    workspace: opts?.workspace,
     payload: {
       id: `evt_vcs_${branch}`,
       type: "vcs.branch.updated",
       properties: { branch },
+    },
+  }
+}
+
+function sessionEvent(id: string, sessionDirectory: string): GlobalEvent {
+  const info = {
+    id,
+    slug: "test-session",
+    directory: sessionDirectory,
+    path: "",
+    title: `session ${id}`,
+    projectID: "proj_test",
+    time: { created: 1, updated: 1 },
+  } satisfies Partial<Session> as Session
+  return {
+    directory: sessionDirectory,
+    project: "proj_test",
+    workspace: undefined,
+    payload: {
+      id: `evt_ses_${id}`,
+      type: "session.updated",
+      properties: { sessionID: id, info },
     },
   }
 }
@@ -40,7 +62,7 @@ describe("tui sync", () => {
     }
   })
 
-  test("vcs branch updates only apply for the active workspace", async () => {
+  test("vcs branch updates only apply for the active workspace and directory", async () => {
     await using tmp = await tmpdir()
     await Bun.write(`${tmp.path}/kv.json`, "{}")
     const { app, emit, project, sync } = await mount(undefined, tmp.path)
@@ -49,15 +71,41 @@ describe("tui sync", () => {
       expect(sync.data.vcs?.branch).toBe("main")
 
       project.workspace.set("ws_a")
-      emit(branchEvent("other", "ws_b"))
-      await Bun.sleep(30)
 
+      // foreign directory + foreign workspace -> dropped
+      emit(branchEvent("other", { workspace: "ws_b" }))
+      await Bun.sleep(30)
       expect(sync.data.vcs?.branch).toBe("main")
 
-      emit(branchEvent("feature", "ws_a"))
+      // foreign directory + active workspace -> dropped (the branch belongs
+      // to another workspace's repository)
+      emit(branchEvent("other-dir", { workspace: "ws_a" }))
+      await Bun.sleep(30)
+      expect(sync.data.vcs?.branch).toBe("main")
+
+      // own directory + active workspace -> applied
+      emit(branchEvent("feature", { workspace: "ws_a", directory }))
       await wait(() => sync.data.vcs?.branch === "feature")
 
       expect(sync.data.vcs?.branch).toBe("feature")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("session updates from other directories do not enter the local session list", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(sessionEvent("ses_foreign", "/tmp/other"))
+      await Bun.sleep(30)
+      expect(sync.session.get("ses_foreign")).toBeUndefined()
+
+      emit(sessionEvent("ses_own", directory))
+      await wait(() => sync.session.get("ses_own") !== undefined)
+      expect(sync.session.get("ses_own")?.directory).toBe(directory)
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
### Issue for this PR

Closes #39181

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI subscribes to the control-plane global event stream (`/global/event`), which broadcasts events from every workspace attached to a shared `opencode serve`. Two handlers in `packages/tui/src/context/sync.tsx` did not use the event envelope's `directory` field:

- `vcs.branch.updated` only checked `workspace === project.workspace.current()`. With experimental workspaces disabled both sides are `undefined`, so the guard always matched and the branch of *any* attached workspace's repository overwrote the statusline branch of *every* attached TUI. The branch does not even need to be switched inside a TUI — switching it externally (GitHub Desktop, shell) produces the same cross-workspace display contamination, since the fs watcher publishes through the same global stream (repro added in #41839).
- `session.updated` upserted every received session into the local session list, so sessions belonging to other directories entered the store and could be picked/continued, routing subsequent requests by that session's directory.

Both handlers now guard on the event's directory against the TUI's own instance directory (`project.instance.directory()`), which the event envelope already carries for exactly this purpose. The `packages/app` event consumer (`server-sync.tsx`) already routes events to per-directory stores by envelope directory, so no change is needed there.

#39181 additionally documents a related fan-out for plugin-driven events (`tui.session.select`, `tui.toast.show`, `tui.command.execute`, `tui.prompt.append`); that is not addressed here and remains tracked there.

### How did you verify your code works?

- Updated the existing `vcs.branch.updated` test to cover the foreign-directory case (foreign directory + active workspace is now rejected; own directory + active workspace is applied).
- Added a test asserting that `session.updated` events from other directories do not enter the local session list, while events for the local directory do.
- `bun test test/cli/cmd/tui/` — 24 pass, 0 fail; `tsgo --noEmit` clean for `packages/tui`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
