### PR TITLE
docs: clarify skill source precedence

### DIFF
--- a/packages/www/content/docs/(Configure)/skills.mdx
+++ b/packages/www/content/docs/(Configure)/skills.mdx
@@ -161,8 +161,8 @@ Skills are keyed by ID. If several sources define the same ID, the later source
 wins. Sources are registered in this order, from lower to higher precedence:
 
 1. Built-in skills
-2. `.claude/skills` sources, global first and then from the current directory upward
-3. `.agents/skills` sources, global first and then from the current directory upward
+2. `.claude/skills` sources, global first and then from the farthest ancestor toward the current directory
+3. `.agents/skills` sources, global first and then from the farthest ancestor toward the current directory
 4. `~/.config/opencode/skills`
 5. Project `.opencode/skills`, from the project root toward the current directory
 6. Explicit `skills` config entries, in config priority and array order


### PR DESCRIPTION
## What

Align the skills precedence documentation with the nearest-source behavior merged in #41788. Ancestor `.claude/skills` and `.agents/skills` sources are registered from the farthest ancestor toward the current directory, allowing the nearest duplicate ID to win.

## How

- Correct the two ancestor-order descriptions in `packages/www/content/docs/(Configure)/skills.mdx`.

## Scope

Documentation only. The runtime behavior and regression coverage landed in #41788.

## Testing

- `bun typecheck` from `packages/www` (passed)
- `bun validate` from `packages/www` (passed with the existing duplicate-navigation warning)
- `bunx prettier --check 'content/docs/(Configure)/skills.mdx'` from `packages/www` (passed)\n- `bun run build` from `packages/www` (blocked by the existing Astro/CommonJS `cookie` named-export incompatibility after successful content generation and bundling)