### PR TITLE
test(core): narrow plugin test layer

### DIFF
--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -4,7 +4,6 @@ import { Catalog } from "@opencode-ai/core/catalog"
 import { Command } from "@opencode-ai/core/command"
 import { Config } from "@opencode-ai/core/config"
 import { Credential } from "@opencode-ai/core/credential"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNodePlatform } from "@opencode-ai/util/effect/app-node-platform"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
@@ -35,7 +34,7 @@ const npmLayer = Layer.succeed(
   }),
 )
 
-export const PluginTestLayer = AppNodeBuilder.build(
+export const PluginTestLayer = LayerNode.compile(
   LayerNode.group([
     FileSystem.node,
     FSUtil.node,


### PR DESCRIPTION
## What

Avoid loading the full location-service graph in the shared Core plugin test fixture when its node graph has no `LocationServiceMap` dependency.

Across the 29 files using `PluginTestLayer`, eight repeated runs improved from 32.89s to 31.77s, saving 1.11s while preserving all 1,736 test executions.

## How

- Replace `AppNodeBuilder.build(...)` with `LayerNode.compile(...)` in `packages/core/test/plugin/fixture.ts`.
- Keep the same node group, replacements, and fresh per-test layer acquisition.
- Leave full-production location/plugin lifecycle suites on `AppNodeBuilder`.

## Scope

This only narrows the shared plugin fixture. Other test fixtures and production layer construction are unchanged.

## Testing

- `bun test $(rg -l 'PluginTestLayer' test --glob '*.test.ts') --rerun-each 8` from `packages/core`: 1,736 pass, 0 fail
- `bun typecheck` from `packages/core`
- Push hook: typechecked all 39 workspace packages
- `git diff --check`
