### PR TITLE
docs: add opencode-pr-tracker to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [@hcrosse/opencode-pr-tracker](https://github.com/hcrosse/opencode-pr-tracker)                     | Track GitHub pull requests in the OpenCode sidebar                                                 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #41857

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `@hcrosse/opencode-pr-tracker` to the ecosystem plugin table with its repository link and a concise description. The plugin is published as version `0.2.0` on npm.

### How did you verify your code works?

- Ran `bunx prettier@3.6.2 --check packages/web/src/content/docs/ecosystem.mdx`.
- Installed `@hcrosse/opencode-pr-tracker@0.2.0` on a clean OpenCode 1.18.15 setup and confirmed both server and TUI plugin entries.

### Screenshots / recordings

Not applicable; this changes one row in a documentation table.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR