### PR TITLE
feat(tui): hidden experiments section with per-tab prompt drafts

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -307,6 +307,8 @@ export interface KeymapCommand {
     readonly aliases?: string[]
     /** Keeps the slash command in the prompt and passes its raw input to run. */
     readonly arguments?: true
+    /** Hides the command from slash completion until its exact name is typed. */
+    readonly secret?: true
   }
   /** Promotes the command in discovery UI. */
   readonly suggested?: boolean | (() => boolean)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -30,7 +30,7 @@ import {
   batch,
   Show,
 } from "solid-js"
-import { createStore } from "solid-js/store"
+import { createStore, unwrap } from "solid-js/store"
 import {
   TuiLifecycleProvider,
   TuiAppProvider,
@@ -62,6 +62,7 @@ import { useConnected } from "./component/use-connected"
 import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
 import { DialogConfig } from "./component/dialog-config"
+import { DialogExperiments } from "./component/dialog-experiments"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogPair, type DialogPairCredentials } from "./component/dialog-pair"
 import { DialogThemeList } from "./component/dialog-theme-list"
@@ -657,8 +658,20 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "Session",
         slash: { name: "new", aliases: ["clear"] },
         run: () => {
+          // With per-tab drafts, a new session is an explicit "this belongs
+          // elsewhere" gesture: move the in-progress draft instead of leaving
+          // a copy behind on the tab it came from.
+          const carried = (() => {
+            if (config.data.experimental?.tab_drafts !== true) return undefined
+            const current = promptRef.current
+            if (!current?.current.text) return undefined
+            const prompt = unwrap(current.current)
+            current.reset()
+            return prompt
+          })()
           route.navigate({
             type: "home",
+            prompt: carried,
             location:
               route.data.type === "session"
                 ? (data.session.get(route.data.sessionID)?.location ?? location.ref)
@@ -867,6 +880,17 @@ function App(props: { pair?: DialogPairCredentials }) {
         slash: { name: "settings" },
         run: () => {
           dialog.replace(() => <DialogConfig />)
+        },
+        category: "System",
+      },
+      {
+        // Deliberately absent from the command palette; reachable only as /experiments.
+        name: "opencode.experiments",
+        title: "Experiments",
+        palette: undefined,
+        slash: { name: "experiments" },
+        run: () => {
+          dialog.replace(() => <DialogExperiments />)
         },
         category: "System",
       },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -665,7 +665,9 @@ function App(props: { pair?: DialogPairCredentials }) {
             if (config.data.experimental?.tab_drafts !== true) return undefined
             const current = promptRef.current
             if (!current?.current.text) return undefined
-            const prompt = unwrap(current.current)
+            // Copy before reset: reset() merges an empty prompt into the same
+            // underlying store object that unwrap exposes.
+            const prompt = { ...unwrap(current.current) }
             current.reset()
             return prompt
           })()

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -890,9 +890,9 @@ function App(props: { pair?: DialogPairCredentials }) {
         // secret /baldbeard incantation.
         name: "opencode.experiments",
         title: "Experiments",
-        description: "Arr. Here be experiments.",
+        description: "look is my devrel meme face",
         palette: undefined,
-        slash: { name: "baldbeard" },
+        slash: { name: "baldbeard", secret: true as const },
         run: () => {
           dialog.replace(() => <DialogExperiments />)
         },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -886,11 +886,12 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "System",
       },
       {
-        // Deliberately absent from the command palette; reachable only as /experiments.
+        // Deliberately absent from the command palette; reachable only by the
+        // secret /baldbeard incantation.
         name: "opencode.experiments",
         title: "Experiments",
         palette: undefined,
-        slash: { name: "experiments" },
+        slash: { name: "baldbeard" },
         run: () => {
           dialog.replace(() => <DialogExperiments />)
         },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -890,6 +890,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         // secret /baldbeard incantation.
         name: "opencode.experiments",
         title: "Experiments",
+        description: "Arr. Here be experiments.",
         palette: undefined,
         slash: { name: "baldbeard" },
         run: () => {

--- a/packages/tui/src/component/dialog-experiments.tsx
+++ b/packages/tui/src/component/dialog-experiments.tsx
@@ -1,0 +1,63 @@
+import { createMemo, createSignal } from "solid-js"
+import { useConfig } from "../config"
+import { DialogSelect } from "../ui/dialog-select"
+import { useToast } from "../ui/toast"
+
+type Experiment = {
+  id: "tab_drafts"
+  title: string
+  description: string
+}
+
+// In-flight features anyone can opt into. Each entry is temporary: an
+// experiment either graduates (delete the entry, make the behavior
+// unconditional) or dies (delete the entry and the branch it gated).
+export const experiments: Experiment[] = [
+  {
+    id: "tab_drafts",
+    title: "Per-tab prompt drafts",
+    description: "Keep unsent prompt drafts on the tab where they were written. New session moves the current draft.",
+  },
+]
+
+export function DialogExperiments() {
+  const config = useConfig()
+  const toast = useToast()
+  const [saving, setSaving] = createSignal(false)
+
+  const enabled = (experiment: Experiment) => config.data.experimental?.[experiment.id] === true
+
+  const options = createMemo(() =>
+    experiments.map((experiment, index) => ({
+      title: experiment.title,
+      description: experiment.description,
+      category: "Experiments",
+      footer: enabled(experiment) ? "on" : "off",
+      value: index,
+    })),
+  )
+
+  async function toggle(index: number) {
+    if (saving()) return
+    const experiment = experiments[index]
+    if (!experiment) return
+    const next = !enabled(experiment)
+    setSaving(true)
+    await config
+      .update((draft) => {
+        if (!draft.experimental || typeof draft.experimental !== "object") draft.experimental = {}
+        draft.experimental[experiment.id] = next
+      })
+      .catch(toast.error)
+      .finally(() => setSaving(false))
+  }
+
+  return (
+    <DialogSelect
+      title="Experiments"
+      options={options()}
+      onSelect={(option) => void toggle(option.value)}
+      footerHints={[{ title: "enter", label: "toggle" }]}
+    />
+  )
+}

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -431,6 +431,9 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = keymapCommands().flatMap((command) => {
       const slash = command.slash
       if (!slash) return []
+      // Secret commands are incantations: absent from the "/" listing and from
+      // fuzzy matching until the exact name is typed.
+      if (slash.secret && search().toLowerCase() !== slash.name) return []
       return {
         display: `/${slash.name}`,
         description: command.description ?? command.title,

--- a/packages/tui/src/component/prompt/draft-stash.ts
+++ b/packages/tui/src/component/prompt/draft-stash.ts
@@ -1,0 +1,30 @@
+import type { PromptInfo } from "../../prompt/history"
+
+// Holds one in-progress draft per slot across Prompt remounts. The undefined
+// key is the default single global slot that follows focus across tabs; the
+// tab_drafts experiment keys drafts by the tab (sessionID or "home") they
+// were written in. A draft is consumed on take: restoring it moves it out of
+// the stash, so a stale copy never shadows newer input.
+export type DraftEntry = { prompt: PromptInfo; cursor: number }
+
+let global: DraftEntry | undefined
+const byTab = new Map<string, DraftEntry>()
+
+export function takeDraft(key: string | undefined) {
+  if (key === undefined) {
+    const entry = global
+    global = undefined
+    return entry
+  }
+  const entry = byTab.get(key)
+  byTab.delete(key)
+  return entry
+}
+
+export function saveDraft(key: string | undefined, entry: DraftEntry) {
+  if (key === undefined) {
+    global = entry
+    return
+  }
+  byTab.set(key, entry)
+}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -130,7 +130,11 @@ function formatEditorContext(selection: EditorSelection) {
   return `<system-reminder>${ranges.join("\n")} This may or may not be relevant to the current task.</system-reminder>\n`
 }
 
+// One in-progress draft survives remounts. By default a single slot follows
+// focus across tabs; the tab_drafts experiment keys drafts to the tab (session
+// or home) they were written in.
 let stashed: { prompt: PromptInfo; cursor: number } | undefined
+const stashedByTab = new Map<string, { prompt: PromptInfo; cursor: number }>()
 
 function argumentSlash(input: string, commands: readonly KeymapCommand[]) {
   const head = parseSlashHead(input, /\s/)
@@ -647,9 +651,13 @@ export function Prompt(props: PromptProps) {
     },
   }
 
+  const stashKey = () => (config.experimental?.tab_drafts === true ? (props.sessionID ?? "home") : undefined)
+
   onMount(() => {
-    const saved = stashed
-    stashed = undefined
+    const key = stashKey()
+    const saved = key === undefined ? stashed : stashedByTab.get(key)
+    if (key === undefined) stashed = undefined
+    else stashedByTab.delete(key)
     if (store.prompt.text) return
     if (saved && saved.prompt.text) {
       input.setText(saved.prompt.text)
@@ -662,7 +670,10 @@ export function Prompt(props: PromptProps) {
   onCleanup(() => {
     disposed = true
     if (store.prompt.text) {
-      stashed = { prompt: unwrap(store.prompt), cursor: input.cursorOffset }
+      const entry = { prompt: unwrap(store.prompt), cursor: input.cursorOffset }
+      const key = stashKey()
+      if (key === undefined) stashed = entry
+      else stashedByTab.set(key, entry)
     }
     setInputTarget(undefined)
     props.ref?.(undefined)

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -651,7 +651,11 @@ export function Prompt(props: PromptProps) {
     },
   }
 
-  const stashKey = () => (config.experimental?.tab_drafts === true ? (props.sessionID ?? "home") : undefined)
+  // Captured once: the session route is keyed by sessionID, so this Prompt
+  // instance belongs to exactly one tab. Reading props.sessionID lazily would
+  // observe the *next* route during onCleanup and stash under the wrong tab.
+  const stashSessionID = props.sessionID
+  const stashKey = () => (config.experimental?.tab_drafts === true ? (stashSessionID ?? "home") : undefined)
 
   onMount(() => {
     const key = stashKey()

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,6 +28,7 @@ import { parseSlashHead } from "../../prompt/parse"
 import { stringWidth } from "../../util/string-width"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { emptyPrompt, usePromptHistory, type PromptInfo, type PromptPartRef } from "../../prompt/history"
+import { saveDraft, takeDraft } from "./draft-stash"
 import { Skill } from "@opencode-ai/schema/skill"
 import { computePromptTraits } from "../../prompt/traits"
 import { expandPastedTextPlaceholders, expandTrackedPastedText } from "../../prompt/part"
@@ -129,12 +130,6 @@ function formatEditorContext(selection: EditorSelection) {
 
   return `<system-reminder>${ranges.join("\n")} This may or may not be relevant to the current task.</system-reminder>\n`
 }
-
-// One in-progress draft survives remounts. By default a single slot follows
-// focus across tabs; the tab_drafts experiment keys drafts to the tab (session
-// or home) they were written in.
-let stashed: { prompt: PromptInfo; cursor: number } | undefined
-const stashedByTab = new Map<string, { prompt: PromptInfo; cursor: number }>()
 
 function argumentSlash(input: string, commands: readonly KeymapCommand[]) {
   const head = parseSlashHead(input, /\s/)
@@ -658,10 +653,7 @@ export function Prompt(props: PromptProps) {
   const stashKey = () => (config.experimental?.tab_drafts === true ? (stashSessionID ?? "home") : undefined)
 
   onMount(() => {
-    const key = stashKey()
-    const saved = key === undefined ? stashed : stashedByTab.get(key)
-    if (key === undefined) stashed = undefined
-    else stashedByTab.delete(key)
+    const saved = takeDraft(stashKey())
     if (store.prompt.text) return
     if (saved && saved.prompt.text) {
       input.setText(saved.prompt.text)
@@ -674,10 +666,7 @@ export function Prompt(props: PromptProps) {
   onCleanup(() => {
     disposed = true
     if (store.prompt.text) {
-      const entry = { prompt: unwrap(store.prompt), cursor: input.cursorOffset }
-      const key = stashKey()
-      if (key === undefined) stashed = entry
-      else stashedByTab.set(key, entry)
+      saveDraft(stashKey(), { prompt: unwrap(store.prompt), cursor: input.cursorOffset })
     }
     setInputTarget(undefined)
     props.ref?.(undefined)

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -189,6 +189,13 @@ export const Info = Schema.Struct({
       }),
     }),
   ).annotate({ description: "Debugging settings" }),
+  experimental: Schema.optional(
+    Schema.Struct({
+      tab_drafts: Schema.optional(Schema.Boolean).annotate({
+        description: "Keep unsent prompt drafts on the tab where they were written",
+      }),
+    }),
+  ).annotate({ description: "Experimental features that may change or be removed at any time" }),
   animations: Schema.optional(Schema.Boolean).annotate({ description: "Enable interface animations" }),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable terminal mouse capture" }),
   cursor: Schema.optional(Cursor),

--- a/packages/tui/src/context/keymap.tsx
+++ b/packages/tui/src/context/keymap.tsx
@@ -24,6 +24,7 @@ declare module "@opentui/keymap" {
       name: string
       aliases?: string[]
       arguments?: true
+      secret?: true
     }
   }
 }

--- a/packages/tui/test/prompt/draft-stash.test.ts
+++ b/packages/tui/test/prompt/draft-stash.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { saveDraft, takeDraft } from "../../src/component/prompt/draft-stash"
+import { emptyPrompt } from "../../src/prompt/history"
+
+// The Prompt component stashes an unsent draft in onCleanup and takes it back
+// in onMount across route remounts. The key it uses is undefined by default
+// (one global slot that follows focus across tabs) and the tab identity
+// (sessionID, or "home") when the tab_drafts experiment is on.
+
+function draft(text: string, cursor = text.length) {
+  return { prompt: { ...emptyPrompt(), text }, cursor }
+}
+
+describe("prompt draft stash", () => {
+  test("global slot follows focus: any tab takes the last stashed draft", () => {
+    const entry = draft("follow me")
+    saveDraft(undefined, entry)
+    expect(takeDraft(undefined)).toBe(entry)
+    // Consumed on take, so a remount never restores a stale copy.
+    expect(takeDraft(undefined)).toBeUndefined()
+  })
+
+  test("tab-keyed drafts stay on the tab they were written in", () => {
+    const two = draft("notes for session two")
+    saveDraft("ses_two", two)
+
+    // Switching to another tab or home finds nothing.
+    expect(takeDraft("ses_one")).toBeUndefined()
+    expect(takeDraft("home")).toBeUndefined()
+
+    // Returning to the original tab restores exactly its draft, once.
+    expect(takeDraft("ses_two")).toBe(two)
+    expect(takeDraft("ses_two")).toBeUndefined()
+  })
+
+  test("each tab keeps its own draft, including home", () => {
+    const one = draft("DRAFT-ONE")
+    const home = draft("draft on home")
+    saveDraft("ses_one", one)
+    saveDraft("home", home)
+
+    expect(takeDraft("home")).toBe(home)
+    expect(takeDraft("ses_one")).toBe(one)
+  })
+
+  test("global and tab slots never leak into each other when the experiment toggles mid-draft", () => {
+    const global = draft("stashed before enabling tab_drafts")
+    const keyed = draft("stashed after enabling tab_drafts")
+    saveDraft(undefined, global)
+    saveDraft("ses_a", keyed)
+
+    // A keyed lookup must not surface the global draft on the wrong tab...
+    expect(takeDraft("ses_b")).toBeUndefined()
+    // ...and the global slot must not surface a tab's draft.
+    expect(takeDraft(undefined)).toBe(global)
+    expect(takeDraft("ses_a")).toBe(keyed)
+  })
+
+  test("a newer draft for the same slot replaces the older one", () => {
+    saveDraft("ses_a", draft("first"))
+    const second = draft("second")
+    saveDraft("ses_a", second)
+    expect(takeDraft("ses_a")).toBe(second)
+  })
+})


### PR DESCRIPTION
## What

Adds a hidden **Experiments** surface to the TUI: an opt-in home for in-flight features on any channel, reachable only by typing the secret `/baldbeard` incantation in full (it is absent from the ctrl+p command palette, absent from the bare `/` slash listing, and excluded from fuzzy matching until the exact name is typed; the reward for typing it is the autocomplete row `/baldbeard  look is my devrel meme face`). Each experiment is a registry entry with a title and description; toggling writes `experimental.<id>` to the TUI config. Graduating or killing an experiment means deleting one registry entry plus its gated branch.

Ships one experiment to give the surface a real tenant:

**Per-tab prompt drafts** (`tab_drafts`) — today an unsent prompt draft is a single global slot that follows focus across session tabs. With the experiment on, drafts stay on the tab where they were written, and `<leader>n` (new session) *moves* the current draft into the new session instead of leaving a copy behind.

**1. Draft on tab two**
```text
[Session one]  [Session two]
                active
> WIP draft: notes for session two_
```

**2. Switch to tab one — draft stays behind**
```text
[Session one]  [Session two]
 active
> _
```

**3. Switch back — draft restored**
```text
[Session one]  [Session two]
                active
> WIP draft: notes for session two_
```

**4. `<leader>n` — draft moves to the new session**
```text
[Session one]  [Session two]  [New session]
                               active
> WIP draft: notes for session two_
```
Tab two's composer is now empty (moved, not copied).

## How

- `packages/tui/src/config/index.tsx` — adds an `experimental` struct to the TUI config schema (`experimental.tab_drafts`).
- `packages/tui/src/component/dialog-experiments.tsx` — new experiment registry + `DialogExperiments` (a `DialogSelect` that toggles `experimental.<id>` via `config.update`).
- `packages/tui/src/app.tsx` — registers `opencode.experiments` with `palette: undefined` + `slash: { name: "baldbeard", secret: true }`; the new `slash.secret` flag (`packages/plugin/src/tui/context.ts`, gate in `packages/tui/src/component/prompt/autocomplete.tsx`) keeps a command out of slash completion until its exact name is typed; `session.new` moves the in-progress draft into the home route's prompt seed when the experiment is on.
- `packages/tui/src/component/prompt/index.tsx` — the module-level draft stash gains a `Map` keyed by tab (sessionID, or `home`) when the experiment is on. Two subtleties:
  - the session ID is captured once at Prompt setup; reading `props.sessionID` lazily would observe the *next* route during `onCleanup` and stash the draft under the wrong tab (the draft would follow you, one tab behind)
  - the carried draft is shallow-copied before `reset()`, because `reset()` merges an empty prompt into the same underlying store object that `unwrap` exposes

Default behavior (experiment off) is byte-identical to today: one global stash slot.

## Scope

- No experiments UI in `/settings` — the section is intentionally separate and unlisted. Happy to surface it differently if we want more/less discoverability.
- The stash map is unbounded across closed tabs (entries are consumed on restore; abandoned drafts of closed sessions linger in memory for the process lifetime). Trivial to cap if we care.

## Testing

- `bun typecheck` in `packages/tui` — clean.
- The stash now lives in `packages/tui/src/component/prompt/draft-stash.ts` (extracted so the actual implementation is testable); `test/prompt/draft-stash.test.ts` covers the slot semantics: global slot follows focus, tab-keyed drafts stay put and restore once, home is its own tab, no leakage between global and keyed slots when the experiment toggles mid-draft.
- End-to-end via opencode-drive against this branch (`--dev`): created two sessions, enabled the experiment through `/baldbeard`, verified the draft stays on its tab, restores on return, moves on `<leader>n`, and the source tab's composer is empty afterwards. Also verified `experimental.tab_drafts: true` lands in the config file.

## Demo

Real end-to-end run recorded with opencode-drive (simulated model, real TUI from this branch): creates two sessions, shows the bare `/` listing with no baldbeard and `/bald` revealing nothing, completes the exact `/baldbeard` incantation to surface `look is my devrel meme face`, toggles the experiment on, writes a draft on tab two, clicks between tabs to show the draft staying put, then `ctrl+x n` moving it into a new session and leaving the source tab empty.

https://github.com/user-attachments/assets/ccb28731-473d-4c1c-b5a4-f69e48a68404





