### PR TITLE
fix(opencode): preserve command scope in subtask continuation message

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -429,6 +429,10 @@ const layer = Layer.effect(
 
       if (!task.command) return
 
+      // Synthetic user message required: reasoning models like gemini error on a
+      // mid-loop assistant message with no user message after it (#5650).
+      // Keep the wording non-imperative — an open-ended "continue" reads as user
+      // permission to act beyond the command's scope (#41866).
       const summaryUserMsg: SessionV1.User = {
         id: MessageID.ascending(),
         sessionID,
@@ -443,7 +447,7 @@ const layer = Layer.effect(
         messageID: summaryUserMsg.id,
         sessionID,
         type: "text",
-        text: "Summarize the task tool output above and continue with your task.",
+        text: `The /${task.command} command ran as a subtask and its output is shown above. Summarize that output for the user. The command's work is complete: do not take further actions or make changes unless the user explicitly requests them.`,
         synthetic: true,
       } satisfies SessionV1.TextPart)
     })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -417,7 +417,7 @@ const seed = Effect.fn("test.seed")(function* (sessionID: SessionID, opts?: { fi
   return { user: msg, assistant }
 })
 
-const addSubtask = (sessionID: SessionID, messageID: MessageID, model = ref) =>
+const addSubtask = (sessionID: SessionID, messageID: MessageID, model = ref, command?: string) =>
   Effect.gen(function* () {
     const session = yield* Session.Service
     yield* session.updatePart({
@@ -429,6 +429,7 @@ const addSubtask = (sessionID: SessionID, messageID: MessageID, model = ref) =>
       description: "inspect bug",
       agent: "general",
       model,
+      command,
     })
   })
 
@@ -985,6 +986,53 @@ it.instance("subtask child inherits parent session external_directory allow", ()
     )
     expect(Permission.evaluate("external_directory", "/tmp/allowed/file", rules).action).toBe("allow")
     expect(Permission.evaluate("task", "anything", rules).action).toBe("deny")
+  }),
+)
+
+it.instance("command subtask injects scope-preserving synthetic user message", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* llm.text("review findings")
+    yield* llm.text("summary for user")
+    const msg = yield* user(chat.id, "hello")
+    yield* addSubtask(chat.id, msg.id, ref, "review")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(result.info.role).toBe("assistant")
+    expect(yield* llm.calls).toBe(2)
+
+    const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+    const synthetic = msgs
+      .filter((item) => item.info.role === "user")
+      .flatMap((item) => item.parts)
+      .find((part): part is SessionV1.TextPart => part.type === "text" && part.synthetic === true)
+    expect(synthetic).toBeDefined()
+    expect(synthetic?.text).toContain("/review")
+    expect(synthetic?.text).not.toContain("continue with your task")
+  }),
+)
+
+it.instance("subtask without command adds no synthetic user message", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* llm.text("done")
+    const msg = yield* user(chat.id, "hello")
+    yield* addSubtask(chat.id, msg.id)
+
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+    const synthetic = msgs
+      .filter((item) => item.info.role === "user")
+      .flatMap((item) => item.parts)
+      .find((part) => part.type === "text" && part.synthetic === true)
+    expect(synthetic).toBeUndefined()
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #41866

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
  
### What does this PR do?

The synthetic user message injected after a user-invoked subtask command says "continue with your task".
But for the`/review` command, that strongly suggests the model should fix any findings the subtask reported.
This is unfortunate, since when you run that command you expect it to review a PR, not try to fix everything wrong with it.

The message itself cannot be removed. 
PR #5650 added it because reasoning models like Gemini error when an assistant message has no user message after it.
So this PR keeps the message but changes its text. 
The new text names the command that ran, asks for a summary of the output, and defers any further action to the user.
It also restores the code comment from #5650 that explains why the message must exist.
 
### How did you verify your code works?

- Added tests to `packages/opencode/test/session/prompt.test.ts`
- Ran the test suite
- Ran typecheck

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR