### PR TITLE
fix(desktop): skip web ui build in dev

### DIFF
--- a/packages/cli/script/app-assets.ts
+++ b/packages/cli/script/app-assets.ts
@@ -3,7 +3,8 @@ import { readdir } from "node:fs/promises"
 import path from "node:path"
 import { brotliCompressSync, constants } from "node:zlib"
 
-export async function buildAppArchive(channel: string) {
+export async function buildAppArchive(channel: string, options?: { skipBuild?: boolean }) {
+  if (options?.skipBuild) return compress({})
   const root = path.resolve(import.meta.dirname, "../../app")
   await $`bun run build`.cwd(root).env({ ...process.env, OPENCODE_CHANNEL: channel })
   const assets = Object.fromEntries(
@@ -18,6 +19,10 @@ export async function buildAppArchive(channel: string) {
         }),
     ),
   )
+  return compress(assets)
+}
+
+function compress(assets: object) {
   return brotliCompressSync(JSON.stringify(assets), {
     params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
   }).toString("base64")

--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -24,6 +24,7 @@ await rm(outdir, { recursive: true, force: true })
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
+const skipWebUi = process.argv.includes("--skip-web-ui")
 const solidPlugin = createSolidTransformPlugin()
 
 const allTargets: {
@@ -55,7 +56,7 @@ const targets = singleFlag
   : allTargets
 
 if (!skipInstall) await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
-const appArchive = await buildAppArchive(Script.channel)
+const appArchive = await buildAppArchive(Script.channel, { skipBuild: skipWebUi })
 const appAssetsPlugin: BunPlugin = {
   name: "opencode-app-assets",
   setup(build) {

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -90,7 +90,7 @@ export async function buildCliToResources(dest = windowsify("resources/opencode-
   const directory = await mkdtemp(join(tmpdir(), "opencode-cli-"))
   const target = `cli-${process.platform === "win32" ? "windows" : process.platform}-${process.arch}`
   try {
-    await $`bun ${join(import.meta.dirname, "../../cli/script/build.ts")} --single --skip-install --outdir=${directory}`.env(
+    await $`bun ${join(import.meta.dirname, "../../cli/script/build.ts")} --single --skip-install --skip-web-ui --outdir=${directory}`.env(
       {
         ...process.env,
         OPENCODE_VERSION: `0.0.0-local-${Date.now()}`,


### PR DESCRIPTION
## Summary
- add a CLI build flag for omitting the embedded web UI
- use an empty valid asset archive when the web UI is omitted
- make desktop development pass the flag when building its local CLI

## Verification
- bun typecheck in packages/cli
- bun typecheck in packages/desktop
- local CLI build with --skip-web-ui (no Vite production build)