### PR TITLE
fix(core): restore bundler resolution for source-imported deps

### DIFF
--- a/packages/core/script/migration.ts
+++ b/packages/core/script/migration.ts
@@ -130,7 +130,7 @@ async function typescriptMigrations() {
 
 function renderMigration(name: string, sql: string) {
   return `import { Effect } from "effect"
-import type { DatabaseMigration } from "../migration"
+import type { DatabaseMigration } from "../migration.js"
 
 const migration: DatabaseMigration.Migration = {
   id: ${JSON.stringify(name)},
@@ -147,7 +147,7 @@ export default migration
 
 function renderSchema(sql: string) {
   return `import { Effect } from "effect"
-import type { DatabaseMigration } from "./migration"
+import type { DatabaseMigration } from "./migration.js"
 
 const schema: Omit<DatabaseMigration.Migration, "id"> = {
   up(tx) {
@@ -193,8 +193,8 @@ async function formatTypescript(input: string) {
 }
 
 function renderRegistry(names: string[]) {
-  return `import type { DatabaseMigration } from "./migration"
-${names.map((name, index) => `import m${index.toString().padStart(2, "0")} from "./migration/${name}"`).join("\n")}
+  return `import type { DatabaseMigration } from "./migration.js"
+${names.map((name, index) => `import m${index.toString().padStart(2, "0")} from "./migration/${name}.js"`).join("\n")}
 
 export const migrations = [
 ${names.map((_, index) => `  m${index.toString().padStart(2, "0")},`).join("\n")}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,9 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/bun/tsconfig.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "allowImportingTsExtensions": false,
     "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## What

Restore a green typecheck on `v2` by reverting the three `NodeNext` compiler options added to `packages/core/tsconfig.json` in 4acdeffbe9 (`refactor(core): require explicit import extensions`), while keeping that commit's ~300 files of explicit `.js` import extensions.

## Before / After

**Before:** `bun typecheck` failed repo-wide at `v2` HEAD (`c217ebe2ad`), blocking the pre-push hook for everyone. `packages/core` imports `@opencode-ai/ai` and `@ff-labs/fff-bun` as raw TypeScript sources (their package exports point at `src/*.ts`), so their files are compiled inside core's program under core's compiler options. With `moduleResolution: NodeNext`, their extensionless relative imports produce hundreds of `TS2835` errors, which cascade into `packages/plugin` and `packages/desktop` as `TS2305` "has no exported member" failures for `Message`, `SystemPart`, `CommandInfo`, `ConnectionInfo`, and others.

**After:** Core resolves modules with the bundler settings from `@tsconfig/bun` again. The explicit `.js` extensions in core sources remain valid (TypeScript maps `./agent.js` to `agent.ts` in bundler resolution too), so none of the 300-file refactor is reverted. All 33 packages typecheck.

## How

- `packages/core/tsconfig.json`: remove `"module": "NodeNext"`, `"moduleResolution": "NodeNext"`, and `"allowImportingTsExtensions": false`.
- `packages/core/script/migration.ts`: emit `.js` extensions from the `renderMigration`, `renderSchema`, and `renderRegistry` templates. 4acdeffbe9 hand-updated the generated `schema.gen.ts`, `migration.gen.ts`, and migration files but not the generator, so the `database-migration` freshness check regenerated old-style imports and failed CI (`Current database schema is stale`). The templates now reproduce the checked-in files byte for byte.

## Scope

- This does not add tooling to *enforce* explicit extensions, which was presumably the intent of the flags. Strict `NodeNext` is not currently feasible while the repo consumes raw-TS dependencies: `@ff-labs/fff-bun` ships extensionless `.ts` sources in `node_modules`, which cannot be edited. Enforcement would need a lint rule (e.g. ESLint `import/extensions` or a Biome rule) instead of compiler options, or built `.d.ts` boundaries for source-imported packages. Happy to follow up either way — flagging for @thdxr since 4acdeffbe9 landed directly on `v2`.

## Testing

- `bun typecheck` at repo root: 33/33 packages pass (previously `@opencode-ai/desktop` and core itself failed)
- `bun typecheck` in `packages/core` including `tsconfig.tests.json`
- `bun script/migration.ts --check` in `packages/core` passes with no changes to generated files (fails on `v2` HEAD and on the first commit of this branch)
