### PR TITLE
feat(tui): add plus button to session tab bar

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -27,6 +27,8 @@ import { marqueeText } from "../util/marquee"
 
 // A long title fades out over its last cells instead of cutting hard.
 const FADE_WIDTH = 4
+// The add button renders as " + " at the end of the strip, so the tab layout leaves it room.
+const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
 const MARQUEE_INTERVAL = 100
 
@@ -42,6 +44,7 @@ export const EMPTY_SESSION_TAB_STATUS: SessionTabsStatus = {
 }
 export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
   newTab?: () => boolean
+  add?: () => void
   status(sessionID: string): SessionTabsStatus
 }
 
@@ -103,6 +106,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
   const separatorUpperPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.04))
   const separatorLowerPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.05))
   const [hovered, setHovered] = createSignal<string>()
+  const [addHovered, setAddHovered] = createSignal(false)
   const marquee = createMarquee(hovered, animations)
   const [dragging, setDragging] = createSignal<string>()
   const [preview, setPreview] = createSignal<{ sessionID: string; index: number }>()
@@ -417,6 +421,29 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               )
             }}
           </For>
+          <Show when={tabs.add}>
+            <box
+              height={1}
+              width="100%"
+              flexDirection="row"
+              paddingLeft={1}
+              backgroundColor={addHovered() ? theme.background.action.primary.hovered : theme.background.default}
+              onMouseOver={() => setAddHovered(true)}
+              onMouseOut={() => setAddHovered(false)}
+              onMouseUp={() => tabs.add?.()}
+            >
+              <text width={2} fg={addHovered() ? theme.text.default : idleNumber()} selectable={false}>
+                +
+              </text>
+              <text
+                fg={addHovered() ? theme.text.default : theme.text.subdued}
+                wrapMode="none"
+                selectable={false}
+              >
+                {NEW_SESSION_TAB_TITLE}
+              </text>
+            </box>
+          </Show>
         </box>
       </scrollbox>
     </box>
@@ -431,6 +458,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const [hovered, setHovered] = createSignal<string>()
+  const [addHovered, setAddHovered] = createSignal(false)
   const marquee = createMarquee(hovered, animations)
   const [dragging, setDragging] = createSignal<string>()
   // A drag reorders a local preview and persists one move on release instead of writing
@@ -457,7 +485,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
     if (index === -1 || index === Math.min(pending.index, tabs.tabs().length - 1)) setPreview(undefined)
   })
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
-    adaptiveSessionTabLayout(items(), activeID(), dimensions().width, previous?.start),
+    adaptiveSessionTabLayout(items(), activeID(), dimensions().width - (tabs.add ? ADD_TAB_WIDTH : 0), previous?.start),
   )
   const statuses = createMemo(
     () =>
@@ -744,6 +772,19 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
       <Show when={layout().after > 0}>
         <text width={sessionTabOverflowWidth(layout().after)} fg={theme.text.subdued} selectable={false}>
           {" " + layout().after}›
+        </text>
+      </Show>
+      <Show when={tabs.add}>
+        <text
+          width={ADD_TAB_WIDTH}
+          fg={addHovered() ? theme.text.default : theme.text.subdued}
+          bg={addHovered() ? theme.background.action.primary.hovered : undefined}
+          selectable={false}
+          onMouseOver={() => setAddHovered(true)}
+          onMouseOut={() => setAddHovered(false)}
+          onMouseUp={() => tabs.add?.()}
+        >
+          {" + "}
         </text>
       </Show>
     </box>

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -111,18 +111,18 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
   const [dragging, setDragging] = createSignal<string>()
   const [preview, setPreview] = createSignal<{ sessionID: string; index: number }>()
   const newTab = () => tabs.newTab?.() ?? false
-  const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB.sessionID : tabs.current()))
+  const activeID = createMemo(() => (newTab() ? undefined : tabs.current()))
   const ordered = createMemo(() => {
     const pending = preview()
     if (!pending) return tabs.tabs()
     return moveSessionTab(tabs.tabs(), pending.sessionID, pending.index)
   })
-  const items = createMemo(() => (newTab() ? [...ordered(), NEW_SESSION_TAB] : ordered()))
+  const items = ordered
   const statuses = createMemo(
     () =>
       new Map(
         items().map((tab) => {
-          const status = tab === NEW_SESSION_TAB ? EMPTY_SESSION_TAB_STATUS : tabs.status(tab.sessionID)
+          const status = tabs.status(tab.sessionID)
           return [
             tab.sessionID,
             {
@@ -149,6 +149,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
 
   createEffect(() => {
     if (!scroll) return
+    // The promoted new-session slot sits below the list, so bring the rail's bottom into view.
+    if (newTab()) return scroll.scrollTo(Math.max(0, items().length * 3 + 1 - scroll.viewport.height))
     const index = items().findIndex((tab) => tab.sessionID === activeID())
     if (index === -1) return
     const top = index * 3
@@ -175,7 +177,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const selected = () => activeID() === tab.sessionID
               const status = createMemo(() => itemStatus(tab))
               const [sweepLevel, setSweepLevel] = createSignal(0)
-              const session = createMemo(() => (tab === NEW_SESSION_TAB ? undefined : data.session.get(tab.sessionID)))
+              const session = createMemo(() => data.session.get(tab.sessionID))
               const project = createMemo(() => {
                 const value = session()
                 return value ? data.project.get(value.projectID) : undefined
@@ -192,7 +194,6 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
               const titleFades = createMemo(() => stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
-                if (tab === NEW_SESSION_TAB) return Locale.takeWidth("Start a new session", titleWidth())
                 const value = session()
                 return Locale.takeWidth(projectName(project(), value?.location.directory) ?? "", titleWidth())
               })
@@ -264,7 +265,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 setDragging(undefined)
                 const pending = preview()
                 if (pending?.sessionID === tab.sessionID) tabs.move(pending.sessionID, pending.index)
-                if (tab !== NEW_SESSION_TAB) tabs.select(tab.sessionID)
+                tabs.select(tab.sessionID)
               }
               return (
                 <box
@@ -281,7 +282,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   }}
                   onMouseUp={release}
                   onMouseDrag={(event) => {
-                    if (!rail || tab === NEW_SESSION_TAB) return
+                    if (!rail) return
                     const target = Math.max(
                       0,
                       Math.min(
@@ -390,7 +391,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                         onMouseUp={(event) => {
                           if (hovered() !== tab.sessionID) return
                           event.stopPropagation()
-                          tabs.close(tab === NEW_SESSION_TAB ? undefined : tab.sessionID)
+                          tabs.close(tab.sessionID)
                         }}
                       >
                         {hovered() === tab.sessionID ? "×" : ""}
@@ -421,27 +422,61 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               )
             }}
           </For>
-          <Show when={tabs.add}>
+          {/* One slot with two states: a subdued affordance that promotes in place into the
+              active new-session tab, instead of spawning a separate pseudo tab above itself. */}
+          <Show when={tabs.add || newTab()}>
             <box
               height={1}
               width="100%"
+              position="relative"
               flexDirection="row"
               paddingLeft={1}
-              backgroundColor={addHovered() ? theme.background.action.primary.hovered : theme.background.default}
+              backgroundColor={
+                newTab()
+                  ? theme.background.action.primary.selected
+                  : addHovered()
+                    ? theme.background.action.primary.hovered
+                    : theme.background.default
+              }
               onMouseOver={() => setAddHovered(true)}
               onMouseOut={() => setAddHovered(false)}
-              onMouseUp={() => tabs.add?.()}
+              onMouseUp={() => {
+                if (!newTab()) tabs.add?.()
+              }}
             >
-              <text width={2} fg={addHovered() ? theme.text.default : idleNumber()} selectable={false}>
+              <text
+                width={2}
+                fg={newTab() ? activeNumber() : addHovered() ? theme.text.default : idleNumber()}
+                selectable={false}
+                attributes={newTab() ? TextAttributes.BOLD : undefined}
+              >
                 +
               </text>
               <text
-                fg={addHovered() ? theme.text.default : theme.text.subdued}
+                fg={newTab() || addHovered() ? theme.text.default : theme.text.subdued}
                 wrapMode="none"
                 selectable={false}
+                attributes={newTab() ? TextAttributes.BOLD : undefined}
               >
                 {NEW_SESSION_TAB_TITLE}
               </text>
+              <Show when={newTab()}>
+                <text
+                  position="absolute"
+                  right={1}
+                  zIndex={2}
+                  width={1}
+                  fg={theme.text.subdued}
+                  selectable={false}
+                  onMouseUp={(event) => {
+                    if (!addHovered()) return
+                    event.stopPropagation()
+                    tabs.close()
+                  }}
+                >
+                  {addHovered() ? "×" : ""}
+                </text>
+              </Show>
             </box>
           </Show>
         </box>
@@ -477,7 +512,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
     if (!pending) return tabs.tabs()
     return moveSessionTab(tabs.tabs(), pending.sessionID, pending.index)
   })
+  // The promoted new-session slot joins the strip as the active tab; the idle plus affordance
+  // and the promoted slot are mutually exclusive states of one control.
   const items = createMemo(() => (newTab() ? [...ordered(), NEW_SESSION_TAB] : ordered()))
+  const showPlus = () => Boolean(tabs.add) && !newTab()
   createEffect(() => {
     const pending = preview()
     if (!pending || dragging()) return
@@ -485,7 +523,12 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
     if (index === -1 || index === Math.min(pending.index, tabs.tabs().length - 1)) setPreview(undefined)
   })
   const layout = createMemo((previous: ReturnType<typeof adaptiveSessionTabLayout> | undefined) =>
-    adaptiveSessionTabLayout(items(), activeID(), dimensions().width - (tabs.add ? ADD_TAB_WIDTH : 0), previous?.start),
+    adaptiveSessionTabLayout(
+      items(),
+      activeID(),
+      dimensions().width - (showPlus() ? ADD_TAB_WIDTH : 0),
+      previous?.start,
+    ),
   )
   const statuses = createMemo(
     () =>
@@ -732,7 +775,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   {" "}
                 </text>
                 <text width={numberWidth()} fg={numberColor()} selectable={false} attributes={bold()}>
-                  {sessionTabShortcutLabel(tabNumber() - 1)}
+                  {tab === NEW_SESSION_TAB ? "+" : sessionTabShortcutLabel(tabNumber() - 1)}
                 </text>
                 <text
                   width={availableTitleWidth()}
@@ -774,7 +817,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           {" " + layout().after}›
         </text>
       </Show>
-      <Show when={tabs.add}>
+      <Show when={showPlus()}>
         <text
           width={ADD_TAB_WIDTH}
           fg={addHovered() ? theme.text.default : theme.text.subdued}

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -7,6 +7,7 @@ import { withTimestampedFallback } from "@opencode-ai/util/session-title-fallbac
 import { useEvent } from "./event"
 import { useRoute } from "./route"
 import { useConfig } from "../config"
+import { useLocation } from "./location"
 import { useStorage } from "./storage"
 import { useTuiPaths } from "./runtime"
 import {
@@ -48,6 +49,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     const data = useData()
     const event = useEvent()
     const config = useConfig().data
+    const location = useLocation()
     const paths = useTuiPaths()
     const enabled = () => config.tabs.enabled
     // Keyed reconcile keeps tab object identity across reorders, so strip rows move instead of
@@ -248,6 +250,14 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       select(sessionID: string) {
         if (!enabled()) return
         route.navigate({ type: "session", sessionID: root(sessionID) })
+      },
+      add() {
+        if (!enabled()) return
+        const sessionID = current()
+        route.navigate({
+          type: "home",
+          location: (sessionID ? data.session.get(sessionID)?.location : undefined) ?? location.ref,
+        })
       },
       close(sessionID?: string) {
         if (!enabled()) return

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -105,9 +105,21 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     }
   }
 
+  const addTab = () => {
+    const next = FIXTURE_TABS.find((fixture) => !tabs().some((tab) => tab.sessionID === fixture.sessionID))
+    if (!next) {
+      setLastEvent("all fixture tabs are open")
+      return
+    }
+    setItems([...tabs().map((tab) => ({ ...tab })), { sessionID: next.sessionID }])
+    select(next.sessionID)
+    setLastEvent(`tab ${number(next.sessionID)} opened untitled; run it to earn its title`)
+  }
+
   const controller = {
     tabs,
     current: active,
+    add: addTab,
     status(sessionID) {
       return statuses()[sessionID] ?? EMPTY_SESSION_TAB_STATUS
     },
@@ -283,21 +295,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           startRun(current)
         },
       },
-      {
-        bind: "t",
-        title: "Add tab",
-        group: "Storybook",
-        run() {
-          const next = FIXTURE_TABS.find((fixture) => !tabs().some((tab) => tab.sessionID === fixture.sessionID))
-          if (!next) {
-            setLastEvent("all fixture tabs are open")
-            return
-          }
-          setItems([...tabs().map((tab) => ({ ...tab })), { sessionID: next.sessionID }])
-          select(next.sessionID)
-          setLastEvent(`tab ${number(next.sessionID)} opened untitled; run it to earn its title`)
-        },
-      },
+      { bind: "t", title: "Add tab", group: "Storybook", run: addTab },
       { bind: "d", title: "Close tab", group: "Storybook", run: () => controller.close() },
       {
         bind: "r",

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -7,6 +7,7 @@ import path from "path"
 import { ConfigProvider } from "../../src/config"
 import { ClientProvider, useClient } from "../../src/context/client"
 import { DataProvider, useData } from "../../src/context/data"
+import { LocationProvider } from "../../src/context/location"
 import { RouteProvider, useRoute } from "../../src/context/route"
 import { TuiAppProvider } from "../../src/context/runtime"
 import { SessionTabsProvider, useSessionTabs } from "../../src/context/session-tabs"
@@ -86,9 +87,11 @@ async function renderSessionTabs(
             >
               <ClientProvider api={createApi(calls.fetch)}>
                 <DataProvider>
-                  <SessionTabsProvider>
-                    <Probe />
-                  </SessionTabsProvider>
+                  <LocationProvider>
+                    <SessionTabsProvider>
+                      <Probe />
+                    </SessionTabsProvider>
+                  </LocationProvider>
                 </DataProvider>
               </ClientProvider>
             </RouteProvider>
@@ -268,6 +271,20 @@ test("tracks a temporary new session tab across close and creation", async () =>
 
     expect(setup.tabs.newTab()).toBe(false)
     expect(setup.tabs.tabs().find((tab) => tab.sessionID === "third")?.title).toBe(NEW_SESSION_TAB_TITLE)
+  } finally {
+    await setup.destroy()
+  }
+})
+
+test("add opens the new session tab carrying the current session's location", async () => {
+  const setup = await renderSessionTabs("first")
+
+  try {
+    await wait(() => setup.tabs.current() === "first" && setup.data.session.get("first") !== undefined)
+    setup.tabs.add()
+    expect(setup.route.data).toEqual({ type: "home", location: { directory } })
+    await wait(() => setup.tabs.newTab())
+    expect(setup.tabs.tabs().map((tab) => tab.sessionID)).toEqual(["first"])
   } finally {
     await setup.destroy()
   }


### PR DESCRIPTION
## What

Adds a plus affordance to the session tab bar so a new tab can be opened with the mouse, matching browser tab strips. Previously the only way to open a new tab was the `session.new` command or navigating home via keybinds.

The plus and the temporary new-session tab are **one control with two states**: a subdued `+` affordance that promotes in place into the active new-session slot when clicked, then demotes back (or becomes a real numbered tab once a prompt is submitted). There is never a separate pseudo tab plus a redundant `+` at the same time.

- Horizontal strip: a subdued ` + ` sits at the end of the strip (hover lifts it like a tab). Clicking it grows the slot into the active tab — bold `+ New session` on the selected background, with the `+` glyph where the number would be, and a close `×` on hover. While promoted, the trailing plus is hidden. On submit, the slot becomes a real numbered tab and a fresh `+` reappears after it.
- Vertical rail: a `+ New session` row renders below the tab list. Same promotion in place: bold, blue `+`, selected background, hover close `×`. Real tabs never share the rail with a "New session" pseudo tab anymore.
- Opening carries the current session's location so the new session lands in the same project, exactly like the `session.new` command.

## How

- `packages/tui/src/context/session-tabs.tsx` — new `add()` action on the session-tabs context: navigates home with the current session's location, falling back to `location.ref`. Same semantics as the `session.new` command in `app.tsx`.
- `packages/tui/src/component/session-tabs.tsx` — optional `add` on `SessionTabsController`.
  - Horizontal: the promoted `NEW_SESSION_TAB` still joins the adaptive layout as the active tab (so the existing width-growth animation carries the `+` stretching into the tab), but renders `+` in the number cell; `showPlus()` hides the trailing affordance while promoted and drops its `ADD_TAB_WIDTH` (3) reservation.
  - Vertical: the pseudo tab is gone from the list entirely; the affordance row itself renders the promoted state (`newTab()`), and the rail scrolls its bottom into view while promoted.
- `packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx` — storybook controller wires `add` to the existing fixture add-tab logic (shared with the `t` keybind).

## Flow

```mermaid
flowchart LR
    idle["subdued + affordance"] -->|click| promoted["slot promotes in place:\nbold + New session, selected bg"]
    promoted -->|submit prompt| real["real numbered tab"]
    real --> idle2["fresh + appears after it"]
    promoted -->|close × / switch away| idle
```

## Scope

- No new keybind: `session.new` already covers keyboard access; this is mouse parity for the tab strip.
- Follow-ups discussed but not in this PR: reviving the title wipe animation for background title updates, and dimming the placeholder title on not-yet-named sessions.

## Testing

- `bun typecheck` (packages/tui) clean.
- `bun run test` (packages/tui): 642 pass, 0 fail.
- New test: `add opens the new session tab carrying the current session's location` in `test/context/session-tabs.test.tsx`.
- Manually verified both orientations in a real PTY via terminal-control: idle affordance, hover, promotion on click, and the promoted slot rendering with no second `+` anywhere.

## Demo

OpenCode Drive recording (simulated LLM): a session starts from the promoted new-session slot, the `+` is clicked and promotes into the active tab, a second session starts there, and clicking tab 1 switches back — the slot demotes to the subdued `+`.

https://github.com/user-attachments/assets/ef10f7f7-6dc4-4279-9dab-8f1a116255ed
