### PR TITLE
fix(desktop): align local development identity

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -658,7 +658,7 @@ function ChannelIndicator(props: { debugTools?: { visible: boolean; toggle: () =
 
   return (
     <>
-      {["beta", "dev"].includes(channel) && (
+      {["local", "beta", "dev"].includes(channel) && (
         <div class="bg-icon-interactive-base text-[#FFF] font-medium px-2 rounded-sm uppercase font-mono">
           {channel.toUpperCase()}
         </div>

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -1,7 +1,7 @@
 interface ImportMetaEnv {
   readonly VITE_OPENCODE_SERVER_HOST: string
   readonly VITE_OPENCODE_SERVER_PORT: string
-  readonly VITE_OPENCODE_CHANNEL?: "dev" | "beta" | "prod"
+  readonly VITE_OPENCODE_CHANNEL?: "local" | "dev" | "beta" | "prod"
 
   readonly VITE_SENTRY_DSN?: string
   readonly VITE_SENTRY_ENVIRONMENT?: string

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -4,7 +4,7 @@ import appPlugin from "@opencode-ai/app/vite"
 
 const channel = (() => {
   const raw = process.env.OPENCODE_CHANNEL
-  if (raw === "dev" || raw === "beta" || raw === "prod") return raw
+  if (raw === "local" || raw === "dev" || raw === "beta" || raw === "prod") return raw
   if (process.env.OPENCODE_CHANNEL === "latest") return "prod"
   return "dev"
 })()
@@ -72,6 +72,10 @@ const require = __cjs_mod__.createRequire(import.meta.url);
     },
   },
   renderer: {
+    define: {
+      "import.meta.env.OPENCODE_VERSION": JSON.stringify(process.env.OPENCODE_VERSION),
+      "import.meta.env.VITE_OPENCODE_CHANNEL": JSON.stringify(channel),
+    },
     plugins: [appPlugin, sentry],
     publicDir: "../../../app/public",
     root: "src/renderer",

--- a/packages/desktop/scripts/dev.ts
+++ b/packages/desktop/scripts/dev.ts
@@ -7,7 +7,10 @@ type ServerSource = { type: "build" } | { type: "download"; version: string }
 type DevOptions = { server: ServerSource; electron: string[] }
 
 async function main() {
+  process.env.OPENCODE_CHANNEL = "local"
+  process.env.OPENCODE_VERSION = `2.0.0-local-${Date.now()}`
   const options = selectOptions()
+  if (options.server.type === "build") process.env.OPENCODE_DESKTOP_SERVER_CHANNEL = "local"
   await prepareDesktop()
   await prepareServer(options.server)
   await startDesktop(options.electron)

--- a/packages/desktop/scripts/dev.ts
+++ b/packages/desktop/scripts/dev.ts
@@ -9,6 +9,7 @@ type DevOptions = { server: ServerSource; electron: string[] }
 async function main() {
   process.env.OPENCODE_CHANNEL = "local"
   process.env.OPENCODE_VERSION = `2.0.0-local-${Date.now()}`
+  process.env.OPENCODE_DISABLE_CHANNEL_DB = "0"
   const options = selectOptions()
   if (options.server.type === "build") process.env.OPENCODE_DESKTOP_SERVER_CHANNEL = "local"
   await prepareDesktop()

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -93,7 +93,7 @@ export async function buildCliToResources(dest = windowsify("resources/opencode-
     await $`bun ${join(import.meta.dirname, "../../cli/script/build.ts")} --single --skip-install --skip-web-ui --outdir=${directory}`.env(
       {
         ...process.env,
-        OPENCODE_VERSION: `0.0.0-local-${Date.now()}`,
+        OPENCODE_VERSION: process.env.OPENCODE_VERSION,
       },
     )
     if (stateHome && (await Bun.file(dest).exists())) {

--- a/packages/desktop/src/main/background-cli.ts
+++ b/packages/desktop/src/main/background-cli.ts
@@ -25,6 +25,10 @@ export async function startBackgroundCli(logger: Logger) {
   const binary = app.isPackaged || isolated ? await installCli(bundled, version, logger) : bundled
   if (isolated) process.env.XDG_STATE_HOME = app.getPath("userData")
   const service = await Service.ensure({
+    file:
+      isolated && process.env.OPENCODE_DESKTOP_SERVER_CHANNEL === "local"
+        ? join(app.getPath("userData"), "opencode", "service-local.json")
+        : undefined,
     version,
     command: [binary, "serve", "--service"],
     onStart: (reason, previousVersion) => logger.log("v2 CLI background service starting", { reason, previousVersion }),

--- a/packages/desktop/src/main/constants.ts
+++ b/packages/desktop/src/main/constants.ts
@@ -1,7 +1,8 @@
 import { app } from "electron"
 
-type Channel = "dev" | "beta" | "prod"
+type Channel = "local" | "dev" | "beta" | "prod"
 const raw = import.meta.env.OPENCODE_CHANNEL
-export const CHANNEL: Channel = raw === "dev" || raw === "beta" || raw === "prod" ? raw : "dev"
+export const CHANNEL: Channel = raw === "local" || raw === "dev" || raw === "beta" || raw === "prod" ? raw : "dev"
+export const VERSION = app.isPackaged ? app.getVersion() : (process.env.OPENCODE_VERSION ?? app.getVersion())
 
 export const UPDATER_ENABLED = app.isPackaged && CHANNEL !== "dev"

--- a/packages/desktop/src/main/env.d.ts
+++ b/packages/desktop/src/main/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
   readonly OPENCODE_CHANNEL: string
+  readonly OPENCODE_VERSION?: string
 }
 
 interface ImportMeta {

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -12,7 +12,7 @@ import contextMenu from "electron-context-menu"
 
 import type { ServerReadyData } from "../preload/types"
 import { checkAppExists, resolveAppPath } from "./apps"
-import { CHANNEL } from "./constants"
+import { CHANNEL, VERSION } from "./constants"
 import { registerIpcHandlers, sendDeepLinks, sendMenuCommand } from "./ipc"
 import { forwardInitializationFailure } from "./initialization"
 import { exportDebugLogs, initCrashReporter, initLogging, startNetLog, write as writeLog } from "./logging"
@@ -135,7 +135,7 @@ const main = Effect.gen(function* () {
   initCrashReporter()
 
   const wslServers = createWslServersController(
-    app.getVersion(),
+    VERSION,
     async (distro) => {
       logger.log("spawning wsl sidecar", { distro })
       return spawnWslSidecar(distro, {
@@ -165,7 +165,7 @@ const main = Effect.gen(function* () {
   }
 
   logger.log("app starting", {
-    version: app.getVersion(),
+    version: VERSION,
     packaged: app.isPackaged,
     onboardingTest: Boolean(onboardingTestRoot),
   })

--- a/packages/desktop/src/main/logging.ts
+++ b/packages/desktop/src/main/logging.ts
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, wri
 import { ZipWriter, BlobWriter, BlobReader } from "@zip.js/zip.js"
 import { dirname, join } from "node:path"
 import { homedir } from "node:os"
+import { VERSION } from "./constants"
 
 const MAX_LOG_AGE_DAYS = 7
 const TAIL_LINES = 1000
@@ -133,7 +134,7 @@ function cleanup() {
 function manifest() {
   return {
     generated: new Date().toISOString(),
-    version: app.getVersion(),
+    version: VERSION,
     name: app.getName(),
     packaged: app.isPackaged,
     platform: process.platform,

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -33,6 +33,7 @@ import { Splash } from "@opencode-ai/ui/logo"
 import { useTheme } from "@opencode-ai/ui/theme/context"
 
 const root = document.getElementById("root")
+const version = import.meta.env.OPENCODE_VERSION ?? pkg.version
 if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   throw new Error(t("desktop.error.dev.rootNotFound"))
 }
@@ -41,7 +42,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? import.meta.env.MODE,
-    release: import.meta.env.VITE_SENTRY_RELEASE ?? `desktop@${pkg.version}`,
+    release: import.meta.env.VITE_SENTRY_RELEASE ?? `desktop@${version}`,
     initialScope: {
       tags: {
         platform: "desktop",
@@ -168,7 +169,7 @@ const createPlatform = (windowState: DesktopWindowState): Platform => {
   return {
     platform: "desktop",
     os,
-    version: pkg.version,
+    version,
     windowID: windowState.id,
 
     async openDirectoryPickerDialog(opts) {


### PR DESCRIPTION
## Summary
- use the existing local channel throughout desktop development
- share one 2.0.0-local timestamp version between Electron and the local CLI
- discover the isolated server through service-local.json
- show LOCAL in the titlebar and the local version in Settings

## Verification
- built the Electron main, preload, and renderer bundles with a fixed local identity
- confirmed the renderer bundle contains the local version and LOCAL badge
- built the CLI with channel local and the same version
- confirmed the server writes service-local.json with that version

## Type checking
Package type checks remain blocked by existing upstream Core, AI, and Plugin workspace errors. No reported error points to these changed files.