### PR TITLE
fix(tui): truncate fractional mtimes in fresh plugin specifiers

### DIFF
--- a/packages/tui/src/plugin/discovery.ts
+++ b/packages/tui/src/plugin/discovery.ts
@@ -49,7 +49,11 @@ export function localSource(spec: string, directory: string) {
 // of hitting the ESM cache. Bun ignores query params when caching file:// URL
 // imports, so bust with a plain path there; Node keys its cache on the full
 // URL. Mirrors the core plugin supervisor's loader.
+// The mtime is truncated to whole milliseconds: a fractional mtimeMs puts a
+// dot in the query, and Bun's compiled binaries then skip runtime plugin
+// hooks for the import, breaking JSX/solid rewriting for external plugins.
 export function freshSpecifier(entrypoint: string, mtime: number) {
-  if (typeof Bun !== "undefined") return `${fileURLToPath(entrypoint).replaceAll("\\", "/")}?mtime=${mtime}`
-  return `${entrypoint}?mtime=${mtime}`
+  const version = Math.trunc(mtime)
+  if (typeof Bun !== "undefined") return `${fileURLToPath(entrypoint).replaceAll("\\", "/")}?mtime=${version}`
+  return `${entrypoint}?mtime=${version}`
 }

--- a/packages/tui/test/plugin-discovery.test.ts
+++ b/packages/tui/test/plugin-discovery.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
+import { pathToFileURL } from "node:url"
 import { expect, test } from "bun:test"
-import { discoverTuiPlugins, tuiPluginDirectories } from "../src/plugin/discovery"
+import { discoverTuiPlugins, freshSpecifier, tuiPluginDirectories } from "../src/plugin/discovery"
 import { localProjectDirectory } from "../src/util/config-directories"
 import { tmpdir } from "./fixture/fixture"
 
@@ -65,6 +66,14 @@ test("uses an Hg root for a missing project plugin directory", async () => {
   expect(await tuiPluginDirectories(cwd, path.join(tmp.path, "config"))).toContain(
     path.join(project, ".opencode", "plugins", "tui"),
   )
+})
+
+test("truncates fractional mtimes in fresh specifiers", () => {
+  // A dot in the query makes Bun's compiled binaries skip runtime plugin
+  // hooks for the import, breaking JSX/solid rewriting for external plugins.
+  const entrypoint = pathToFileURL(path.resolve("example.tsx")).href
+  const specifier = freshSpecifier(entrypoint, 1786494961337.0317)
+  expect(specifier.endsWith("example.tsx?mtime=1786494961337")).toBe(true)
 })
 
 test("propagates non-missing filesystem errors", async () => {


### PR DESCRIPTION
## What

External TUI plugins that use JSX or import `solid-js` / `@opentui/solid` fail to load in the compiled `opencode2` binary unless a compatible `node_modules` happens to sit above the plugin file. The cause is one character: `freshSpecifier` appends raw `stat.mtimeMs` to the import specifier, and on APFS that value is almost always fractional — `plugin.tsx?mtime=1786494961337.0317`. The extra dot in the query makes Bun's compiled binaries skip runtime plugin hooks (the solid transform and the `opentui:runtime-module:*` resolvers) for that import.

## Before / After

**Before**: the TUI discovers `~/.config/opencode/plugins/tui/pr-indicator.tsx` and imports it as `pr-indicator.tsx?mtime=1786494961337.0317`. OpenTUI's runtime plugin support never sees the import, so the JSX pragma falls through to Bun's native transpiler, which emits `import "@opentui/solid/jsx-dev-runtime"`. That specifier resolves via ordinary `node_modules` walking from the plugin's own directory:

- global config dir (no `node_modules`): hard failure — toast `Plugin: Cannot find module '@opentui/solid/jsx-dev-runtime'`, plugin never loads
- project dir inside a repo with `@opentui/solid` installed: loads a **second** solid instance, so the plugin renders once but host-store reactivity silently breaks

**After**: the specifier is `pr-indicator.tsx?mtime=1786494961337`. Runtime plugin hooks fire, JSX and solid imports rewrite to the host's embedded runtime modules, and the same plugin loads and stays reactive from any discovery directory.

Verified against a minimal compiled repro (`ensureRuntimePluginSupport()` + dynamic import) built with the production build options: the fractional query fails deterministically, the truncated query loads, on both plain and `minify + splitting + solid-plugin` builds.

## How

- `packages/tui/src/plugin/discovery.ts`: `freshSpecifier` truncates the mtime to whole milliseconds before appending it, in both the Bun and Node branches, with a comment pinning why. Cache-bust granularity coarsens from sub-millisecond to 1ms, matching the core plugin supervisor (`Date#getTime()`); the watcher's 100ms reconcile debounce makes a same-millisecond staleness miss unreachable in practice.
- `packages/tui/test/plugin-discovery.test.ts`: regression test asserting a fractional `mtimeMs` produces a dot-free query.

## Scope

- Does not touch the underlying Bun behavior: a dependency-free repro shows `Bun.plugin` onResolve/onLoad are silently bypassed whenever the import specifier's text after its last dot starts with a non-letter (`?mtime=123.456`), in plain `bun` and compiled binaries alike — it only surfaces as a hard failure in compiled binaries because the natively transpiled output can't resolve host packages. Reported upstream as oven-sh/bun#37699; this fix removes the only place we generate such specifiers.
- Does not change how plugin load failures surface (toast only, no dialog row) — separate UX question.

## Testing

- `bun test test/plugin-discovery.test.ts` — new regression test passes.
- `bun test` in `packages/tui` — 661 pass / 0 fail.
- `bun typecheck` in `packages/tui` — clean after rebasing onto `v2` with #41885 (an earlier `v2` HEAD breakage made the first CI run fail; unrelated to this change).
- End-to-end: compiled repro binary loads a real-world JSX plugin (`~/.config/opencode/plugins/tui/pr-indicator.tsx`) with the truncated specifier and fails with the fractional one.
- Independently reviewed pre-merge: version-equality semantics in the plugin registry, 1ms granularity risk, Node-branch URL safety, Windows test behavior, and blast radius (the only other `?mtime=` builder, core's plugin supervisor, already interpolates integers).

```mermaid
sequenceDiagram
    participant R as TUI reconcile
    participant B as Bun module loader
    participant P as runtime plugin hooks
    R->>B: import plugin.tsx?mtime=...337.0317
    Note over B,P: before: hooks skipped (dot in query)
    B-->>R: Cannot find module '@opentui/solid/jsx-dev-runtime'
    R->>B: import plugin.tsx?mtime=...337
    B->>P: onLoad / onResolve fire
    P-->>B: rewrite to opentui:runtime-module:*
    B-->>R: plugin loaded against host solid
```
