### PR TITLE
chore(core): drop obsolete StreamSse hunk from effect patch

### DIFF
--- a/packages/codemode/test/fixtures/opencode-v2-openapi.json
+++ b/packages/codemode/test/fixtures/opencode-v2-openapi.json
@@ -2944,7 +2944,7 @@
                       "type": "string"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/SessionLogItemStream"
+                      "$ref": "#/components/schemas/SessionLogItemJsonString"
                     }
                   },
                   "required": ["id", "event", "data"],
@@ -7211,7 +7211,7 @@
                       "type": "string"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/V2EventStream"
+                      "$ref": "#/components/schemas/V2EventJsonString"
                     }
                   },
                   "required": ["id", "event", "data"],
@@ -14991,7 +14991,7 @@
           }
         ]
       },
-      "SessionLogItemStream": {
+      "SessionLogItemJsonString": {
         "type": "string",
         "contentSchema": {
           "$ref": "#/components/schemas/SessionLogItem"
@@ -23236,7 +23236,7 @@
           }
         ]
       },
-      "V2EventStream": {
+      "V2EventJsonString": {
         "type": "string",
         "contentSchema": {
           "$ref": "#/components/schemas/V2Event"

--- a/patches/effect@4.0.0-beta.101.patch
+++ b/patches/effect@4.0.0-beta.101.patch
@@ -16,34 +16,6 @@ index dd5334d6e42b0881f411fca56688e639cd49c176..ea200a80d6186f07a29d0d231ff1f038
    });
  });
  export {
-diff --git a/dist/unstable/httpapi/HttpApiSchema.js b/dist/unstable/httpapi/HttpApiSchema.js
-index e0fd59143c398fcb13680c74e571ef53f5b4bdc0..5df252aabaf8f9f16dff5b93dcce022745fa52ca 100644
---- a/dist/unstable/httpapi/HttpApiSchema.js
-+++ b/dist/unstable/httpapi/HttpApiSchema.js
-@@ -151,7 +151,7 @@ export const StreamSse = options => {
-   const events = options.events ?? (options.data === undefined ? undefined : Schema.Struct({
-     id: Schema.UndefinedOr(Schema.String),
-     event: Schema.String,
--    data: Schema.fromJsonString(options.data)
-+    data: sseDataJsonSchema(options.data)
-   }));
-   if (events === undefined) {
-     throw new Error("StreamSse requires either an events schema or a data schema");
-@@ -166,6 +166,14 @@ export const StreamSse = options => {
-     error: options.error ?? Schema.Never
-   });
- };
-+const sseDataJsonSchema = data => {
-+  const identifier = SchemaAST.resolveIdentifier(data.ast);
-+  return identifier === undefined ? Schema.fromJsonString(data) : Schema.fromJsonString(data).annotate({
-+    // The SSE transport field is a JSON string. Give that wrapper its own
-+    // OpenAPI identifier so it does not claim the decoded data schema's name.
-+    identifier: `${identifier}Stream`
-+  });
-+};
- /**
-  * Creates a streaming `Uint8Array` success response schema.
-  *
 diff --git a/src/Deferred.ts b/src/Deferred.ts
 index f6d37948bfbe690a7998b06c562e434e1b8ae084..da91e4dc0fd32e534fbc72f7beb0514e67e4ce74 100644
 --- a/src/Deferred.ts
@@ -63,32 +35,3 @@ index f6d37948bfbe690a7998b06c562e434e1b8ae084..da91e4dc0fd32e534fbc72f7beb0514e
      })
    })
  
-diff --git a/src/unstable/httpapi/HttpApiSchema.ts b/src/unstable/httpapi/HttpApiSchema.ts
-index 3899f4fabbbc5f72ab5e6c759db332ee6c3c5633..7e742f76abe64c93b37534c0e1070b0012a4f74f 100644
---- a/src/unstable/httpapi/HttpApiSchema.ts
-+++ b/src/unstable/httpapi/HttpApiSchema.ts
-@@ -430,7 +430,7 @@ export const StreamSse: {
-   const events = options.events ?? (options.data === undefined ? undefined : Schema.Struct({
-     id: Schema.UndefinedOr(Schema.String),
-     event: Schema.String,
--    data: Schema.fromJsonString(options.data)
-+    data: sseDataJsonSchema(options.data)
-   }))
-   if (events === undefined) {
-     throw new Error("StreamSse requires either an events schema or a data schema")
-@@ -446,6 +446,15 @@ export const StreamSse: {
-   })
- }
- 
-+const sseDataJsonSchema = (data: Schema.Constraint) => {
-+  const identifier = SchemaAST.resolveIdentifier(data.ast)
-+  return identifier === undefined ? Schema.fromJsonString(data) : Schema.fromJsonString(data).annotate({
-+    // The SSE transport field is a JSON string. Give that wrapper its own
-+    // OpenAPI identifier so it does not claim the decoded data schema's name.
-+    identifier: `${identifier}Stream`
-+  })
-+}
-+
- /**
-  * Creates a streaming `Uint8Array` success response schema.
-  *


### PR DESCRIPTION
## What

Removes the `StreamSse` hunk from `patches/effect@4.0.0-beta.101.patch`, leaving only the Deferred cleanup guard. Net: **-57 lines of patch**, two OpenAPI components renamed to their upstream-canonical names.

## Why the hunk is obsolete

The hunk dates to #34171 (June 27): at beta.83, `Schema.fromJsonString`'s encoded wrapper inherited the decoded schema's identifier, so the SSE transport wrapper stole `V2Event`'s OpenAPI component name and the real union got renamed `V2Event1`. The hunk worked around it by pinning the wrapper to `${identifier}Stream`.

Upstream accepted this as their bug ([effect-smol#2496](https://github.com/Effect-TS/effect-smol/issues/2496), filed citing opencode) and fixed it **more generally** in [effect-smol#2512](https://github.com/Effect-TS/effect-smol/pull/2512) (merged July 1, shipped since **beta.93**): `fromJsonString` now names its encoded wrapper `${identifier}JsonString` at the transformation boundary. The vendored **beta.101 already contains that fix** — the hunk's only remaining effect was renaming the wrapper components away from what every other Effect user sees.

## Blast radius

- `V2EventStream` → `V2EventJsonString`, `SessionLogItemStream` → `SessionLogItemJsonString` in the served OpenAPI spec
- **Zero TypeScript references** to either name repo-wide; the only committed occurrence is the codemode fixture, renamed in step
- Payload components (`V2Event`, `SessionLogItem`) unaffected — their protection is upstream's fix, verified by upstream tests
- Maintenance win: this exact hunk had stale line offsets that made bun fuzz-apply it mid-overload-signature, shipping syntactically broken TS into the vendored src on every install (repaired in #41858). Fewer hunks, fewer regenerations per effect bump.
- Endgame: the patch file now carries only the Deferred guard (upstream PR in flight) — it deletes entirely at the next effect version bump.

## Testing

- Fresh `bun install --force`: patch applies cleanly; Deferred guard present; SSE code pristine upstream
- Booted the server from this branch: `/openapi.json` serves `V2EventJsonString`/`SessionLogItemJsonString`, payload components intact
- `packages/codemode`: 1089/1089 tests pass against the renamed fixture