### PR TITLE
test(tui): resolve autocomplete paths per platform

### DIFF
--- a/packages/tui/test/prompt/autocomplete.test.ts
+++ b/packages/tui/test/prompt/autocomplete.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import path from "path"
 import type { KeymapCommand } from "@opencode-ai/plugin/tui/context"
 import {
   directoryAutocompleteExactValue,
@@ -58,7 +59,9 @@ describe("directoryAutocompleteSearch", () => {
       query: "pro",
     })
     expect(directoryAutocompleteSearch("~/projects/open", "/project", "/home/user")).toEqual({
-      directory: "/home/user/projects",
+      // The implementation resolves subdirectories with the platform path
+      // module, so expectations resolve too (drive-prefixed on Windows).
+      directory: path.resolve("/home/user/projects"),
       prefix: "~/projects/",
       query: "open",
     })
@@ -66,17 +69,17 @@ describe("directoryAutocompleteSearch", () => {
 
   test("searches from parent prefixes", () => {
     expect(directoryAutocompleteSearch("..", "/project/src", "/home/user")).toEqual({
-      directory: "/project",
+      directory: path.resolve("/project"),
       prefix: "../",
       query: "",
     })
     expect(directoryAutocompleteSearch("../../pac", "/project/src/lib", "/home/user")).toEqual({
-      directory: "/project",
+      directory: path.resolve("/project"),
       prefix: "../../",
       query: "pac",
     })
     expect(directoryAutocompleteSearch("../../..", "/project/src/lib", "/home/user")).toEqual({
-      directory: "/",
+      directory: path.resolve("/"),
       prefix: "../../../",
       query: "",
     })
@@ -89,12 +92,12 @@ describe("directoryAutocompleteSearch", () => {
       query: "src",
     })
     expect(directoryAutocompleteSearch("packages/core", "/project", "/home/user")).toEqual({
-      directory: "/project/packages",
+      directory: path.resolve("/project/packages"),
       prefix: "packages/",
       query: "core",
     })
     expect(directoryAutocompleteSearch("/root/pro", "/project", "/home/user")).toEqual({
-      directory: "/root",
+      directory: path.resolve("/root"),
       prefix: "/root/",
       query: "pro",
     })


### PR DESCRIPTION
## What

Fix `unit (windows)` failures in `packages/tui/test/prompt/autocomplete.test.ts`, introduced with #41870.

## Before / After

**Before:** `directoryAutocompleteSearch` resolves subdirectories with the platform `path` module, but the tests asserted literal POSIX paths. On Windows, `path.resolve("/home/user", "projects/")` produces `C:\home\user\projects`, so three tests failed and blocked any PR that runs the tui test suite on Windows (the `v2` push runs around the merge were failing or cancelled for unrelated reasons, so this surfaced on downstream PRs first, e.g. #41880 and #41883).

**After:** The expected `directory` values that flow through `path.resolve` in the implementation are wrapped in `path.resolve(...)` in the test too — identity on POSIX, drive-prefixed backslash paths on Windows, matching the implementation exactly. Expectations that pass through untouched input strings stay literal.

## Scope

No implementation changes. cc @jlongster in case you'd rather the implementation normalize to forward slashes instead.

## Testing

- `bun run test test/prompt/autocomplete.test.ts` in `packages/tui` (14 pass)
- `bun typecheck` in `packages/tui`
- Windows verification via this PR's `unit (windows)` check
