### PR TITLE
fix(app): use Sublime CLI for open with

### DIFF
--- a/packages/app/src/components/session/open-in-app.test.ts
+++ b/packages/app/src/components/session/open-in-app.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+import { LINUX_OPEN_APPS, WINDOWS_OPEN_APPS } from "./open-in-app"
+
+describe("open in app", () => {
+  test("uses the Sublime Text CLI command outside macOS", () => {
+    expect(WINDOWS_OPEN_APPS.find((app) => app.id === "sublime-text")?.openWith).toBe("subl")
+    expect(LINUX_OPEN_APPS.find((app) => app.id === "sublime-text")?.openWith).toBe("subl")
+  })
+})

--- a/packages/app/src/components/session/open-in-app.tsx
+++ b/packages/app/src/components/session/open-in-app.tsx
@@ -75,7 +75,7 @@ export const WINDOWS_OPEN_APPS = [
     id: "sublime-text",
     label: "session.header.open.app.sublimeText",
     icon: "sublime-text",
-    openWith: "Sublime Text",
+    openWith: "subl",
   },
 ] as const
 
@@ -87,7 +87,7 @@ export const LINUX_OPEN_APPS = [
     id: "sublime-text",
     label: "session.header.open.app.sublimeText",
     icon: "sublime-text",
-    openWith: "Sublime Text",
+    openWith: "subl",
   },
 ] as const
 

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -103,7 +103,7 @@ const WINDOWS_APPS = [
     id: "sublime-text",
     label: "session.header.open.app.sublimeText",
     icon: "sublime-text",
-    openWith: "Sublime Text",
+    openWith: "subl",
   },
 ] as const
 
@@ -115,7 +115,7 @@ const LINUX_APPS = [
     id: "sublime-text",
     label: "session.header.open.app.sublimeText",
     icon: "sublime-text",
-    openWith: "Sublime Text",
+    openWith: "subl",
   },
 ] as const
 


### PR DESCRIPTION
### Issue for this PR

Closes #41694

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the duplicated desktop "Open With" app maps so Sublime Text uses the `subl` CLI on Windows and Linux. The menu label stays "Sublime Text", but the resolver now looks up the executable users actually put on PATH.

### How did you verify your code works?

- `bun test --conditions=solid --preload ./happydom.ts ./src/components/session/open-in-app.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
