### PR TITLE
fix(llm): finalize pending OpenAI Responses tool calls at completion

### DIFF
--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -872,21 +872,43 @@ const onOutputItemDone = Effect.fn("OpenAIResponses.onOutputItemDone")(function*
   return [state, NO_EVENTS] satisfies StepResult
 })
 
-const onResponseFinish = (state: ParserState, event: OpenAIResponsesEvent): StepResult => {
+const onResponseFinish = Effect.fn("OpenAIResponses.onResponseFinish")(function* (
+  state: ParserState,
+  event: OpenAIResponsesEvent,
+) {
+  // A function call announced via `response.output_item.added` but never
+  // completed by `response.output_item.done` stays pending in `state.tools`.
+  // Finalize any remaining assembly so the call settles instead of leaving a
+  // client tool permanently pending. Empty accumulated input parses to `{}`,
+  // so an abandoned call fails normal schema validation rather than hanging.
+  const pending = Object.keys(state.tools)
+  const flush = pending.length > 0 ? yield* ToolStream.finishAll(ADAPTER, state.tools) : undefined
   const events: LLMEvent[] = []
-  const lifecycle = Lifecycle.finish(state.lifecycle, events, {
-    reason: mapFinishReason(event, state.hasFunctionCall),
-    usage: mapUsage(event.response?.usage),
-    providerMetadata:
-      event.response?.id || event.response?.service_tier
-        ? openaiMetadata({
-            responseId: event.response.id,
-            serviceTier: event.response.service_tier,
-          })
-        : undefined,
-  })
-  return [{ ...state, lifecycle }, events]
-}
+  const lifecycle = Lifecycle.finish(
+    flush?.events.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle,
+    events,
+    {
+      reason: mapFinishReason(event, pending.length > 0 || state.hasFunctionCall),
+      usage: mapUsage(event.response?.usage),
+      providerMetadata:
+        event.response?.id || event.response?.service_tier
+          ? openaiMetadata({
+              responseId: event.response.id,
+              serviceTier: event.response.service_tier,
+            })
+          : undefined,
+    },
+  )
+  return [
+    {
+      ...state,
+      lifecycle,
+      hasFunctionCall: pending.length > 0 || state.hasFunctionCall,
+      tools: flush?.tools ?? state.tools,
+    },
+    [...(flush?.events ?? []), ...events],
+  ] satisfies StepResult
+})
 
 // Build a single human-readable message from whatever the provider supplied.
 // When both code and message are present, prefix the code so consumers see
@@ -940,9 +962,9 @@ const step = (state: ParserState, event: OpenAIResponsesEvent) => {
     return Effect.succeed(onReasoningSummaryPartDone(state, event))
   if (event.type === "response.output_item.added") return Effect.succeed(onOutputItemAdded(state, event))
   if (event.type === "response.function_call_arguments.delta") return onFunctionCallArgumentsDelta(state, event)
-  if (event.type === "response.output_item.done") return onOutputItemDone(state, event)
+if (event.type === "response.output_item.done") return onOutputItemDone(state, event)
   if (event.type === "response.completed" || event.type === "response.incomplete")
-    return Effect.succeed(onResponseFinish(state, event))
+    return onResponseFinish(state, event)
   if (event.type === "response.failed") return Effect.succeed(onResponseFailed(state, event))
   if (event.type === "error") return Effect.succeed(onError(state, event))
   return Effect.succeed<StepResult>([state, NO_EVENTS])

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1209,7 +1209,7 @@ describe("OpenAI Responses route", () => {
           providerExecuted: undefined,
           providerMetadata: { openai: { itemId: "item_1" } },
         },
-        { type: "step-finish", index: 0, reason: "tool-calls", usage, providerMetadata: undefined },
+{ type: "step-finish", index: 0, reason: "tool-calls", usage, providerMetadata: undefined },
         {
           type: "finish",
           reason: "tool-calls",
@@ -1217,6 +1217,63 @@ describe("OpenAI Responses route", () => {
           usage,
         },
       ])
+    }),
+  )
+
+  it.effect("finalizes an announced function call when the response completes without output_item.done", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        {
+          type: "response.output_item.added",
+          item: { type: "function_call", id: "item_1", call_id: "call_1", name: "patch", arguments: "" },
+        },
+        { type: "response.completed", response: { usage: { input_tokens: 5, output_tokens: 1 } } },
+      )
+      const response = yield* LLMClient.generate(
+        LLM.updateRequest(request, {
+          tools: [{ name: "patch", description: "Apply changes", inputSchema: { type: "object" } }],
+        }),
+      ).pipe(Effect.provide(fixedResponse(body)))
+      const usage = new Usage({
+        inputTokens: 5,
+        outputTokens: 1,
+        nonCachedInputTokens: 5,
+        cacheReadInputTokens: undefined,
+        reasoningTokens: undefined,
+        totalTokens: 6,
+        providerMetadata: { openai: { input_tokens: 5, output_tokens: 1 } },
+      })
+
+      expect(response.events).toEqual([
+        { type: "step-start", index: 0 },
+        {
+          type: "tool-input-start",
+          id: "call_1",
+          name: "patch",
+          providerMetadata: { openai: { itemId: "item_1" } },
+        },
+        {
+          type: "tool-input-end",
+          id: "call_1",
+          name: "patch",
+          providerMetadata: { openai: { itemId: "item_1" } },
+        },
+        {
+          type: "tool-call",
+          id: "call_1",
+          name: "patch",
+          input: {},
+          providerExecuted: undefined,
+          providerMetadata: { openai: { itemId: "item_1" } },
+        },
+        { type: "step-finish", index: 0, reason: "tool-calls", usage, providerMetadata: undefined },
+        {
+          type: "finish",
+          reason: "tool-calls",
+          providerMetadata: undefined,
+          usage,
+        },
+])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #37159

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A V2 session can leave a local tool permanently "pending" when an OpenAI Responses-compatible stream announces a function call with `response.output_item.added` but reaches `response.completed` without a matching `response.output_item.done`. The parser only finalized pending `ToolStream` entries in `onOutputItemDone`, so the terminal handler closed the lifecycle without flushing `state.tools`. The client then has `tool-input-start` but no call to settle or fail, and the Patch card stays stuck until the session is interrupted.

The fix flushes any remaining pending tool assembly when the response completes or finishes incomplete. `response.completed` / `response.incomplete` now finalize pending tool input through `ToolStream.finishAll`, which emits `tool-input-end` followed by a parsed `tool-call`. Empty accumulated arguments parse to `{}` (via the existing `parseToolInput` fallback), so an abandoned call fails ordinary schema validation immediately instead of hanging. `hasFunctionCall` is set so the emitted `step-finish` uses the `tool-calls` reason. A regression test reproduces the exact reported sequence and asserts the settled call.

### How did you verify your code works?

- `bun test --timeout 30000` in `packages/llm` passes (299 pass / 0 fail), including the new regression test streaming `output_item.added` (empty `patch` arguments) then `response.completed`.
- `tsgo --noEmit` clean in `packages/llm`.
- `oxlint` clean on the changed files.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR