### PR TITLE
feat(server): web-standard fetch handler entry

### DIFF
--- a/packages/server/src/fetch.ts
+++ b/packages/server/src/fetch.ts
@@ -1,0 +1,54 @@
+export * as ServerFetch from "./fetch"
+
+import { Context, Effect, Layer } from "effect"
+import { HttpEffect, HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http"
+import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
+import { isAllowedCorsOrigin } from "./cors"
+import { createRoutes } from "./routes"
+import type { ServerOptions } from "./options"
+
+export interface BootOptions {
+  /**
+   * Resumes execution-journaled Sessions once the application layer boots. Pair with
+   * `SessionExecution.configured({ suspendOnStart: true })` on runtimes that can die without
+   * teardown, so turns orphaned by a hard death replay on the next boot.
+   */
+  readonly resumeSuspendedSessions?: boolean
+}
+
+/**
+ * Builds a web-standard fetch handler — `(request: Request) => Promise<Response>` — serving the
+ * same HttpApi routes as the Node server process without binding a port, owning a listener, or
+ * installing signal handlers. This is the entry for runtimes that hand requests to the embedder
+ * instead of letting it listen: workerd (Workers and Durable Objects), Deno.serve, Bun.serve, or
+ * a test harness.
+ *
+ * The application layer builds EAGERLY, inside the caller's `Scope`, before the handler is
+ * returned. Do not convert this to a lazy first-request build: on workerd, a first request that
+ * aborts mid-build interrupts the layer construction and wedges every subsequent request
+ * (Effect-TS/effect#6319 class). The embedder owns the lifecycle — closing the scope releases
+ * the application layer.
+ *
+ * Auth follows `createRoutes` semantics: `options.password` enforces Basic auth; omitting it
+ * serves unauthenticated, so an embedder without a password must front the handler with its own
+ * access control.
+ */
+export const make = Effect.fn("ServerFetch.make")(function* (
+  options: ServerOptions = {},
+  boot: BootOptions = {},
+) {
+  const context = yield* Layer.build(
+    createRoutes(options, () => []).pipe(Layer.provide(HttpServer.layerServices)),
+  )
+  // Forked so the returned handler is never delayed; resumed drains are already
+  // logged and durably recorded by the execution layer.
+  if (boot.resumeSuspendedSessions)
+    yield* Effect.forkDetach(Context.get(context, SessionRestart.Service).resumeSuspendedSessions)
+  return Context.get(context, HttpRouter.HttpRouter)
+    .asHttpEffect()
+    .pipe(
+      HttpMiddleware.cors({ allowedOrigins: isAllowedCorsOrigin, maxAge: 86_400 }),
+      HttpEffect.toWebHandlerWith(context),
+    )
+})
+

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -1,0 +1,76 @@
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { it } from "../../core/test/lib/effect"
+import { ServerFetch } from "../src/fetch"
+
+const options = {
+  app: { version: "test-version" },
+  database: { path: ":memory:" },
+  fs: { filewatcher: false },
+} as const
+
+it.live("serves the HttpApi and enforces Basic auth like the Node server", () =>
+  Effect.gen(function* () {
+    const handler = yield* ServerFetch.make({ ...options, password: "secret" })
+
+    const denied = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/health")))
+    expect(denied.status).toBe(401)
+
+    const response = yield* Effect.promise(() =>
+      handler(
+        new Request("http://opencode.local/api/health", {
+          headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+        }),
+      ),
+    )
+    expect(response.status).toBe(200)
+    const body: unknown = yield* Effect.promise(() => response.json())
+    if (typeof body !== "object" || body === null) throw new Error("Expected a health response object")
+    expect((body as Record<string, unknown>)["healthy"]).toBe(true)
+  }).pipe(Effect.scoped),
+)
+
+it.live("serves unauthenticated and answers CORS preflight when no password is configured", () =>
+  Effect.gen(function* () {
+    const handler = yield* ServerFetch.make(options)
+
+    const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/health")))
+    expect(response.status).toBe(200)
+
+    const preflight = yield* Effect.promise(() =>
+      handler(
+        new Request("http://opencode.local/api/health", {
+          method: "OPTIONS",
+          headers: {
+            origin: "http://localhost:3000",
+            "access-control-request-method": "GET",
+          },
+        }),
+      ),
+    )
+    expect(preflight.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
+  }).pipe(Effect.scoped),
+)
+
+// Pins the eager-boot guarantee: the application layer is built before the handler returns, so
+// an aborted first request cannot interrupt layer construction and wedge every later request
+// (the Effect-TS/effect#6319 failure class that lazy first-request builds are prone to).
+it.live("stays serviceable when the first request aborts", () =>
+  Effect.gen(function* () {
+    const handler = yield* ServerFetch.make(options)
+
+    const aborted = yield* Effect.promise(() => {
+      const controller = new AbortController()
+      const first = handler(new Request("http://opencode.local/api/health", { signal: controller.signal }))
+      controller.abort()
+      return first.then(
+        () => "resolved" as const,
+        () => "rejected" as const,
+      )
+    })
+    expect(["resolved", "rejected"]).toContain(aborted)
+
+    const second = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/health")))
+    expect(second.status).toBe(200)
+  }).pipe(Effect.scoped),
+)


### PR DESCRIPTION
## What

Adds `ServerFetch.make` to `@opencode-ai/server`: the same HttpApi routes as the Node server process, exposed as a web-standard `(request: Request) => Promise<Response>` handler — no port binding, no listener ownership, no signal handlers.

```ts
// Effect-native, scoped — the embedder owns the lifecycle; closing the scope releases the app layer
const handler = yield* ServerFetch.make({ database: { path: ":memory:" } })
const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/health")))
```

## Destination context — who consumes this

The consumer is the embedded SDK: an `OpenCode.create` that boots the full server in-process and talks to it through this handler instead of a socket, so a Cloudflare Durable Object can host one OpenCode server per Slack thread (live today against a local branch). Follow-ups stack on this seam in order: (1) a workerd runtime profile — Shell/FileSystem/Pty service replacements for a runtime with no subprocesses; (2) an SDK `./workerd` entrypoint wiring profile + handler + DO-SQLite; (3) a workerd-spike test package as a CI purity guard that the server bundle stays free of node-only imports. The same entry serves Deno.serve/Bun.serve embedders and plain test harnesses. This PR is deliberately just the transport seam.

## Design: eager, not lazy — this is load-bearing

Effect v4 offers two converter shapes. `toWebHandlerLayerWith` builds the application layer lazily on the **first request** — and on workerd, a first request that aborts mid-build interrupts layer construction and permanently wedges every subsequent request (the Effect-TS/effect#6319 failure class, independently rediscovered by alchemy's workerd deploy post-mortem). `ServerFetch.make` therefore builds the layer **eagerly inside the caller's `Scope`** before any handler exists, and `toWebHandlerWith(context)` serves requests from the pre-built context. A regression test pins abort-the-first-request-then-serve.

## Parity

- **Auth**: `createRoutes` semantics exactly — `options.password` enforces Basic auth; omitting it serves open (documented; embedders front it with their own access control).
- **CORS**: same `isAllowedCorsOrigin` middleware as the Node listener path.
- **Recovery**: opt-in `resumeSuspendedSessions` boot hook forks the execution-journal resume after layer boot, for runtimes that die without teardown.

## Testing

`packages/server/test/fetch.test.ts`, all against in-memory databases:
- Basic-auth parity (401 unauthenticated / 200 authorized)
- open + CORS preflight when no password configured
- abort-first-request-then-serve (the #6319 regression pin)

Full `packages/server` suite green (33 tests). Note: repo-wide `typecheck` is currently red at v2 head itself (pre-existing nodenext TS2835s in `fff-bun`/`packages/ai`, unrelated).