### PR TITLE
fix(session): fail empty assistant responses instead of recording success

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -315,25 +315,29 @@ const layer = Layer.effect(
           }
           const stepSettlement = publisher.stepSettlement()
           if (stepSettlement && !publisher.hasProviderError()) {
-            const endSnapshot = yield* snapshots.capture()
-            const files =
-              startSnapshot && endSnapshot
-                ? yield* snapshots
-                    .files({ from: startSnapshot, to: endSnapshot })
-                    .pipe(Effect.catch(() => Effect.succeed(undefined)))
-                : undefined
-            yield* withPublication(
-              events.publish(SessionEvent.Step.Ended, {
-                sessionID: session.id,
-                timestamp: yield* DateTime.now,
-                assistantMessageID: yield* publisher.startAssistant(),
-                finish: stepSettlement.finish,
-                cost: 0,
-                tokens: stepSettlement.tokens,
-                snapshot: endSnapshot,
-                files,
-              }),
-            )
+            if (!publisher.hasUsableOutput()) {
+              yield* withPublication(publisher.failAssistant("Provider returned an empty response"))
+            } else {
+              const endSnapshot = yield* snapshots.capture()
+              const files =
+                startSnapshot && endSnapshot
+                  ? yield* snapshots
+                      .files({ from: startSnapshot, to: endSnapshot })
+                      .pipe(Effect.catch(() => Effect.succeed(undefined)))
+                  : undefined
+              yield* withPublication(
+                events.publish(SessionEvent.Step.Ended, {
+                  sessionID: session.id,
+                  timestamp: yield* DateTime.now,
+                  assistantMessageID: yield* publisher.startAssistant(),
+                  finish: stepSettlement.finish,
+                  cost: 0,
+                  tokens: stepSettlement.tokens,
+                  snapshot: endSnapshot,
+                  files,
+                }),
+              )
+            }
           }
           if (publisher.hasProviderError())
             yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -69,6 +69,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
   let assistantActive = false
   let assistantFailed = false
   let providerFailed = false
+  let hasUsableOutput = false
   let stepSettlement: { readonly finish: string; readonly tokens: ReturnType<typeof tokens> } | undefined
 
   const startAssistant = Effect.fnUntraced(function* () {
@@ -120,6 +121,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
 
   const text = fragments("text", (textID, value) =>
     Effect.gen(function* () {
+      if (value.length > 0) hasUsableOutput = true
       yield* events.publish(SessionEvent.Text.Ended, {
         sessionID: input.sessionID,
         assistantMessageID: yield* currentAssistantMessageID(),
@@ -131,6 +133,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
   )
   const reasoning = fragments("reasoning", (reasoningID, value, providerMetadata) =>
     Effect.gen(function* () {
+      if (value.length > 0) hasUsableOutput = true
       yield* events.publish(SessionEvent.Reasoning.Ended, {
         sessionID: input.sessionID,
         assistantMessageID: yield* currentAssistantMessageID(),
@@ -318,6 +321,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           return yield* Effect.die(`Tool call name changed for ${event.id}: ${tool.name} -> ${event.name}`)
         if (tool.called) return yield* Effect.die(`Duplicate tool call: ${event.id}`)
         tool.called = true
+        hasUsableOutput = true
         tool.providerExecuted = event.providerExecuted === true
         tool.providerMetadata = event.providerMetadata
         yield* events.publish(SessionEvent.Tool.Called, {
@@ -416,6 +420,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     hasActiveAssistant: () => assistantActive,
     hasAssistantStarted: () => assistantMessageID !== undefined,
     hasProviderError: () => providerFailed,
+    hasUsableOutput: () => hasUsableOutput,
     stepSettlement: () => stepSettlement,
     startAssistant,
     assistantMessageID: assistantMessageIDForTool,

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -134,3 +134,56 @@ test("step finish records settlement without publishing step ended", async () =>
   expect(published.some((event) => event.type === "session.next.step.ended.2")).toBe(false)
   expect(publisher.stepSettlement()).toMatchObject({ finish: "stop" })
 })
+
+test("reasoning-only step with content records usable output", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.stepStart({ index: 0 })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningStart({ id: "reasoning-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningDelta({ id: "reasoning-0", text: "thinking" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningEnd({ id: "reasoning-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.stepFinish({ index: 0, reason: "stop" })))
+
+  expect(publisher.hasUsableOutput()).toBe(true)
+  expect(publisher.stepSettlement()).toMatchObject({ finish: "stop" })
+})
+
+test("empty reasoning-only step records no usable output", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.stepStart({ index: 0 })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningStart({ id: "reasoning-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningEnd({ id: "reasoning-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.stepFinish({ index: 0, reason: "stop" })))
+
+  expect(publisher.hasUsableOutput()).toBe(false)
+})
+
+test("empty text fragment records no usable output", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.stepStart({ index: 0 })))
+  await Effect.runPromise(publisher.publish(LLMEvent.textStart({ id: "text-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.textEnd({ id: "text-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.stepFinish({ index: 0, reason: "stop" })))
+
+  expect(publisher.hasUsableOutput()).toBe(false)
+})
+
+test("text content records usable output", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.stepStart({ index: 0 })))
+  await Effect.runPromise(publisher.publish(LLMEvent.textStart({ id: "text-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.textDelta({ id: "text-0", text: "Hello" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.textEnd({ id: "text-0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.stepFinish({ index: 0, reason: "stop" })))
+
+  expect(publisher.hasUsableOutput()).toBe(true)
+})
+
+test("tool call records usable output", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.stepStart({ index: 0 })))
+  await Effect.runPromise(publisher.publish(call))
+  await Effect.runPromise(publisher.publish(LLMEvent.stepFinish({ index: 0, reason: "tool-calls" })))
+
+  expect(publisher.hasUsableOutput()).toBe(true)
+})
+

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2653,7 +2653,7 @@ describe("SessionRunnerLLM", () => {
             { type: "tool", id: "call-blocked", state: { status: "error", error: { message: "Permission blocked" } } },
           ],
         },
-        { type: "assistant", finish: "stop" },
+        { type: "assistant", finish: "error", error: { type: "unknown", message: "Provider returned an empty response" } },
       ])
     }),
   )
@@ -2746,7 +2746,7 @@ describe("SessionRunnerLLM", () => {
             { type: "tool", id: "call-corrected", state: { status: "error", error: { message: "Use another tool" } } },
           ],
         },
-        { type: "assistant", finish: "stop" },
+        { type: "assistant", finish: "error", error: { type: "unknown", message: "Provider returned an empty response" } },
       ])
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #37372

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 records a reasoning-only assistant response with no visible text and no tool calls as a successful execution. When a provider settles a step with an empty completion (six output tokens but no publishable content), the runner emits `session.step.ended.1` with `finish: "stop"` followed by `session.execution.succeeded.1` — the user gets neither an answer nor a surfaced failure, and the client stops its typing state silently.

The fix makes the runner judge a settled step by its usable assistant output instead of its token count. The event publisher now records whether a step produced non-empty text, non-empty reasoning, or a tool call. When a step settles with no usable output, the runner publishes `Step.Failed` with a typed `"Provider returned an empty response"` error rather than a successful `Step.Ended`, so clients can surface the failure to the user. Non-empty reasoning-only turns (which providers legitimately emit and existing tests cover) still settle as a successful step. The two runner tests that modeled a completely empty second turn now expect the error.

### How did you verify your code works?

- `bun test --timeout 30000` in `packages/core` passes (1080 pass / 0 fail), including new publisher tests for usable output (text / reasoning / tool call) and empty output (empty text fragment, empty reasoning).
- `tsgo --noEmit` clean in `packages/core`.
- Confirmed the two previously-passing tests that modeled empty continuation turns now assert the empty-response error.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR