### PR TITLE
fix(tui): render instruction updates as compact notices

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -65,6 +65,7 @@ export type SessionMessageSystem = {
   time: { created: number }
   type: "system"
   text: string
+  description?: string
 }
 
 export type SessionMessageSkill = {
@@ -2585,6 +2586,7 @@ export type SessionImportInput = {
           readonly time: { readonly created: number }
           readonly type: "system"
           readonly text: string
+          readonly description?: string
         }
       | {
           readonly id: string
@@ -2837,6 +2839,7 @@ export type SessionImportInput = {
           readonly time: { readonly created: number }
           readonly type: "system"
           readonly text: string
+          readonly description?: string
         }
       | {
           readonly id: string
@@ -3089,6 +3092,7 @@ export type SessionImportInput = {
           readonly time: { readonly created: number }
           readonly type: "system"
           readonly text: string
+          readonly description?: string
         }
       | {
           readonly id: string

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -109,6 +109,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             id: SessionMessage.ID.fromEvent(event.id),
             type: "system",
             text: event.data.text,
+            description: `Instructions updated: ${Object.keys(event.data.delta).join(", ")}`,
             metadata: event.metadata,
             time: { created: event.created },
           }),

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -75,7 +75,10 @@ export interface System extends Schema.Schema.Type<typeof System> {}
 export const System = Schema.Struct({
   ...Base,
   type: Schema.tag("system"),
+  /** The model-facing update text, frozen at emit time. */
   text: Schema.String,
+  /** A short human-readable summary for transcript display. */
+  description: Schema.String.pipe(optional),
 }).annotate({ identifier: "Session.Message.System" })
 
 export interface Skill extends Schema.Schema.Type<typeof Skill> {}

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -505,19 +505,16 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           })
           break
         case "session.instructions.updated":
-          const instructions = event.metadata?.instructions
-          if (
-            typeof instructions === "object" &&
-            instructions !== null &&
-            "initial" in instructions &&
-            instructions.initial === true
-          )
-            break
+          // Mirror the projector: the initial baseline and empty-rendering deltas carry no text
+          // and produce no transcript message.
+          const updateText = event.data.text
+          if (updateText === undefined) break
           message.update(event.data.sessionID, (draft, index) => {
             message.append(draft, index, {
               id: messageIDFromEvent(event.id),
               type: "system",
-              text: `Instructions updated: ${Object.keys(event.data.delta).join(", ")}`,
+              text: updateText,
+              description: `Instructions updated: ${Object.keys(event.data.delta).join(", ")}`,
               metadata: event.metadata,
               time: { created: event.created },
             })

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1688,7 +1688,7 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const state = () => stringValue(metadata()?.state)
   const actor = () => (source() === "shell" ? "Shell" : Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent"))
   const text = () => {
-    if (props.message.type === "system") return props.message.text
+    if (props.message.type === "system") return props.message.description ?? "Instructions updated"
     if (props.message.type === "synthetic") return props.message.description ?? ""
     return ""
   }

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -2889,14 +2889,26 @@ test("skips initial instruction state and projects later updates with their mess
         delta: { "core/date": "1".repeat(64) },
       },
     })
+    emitEvent(events, {
+      id: "evt_instructions_3",
+      created: 2,
+      type: "session.instructions.updated",
+      durable: durable("session-1", 2, 2),
+      data: {
+        sessionID: "session-1",
+        delta: { "core/date": "2".repeat(64) },
+        text: "The current date has changed.",
+      },
+    })
 
-    await wait(() => sync.session.message.list("session-1")?.some((message) => message.time.created === 1))
+    await wait(() => sync.session.message.list("session-1")?.some((message) => message.time.created === 2))
     expect(sync.session.message.list("session-1")).toHaveLength(1)
     expect(sync.session.message.list("session-1")?.[0]).toMatchObject({
-      id: SessionMessage.ID.fromEvent(Event.ID.make("evt_instructions_2")),
+      id: SessionMessage.ID.fromEvent(Event.ID.make("evt_instructions_3")),
       type: "system",
-      text: "Instructions updated: core/date",
-      time: { created: 1 },
+      text: "The current date has changed.",
+      description: "Instructions updated: core/date",
+      time: { created: 2 },
     })
   } finally {
     app.renderer.destroy()


### PR DESCRIPTION
## What

Instruction-update notices in the TUI now always render as a compact one-liner (`◈ Instructions updated: core/codemode`) instead of sometimes dumping the entire model-facing update text — up to a full multi-hundred-line Code Mode catalog — into the transcript.

## Before / After

**Before:** the TUI had two divergent paths for `session.instructions.updated`, and which one you saw depended on *how the message reached you*:

- **Live**: while connected, the client-side event fold synthesized a system message with compact text `Instructions updated: <source keys>`. This is the small notice users are used to.
- **Projected**: on session load or reconnect — which is *always* the path after a server restart — the projected message carries the full frozen model-facing text, and `SessionNoticeMessageV2` rendered `message.text` verbatim. A restart-triggered Code Mode catalog update therefore appeared as a wall of text.

The verbatim render regressed in #36254 (July 10), which replaced the previous hardcoded `"Instructions updated"` label with `props.message.text`. The two paths also disagreed on *whether* to show a message: the projector skips text-less deltas (initial baseline, empty renders), but the live fold only skipped the initial baseline — so a live-shown notice could silently vanish on reload.

**After:** both paths produce the same message shape and the renderer never shows the full text:

- The projected `System` message gains an optional `description` — `Instructions updated: <delta keys>` — built by the projector from the durable event's delta.
- The live fold emits the same shape (full `text`, compact `description`) and now skips text-less deltas exactly like the projector.
- `SessionNoticeMessageV2` renders `description ?? "Instructions updated"` for system messages. The plain-label fallback covers messages projected before this change.

The model-facing contract is untouched: `message.text` still carries the full frozen update, which `to-llm-message.ts` sends as the system message on every request rebuild and compaction summarizes. Only human display changes.

## How

- `packages/schema/src/session-message.ts` — `Session.Message.System` gains optional `description`, mirroring `Synthetic`.
- `packages/core/src/session/message-updater.ts` — projector populates `description` from `event.data.delta` keys.
- `packages/tui/src/context/data.tsx` — live event fold mirrors the projector: skips `text: undefined` events, stores full `text` plus compact `description`.
- `packages/tui/src/routes/session/index.tsx` — `SessionNoticeMessageV2` shows `description ?? "Instructions updated"`, never `text`.
- `packages/client/src/promise/generated/types.ts` — regenerated (`bun run generate` from `packages/client`).

```mermaid
sequenceDiagram
    participant Core as Projector (core)
    participant TUI as TUI event fold
    participant View as SessionNoticeMessageV2

    Note over Core,TUI: session.instructions.updated { delta, text? }
    Core->>Core: skip if text undefined
    Core->>View: System { text, description: "Instructions updated: keys" }
    TUI->>TUI: skip if text undefined (now matching)
    TUI->>View: same shape, synthesized live
    View->>View: render description ?? "Instructions updated"
```

## Scope

- Does not change what the model sees: the frozen full text remains the durable payload and the LLM-request content.
- Does not backfill `description` onto previously projected messages; they fall back to the plain `"Instructions updated"` label. Projections are rebuildable if exact parity is ever wanted.
- The upstream cause of the most common phantom notice (restart snapshot race) is fixed separately in #41884; this PR makes even legitimate updates render compactly.

## Testing

From package directories:

- `packages/schema`, `packages/core`, `packages/tui`, `packages/client`: `bun typecheck` — clean.
- `packages/core`: `bun test test/instruction-state.test.ts test/session-runner.test.ts test/bus.test.ts` — 204 pass.
- `packages/tui`: `bun test test/cli/tui/data.test.tsx test/cli/tui/inline-tool-wrap-snapshot.test.tsx` — 52 pass. The data test previously asserted the divergent live behavior (message for a text-less delta, compact string stored in `text`); it now asserts the unified shape and the text-less skip.
