### PR TITLE
feat(tui): wipe in first generated titles

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -66,6 +66,58 @@ function isPlaceholderSessionTitle(value: string | undefined) {
   return value === NEW_SESSION_TAB_TITLE || value === "Untitled session" || isFallbackTitle(value)
 }
 
+// The soft edge of the title wipe spans a few cells behind the front.
+const WIPE_FEATHER = 3
+// The outgoing title sits dimmed toward the background while it is being replaced.
+const WIPE_OUTGOING_DIM = 0.5
+
+// The first real title wipes in from the left over the placeholder it replaces. Only the
+// placeholder → real transition animates; every other title change jumps, so routine
+// syncs and renames never lag behind the data (the reason the original wipe was removed).
+function createTitleWipe(title: () => string, parts: () => readonly string[], width: () => number, animations: () => boolean) {
+  const [outgoing, setOutgoing] = createSignal<string>()
+  const wipe = createAnimatable(
+    { front: 1 },
+    { enabled: animations, transition: tween({ duration: 0.45, ease: (progress) => 1 - (1 - progress) ** 3 }) },
+  )
+  createEffect((previous: string) => {
+    const next = title()
+    if (next === previous) return next
+    if (!isPlaceholderSessionTitle(previous) || isPlaceholderSessionTitle(next)) {
+      setOutgoing(undefined)
+      wipe.jump({ front: 1 })
+      return next
+    }
+    setOutgoing(previous)
+    wipe.jump({ front: 0 })
+    wipe.animate({ front: 1 })
+    return next
+  }, untrack(title))
+  const active = () => outgoing() !== undefined && wipe.value().front < 1
+  const displayed = createMemo(() => {
+    const front = wipe.value().front
+    const incoming = parts()
+    const previous = outgoing()
+    if (previous === undefined || front >= 1) return incoming
+    const previousParts = Locale.graphemes(Locale.takeWidth(previous, width()))
+    const length = Math.max(incoming.length, previousParts.length)
+    const cut = front * length
+    return Array.from({ length }, (_, index) => (cut - index > 0 ? (incoming[index] ?? " ") : (previousParts[index] ?? " ")))
+  })
+  // Tint toward the background per cell: the outgoing text dims as a block (deepening slightly
+  // as the wipe advances), and freshly revealed characters brighten over the feather behind the
+  // front, so the edge reads as a soft gradient instead of a hard cut.
+  const mix = (index: number) => {
+    if (!active()) return 0
+    const front = wipe.value().front
+    const distance = front * displayed().length - index
+    if (distance <= 0) return Math.min(1, front * 6) * (WIPE_OUTGOING_DIM + 0.25 * front)
+    if (distance < WIPE_FEATHER) return WIPE_OUTGOING_DIM * (1 - distance / WIPE_FEATHER)
+    return 0
+  }
+  return { parts: displayed, mix, active }
+}
+
 function createMarquee(hovered: () => string | undefined, animations: () => boolean) {
   const [offset, setOffset] = createSignal(0)
   const leading = createAnimatable({ opacity: 0 }, { enabled: animations, transition: tween({ duration: 0.25 }) })
@@ -198,7 +250,13 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   ? marqueeText(title(), titleWidth(), marquee.offset())
                   : Locale.takeWidth(title(), titleWidth()),
               )
-              const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
+              const wipe = createTitleWipe(
+                title,
+                createMemo(() => Locale.graphemes(visibleTitle())),
+                titleWidth,
+                animations,
+              )
+              const visibleTitleParts = wipe.parts
               const titleFades = createMemo(() => stringWidth(title()) >= titleWidth() && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
                 const value = session()
@@ -260,7 +318,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 const color = glows()
                   ? glowTextColor(foreground(), glowColor(), 1 + numberWidth() + index, width())
                   : foreground()
-                return titleFades()
+                const faded = titleFades()
                   ? fadeTitleColor(
                       color,
                       pulseBackground(),
@@ -269,6 +327,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       scrolling() ? marquee.leading() : 0,
                     )
                   : color
+                const mix = wipe.mix(index)
+                return mix > 0 ? tint(faded, pulseBackground(), mix) : faded
               }
               const release = () => {
                 setDragging(undefined)
@@ -387,7 +447,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                           undefined
                         }
                       >
-                        <Show when={glows() || titleFades()} fallback={visibleTitle()}>
+                        <Show when={glows() || titleFades() || wipe.active()} fallback={visibleTitleParts().join("")}>
                           <For each={visibleTitleParts()}>
                             {(character, index) => <span style={{ fg: titleColor(index()) }}>{character}</span>}
                           </For>
@@ -701,7 +761,13 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
               ? marqueeText(title(), availableTitleWidth(), marquee.offset())
               : Locale.takeWidth(title(), availableTitleWidth()),
           )
-          const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
+          const wipe = createTitleWipe(
+            title,
+            createMemo(() => Locale.graphemes(visibleTitle())),
+            availableTitleWidth,
+            animations,
+          )
+          const visibleTitleParts = wipe.parts
           const titleFades = createMemo(
             () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
           )
@@ -716,7 +782,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const characterColor = (index: number) => {
             const base = foreground()
             const color = glows() ? glowTextColor(base, glowColor(), 1 + numberWidth() + index, width()) : base
-            return titleFades()
+            const faded = titleFades()
               ? fadeTitleColor(
                   color,
                   background(),
@@ -725,6 +791,8 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   scrolling() ? marquee.leading() : 0,
                 )
               : color
+            const mix = wipe.mix(index)
+            return mix > 0 ? tint(faded, background(), mix) : faded
           }
           // The running sweep's level under the number cell, reported by the pulse renderable.
           const [sweepLevel, setSweepLevel] = createSignal(0)
@@ -799,7 +867,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   selectable={false}
                   attributes={(bold() ?? 0) | (placeholder() ? TextAttributes.ITALIC : 0) || undefined}
                 >
-                  <Show when={glows() || titleFades()} fallback={visibleTitle()}>
+                  <Show when={glows() || titleFades() || wipe.active()} fallback={visibleTitleParts().join("")}>
                     <For each={visibleTitleParts()}>
                       {(character, index) => <span style={{ fg: characterColor(index()) }}>{character}</span>}
                     </For>


### PR DESCRIPTION
## What

The left-to-right title wipe removed in #40318 returns, gated and feathered: when a session's first real title arrives, it wipes in over the placeholder instead of popping.

Stacked on #41921 (dim placeholders), which supplies the placeholder predicate the gate uses.

## Before / After

**Before:** the generated title replaces "Untitled session"/"New session" in a single frame. (And in the original pre-#40318 wipe: a hard splice — full-brightness new characters cut against full-brightness old ones, firing on every title change.)

**After:** the wipe fires only on the placeholder → real transition — the background generated-title moment. The outgoing title dims toward the background the moment the wipe starts, the new title reveals left-to-right behind a 3-cell feathered edge (freshly revealed characters brighten as the front passes), and the front decelerates on an ease-out cubic over 450 ms. Every other title change — user renames, persisted-title sync corrections, real → real updates — jumps immediately, which is what #40318 was fixing.

## How

`packages/tui/src/component/session-tabs.tsx` — `createTitleWipe`, shared by both orientations:

- Keeps the outgoing title and tweens a `front` cut 0 → 1 (`tween` with ease-out cubic, 0.45 s). The gate lives in its effect: any transition that is not placeholder → real jumps to `front: 1` with no outgoing title retained.
- `parts` splices incoming graphemes over outgoing ones per cell (padded with spaces where lengths differ, so a shorter incoming title erases the tail as the front passes).
- `mix(index)` returns a per-cell tint toward the background: the outgoing block sits at ~50% dim (deepening slightly as the wipe advances, with a fast ramp-in so the start doesn't flash), and the `WIPE_FEATHER` cells behind the front ramp freshly revealed characters from dim to full.
- Both layouts feed their existing visible-parts memos through the helper; `characterColor`/`titleColor` apply `mix` after the existing glow and fade treatments, and the per-character render path is forced while a wipe is active.

## Flow

```mermaid
flowchart LR
    change["tab.title changes"] --> gate{"previous title was\na placeholder?"}
    gate -->|no| jump["jump: render new title immediately"]
    gate -->|yes| wipe["wipe: outgoing dims,\nfront reveals with feathered edge"]
    wipe --> settle["450ms ease-out → settled title"]
```

## Scope

- No change to when titles update — only how the one placeholder → real transition renders.
- The tab strip cannot distinguish a user rename from a generated title (`session.renamed` carries no source), so the gate is prior-state based; a user manually titling an untitled session also wipes, which reads fine.

## Testing

- `bun typecheck` (packages/tui) clean.
- `bun run test` (packages/tui): 647 tests, 0 fail.
- Verified live in a real PTY via terminal-control in both orientations: captured mid-wipe frames show the bright incoming prefix, the feathered edge, and the uniformly dimmed outgoing remainder ("**Que**itled session"); a failed first run keeps the placeholder without firing the wipe.

## Demo

Storybook (`OPENCODE_STORY=session-tabs`), vertical rail: two tabs open untitled (dim, italic — from #41921) and earn their titles on their first completed run, each wiping in with the dimmed-outgoing, feathered-edge treatment.

https://github.com/user-attachments/assets/ec4fb121-b20f-4533-8d5e-96d62e4c7fe0
