### PR TITLE
feat(tui): experiments via devtools bar, drafts stay put

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -372,8 +372,6 @@ export interface KeymapCommand {
     readonly aliases?: string[]
     /** Keeps the slash command in the prompt and passes its raw input to run. */
     readonly arguments?: true
-    /** Hides the command from slash completion until its exact name is typed. */
-    readonly secret?: true
   }
   /** Promotes the command in discovery UI. */
   readonly suggested?: boolean | (() => boolean)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -30,7 +30,7 @@ import {
   batch,
   Show,
 } from "solid-js"
-import { createStore, unwrap } from "solid-js/store"
+import { createStore } from "solid-js/store"
 import {
   TuiLifecycleProvider,
   TuiAppProvider,
@@ -62,7 +62,6 @@ import { useConnected } from "./component/use-connected"
 import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
 import { DialogConfig } from "./component/dialog-config"
-import { DialogExperiments } from "./component/dialog-experiments"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogPair, type DialogPairCredentials } from "./component/dialog-pair"
 import { DialogThemeList } from "./component/dialog-theme-list"
@@ -658,22 +657,8 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "Session",
         slash: { name: "new", aliases: ["clear"] },
         run: () => {
-          // With per-tab drafts, a new session is an explicit "this belongs
-          // elsewhere" gesture: move the in-progress draft instead of leaving
-          // a copy behind on the tab it came from.
-          const carried = (() => {
-            if (config.data.experimental?.tab_drafts !== true) return undefined
-            const current = promptRef.current
-            if (!current?.current.text) return undefined
-            // Copy before reset: reset() merges an empty prompt into the same
-            // underlying store object that unwrap exposes.
-            const prompt = { ...unwrap(current.current) }
-            current.reset()
-            return prompt
-          })()
           route.navigate({
             type: "home",
-            prompt: carried,
             location:
               route.data.type === "session"
                 ? (data.session.get(route.data.sessionID)?.location ?? location.ref)
@@ -882,19 +867,6 @@ function App(props: { pair?: DialogPairCredentials }) {
         slash: { name: "settings" },
         run: () => {
           dialog.replace(() => <DialogConfig />)
-        },
-        category: "System",
-      },
-      {
-        // Deliberately absent from the command palette; reachable only by the
-        // secret /baldbeard incantation.
-        name: "opencode.experiments",
-        title: "Experiments",
-        description: "look is my devrel meme face",
-        palette: undefined,
-        slash: { name: "baldbeard", secret: true as const },
-        run: () => {
-          dialog.replace(() => <DialogExperiments />)
         },
         category: "System",
       },

--- a/packages/tui/src/component/devtools-bar.tsx
+++ b/packages/tui/src/component/devtools-bar.tsx
@@ -13,6 +13,8 @@ import { useRoute } from "../context/route"
 import { Keymap } from "../context/keymap"
 import { useTheme, useThemes } from "../context/theme"
 import { DevTools } from "../devtools"
+import { useDialog } from "../ui/dialog"
+import { DialogExperiments } from "./dialog-experiments"
 import { usePlugin } from "../plugin/context"
 import { errorMessage } from "../util/error"
 
@@ -27,6 +29,7 @@ export type RuntimeStatus = "normal" | "medium" | "high"
 export function DevToolsBar() {
   const client = useClient()
   const config = useConfig()
+  const dialog = useDialog()
   const data = useData()
   const location = useLocation()
   const route = useRoute()
@@ -404,6 +407,15 @@ export function DevToolsBar() {
             </For>
           </PanelBox>
         </Show>
+      </BarItem>
+      <BarItem
+        active={false}
+        onClick={() => {
+          close()
+          dialog.replace(() => <DialogExperiments />)
+        }}
+      >
+        <text fg={theme.text.subdued}>Experiments</text>
       </BarItem>
       <box flexGrow={1} minWidth={0}>
         <TimeToFirstDraw visible={timing()} width="100%" fg={theme.text.subdued} label="Time to first draw" />

--- a/packages/tui/src/component/dialog-experiments.tsx
+++ b/packages/tui/src/component/dialog-experiments.tsx
@@ -16,13 +16,14 @@ export const experiments: Experiment[] = [
   {
     id: "tab_drafts",
     title: "Per-tab prompt drafts",
-    description: "Keep unsent prompt drafts on the tab where they were written. New session moves the current draft.",
+    description: "Keep unsent prompt drafts on the tab where they were written. New sessions start blank.",
   },
 ]
 
 export function DialogExperiments() {
   const config = useConfig()
   const toast = useToast()
+  const [selected, setSelected] = createSignal(0)
   const [saving, setSaving] = createSignal(false)
 
   const enabled = (experiment: Experiment) => config.data.experimental?.[experiment.id] === true
@@ -30,14 +31,15 @@ export function DialogExperiments() {
   const options = createMemo(() =>
     experiments.map((experiment, index) => ({
       title: experiment.title,
-      description: experiment.description,
       category: "Experiments",
+      searchText: experiment.description,
       footer: enabled(experiment) ? "on" : "off",
       value: index,
     })),
   )
 
-  async function toggle(index: number) {
+  // All experiments are booleans, so either direction toggles.
+  async function change(index = selected()) {
     if (saving()) return
     const experiment = experiments[index]
     if (!experiment) return
@@ -56,8 +58,23 @@ export function DialogExperiments() {
     <DialogSelect
       title="Experiments"
       options={options()}
-      onSelect={(option) => void toggle(option.value)}
-      footerHints={[{ title: "enter", label: "toggle" }]}
+      onMove={(option) => setSelected(option.value)}
+      onSelect={(option) => void change(option.value)}
+      footerHints={[{ title: "←/→", label: "change" }]}
+      bindings={[
+        {
+          bind: "left",
+          title: "Previous value",
+          group: "Experiments",
+          run: () => void change(),
+        },
+        {
+          bind: "right",
+          title: "Next value",
+          group: "Experiments",
+          run: () => void change(),
+        },
+      ]}
     />
   )
 }

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -512,9 +512,6 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = keymapCommands().flatMap((command) => {
       const slash = command.slash
       if (!slash) return []
-      // Secret commands are incantations: absent from the "/" listing and from
-      // fuzzy matching until the exact name is typed.
-      if (slash.secret && search().toLowerCase() !== slash.name) return []
       return {
         display: `/${slash.name}`,
         description: command.description ?? command.title,

--- a/packages/tui/src/context/keymap.tsx
+++ b/packages/tui/src/context/keymap.tsx
@@ -24,7 +24,6 @@ declare module "@opentui/keymap" {
       name: string
       aliases?: string[]
       arguments?: true
-      secret?: true
     }
   }
 }


### PR DESCRIPTION
## What

Follow-up to #41862 based on first real use of the experiments surface:

1. **The DevTools bar is now the way in.** A new `Experiments` item at the end of the bottom bar opens the experiments dialog. The `/baldbeard` easter-egg command is deleted, along with the `slash.secret` mechanism that existed only to hide it — it was too much special machinery for one joke.
2. **The dialog now matches the settings screen**: current value in the row footer, `←/→ change` hints and bindings, selection tracking — the same interaction grammar as `/settings` instead of a bespoke enter-to-toggle list.
3. **New session no longer steals the draft.** With per-tab drafts on, `<leader>n` previously *moved* the in-progress draft into the new session. Now the new tab starts blank and the draft stays on the tab where it was written — you can always go back and copy it.

## Before / After

**Before:** with `tab_drafts` enabled, typing a draft on tab two and pressing `<leader>n` opened the new session *with the draft in its composer*, and returning to tab two found it empty — the draft had been moved. Reported by Kit as "it stole my stash."

**After:** `<leader>n` opens a blank composer; returning to tab two finds the draft exactly where it was left. Draft movement between tabs is no longer a thing in either direction.

## How

- `packages/tui/src/app.tsx` — deletes the `opencode.experiments` command (and its carried-draft logic in `session.new`); `session.new` is back to the plain navigate-home it was before #41862.
- `packages/tui/src/component/devtools-bar.tsx` — new `Experiments` `BarItem` that closes any open panel and opens `DialogExperiments`.
- `packages/tui/src/component/dialog-experiments.tsx` — restyled to the `DialogConfig` grammar (footer value, left/right bindings, `onMove` selection tracking); description text updated to "New sessions start blank."
- `packages/tui/src/component/prompt/autocomplete.tsx`, `packages/tui/src/context/keymap.tsx`, `packages/plugin/src/tui/context.ts` — remove the `slash.secret` flag and its autocomplete gate.

The draft stash itself (`draft-stash.ts`, per-tab keying, its tests) is untouched — new-session simply no longer reaches into it.

## Scope

- The bar item only exists while `debug.devtools` is on, making DevTools the sole entry point. If experiments should be reachable without DevTools later, the dialog is one `dialog.replace` call from anywhere.
- Arrow-key value cycling matches `/settings` structurally but could not be exercised through opencode-drive (plain arrow presses do not land through the harness — the same limitation as modifier keys, confirmed against `/settings` itself in the same instance). Enter/`onSelect` toggling is verified end-to-end.

## Testing

- `bun typecheck` clean in `packages/tui` and `packages/plugin`; `test/prompt/draft-stash.test.ts` still green.
- End-to-end via opencode-drive against this branch: `/baldbeard` no longer resolves; `Experiments` appears in the DevTools bar; clicking it opens the dialog; toggling writes `experimental.tab_drafts: true`; with the experiment on, a drafted-then-`<leader>n` flow leaves the new tab blank and preserves the draft on the original tab.

## Demo

Recorded end-to-end run: DevTools bar → Experiments dialog → toggle on → draft on session one → `ctrl+x n` opens a blank new session → clicking back to the original tab shows the draft intact.

https://github.com/user-attachments/assets/f7fd8bc8-f029-419c-a55f-23a03d09049a
