### PR TITLE
feat(tui): dim placeholder tab titles

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -16,6 +16,7 @@ import {
   type SessionTab,
   type SessionTabUnread,
 } from "../context/session-tabs-model"
+import { isFallbackTitle } from "@opencode-ai/util/session-title-fallback"
 import { createAnimatable, spring, tween } from "../ui/animation"
 import { Locale } from "../util/locale"
 import { stringWidth } from "../util/string-width"
@@ -58,6 +59,11 @@ function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: nu
   const end = index - (length - FADE_WIDTH) + 1
   const opacity = Math.max(fade(start) * leading, fade(end))
   return opacity === 0 ? color : tint(color, background, opacity)
+}
+
+// A tab title is provisional until the session earns a generated or user-provided one.
+function isPlaceholderSessionTitle(value: string | undefined) {
+  return value === NEW_SESSION_TAB_TITLE || value === "Untitled session" || isFallbackTitle(value)
 }
 
 function createMarquee(hovered: () => string | undefined, animations: () => boolean) {
@@ -185,6 +191,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const numberWidth = () => 2
               const titleWidth = () => Math.max(1, width() - numberWidth() - 2 - (hovered() === tab.sessionID ? 1 : 0))
               const title = () => tab.title ?? "Untitled session"
+              const placeholder = () => isPlaceholderSessionTitle(tab.title)
               const scrolling = () => hovered() === tab.sessionID && marquee.offset() > 0
               const visibleTitle = createMemo(() =>
                 scrolling()
@@ -215,8 +222,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 return sweepLevel() === 0 ? color : tint(color, theme.text.default, 0.15 * sweepLevel())
               }
               const foreground = () => {
-                if (hovered() === tab.sessionID) return theme.text.default
-                return selected() ? theme.text.default : theme.text.subdued
+                const base =
+                  hovered() === tab.sessionID || selected() ? theme.text.default : theme.text.subdued
+                // A provisional title reads dimmer than its neighbors until the real one arrives.
+                return placeholder() ? tint(base, pulseBackground(), 0.35) : base
               }
               const complete = () => status().complete
               const glowHue = () => {
@@ -373,7 +382,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                         fg={foreground()}
                         wrapMode="none"
                         selectable={false}
-                        attributes={selected() ? TextAttributes.BOLD : undefined}
+                        attributes={
+                          (selected() ? TextAttributes.BOLD : 0) | (placeholder() ? TextAttributes.ITALIC : 0) ||
+                          undefined
+                        }
                       >
                         <Show when={glows() || titleFades()} fallback={visibleTitle()}>
                           <For each={visibleTitleParts()}>
@@ -676,6 +688,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const glowColor = () => feedbackColor() ?? accent()
           const glows = () => !selected() && (status().attention || (!status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
+          const placeholder = () => tab !== NEW_SESSION_TAB && isPlaceholderSessionTitle(tab.title)
           const tabNumber = createMemo(() => items().findIndex((item) => item.sessionID === tab.sessionID) + 1)
           // Shortcut labels stay one cell wide: 1-9, 0 for ten, then a neutral dot.
           const numberWidth = () => 2
@@ -693,8 +706,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
             () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > FADE_WIDTH,
           )
           const foreground = () => {
-            if (hovered() === tab.sessionID) return theme.text.default
-            return tint(theme.text.subdued, theme.text.default, selection())
+            const base =
+              hovered() === tab.sessionID ? theme.text.default : tint(theme.text.subdued, theme.text.default, selection())
+            // A provisional title reads dimmer than its neighbors until the real one arrives.
+            return placeholder() ? tint(base, background(), 0.35) : base
           }
           // Title characters sitting over the glow tinge toward its color, following the same
           // spatial falloff as the glow itself; characters beyond the tail stay neutral.
@@ -782,7 +797,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   fg={foreground()}
                   wrapMode="none"
                   selectable={false}
-                  attributes={bold()}
+                  attributes={(bold() ?? 0) | (placeholder() ? TextAttributes.ITALIC : 0) || undefined}
                 >
                   <Show when={glows() || titleFades()} fallback={visibleTitle()}>
                     <For each={visibleTitleParts()}>

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -1,6 +1,7 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
-import { batch, createSignal, For, onCleanup } from "solid-js"
+import { batch, createSignal, For, onCleanup, Show } from "solid-js"
+import { useConfig } from "../../../config"
 import { createStore, reconcile } from "solid-js/store"
 import { EMPTY_SESSION_TAB_STATUS, SessionTabs, type SessionTabsController } from "../../../component/session-tabs"
 import { moveSessionTab } from "../../../context/session-tabs-model"
@@ -38,6 +39,9 @@ const TRANSCRIPT_FILES = [
 
 function SessionTabsStory(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
+  const config = useConfig().data
+  // The story follows the configured layout so both orientations are exercised.
+  const orientation = () => (config.tabs.layout === "vertical" ? ("vertical" as const) : undefined)
   const theme = props.context.theme
   const elevatedTheme = theme.contextual.elevated
   // A keyed store mirrors production: retitles mutate rows in place instead of remounting them.
@@ -320,39 +324,43 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     <box
       width={dimensions().width}
       height={dimensions().height}
-      flexDirection="column"
+      flexDirection={orientation() === "vertical" ? "row" : "column"}
       backgroundColor={theme.background.default}
     >
-      <SessionTabs controller={controller} />
-      <box height={1} />
-      <box flexGrow={1} paddingLeft={2} paddingRight={2} flexDirection="column">
-        <For each={transcript()}>
-          {(line) => (
-            <text fg={line.color} wrapMode="none" selectable={false}>
-              {line.text || " "}
-            </text>
-          )}
-        </For>
-      </box>
-      <box paddingLeft={2} flexDirection="column">
-        <text fg={theme.text.subdued}>
-          selected: {number(active() ?? "")} | state: {selectedState()}
-        </text>
-        <text fg={theme.text.subdued}>background: {lastEvent()}</text>
-      </box>
-      <box
-        height={1}
-        flexShrink={0}
-        backgroundColor={elevatedTheme.background.default}
-        paddingLeft={1}
-        paddingRight={1}
-        flexDirection="row"
-      >
-        <text fg={elevatedTheme.text.subdued}>storybook / tabs</text>
-        <box flexGrow={1} />
-        <text fg={elevatedTheme.text.subdued}>
-          space/s run | t add | d close | r reset | ←/→ 1-0 move | drag reorders | esc back
-        </text>
+      <SessionTabs controller={controller} orientation={orientation()} />
+      <box flexGrow={1} flexDirection="column">
+        <Show when={orientation() === undefined}>
+          <box height={1} />
+        </Show>
+        <box flexGrow={1} paddingLeft={2} paddingRight={2} flexDirection="column">
+          <For each={transcript()}>
+            {(line) => (
+              <text fg={line.color} wrapMode="none" selectable={false}>
+                {line.text || " "}
+              </text>
+            )}
+          </For>
+        </box>
+        <box paddingLeft={2} flexDirection="column">
+          <text fg={theme.text.subdued}>
+            selected: {number(active() ?? "")} | state: {selectedState()}
+          </text>
+          <text fg={theme.text.subdued}>background: {lastEvent()}</text>
+        </box>
+        <box
+          height={1}
+          flexShrink={0}
+          backgroundColor={elevatedTheme.background.default}
+          paddingLeft={1}
+          paddingRight={1}
+          flexDirection="row"
+        >
+          <text fg={elevatedTheme.text.subdued}>storybook / tabs</text>
+          <box flexGrow={1} />
+          <text fg={elevatedTheme.text.subdued}>
+            space/s run | t add | d close | r reset | ←/→ 1-0 move | drag reorders | esc back
+          </text>
+        </box>
       </box>
     </box>
   )


### PR DESCRIPTION
## What

A tab whose session has not earned a real title yet ("Untitled session", "New session", or a legacy timestamped fallback) renders dimmer and italic in both tab orientations, so a provisional title is visually distinct from a real one — even while the tab is selected and bold.

Follow-up to #41887. The title arrival animation builds on this separately in #41903.

## How

- `packages/tui/src/component/session-tabs.tsx` — `isPlaceholderSessionTitle` centralizes the provisional-title predicate over `isFallbackTitle` from `@opencode-ai/util/session-title-fallback` plus the tab-local placeholder strings. Both layouts tint a placeholder title 35% toward the row background in `foreground()` and add `ITALIC` to the title text.
- `packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx` — the tabs story now follows the configured `tabs.layout`, so the vertical rail is exercisable in the storybook; its untitled-tab fixture (add a tab, run it, it "earns" its title) drives the placeholder → real transition end to end. Separate commit.

## Scope

- The placeholder *text* is unchanged in this PR; replacing "New session"/"Untitled session" with something better (e.g. an excerpt of the first prompt) is under discussion.
- Whether italic should be reserved for a future VS Code-style preview-tab affordance is also open; dropping italic here would be a one-line change per layout.

## Testing

- `bun typecheck` (packages/tui) clean.
- `bun run test` (packages/tui): 647 tests, 0 fail, verified per commit.
- Verified live in a real PTY via terminal-control in both orientations, including the selected + placeholder combination (dim wins over the selected brightening, bold is kept).

## Demo

Horizontal strip — tab 7 is selected yet visibly provisional next to real titles:

![placeholder-untitled.png](https://github.com/user-attachments/assets/3c9723b6-7c54-4f5d-80b4-d4ece4fc844e)

Vertical rail — same treatment, selected placeholder above the new-session affordance:

![rail-placeholder.png](https://github.com/user-attachments/assets/dcdd75e6-b513-44de-82f5-db8908e939f9)
