### PR TITLE
feat(tui): compact turn token usage with expandable steps

### DIFF
--- a/packages/tui/src/component/devtools-bar.tsx
+++ b/packages/tui/src/component/devtools-bar.tsx
@@ -381,16 +381,18 @@ export function DevToolsBar() {
               >
                 {turnTokens() ? "[x]" : "[ ]"} Turn token usage
               </Action>
-              <Action
-                onClick={() =>
-                  void config.update((draft) => {
-                    draft.debug = { ...draft.debug, turn_tokens: verboseTurnTokens() ? true : "verbose" }
-                  })
-                }
-                hoverBackground
-              >
-                {verboseTurnTokens() ? "[x]" : "[ ]"} Turn token usage (verbose)
-              </Action>
+              <Show when={Boolean(turnTokens())}>
+                <Action
+                  onClick={() =>
+                    void config.update((draft) => {
+                      draft.debug = { ...draft.debug, turn_tokens: verboseTurnTokens() ? true : "verbose" }
+                    })
+                  }
+                  hoverBackground
+                >
+                  {verboseTurnTokens() ? "[x]" : "[ ]"} Turn token usage (verbose)
+                </Action>
+              </Show>
             </box>
             <For each={groups()}>
               {(group) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1285,9 +1285,6 @@ function TurnTokenUsage(props: {
             setExpanded((value) => !value)
           }}
         >
-          <text width={INLINE_TOOL_ICON_WIDTH} fg={theme.text.subdued}>
-            ◈
-          </text>
           <text fg={hover() ? theme.text.default : theme.text.subdued} wrapMode="none">
             <span>{expanded() ? "- " : "+ "}</span>
             <span style={{ attributes: TextAttributes.BOLD }}>Tokens</span>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1222,6 +1222,11 @@ function TurnTokenUsage(props: {
 }) {
   const config = useConfig()
   const theme = useTheme()
+  const renderer = useRenderer()
+  // Collapsed by default: one summary line for the whole turn. Click to
+  // open the full per-step table, click again to close.
+  const [expanded, setExpanded] = createSignal(false)
+  const [hover, setHover] = createSignal(false)
   const verbose = () => config.data.debug?.turn_tokens === "verbose"
   const steps = createMemo(() => {
     let previousCache = props.previousCache
@@ -1257,49 +1262,82 @@ function TurnTokenUsage(props: {
     cached: Math.max("Cached".length, ...steps().map((item) => item.cached.toLocaleString().length)),
     total: Math.max("Total".length, ...steps().map((item) => item.total.toLocaleString().length)),
   }))
+  const summary = createMemo(() => {
+    const items = steps()
+    const last = items[items.length - 1]
+    return {
+      count: items.length,
+      newTokens: items.reduce((sum, item) => sum + item.newTokens, 0),
+      cached: last?.cached ?? 0,
+      total: last?.total ?? 0,
+      reuseDrops: items.filter((item) => item.reuseDrop !== undefined).length,
+    }
+  })
   return (
     <Show when={Boolean(config.data.debug?.turn_tokens) && steps().length > 0}>
       <box paddingLeft={3} flexDirection="column">
-        <box flexDirection="row">
+        <box
+          flexDirection="row"
+          onMouseOver={() => setHover(true)}
+          onMouseOut={() => setHover(false)}
+          onMouseUp={() => {
+            if (renderer.getSelection()?.getSelectedText()) return
+            setExpanded((value) => !value)
+          }}
+        >
           <text width={INLINE_TOOL_ICON_WIDTH} fg={theme.text.subdued}>
             ◈
           </text>
-          <text fg={theme.text.subdued} attributes={TextAttributes.BOLD}>
-            Tokens
+          <text fg={hover() ? theme.text.default : theme.text.subdued} wrapMode="none">
+            <span>{expanded() ? "- " : "+ "}</span>
+            <span style={{ attributes: TextAttributes.BOLD }}>Tokens</span>
+            <span>
+              : {summary().count} {summary().count === 1 ? "step" : "steps"} ·{" "}
+              {summary().newTokens.toLocaleString()} new · {summary().cached.toLocaleString()} cached ·{" "}
+              {summary().total.toLocaleString()} total
+            </span>
+            <Show when={summary().reuseDrops > 0}>
+              <span style={{ fg: theme.text.feedback.warning.default }}>
+                {" "}
+                · ! {summary().reuseDrops} likely cache {summary().reuseDrops === 1 ? "bust" : "busts"}
+              </span>
+            </Show>
           </text>
         </box>
-        <box paddingLeft={INLINE_TOOL_ICON_WIDTH}>
-          <text fg={theme.text.subdued} attributes={TextAttributes.ITALIC}>
-            {"Step".padEnd(columns().step + 2)}
-            {"New".padStart(columns().newTokens)}
-            {"  "}
-            {"Cached".padStart(columns().cached)}
-            {"  "}
-            {"Total".padStart(columns().total)}
-          </text>
-        </box>
-        <For each={steps()}>
-          {(item) => (
-            <box paddingLeft={INLINE_TOOL_ICON_WIDTH} flexDirection="column">
-              <text fg={verbose() && item.finish === "tool-call" ? undefined : theme.text.subdued}>
-                {item.finish.padEnd(columns().step + 2)}
-                <span style={{ attributes: TextAttributes.BOLD }}>
-                  {item.newTokens.toLocaleString().padStart(columns().newTokens)}
-                </span>
-                {"  "}
-                {item.cached.toLocaleString().padStart(columns().cached)}
-                {"  "}
-                {item.total.toLocaleString().padStart(columns().total)}
-              </text>
-              <TurnTokenToolCalls tools={item.tools} />
-              <Show when={item.reuseDrop !== undefined}>
-                <text fg={theme.text.feedback.warning.default}>
-                  ! Likely cache bust: {item.reuseDrop?.toLocaleString()} fewer cached tokens than the previous step
+        <Show when={expanded()}>
+          <box paddingLeft={INLINE_TOOL_ICON_WIDTH}>
+            <text fg={theme.text.subdued} attributes={TextAttributes.ITALIC}>
+              {"Step".padEnd(columns().step + 2)}
+              {"New".padStart(columns().newTokens)}
+              {"  "}
+              {"Cached".padStart(columns().cached)}
+              {"  "}
+              {"Total".padStart(columns().total)}
+            </text>
+          </box>
+          <For each={steps()}>
+            {(item) => (
+              <box paddingLeft={INLINE_TOOL_ICON_WIDTH} flexDirection="column">
+                <text fg={verbose() && item.finish === "tool-call" ? undefined : theme.text.subdued}>
+                  {item.finish.padEnd(columns().step + 2)}
+                  <span style={{ attributes: TextAttributes.BOLD }}>
+                    {item.newTokens.toLocaleString().padStart(columns().newTokens)}
+                  </span>
+                  {"  "}
+                  {item.cached.toLocaleString().padStart(columns().cached)}
+                  {"  "}
+                  {item.total.toLocaleString().padStart(columns().total)}
                 </text>
-              </Show>
-            </box>
-          )}
-        </For>
+                <TurnTokenToolCalls tools={item.tools} />
+                <Show when={item.reuseDrop !== undefined}>
+                  <text fg={theme.text.feedback.warning.default}>
+                    ! Likely cache bust: {item.reuseDrop?.toLocaleString()} fewer cached tokens than the previous step
+                  </text>
+                </Show>
+              </box>
+            )}
+          </For>
+        </Show>
       </box>
     </Show>
   )


### PR DESCRIPTION
## What

The `debug.turn_tokens` diagnostic renders a per-turn "Tokens" table in the session transcript. With tool-heavy turns it prints one row per step and easily exceeds 30 rows per turn, even in non-verbose mode. This PR collapses that table into a single compact summary line by default and makes it click-to-expand.

## Before / After

**Before**: enabling `debug.turn_tokens` rendered the full table for every completed turn — a header row plus one row per LLM step (Step / New / Cached / Total), unconditionally. A 30-step agentic turn produced 30+ transcript rows of diagnostics. The "Turn token usage (verbose)" checkbox in the DevTools Tools panel was always visible, even when the parent "Turn token usage" toggle was off, where toggling it had no visible effect.

**After**: each turn renders one line:

```
+ Tokens: 4 steps · 5,944 new · 4,500 cached · 5,520 total
```

- step count, summed new tokens across steps, and the final step's cached/total figures
- clicking the line expands the original per-step table in place (`+` becomes `-`); clicking again collapses it
- likely cache busts surface on the compact line as a warning-colored suffix (`· ! 2 likely cache busts`), so the signal that matters is never hidden behind the fold
- the verbose checkbox only appears in the DevTools Tools panel once "Turn token usage" is enabled

Nothing renders when the setting is off, exactly as before.

## How

- `packages/tui/src/routes/session/index.tsx` — `TurnTokenUsage` gains `expanded`/`hover` signals. The header row follows the existing transcript idioms: `+ `/`- ` toggle prefix (as in the collapsed reasoning header), hover highlight, and a `renderer.getSelection()` guard so text selection doesn't toggle (as in `InlineTool`). The per-step table and cache-bust detail rows are unchanged, just wrapped in `<Show when={expanded()}>`. A `summary` memo derives the compact figures from the existing `steps` memo.
- `packages/tui/src/component/devtools-bar.tsx` — the "Turn token usage (verbose)" `Action` is wrapped in `<Show when={Boolean(turnTokens())}>`, making it a visible refinement of the parent toggle rather than a peer.

## Scope

- No changes to how token usage is collected or to the `turn-usage` row reduction in `rows.ts`.
- Expanded/collapsed state is per-render component state; it intentionally resets on transcript rebuild (replay, resize), like other transcript expand states.
- Verbose mode still only affects the expanded table (tool-call detail rows); the compact line is identical in both modes.

## Testing

- `bun typecheck` in `packages/tui` — clean.
- End-to-end via opencode-drive against this branch (`--dev` worktree): scripted a 4-step turn (3 tool calls + final text) with simulated OpenAI usage chunks, enabled the setting from the DevTools Tools panel, and verified compact line → click to expand (full Step/New/Cached/Total table) → click to collapse, plus the verbose checkbox appearing only after enabling the parent toggle.

## Demo

Recorded from the end-to-end run above (simulated model; real TUI):

https://github.com/user-attachments/assets/58047a13-11e1-4d16-8da6-05d8f5aae159
