### PR TITLE
docs(ecosystem): add director plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [director](https://github.com/colinsurprenant/director)                                            | Coordination ledger: decisions, open loops, handoffs; one log across OpenCode, Claude Code, Codex  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A (the ecosystem page invites listing PRs directly)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `director` to the ecosystem docs plugin list in `packages/web/src/content/docs/ecosystem.mdx`.

Director is an Apache-2.0 coordination ledger for coding-agent work: sessions record decisions, open loops, and handoffs to an append-only log, and the current state is injected into every new session as ground truth. Its OpenCode integration is a managed plugin: `director install --opencode` drops a self-contained plugin at `~/.config/opencode/plugin/director.js` plus `/director-*` custom commands, and modifies no config files. The same log is shared with its Claude Code and Codex integrations.

Project link: https://github.com/colinsurprenant/director

### How did you verify your code works?

- Confirmed the entry was added to the `Plugins` table in `packages/web/src/content/docs/ecosystem.mdx` only, padded to the table's column width
- Verified the link target and description match the project's GitHub repo
- English page only, matching how prior listing PRs were handled (e.g. #29788)

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

