### PR TITLE
fix(opencode): reject ambiguous fuzzy edits

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -702,22 +702,36 @@ export function replace(content: string, oldString: string, newString: string, r
     ContextAwareReplacer,
     MultiOccurrenceReplacer,
   ]) {
+    const matches = new Map<string, { index: number; search: string }>()
     for (const search of replacer(content, oldString)) {
-      const index = content.indexOf(search)
-      if (index === -1) continue
-      notFound = false
       if (isDisproportionateMatch(search, oldString)) {
         throw new Error(
           "Refusing replacement because the matched span is much larger than oldString. Re-read the file and provide the full exact oldString for the intended replacement.",
         )
       }
-      if (replaceAll) {
-        return content.replaceAll(search, newString)
+      for (const index of searchIndices(content, search)) {
+        matches.set(`${index}:${index + search.length}`, { index, search })
       }
-      const lastIndex = content.lastIndexOf(search)
-      if (index !== lastIndex) continue
-      return content.substring(0, index) + newString + content.substring(index + search.length)
     }
+
+    if (matches.size === 0) continue
+    notFound = false
+    const candidates = Array.from(matches.values())
+
+    if (replaceAll) {
+      return candidates
+        .sort((a, b) => b.index - a.index)
+        .reduce(
+          (next, match) =>
+            next.substring(0, match.index) + newString + next.substring(match.index + match.search.length),
+          content,
+        )
+    }
+    if (candidates.length === 1) {
+      const [match] = candidates
+      return content.substring(0, match.index) + newString + content.substring(match.index + match.search.length)
+    }
+    throw new Error("Found multiple matches for oldString. Provide more surrounding context to make the match unique.")
   }
 
   if (notFound) {
@@ -726,6 +740,19 @@ export function replace(content: string, oldString: string, newString: string, r
     )
   }
   throw new Error("Found multiple matches for oldString. Provide more surrounding context to make the match unique.")
+}
+
+function searchIndices(content: string, search: string) {
+  const indices: number[] = []
+  if (search === "") return indices
+  let start = 0
+
+  while (true) {
+    const index = content.indexOf(search, start)
+    if (index === -1) return indices
+    indices.push(index)
+    start = index + search.length
+  }
 }
 
 function isDisproportionateMatch(search: string, oldString: string) {

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -263,6 +263,20 @@ describe("tool.edit", () => {
       }),
     )
 
+    it.instance("rejects ambiguous whitespace-normalized matches", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "file.txt")
+        const original = "alpha   beta\nalpha\tbeta\n"
+        yield* put(filepath, original)
+
+        expect(
+          (yield* fail({ filePath: filepath, oldString: "alpha beta", newString: "updated" })).message,
+        ).toContain("Found multiple matches")
+        expect(yield* load(filepath)).toBe(original)
+      }),
+    )
+
     it.instance("emits change event for existing files", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #41872

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The edit replacer now collects all spans found by a matching strategy before applying a change. If a fuzzy strategy matches multiple concrete spans and `replaceAll` is false, it reports the existing multiple-match error instead of editing the first byte-unique candidate. With `replaceAll`, it applies the replacement across the matched spans.

This keeps whitespace-normalized matches like `alpha   beta` and `alpha\tbeta` from bypassing the ambiguity guard.

### How did you verify your code works?

- `bun test test/tool/edit.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

N/A; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR