### PR TITLE
fix(tui): configure new session location

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -38,6 +38,7 @@ import {
   TuiStartupProvider,
   TuiTerminalEnvironmentProvider,
   useTuiApp,
+  useTuiPaths,
   useTuiStartup,
   type TuiApp,
 } from "./context/runtime"
@@ -85,6 +86,7 @@ import { ArgsProvider, useArgs, type Args } from "./context/args"
 import open from "open"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { Config, ConfigProvider, useConfig } from "./config"
+import { newSessionLocation } from "./config/new-session-location"
 import { PluginProvider, usePlugin, type PackageResolver } from "./plugin/context"
 import { tuiPluginDirectories } from "./plugin/discovery"
 import { PluginRoute, Slot } from "./plugin/render"
@@ -453,6 +455,7 @@ function App(props: { pair?: DialogPairCredentials }) {
   const log = useLog({ component: "app" })
   const app = useTuiApp()
   const startup = useTuiStartup()
+  const paths = useTuiPaths()
   const config = useConfig()
   const devtools = createMemo(() => config.data.debug?.devtools ?? app.channel === "local")
   const route = useRoute()
@@ -659,10 +662,13 @@ function App(props: { pair?: DialogPairCredentials }) {
         run: () => {
           route.navigate({
             type: "home",
-            location:
+            location: newSessionLocation(
+              config.data.session.new_location,
+              paths.cwd,
               route.data.type === "session"
                 ? (data.session.get(route.data.sessionID)?.location ?? location.ref)
                 : undefined,
+            ),
           })
           dialog.clear()
         },

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -94,6 +94,15 @@ export const settings: Setting[] = [
     keywords: ["attachments", "images", "tool output"],
   },
   {
+    title: "New session location",
+    category: "Session",
+    path: ["session", "new_location"],
+    default: "launch",
+    values: ["launch", "inherit"],
+    labels: ["launch directory", "active session"],
+    keywords: ["directory", "cwd", "inherit"],
+  },
+  {
     title: "Enabled",
     category: "Tabs",
     path: ["tabs", "enabled"],

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -137,6 +137,9 @@ export const Info = Schema.Struct({
       markdown: Schema.optional(Schema.Literals(["source", "rendered"])).annotate({
         description: "Show Markdown syntax markers or conceal them in rendered transcript content",
       }),
+      new_location: Schema.optional(Schema.Literals(["launch", "inherit"])).annotate({
+        description: "Start new sessions in the TUI launch directory or inherit the active session location",
+      }),
     }),
   ).annotate({ description: "Session transcript presentation settings" }),
   tabs: Schema.optional(
@@ -202,7 +205,7 @@ export const Info = Schema.Struct({
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "cursor" | "keybinds" | "leader" | "mouse" | "tabs"> & {
+export type Resolved = Omit<Info, "attention" | "cursor" | "keybinds" | "leader" | "mouse" | "session" | "tabs"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -217,6 +220,9 @@ export type Resolved = Omit<Info, "attention" | "cursor" | "keybinds" | "leader"
   cursor?: {
     style: "block" | "underline" | "line" | "default"
     blinking: boolean
+  }
+  session: Omit<NonNullable<Info["session"]>, "new_location"> & {
+    new_location: "launch" | "inherit"
   }
   tabs: {
     enabled: boolean
@@ -259,6 +265,10 @@ export function resolve(input: Info, options: { terminalSuspend: boolean }): Res
           blinking: input.cursor.blinking ?? true,
         }
       : undefined,
+    session: {
+      ...input.session,
+      new_location: input.session?.new_location ?? "launch",
+    },
     tabs: {
       ...input.tabs,
       enabled: input.tabs?.enabled ?? true,

--- a/packages/tui/src/config/new-session-location.ts
+++ b/packages/tui/src/config/new-session-location.ts
@@ -1,0 +1,10 @@
+import type { LocationRef } from "@opencode-ai/client/promise"
+
+export function newSessionLocation(
+  mode: "launch" | "inherit",
+  launchDirectory: string,
+  current?: LocationRef,
+): LocationRef {
+  if (mode === "inherit" && current) return current
+  return { directory: launchDirectory }
+}

--- a/packages/tui/src/mini/runtime.ts
+++ b/packages/tui/src/mini/runtime.ts
@@ -11,6 +11,7 @@
 import { SessionMessage } from "@opencode-ai/schema/session-message"
 import type { LocationRef } from "@opencode-ai/client/promise"
 import type { Config } from "../config"
+import { newSessionLocation } from "../config/new-session-location"
 import { loadRunAgents, loadRunCommands, loadRunReferences } from "./catalog.shared"
 import {
   resolveMiniSettings,
@@ -48,6 +49,7 @@ type Reconnect = (signal: AbortSignal) => Promise<RunInput["sdk"]>
 
 type RunRuntimeInput = {
   host: MiniHost
+  directory: string
   boot: () => Promise<BootContext>
   resolveSession: (sdk: RunInput["sdk"], signal: AbortSignal) => Promise<ResolvedSession>
   createSession?: CreateSession
@@ -941,7 +943,11 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
               const created = await createSession(
                 state.sdk,
                 {
-                  location: state.location,
+                  location: newSessionLocation(
+                    (await tuiConfigTask).session.new_location,
+                    input.directory,
+                    state.location,
+                  ),
                   agent: state.agent,
                   model: state.model,
                   variant: state.activeVariant,
@@ -1099,6 +1105,7 @@ export async function runInteractiveDeferredMode(input: RunDeferredInput, deps?:
   return runInteractiveRuntime(
     {
       host: input.host,
+      directory: input.directory,
       files: input.files,
       initialInput: input.initialInput,
       thinking: input.thinking,

--- a/packages/tui/src/mini/types.ts
+++ b/packages/tui/src/mini/types.ts
@@ -392,7 +392,7 @@ export type FormCancel = {
   location?: LocationRef
 }
 
-export type RunTuiConfig = Pick<Config.Resolved, "keybinds" | "leader" | "theme" | "mini">
+export type RunTuiConfig = Pick<Config.Resolved, "keybinds" | "leader" | "theme" | "mini" | "session">
 
 export type MiniSettings = {
   thinking: "show" | "hide"

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -25,6 +25,8 @@ test("validates the session tabs setting", () => {
   expect(() => decode({ tabs: { enabled: "on" } })).toThrow()
   expect(decode({ prompt: { image_preview: true } })).toEqual({ prompt: { image_preview: true } })
   expect(decode({ session: { image_preview: true } })).toEqual({ session: { image_preview: true } })
+  expect(decode({ session: { new_location: "inherit" } })).toEqual({ session: { new_location: "inherit" } })
+  expect(() => decode({ session: { new_location: "current" } })).toThrow()
 })
 
 test("resolves nested config and keybind defaults", () => {
@@ -45,12 +47,17 @@ test("resolves nested config and keybind defaults", () => {
   expect(config.diffs).toEqual({ view: "split" })
   expect(config.debug).toEqual({ devtools: true })
   expect(config.tabs).toEqual({ enabled: true, scope: "cwd", layout: "horizontal" })
+  expect(config.session.new_location).toBe("launch")
 })
 
 test("shows resolved tab defaults in settings", () => {
   expect(settings.find((setting) => setting.path.join(".") === "tabs.enabled")?.default).toBe(true)
   expect(settings.find((setting) => setting.path.join(".") === "tabs.scope")?.default).toBe("cwd")
   expect(settings.find((setting) => setting.path.join(".") === "tabs.layout")?.default).toBe("horizontal")
+})
+
+test("shows the new session location default in settings", () => {
+  expect(settings.find((setting) => setting.path.join(".") === "session.new_location")?.default).toBe("launch")
 })
 
 test("provides config and its host interface", async () => {

--- a/packages/tui/test/new-session-location.test.ts
+++ b/packages/tui/test/new-session-location.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { newSessionLocation } from "../src/config/new-session-location"
+
+test("uses the launch directory by default", () => {
+  expect(newSessionLocation("launch", "/launch", { directory: "/session", workspaceID: "work-1" })).toEqual({
+    directory: "/launch",
+  })
+})
+
+test("inherits the active session location when configured", () => {
+  expect(newSessionLocation("inherit", "/launch", { directory: "/session", workspaceID: "work-1" })).toEqual({
+    directory: "/session",
+    workspaceID: "work-1",
+  })
+})
+
+test("falls back to the launch directory without an active session", () => {
+  expect(newSessionLocation("inherit", "/launch")).toEqual({ directory: "/launch" })
+})


### PR DESCRIPTION
## What

Make new-session location behavior configurable in the client-local TUI settings.

`session.new_location` supports:

- `launch` (default): start `/new` sessions in the directory where this TUI invocation launched
- `inherit`: start `/new` sessions in the active session's location

This applies consistently to the full TUI and Mini.

Fixes #41905.

## Before / After

**Before:** `/new` inherited the active session location unconditionally, so a TUI connected to the singleton service could keep creating sessions in a directory unrelated to that TUI invocation.

**After:** `/new` resets to the invocation's launch directory by default. Users who prefer the existing workflow can select `active session` under **Settings > Session > New session location**, which persists to client-local `cli.json`.

## How

- Add and resolve `session.new_location` in the TUI config, defaulting to `launch`.
- Add the preference to the TUI Settings dialog.
- Centralize launch-versus-inherit selection and use it in full TUI and Mini `/new` paths.
- Keep the setting out of project/server config because it controls client navigation, not server execution policy.

## Scope

- No Protocol, Server HttpApi, generated client, or project `opencode.json` changes.
- Explicit project selection and `/cd` continue to choose the pending session location.

## Testing

- `bun run test test/config-v2.test.tsx test/new-session-location.test.ts test/mini/runtime.queue.test.ts test/mini/runtime.test.ts` (32 passed)
- `bun typecheck` from `packages/tui`
- Repository push hook: `bun turbo typecheck --concurrency=3` (32 packages passed)
- Prettier check and `git diff --check`

## Flow

```mermaid
flowchart TD
  A[User invokes /new] --> B{session.new_location}
  B -->|launch, default| C[TUI invocation launch directory]
  B -->|inherit| D[Active session location]
  C --> E[Create next session]
  D --> E
```
