### PR TITLE
fix(util): bound npm installs with a configurable timeout

### DIFF
--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -36,6 +36,15 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Np
 
 const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|", "?", "*"]) : undefined
 
+// Matches npm's own fetch-timeout default so a slow registry fails like npm
+// itself would instead of hanging the awaiting session path forever.
+const DEFAULT_INSTALL_TIMEOUT = 300_000
+
+const installTimeout = () => {
+  const configured = Number(process.env.OPENCODE_NPM_INSTALL_TIMEOUT)
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_INSTALL_TIMEOUT
+}
+
 export function sanitize(pkg: string) {
   if (!illegal) return pkg
   return Array.from(pkg, (char) => (illegal.has(char) || char.charCodeAt(0) < 32 ? "_" : char)).join("")
@@ -102,7 +111,19 @@ const layer = Layer.effect(
               add,
               dir: input.dir,
             }),
-        }) as Effect.Effect<ArboristTree, InstallFailedError>
+        }).pipe(
+          Effect.timeout(installTimeout()),
+          Effect.catchTag("TimeoutError", () =>
+            new InstallFailedError({
+              add,
+              dir: input.dir,
+              cause: new Error(`npm install timed out after ${installTimeout()}ms`),
+            }),
+          ),
+          Effect.tapError((error) =>
+            Effect.logError("npm install failed", { add, dir: input.dir, error: error.message }),
+          ),
+        ) as Effect.Effect<ArboristTree, InstallFailedError>
       }).pipe(
         Effect.withSpan("Npm.reify", {
           attributes: input,

--- a/packages/util/test/npm.test.ts
+++ b/packages/util/test/npm.test.ts
@@ -2,42 +2,36 @@ import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
+import { Global } from "../src/global.js"
 import { InstallFailedError, Npm } from "../src/npm.js"
 
-describe("Npm.install", () => {
-  test("installs file: dependencies without timing out", async () => {
+const cacheDir = (spec: string) => path.join(Global.Path.cache, "packages", Npm.sanitize(spec))
+
+describe("Npm.add", () => {
+  test("installs a file: package without timing out", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-npm-install-"))
-    await fs.writeFile(
-      path.join(dir, "package.json"),
-      JSON.stringify({
-        name: "fixture",
-        version: "1.0.0",
-        dependencies: { "fixture-provider": "file:./fixture-provider" },
-      }),
-    )
     await fs.mkdir(path.join(dir, "fixture-provider"))
     await fs.writeFile(
       path.join(dir, "fixture-provider", "package.json"),
       JSON.stringify({ name: "fixture-provider", version: "1.0.0", main: "index.js" }),
     )
     await fs.writeFile(path.join(dir, "fixture-provider", "index.js"), "export const value = 1\n")
+    const spec = `fixture-provider@file:${path.join(dir, "fixture-provider")}`
     try {
-      await expect(Npm.install(dir)).resolves.toBeUndefined()
+      await expect(Npm.add(spec)).resolves.toMatchObject({ entrypoint: expect.any(String) })
     } finally {
+      await fs.rm(cacheDir(spec), { recursive: true, force: true })
       await fs.rm(dir, { recursive: true, force: true })
     }
   })
 
   test("fails with InstallFailedError when the registry never responds within the timeout", async () => {
     const server = Bun.serve({ port: 0, fetch: () => new Promise(() => {}) })
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-npm-timeout-"))
-    await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "fixture", version: "1.0.0" }))
+    const spec = "never-resolves-package@1.0.0"
     process.env.npm_config_registry = `http://127.0.0.1:${server.port}/`
     process.env.OPENCODE_NPM_INSTALL_TIMEOUT = "1000"
     try {
-      const outcome = await Npm.install(dir, {
-        add: [{ name: "never-resolves-package", version: "1.0.0" }],
-      }).then(
+      const outcome = await Npm.add(spec).then(
         () => undefined,
         (error) => error,
       )
@@ -46,7 +40,7 @@ describe("Npm.install", () => {
       delete process.env.npm_config_registry
       delete process.env.OPENCODE_NPM_INSTALL_TIMEOUT
       server.stop()
-      await fs.rm(dir, { recursive: true, force: true })
+      await fs.rm(cacheDir(spec), { recursive: true, force: true })
     }
   })
 })

--- a/packages/util/test/npm.test.ts
+++ b/packages/util/test/npm.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { InstallFailedError, Npm } from "../src/npm.js"
+
+describe("Npm.install", () => {
+  test("installs file: dependencies without timing out", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-npm-install-"))
+    await fs.writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({
+        name: "fixture",
+        version: "1.0.0",
+        dependencies: { "fixture-provider": "file:./fixture-provider" },
+      }),
+    )
+    await fs.mkdir(path.join(dir, "fixture-provider"))
+    await fs.writeFile(
+      path.join(dir, "fixture-provider", "package.json"),
+      JSON.stringify({ name: "fixture-provider", version: "1.0.0", main: "index.js" }),
+    )
+    await fs.writeFile(path.join(dir, "fixture-provider", "index.js"), "export const value = 1\n")
+    try {
+      await expect(Npm.install(dir)).resolves.toBeUndefined()
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("fails with InstallFailedError when the registry never responds within the timeout", async () => {
+    const server = Bun.serve({ port: 0, fetch: () => new Promise(() => {}) })
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-npm-timeout-"))
+    await fs.writeFile(path.join(dir, "package.json"), JSON.stringify({ name: "fixture", version: "1.0.0" }))
+    process.env.npm_config_registry = `http://127.0.0.1:${server.port}/`
+    process.env.OPENCODE_NPM_INSTALL_TIMEOUT = "1000"
+    try {
+      const outcome = await Npm.install(dir, {
+        add: [{ name: "never-resolves-package", version: "1.0.0" }],
+      }).then(
+        () => undefined,
+        (error) => error,
+      )
+      expect(outcome).toBeInstanceOf(InstallFailedError)
+    } finally {
+      delete process.env.npm_config_registry
+      delete process.env.OPENCODE_NPM_INSTALL_TIMEOUT
+      server.stop()
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41934

### Type of change

- [x] Bug fix

### What does this PR do?

`Npm.reify` (Arborist) currently runs with no timeout and no retry. With a cold cache and a slow or wedged registry, the install can hang indefinitely, blocking whatever path awaits the plugin/package load (`PluginSupervisor.load` waits on `npm.add`, and startup config dependency installs wait on `Npm.install`). This is the same unguarded-install mechanism as V1 issues #31463 (open) and #33905 (closed as a mis-triage, left untracked).

This PR bounds every `reify` with `Effect.timeout`, defaulting to npm's own fetch-timeout default (300s) and configurable via `OPENCODE_NPM_INSTALL_TIMEOUT`. Timeouts surface as `InstallFailedError` with the package and install directory, and a diagnostic log is emitted on any install failure.

### How did you verify your code works?

- Added `packages/util/test/npm.test.ts`:
  - registry that never responds -> `InstallFailedError` after the configured timeout
  - `file:` dependency install still succeeds (no regression on the normal path)
- `bun test` (packages/util) — 9 pass
- `tsgo --noEmit` (packages/util) — clean

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
