### PR TITLE
fix(tui): pad markdown table cells

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1814,7 +1814,7 @@ function CompactionMessage(props: { message: Extract<SessionMessageInfo, { type:
             streaming={true}
             internalBlockMode="top-level"
             content={content()}
-            tableOptions={{ style: "grid" }}
+            tableOptions={{ style: "grid", cellPaddingX: 1 }}
             conceal={ctx.markdownMode() === "rendered"}
             fg={theme.markdown.text}
             bg={theme.background.default}
@@ -2264,7 +2264,7 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
           streaming={true}
           internalBlockMode="top-level"
           content={props.part.text.trim()}
-          tableOptions={{ style: "grid" }}
+          tableOptions={{ style: "grid", cellPaddingX: 1 }}
           conceal={ctx.markdownMode() === "rendered"}
           fg={theme.markdown.text}
           bg={theme.background.default}


### PR DESCRIPTION
## What

Add one column of horizontal padding inside markdown table cells in the V2 TUI. Tables remain vertically compact, but borders no longer touch their content.

## Before / After

**Before:** Grid tables used OpenTUI's default zero horizontal cell padding, so headings and body text sat directly against cell borders.

**After:** Assistant messages and compaction summaries pass `cellPaddingX: 1`, leaving one terminal column on each side of cell content without adding blank rows.

## How

- Update both session-route markdown renderers in `packages/tui/src/routes/session/index.tsx`.
- Leave mini and mono table rendering unchanged so those intentionally compact surfaces retain their current layout.

## Testing

- `bun typecheck` from `packages/tui`
- Repository pre-push typecheck, 32 packages successful
- `bun run lint packages/tui/src/routes/session/index.tsx`, 0 errors (existing warnings remain)
- OpenCode Drive scripted TUI capture using the simulated model and the production markdown renderer

## Demo

The simulated response exercises a grid table in the modified V2 TUI:

![Markdown table with horizontal cell padding](https://github.com/user-attachments/assets/4236a8ea-8ade-45c4-8c84-4a1e0066113a)
