### PR TITLE
refactor(server): resume suspended sessions unconditionally in the fetch entry

### DIFF
--- a/packages/server/src/fetch.ts
+++ b/packages/server/src/fetch.ts
@@ -7,15 +7,6 @@ import { isAllowedCorsOrigin } from "./cors"
 import { createRoutes } from "./routes"
 import type { ServerOptions } from "./options"
 
-export interface BootOptions {
-  /**
-   * Resumes execution-journaled Sessions once the application layer boots. Pair with
-   * `SessionExecution.configured({ suspendOnStart: true })` on runtimes that can die without
-   * teardown, so turns orphaned by a hard death replay on the next boot.
-   */
-  readonly resumeSuspendedSessions?: boolean
-}
-
 /**
  * Builds a web-standard fetch handler — `(request: Request) => Promise<Response>` — serving the
  * same HttpApi routes as the Node server process without binding a port, owning a listener, or
@@ -32,13 +23,17 @@ export interface BootOptions {
  * Auth follows `createRoutes` semantics: `options.password` enforces Basic auth; omitting it
  * serves unauthenticated, so an embedder without a password must front the handler with its own
  * access control.
+ *
+ * Sessions whose execution claim was never released resume once the layer is built, exactly as
+ * the Node server process does: a runtime that dies without teardown — an evicted Durable
+ * Object leaves the same durable signature as a killed process — replays orphaned turns on the
+ * next boot, and the sweep is a no-op when nothing is suspended.
  */
-export const make = Effect.fn("ServerFetch.make")(function* (options: ServerOptions = {}, boot: BootOptions = {}) {
+export const make = Effect.fn("ServerFetch.make")(function* (options: ServerOptions = {}) {
   const context = yield* Layer.build(createRoutes(options, () => []).pipe(Layer.provide(HttpServer.layerServices)))
   // Forked so the returned handler is never delayed; resumed drains are already
   // logged and durably recorded by the execution layer.
-  if (boot.resumeSuspendedSessions)
-    yield* Effect.forkDetach(Context.get(context, SessionRestart.Service).resumeSuspendedSessions)
+  yield* Effect.forkDetach(Context.get(context, SessionRestart.Service).resumeSuspendedSessions)
   return Context.get(context, HttpRouter.HttpRouter)
     .asHttpEffect()
     .pipe(


### PR DESCRIPTION
## What

Removes `ServerFetch.BootOptions.resumeSuspendedSessions` (added in #41896) and makes the web-standard fetch entry resume execution-claimed Sessions unconditionally after the layer builds, matching `ServerProcess.start` (which has resumed unconditionally since #36105).

## Why

The flag was speculative API: the resume sweep filters live claims and is a no-op when nothing is suspended, so there is no embedder that wants `false` — a runtime with a fresh `:memory:` database has nothing to resume, and a runtime with durable storage wants orphaned turns replayed. The only caller that would ever exist passes `true` (the workerd profile in #41918, which simplifies further on top of this).

## Testing

`packages/server` suite green (32 tests) including the `ServerFetch` handler tests.