### PR TITLE
fix(opencode): isolate workspace config state

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -289,7 +289,7 @@ const layer = Layer.effect(
     )
 
     const getGlobal = Effect.fn("Config.getGlobal")(function* () {
-      return yield* cachedGlobal
+      return structuredClone(yield* cachedGlobal)
     })
 
     const ensureGitignore = Effect.fn("Config.ensureGitignore")(function* (dir: string) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1018,6 +1018,30 @@ it.effect("merges plugin arrays from global and local configs", () =>
   ),
 )
 
+it.effect("does not share mutable nested config between workspaces", () =>
+  withGlobalConfig(
+    {
+      config: {
+        mcp: {
+          global: { type: "remote", url: "https://global.example.com/mcp" },
+        },
+      },
+    },
+    () =>
+      Effect.gen(function* () {
+        const first = yield* tmpdirScoped()
+        const second = yield* tmpdirScoped()
+        const firstConfig = yield* Config.use.get().pipe(provideInstanceEffect(first))
+
+        firstConfig.mcp!["workspace-only"] = { type: "remote", url: "https://workspace.example.com/mcp" }
+
+        const secondConfig = yield* Config.use.get().pipe(provideInstanceEffect(second))
+        expect(firstConfig.mcp).toHaveProperty("workspace-only")
+        expect(secondConfig.mcp).not.toHaveProperty("workspace-only")
+      }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(LayerNode.compile(CrossSpawnSpawner.node))),
+  ),
+)
+
 it.effect("global config remains global when project config is disabled", () =>
   withConfigTree(
     {


### PR DESCRIPTION
### Issue for this PR

Closes #41916

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Nested values merged from the global config cache could retain shared references. A plugin config hook mutating one workspace could therefore leak MCP configuration into workspaces loaded later by the same process.

This returns a structured clone from `Config.getGlobal()` before workspace merging. Plugin hooks can still mutate their workspace config, while the global cache and other workspaces remain isolated.

A regression test covers two workspaces loaded in the same process.

### How did you verify your code works?

- `bun test test/config/config.test.ts --timeout 30000` — 97 passed
- `bun x prettier --check src/config/config.ts test/config/config.test.ts`
- `git diff --check`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
