### PR TITLE
fix(cli): harden managed service replacement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,12 +188,14 @@
       "dependencies": {
         "@opencode-ai/protocol": "workspace:*",
         "@opencode-ai/schema": "workspace:*",
+        "semver": "catalog:",
       },
       "devDependencies": {
         "@effect/platform-node": "catalog:",
         "@opencode-ai/httpapi-codegen": "workspace:*",
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
+        "@types/semver": "catalog:",
         "@typescript/native-preview": "catalog:",
         "effect": "catalog:",
       },
@@ -6347,6 +6349,8 @@
     "@openauthjs/openauth/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
 
     "@opencode-ai/cli/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@opencode-ai/client/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@opencode-ai/console-app/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.7", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DrpkEoM3j9cBBWhufqBwnbbn+3nf1N9FP6xuVJ+e220jbactKuQgaZwjwP5CP1t+O94brm2JgVMD2atMGX3xIQ=="],
 

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -23,7 +23,14 @@ export default Runtime.handler(Commands, (input) =>
       server: Option.getOrUndefined(input.server),
       standalone: input.standalone,
       mismatch: "replace",
+      confirmDowngrade: (serverVersion) =>
+        Effect.promise(async () => {
+          const confirmed = await preflight.confirmDowngrade(serverVersion)
+          if (confirmed) preflight.begin(serverVersion)
+          return confirmed
+        }),
       onStart: (reason, previousVersion) => {
+        if (preflight.active()) return
         if (reason === "version-mismatch" && preflight.begin(previousVersion)) return
         process.stderr.write(
           reason === "version-mismatch"

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -23,14 +23,7 @@ export default Runtime.handler(Commands, (input) =>
       server: Option.getOrUndefined(input.server),
       standalone: input.standalone,
       mismatch: "replace",
-      confirmDowngrade: (serverVersion) =>
-        Effect.promise(async () => {
-          const confirmed = await preflight.confirmDowngrade(serverVersion)
-          if (confirmed) preflight.begin(serverVersion)
-          return confirmed
-        }),
       onStart: (reason, previousVersion) => {
-        if (preflight.active()) return
         if (reason === "version-mismatch" && preflight.begin(previousVersion)) return
         process.stderr.write(
           reason === "version-mismatch"

--- a/packages/cli/src/commands/handlers/service/restart.ts
+++ b/packages/cli/src/commands/handlers/service/restart.ts
@@ -8,7 +8,7 @@ import { ServiceConfig } from "../../../services/service-config"
 export default Runtime.handler(
   Commands.commands.service.commands.restart,
   Effect.fn("cli.service.restart")(function* () {
-    const options = yield* ServiceConfig.options()
+    const options = yield* ServiceConfig.options({ checkVersion: true })
     yield* Service.stop(options)
     const transport = yield* Service.ensure(options)
     process.stdout.write(transport.url + EOL)

--- a/packages/cli/src/services/server-connection.ts
+++ b/packages/cli/src/services/server-connection.ts
@@ -57,7 +57,7 @@ function managedService(options: EnsureOptions) {
     restart: () =>
       Effect.gen(function* () {
         yield* Service.stop(options)
-        yield* Service.ensure(reconnectOptions)
+        yield* Service.ensure(options)
       }),
   }
 }

--- a/packages/cli/src/services/server-connection.ts
+++ b/packages/cli/src/services/server-connection.ts
@@ -1,7 +1,7 @@
-import { Service, type Endpoint, type EnsureOptions } from "@opencode-ai/client/effect/service"
+import { Service, VersionMismatchError, type Endpoint, type EnsureOptions } from "@opencode-ai/client/effect/service"
 import { ClientError, isUnauthorizedError, OpenCode } from "@opencode-ai/client/promise"
 import { OPENCODE_VERSION } from "../version"
-import { Effect, Redacted } from "effect"
+import { Effect, Redacted, Result } from "effect"
 import { Env } from "../env"
 import { ServiceConfig } from "./service-config"
 import { Standalone } from "./standalone"
@@ -11,6 +11,7 @@ export type Args = {
   readonly standalone?: boolean
   readonly mismatch?: "replace" | "ignore" | "error"
   readonly onStart?: EnsureOptions["onStart"]
+  readonly confirmDowngrade?: (serverVersion: string, clientVersion: string) => Effect.Effect<boolean>
 }
 
 export type Resolved = {
@@ -45,7 +46,7 @@ export const resolve = Effect.fn("cli.server-connection.resolve")(function* (arg
   const mismatch = args.mismatch ?? "ignore"
   const options = yield* ServiceConfig.options({ checkVersion: mismatch !== "ignore" })
   return {
-    endpoint: yield* resolveManaged({ ...options, onStart: args.onStart }, mismatch),
+    endpoint: yield* resolveManaged({ ...options, onStart: args.onStart }, mismatch, args.confirmDowngrade),
     service: managedService(options),
   } satisfies Resolved
 })
@@ -62,8 +63,16 @@ function managedService(options: EnsureOptions) {
   }
 }
 
-const resolveManaged = Effect.fnUntraced(function* (options: EnsureOptions, mismatch: NonNullable<Args["mismatch"]>) {
-  if (mismatch === "replace") return yield* Service.ensure(options)
+const resolveManaged = Effect.fnUntraced(function* (
+  options: EnsureOptions,
+  mismatch: NonNullable<Args["mismatch"]>,
+  confirmDowngrade?: Args["confirmDowngrade"],
+) {
+  if (mismatch === "replace") {
+    const result = yield* Effect.result(Service.ensure(options))
+    if (Result.isSuccess(result)) return result.success
+    return yield* confirmManagedDowngrade(options, result.failure, confirmDowngrade)
+  }
   if (mismatch === "ignore") return yield* Service.ensure({ ...options, version: undefined })
 
   const compatible = yield* Service.discover(options)
@@ -71,6 +80,29 @@ const resolveManaged = Effect.fnUntraced(function* (options: EnsureOptions, mism
   const existing = yield* Service.discover({ ...options, version: undefined })
   if (existing !== undefined)
     return yield* Effect.fail(new Error("Background server version does not match this client"))
+  return yield* Service.ensure(options)
+})
+
+export const confirmManagedDowngrade = Effect.fnUntraced(function* (
+  options: EnsureOptions,
+  error: unknown,
+  confirm?: Args["confirmDowngrade"],
+) {
+  if (
+    !(error instanceof VersionMismatchError) ||
+    error.serverVersion === undefined ||
+    error.clientVersion === undefined ||
+    !Service.canReplaceVersion(error.clientVersion, error.serverVersion) ||
+    confirm === undefined
+  )
+    return yield* Effect.fail(error)
+  if (!(yield* confirm(error.serverVersion, error.clientVersion)))
+    return yield* Effect.fail(
+      new Error(`${error.message}. Run \`opencode2 service restart\` to activate this installed version.`, {
+        cause: error,
+      }),
+    )
+  yield* Service.stop(options)
   return yield* Service.ensure(options)
 })
 

--- a/packages/cli/src/services/server-connection.ts
+++ b/packages/cli/src/services/server-connection.ts
@@ -1,7 +1,7 @@
 import { Service, VersionMismatchError, type Endpoint, type EnsureOptions } from "@opencode-ai/client/effect/service"
 import { ClientError, isUnauthorizedError, OpenCode } from "@opencode-ai/client/promise"
 import { OPENCODE_VERSION } from "../version"
-import { Effect, Redacted, Result } from "effect"
+import { Effect, Redacted } from "effect"
 import { Env } from "../env"
 import { ServiceConfig } from "./service-config"
 import { Standalone } from "./standalone"
@@ -11,7 +11,6 @@ export type Args = {
   readonly standalone?: boolean
   readonly mismatch?: "replace" | "ignore" | "error"
   readonly onStart?: EnsureOptions["onStart"]
-  readonly confirmDowngrade?: (serverVersion: string, clientVersion: string) => Effect.Effect<boolean>
 }
 
 export type Resolved = {
@@ -46,7 +45,7 @@ export const resolve = Effect.fn("cli.server-connection.resolve")(function* (arg
   const mismatch = args.mismatch ?? "ignore"
   const options = yield* ServiceConfig.options({ checkVersion: mismatch !== "ignore" })
   return {
-    endpoint: yield* resolveManaged({ ...options, onStart: args.onStart }, mismatch, args.confirmDowngrade),
+    endpoint: yield* resolveManaged({ ...options, onStart: args.onStart }, mismatch),
     service: managedService(options),
   } satisfies Resolved
 })
@@ -63,16 +62,17 @@ function managedService(options: EnsureOptions) {
   }
 }
 
-const resolveManaged = Effect.fnUntraced(function* (
-  options: EnsureOptions,
-  mismatch: NonNullable<Args["mismatch"]>,
-  confirmDowngrade?: Args["confirmDowngrade"],
-) {
-  if (mismatch === "replace") {
-    const result = yield* Effect.result(Service.ensure(options))
-    if (Result.isSuccess(result)) return result.success
-    return yield* confirmManagedDowngrade(options, result.failure, confirmDowngrade)
-  }
+const resolveManaged = Effect.fnUntraced(function* (options: EnsureOptions, mismatch: NonNullable<Args["mismatch"]>) {
+  if (mismatch === "replace")
+    return yield* Service.ensure(options).pipe(
+      Effect.mapError((error) =>
+        error instanceof VersionMismatchError
+          ? new Error(`${error.message}. Run \`opencode2 service restart\` to activate this installed version.`, {
+              cause: error,
+            })
+          : error,
+      ),
+    )
   if (mismatch === "ignore") return yield* Service.ensure({ ...options, version: undefined })
 
   const compatible = yield* Service.discover(options)
@@ -80,29 +80,6 @@ const resolveManaged = Effect.fnUntraced(function* (
   const existing = yield* Service.discover({ ...options, version: undefined })
   if (existing !== undefined)
     return yield* Effect.fail(new Error("Background server version does not match this client"))
-  return yield* Service.ensure(options)
-})
-
-export const confirmManagedDowngrade = Effect.fnUntraced(function* (
-  options: EnsureOptions,
-  error: unknown,
-  confirm?: Args["confirmDowngrade"],
-) {
-  if (
-    !(error instanceof VersionMismatchError) ||
-    error.serverVersion === undefined ||
-    error.clientVersion === undefined ||
-    !Service.canReplaceVersion(error.clientVersion, error.serverVersion) ||
-    confirm === undefined
-  )
-    return yield* Effect.fail(error)
-  if (!(yield* confirm(error.serverVersion, error.clientVersion)))
-    return yield* Effect.fail(
-      new Error(`${error.message}. Run \`opencode2 service restart\` to activate this installed version.`, {
-        cause: error,
-      }),
-    )
-  yield* Service.stop(options)
   return yield* Service.ensure(options)
 })
 

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -5,6 +5,7 @@ import { Service } from "@opencode-ai/client/effect/service"
 import { Effect, FileSystem, Option, Schema } from "effect"
 import { randomBytes } from "crypto"
 import path from "path"
+import semver from "semver"
 import { selfCommand } from "../util/process"
 
 // The CLI's service configuration file, plus the Service.EnsureOptions binding that
@@ -104,9 +105,19 @@ export const options = Effect.fnUntraced(function* (input: { readonly checkVersi
   return {
     file,
     version: input.checkVersion ? OPENCODE_VERSION : undefined,
+    canReplace: (version: string | undefined) => canReplaceVersion(version),
     command: [...selfCommand(), "serve", "--service"],
   }
 })
+
+export function canReplaceVersion(serverVersion: string | undefined, clientVersion = OPENCODE_VERSION) {
+  if (serverVersion === undefined) return false
+  // Compare preview build numbers numerically rather than as semver prerelease strings.
+  const server = serverVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
+  const client = clientVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
+  if (!semver.valid(server) || !semver.valid(client)) return false
+  return semver.lt(server, client)
+}
 
 export const read = Effect.fn("cli.service-config.read")(function* () {
   const { fs, configFile, legacyConfigFile } = yield* paths

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -109,10 +109,6 @@ export const options = Effect.fnUntraced(function* (input: { readonly checkVersi
   }
 })
 
-export function canReplaceVersion(serverVersion: string | undefined, clientVersion = OPENCODE_VERSION) {
-  return Service.canReplaceVersion(serverVersion, clientVersion)
-}
-
 export const read = Effect.fn("cli.service-config.read")(function* () {
   const { fs, configFile, legacyConfigFile } = yield* paths
   if (legacyConfigFile) yield* migrateConfig(legacyConfigFile, configFile)

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -5,7 +5,6 @@ import { Service } from "@opencode-ai/client/effect/service"
 import { Effect, FileSystem, Option, Schema } from "effect"
 import { randomBytes } from "crypto"
 import path from "path"
-import semver from "semver"
 import { selfCommand } from "../util/process"
 
 // The CLI's service configuration file, plus the Service.EnsureOptions binding that
@@ -105,18 +104,13 @@ export const options = Effect.fnUntraced(function* (input: { readonly checkVersi
   return {
     file,
     version: input.checkVersion ? OPENCODE_VERSION : undefined,
-    canReplace: (version: string | undefined) => canReplaceVersion(version),
+    canReplace: (version: string | undefined) => Service.canReplaceVersion(version, OPENCODE_VERSION),
     command: [...selfCommand(), "serve", "--service"],
   }
 })
 
 export function canReplaceVersion(serverVersion: string | undefined, clientVersion = OPENCODE_VERSION) {
-  if (serverVersion === undefined) return false
-  // Compare preview build numbers numerically rather than as semver prerelease strings.
-  const server = serverVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
-  const client = clientVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
-  if (!semver.valid(server) || !semver.valid(client)) return false
-  return semver.lt(server, client)
+  return Service.canReplaceVersion(serverVersion, clientVersion)
 }
 
 export const read = Effect.fn("cli.service-config.read")(function* () {

--- a/packages/cli/src/services/update-preflight.tsx
+++ b/packages/cli/src/services/update-preflight.tsx
@@ -28,7 +28,9 @@ const transitionDuration = 420
 const completionHold = 650
 
 export type Handle = {
+  readonly active: () => boolean
   readonly begin: (from?: string) => boolean
+  readonly confirmDowngrade: (from: string) => Promise<boolean>
   readonly loading: () => void
   readonly finish: () => Promise<Handoff | undefined>
   readonly fail: (message: string) => Promise<void>
@@ -44,6 +46,7 @@ export type Handoff = {
 export const make = (): Handle => {
   let session: Promise<Session | undefined> | undefined
   return {
+    active: () => session !== undefined,
     begin: (from) => {
       if (!process.stdout.isTTY || !process.stdin.isTTY) return false
       session ??= open(from).catch(() => {
@@ -52,6 +55,7 @@ export const make = (): Handle => {
       })
       return true
     },
+    confirmDowngrade: (from) => confirmDowngrade(from),
     loading: () => {
       void session?.then((active) => active?.loading())
     },
@@ -195,6 +199,40 @@ async function open(from?: string): Promise<Session> {
       }),
     close,
   }
+}
+
+async function confirmDowngrade(from: string) {
+  if (!process.stdout.isTTY || !process.stdin.isTTY) return false
+  const renderer = await createCliRenderer({
+    stdin: process.stdin,
+    useMouse: false,
+    autoFocus: true,
+    openConsoleOnError: false,
+    exitOnCtrlC: false,
+    screenMode: "split-footer",
+    footerHeight: 4,
+    targetFps: 30,
+    useKittyKeyboard: {},
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+  const result = Promise.withResolvers<boolean>()
+  const onKeypress = (event: { readonly name: string; readonly ctrl: boolean }) => {
+    if (event.name === "return") return finish(true)
+    if (event.name === "escape" || (event.ctrl && event.name === "c")) finish(false)
+  }
+  const finish = (confirmed: boolean) => {
+    renderer.keyInput.off("keypress", onKeypress)
+    if (!renderer.isDestroyed) renderer.destroy()
+    result.resolve(confirmed)
+  }
+  renderer.keyInput.on("keypress", onKeypress)
+  await render(() => <DowngradeFooter from={from} />, renderer).catch((error) => {
+    renderer.keyInput.off("keypress", onKeypress)
+    if (!renderer.isDestroyed) renderer.destroy()
+    throw error
+  })
+  return result.promise
 }
 
 const colors = {
@@ -447,7 +485,7 @@ function UpdateFooter(props: {
   })
 
   return (
-    <box width="100%" height={4} flexDirection="row" gap={1} live={props.animating()}>
+    <box width="100%" height={4} flexDirection="row" gap={1} paddingLeft={1} live={props.animating()}>
       <Monogram ink={monogramInk} />
       <box flexDirection="column" flexGrow={1} overflow="hidden">
         <CellLine cells={header()} />
@@ -467,6 +505,20 @@ function UpdateFooter(props: {
           </text>
         </box>
       </box>
+    </box>
+  )
+}
+
+function DowngradeFooter(props: { from: string }) {
+  return (
+    <box width="100%" height={4} flexDirection="column" paddingLeft={1}>
+      <text fg={colors.text}>
+        <span style={{ fg: colors.muted }}>Background service </span>
+        <span style={{ fg: colors.accent }}>{props.from}</span>
+        <span style={{ fg: colors.muted }}> is newer than installed </span>
+        <span style={{ fg: colors.accent }}>{OPENCODE_VERSION}</span>
+      </text>
+      <text fg={colors.muted}>Press Enter to downgrade and restart · Esc to cancel</text>
     </box>
   )
 }

--- a/packages/cli/src/services/update-preflight.tsx
+++ b/packages/cli/src/services/update-preflight.tsx
@@ -28,9 +28,7 @@ const transitionDuration = 420
 const completionHold = 650
 
 export type Handle = {
-  readonly active: () => boolean
   readonly begin: (from?: string) => boolean
-  readonly confirmDowngrade: (from: string) => Promise<boolean>
   readonly loading: () => void
   readonly finish: () => Promise<Handoff | undefined>
   readonly fail: (message: string) => Promise<void>
@@ -46,7 +44,6 @@ export type Handoff = {
 export const make = (): Handle => {
   let session: Promise<Session | undefined> | undefined
   return {
-    active: () => session !== undefined,
     begin: (from) => {
       if (!process.stdout.isTTY || !process.stdin.isTTY) return false
       session ??= open(from).catch(() => {
@@ -55,7 +52,6 @@ export const make = (): Handle => {
       })
       return true
     },
-    confirmDowngrade: (from) => confirmDowngrade(from),
     loading: () => {
       void session?.then((active) => active?.loading())
     },
@@ -199,40 +195,6 @@ async function open(from?: string): Promise<Session> {
       }),
     close,
   }
-}
-
-async function confirmDowngrade(from: string) {
-  if (!process.stdout.isTTY || !process.stdin.isTTY) return false
-  const renderer = await createCliRenderer({
-    stdin: process.stdin,
-    useMouse: false,
-    autoFocus: true,
-    openConsoleOnError: false,
-    exitOnCtrlC: false,
-    screenMode: "split-footer",
-    footerHeight: 4,
-    targetFps: 30,
-    useKittyKeyboard: {},
-    externalOutputMode: "capture-stdout",
-    consoleMode: "disabled",
-  })
-  const result = Promise.withResolvers<boolean>()
-  const onKeypress = (event: { readonly name: string; readonly ctrl: boolean }) => {
-    if (event.name === "return") return finish(true)
-    if (event.name === "escape" || (event.ctrl && event.name === "c")) finish(false)
-  }
-  const finish = (confirmed: boolean) => {
-    renderer.keyInput.off("keypress", onKeypress)
-    if (!renderer.isDestroyed) renderer.destroy()
-    result.resolve(confirmed)
-  }
-  renderer.keyInput.on("keypress", onKeypress)
-  await render(() => <DowngradeFooter from={from} />, renderer).catch((error) => {
-    renderer.keyInput.off("keypress", onKeypress)
-    if (!renderer.isDestroyed) renderer.destroy()
-    throw error
-  })
-  return result.promise
 }
 
 const colors = {
@@ -505,20 +467,6 @@ function UpdateFooter(props: {
           </text>
         </box>
       </box>
-    </box>
-  )
-}
-
-function DowngradeFooter(props: { from: string }) {
-  return (
-    <box width="100%" height={4} flexDirection="column" paddingLeft={1}>
-      <text fg={colors.text}>
-        <span style={{ fg: colors.muted }}>Background service </span>
-        <span style={{ fg: colors.accent }}>{props.from}</span>
-        <span style={{ fg: colors.muted }}> is newer than installed </span>
-        <span style={{ fg: colors.accent }}>{OPENCODE_VERSION}</span>
-      </text>
-      <text fg={colors.muted}>Press Enter to downgrade and restart · Esc to cancel</text>
     </box>
   )
 }

--- a/packages/cli/test/server-connection.test.ts
+++ b/packages/cli/test/server-connection.test.ts
@@ -8,7 +8,6 @@ import os from "node:os"
 import path from "node:path"
 import { ServerConnection } from "../src/services/server-connection"
 import { ServiceConfig } from "../src/services/service-config"
-import { VersionMismatchError } from "@opencode-ai/client/effect/service"
 
 test("resolution groups Effect-native lifecycle operations only for the managed service", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-server-resolution-"))
@@ -71,34 +70,33 @@ test("service options only require a matching version when requested", async () 
   }
 })
 
-test("downgrade confirmation is offered only when the running service is newer", async () => {
-  const options = { version: "0.0.0-next-17271" }
-  const offered: string[] = []
-  const confirm = (serverVersion: string) =>
-    Effect.sync(() => {
-      offered.push(serverVersion)
-      return false
-    })
+test("normal launch refuses to replace a newer managed service", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-newer-service-"))
+  const layer = Global.layerWith({ config: path.join(root, "config"), state: path.join(root, "state") })
+  const registration = path.join(root, "state", ServiceConfig.filename())
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return Response.json({ healthy: true, version: "999.0.0", pid: process.pid })
+    },
+  })
 
-  await expect(
-    Effect.runPromise(
-      ServerConnection.confirmManagedDowngrade(
-        options,
-        new VersionMismatchError(options.version, "0.0.0-next-17272"),
-        confirm,
-      ).pipe(Effect.provide(NodeFileSystem.layer)),
-    ),
-  ).rejects.toThrow("Run `opencode2 service restart`")
-  expect(offered).toEqual(["0.0.0-next-17272"])
-
-  await expect(
-    Effect.runPromise(
-      ServerConnection.confirmManagedDowngrade(
-        { version: "0.0.0-next-17272" },
-        new VersionMismatchError("0.0.0-next-17272", "0.0.0-next-17271"),
-        confirm,
-      ).pipe(Effect.provide(NodeFileSystem.layer)),
-    ),
-  ).rejects.toThrow("does not match")
-  expect(offered).toEqual(["0.0.0-next-17272"])
+  try {
+    await fs.mkdir(path.dirname(registration), { recursive: true })
+    await fs.writeFile(
+      registration,
+      JSON.stringify({ id: "newer-service", version: "999.0.0", url: server.url.toString(), pid: process.pid }),
+    )
+    await expect(
+      Effect.runPromise(
+        ServerConnection.resolve({ mismatch: "replace" }).pipe(
+          Effect.provide(layer),
+          Effect.provide(NodeFileSystem.layer),
+          Effect.scoped,
+        ),
+      ),
+    ).rejects.toThrow("Run `opencode2 service restart` to activate this installed version")
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
 })

--- a/packages/cli/test/server-connection.test.ts
+++ b/packages/cli/test/server-connection.test.ts
@@ -8,6 +8,7 @@ import os from "node:os"
 import path from "node:path"
 import { ServerConnection } from "../src/services/server-connection"
 import { ServiceConfig } from "../src/services/service-config"
+import { VersionMismatchError } from "@opencode-ai/client/effect/service"
 
 test("resolution groups Effect-native lifecycle operations only for the managed service", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-server-resolution-"))
@@ -68,4 +69,36 @@ test("service options only require a matching version when requested", async () 
   } finally {
     await fs.rm(root, { recursive: true, force: true })
   }
+})
+
+test("downgrade confirmation is offered only when the running service is newer", async () => {
+  const options = { version: "0.0.0-next-17271" }
+  const offered: string[] = []
+  const confirm = (serverVersion: string) =>
+    Effect.sync(() => {
+      offered.push(serverVersion)
+      return false
+    })
+
+  await expect(
+    Effect.runPromise(
+      ServerConnection.confirmManagedDowngrade(
+        options,
+        new VersionMismatchError(options.version, "0.0.0-next-17272"),
+        confirm,
+      ).pipe(Effect.provide(NodeFileSystem.layer)),
+    ),
+  ).rejects.toThrow("Run `opencode2 service restart`")
+  expect(offered).toEqual(["0.0.0-next-17272"])
+
+  await expect(
+    Effect.runPromise(
+      ServerConnection.confirmManagedDowngrade(
+        { version: "0.0.0-next-17272" },
+        new VersionMismatchError("0.0.0-next-17272", "0.0.0-next-17271"),
+        confirm,
+      ).pipe(Effect.provide(NodeFileSystem.layer)),
+    ),
+  ).rejects.toThrow("does not match")
+  expect(offered).toEqual(["0.0.0-next-17272"])
 })

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -47,6 +47,35 @@ test("service filenames share release channels and identify preview channels", (
   expect(ServiceConfig.versionBelongsToChannel("1.2.3", "preview-a")).toBe(false)
 })
 
+test("only newer clients replace managed service versions", () => {
+  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17271", "0.0.0-next-17272")).toBe(true)
+  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17271")).toBe(false)
+  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17272")).toBe(false)
+  expect(ServiceConfig.canReplaceVersion(undefined, "0.0.0-next-17272")).toBe(false)
+  expect(ServiceConfig.canReplaceVersion("development-a", "development-b")).toBe(false)
+  expect(ServiceConfig.canReplaceVersion("development-b", "development-a")).toBe(false)
+})
+
+test("managed version replacement can never be mutual", () => {
+  const versions = [
+    undefined,
+    "1.0.0",
+    "1.0.1",
+    "0.0.0-next-9999",
+    "0.0.0-next-15000",
+    "0.0.0-next-15000.1",
+    "0.0.0-next-15000.2",
+    "development-a",
+    "development-b",
+  ]
+  for (const left of versions) {
+    for (const right of versions) {
+      if (left === undefined || right === undefined) continue
+      expect(ServiceConfig.canReplaceVersion(left, right) && ServiceConfig.canReplaceVersion(right, left)).toBe(false)
+    }
+  }
+})
+
 test("service config migrates from the hashed channel filename", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-config-migration-"))
   const legacy = path.join(root, ServiceConfig.legacyFilename("preview-a")!)

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { Service, type Info } from "@opencode-ai/client/effect/service"
+import { Service, canReplaceVersion, type Info } from "@opencode-ai/client/effect/service"
 import { Global } from "@opencode-ai/util/global"
 import { OPENCODE_VERSION } from "../src/version"
 import { expect, test } from "bun:test"
@@ -48,12 +48,12 @@ test("service filenames share release channels and identify preview channels", (
 })
 
 test("only newer clients replace managed service versions", () => {
-  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17271", "0.0.0-next-17272")).toBe(true)
-  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17271")).toBe(false)
-  expect(ServiceConfig.canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17272")).toBe(false)
-  expect(ServiceConfig.canReplaceVersion(undefined, "0.0.0-next-17272")).toBe(false)
-  expect(ServiceConfig.canReplaceVersion("development-a", "development-b")).toBe(false)
-  expect(ServiceConfig.canReplaceVersion("development-b", "development-a")).toBe(false)
+  expect(canReplaceVersion("0.0.0-next-17271", "0.0.0-next-17272")).toBe(true)
+  expect(canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17271")).toBe(false)
+  expect(canReplaceVersion("0.0.0-next-17272", "0.0.0-next-17272")).toBe(false)
+  expect(canReplaceVersion(undefined, "0.0.0-next-17272")).toBe(false)
+  expect(canReplaceVersion("development-a", "development-b")).toBe(false)
+  expect(canReplaceVersion("development-b", "development-a")).toBe(false)
 })
 
 test("managed version replacement can never be mutual", () => {
@@ -71,7 +71,7 @@ test("managed version replacement can never be mutual", () => {
   for (const left of versions) {
     for (const right of versions) {
       if (left === undefined || right === undefined) continue
-      expect(ServiceConfig.canReplaceVersion(left, right) && ServiceConfig.canReplaceVersion(right, left)).toBe(false)
+      expect(canReplaceVersion(left, right) && canReplaceVersion(right, left)).toBe(false)
     }
   }
 })

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@opencode-ai/schema": "workspace:*",
-    "@opencode-ai/protocol": "workspace:*"
+    "@opencode-ai/protocol": "workspace:*",
+    "semver": "catalog:"
   },
   "peerDependencies": {
     "effect": "4.0.0-beta.101"
@@ -49,6 +50,7 @@
     "@tsconfig/bun": "catalog:",
     "@types/bun": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "@types/semver": "catalog:",
     "effect": "catalog:"
   }
 }

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -2,7 +2,7 @@ import { ServiceStatus } from "@opencode-ai/protocol/groups/health"
 import { Effect, FileSystem, Option, Schedule, Schema } from "effect"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { DiscoverOptions, Endpoint, EnsureOptions, StopOptions } from "../service.js"
+import { VersionMismatchError, type DiscoverOptions, type Endpoint, type EnsureOptions, type StopOptions } from "../service.js"
 import {
   contenderFailure,
   contenderFinished,
@@ -56,7 +56,6 @@ const discoverLocal = Effect.fnUntraced(function* (options: DiscoverOptions) {
 export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOptions = {}) {
   const timing = ensureTiming(options)
   const contenders = new Set<ServiceContender>()
-  let timeouts: { readonly info: Info; readonly count: number } | undefined
   let announced = false
   let lastSpawn = 0
   let spawnDelay = timing.spawnDelay
@@ -80,18 +79,6 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
     const registration = yield* registered(options.file, true, timing.requestTimeout)
     const info = registration.info
     const service = registration.service
-    if (registration.timedOut && info !== undefined) {
-      timeouts = {
-        info,
-        count: timeouts !== undefined && same(timeouts.info, info) ? timeouts.count + 1 : 1,
-      }
-      if (timeouts.count >= 3) {
-        yield* announce("missing")
-        yield* evict(info, options, timing)
-        timeouts = undefined
-        lastSpawn = Date.now() - spawnDelay
-      }
-    } else timeouts = undefined
     if (service !== undefined) {
       spawnDelay = timing.spawnDelay
       const compatible = !service.legacy && matchesVersion(service.version, options)
@@ -99,8 +86,10 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
       if (compatible && service.state === "failed")
         return yield* Effect.fail(new Error("Background service failed to start"))
       if (compatible) return Option.none<LocalService>()
+      if (!service.legacy && options.canReplace?.(service.version) === false)
+        return yield* Effect.fail(new VersionMismatchError(options.version, service.version))
       yield* announce("version-mismatch", service.version)
-      yield* kill(service, options, timing).pipe(Effect.ignore)
+      yield* kill(service, options, timing)
       lastSpawn = 0
       return Option.none<LocalService>()
     } else if (lastSpawn === 0 && info !== undefined) lastSpawn = Date.now()
@@ -135,6 +124,8 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
 export const stop = Effect.fn("service.stop")(function* (options: StopOptions = {}) {
   const existing = yield* find(options)
   if (existing !== undefined) yield* kill(existing, options, defaultEnsureTiming)
+  if (existing === undefined && (yield* read(options.file)) !== undefined)
+    return yield* Effect.fail(new Error("Background service is not responding; stop its process manually and try again"))
 })
 
 function fallback() {
@@ -254,9 +245,6 @@ const find = Effect.fnUntraced(function* (options: { readonly file?: string }) {
 const poll = (timing: EnsureTiming) =>
   Schedule.max([Schedule.spaced(timing.stopPollInterval), Schedule.recurs(timing.stopPollAttempts)])
 
-const signal = (pid: number, name: NodeJS.Signals) =>
-  Effect.try({ try: () => process.kill(pid, name), catch: (cause) => cause }).pipe(Effect.ignore)
-
 const stopped = Effect.fnUntraced(function* (pid: number) {
   const running = yield* Effect.try({ try: () => process.kill(pid, 0), catch: () => false }).pipe(
     Effect.orElseSucceed(() => false),
@@ -266,43 +254,25 @@ const stopped = Effect.fnUntraced(function* (pid: number) {
 })
 
 function same(left: Info, right: Info) {
-  return left.id === right.id && left.version === right.version && left.url === right.url && left.pid === right.pid
+  return (
+    left.id === right.id &&
+    left.version === right.version &&
+    left.url === right.url &&
+    left.pid === right.pid &&
+    left.password === right.password
+  )
 }
 
-const evict = Effect.fnUntraced(function* (info: Info, options: { readonly file?: string }, timing: EnsureTiming) {
-  const current = yield* read(options.file)
-  if (current === undefined || !same(current, info)) return
-  yield* signal(info.pid, "SIGTERM")
-  const done = yield* stopped(info.pid).pipe(Effect.retry(poll(timing)), Effect.option)
-  if (Option.isSome(done)) return
-
-  const latest = yield* read(options.file)
-  if (latest === undefined || !same(latest, info)) return
-  yield* signal(info.pid, "SIGKILL")
-  yield* stopped(info.pid).pipe(Effect.retry(poll(timing)))
-})
-
-const kill = Effect.fnUntraced(function* (
-  service: LocalService,
-  options: { readonly file?: string },
-  timing: EnsureTiming,
-) {
+const kill = Effect.fnUntraced(function* (service: LocalService, _options: { readonly file?: string }, timing: EnsureTiming) {
   const requested = yield* requestStop(service, timing.requestTimeout)
-  if (requested === "rejected") return
+  if (requested === "rejected") return yield* Effect.fail(new Error("Background service rejected the stop request"))
   if (requested === "unsupported") {
-    // A stale registration may point at a reused PID. Authenticate again
-    // immediately before the legacy signal fallback.
-    const current = yield* find(options)
-    if (current === undefined || !same(current.info, service.info)) return
-    yield* signal(service.info.pid, "SIGTERM")
+    return yield* Effect.fail(new Error("Background service does not support authenticated stop requests"))
   }
   const done = yield* stopped(service.info.pid).pipe(Effect.retry(poll(timing)), Effect.option)
   if (Option.isSome(done)) return
 
-  const latest = yield* find(options)
-  if (latest === undefined || !same(latest.info, service.info)) return
-  yield* signal(service.info.pid, "SIGKILL")
-  yield* stopped(service.info.pid).pipe(Effect.retry(poll(timing)))
+  return yield* Effect.fail(new Error("Background service accepted the stop request but did not exit"))
 })
 
 const decodeStopResponse = Schema.decodeUnknownOption(ServiceStatus.StopResponse)
@@ -317,7 +287,8 @@ const requestStop = Effect.fnUntraced(function* (service: LocalService, timeout 
       signal: AbortSignal.timeout(timeout),
     }),
   ).pipe(Effect.option, Effect.map(Option.getOrUndefined))
-  if (response === undefined || response.status === 404 || response.status === 405) return "unsupported" as const
+  if (response === undefined) return "rejected" as const
+  if (response.status === 404 || response.status === 405) return "unsupported" as const
   const body = yield* Effect.tryPromise(() => response.json()).pipe(Effect.option, Effect.map(Option.getOrUndefined))
   const decoded = decodeStopResponse(body)
   if (!response.ok || Option.isNone(decoded) || !decoded.value.accepted) return "rejected" as const

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -43,7 +43,7 @@ export const incumbent = Effect.fn("service.incumbent")(function* (
   options: DiscoverOptions & { readonly url: string },
 ) {
   const info = yield* read(options.file)
-  const found = info === undefined ? undefined : yield* probe({ ...info, url: options.url })
+  const found = info === undefined ? undefined : yield* probeResult({ ...info, url: options.url })
   if (found === undefined || found.legacy) return undefined
   if (!matchesVersion(found.version, options)) return undefined
   return { endpoint: found.endpoint, state: found.state }
@@ -131,9 +131,9 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
 
 /** Stop the registered local service. */
 export const stop = Effect.fn("service.stop")(function* (options: StopOptions = {}) {
-  const existing = yield* find(options)
-  if (existing !== undefined) yield* kill(existing, defaultEnsureTiming)
-  if (existing === undefined && (yield* read(options.file)) !== undefined)
+  const registration = yield* registered(options.file, true)
+  if (registration.service !== undefined) yield* kill(registration.service, defaultEnsureTiming)
+  if (registration.service === undefined && registration.info !== undefined)
     return yield* Effect.fail(
       new Error("Background service is not responding; stop its process manually and try again"),
     )
@@ -179,10 +179,6 @@ type LocalService = {
   readonly state: "ready" | "waiting" | "failed"
   readonly legacy: boolean
 }
-
-const probe = Effect.fnUntraced(function* (info: Info, allowLegacy = false) {
-  return yield* probeResult(info, allowLegacy)
-})
 
 const probeResult = Effect.fnUntraced(function* (
   info: Info,
@@ -236,12 +232,6 @@ const registered = Effect.fnUntraced(function* (file?: string, allowLegacy = fal
   const info = yield* read(file)
   if (info === undefined) return { info: undefined, service: undefined }
   return { info, service: yield* probeResult(info, allowLegacy, timeout) }
-})
-
-// Health-checked lookup without the version gate: lifecycle operations must be
-// able to see (and replace or stop) a server from a different version.
-const find = Effect.fnUntraced(function* (options: { readonly file?: string }) {
-  return (yield* registered(options.file, true)).service
 })
 
 // Poll until an authenticated stop exits, bounded by the configured stop window.

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -2,7 +2,14 @@ import { ServiceStatus } from "@opencode-ai/protocol/groups/health"
 import { Effect, FileSystem, Option, Schedule, Schema } from "effect"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { VersionMismatchError, type DiscoverOptions, type Endpoint, type EnsureOptions, type StopOptions } from "../service.js"
+import {
+  canReplaceVersion,
+  VersionMismatchError,
+  type DiscoverOptions,
+  type Endpoint,
+  type EnsureOptions,
+  type StopOptions,
+} from "../service.js"
 import {
   contenderFailure,
   contenderFinished,
@@ -86,10 +93,12 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
       if (compatible && service.state === "failed")
         return yield* Effect.fail(new Error("Background service failed to start"))
       if (compatible) return Option.none<LocalService>()
-      if (!service.legacy && options.canReplace?.(service.version) === false)
-        return yield* Effect.fail(new VersionMismatchError(options.version, service.version))
+      if (options.canReplace?.(service.version) !== true)
+        return yield* Effect.fail(
+          new VersionMismatchError(typeof options.version === "string" ? options.version : undefined, service.version),
+        )
+      yield* kill(service, timing)
       yield* announce("version-mismatch", service.version)
-      yield* kill(service, options, timing)
       lastSpawn = 0
       return Option.none<LocalService>()
     } else if (lastSpawn === 0 && info !== undefined) lastSpawn = Date.now()
@@ -123,9 +132,11 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
 /** Stop the registered local service. */
 export const stop = Effect.fn("service.stop")(function* (options: StopOptions = {}) {
   const existing = yield* find(options)
-  if (existing !== undefined) yield* kill(existing, options, defaultEnsureTiming)
+  if (existing !== undefined) yield* kill(existing, defaultEnsureTiming)
   if (existing === undefined && (yield* read(options.file)) !== undefined)
-    return yield* Effect.fail(new Error("Background service is not responding; stop its process manually and try again"))
+    return yield* Effect.fail(
+      new Error("Background service is not responding; stop its process manually and try again"),
+    )
 })
 
 function fallback() {
@@ -170,7 +181,7 @@ type LocalService = {
 }
 
 const probe = Effect.fnUntraced(function* (info: Info, allowLegacy = false) {
-  return (yield* probeResult(info, allowLegacy)).service
+  return yield* probeResult(info, allowLegacy)
 })
 
 const probeResult = Effect.fnUntraced(function* (
@@ -197,41 +208,34 @@ const probeResult = Effect.fnUntraced(function* (
         (cause: unknown) => ({ cause }),
       ),
   )
-  if ("cause" in result) return { service: undefined, timedOut: signal.aborted }
+  if ("cause" in result) return undefined
   const response = result.value.response
   const body = result.value.body
   const health = decodeHealth(body)
   if (Option.isSome(health)) {
-    if (health.value.pid !== info.pid) return { service: undefined, timedOut: false }
-    if (info.version !== undefined && health.value.version !== info.version)
-      return { service: undefined, timedOut: false }
+    if (health.value.pid !== info.pid) return undefined
+    if (info.version !== undefined && health.value.version !== info.version) return undefined
     return {
-      service: {
-        info,
-        endpoint,
-        version: health.value.version,
-        state: response.ok ? "ready" : response.status === 500 ? "failed" : "waiting",
-        legacy: false,
-      } satisfies LocalService,
-      timedOut: false,
-    }
+      info,
+      endpoint,
+      version: health.value.version,
+      state: response.ok ? "ready" : response.status === 500 ? "failed" : "waiting",
+      legacy: false,
+    } satisfies LocalService
   }
   if (
     !allowLegacy ||
     Option.isNone(decodeLegacyHealth(body)) ||
     (typeof body === "object" && body !== null && ("version" in body || "pid" in body))
   )
-    return { service: undefined, timedOut: false }
-  return {
-    service: { info, endpoint, state: "ready", legacy: true } satisfies LocalService,
-    timedOut: false,
-  }
+    return undefined
+  return { info, endpoint, state: "ready", legacy: true } satisfies LocalService
 })
 
 const registered = Effect.fnUntraced(function* (file?: string, allowLegacy = false, timeout?: number) {
   const info = yield* read(file)
-  if (info === undefined) return { info: undefined, service: undefined, timedOut: false }
-  return { info, ...(yield* probeResult(info, allowLegacy, timeout)) }
+  if (info === undefined) return { info: undefined, service: undefined }
+  return { info, service: yield* probeResult(info, allowLegacy, timeout) }
 })
 
 // Health-checked lookup without the version gate: lifecycle operations must be
@@ -240,8 +244,7 @@ const find = Effect.fnUntraced(function* (options: { readonly file?: string }) {
   return (yield* registered(options.file, true)).service
 })
 
-// 50ms cadence bounded at ~5s, shared by stop escalation and each ensure
-// discovery window.
+// Poll until an authenticated stop exits, bounded by the configured stop window.
 const poll = (timing: EnsureTiming) =>
   Schedule.max([Schedule.spaced(timing.stopPollInterval), Schedule.recurs(timing.stopPollAttempts)])
 
@@ -253,17 +256,7 @@ const stopped = Effect.fnUntraced(function* (pid: number) {
   return yield* Effect.fail(new Error(`Server process ${pid} is still running`))
 })
 
-function same(left: Info, right: Info) {
-  return (
-    left.id === right.id &&
-    left.version === right.version &&
-    left.url === right.url &&
-    left.pid === right.pid &&
-    left.password === right.password
-  )
-}
-
-const kill = Effect.fnUntraced(function* (service: LocalService, _options: { readonly file?: string }, timing: EnsureTiming) {
+const kill = Effect.fnUntraced(function* (service: LocalService, timing: EnsureTiming) {
   const requested = yield* requestStop(service, timing.requestTimeout)
   if (requested === "rejected") return yield* Effect.fail(new Error("Background service rejected the stop request"))
   if (requested === "unsupported") {
@@ -296,4 +289,4 @@ const requestStop = Effect.fnUntraced(function* (service: LocalService, timeout 
 })
 
 /** Effect-based local service lifecycle operations. */
-export const Service = { discover, incumbent, ensure, stop, headers, Info }
+export const Service = { discover, incumbent, ensure, stop, headers, canReplaceVersion, Info }

--- a/packages/client/src/promise/service.ts
+++ b/packages/client/src/promise/service.ts
@@ -76,7 +76,10 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
         if (compatible && service.state === "failed") throw new Error("Background service failed to start")
         if (!compatible) {
           if (options.canReplace?.(service.version) !== true)
-            throw new VersionMismatchError(typeof options.version === "string" ? options.version : undefined, service.version)
+            throw new VersionMismatchError(
+              typeof options.version === "string" ? options.version : undefined,
+              service.version,
+            )
           await kill(service, timing)
           announce("version-mismatch", service.version)
           lastSpawn = 0
@@ -106,9 +109,9 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
 
 /** Stop the registered local service. */
 export async function stop(options: StopOptions = {}) {
-  const existing = await find(options)
-  if (existing !== undefined) await kill(existing, defaultEnsureTiming)
-  if (existing === undefined && (await read(options.file)) !== undefined)
+  const registration = await registered(options.file, true)
+  if (registration.service !== undefined) await kill(registration.service, defaultEnsureTiming)
+  if (registration.service === undefined && registration.info !== undefined)
     throw new Error("Background service is not responding; stop its process manually and try again")
 }
 
@@ -213,10 +216,6 @@ async function registered(file?: string, allowLegacy = false, timeout?: number) 
   const info = await read(file)
   if (info === undefined) return { info: undefined, service: undefined }
   return { info, service: await probeResult(info, allowLegacy, timeout) }
-}
-
-async function find(options: { readonly file?: string }) {
-  return (await registered(options.file, true)).service
 }
 
 function stopped(pid: number) {

--- a/packages/client/src/promise/service.ts
+++ b/packages/client/src/promise/service.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import {
+  canReplaceVersion,
   VersionMismatchError,
   type DiscoverOptions,
   type Endpoint,
@@ -17,7 +18,7 @@ import {
 } from "../service-contender.js"
 import { defaultEnsureTiming, ensureTiming, type EnsureTiming } from "../service-timing.js"
 import { matchesVersion } from "../service-version.js"
-import type { ServiceHealth, ServiceStopResponse } from "./generated/types.js"
+import type { ServiceStopResponse } from "./generated/types.js"
 
 export * from "../service.js"
 
@@ -74,10 +75,10 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
         if (compatible && service.state === "ready") return service.endpoint
         if (compatible && service.state === "failed") throw new Error("Background service failed to start")
         if (!compatible) {
-          if (!service.legacy && options.canReplace?.(service.version) === false)
-            throw new VersionMismatchError(options.version, service.version)
+          if (options.canReplace?.(service.version) !== true)
+            throw new VersionMismatchError(typeof options.version === "string" ? options.version : undefined, service.version)
+          await kill(service, timing)
           announce("version-mismatch", service.version)
-          await kill(service, options, timing)
           lastSpawn = 0
         }
       } else {
@@ -106,7 +107,7 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
 /** Stop the registered local service. */
 export async function stop(options: StopOptions = {}) {
   const existing = await find(options)
-  if (existing !== undefined) await kill(existing, options, defaultEnsureTiming)
+  if (existing !== undefined) await kill(existing, defaultEnsureTiming)
   if (existing === undefined && (await read(options.file)) !== undefined)
     throw new Error("Background service is not responding; stop its process manually and try again")
 }
@@ -149,10 +150,6 @@ type LocalService = {
   readonly legacy: boolean
 }
 
-async function probe(info: Info, allowLegacy = false): Promise<LocalService | undefined> {
-  return (await probeResult(info, allowLegacy)).service
-}
-
 async function probeResult(info: Info, allowLegacy = false, timeout = defaultEnsureTiming.requestTimeout) {
   const endpoint = {
     url: info.url,
@@ -168,13 +165,13 @@ async function probeResult(info: Info, allowLegacy = false, timeout = defaultEns
   })
     .then(async (response) => ({
       response,
-      body: (await response.json()) as ServiceHealth | { readonly healthy: true },
+      body: (await response.json()) as unknown,
     }))
     .then(
       (value) => ({ value }),
       (cause: unknown) => ({ cause }),
     )
-  if ("cause" in result) return { service: undefined, timedOut: signal.aborted }
+  if ("cause" in result) return undefined
   const response = result.value.response
   const body = result.value.body
   if (
@@ -189,18 +186,15 @@ async function probeResult(info: Info, allowLegacy = false, timeout = defaultEns
     Number.isInteger(body.pid) &&
     body.pid > 0
   ) {
-    if (body.pid !== info.pid) return { service: undefined, timedOut: false }
-    if (info.version !== undefined && body.version !== info.version) return { service: undefined, timedOut: false }
+    if (body.pid !== info.pid) return undefined
+    if (info.version !== undefined && body.version !== info.version) return undefined
     return {
-      service: {
-        info,
-        endpoint,
-        version: body.version,
-        state: response.ok ? "ready" : response.status === 500 ? "failed" : "waiting",
-        legacy: false,
-      } satisfies LocalService,
-      timedOut: false,
-    }
+      info,
+      endpoint,
+      version: body.version,
+      state: response.ok ? "ready" : response.status === 500 ? "failed" : "waiting",
+      legacy: false,
+    } satisfies LocalService
   }
   if (
     !allowLegacy ||
@@ -211,17 +205,14 @@ async function probeResult(info: Info, allowLegacy = false, timeout = defaultEns
     "version" in body ||
     "pid" in body
   )
-    return { service: undefined, timedOut: false }
-  return {
-    service: { info, endpoint, state: "ready", legacy: true } satisfies LocalService,
-    timedOut: false,
-  }
+    return undefined
+  return { info, endpoint, state: "ready", legacy: true } satisfies LocalService
 }
 
 async function registered(file?: string, allowLegacy = false, timeout?: number) {
   const info = await read(file)
-  if (info === undefined) return { info: undefined, service: undefined, timedOut: false }
-  return { info, ...(await probeResult(info, allowLegacy, timeout)) }
+  if (info === undefined) return { info: undefined, service: undefined }
+  return { info, service: await probeResult(info, allowLegacy, timeout) }
 }
 
 async function find(options: { readonly file?: string }) {
@@ -245,21 +236,7 @@ async function waitUntilStopped(pid: number, timing: EnsureTiming) {
   return false
 }
 
-function same(left: Info, right: Info) {
-  return (
-    left.id === right.id &&
-    left.version === right.version &&
-    left.url === right.url &&
-    left.pid === right.pid &&
-    left.password === right.password
-  )
-}
-
-async function kill(
-  service: LocalService,
-  _options: { readonly file?: string },
-  timing: EnsureTiming,
-) {
+async function kill(service: LocalService, timing: EnsureTiming) {
   const requested = await requestStop(service, timing.requestTimeout)
   if (requested === "rejected") throw new Error("Background service rejected the stop request")
   if (requested === "unsupported") throw new Error("Background service does not support authenticated stop requests")
@@ -287,4 +264,4 @@ function delay(milliseconds: number) {
 }
 
 /** Promise-based local service lifecycle operations. */
-export const Service = { discover, ensure, stop, headers }
+export const Service = { discover, ensure, stop, headers, canReplaceVersion }

--- a/packages/client/src/promise/service.ts
+++ b/packages/client/src/promise/service.ts
@@ -1,7 +1,14 @@
 import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import type { DiscoverOptions, Endpoint, Info, EnsureOptions, StopOptions } from "../service.js"
+import {
+  VersionMismatchError,
+  type DiscoverOptions,
+  type Endpoint,
+  type Info,
+  type EnsureOptions,
+  type StopOptions,
+} from "../service.js"
 import {
   contenderFailure,
   contenderFinished,
@@ -37,7 +44,6 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
   const timing = ensureTiming(options)
   const deadline = Date.now() + timing.promiseTimeout
   const contenders = new Set<ServiceContender>()
-  let timeouts: { readonly info: Info; readonly count: number } | undefined
   let announced = false
   let lastSpawn = 0
   let spawnDelay = timing.spawnDelay
@@ -61,19 +67,6 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
     while (true) {
       if (Date.now() >= deadline) throw new Error("Timed out waiting for the background service to start")
       const registration = await registered(options.file, true, timing.requestTimeout)
-      if (registration.timedOut && registration.info !== undefined) {
-        timeouts = {
-          info: registration.info,
-          count: timeouts !== undefined && same(timeouts.info, registration.info) ? timeouts.count + 1 : 1,
-        }
-        if (timeouts.count >= 3) {
-          announce("missing")
-          await evict(registration.info, options, timing)
-          timeouts = undefined
-          lastSpawn = Date.now() - spawnDelay
-        }
-      } else timeouts = undefined
-
       if (registration.service !== undefined) {
         spawnDelay = timing.spawnDelay
         const service = registration.service
@@ -81,8 +74,10 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
         if (compatible && service.state === "ready") return service.endpoint
         if (compatible && service.state === "failed") throw new Error("Background service failed to start")
         if (!compatible) {
+          if (!service.legacy && options.canReplace?.(service.version) === false)
+            throw new VersionMismatchError(options.version, service.version)
           announce("version-mismatch", service.version)
-          await kill(service, options, timing).catch(() => undefined)
+          await kill(service, options, timing)
           lastSpawn = 0
         }
       } else {
@@ -112,6 +107,8 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
 export async function stop(options: StopOptions = {}) {
   const existing = await find(options)
   if (existing !== undefined) await kill(existing, options, defaultEnsureTiming)
+  if (existing === undefined && (await read(options.file)) !== undefined)
+    throw new Error("Background service is not responding; stop its process manually and try again")
 }
 
 function fallback() {
@@ -130,7 +127,15 @@ async function read(file?: string) {
   const text = await readFile(file ?? fallback(), "utf8").catch(() => undefined)
   if (text === undefined) return undefined
   try {
-    return JSON.parse(text) as Info
+    const value: unknown = JSON.parse(text)
+    if (typeof value !== "object" || value === null) return undefined
+    if (!("url" in value) || typeof value.url !== "string") return undefined
+    if (!("pid" in value) || !Number.isInteger(value.pid) || typeof value.pid !== "number" || value.pid <= 0)
+      return undefined
+    if ("id" in value && value.id !== undefined && typeof value.id !== "string") return undefined
+    if ("version" in value && value.version !== undefined && typeof value.version !== "string") return undefined
+    if ("password" in value && value.password !== undefined && typeof value.password !== "string") return undefined
+    return value as Info
   } catch {
     return undefined
   }
@@ -172,7 +177,18 @@ async function probeResult(info: Info, allowLegacy = false, timeout = defaultEns
   if ("cause" in result) return { service: undefined, timedOut: signal.aborted }
   const response = result.value.response
   const body = result.value.body
-  if (body !== undefined && "version" in body && "pid" in body) {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    "healthy" in body &&
+    body.healthy === true &&
+    "version" in body &&
+    typeof body.version === "string" &&
+    "pid" in body &&
+    typeof body.pid === "number" &&
+    Number.isInteger(body.pid) &&
+    body.pid > 0
+  ) {
     if (body.pid !== info.pid) return { service: undefined, timedOut: false }
     if (info.version !== undefined && body.version !== info.version) return { service: undefined, timedOut: false }
     return {
@@ -186,7 +202,16 @@ async function probeResult(info: Info, allowLegacy = false, timeout = defaultEns
       timedOut: false,
     }
   }
-  if (!allowLegacy || body?.healthy !== true) return { service: undefined, timedOut: false }
+  if (
+    !allowLegacy ||
+    typeof body !== "object" ||
+    body === null ||
+    !("healthy" in body) ||
+    body.healthy !== true ||
+    "version" in body ||
+    "pid" in body
+  )
+    return { service: undefined, timedOut: false }
   return {
     service: { info, endpoint, state: "ready", legacy: true } satisfies LocalService,
     timedOut: false,
@@ -201,12 +226,6 @@ async function registered(file?: string, allowLegacy = false, timeout?: number) 
 
 async function find(options: { readonly file?: string }) {
   return (await registered(options.file, true)).service
-}
-
-function signal(pid: number, name: NodeJS.Signals) {
-  try {
-    process.kill(pid, name)
-  } catch {}
 }
 
 function stopped(pid: number) {
@@ -227,36 +246,25 @@ async function waitUntilStopped(pid: number, timing: EnsureTiming) {
 }
 
 function same(left: Info, right: Info) {
-  return left.id === right.id && left.version === right.version && left.url === right.url && left.pid === right.pid
+  return (
+    left.id === right.id &&
+    left.version === right.version &&
+    left.url === right.url &&
+    left.pid === right.pid &&
+    left.password === right.password
+  )
 }
 
-async function evict(info: Info, options: { readonly file?: string }, timing: EnsureTiming) {
-  const current = await read(options.file)
-  if (current === undefined || !same(current, info)) return
-  signal(info.pid, "SIGTERM")
-  if (await waitUntilStopped(info.pid, timing)) return
-
-  const latest = await read(options.file)
-  if (latest === undefined || !same(latest, info)) return
-  signal(info.pid, "SIGKILL")
-  if (!(await waitUntilStopped(info.pid, timing))) throw new Error(`Server process ${info.pid} is still running`)
-}
-
-async function kill(service: LocalService, options: { readonly file?: string }, timing: EnsureTiming) {
+async function kill(
+  service: LocalService,
+  _options: { readonly file?: string },
+  timing: EnsureTiming,
+) {
   const requested = await requestStop(service, timing.requestTimeout)
-  if (requested === "rejected") return
-  if (requested === "unsupported") {
-    const current = await find(options)
-    if (current === undefined || !same(current.info, service.info)) return
-    signal(service.info.pid, "SIGTERM")
-  }
+  if (requested === "rejected") throw new Error("Background service rejected the stop request")
+  if (requested === "unsupported") throw new Error("Background service does not support authenticated stop requests")
   if (await waitUntilStopped(service.info.pid, timing)) return
-
-  const latest = await find(options)
-  if (latest === undefined || !same(latest.info, service.info)) return
-  signal(service.info.pid, "SIGKILL")
-  if (!(await waitUntilStopped(service.info.pid, timing)))
-    throw new Error(`Server process ${service.info.pid} is still running`)
+  throw new Error("Background service accepted the stop request but did not exit")
 }
 
 async function requestStop(service: LocalService, timeout = defaultEnsureTiming.requestTimeout) {
@@ -267,7 +275,8 @@ async function requestStop(service: LocalService, timeout = defaultEnsureTiming.
     body: JSON.stringify({ instanceID: service.info.id }),
     signal: AbortSignal.timeout(timeout),
   }).catch(() => undefined)
-  if (response === undefined || response.status === 404 || response.status === 405) return "unsupported" as const
+  if (response === undefined) return "rejected" as const
+  if (response.status === 404 || response.status === 405) return "unsupported" as const
   const body = (await response.json().catch(() => undefined)) as ServiceStopResponse | undefined
   if (!response.ok || body?.accepted !== true) return "rejected" as const
   return "accepted" as const

--- a/packages/client/src/service-version.ts
+++ b/packages/client/src/service-version.ts
@@ -1,8 +1,19 @@
 import type { DiscoverOptions } from "./service.js"
+import semver from "semver"
 
 export function matchesVersion(version: string | undefined, options: DiscoverOptions) {
   if (options.version === undefined) return true
   if (version === undefined) return false
   if (typeof options.version === "function") return options.version(version)
   return version === options.version
+}
+
+/** Whether a client version is strictly newer than a service version. */
+export function canReplaceVersion(serverVersion: string | undefined, clientVersion: string) {
+  if (serverVersion === undefined) return false
+  // Compare preview build numbers numerically rather than as semver prerelease strings.
+  const server = serverVersion.replace(/^(0\.0\.0-.+)-(\d+(?:\.\d+)?)$/, "$1.$2")
+  const client = clientVersion.replace(/^(0\.0\.0-.+)-(\d+(?:\.\d+)?)$/, "$1.$2")
+  if (!semver.valid(server) || !semver.valid(client)) return false
+  return semver.lt(server, client)
 }

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -1,4 +1,4 @@
-import semver from "semver"
+export { canReplaceVersion } from "./service-version.js"
 
 /** Connection details for a local OpenCode service. */
 export type Endpoint = {
@@ -46,16 +46,6 @@ export class VersionMismatchError extends Error {
   ) {
     super(`Background service ${serverVersion ?? "unknown"} does not match client ${clientVersion ?? "unknown"}`)
   }
-}
-
-/** Whether a client version is strictly newer than a service version. */
-export function canReplaceVersion(serverVersion: string | undefined, clientVersion: string) {
-  if (serverVersion === undefined) return false
-  // Compare preview build numbers numerically rather than as semver prerelease strings.
-  const server = serverVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
-  const client = clientVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
-  if (!semver.valid(server) || !semver.valid(client)) return false
-  return semver.lt(server, client)
 }
 
 /** Options used to stop the local OpenCode service. */

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -1,3 +1,5 @@
+import semver from "semver"
+
 /** Connection details for a local OpenCode service. */
 export type Endpoint = {
   /** Base URL of the service. */
@@ -28,7 +30,7 @@ export type EnsureReason = "missing" | "version-mismatch"
 export type EnsureOptions = DiscoverOptions & {
   /** Service command and arguments. Defaults to `opencode serve --service`. */
   readonly command?: ReadonlyArray<string>
-  /** Decide whether a version-mismatched service may be replaced. Defaults to true. */
+  /** Decide whether a version-mismatched service may be replaced. Defaults to false. */
   readonly canReplace?: (version: string | undefined) => boolean
   /** Called once before spawning a new service process. */
   readonly onStart?: (reason: EnsureReason, previousVersion?: string) => void
@@ -42,11 +44,18 @@ export class VersionMismatchError extends Error {
     readonly clientVersion: string | undefined,
     readonly serverVersion: string | undefined,
   ) {
-    super(
-      `Background service ${serverVersion ?? "unknown"} is newer than this client ${clientVersion ?? "unknown"}. ` +
-        "Run `opencode2 service restart` to activate this installed version.",
-    )
+    super(`Background service ${serverVersion ?? "unknown"} does not match client ${clientVersion ?? "unknown"}`)
   }
+}
+
+/** Whether a client version is strictly newer than a service version. */
+export function canReplaceVersion(serverVersion: string | undefined, clientVersion: string) {
+  if (serverVersion === undefined) return false
+  // Compare preview build numbers numerically rather than as semver prerelease strings.
+  const server = serverVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
+  const client = clientVersion.replace(/-(\d+)(?=(?:\.\d+)?$)/, ".$1")
+  if (!semver.valid(server) || !semver.valid(client)) return false
+  return semver.lt(server, client)
 }
 
 /** Options used to stop the local OpenCode service. */

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -28,8 +28,25 @@ export type EnsureReason = "missing" | "version-mismatch"
 export type EnsureOptions = DiscoverOptions & {
   /** Service command and arguments. Defaults to `opencode serve --service`. */
   readonly command?: ReadonlyArray<string>
+  /** Decide whether a version-mismatched service may be replaced. Defaults to true. */
+  readonly canReplace?: (version: string | undefined) => boolean
   /** Called once before spawning a new service process. */
   readonly onStart?: (reason: EnsureReason, previousVersion?: string) => void
+}
+
+/** A healthy service exists, but the caller's replacement policy protects it. */
+export class VersionMismatchError extends Error {
+  override readonly name = "VersionMismatchError"
+
+  constructor(
+    readonly clientVersion: string | undefined,
+    readonly serverVersion: string | undefined,
+  ) {
+    super(
+      `Background service ${serverVersion ?? "unknown"} is newer than this client ${clientVersion ?? "unknown"}. ` +
+        "Run `opencode2 service restart` to activate this installed version.",
+    )
+  }
 }
 
 /** Options used to stop the local OpenCode service. */

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -44,7 +44,7 @@ const server = Bun.serve({
       await appendFile(registration + ".stop-attempts", process.pid + "\n")
       return new Promise<Response>(() => {})
     }
-    if (pathname === "/api/service/stop" && (mode === "graceful" || mode === "old")) {
+    if (pathname === "/api/service/stop" && (mode === "graceful" || mode === "old" || mode === "incompatible")) {
       const body = await request.json()
       if (typeof body !== "object" || body === null || body.instanceID !== id) return Response.json({ accepted: false })
       await writeFile(registration + ".stop", JSON.stringify(body))
@@ -67,8 +67,6 @@ const server = Bun.serve({
     if (mode === "starting" && !(await Bun.file(registration + ".release").exists()))
       return Response.json({ healthy: true, version, pid: process.pid }, { status: 503 })
     if (mode === "failed-owner") return Response.json({ healthy: true, version, pid: process.pid }, { status: 500 })
-    if (mode === "starting" || mode === "graceful" || mode === "reject-stop" || mode === "stop-hanging")
-      return Response.json({ healthy: true, version, pid: process.pid })
     return Response.json({ healthy: true, version, pid: process.pid })
   },
 })

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -28,7 +28,7 @@ if (mode === "delayed" || mode === "delayed-failed" || mode === "coordinated" ||
 
 let requests = 0
 let version = "test"
-if (mode === "old" || mode === "reject-stop") version = "old"
+if (mode === "old" || mode === "reject-stop" || mode === "stop-hanging") version = "old"
 if (mode === "incompatible") version = "1.9.0"
 if (mode === "compatible" || mode === "delayed-compatible") version = "2.1.0-next.1"
 const id = crypto.randomUUID()
@@ -40,7 +40,11 @@ const server = Bun.serve({
       await appendFile(registration + ".stop-attempts", process.pid + "\n")
       return Response.json({ accepted: false })
     }
-    if (pathname === "/api/service/stop" && mode === "graceful") {
+    if (pathname === "/api/service/stop" && mode === "stop-hanging") {
+      await appendFile(registration + ".stop-attempts", process.pid + "\n")
+      return new Promise<Response>(() => {})
+    }
+    if (pathname === "/api/service/stop" && (mode === "graceful" || mode === "old")) {
       const body = await request.json()
       if (typeof body !== "object" || body === null || body.instanceID !== id) return Response.json({ accepted: false })
       await writeFile(registration + ".stop", JSON.stringify(body))
@@ -63,7 +67,7 @@ const server = Bun.serve({
     if (mode === "starting" && !(await Bun.file(registration + ".release").exists()))
       return Response.json({ healthy: true, version, pid: process.pid }, { status: 503 })
     if (mode === "failed-owner") return Response.json({ healthy: true, version, pid: process.pid }, { status: 500 })
-    if (mode === "starting" || mode === "graceful" || mode === "reject-stop")
+    if (mode === "starting" || mode === "graceful" || mode === "reject-stop" || mode === "stop-hanging")
       return Response.json({ healthy: true, version, pid: process.pid })
     return Response.json({ healthy: true, version, pid: process.pid })
   },

--- a/packages/client/test/promise-service.test.ts
+++ b/packages/client/test/promise-service.test.ts
@@ -187,10 +187,9 @@ test("a stale native client refuses to replace a newer service", async () => {
     ensure({
       file: registration,
       version: "old",
-      canReplace: () => false,
       command: [process.execPath, fixture, contender, "record-start"],
     }),
-  ).rejects.toThrow("Run `opencode2 service restart` to activate this installed version")
+  ).rejects.toThrow("Background service test does not match client old")
 
   expect(await Bun.file(contender + ".started").exists()).toBe(false)
   expect(process.kill(info.pid, 0)).toBe(true)

--- a/packages/client/test/promise-service.test.ts
+++ b/packages/client/test/promise-service.test.ts
@@ -38,6 +38,50 @@ test("discovers a compatible registered service", async () => {
   expect(await Service.discover({ file: registration, version: (version) => version.startsWith("3.") })).toBeUndefined()
 })
 
+test("rejects malformed registrations without probing or signaling", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const malformed = [
+    null,
+    [],
+    {},
+    { url: "http://127.0.0.1:1" },
+    { url: "http://127.0.0.1:1", pid: 0 },
+    { url: "http://127.0.0.1:1", pid: -1 },
+    { url: "http://127.0.0.1:1", pid: 1.5 },
+    { url: "http://127.0.0.1:1", pid: "1" },
+    { url: "http://127.0.0.1:1", pid: 1, id: 1 },
+  ]
+
+  for (const value of malformed) {
+    await Bun.write(registration, JSON.stringify(value))
+    expect(await Service.discover({ file: registration })).toBeUndefined()
+  }
+})
+
+test("rejects primitive and partial modern health responses", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const bodies = [
+    null,
+    1,
+    "healthy",
+    [],
+    {},
+    { healthy: false, version: "test", pid: process.pid },
+    { healthy: true, version: null, pid: process.pid },
+    { healthy: true, version: "test", pid: "1" },
+    { healthy: true, version: "test" },
+    { healthy: true, pid: process.pid },
+  ]
+
+  for (const body of bodies) {
+    using server = Bun.serve({ port: 0, fetch: () => Response.json(body) })
+    await Bun.write(registration, JSON.stringify({ url: server.url.toString(), pid: process.pid }))
+    expect(await Service.discover({ file: registration })).toBeUndefined()
+  }
+})
+
 test("ensures a missing service with native promises", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")
@@ -100,7 +144,7 @@ test("reports a bounded contender stderr tail with native promises", async () =>
   expect(error.message.length).toBeLessThan(9_000)
 }, 10_000)
 
-test("evicts an unresponsive registered service before starting its replacement", async () => {
+test("never evicts an unresponsive registered service automatically", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")
   const existing = Bun.spawn([process.execPath, fixture, registration, "hanging"], {
@@ -111,19 +155,46 @@ test("evicts an unresponsive registered service before starting its replacement"
   await waitForFile(registration)
   const original = await Bun.file(registration).json()
 
-  const endpoint = await ensure({
+  const options = {
     file: registration,
     version: "test",
-    command: [process.execPath, fixture, registration, "delayed", "10"],
-  })
-  const replacement = await Bun.file(registration).json()
+    command: [process.execPath, fixture, registration, "record-start"],
+  }
+  const result = ensure(options)
+  await waitForLines(registration + ".requests", 3)
 
-  expect((await Bun.file(registration + ".requests").text()).trim().split("\n")).toHaveLength(3)
-  expect(await existing.exited).toBe(0)
-  expect(replacement.pid).not.toBe(original.pid)
-  expect(endpoint.url).toBe(replacement.url)
-  process.kill(replacement.pid, "SIGTERM")
-  await waitForExit(replacement.pid)
+  expect(existing.exitCode).toBe(null)
+  expect(await Bun.file(registration).json()).toEqual(original)
+  await expect(result).rejects.toThrow()
+})
+
+test("explicit native stop refuses to signal an unidentified unresponsive PID", async () => {
+  const registration = await setup("hanging")
+  const info = await Bun.file(registration).json()
+
+  await expect(Service.stop({ file: registration })).rejects.toThrow("stop its process manually")
+
+  expect(process.kill(info.pid, 0)).toBe(true)
+})
+
+test("a stale native client refuses to replace a newer service", async () => {
+  const registration = await setup("graceful")
+  const directory = await temp()
+  const contender = join(directory, "contender.json")
+  const info = await Bun.file(registration).json()
+
+  await expect(
+    ensure({
+      file: registration,
+      version: "old",
+      canReplace: () => false,
+      command: [process.execPath, fixture, contender, "record-start"],
+    }),
+  ).rejects.toThrow("Run `opencode2 service restart` to activate this installed version")
+
+  expect(await Bun.file(contender + ".started").exists()).toBe(false)
+  expect(process.kill(info.pid, 0)).toBe(true)
+  expect(await Bun.file(registration).json()).toEqual(info)
 })
 
 test("requests graceful stop of the exact service instance", async () => {
@@ -155,4 +226,15 @@ async function waitForFile(file: string) {
     await Bun.sleep(5)
   }
   throw new Error(`Timed out waiting for ${file}`)
+}
+
+async function waitForLines(file: string, count: number) {
+  for (let attempt = 0; attempt < 600; attempt++) {
+    const text = await Bun.file(file)
+      .text()
+      .catch(() => "")
+    if (text.trim().split("\n").length >= count) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${count} lines in ${file}`)
 }

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -175,6 +175,7 @@ test("does not spawn contenders while an incompatible service rejects replacemen
     ensure({
       file: registration,
       version: "test",
+      canReplace: () => true,
       command: [process.execPath, fixture, contender, "record-start"],
     }),
   )
@@ -196,6 +197,7 @@ test("does not signal a modern service when its stop request times out", async (
     ensure({
       file: registration,
       version: "test",
+      canReplace: () => true,
       command: [process.execPath, fixture, contender, "record-start"],
     }),
   )
@@ -213,7 +215,9 @@ test("explicit stop refuses to signal when a modern stop request times out", asy
   const existing = spawn(registration, "stop-hanging")
   await waitForFile(registration)
 
-  await expect(run(Service.stop({ file: registration }))).rejects.toThrow("Background service rejected the stop request")
+  await expect(run(Service.stop({ file: registration }))).rejects.toThrow(
+    "Background service rejected the stop request",
+  )
 
   expect(existing.exitCode).toBe(null)
 })
@@ -231,11 +235,10 @@ test("a stale client refuses to replace a newer service", async () => {
       ensure({
         file: registration,
         version: "old",
-        canReplace: () => false,
         command: [process.execPath, fixture, contender, "record-start"],
       }),
     ),
-  ).rejects.toThrow("Run `opencode2 service restart` to activate this installed version")
+  ).rejects.toThrow("Background service test does not match client old")
 
   expect(await Bun.file(contender + ".started").exists()).toBe(false)
   expect(existing.exitCode).toBe(null)
@@ -255,7 +258,7 @@ test("explicit restart can activate an installed downgrade", async () => {
     command: [process.execPath, fixture, registration, "old"],
   }
 
-  await expect(run(ensure(options))).rejects.toThrow("Run `opencode2 service restart`")
+  await expect(run(ensure(options))).rejects.toThrow("Background service test does not match client old")
   expect(current.exitCode).toBe(null)
 
   await run(Service.stop({ file: registration }))
@@ -279,10 +282,12 @@ test("refuses to signal a legacy service without authenticated stop", async () =
   await waitForFile(registration)
 
   const starts: EnsureReason[] = []
-  const result = run(ensure({ file: registration, command: [], onStart: (reason) => starts.push(reason) }))
+  const result = run(
+    ensure({ file: registration, command: [], canReplace: () => true, onStart: (reason) => starts.push(reason) }),
+  )
 
   await expect(result).rejects.toThrow("does not support authenticated stop requests")
-  expect(starts).toEqual(["version-mismatch"])
+  expect(starts).toEqual([])
   expect(existing.exitCode).toBe(null)
 })
 
@@ -392,6 +397,7 @@ test("replaces an incompatible owner that appears during startup", async () => {
     ensure({
       file: registration,
       version: "test",
+      canReplace: () => true,
       command: [process.execPath, fixture, registration, "delayed", "500"],
     }),
   )
@@ -424,7 +430,9 @@ test("concurrent current-version launchers converge on one replacement", async (
         command: [process.execPath, fixture, registration, "coordinated"],
         canReplace: (version: string | undefined) => version === "old",
       }
-      return index % 2 === 0 ? run(ensure(options)) : import("../src/promise/service").then((mod) => mod.Service.ensure(options))
+      return index % 2 === 0
+        ? run(ensure(options))
+        : import("../src/promise/service").then((mod) => mod.Service.ensure(options))
     }),
   )
   const info = await Bun.file(registration).json()

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -118,29 +118,39 @@ test("reports a failed registered service without spawning", async () => {
   expect(process.exitCode).toBe(null)
 })
 
-test("evicts an unresponsive registered service before starting its replacement", async () => {
+test("never evicts an unresponsive registered service automatically", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")
   const existing = spawn(registration, "hanging")
   await waitForFile(registration)
   const original = await Bun.file(registration).json()
 
-  const endpoint = await run(
+  const controller = new AbortController()
+  const result = Effect.runPromise(
     ensure({
       file: registration,
       version: "test",
-      command: [process.execPath, fixture, registration, "delayed", "10"],
-    }),
+      command: [process.execPath, fixture, registration, "record-start"],
+    }).pipe(Effect.provide(NodeFileSystem.layer)),
+    { signal: controller.signal },
   )
-  const replacement = await Bun.file(registration).json()
+  await waitForLines(registration + ".requests", 3)
+  controller.abort()
+  await result.catch(() => undefined)
 
-  expect((await Bun.file(registration + ".requests").text()).trim().split("\n")).toHaveLength(3)
-  expect(await existing.exited).toBe(0)
-  expect(replacement.pid).not.toBe(original.pid)
-  expect(endpoint.url).toBe(replacement.url)
-  expect(await health(endpoint.url)).toEqual({ healthy: true, version: "test", pid: replacement.pid })
-  process.kill(replacement.pid, "SIGTERM")
-  await waitForExit(replacement.pid)
+  expect(existing.exitCode).toBe(null)
+  expect(await Bun.file(registration).json()).toEqual(original)
+})
+
+test("explicit stop refuses to signal an unidentified unresponsive PID", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const existing = spawn(registration, "hanging")
+  await waitForFile(registration)
+
+  await expect(run(Service.stop({ file: registration }))).rejects.toThrow("stop its process manually")
+
+  expect(existing.exitCode).toBe(null)
 })
 
 test("requests graceful stop of the exact service instance", async () => {
@@ -161,25 +171,108 @@ test("does not spawn contenders while an incompatible service rejects replacemen
   const contender = join(directory, "contender.json")
   const existing = spawn(registration, "reject-stop")
   await waitForFile(registration)
-  const controller = new AbortController()
-  const starting = Effect.runPromise(
+  const starting = run(
     ensure({
       file: registration,
       version: "test",
       command: [process.execPath, fixture, contender, "record-start"],
-    }).pipe(Effect.provide(NodeFileSystem.layer)),
-    { signal: controller.signal },
+    }),
   )
 
-  await waitForLines(registration + ".stop-attempts", 2)
-  controller.abort()
-  await starting.catch(() => undefined)
+  await expect(starting).rejects.toThrow("Background service rejected the stop request")
 
   expect(await Bun.file(contender + ".started").exists()).toBe(false)
+  expect((await Bun.file(registration + ".stop-attempts").text()).trim().split("\n")).toHaveLength(1)
   expect(existing.exitCode).toBe(null)
 })
 
-test("a legacy health response is still replaced", async () => {
+test("does not signal a modern service when its stop request times out", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const contender = join(directory, "contender.json")
+  const existing = spawn(registration, "stop-hanging")
+  await waitForFile(registration)
+  const starting = run(
+    ensure({
+      file: registration,
+      version: "test",
+      command: [process.execPath, fixture, contender, "record-start"],
+    }),
+  )
+
+  await expect(starting).rejects.toThrow("Background service rejected the stop request")
+
+  expect(await Bun.file(contender + ".started").exists()).toBe(false)
+  expect((await Bun.file(registration + ".stop-attempts").text()).trim().split("\n")).toHaveLength(1)
+  expect(existing.exitCode).toBe(null)
+})
+
+test("explicit stop refuses to signal when a modern stop request times out", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const existing = spawn(registration, "stop-hanging")
+  await waitForFile(registration)
+
+  await expect(run(Service.stop({ file: registration }))).rejects.toThrow("Background service rejected the stop request")
+
+  expect(existing.exitCode).toBe(null)
+})
+
+test("a stale client refuses to replace a newer service", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const contender = join(directory, "contender.json")
+  const existing = spawn(registration, "graceful")
+  await waitForFile(registration)
+  const info = await Bun.file(registration).json()
+
+  await expect(
+    run(
+      ensure({
+        file: registration,
+        version: "old",
+        canReplace: () => false,
+        command: [process.execPath, fixture, contender, "record-start"],
+      }),
+    ),
+  ).rejects.toThrow("Run `opencode2 service restart` to activate this installed version")
+
+  expect(await Bun.file(contender + ".started").exists()).toBe(false)
+  expect(existing.exitCode).toBe(null)
+  expect(await Bun.file(registration).json()).toEqual(info)
+})
+
+test("explicit restart can activate an installed downgrade", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const current = spawn(registration, "graceful")
+  await waitForFile(registration)
+  const before = await Bun.file(registration).json()
+  const options = {
+    file: registration,
+    version: "old",
+    canReplace: () => false,
+    command: [process.execPath, fixture, registration, "old"],
+  }
+
+  await expect(run(ensure(options))).rejects.toThrow("Run `opencode2 service restart`")
+  expect(current.exitCode).toBe(null)
+
+  await run(Service.stop({ file: registration }))
+  const endpoint = await run(ensure(options))
+  const after = await Bun.file(registration).json()
+
+  try {
+    expect(after.pid).not.toBe(before.pid)
+    expect(after.version).toBe("old")
+    expect(endpoint.url).toBe(after.url)
+  } finally {
+    process.kill(after.pid, "SIGTERM")
+    await waitForExit(after.pid)
+  }
+})
+
+test("refuses to signal a legacy service without authenticated stop", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")
   const existing = spawn(registration, "legacy")
@@ -188,9 +281,9 @@ test("a legacy health response is still replaced", async () => {
   const starts: EnsureReason[] = []
   const result = run(ensure({ file: registration, command: [], onStart: (reason) => starts.push(reason) }))
 
-  await expect(result).rejects.toThrow("Missing service command")
+  await expect(result).rejects.toThrow("does not support authenticated stop requests")
   expect(starts).toEqual(["version-mismatch"])
-  await existing.exited
+  expect(existing.exitCode).toBe(null)
 })
 
 test("waits for a slow winner while bounding lock probes", async () => {
@@ -311,6 +404,36 @@ test("replaces an incompatible owner that appears during startup", async () => {
     expect(endpoint.url).toBe(info.url)
     expect(info.version).toBe("test")
     await old.exited
+  } finally {
+    process.kill(info.pid, "SIGTERM")
+    await waitForExit(info.pid)
+  }
+})
+
+test("concurrent current-version launchers converge on one replacement", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const old = spawn(registration, "old")
+  await waitForFile(registration)
+
+  const endpoints = await Promise.all(
+    Array.from({ length: 20 }, (_, index) => {
+      const options = {
+        file: registration,
+        version: "test",
+        command: [process.execPath, fixture, registration, "coordinated"],
+        canReplace: (version: string | undefined) => version === "old",
+      }
+      return index % 2 === 0 ? run(ensure(options)) : import("../src/promise/service").then((mod) => mod.Service.ensure(options))
+    }),
+  )
+  const info = await Bun.file(registration).json()
+
+  try {
+    expect(new Set(endpoints.map((endpoint) => endpoint.url))).toEqual(new Set([info.url]))
+    expect(info.version).toBe("test")
+    expect(old.exitCode).not.toBe(null)
+    expect(await health(info.url)).toEqual({ healthy: true, version: "test", pid: info.pid })
   } finally {
     process.kill(info.pid, "SIGTERM")
     await waitForExit(info.pid)

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -79,6 +79,7 @@ test("replaces an incompatible registered service", async () => {
     ensure({
       file: registration,
       version: (version) => version.startsWith("2."),
+      canReplace: () => true,
       command: [process.execPath, fixture, registration, "delayed-compatible", "10"],
       onStart: (reason) => starts.push(reason),
     }),

--- a/packages/desktop/src/main/background-cli.ts
+++ b/packages/desktop/src/main/background-cli.ts
@@ -30,6 +30,7 @@ export async function startBackgroundCli(logger: Logger) {
         ? join(app.getPath("userData"), "opencode", "service-local.json")
         : undefined,
     version,
+    canReplace: (serverVersion) => Service.canReplaceVersion(serverVersion, version),
     command: [binary, "serve", "--service"],
     onStart: (reason, previousVersion) => logger.log("v2 CLI background service starting", { reason, previousVersion }),
   })

--- a/packages/tui/src/component/migration-overlay.tsx
+++ b/packages/tui/src/component/migration-overlay.tsx
@@ -17,6 +17,7 @@ export function MigrationOverlay() {
 
   onMount(async () => {
     await Bun.sleep(1_000)
+    if (abort.signal.aborted) return
     void (async () => {
       while (true) {
         const result = await client.api.migration.v1.status({ signal: abort.signal }).then(
@@ -25,7 +26,9 @@ export function MigrationOverlay() {
         )
         if ("error" in result) {
           if (result.error instanceof ClientError && result.error.reason === "Transport") {
+            if (abort.signal.aborted) return
             await Bun.sleep(1_000)
+            if (abort.signal.aborted) return
             continue
           }
           throw result.error

--- a/packages/tui/src/component/migration-overlay.tsx
+++ b/packages/tui/src/component/migration-overlay.tsx
@@ -1,3 +1,4 @@
+import { ClientError } from "@opencode-ai/client"
 import { createSignal, onCleanup, onMount, Show } from "solid-js"
 import { useClient } from "../context/client"
 import { useTheme } from "../context/theme"
@@ -18,7 +19,18 @@ export function MigrationOverlay() {
     await Bun.sleep(1_000)
     void (async () => {
       while (true) {
-        const status = await client.api.migration.v1.status({ signal: abort.signal })
+        const result = await client.api.migration.v1.status({ signal: abort.signal }).then(
+          (status) => ({ status }),
+          (error: unknown) => ({ error }),
+        )
+        if ("error" in result) {
+          if (result.error instanceof ClientError && result.error.reason === "Transport") {
+            await Bun.sleep(1_000)
+            continue
+          }
+          throw result.error
+        }
+        const status = result.status
         setProgress(status.status === "running" ? status.progress : undefined)
         if (status.status === "completed") return
         if (status.status === "error") throw new Error(status.error)


### PR DESCRIPTION
## What

Prevent managed-service restart storms when a running TUI outlives an automatic CLI update, and harden lifecycle recovery so clients never terminate a process from registration data alone.

This fixes the incident where a `next-17271` TUI remained alive after the installed package became `next-17272`. The old process repeatedly treated each `17272` service it spawned as incompatible, stopped it, and spawned the same newer binary again. The TUI repeatedly lost transport, migration polling mislabeled the disconnect as a data migration failure, and restart recovery added repeated continuation entries.

The lifecycle rules are now explicit:

| Caller | Registered service | Behavior |
| --- | --- | --- |
| fresh newer client | older service | authenticated exact-instance stop, then start installed version |
| interactive older TUI | newer service | ask once; Enter performs authenticated downgrade, cancel leaves the owner untouched |
| noninteractive older client | newer service | bounded `VersionMismatchError`; never stop or spawn |
| explicit `service restart` | newer service after deliberate downgrade | authenticated exact-instance stop, then require installed older version |
| reconnecting TUI | any modern version | version-agnostic reconnect; never activate replacement |
| any client | unresponsive or legacy service | never send an OS signal; return manual recovery guidance |
| any client | unknown/incomparable version | non-destructive mismatch; replacement can never be mutual |

## Before / After

**Before**

1. A `next-17271` TUI launched and started an asynchronous update.
2. The installed executable became `next-17272`, while the TUI process image remained `17271`.
3. The stale TUI spawned `serve --service`; the on-disk executable started `17272`.
4. The stale TUI observed `17272` as a mismatch and stopped it.
5. It spawned the same `17272` executable again, repeating roughly every two seconds.
6. Each short-lived server ran restart continuity, disconnected event streams, and made migration polling throw `Transport`.

**After**

1. Version replacement has a directional policy.
2. A newer fresh launch may activate an upgrade.
3. An older interactive TUI asks before activating a downgrade; Escape or Ctrl+C leaves the newer service untouched.
4. Noninteractive clients receive an actionable error, while explicit restart remains the deliberate command-level downgrade operation.
5. Reconnect remains versionless and cannot join a replacement loop.
6. Lifecycle code uses only authenticated `/api/service/stop`; it has no `SIGTERM` or `SIGKILL` path.
7. Transport failure during migration polling is retried instead of reported as migration corruption.

## How

- `packages/client/src/service.ts`
  - compares release and preview build numbers directionally for CLI and desktop;
  - makes replacement explicit opt-in for all client consumers;
  - treats missing, malformed, and incomparable versions as non-destructive;
  - guarantees that two versions can never both replace each other.
- `packages/client/src/effect/service.ts` and `packages/client/src/promise/service.ts`
  - return `VersionMismatchError` when replacement policy protects the owner;
  - remove automatic unresponsive-owner eviction;
  - remove legacy and timeout-based OS signal fallback;
  - surface rejected, unsupported, timed-out, and non-exiting stop failures;
  - remove dead timeout, identity-comparison, and probe-wrapper machinery.
- `packages/client/src/promise/service.ts`
  - validates registration and health structures with Effect-equivalent constraints;
  - rejects invalid PIDs, primitive health JSON, partial modern responses, and wrong field types.
- `packages/cli/src/commands/handlers/service/restart.ts`
  - requires the installed version after explicit restart, including deliberate downgrade.
- `packages/cli/src/services/server-connection.ts`
  - preserves versionless reconnect;
  - offers interactive confirmation only when the running service is provably newer;
  - makes confirmed and command-level restart require the installed version.
- `packages/cli/src/services/update-preflight.tsx`
  - renders the downgrade confirmation before the existing restart footer;
  - adds one cell of left padding to both mini-TUI states.
- `packages/desktop/src/main/background-cli.ts`
  - shares the directional upgrade-only policy instead of inheriting permissive replacement.
- `packages/tui/src/component/migration-overlay.tsx`
  - retries transient `ClientError("Transport")` instead of showing `Data migration failed`;
  - exits retry delays after overlay cleanup.

## Scope

This PR is the incident containment and client-side safety layer. It deliberately does not implement the larger ownership redesign already described in `docs/design/service-lifecycle.md`:

- lifetime process-held OS service ownership;
- registration self-repair instead of registration-driven owner shutdown;
- globally coordinated contender spawning across client processes;
- exact health `instanceID` and explicit lifecycle-state protocol fields;
- automatic recovery of a truly frozen service without a safe OS process-identity primitive.

The last point is intentionally conservative: a stale registration PID may have been reused by another application, so this PR refuses to signal it.

## Testing

- `cd packages/client && bun run test`: 64 passed.
- `cd packages/client && bun typecheck`: passed.
- `cd packages/cli && bun run test test/service.test.ts test/server-connection.test.ts --test-name-pattern 'managed version replacement|only newer clients|resolution groups|service options|concurrent service processes'`: 5 passed.
- `cd packages/cli && bun typecheck`: passed.
- `cd packages/desktop && bun typecheck`: passed.
- `cd packages/tui && bun run test`: 661 passed, 5 skipped.
- `cd packages/tui && bun typecheck`: passed.
- High-risk lifecycle subset repeated 10 times on the committed code: no failures.
- Version-order and anti-mutual-replacement subset repeated 25 times after the final simplify pass: no failures.
- Pre-push repository typecheck: 32 packages passed.
- PTY checks at 100 and 64 columns: Enter confirmed; Escape and Ctrl+C cancelled; renderer teardown returned clean output; left inset and wrapping verified.

The lifecycle battery covers:

- twenty mixed Effect/Promise launchers converging on one replacement owner;
- stale clients refusing to replace newer owners;
- explicit downgrade activation through restart;
- ready, starting, failed, unresponsive, rejecting, timeout, and legacy owners;
- malformed registrations and health payloads;
- no automatic eviction and no OS signal fallback;
- exact authenticated stop identity;
- contender success, failure, signal, delay, and loser convergence;
- symmetric version-pair checks proving replacement is never mutual.

## Flow

```mermaid
sequenceDiagram
    participant TUI as Fresh TUI
    participant Reg as Registration
    participant Old as Current service
    participant New as Installed service

    TUI->>Reg: Read and authenticate owner
    Reg-->>TUI: version + exact instance
    alt installed version is newer
        TUI->>Old: POST /api/service/stop(instanceID)
        Old-->>TUI: accepted
        Old-->>Old: graceful shutdown
        TUI->>New: spawn installed binary
        New-->>Reg: publish new owner
        TUI->>New: attach when ready
    else installed version is older
        TUI-->>TUI: Ask for downgrade confirmation
        alt user confirms
            TUI->>Old: POST /api/service/stop(instanceID)
            TUI->>New: spawn installed older binary
        else user cancels or caller is noninteractive
            TUI-->>TUI: Keep newer owner untouched
        end
    else reconnect
        TUI->>Reg: rediscover without version gate
        TUI->>Old: attach to current owner
    end
```
