### PR TITLE
fix(config): clone global cache to prevent cross-workspace mutation leak

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -395,7 +395,12 @@ const layer = Layer.effect(
           }
         }
 
-        const global = Object.keys(authEnv).length ? yield* loadGlobal(authEnv) : yield* getGlobal()
+        // Clone the cached global config so plugin config hooks and other consumers
+        // can freely mutate the per-workspace result without leaking writes back
+        // into the process-global cache (shared across all workspaces on serve).
+        const global = Object.keys(authEnv).length
+          ? yield* loadGlobal(authEnv)
+          : structuredClone(yield* getGlobal())
         yield* merge(Global.Path.config, global, "global")
 
         if (Flag.OPENCODE_CONFIG) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1477,6 +1477,39 @@ it.instance("local .opencode config can override MCP from project config", () =>
   }),
 )
 
+// Regression for #41916: mergeDeep shares nested object references between the
+// cached global config and the per-workspace result when the workspace has no
+// value for that key. Plugin config hooks mutate the workspace result, and those
+// writes leak back into the global cache — visible to every other workspace on
+// the same server.
+it.effect("workspace config mutation does not leak into the global cache", () =>
+  withConfigTree(
+    {
+      global: { mcp: { server1: { type: "remote", url: "https://server1.example.com/mcp", enabled: true } } },
+    },
+    // Clear OPENCODE_CONFIG_DIR so the developer's real config (which may contain
+    // mcp: {}) doesn't incidentally break the shared reference chain and mask the bug.
+    withProcessEnv("OPENCODE_CONFIG_DIR", undefined,
+      Effect.gen(function* () {
+        const cfg = yield* Config.use.get()
+        expect(cfg.mcp?.server1).toBeDefined()
+
+        // Simulate a plugin config hook mutation: `config.mcp[name] ??= {...}`
+        cfg.mcp!.injected = { type: "remote", url: "https://injected.example.com/mcp", enabled: true }
+
+        // The global cache must not see the mutation.
+        const globalCfg = yield* Config.use.getGlobal()
+        expect(globalCfg.mcp?.injected).toBeUndefined()
+        expect(globalCfg.mcp?.server1).toEqual({
+          type: "remote",
+          url: "https://server1.example.com/mcp",
+          enabled: true,
+        })
+      }),
+    ),
+  ),
+)
+
 const remoteProjectOverride = wellKnown({
   config: {
     mcp: { jira: { type: "remote", url: "https://jira.example.com/mcp", enabled: false } },


### PR DESCRIPTION
### Issue for this PR

Closes #41916

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Config.loadInstanceState` merges the process-global config cache into the per-workspace result via remeda `mergeDeep`. When the workspace has no project-level value for a nested key (e.g. `mcp`), `mergeDeep` copies the **same object reference** from the global cache into the result — verified against remeda 2.26.0:

```
mergeDeep({}, { mcp: { server1: {...} } }).mcp === global.mcp  // true
```

Plugin `config` hooks receive the workspace's live config-state object (`packages/opencode/src/plugin/index.ts:245`) and commonly mutate it in place (`config.mcp[name] ??= {...}`). When the workspace config shares a nested reference with the global cache, those writes leak back into `cachedGlobal` — which has `Duration.infinity` TTL. Every other workspace attached to the same `opencode serve` process then sees the leaked MCP servers (or any other nested config) in its `/mcp` status.

**Fix:** `structuredClone` the cached global config before merging it into the per-workspace result. The `loadGlobal(authEnv)` path already returns freshly parsed objects (no caching), so only the `getGlobal()` path needs cloning.

### How did you verify your code works?

Added a regression test in `test/config/config.test.ts` that:
1. Sets up a global-only config with `mcp` (no project-level override)
2. Loads the instance config, simulates a plugin config hook mutation (`cfg.mcp.injected = {...}`)
3. Asserts `Config.use.getGlobal()` does not see the mutation

The test **fails without the fix** (`globalCfg.mcp.injected` is the injected object) and **passes with it**. Full config test suite: 93 pass, 4 pre-existing Windows-specific failures (unrelated — `ENOENT` on `.jsonc` auto-creation, Git Bash/Cygwin path timeout, permission key-order on Windows).

Note: the test clears `OPENCODE_CONFIG_DIR` because a developer's local config may contain `mcp: {}`, which incidentally breaks the shared reference chain via `mergeDeep` and masks the bug.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
