### PR TITLE
docs: name tools/ as the canonical custom-tools directory

### DIFF
--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -20,6 +20,11 @@ They can be defined:
 - Locally by placing them in the `.opencode/tools/` directory of your project.
 - Or globally, by placing them in `~/.config/opencode/tools/`.
 
+:::note
+`tools/` is the canonical name. The singular `tool/` is also loaded for
+backwards compatibility with the config directory convention.
+:::
+
 ---
 
 ### Structure


### PR DESCRIPTION
### Issue for this PR

Closes #41925

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The loader that discovers custom tools accepts both plural `tools/` and the
singular `tool/` directory (see `tool/registry.ts`, the `{tool,tools}` glob),
and `config.mdx` already documents the convention: the plural name is
canonical, the singular is kept for backwards compatibility.

However the dedicated `custom-tools.mdx` page only ever showed the plural
`tools/` path and never mentioned that the singular `tool/` is also accepted.
This left a reader who only consults the custom-tools page with no way to know
the loader will accept a `tool/` directory they might encounter (or already
have) — and made the two doc pages disagree on the actual behavior.

This PR adds a short note on the custom-tools page that `tools/` is canonical
and `tool/` is still supported for backwards compatibility, matching the
behavior already documented in `config.mdx` and implemented by the glob. It
resolves the ambiguity #41925 flagged: one directory name is now named
canonical, while the compatibility alias is documented rather than hidden.

### How did you verify your code works?

- Confirmed the loader glob accepts both spellings: `packages/opencode/src/tool/registry.ts` uses `{tool,tools}`.
- Confirmed `config.mdx` already states the plural-is-canonical / singular-back-compat convention; this PR makes `custom-tools.mdx` agree with it.
- `custom-tools.mdx` is a docs change only; no code, build, or tests affected.

### Screenshots / recordings

N/A — documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR