### PR TITLE
feat(provider): add none reasoning variant for DeepSeek V4

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1656,6 +1656,16 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
   if (options === undefined) return
   if (options.length === 0) return {}
 
+  // DeepSeek V4 exposes a thinking toggle; `reasoning_effort: "none"` turns it
+  // off. Add a `none` variant alongside its effort tiers so thinking can be
+  // disabled from the model variants menu.
+  if (target.api.id.toLowerCase().includes("deepseek-v4")) {
+    return nonEmptyVariants({
+      none: { reasoningEffort: "none" },
+      ...effortVariants(target, options.find((option) => option.type === "effort")?.values ?? []),
+    })
+  }
+
   const effort = options.find((option) => option.type === "effort")
   if (effort) return effortVariants(target, effort.values)
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3378,6 +3378,20 @@ describe("ProviderTransform.reasoningVariants", () => {
     )
   })
 
+  test("adds a none variant to disable thinking for DeepSeek V4", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "toggle" }, { type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/openai-compatible", "deepseek-v4-flash"),
+      ),
+    ).toEqual({
+      none: { reasoningEffort: "none" },
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
   test("combines effort with extended thinking for Claude Opus 4.5", () => {
     expect(
       ProviderTransform.reasoningVariants(


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DeepSeek V4 exposes a thinking toggle, and its model variants menu currently only surfaced reasoning_effort tiers (low/high/max). This left no way to disable thinking entirely from the variants menu, even though the provider supports reasoning_effort: "none".

This PR adds a none variant alongside DeepSeek V4's existing effort tiers. In packages/opencode/src/provider/transform.ts:1656, reasoningVariants now short-circuits for DeepSeek V4 (deepseek-v4 in the API id) and returns none: { reasoningEffort: "none" } combined with the existing effort variants. Because it only triggers when the target API matches deepseek-v4, behavior for all other providers is unchanged.

### How did you verify your code works?

Added a unit test in packages/opencode/test/provider/transform.test.ts asserting that a DeepSeek V4 target with a toggle + effort option produces none, low, high, and max variants, while the rest of the reasoning-variants test suite (Claude extended thinking, etc.) continues to pass.

### Screenshots / recordings

<img width="626" height="201" alt="image" src="https://github.com/user-attachments/assets/6da9fdd9-738e-425b-af35-2d839363231b" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
