### PR TITLE
docs: document opencode run exit codes

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -383,6 +383,25 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--thinking"}</code></nobr> |       | Show thinking blocks                                                       |
 | <nobr><code>{"--auto"}</code></nobr>     |       | Auto-approve permissions that are not explicitly denied                    |
 
+#### Exit codes
+
+`opencode run` exits `0` on success and `1` on failure. No other codes are used.
+
+| Code | Meaning                                                                   |
+| ---- | ------------------------------------------------------------------------- |
+| `0`  | The session ran to completion.                                             |
+| `1`  | Startup or argument validation failed, or the session reported an error.   |
+
+Exit `1` covers argument and startup failures — an unreadable `--dir`, a missing
+`--file`, an empty message, `--fork` without `--continue` or `--session`, or an
+unknown `--session` id — and runtime failures, where the session emits an error or
+the prompt request itself fails.
+
+A run whose tool calls were denied by the [permission](/docs/permissions) system
+still exits `0`, because a denied tool call is reported back to the model rather
+than raised as a session error. When scripting against `opencode run`, read the
+event stream from `--format json` as well as the exit code.
+
 ---
 
 ### serve


### PR DESCRIPTION
### Issue for this PR

Not closing one — this documents existing behaviour rather than changing it. Related context: #36413 and #32633.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an `Exit codes` section to the `run` command docs. No code change.

`cli.mdx` has no mention of exit codes anywhere, so anyone scripting against `opencode run` has to read `run.ts` to learn that `1` is the only failure code — and that a run whose tool calls were denied still exits `0`.

I drive `opencode run` non-interactively from an orchestrator and hit exactly that: the exit status alone doesn't tell you whether the run did the work. Writing down what the CLI does today seemed the useful first step, independent of whether the behaviour itself changes later.

### How did you verify your code works?

Docs-only change, no behaviour touched.

**Content.** I listed the exit paths from `packages/opencode/src/cli/cmd/run.ts` at `v1.18.16`: every non-zero exit is argument or startup validation (bad `--dir`, missing `--file`, empty message, `--fork` without `--continue`/`--session`, unknown `--session`), plus the runtime paths where the session reports an error. `error` is assigned only from `session.error`, and the permission auto-reject branch does not set it — which is the `0` case the last paragraph describes. That case is also reproduced end to end by the reporter in #36413; I have not reproduced it myself, so the text describes the code path rather than claiming a test.

**Rendering.** I compiled `cli.mdx` with `@mdx-js/mdx` v3 plus `remark-gfm`, before and after the change — both compile clean. Inspecting the compiled tree for the new section gives `h4` → paragraph → `table` (with `thead` and three rows) → paragraphs, and the `/docs/permissions` link resolves in the output, so the table parses as a table and not as prose. I did not run the full Astro site build.

**Placement.** The section sits at the end of the existing `run` block, before the separator preceding `### serve`, and uses the same plain-table style as the rest of the page.

### Screenshots / recordings

n/a — text-only docs change.

### Checklist

- [x] I have tested my changes locally — MDX compile plus rendered-tree inspection, as described above; not a full site build.
- [x] I have not included unrelated changes in this PR — the diff is a single insertion into `cli.mdx`, +19 / −0, no other files.
