### PR TITLE
test(app): deflake cached tab paint probe

### DIFF
--- a/packages/app/e2e/smoke/session-timeline.spec.ts
+++ b/packages/app/e2e/smoke/session-timeline.spec.ts
@@ -189,7 +189,12 @@ test.describe("smoke: session timeline", () => {
                 .querySelector<HTMLElement>('[data-timeline-row="bottom-spacer"]')
                 ?.getBoundingClientRect()
               samples.push({ ids: visible, last: visible.includes(last), bottomError: bottom?.bottom - view.bottom })
-              if (!firstPaint && visible.includes(last) && Math.abs((bottom?.bottom ?? Infinity) - view.bottom) <= 1) {
+              if (
+                !firstPaint &&
+                visible.includes(last) &&
+                Math.abs((bottom?.bottom ?? Infinity) - view.bottom) <= 1 &&
+                !root.querySelector('[data-markdown-key="initial"]')
+              ) {
                 firstPaint = true
                 root.querySelectorAll<HTMLElement>("[data-timeline-key]").forEach((row) => {
                   const rect = row.getBoundingClientRect()
@@ -204,10 +209,16 @@ test.describe("smoke: session timeline", () => {
         }
         ;(
           window as Window & {
-            __sessionTabPaint?: { samples: typeof samples; removed: () => number; stop: () => void }
+            __sessionTabPaint?: {
+              samples: typeof samples
+              painted: () => boolean
+              removed: () => number
+              stop: () => void
+            }
           }
         ).__sessionTabPaint = {
           samples,
+          painted: () => firstPaint,
           removed: () => removedFirstPaintNodes,
           stop: () => {
             running = false
@@ -219,17 +230,19 @@ test.describe("smoke: session timeline", () => {
     )
 
     await switchTitlebarSession(page, fixture.targetID, fixture.expected.targetTitle)
-    await page.waitForFunction(() =>
-      (
-        window as Window & { __sessionTabPaint?: { samples: Array<{ ids: string[] }> } }
-      ).__sessionTabPaint?.samples.some((sample) => sample.ids.length > 0),
-    )
+    await page.waitForFunction(() => {
+      const probe = (
+        window as Window & { __sessionTabPaint?: { samples: Array<{ ids: string[] }>; painted: () => boolean } }
+      ).__sessionTabPaint
+      return probe?.painted() && probe.samples.some((sample) => sample.ids.length > 0)
+    })
     await page.waitForTimeout(200)
     const first = await page.evaluate(() => {
       const probe = (
         window as Window & {
           __sessionTabPaint?: {
             samples: Array<{ ids: string[]; last: boolean; bottomError?: number }>
+            painted: () => boolean
             removed: () => number
             stop: () => void
           }


### PR DESCRIPTION
## Flake

`smoke: session timeline › paints cached session tabs at the latest message` fails under CPU load with `Expected: 0, Received: 10` on the `removed` assertion. On unmodified `v2` it fails 4-6 of 8 with `--repeat-each=8 --workers=4 --retries=0`, while passing in isolation.

The ten removed nodes are exactly the ten `<br>` elements from the markdown renderer's synchronous fallback pass. The `Markdown` component renders in two passes: a sync fallback block (key `initial`) that escapes text and converts newlines to `<br>`, then an async worker-parsed result that replaces the fallback block via morphdom because the block key changes. On a fast machine the parsed result lands before the probe records first paint; under load it lands after, so the probe snapshots the fallback `<br>` nodes into its first-paint WeakSet and then counts their intended replacement as cached-tab row teardown.

## Fix

The probe now only records first paint once markdown hydration has settled: in addition to the existing conditions (last message visible, bottom spacer aligned), the timeline root must contain no `[data-markdown-key="initial"]` element. The test also waits for first paint to be recorded before the 200ms observation window, so the `removed === 0` assertion still observes a real post-hydration window and still guards against genuine cached-tab row teardown.

The two-pass markdown render is intended product behavior; only the test probe changes. The `samples` collection is unchanged, so the paint-at-latest and bottom-alignment assertions still evaluate the first non-empty sample.

## Validation

- `bunx playwright test e2e/smoke/session-timeline.spec.ts:120 --repeat-each=10 --workers=4 --retries=0` → 10/10 pass
- `bunx playwright test e2e/smoke/session-timeline.spec.ts` → 5/5 pass
- `bun typecheck` in `packages/app` passes
