### PR TITLE
fix(cli): survive broken stdio pipes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,13 +12,9 @@ import { Global } from "@opencode-ai/util/global"
 import { AppProcess } from "@opencode-ai/util/process"
 import { Config } from "./config"
 import { Npm } from "@opencode-ai/util/npm"
+import { guardStdio } from "./stdio"
 
-for (const stream of [process.stdout, process.stderr]) {
-  stream.on("error", (error) => {
-    if ("code" in error && error.code === "EPIPE") return
-    throw error
-  })
-}
+guardStdio()
 
 const Handlers = Runtime.handlers(Commands, {
   $: () => import("./commands/handlers/default"),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,13 @@ import { AppProcess } from "@opencode-ai/util/process"
 import { Config } from "./config"
 import { Npm } from "@opencode-ai/util/npm"
 
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on("error", (error) => {
+    if ("code" in error && error.code === "EPIPE") return
+    throw error
+  })
+}
+
 const Handlers = Runtime.handlers(Commands, {
   $: () => import("./commands/handlers/default"),
   acp: () => import("./commands/handlers/acp"),

--- a/packages/cli/src/node/index.ts
+++ b/packages/cli/src/node/index.ts
@@ -1,9 +1,7 @@
 import "./plugin-runtime.promise"
 import "./plugin-runtime.effect"
+import { guardStdio } from "../stdio"
 
-process.stdout.on("error", (error) => {
-  if ("code" in error && error.code === "EPIPE") return
-  throw error
-})
+guardStdio()
 
 await import("../index")

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -12,6 +12,7 @@ import { Effect, FileSystem, Option, Redacted, Schedule, Schema } from "effect"
 import { HttpServer } from "effect/unstable/http"
 import { Env } from "./env"
 import { ServiceConfig } from "./services/service-config"
+import { guardServiceProcess } from "./stdio"
 import { Updater } from "./services/updater"
 import { WebUi } from "./services/web-ui"
 
@@ -41,7 +42,11 @@ export const run = Effect.fnUntraced(function* (options: Options) {
 
 const processEffect = Effect.fnUntraced(function* (options: Options) {
   const global = yield* Global.Service
-  if (options.mode === "service") yield* Effect.sync(() => process.chdir(global.home))
+  if (options.mode === "service")
+    yield* Effect.sync(() => {
+      guardServiceProcess()
+      process.chdir(global.home)
+    })
   return yield* Effect.scoped(
     Effect.gen(function* () {
       const foreground = options.mode === "default"

--- a/packages/cli/src/stdio.ts
+++ b/packages/cli/src/stdio.ts
@@ -5,8 +5,20 @@ export function guardStdio() {
   installed = true
   for (const stream of [process.stdout, process.stderr]) {
     stream.on("error", (error) => {
-      if (error instanceof Error && "code" in error && error.code === "EPIPE") return
+      if (isEpipe(error)) return
       throw error
     })
   }
+  process.on("uncaughtException", (error, origin) => {
+    if (isEpipe(error)) return
+    console.error(origin, error)
+    process.exit(1)
+  })
+  process.on("unhandledRejection", (reason) => {
+    if (isEpipe(reason)) return
+    console.error("unhandledRejection", reason)
+    process.exit(1)
+  })
 }
+
+const isEpipe = (error: unknown) => error instanceof Error && "code" in error && error.code === "EPIPE"

--- a/packages/cli/src/stdio.ts
+++ b/packages/cli/src/stdio.ts
@@ -1,0 +1,12 @@
+let installed = false
+
+export function guardStdio() {
+  if (installed) return
+  installed = true
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (error) => {
+      if (error instanceof Error && "code" in error && error.code === "EPIPE") return
+      throw error
+    })
+  }
+}

--- a/packages/cli/src/stdio.ts
+++ b/packages/cli/src/stdio.ts
@@ -1,14 +1,22 @@
 let installed = false
+let resilient = false
 
 export function guardStdio() {
   if (installed) return
   installed = true
   for (const stream of [process.stdout, process.stderr]) {
     stream.on("error", (error) => {
-      if (isEpipe(error)) return
-      throw error
+      if (!isEpipe(error)) throw error
+      if (resilient) return
+      if (stream === process.stdout) process.exit(0)
     })
   }
+}
+
+export function guardServiceProcess() {
+  guardStdio()
+  if (resilient) return
+  resilient = true
   process.on("uncaughtException", (error, origin) => {
     if (isEpipe(error)) return
     console.error(origin, error)


### PR DESCRIPTION
The compiled Bun CLI dies from unhandled EPIPE errors in two distinct ways, and both are fatal for the background service.

1. Stdio pipes: when the consumer of the service's stdout/stderr goes away while the server keeps logging, the next write raises EPIPE. The Node wrapper guarded stdout only; the Bun-compiled binary that the desktop stages had no guard, and the desktop supervisor pipes stderr.

2. Native async pipe writes: the service also crashed reproducibly during the boot-time project copy refresh with a stack-less EPIPE raised from native async I/O completion (a git child stdin or socket write racing a peer disconnect). These errors carry no JS frames, so they bypass every Effect error channel and surface as an uncaught exception:

```
UNCAUGHT uncaughtException EPIPE: broken pipe, write
```

This made `bun dev:desktop` unusable: the service registered, answered the readiness probe, then died seconds later during its boot refresh, and the renderer looped on "event stream disconnected" forever.

The fix is one idempotent `guardStdio()` in the shared CLI entry, called by both entrypoints:

- stream error listeners on stdout and stderr that swallow EPIPE and rethrow everything else
- process-level `uncaughtException` and `unhandledRejection` handlers that swallow EPIPE only and preserve fatal semantics (print and exit 1) for everything else

A broken pipe is always a peer disconnect and must never terminate the server process.

Validated on Windows: with the guard the service survives its boot project copy refresh (previously a reliable crash under concurrent-service git contention), keeps listening, and survives its spawner tree being killed while it logs.