### PR TITLE
feat(tui): add permission_prompt size options

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -57,6 +57,14 @@ export const Prompt = Schema.Struct({
     description: "Home prompt max width: a positive integer for a fixed cap, or 'auto' to scale with terminal width",
   }),
 }).annotate({ description: "Prompt size settings" })
+export const PermissionPrompt = Schema.Struct({
+  max_height: Schema.optional(PromptSize).annotate({
+    description: "Permission prompt max height when not fullscreen",
+  }),
+  default_expanded: Schema.optional(Schema.Boolean).annotate({
+    description: "Open the permission prompt in fullscreen mode by default",
+  }),
+}).annotate({ description: "Permission prompt size settings" })
 
 export const Info = Schema.Struct({
   $schema: Schema.optional(Schema.String),
@@ -67,6 +75,7 @@ export const Info = Schema.Struct({
   leader_timeout: Schema.optional(LeaderTimeout),
   attention: Schema.optional(Attention),
   prompt: Schema.optional(Prompt),
+  permission_prompt: Schema.optional(PermissionPrompt),
   scroll_speed: Schema.optional(ScrollSpeed).annotate({ description: "TUI scroll speed" }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -537,7 +537,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
-    expanded: false,
+    expanded: props.fullscreen === true && tuiConfig.permission_prompt?.default_expanded === true,
   })
   const narrow = createMemo(() => dimensions().width < 80)
   const fullscreenHint = useCommandShortcut("permission.prompt.fullscreen")
@@ -639,7 +639,7 @@ function Prompt<const T extends Record<string, string>>(props: {
         ? { top: dimensions().height * -1 + 1, bottom: 1, left: 2, right: 2, position: "absolute" }
         : {
             top: 0,
-            maxHeight: 15,
+            maxHeight: tuiConfig.permission_prompt?.max_height ?? 15,
             bottom: 0,
             left: 0,
             right: 0,

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -29,6 +29,7 @@ test("validates config constraints", () => {
       leader_timeout: 250,
       attention: { volume: 1, sounds: { done: "done.wav" } },
       prompt: { max_height: 10, max_width: "auto" },
+      permission_prompt: { max_height: 30, default_expanded: true },
       scroll_speed: 0.001,
       diff_style: "stacked",
       cursor: { blinking: false },
@@ -37,12 +38,14 @@ test("validates config constraints", () => {
   ).toMatchObject({
     leader_timeout: 250,
     attention: { volume: 1 },
+    permission_prompt: { max_height: 30, default_expanded: true },
     diff_style: "stacked",
     cursor: { blinking: false },
   })
   expect(() => decodeInfo({ leader_timeout: 0 })).toThrow()
   expect(() => decodeInfo({ attention: { volume: 1.1 } })).toThrow()
   expect(() => decodeInfo({ prompt: { max_width: 0 } })).toThrow()
+  expect(() => decodeInfo({ permission_prompt: { max_height: 0 } })).toThrow()
   expect(() => decodeInfo({ scroll_speed: 0 })).toThrow()
   expect(() => decodeInfo({ cursor: { style: "beam" } })).toThrow()
   expect(decodeInfo({ attention: { sounds: { unknown: "sound.wav" } } })).toEqual({ attention: { sounds: {} } })

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -399,6 +399,8 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `0.001`, supports decimal values). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
+- `permission_prompt.max_height` - Sets the max height of the permission prompt when not fullscreen (minimum: `1`). Defaults to `15`.
+- `permission_prompt.default_expanded` - Opens the permission prompt in fullscreen mode by default. Defaults to `false`.
 - `cursor` - Controls the terminal cursor in TUI input fields. `style` defaults to `"block"`, can be `"underline"`, `"line"`, or `"default"`; `blinking` defaults to `true`. When `style` is `"default"`, the terminal default cursor is restored, so `blinking` has no effect.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.


### PR DESCRIPTION
### Issue for this PR

Closes #28191

### Type of change

- [x] New feature

### What does this PR do?

Adds two optional `tui.json` options to control the permission prompt panel:

- `permission_prompt.max_height` — max height of the panel when not fullscreen (defaults to `15`, the previous hardcoded value).
- `permission_prompt.default_expanded` — open the permission prompt in fullscreen by default (`false`).

The height was previously hardcoded (`maxHeight: 15`) in `packages/tui/src/routes/session/permission.tsx`. When a large diff needs approval, 15 lines is often too small and users had to press `ctrl+f` every time. Both options are optional and backward-compatible: behavior is unchanged unless the user opts in.

Schema added in `packages/tui/src/config/index.tsx` following the existing `prompt`/`cursor` config patterns; `default_expanded` only takes effect when the prompt supports fullscreen (the main permission stage).

### How did you verify your code works?

- Added config decode coverage in `packages/tui/test/config.test.tsx` (valid values pass, `max_height: 0` throws).
- Ran `bun test test/config.test.tsx` in `packages/tui` — 9 pass.
- Ran `bun typecheck` from `packages/tui` and the full root `bun typecheck` — clean.

### Screenshots / recordings

N/A (behavior only; no new UI surface).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR