### PR TITLE
docs(tui): document prompt size options

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -401,6 +401,8 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
 - `cursor` - Controls the terminal cursor in TUI input fields. `style` defaults to `"block"`, can be `"underline"`, `"line"`, or `"default"`; `blinking` defaults to `true`. When `style` is `"default"`, the terminal default cursor is restored, so `blinking` has no effect.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
+- `prompt.max_height` - Sets the max height of the prompt textarea in lines (defaults to a third of the terminal height, minimum `6`).
+- `prompt.max_width` - Sets the max width of the home prompt in columns. Defaults to `75`; use `"auto"` to scale with the terminal width.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.
 
 Use `OPENCODE_TUI_CONFIG` to load a custom TUI config path.


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Documentation

### What does this PR do?

Documents the `prompt` options in `tui.json` (`prompt.max_height` and `prompt.max_width`) in the TUI docs. These options already exist in the config schema and control the home prompt textarea height and width, but were missing from the options list in `packages/web/src/content/docs/tui.mdx`.

### How did you verify your code works?

Docs-only change. Descriptions were verified against the schema in `packages/tui/src/config/index.tsx` and the usages in `packages/tui/src/routes/home.tsx` and `packages/tui/src/component/prompt/index.tsx`.

### Screenshots / recordings

N/A.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR