### PR TITLE
feat(tui): add content_padding option

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -57,6 +57,7 @@ export const Prompt = Schema.Struct({
     description: "Home prompt max width: a positive integer for a fixed cap, or 'auto' to scale with terminal width",
   }),
 }).annotate({ description: "Prompt size settings" })
+const ContentPadding = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(20))
 
 export const Info = Schema.Struct({
   $schema: Schema.optional(Schema.String),
@@ -72,6 +73,9 @@ export const Info = Schema.Struct({
   diff_style: Schema.optional(DiffStyle),
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  content_padding: Schema.optional(ContentPadding).annotate({
+    description: "Horizontal padding of the session content area in columns (default: 2)",
+  }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -276,7 +276,8 @@ export function Session() {
     return false
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentPadding = createMemo(() => tuiConfig.content_padding ?? 2)
+  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - contentPadding() * 2)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1176,7 +1177,7 @@ export function Session() {
         }}
       >
         <box flexDirection="row" flexGrow={1} minHeight={0}>
-          <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+          <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={contentPadding()} paddingRight={contentPadding()} gap={1}>
             <Show when={session()}>
               <scrollbox
                 ref={(r) => (scroll = r)}

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -32,6 +32,7 @@ test("validates config constraints", () => {
       scroll_speed: 0.001,
       diff_style: "stacked",
       cursor: { blinking: false },
+      content_padding: 4,
       plugin: ["example-plugin"],
     }),
   ).toMatchObject({
@@ -39,12 +40,15 @@ test("validates config constraints", () => {
     attention: { volume: 1 },
     diff_style: "stacked",
     cursor: { blinking: false },
+    content_padding: 4,
   })
   expect(() => decodeInfo({ leader_timeout: 0 })).toThrow()
   expect(() => decodeInfo({ attention: { volume: 1.1 } })).toThrow()
   expect(() => decodeInfo({ prompt: { max_width: 0 } })).toThrow()
   expect(() => decodeInfo({ scroll_speed: 0 })).toThrow()
   expect(() => decodeInfo({ cursor: { style: "beam" } })).toThrow()
+  expect(() => decodeInfo({ content_padding: 21 })).toThrow()
+  expect(() => decodeInfo({ content_padding: -1 })).toThrow()
   expect(decodeInfo({ attention: { sounds: { unknown: "sound.wav" } } })).toEqual({ attention: { sounds: {} } })
 })
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -399,6 +399,7 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `0.001`, supports decimal values). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
+- `content_padding` - Sets the horizontal padding of the session content area in columns (0–20). Defaults to `2`.
 - `cursor` - Controls the terminal cursor in TUI input fields. `style` defaults to `"block"`, can be `"underline"`, `"line"`, or `"default"`; `blinking` defaults to `true`. When `style` is `"default"`, the terminal default cursor is restored, so `blinking` has no effect.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.


### PR DESCRIPTION
### Issue for this PR

Closes #25142

### Type of change

- [x] New feature

### What does this PR do?

Adds an optional `content_padding` option to `tui.json` (integer 0–20, default `2`) that controls the horizontal padding of the main session content area. Previously the padding was hardcoded to `2` columns on each side (`paddingLeft`/`paddingRight` in the session route, and the `- 4` in `contentWidth`), which made the readable content area narrower than necessary on wide terminals.

Backward-compatible: behavior is unchanged unless the user sets `content_padding`.

### How did you verify your code works?

- Added config decode coverage in `packages/tui/test/config.test.tsx` (valid value passes, `0`/`20` boundaries, `21`/`-1` throw).
- Ran `bun test test/config.test.tsx` in `packages/tui` — 9 pass.
- Ran `bun typecheck` from `packages/tui` and `packages/opencode` — clean.

### Screenshots / recordings

N/A (behavior only; no new UI surface).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR