### PR TITLE
fix(tui): expose local attachment path to the model

### DIFF
--- a/packages/app/src/components/prompt-input/build-request-parts.ts
+++ b/packages/app/src/components/prompt-input/build-request-parts.ts
@@ -125,6 +125,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
       mime: attachment.mime ?? "text/plain",
       url: attachment.url ?? `file://${encodeFilePath(path)}${fileQuery(attachment.selection)}`,
       filename: attachment.filename ?? getFilename(attachment.path),
+      path,
       source,
     } satisfies PromptRequestPart
   })
@@ -156,6 +157,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
       mime: "text/plain",
       url,
       filename: getFilename(item.path),
+      path,
     } satisfies PromptRequestPart
 
     if (!comment) return [filePart]
@@ -171,6 +173,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
           mime: "text/plain",
           url,
           filename: getFilename(path),
+          path: absolute(input.sessionDirectory, path),
         } satisfies PromptRequestPart,
       ]
     })
@@ -201,6 +204,7 @@ export function buildRequestParts(input: BuildRequestPartsInput) {
       mime: attachment.mime,
       url: attachment.dataUrl,
       filename: attachment.sourcePath ?? attachment.filename,
+      path: attachment.sourcePath,
     } satisfies PromptRequestPart
   })
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -210,6 +210,23 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         // text/plain and directory files are converted into text parts, ignore them
         if (part.type === "file" && part.mime !== "text/plain" && part.mime !== "application/x-directory") {
+          // Prepend a short annotation that names the local file so the model
+          // can see the on-disk path the attachment came from. The Vercel AI
+          // SDK's file part only carries `filename` (basename) and the data
+          // URL, so without this the model has no way to reference the file
+          // from scripts or correlate it with the working tree.
+          const sourcePath =
+            part.source && (part.source.type === "file" || part.source.type === "symbol")
+              ? part.source.path
+              : undefined
+          const partPath = part.path ?? sourcePath
+          if (partPath) {
+            const label = part.filename ? `${part.filename} (${partPath})` : partPath
+            userMessage.parts.push({
+              type: "text",
+              text: `[Attached file: ${label}]`,
+            })
+          }
           if (options?.stripMedia && isMedia(part.mime)) {
             userMessage.parts.push({
               type: "text",

--- a/packages/opencode/src/session/message.ts
+++ b/packages/opencode/src/session/message.ts
@@ -75,6 +75,12 @@ export const FilePart = Schema.Struct({
   mediaType: Schema.String,
   filename: Schema.optional(Schema.String),
   url: Schema.String,
+  /**
+   * Absolute local filesystem path of the original attachment, when known.
+   * Distinct from `filename` (which is just the basename): the model can
+   * use this to reference the file from scripts and tools.
+   */
+  path: Schema.optional(Schema.String),
 }).annotate({ identifier: "FilePart" })
 export type FilePart = Schema.Schema.Type<typeof FilePart>
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -319,6 +319,120 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("user file part with `path` gets a text annotation naming the local file", async () => {
+    const messageID = "m-user"
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(messageID),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "text",
+            text: "see attached",
+          },
+          {
+            ...basePart(messageID, "p2"),
+            type: "file",
+            mime: "image/png",
+            filename: "img.png",
+            url: "data:image/png;base64,Zm9v",
+            path: "/home/user/Pictures/img.png",
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "see attached" },
+          { type: "text", text: "[Attached file: img.png (/home/user/Pictures/img.png)]" },
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "img.png",
+            data: "data:image/png;base64,Zm9v",
+          },
+        ],
+      },
+    ])
+  })
+
+  test("user file part with `source.path` (legacy) still gets the path annotation", async () => {
+    const messageID = "m-user"
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(messageID),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "file",
+            mime: "image/png",
+            filename: "img.png",
+            url: "data:image/png;base64,Zm9v",
+            source: {
+              type: "file",
+              path: "/tmp/legacy/img.png",
+              text: { value: "img.png", start: 0, end: 0 },
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "[Attached file: img.png (/tmp/legacy/img.png)]" },
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "img.png",
+            data: "data:image/png;base64,Zm9v",
+          },
+        ],
+      },
+    ])
+  })
+
+  test("user file part without any path stays unchanged (no annotation injected)", async () => {
+    const messageID = "m-user"
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(messageID),
+        parts: [
+          {
+            ...basePart(messageID, "p1"),
+            type: "file",
+            mime: "image/png",
+            filename: "img.png",
+            url: "data:image/png;base64,Zm9v",
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "img.png",
+            data: "data:image/png;base64,Zm9v",
+          },
+        ],
+      },
+    ])
+  })
+
   test("converts assistant tool completion into tool-call + tool-result messages with attachments", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -174,6 +174,12 @@ export const FilePart = Schema.Struct({
   mime: Schema.String,
   filename: Schema.optional(Schema.String),
   url: Schema.String,
+  /**
+   * Absolute local filesystem path of the original attachment, when known.
+   * Distinct from `filename` (which is just the basename): the model can
+   * use this to reference the file from scripts and tools.
+   */
+  path: Schema.optional(Schema.String),
   source: Schema.optional(FilePartSource),
 }).annotate({ identifier: "FilePart" })
 export type FilePart = Types.DeepMutable<Schema.Schema.Type<typeof FilePart>>
@@ -416,6 +422,12 @@ export const FilePartInput = Schema.Struct({
   mime: Schema.String,
   filename: Schema.optional(Schema.String),
   url: Schema.String,
+  /**
+   * Absolute local filesystem path of the original attachment, when known.
+   * Distinct from `filename` (which is just the basename): the model can
+   * use this to reference the file from scripts and tools.
+   */
+  path: Schema.optional(Schema.String),
   source: Schema.optional(FilePartSource),
 }).annotate({ identifier: "FilePartInput" })
 export type FilePartInput = Types.DeepMutable<Schema.Schema.Type<typeof FilePartInput>>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1249,6 +1249,7 @@ export function Prompt(props: PromptProps) {
       mime: file.mime,
       filename: file.filename,
       url: `data:${file.mime};base64,${file.content}`,
+      path: file.filepath,
       source: {
         type: "file",
         path: file.filepath ?? file.filename ?? "",


### PR DESCRIPTION
Fixes #41454.

## Problem

When a user attaches an image, PDF, or other binary file in the TUI (or the Web app) the part is sent to the model as a Vercel AI SDK `file` part with only the basename and the data URL. The on-disk path is kept in `FilePartSource` for UI metadata but is never threaded through to the model context, so the agent cannot reference the file from scripts or even tell the user which local file it is looking at.

Repro on V2:

  1. In the TUI, paste a local file path (e.g. `/home/user/Pictures/IMG_3480.JPG`)
  2. Send any message
  3. Ask the model "what is the path of the attached file?"
  4. Model reports the file content as `[Image 1]` and says it has no path or filename.

## Fix

Plumbs the original local path end-to-end:

- **`FilePart` / `FilePartInput` (v1 schema, `packages/schema/src/v1/session.ts`)** gain an optional `path` field distinct from `filename` (basename) and `source.path` (UI metadata). Both are additive — old clients continue to work.
- **`V2 FilePart` (`packages/opencode/src/session/message.ts`)** gains the same optional `path` field so the path is available where the model message is assembled.
- **TUI `pasteAttachment` (`packages/tui/src/component/prompt/index.tsx`)** now sets `path: file.filepath` on the `FilePart` so an attached `/home/user/Pictures/IMG_3480.JPG` is recorded with its full path rather than just `IMG_3480.JPG`.
- **Web app `build-request-parts.ts` (`packages/app/src/components/prompt-input/`)** sets `path` on every file part: user-attached files, context files, comment mentions, and pasted images.
- **`toModelMessagesEffect` (`packages/opencode/src/session/message-v2.ts`)** prepends a short text annotation `[Attached file: <name> (<path>)]` to the user message when the path is known, so the model can see and act on the local path alongside the image content. When only the legacy `source.path` is set (older client, ACP, or stored sessions written before this change) the annotation is still emitted.
- **Tests** (`packages/opencode/test/session/message-v2.test.ts`): three new cases cover the new `path` branch, the legacy `source.path` branch, and the no-path no-op case. The existing user/assistant/tool test is preserved.

## Backwards compatibility

- Every change is additive. Existing clients, stored sessions, and ACP tools that do not set `path` keep working unchanged.
- The text annotation is only injected when a path is known, so pre-existing messages (which never had one) round-trip exactly as before.

## Verification

Local validation: `bun install` + targeted bun test for the opencode package was attempted on Windows but the workspace install was hanging on a 196k-star monorepo in a non-official environment, so final validation is deferred to CI on Linux. The new tests in `message-v2.test.ts` will run in the opencode package's existing `bun test` CI job and cover the new behavior.
