### PR TITLE
fix(desktop): only pin @opencode-ai/plugin version for production releases

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -11,7 +11,7 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { existsSync } from "fs"
 import { Account } from "@/account/account"
 import { isRecord } from "@/util/record"
@@ -454,7 +454,7 @@ const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version: InstallationChannel === "latest" ? InstallationVersion : undefined,
                 },
               ],
             })

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -16,7 +16,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CurrentWorkingDirectory } from "./tui-cwd"
 import { ConfigPlugin } from "@/config/plugin"
 import { TuiKeybind } from "@opencode-ai/tui/config/keybind"
-import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { Filesystem } from "@/util/filesystem"
 import { ConfigVariable } from "@/config/variable"
@@ -239,7 +239,7 @@ const layer = Layer.effect(
             add: [
               {
                 name: "@opencode-ai/plugin",
-                version: InstallationLocal ? undefined : InstallationVersion,
+                version: InstallationChannel === "latest" ? InstallationVersion : undefined,
               },
             ],
           })


### PR DESCRIPTION
### Issue for this PR

Closes #42002

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#40764 fixed the `@opencode-ai/plugin@local` install failure for production desktop builds, but the plugin-pin condition in `config.ts` and `tui.ts` still checks `InstallationLocal` (channel === "local") instead of whether the channel is actually a production release. Any non-latest, non-local channel — beta, or a CI/branch build that sets `OPENCODE_CHANNEL` — gets a synthetic, never-published version from `packages/script/src/index.ts` (`0.0.0-<channel>-<timestamp>`), and the installer still tries to pin that exact string. `npm install @opencode-ai/plugin@0.0.0-beta-<timestamp>` 404s, same failure mode as the original bug, just scoped to preview channels.

This changes the condition to `InstallationChannel === "latest"`: only official production releases (guaranteed to have a matching `@opencode-ai/plugin` published) pin an exact version. Everything else — local dev, beta, branch builds — installs `@opencode-ai/plugin@latest` instead of a version that doesn't exist on the registry.

### How did you verify your code works?

Traced `InstallationChannel`/`InstallationVersion` through `packages/core/src/installation/version.ts` and `packages/script/src/index.ts` against current `origin/dev`. Confirmed `CHANNEL`/`VERSION` computation: any channel other than `"latest"` sets `IS_PREVIEW = true`, and `VERSION` becomes a timestamped `0.0.0-<channel>-*` string that is never published to npm — the pin then always fails for those channels regardless of `InstallationLocal`. The fix only changes which channel value triggers the pin; both branches (`InstallationVersion` string vs `undefined`) match the existing type signature the code already used.

### Screenshots / recordings

n/a — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
