### PR TITLE
fix(web/desktop): restore agent mode selector and Linux old-layout eligibility

### DIFF
--- a/packages/app/src/context/local-agent.test.ts
+++ b/packages/app/src/context/local-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { hasCustomAgent, resolveAgent } from "./local-agent"
+import { hasCustomAgent, isAgentsVisible, resolveAgent } from "./local-agent"
 
 describe("hasCustomAgent", () => {
   test("detects explicitly custom agents", () => {
@@ -8,6 +8,21 @@ describe("hasCustomAgent", () => {
 
   test("ignores built-in and unclassified agents", () => {
     expect(hasCustomAgent([{ native: true }, {}])).toBe(false)
+  })
+})
+
+describe("isAgentsVisible", () => {
+  test("is visible when there are multiple selectable agents", () => {
+    expect(isAgentsVisible({ customAgents: false, agents: [{ native: true }, { native: true }] })).toBe(true)
+  })
+
+  test("is hidden for a single built-in agent unless custom agents are enabled", () => {
+    expect(isAgentsVisible({ customAgents: false, agents: [{ native: true }] })).toBe(false)
+    expect(isAgentsVisible({ customAgents: true, agents: [{ native: true }] })).toBe(true)
+  })
+
+  test("is visible when any custom agent is present", () => {
+    expect(isAgentsVisible({ customAgents: false, agents: [{ native: false }] })).toBe(true)
   })
 })
 

--- a/packages/app/src/context/local-agent.ts
+++ b/packages/app/src/context/local-agent.ts
@@ -2,6 +2,10 @@ export function hasCustomAgent(items: Array<{ native?: boolean }>) {
   return items.some((item) => item.native === false)
 }
 
+export function isAgentsVisible(input: { customAgents: boolean; agents: Array<{ native?: boolean }> }) {
+  return input.customAgents || hasCustomAgent(input.agents) || input.agents.length > 1
+}
+
 export function resolveAgent<T extends { name: string }>(items: T[], name?: string) {
   return items.find((item) => item.name === name) ?? items.find((item) => item.name === "build") ?? items[0]
 }

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -8,7 +8,7 @@ import { useSettings } from "@/context/settings"
 import { useProviders } from "@/hooks/use-providers"
 import { resolveDefaultModel } from "@/hooks/provider-catalog"
 import { Persist, persisted } from "@/utils/persist"
-import { hasCustomAgent, resolveAgent } from "./local-agent"
+import { isAgentsVisible, resolveAgent } from "./local-agent"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
@@ -69,7 +69,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const id = createMemo(() => params.id || undefined)
     const list = createMemo(() => sync().data.agent.filter((item) => item.mode !== "subagent" && !item.hidden))
-    const agentsVisible = createMemo(() => settings.visibility.customAgents() || hasCustomAgent(list()))
+    const agentsVisible = createMemo(() =>
+      isAgentsVisible({ customAgents: settings.visibility.customAgents(), agents: list() }),
+    )
     const connected = createMemo(() => new Set(providers.connected().map((item) => item.id)))
 
     const [saved, setSaved, , savedReady] = persisted(

--- a/packages/desktop/src/main/install-state.test.ts
+++ b/packages/desktop/src/main/install-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { hasExistingAppState } from "./install-state"
+import { hasExistingAppState, hasExistingAppStateAny } from "./install-state"
 
 const file = (name: string) => ({ name, isDirectory: () => false })
 const directory = (name: string) => ({ name, isDirectory: () => true })
@@ -15,5 +15,18 @@ describe("hasExistingAppState", () => {
     expect(hasExistingAppState([file("opencode.global.dat")])).toBe(true)
     expect(hasExistingAppState([file("window-state-abc.json")])).toBe(true)
     expect(hasExistingAppState([directory("opencode")])).toBe(true)
+  })
+})
+
+describe("hasExistingAppStateAny", () => {
+  test("recognizes state in any of the provided directories", () => {
+    expect(hasExistingAppStateAny([file("Local State")], [file("opencode.settings")])).toBe(true)
+    expect(hasExistingAppStateAny([file("Local State")], [file("opencode.global.dat")])).toBe(true)
+    expect(hasExistingAppStateAny([file("Local State")], [file("window-state-abc.json")])).toBe(true)
+    expect(hasExistingAppStateAny([file("Local State")], [directory("opencode")])).toBe(true)
+  })
+
+  test("returns false when no directory has existing state", () => {
+    expect(hasExistingAppStateAny([file("Local State"), directory("Crashpad")], [])).toBe(false)
   })
 })

--- a/packages/desktop/src/main/install-state.ts
+++ b/packages/desktop/src/main/install-state.ts
@@ -6,3 +6,9 @@ export function hasExistingAppState(entries: Array<{ name: string; isDirectory: 
     return entry.isDirectory() && entry.name === "opencode"
   })
 }
+
+export function hasExistingAppStateAny(
+  ...directories: Array<Array<{ name: string; isDirectory: () => boolean }>>
+) {
+  return directories.some(hasExistingAppState)
+}

--- a/packages/desktop/src/main/migrate.ts
+++ b/packages/desktop/src/main/migrate.ts
@@ -10,7 +10,7 @@ const TAURI_MIGRATED_KEY = "tauriMigrated"
 
 // Resolve the directory where Tauri stored its .dat files for the given app identifier.
 // Mirrors Tauri's AppLocalData / AppData resolution per OS.
-function tauriDir(id: string) {
+export function tauriDir(id: string) {
   switch (process.platform) {
     case "darwin":
       return join(homedir(), "Library", "Application Support", id)
@@ -27,7 +27,7 @@ const TAURI_APP_IDS: Record<string, string> = {
   beta: "ai.opencode.desktop.beta",
   prod: "ai.opencode.desktop",
 }
-function tauriAppId() {
+export function tauriAppId() {
   return app.isPackaged ? TAURI_APP_IDS[CHANNEL] : "ai.opencode.desktop.dev"
 }
 

--- a/packages/desktop/src/main/onboarding.ts
+++ b/packages/desktop/src/main/onboarding.ts
@@ -5,17 +5,28 @@ import { app } from "electron"
 import { getStore } from "./store"
 import { FIRST_LAUNCH_ONBOARDING_COMPLETE_KEY, OLD_LAYOUT_ELIGIBLE_KEY } from "./store-keys"
 import { write as writeLog } from "./logging"
-import { hasExistingAppState } from "./install-state"
+import { hasExistingAppStateAny } from "./install-state"
+import { tauriAppId, tauriDir } from "./migrate"
 
 const DEFAULT_PROJECT_DIR = "Default Project"
 
+function listEntries(directory: string) {
+  return existsSync(directory) ? readdirSync(directory, { withFileTypes: true }) : []
+}
+
 export function initializeOldLayoutEligibility(userDataPath: string) {
-  const entries = existsSync(userDataPath) ? readdirSync(userDataPath, { withFileTypes: true }) : []
   const store = getStore()
   const current = store.get(OLD_LAYOUT_ELIGIBLE_KEY)
   if (typeof current === "boolean") return current
 
-  const eligible = hasExistingAppState(entries)
+  const entries = listEntries(userDataPath)
+  // The previous Tauri desktop app stored its state in a different directory on
+  // Linux/macOS (e.g. ~/.local/share/ai.opencode.desktop). Treat existing state
+  // there the same as the Electron userData so users can still opt back into the
+  // previous layout.
+  const tauriEntries = listEntries(tauriDir(tauriAppId()))
+
+  const eligible = hasExistingAppStateAny(entries, tauriEntries)
   store.set(OLD_LAYOUT_ELIGIBLE_KEY, eligible)
   return eligible
 }


### PR DESCRIPTION
Restores the composer agent selector (build/plan) when only built-in agents are present, and makes existing Linux/macOS desktop installs eligible to opt back into the previous dashboard.

- app: `isAgentsVisible` shows the selector whenever more than one selectable agent exists (matches the legacy composer).
- desktop: old-layout eligibility now also checks the previous Tauri data directory.

Closes #39665
Refs #38111