### PR TITLE
docs: fix provider display name and PAT typos

### DIFF
--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -97,7 +97,7 @@ Or you can set it up manually.
     issues: write
   ```
 
-  You can also use a [personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT) if preferred.
+  You can also use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT) if preferred.
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2487,7 +2487,7 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
      "provider": {
        "myprovider": {
          "npm": "@ai-sdk/openai-compatible",
-         "name": "My AI ProviderDisplay Name",
+         "name": "My AI Provider Display Name",
          "options": {
            "baseURL": "https://api.myprovider.com/v1"
          },
@@ -2525,7 +2525,7 @@ Here's an example setting the `apiKey`, `headers`, and model `limit` options.
   "provider": {
     "myprovider": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "My AI ProviderDisplay Name",
+      "name": "My AI Provider Display Name",
       "options": {
         "baseURL": "https://api.myprovider.com/v1",
         "apiKey": "{env:ANTHROPIC_API_KEY}",


### PR DESCRIPTION
### Issue for this PR

Fixes #42032

### Type of change

- [x] Bug fix (docs typo)
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes two typos in the docs:

1. `packages/web/src/content/docs/providers.mdx:2490` and `:2528` — `"My AI ProviderDisplay Name"` → `"My AI Provider Display Name"` (missing space in the example provider config).

2. `packages/web/src/content/docs/github.mdx:100` — "a [personal access tokens]" → "a [personal access token]" (singular/plural mismatch after "a").

### How did you verify your code works?

These are pure doc text changes. `bun typecheck` (30/30 packages) passed via the pre-push hook.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR