### PR TITLE
feat(github): allow configured bots to trigger actions

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -30,6 +30,11 @@ inputs:
     description: "Comma-separated list of trigger phrases (case-insensitive). Defaults to '/opencode,/oc'"
     required: false
 
+  allowed_bots:
+    description: "Comma-separated list of bot usernames allowed to trigger the action, or '*' to allow all bots. Bots are denied by default. Prefer explicit usernames, only use '*' in workflows with tightly restricted permissions."
+    required: false
+    default: ""
+
   variant:
     description: "Model variant for provider-specific reasoning effort (e.g., high, max, minimal)"
     required: false
@@ -75,5 +80,6 @@ runs:
         PROMPT: ${{ inputs.prompt }}
         USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
         MENTIONS: ${{ inputs.mentions }}
+        ALLOWED_BOTS: ${{ inputs.allowed_bots }}
         VARIANT: ${{ inputs.variant }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -33,7 +33,7 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError } from "./github.shared"
+import { extractResponseText, formatPromptTooLargeError, isAllowedBot, isBotActor } from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -1165,6 +1165,16 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
     async function assertPermissions() {
       // Only called for non-schedule events, so actor is defined
       console.log(`Asserting permissions for user ${actor}...`)
+
+      if (isBotActor(payload.sender)) {
+        if (!isAllowedBot(payload.sender, process.env["ALLOWED_BOTS"] || "")) {
+          throw new Error(
+            `Bot ${payload.sender.login} is not allowed to trigger this action. Add it to allowed_bots or use '*' to allow all bots.`,
+          )
+        }
+        console.log(`  allowed bot: ${payload.sender.login}`)
+        return
+      }
 
       let permission
       try {

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -2,6 +2,22 @@ import type { SessionV1 } from "@opencode-ai/core/v1/session"
 
 export { parseGitHubRemote } from "@/util/repository"
 
+export function isBotActor(sender: { type: string }) {
+  return sender.type === "Bot"
+}
+
+export function isAllowedBot(sender: { login: string; type: string }, allowedBots: string) {
+  if (!isBotActor(sender)) return false
+  if (allowedBots.trim() === "*") return true
+
+  const name = sender.login.toLowerCase().replace(/\[bot\]$/, "")
+  return allowedBots
+    .split(",")
+    .map((bot) => bot.trim().toLowerCase().replace(/\[bot\]$/, ""))
+    .filter(Boolean) // remove empty strings
+    .includes(name)
+}
+
 /**
  * Extracts displayable text from assistant response parts.
  * Returns null for non-text responses (signals summary needed).

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -2,7 +2,13 @@ import { Effect } from "effect"
 import { cmd } from "./cmd"
 import { effectCmd } from "../effect-cmd"
 
-export { extractResponseText, formatPromptTooLargeError, parseGitHubRemote } from "./github.shared"
+export {
+  extractResponseText,
+  formatPromptTooLargeError,
+  isAllowedBot,
+  isBotActor,
+  parseGitHubRemote,
+} from "./github.shared"
 
 export const GithubInstallCommand = effectCmd({
   command: "install",

--- a/packages/opencode/test/cli/github-action.test.ts
+++ b/packages/opencode/test/cli/github-action.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { extractResponseText, formatPromptTooLargeError } from "../../src/cli/cmd/github"
+import { extractResponseText, formatPromptTooLargeError, isAllowedBot, isBotActor } from "../../src/cli/cmd/github"
 import type { MessageV2 } from "../../src/session/message-v2"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 
@@ -80,6 +80,42 @@ function createStepFinishPart(): SessionV1.Part {
     tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
   }
 }
+
+describe("bot authorization", () => {
+  test("identifies bots from the webhook sender type", () => {
+    expect(isBotActor({ type: "Bot" })).toBe(true)
+    expect(isBotActor({ type: "User" })).toBe(false)
+    expect(isBotActor({ type: "Organization" })).toBe(false)
+  })
+
+  test("denies bots by default", () => {
+    expect(isAllowedBot({ login: "opencode-agent[bot]", type: "Bot" }, "")).toBe(false)
+  })
+
+  test("allows configured bots with or without the suffix", () => {
+    const sender = { login: "opencode-agent[bot]", type: "Bot" }
+    expect(isAllowedBot(sender, "opencode-agent")).toBe(true)
+    expect(isAllowedBot(sender, "opencode-agent[bot]")).toBe(true)
+  })
+
+  test("normalizes case and whitespace", () => {
+    expect(
+      isAllowedBot(
+        { login: "OpenCode-Agent[bot]", type: "Bot" },
+        " dependabot, OPENCODE-AGENT[BOT] ",
+      ),
+    ).toBe(true)
+  })
+
+  test("allows all bots with a wildcard", () => {
+    expect(isAllowedBot({ login: "unknown[bot]", type: "Bot" }, " * ")).toBe(true)
+  })
+
+  test("does not allow unlisted bots or human actors", () => {
+    expect(isAllowedBot({ login: "unknown[bot]", type: "Bot" }, "opencode-agent")).toBe(false)
+    expect(isAllowedBot({ login: "opencode-agent[bot]", type: "User" }, "*")).toBe(false)
+  })
+})
 
 describe("extractResponseText", () => {
   test("returns text from text part", () => {

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -109,6 +109,19 @@ Or you can set it up manually.
 
   `id-token: write` is not required in this mode because OIDC exchange is skipped. To use a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) or another GitHub App token, store it as a secret and pass that secret as `GITHUB_TOKEN` instead.
 
+- `allowed_bots`: Optional comma-separated list of bot usernames allowed to trigger the action, or `*` to allow all bots. Bots are denied by default. Names are case-insensitive and may include or omit the `[bot]` suffix.
+
+  To allow an OpenCode GitHub App to trigger the action for issues or comments it creates, configure its bot username:
+
+  ```yaml
+  - uses: anomalyco/opencode/github@latest
+    with:
+      model: anthropic/claude-sonnet-4-20250514
+      allowed_bots: opencode-agent
+  ```
+
+  Only allow bots you trust. An allowed bot's issue or comment content is treated as an authorized prompt and bypasses the repository collaborator permission check. Avoid `allowed_bots: "*"` unless any bot with the ability to create a matching issue or comment should be allowed to invoke OpenCode.
+
 ---
 
 ## Supported Events


### PR DESCRIPTION
### Issue for this PR

Closes #7103

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an `allowed_bots` input to the GitHub Action so trusted GitHub App bots can trigger OpenCode workflows. Bots remain denied by default; callers can allow specific comma-separated bot usernames or use `*` to allow all bots.

Bot actors are identified from the webhook sender's explicit `type`, then matched case-insensitively with or without the `[bot]` suffix. Allowed bots bypass the collaborator permission check because GitHub App bot accounts are not repository collaborators and GitHub reports their permission as `none`.

Inspired by https://github.com/anthropics/claude-code-action/pull/117.

### How did you verify your code works?

- `bun test test/cli/github-action.test.ts` from `packages/opencode` (23 tests)
- `bun typecheck` from `packages/opencode`
- Repository pre-push typecheck (30 packages)
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
