### PR TITLE
docs: fix broken DigitalOcean and Daytona links

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -17,7 +17,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 | Name                                                                                               | Description                                                                                        |
 | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| [opencode-daytona](https://github.com/daytonaio/daytona/tree/main/libs/opencode-plugin)            | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews  |
+| [opencode-daytona](https://github.com/daytona/integrations/tree/main/packages/opencode-plugin)     | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews  |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                                 |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                              |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                      |

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -759,7 +759,7 @@ Cloudflare Workers AI lets you run AI models on Cloudflare's global network dire
 
 ### DigitalOcean
 
-DigitalOcean's [Inference Engine](https://docs.digitalocean.com/products/inference/) provides access to open models like GPT-OSS, Llama, Qwen, and DeepSeek, plus custom [Inference Routers](https://docs.digitalocean.com/products/genai-platform/concepts/inference-routers/) that route each request to the cheapest, fastest, or best-fit model for a task.
+DigitalOcean's [Inference Engine](https://docs.digitalocean.com/products/inference/) provides access to open models like GPT-OSS, Llama, Qwen, and DeepSeek, plus custom [Inference Routers](https://docs.digitalocean.com/products/inference/how-to/use-inference-router/) that route each request to the cheapest, fastest, or best-fit model for a task.
 
 OpenCode supports two authentication methods:
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (docs: dead links)
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes two broken (404) links in the docs:

1. `packages/web/src/content/docs/providers.mdx` — the DigitalOcean "Inference Routers" link pointed to `docs.digitalocean.com/products/genai-platform/concepts/inference-routers/` which returns 404. Updated to the current `docs.digitalocean.com/products/inference/how-to/use-inference-router/` (this is the same URL already used later on the same page).

2. `packages/web/src/content/docs/ecosystem.mdx` — the opencode-daytona link pointed to `github.com/daytonaio/daytona/tree/main/libs/opencode-plugin` which returns 404 (that repo is no longer maintained). The opencode plugin now lives in `github.com/daytona/integrations/tree/main/packages/opencode-plugin`.

### How did you verify your code works?

Both replacement URLs were checked and return 200. `bun typecheck` (30/30 packages) passed via the pre-push hook. These are pure doc link changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR