### PR TITLE
feat(tui): display chained shell commands across multiple lines

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -124,6 +124,27 @@ function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
 }
 
+function formatCommand(root: Node, command: string): string {
+  const starts: number[] = []
+  const walk = (node: Node) => {
+    if (node.text === "&&") starts.push(node.startIndex)
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)
+      if (child) walk(child)
+    }
+  }
+  walk(root)
+  if (starts.length === 0) return command
+  const pieces: string[] = []
+  let prev = 0
+  for (const start of starts) {
+    pieces.push(command.slice(prev, start).replace(/\s+$/, ""))
+    prev = start
+  }
+  pieces.push(command.slice(prev))
+  return pieces.join(" \\\n")
+}
+
 function unquote(text: string) {
   if (text.length < 2) return text
   const first = text[0]
@@ -260,7 +281,11 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
-const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, input: { command: string }) {
+const ask = Effect.fn("ShellTool.ask")(function* (
+  ctx: Tool.Context,
+  scan: Scan,
+  input: { command: string; commandDisplay: string },
+) {
   if (scan.dirs.size > 0) {
     const directories = Array.from(scan.dirs)
     const globs = directories.map((dir) => {
@@ -273,6 +298,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
       always: globs,
       metadata: {
         command: input.command,
+        commandDisplay: input.commandDisplay,
         directories,
         patterns: globs,
       },
@@ -286,6 +312,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
     always: Array.from(scan.always),
     metadata: {
       command: input.command,
+      commandDisplay: input.commandDisplay,
     },
   })
 })
@@ -429,6 +456,7 @@ export const ShellTool = Tool.define(
       input: {
         shell: string
         command: string
+        commandDisplay: string
         cwd: string
         env: NodeJS.ProcessEnv
         timeout: number
@@ -475,6 +503,7 @@ export const ShellTool = Tool.define(
       yield* ctx.metadata({
         metadata: {
           output: "",
+          commandDisplay: input.commandDisplay,
         },
       })
 
@@ -515,6 +544,7 @@ export const ShellTool = Tool.define(
                       ctx.metadata({
                         metadata: {
                           output: last,
+                          commandDisplay: input.commandDisplay,
                         },
                       }),
                     ),
@@ -525,6 +555,7 @@ export const ShellTool = Tool.define(
               return ctx.metadata({
                 metadata: {
                   output: last,
+                  commandDisplay: input.commandDisplay,
                 },
               })
             }),
@@ -588,6 +619,7 @@ export const ShellTool = Tool.define(
           output: last || preview(output),
           exit: code,
           truncated: cut,
+          commandDisplay: input.commandDisplay,
           ...(cut && file ? { outputPath: file } : {}),
         },
         output,
@@ -617,14 +649,16 @@ export const ShellTool = Tool.define(
               }
               const timeout = params.timeout ?? defaultTimeoutMs
               const ps = Shell.ps(shell)
-              yield* Effect.scoped(
+              const commandDisplay = yield* Effect.scoped(
                 Effect.gen(function* () {
                   const tree = yield* Effect.acquireRelease(parse(params.command, ps), (tree) =>
                     Effect.sync(() => tree.delete()),
                   )
                   const scan = yield* collect(tree.rootNode, cwd, ps, shell, instanceCtx)
                   if (!containsPath(cwd, instanceCtx)) scan.dirs.add(cwd)
-                  yield* ask(ctx, scan, params)
+                  const display = formatCommand(tree.rootNode, params.command)
+                  yield* ask(ctx, scan, { command: params.command, commandDisplay: display })
+                  return display
                 }),
               )
 
@@ -632,6 +666,7 @@ export const ShellTool = Tool.define(
                 {
                   shell,
                   command: params.command,
+                  commandDisplay,
                   cwd,
                   env: yield* shellEnv(ctx, cwd),
                   timeout,

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -263,6 +263,68 @@ describe("tool.shell permissions", () => {
     }),
   )
 
+  each("exposes commandDisplay split across lines for chained commands", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: "echo foo && echo bar && echo baz",
+            },
+            capture(requests),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.metadata.commandDisplay).toBe("echo foo \\\n&& echo bar \\\n&& echo baz")
+        }),
+      )
+    }),
+  )
+
+  each("leaves single command commandDisplay unchanged", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: "echo hello",
+            },
+            capture(requests),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.metadata.commandDisplay).toBe("echo hello")
+        }),
+      )
+    }),
+  )
+
+  if (process.platform !== "win32") {
+    it.live("does not split && inside quotes in commandDisplay", () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: 'echo "a && b" && echo c',
+            },
+            capture(requests),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.metadata.commandDisplay).toBe('echo "a && b" \\\n&& echo c')
+        }),
+      ),
+    )
+  }
+
   for (const item of ps) {
     it.live(`parses PowerShell conditionals for permission prompts [${item.label}]`, () =>
       withShell(

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2082,8 +2082,13 @@ function Shell(props: ToolProps) {
           onClick={collapsed().overflow ? () => setExpanded((prev) => !prev) : undefined}
         >
           <box gap={1}>
-            <Show when={isRunning()} fallback={<text fg={theme.text}>$ {stringValue(props.input.command)}</text>}>
-              <Spinner color={theme.text}>{stringValue(props.input.command)}</Spinner>
+            <Show
+              when={isRunning()}
+              fallback={<text fg={theme.text}>$ {stringValue(props.metadata.commandDisplay) ?? stringValue(props.input.command)}</text>}
+            >
+              <Spinner color={theme.text}>
+                {stringValue(props.metadata.commandDisplay) ?? stringValue(props.input.command)}
+              </Spinner>
             </Show>
             <Show when={output()}>
               <text fg={theme.text}>{limited()}</text>

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -269,7 +269,8 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
             }
 
             if (permission === "bash") {
-              const command = typeof data.command === "string" ? data.command : ""
+              const raw = props.request.metadata?.commandDisplay
+              const command = (typeof raw === "string" ? raw : "") || (typeof data.command === "string" ? data.command : "")
               return {
                 icon: "#",
                 title: "Shell command",


### PR DESCRIPTION
Add commandDisplay field to shell tool that splits &&-chained commands with backslash continuations for readable display in the session view and permission prompt.

### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Long-chained shell commands quickly become difficult to read. This PR is splitting the output so that '&& command2 ...' is on a new line. To enhance readability.

### How did you verify your code works?

Added three cases to `packages/opencode/test/tool/shell.test.ts` covering the permission metadata flow:

- Chained command splits into `echo foo \\\n&& echo bar \\\n&& echo baz`
- Single command is returned unchanged
- `&&` inside quotes is not split (`echo "a && b" \\\n&& echo c`)

Ran `bun test test/tool/shell.test.ts` from `packages/opencode`: 26 pass, 0 fail.

### Screenshots / recordings

<img width="785" height="408" alt="Screenshot 2026-08-12 at 11 04 07 AM" src="https://github.com/user-attachments/assets/be2df366-ce8a-4c3e-9652-725b41b8b66a" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
