### PR TITLE
fix(tui): keep session directory filter toggle usable in the picker

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -101,6 +101,9 @@ const appGlobalBindingCommands = [
   "session.quick_switch.7",
   "session.quick_switch.8",
   "session.quick_switch.9",
+  // Mode-less: dialogs push "modal", and the session picker is a dialog, so this
+  // has to stay active there or the binding is dead exactly where it is used.
+  "app.toggle.session_directory_filter",
 ] as const
 
 const appBindingCommands = [
@@ -136,7 +139,6 @@ const appBindingCommands = [
   "app.toggle.file_context",
   "app.toggle.diffwrap",
   "app.toggle.paste_summary",
-  "app.toggle.session_directory_filter",
 ] as const
 
 export type TuiInput = {
@@ -405,6 +407,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     }),
   )
   const [ready, setReady] = createSignal(false)
+  // Tracks whether the session picker is the open dialog, so toggling session
+  // directory filtering can re-list in place instead of closing the picker.
+  const [sessionPickerOpen, setSessionPickerOpen] = createSignal(false)
   props.pluginHost
     .start({
       api,
@@ -575,7 +580,11 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashName: "sessions",
         slashAliases: ["resume", "continue"],
         run: () => {
-          dialog.replace(() => <DialogSessionList />)
+          setSessionPickerOpen(true)
+          dialog.replace(
+            () => <DialogSessionList />,
+            () => setSessionPickerOpen(false),
+          )
         },
       },
       {
@@ -940,7 +949,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         run: async () => {
           kv.set("session_directory_filter_enabled", !kv.get("session_directory_filter_enabled", true))
           await sync.session.refresh()
-          dialog.clear()
+          // The picker queries reactively on sync.session.query(), so leaving it open
+          // re-lists in place. Closing it would hide the result of the toggle.
+          if (!sessionPickerOpen()) dialog.clear()
         },
       },
       {


### PR DESCRIPTION
### Issue for this PR

Closes #42060

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A key bound to `app.toggle.session_directory_filter` does nothing inside the session picker, which is where the toggle matters. It works on the main screen, so it looks intermittent.

Cause: the command sits in `appBindingCommands`, which is gathered with `mode: OPENCODE_BASE_MODE`. Opening a dialog pushes `"modal"` in `ui/dialog.tsx`, so that layer goes inactive, and the picker is a dialog.

Fix: move the command to `appGlobalBindingCommands`, which is gathered without a mode. That list already holds `session.list` and the quick-switch commands for the same reason. Dialog-owned layers still win keys they bind, since dialog bindings are registered by the dialog itself, and this keybind defaults to `none` so no new conflict is introduced.

Second change in the same command: `dialog.clear()` ran unconditionally, so toggling from inside the picker closed it and hid the result. The picker's resource queries on `sync.session.query()`, so leaving it open re-lists in place. Palette invocations still clear as before. Happy to drop this part if you would rather keep the PR to the layer move.

### How did you verify your code works?

- Bound `ctrl+a` locally. Before: works on main screen, dead in the picker. After: works in both, and the picker stays open and re-lists.
- Confirmed the mode interaction directly rather than by eye: pushing `"modal"` via `getOpencodeModeStack(keymap).push("modal")` and reading `getCommandBindings({ visibility: "active" })` gives 0 active bindings before the change and 1 after.
- `bun run typecheck` in `packages/tui`, clean.
- `bun test test/keymap.test.tsx test/component/dialog-session-list.test.ts test/config.test.tsx`, 16 pass.

I have a regression test for the modal case but left it out, because asserting it needs `appBindingCommands` and `appGlobalBindingCommands` exported from `app.tsx` and I did not want to widen the module API uninvited. Say the word and I will add it.

### Screenshots / recordings

No visual change. The keybind defaults to `none`, so nothing differs unless a user binds it.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
