### PR TITLE
fix(opencode): reject empty compaction summaries

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Database } from "@opencode-ai/core/database/database"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { Session } from "./session"
@@ -22,6 +23,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { buildPrompt } from "@opencode-ai/core/session/compaction"
 import { SessionCompactionEvent } from "@opencode-ai/schema/session-compaction-event"
+import { NamedError } from "@opencode-ai/core/util/error"
 
 export const Event = SessionCompactionEvent
 
@@ -200,6 +202,7 @@ const layer = Layer.effect(
     const provider = yield* Provider.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const database = yield* Database.Service
 
     const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
       tokens: SessionV1.Assistant["tokens"]
@@ -451,6 +454,20 @@ const layer = Layer.effect(
         return "stop"
       }
 
+      if (
+        result === "continue" &&
+        !processor.message.error &&
+        !summaryText({
+          info: processor.message,
+          parts: yield* MessageV2.parts(processor.message.id).pipe(Effect.provideService(Database.Service, database)),
+        })
+      ) {
+        processor.message.error = new NamedError.Unknown({ message: "Compaction produced no summary" }).toObject()
+        processor.message.finish = "error"
+        yield* session.updateMessage(processor.message)
+        return "stop"
+      }
+
       if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
         yield* session.updatePart({
           ...compactionPart,
@@ -595,6 +612,7 @@ export const node = LayerNode.make({
     Provider.node,
     EventV2Bridge.node,
     RuntimeFlags.node,
+    Database.node,
   ],
 })
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -196,6 +196,7 @@ function createCompactionMarker(sessionID: SessionID) {
 function fake(
   input: Parameters<SessionProcessorModule.SessionProcessor.Interface["create"]>[0],
   result: "continue" | "compact",
+  session: SessionNs.Interface,
 ) {
   const msg = input.assistantMessage
   return {
@@ -204,17 +205,35 @@ function fake(
     },
     updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
     completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
-    process: Effect.fn("TestSessionProcessor.process")(() => Effect.succeed(result)),
+    process: Effect.fn("TestSessionProcessor.process")(function* () {
+      if (result === "compact") return result
+      yield* session.updatePart({
+        id: PartID.ascending(),
+        messageID: msg.id,
+        sessionID: msg.sessionID,
+        type: "text",
+        text: "summary",
+      })
+      return result
+    }),
   } satisfies SessionProcessorModule.SessionProcessor.Handle
 }
 
-function processorLayer(result: "continue" | "compact") {
-  return Layer.succeed(
+function processorNode(result: "continue" | "compact") {
+  const layer = Layer.effect(
     SessionProcessorModule.SessionProcessor.Service,
-    SessionProcessorModule.SessionProcessor.Service.of({
-      create: Effect.fn("TestSessionProcessor.create")((input) => Effect.succeed(fake(input, result))),
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      return SessionProcessorModule.SessionProcessor.Service.of({
+        create: Effect.fn("TestSessionProcessor.create")((input) => Effect.succeed(fake(input, result, session))),
+      })
     }),
   )
+  return LayerNode.make({
+    service: SessionProcessorModule.SessionProcessor.Service,
+    layer,
+    deps: [SessionNs.node],
+  })
 }
 
 function cfg(compaction?: ConfigV1.Info["compaction"]) {
@@ -233,7 +252,7 @@ const compactionTestNode = LayerNode.group([
 ])
 const env = AppNodeBuilder.build(compactionTestNode, [
   [Provider.node, defaultProvider.layer],
-  [SessionProcessorModule.SessionProcessor.node, processorLayer("continue")],
+  [SessionProcessorModule.SessionProcessor.node, processorNode("continue")],
   [RuntimeFlags.node, RuntimeFlags.layer({ experimentalEventSystem: true })],
 ])
 
@@ -265,7 +284,7 @@ function compactionProcessLayer(options?: CompactionProcessOptions) {
   if (!options?.llm) {
     return AppNodeBuilder.build(compactionTestNode, [
       ...replacements,
-      [SessionProcessorModule.SessionProcessor.node, processorLayer(options?.result ?? "continue")],
+      [SessionProcessorModule.SessionProcessor.node, processorNode(options?.result ?? "continue")],
       ...(options?.plugin ? ([[Plugin.node, options.plugin]] as const) : []),
       ...(options?.config ? ([[Config.node, options.config]] as const) : []),
     ])
@@ -888,6 +907,71 @@ describe("session.compaction.process", () => {
         expect(JSON.stringify(summary.info.error)).toContain("Session too large to compact")
       }
     }).pipe(withCompaction({ result: "compact" })),
+  )
+
+  itCompaction.instance(
+    "rejects reasoning-only compaction summaries without hiding history",
+    () => {
+      const stub = llm()
+      stub.push(
+        Stream.make(
+          LLMEvent.reasoningStart({ id: "reasoning-1" }),
+          LLMEvent.reasoningDelta({ id: "reasoning-1", text: "thinking about the conversation" }),
+          LLMEvent.reasoningEnd({ id: "reasoning-1" }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop", usage: basicUsage() }),
+          LLMEvent.finish({ reason: "stop", usage: basicUsage() }),
+        ),
+      )
+
+      return Effect.gen(function* () {
+        const events = yield* EventV2Bridge.Service
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const original = yield* createUserMessage(session.id, "original context")
+        yield* createCompactionMarker(session.id)
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+
+        const seen: string[] = []
+        const unsub = yield* events.listen((event) =>
+          Effect.sync(() => {
+            seen.push(event.type)
+          }),
+        )
+        yield* Effect.addFinalizer(() => unsub)
+
+        const result = yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: true,
+        })
+
+        const all = yield* ssn.messages({ sessionID: session.id })
+        const summary = all.find((item) => item.info.role === "assistant" && item.info.summary)
+        const filtered = MessageV2.filterCompacted(yield* MessageV2.stream(session.id))
+
+        expect(result).toBe("stop")
+        expect(summary?.info.role).toBe("assistant")
+        if (summary?.info.role === "assistant") {
+          expect(summary.info.finish).toBe("error")
+          expect(JSON.stringify(summary.info.error)).toContain("Compaction produced no summary")
+        }
+        expect(summary?.parts.some((part) => part.type === "reasoning")).toBe(true)
+        expect(summary?.parts.some((part) => part.type === "text" && part.text.trim().length > 0)).toBe(false)
+        expect(seen).not.toContain(SessionCompaction.Event.Compacted.type)
+        expect(filtered.map((item) => item.info.id)).toContain(original.id)
+        expect(
+          all.some(
+            (item) =>
+              item.info.role === "user" &&
+              item.parts.some((part) => part.type === "text" && part.metadata?.compaction_continue === true),
+          ),
+        ).toBe(false)
+      }).pipe(withCompaction({ llm: stub.llmLayer }))
+    },
+    { git: true },
   )
 
   it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #41571

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A compaction model can finish with reasoning but no text summary. V1 currently treats that as success, which can hide the previous history behind an empty summary boundary.

This marks the summary as errored and stops before tail, replay, auto-continue, or the compacted event — so a fresh failed attempt cannot filter away earlier messages. It's limited to the safety invariant; #41663 explores the larger structured-input alternative.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/compaction.test.ts` — 54 pass, 1 skip, 0 fail
- `cd packages/opencode && bun typecheck`
- Changed-file Prettier and `git diff --check`

The regression drives a reasoning-only processor response and verifies the error state, stopped result, absent compacted event, and retained history.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
