### PR TITLE
fix(tui): preserve transcript image height

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2372,6 +2372,7 @@ function SessionImages(props: { images: readonly { uri: string }[]; paddingLeft?
     <Show when={visible().length > 0}>
       <box
         flexDirection="row"
+        height={height() + 2}
         flexShrink={0}
         paddingTop={1}
         paddingLeft={props.paddingLeft ?? 3}


### PR DESCRIPTION
## What

Keep transcript image preview rows at the same full height used by composer image previews.

## Before / After

**Before:** The transcript image container could collapse inside the scrolling timeline, so an image submitted from the composer appeared shorter in message history.

**After:** The transcript preview row explicitly reserves the calculated image height plus its vertical padding, preserving the same 4-8 row preview size as the composer.

## How

- `packages/tui/src/routes/session/index.tsx` gives `SessionImages` an explicit total row height of `height() + 2`.
- The existing responsive height calculation, width, cropping, image count, and preview dialog behavior are unchanged.

## Testing

- `bun typecheck` in `packages/tui`
- Full pre-push repository typecheck hook, 32 packages passed
- OpenCode Drive script typecheck and isolated V2 timeline run with an image-bearing prompt

## Demo

OpenCode Drive timeline after admitting an image-bearing prompt. The headless renderer preserves the corrected preview row layout but does not paint terminal image-protocol bitmaps into PNG screenshots.

![OpenCode Drive timeline](https://github.com/user-attachments/assets/0eb0b7e3-0852-494b-8c4e-c002bf510e86)
