### PR TITLE
fix(core): generate session titles before model execution

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -113,8 +113,8 @@ const layer = Layer.effect(
     const compaction = yield* SessionCompaction.Service
     const title = yield* SessionTitle.Service
     const toolOutput = yield* ToolOutput.Service
-    // Title generation is a side effect of a successful step; it must not delay continuation.
-    // The in-flight set coalesces overlapping steps while title presence records success durably.
+    // Title generation starts once input is visible and must not delay model execution.
+    // The in-flight set coalesces overlapping prompts while title presence records success durably.
     const titlesRunning = new Set<SessionSchema.ID>()
     const forkTitle = yield* FiberSet.makeRuntime<never, void, never>()
     /**
@@ -144,7 +144,6 @@ const layer = Layer.effect(
       let step = 1
       while (true) {
         const result = yield* runStep(sessionID, promotable, step)
-        if (step === 1) yield* startTitle(sessionID)
         yield* runPendingCompaction(sessionID)
         if (!result.needsContinuation && !(yield* SessionPending.has(db, sessionID, "steer"))) return
         promotable = "steer"
@@ -236,6 +235,7 @@ const layer = Layer.effect(
       // a blocked first step leaves pending inputs untouched.
       yield* InstructionState.prepare(db, bus, selected.instructions, selected.session.id)
       const promoted = promotable ? yield* SessionPending.promote(db, bus, selected.session.id, promotable) : 0
+      if (promoted > 0) yield* startTitle(sessionID)
       // Promoted input opens a fresh step allowance.
       const currentStep = promoted > 0 ? 1 : step
       const loaded = yield* context.load(selected)

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -816,7 +816,7 @@ const verifyPartialFlushOnInterruption = (kind: FragmentKind) =>
   })
 
 describe("SessionRunnerLLM", () => {
-  it.effect("retries title generation from the first prompt after execution and title failures", () =>
+  it.effect("generates the title while the first model step is still running", () =>
     Effect.gen(function* () {
       const session = yield* setup
       const agents = yield* Agent.Service
@@ -831,16 +831,48 @@ describe("SessionRunnerLLM", () => {
       )
 
       yield* admit(session, "First prompt")
-      yield* TestLLM.push(Stream.fail(invalidRequest()))
+      yield* TestLLM.push(TestLLM.text("Generated title", "text-title"), Stream.never)
+      const bus = yield* Bus.Service
+      const renamed = yield* bus.subscribe(SessionEvent.Renamed).pipe(
+        Stream.filter((event) => event.data.sessionID === sessionID),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      const runner = yield* SessionRunner.Service
+      const fiber = yield* runner.drain({ sessionID, force: true }).pipe(Effect.forkChild)
+      yield* Fiber.join(renamed)
+
+      expect((yield* session.get(sessionID)).title).toBe("Generated title")
+      yield* Fiber.interrupt(fiber)
+    }),
+  )
+
+  it.effect("retries title generation from the first prompt after title and execution failures", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      const agents = yield* Agent.Service
+      const { db } = yield* Database.Service
+      yield* db.update(SessionTable).set({ title: null }).where(eq(SessionTable.id, sessionID)).run().pipe(Effect.orDie)
+      yield* agents.transform((draft) =>
+        draft.update(Agent.ID.make("title"), (agent) => {
+          agent.mode = "primary"
+          agent.hidden = true
+          agent.system = "Generate a title."
+        }),
+      )
+
+      yield* admit(session, "First prompt")
+      yield* TestLLM.push(Stream.fail(invalidRequest()), Stream.fail(invalidRequest()))
       expect((yield* session.resume(sessionID).pipe(Effect.exit))._tag).toBe("Failure")
 
       yield* admit(session, "Second prompt")
       const titleFailed = yield* Deferred.make<void>()
       yield* TestLLM.push(
-        TestLLM.text("Recovered", "text-recovered"),
         Stream.make(LLMEvent.providerError({ message: "Title provider unavailable" })).pipe(
           Stream.ensuring(Deferred.succeed(titleFailed, undefined)),
         ),
+        TestLLM.text("Recovered", "text-recovered"),
       )
       yield* session.resume(sessionID)
       yield* Deferred.await(titleFailed)
@@ -856,13 +888,13 @@ describe("SessionRunnerLLM", () => {
       )
       yield* admit(session, "Third prompt")
       yield* TestLLM.push(
-        TestLLM.text("Recovered again", "text-recovered-again"),
         TestLLM.text("Generated title", "text-title"),
+        TestLLM.text("Recovered again", "text-recovered-again"),
       )
       yield* session.resume(sessionID)
       yield* Fiber.join(renamed)
 
-      expect(requests).toHaveLength(5)
+      expect(requests).toHaveLength(6)
       expect(requests[2]?.messages).toContainEqual(Message.user("First prompt"))
       expect(requests[4]?.messages).toContainEqual(Message.user("First prompt"))
       expect((yield* session.get(sessionID)).title).toBe("Generated title")


### PR DESCRIPTION
## What

Generate a new root session's title as soon as its first admitted prompt becomes visible, instead of waiting for the first model step and its tool calls to finish.

This restores the responsive title behavior from V1 while preserving V2's durable prompt admission boundary: queued input does not trigger title generation until it is promoted.

## Before / After

**Before:** the runner promoted the first prompt, completed the first model step and any local tool execution, then forked title generation. A tool-heavy first response could leave the fallback session title visible for minutes.

**After:** the runner promotes the prompt, forks title generation, and immediately continues into context loading and the main model request. The title and first model step run concurrently, and either title or model failure remains isolated from the other.

## How

- `packages/core/src/session/runner/llm.ts` starts the existing coalesced title fiber immediately after `SessionPending.promote(...)` reports newly visible input.
- Removes the post-`runStep` title trigger.
- Adds a regression test that blocks the first model stream indefinitely and verifies the session is renamed while that step is still running.
- Updates retry coverage for the new title-first request ordering and verifies title generation still retries after both title and execution failures.

## Scope

This does not generate titles for merely admitted queued prompts. It does not change title model selection, title content, truncation, or retry policy.

## Testing

- `bun run test test/session-runner.test.ts` from `packages/core`: 144 passing
- `bun typecheck` from `packages/core`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3`, 32 tasks passing

## Flow

```mermaid
sequenceDiagram
    participant Inbox as Durable prompt inbox
    participant Runner as Session runner
    participant Title as Title model
    participant Model as Main model

    Inbox->>Runner: Promote first eligible prompt
    Runner--)Title: Fork title generation
    Runner->>Model: Start first model step
    Title-->>Runner: Persist session rename
    Model-->>Runner: Stream response and tools
```
