### PR TITLE
docs: add opencode-stream-rules to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-stream-rules](https://github.com/jiesou/opencode-stream-rules)                           | Just-in-time rule injection: teach the agent a rule exactly when it's about to break one           |
 
 ---
 


### PR DESCRIPTION
Adds [opencode-stream-rules](https://github.com/jiesou/opencode-stream-rules) to the ecosystem plugins table.

It's a just-in-time rule injection plugin: rules stay dormant and are surfaced (via a SYSTEM NOTICE or a tool-call rejection) only when the agent is about to break one, keeping the system prompt clean. Inspired by oh-my-pi's time-traveling stream rules.