### PR TITLE
fix(opencode): limit default GPT verbosity

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1305,13 +1305,13 @@ export function options(input: {
       }
     }
 
-    // Only set textVerbosity for non-chat gpt-5.x models
-    // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
+    // Generic OpenAI-compatible APIs do not necessarily support OpenAI's verbosity parameter.
+    // Only enable the default for integrations known to implement it.
     if (
       input.model.api.id.includes("gpt-5.") &&
       !input.model.api.id.includes("codex") &&
       !input.model.api.id.includes("-chat") &&
-      input.model.providerID !== "azure"
+      (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle")
     ) {
       result["textVerbosity"] = "low"
     }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -523,6 +523,7 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.reasoningEffort).toBe("medium")
     expect(result.reasoningSummary).toBeUndefined()
     expect(result.include).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
   })
 
   test("azure chat completions omit Responses-only reasoning options after variants merge", async () => {


### PR DESCRIPTION
Context: when using Bedrock with a Gateway such as LiteLLM, we see rejection errors from the Bedrock mantle.

A fix for now is to create a plugin such as:

```ts
// In plugins/gateway-compat.ts

import type { Plugin } from "@opencode-ai/plugin"

/**
 * gateway-compat: strip parameters the Contentful AI Gateway (LiteLLM) rejects.
 *
 * OpenCode auto-adds `textVerbosity: "low"` for GPT-5.x models. Via the
 * OpenAI-compatible provider this becomes `verbosity`, which Bedrock Mantle
 * behind the gateway rejects. Remove it for all contentful-gateway GPT-5.x
 * models.
 */
const GatewayCompatibility: Plugin = async () => ({
  "chat.params": async (input, output) => {
    if (input.model.providerID !== "contentful-gateway") return
    if (!input.model.api.id.includes("gpt-5")) return

    delete output.options.textVerbosity
  },
})

export default GatewayCompatibility
```

But this PR handles it at the root: opencode ✨

Everything is explained in the plugin comment, but TLDR: OpenCode auto-adds `textVerbosity: "low"` for GPT-5.x models. Bedrock rejects the option for some GTP models.

Note: reviewed by a human (me) and implemented by latest Luna max

----
Here starts the AI generated part:

## Summary

- only add the GPT-5 `textVerbosity` default for provider packages known to support it
- avoid forwarding OpenAI-specific `verbosity` through generic OpenAI-compatible providers
- preserve the existing OpenAI and Bedrock Mantle behavior
- add regression coverage for OpenAI-compatible GPT-5 models

## Testing

- `bun test test/provider/transform.test.ts`
- `bun typecheck` from `packages/opencode`
- `bun turbo typecheck` (pre-push hook)

