### PR TITLE
refactor(core): spawn stdio MCP servers through the location environment

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -1,11 +1,10 @@
 export * as MCPClient from "./client.js"
 
 import path from "node:path"
-import { execFile } from "node:child_process"
 import { pathToFileURL } from "node:url"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import { UnauthorizedError, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
   CallToolResultSchema,
@@ -30,12 +29,11 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Effect, Exit, Schema } from "effect"
 import { ConfigMCP } from "@opencode-ai/schema/config/mcp"
+import { MCPStdio } from "./stdio.js"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_CATALOG_TIMEOUT = 30_000
 const DEFAULT_EXECUTION_TIMEOUT = 12 * 60 * 60 * 1_000 // 12 hours
-
-type Transport = StdioClientTransport | StreamableHTTPClientTransport
 
 // Some servers advertise tool outputSchemas the SDK's strict validator can't resolve; this drops
 // only that field so a single bad schema doesn't blank out the whole tool list.
@@ -176,7 +174,12 @@ export interface Connection {
   readonly onResourcesChanged: (callback: () => void) => void
 }
 
-/** Connects an MCP server; closing the calling scope tears down the transport and any spawned process. */
+/**
+ * Connects an MCP server; closing the calling scope tears down the transport and any spawned process.
+ *
+ * A stdio server is spawned through the location's `Environment`, so it runs on the same execution
+ * plane as the location's shell commands rather than always on the host.
+ */
 export const connect = Effect.fnUntraced(function* (
   server: string,
   config: typeof ConfigMCP.Server.Type,
@@ -190,13 +193,12 @@ export const connect = Effect.fnUntraced(function* (
   const transport: Transport = yield* Effect.gen(function* () {
     if (config.type === "local") {
       const [command, ...args] = config.command
-      return new StdioClientTransport({
+      return yield* MCPStdio.make({
+        server,
         command,
         args,
         cwd: config.cwd ? path.resolve(directory, config.cwd) : directory,
-        stderr: "pipe",
-        env: {
-          ...(process.env as Record<string, string>),
+        environment: {
           ...(command === "opencode" ? { BUN_BE_BUN: "1" } : {}),
           ...config.environment,
         },
@@ -233,9 +235,9 @@ export const connect = Effect.fnUntraced(function* (
     catch: (error) => error,
   }).pipe(Effect.exit)
   if (Exit.isSuccess(exit)) {
-    yield* Effect.addFinalizer(() =>
-      cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => client.close())), Effect.ignore),
-    )
+    // Closing the client closes the transport, which ends stdin and then kills through the spawner
+    // handle if the server does not exit cleanly. The process scope remains a final backstop.
+    yield* Effect.addFinalizer(() => Effect.promise(() => client.close()).pipe(Effect.ignore))
     const catalogTimeout = config.timeout?.catalog ?? DEFAULT_CATALOG_TIMEOUT
     const executionTimeout = config.timeout?.execution ?? DEFAULT_EXECUTION_TIMEOUT
     return {
@@ -434,57 +436,11 @@ export const connect = Effect.fnUntraced(function* (
     } satisfies Connection
   }
 
-  yield* cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => transport.close())), Effect.ignore)
+  yield* Effect.promise(() => transport.close()).pipe(Effect.ignore)
   const error = Cause.squash(exit.cause)
   if (error instanceof UnauthorizedError) return yield* new NeedsAuthError({ server })
   return yield* new ConnectError({ server, message: error instanceof Error ? error.message : String(error) })
 })
-
-// SDK close stops the MCP process, but not child processes it spawned.
-const cleanupStdioDescendants = (transport: Transport) =>
-  Effect.gen(function* () {
-    if (!(transport instanceof StdioClientTransport)) return
-    const pid = transport.pid
-    if (typeof pid !== "number") return
-    yield* Effect.forEach(
-      yield* descendantPids(pid),
-      (pid) =>
-        Effect.try({
-          try: () => process.kill(pid, "SIGTERM"),
-          catch: () => undefined,
-        }).pipe(Effect.ignore),
-      { discard: true },
-    )
-  })
-
-const descendantPids = Effect.fnUntraced(function* (root: number) {
-  if (process.platform === "win32") return []
-  const result: number[] = []
-  const queue = [root]
-  for (let index = 0; index < queue.length; index++) {
-    const parent = queue[index]
-    if (parent === undefined) return result
-    const children = (yield* childPids(parent)).filter((pid) => !result.includes(pid))
-    result.push(...children)
-    queue.push(...children)
-  }
-  return result
-})
-
-const childPids = (pid: number) =>
-  Effect.promise(
-    () =>
-      new Promise<number[]>((resolve) => {
-        execFile("pgrep", ["-P", String(pid)], { encoding: "utf8" }, (_error, stdout) => {
-          resolve(
-            stdout
-              .split("\n")
-              .map((line) => Number.parseInt(line, 10))
-              .filter((pid) => Number.isInteger(pid)),
-          )
-        })
-      }),
-  )
 
 async function paginate<R extends { nextCursor?: string }, T>(
   list: (cursor: string | undefined) => Promise<R>,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -12,6 +12,7 @@ import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Config } from "../config.js"
 import { Credential } from "../credential.js"
 import { Bus } from "../bus.js"
+import { Environment } from "../environment/index.js"
 import { Form } from "../form.js"
 import { Integration } from "../integration.js"
 import { KeyedMutex } from "../effect/keyed-mutex.js"
@@ -173,6 +174,7 @@ export const layer = (options?: Options) =>
     Effect.gen(function* () {
       const config = yield* Config.Service
       const location = yield* Location.Service
+      const environment = yield* Environment.Service
       const bus = yield* Bus.Service
       const forms = yield* Form.Service
       const integration = yield* Integration.Service
@@ -520,6 +522,8 @@ export const layer = (options?: Options) =>
             options?.clientInfo,
           ).pipe(
             Effect.flatMap((connection) => connection.tools().pipe(Effect.map((tools) => ({ connection, tools })))),
+            // A stdio server is spawned on this location's execution plane, not the host's.
+            Effect.provideService(Environment.Service, environment),
             Scope.provide(scope),
             Effect.exit,
           )
@@ -828,7 +832,7 @@ export function configured(options?: Options) {
   return makeLocationNode({
     service: Service,
     layer: layer(options),
-    deps: [Config.node, Location.node, Bus.node, Form.node, Integration.node, Credential.node],
+    deps: [Config.node, Location.node, Environment.node, Bus.node, Form.node, Integration.node, Credential.node],
   })
 }
 

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -460,16 +460,8 @@ export const layer = (options?: Options) =>
         connection.onClose(() =>
           live(
             Effect.gen(function* () {
-              const scope = entry.scope
-              entry.scope = undefined
-              entry.client = undefined
-              entry.tools = undefined
-              entry.prompts = undefined
               entry.status = { status: "failed", error: "Connection closed" }
-              if (scope) yield* Scope.close(scope, Exit.void)
-              yield* bus.publish(McpEvent.ToolsChanged, { server: name }).pipe(Effect.ignore)
-              yield* bus.publish(McpEvent.ResourcesChanged, { server: name }).pipe(Effect.ignore)
-              yield* bus.publish(Command.Event.Updated, {}).pipe(Effect.ignore)
+              yield* stopServer(name, entry)
               yield* bus.publish(McpEvent.StatusChanged, { server: name }).pipe(Effect.ignore)
             }),
           ),

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -179,9 +179,8 @@ export const layer = (options?: Options) =>
       const forms = yield* Form.Service
       const integration = yield* Integration.Service
       const credentials = yield* Credential.Service
-      const root = yield* Scope.make()
+      const root = yield* Effect.scope
       const fork = yield* FiberSet.makeRuntime<never, void, never>()
-      yield* Effect.addFinalizer((exit) => Scope.close(root, exit))
 
       const loadConfig = (entries: readonly Entry[]) => {
         const documents = entries.filter((entry): entry is Document => entry.type === "document")
@@ -461,10 +460,13 @@ export const layer = (options?: Options) =>
         connection.onClose(() =>
           live(
             Effect.gen(function* () {
+              const scope = entry.scope
+              entry.scope = undefined
               entry.client = undefined
               entry.tools = undefined
               entry.prompts = undefined
               entry.status = { status: "failed", error: "Connection closed" }
+              if (scope) yield* Scope.close(scope, Exit.void)
               yield* bus.publish(McpEvent.ToolsChanged, { server: name }).pipe(Effect.ignore)
               yield* bus.publish(McpEvent.ResourcesChanged, { server: name }).pipe(Effect.ignore)
               yield* bus.publish(Command.Event.Updated, {}).pipe(Effect.ignore)

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -3,7 +3,7 @@ export * as MCPStdio from "./stdio.js"
 import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Deferred, Duration, Effect, Exit, Queue, Scope, Stream } from "effect"
+import { Cause, Duration, Effect, Queue, Scope, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 import { Environment } from "../environment/index.js"
@@ -13,6 +13,7 @@ const CLOSE_GRACE = Duration.seconds(2)
 
 /** Mirrors StdioClientTransport: escalate SIGTERM to SIGKILL after this long. */
 const FORCE_KILL_AFTER = Duration.seconds(2)
+const OUTGOING_CAPACITY = 64
 
 export interface Options {
   /** Server name; only used to attribute logs. */
@@ -44,16 +45,22 @@ export const make = Effect.fnUntraced(function* (options: Options) {
   const context = yield* Effect.context<Scope.Scope>()
   // Outgoing frames are queued rather than written to `handle.stdin` directly: the sink closes the
   // stream it is run with, and stdin must stay open across the whole session.
-  const outgoing = yield* Queue.unbounded<Uint8Array, Cause.Done>()
-  const encoder = new TextEncoder()
+  const outgoing = yield* Queue.bounded<string, Cause.Done>(OUTGOING_CAPACITY)
   const buffer = new ReadBuffer()
-  const closed = Deferred.makeUnsafe<void>()
-  const state: { started: boolean; handle?: ChildProcessHandle } = { started: false }
+  const state: { phase: "ready" | "starting" | "open" | "closed"; handle?: ChildProcessHandle } = { phase: "ready" }
+
+  const stop = (handle: ChildProcessHandle) =>
+    Effect.gen(function* () {
+      Queue.endUnsafe(outgoing)
+      const exit = yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE)
+      if (exit._tag === "Some") return
+      yield* handle.kill({ killSignal: "SIGTERM", forceKillAfter: FORCE_KILL_AFTER })
+    }).pipe(Effect.ignore)
 
   const transport: Transport = {
     start: () => {
-      if (state.started) return Promise.reject(new Error("Stdio transport already started"))
-      state.started = true
+      if (state.phase !== "ready") return Promise.reject(new Error("Stdio transport already started"))
+      state.phase = "starting"
       return Effect.runPromiseWith(context)(
         Effect.gen(function* () {
           const handle = yield* environment.spawner.spawn(
@@ -61,34 +68,40 @@ export const make = Effect.fnUntraced(function* (options: Options) {
               cwd: options.cwd,
               env: options.environment,
               extendEnv: true,
-              stdin: { stream: Stream.fromQueue(outgoing), endOnDone: true },
+              stdin: { stream: Stream.encodeText(Stream.fromQueue(outgoing)), endOnDone: true },
               stdout: "pipe",
               stderr: "pipe",
               forceKillAfter: FORCE_KILL_AFTER,
             }),
           )
           state.handle = handle
+          if (state.phase === "closed") {
+            state.handle = undefined
+            return yield* stop(handle)
+          }
+          state.phase = "open"
           yield* startOutput(handle)
         }),
       )
     },
     send: (message: JSONRPCMessage) =>
-      Queue.offerUnsafe(outgoing, encoder.encode(serializeMessage(message)))
-        ? Promise.resolve()
-        : Promise.reject(new Error("Not connected")),
+      state.phase !== "open"
+        ? Promise.reject(new Error("Not connected"))
+        : Effect.runPromise(
+            Queue.offer(outgoing, serializeMessage(message)).pipe(
+              Effect.flatMap((offered) => (offered ? Effect.void : Effect.fail(new Error("Not connected")))),
+            ),
+          ),
     close: () =>
       Effect.runPromise(
         Effect.gen(function* () {
+          state.phase = "closed"
           Queue.endUnsafe(outgoing)
           const handle = state.handle
           if (!handle) return
-          // Give the server the same chance to exit on its own that the SDK transport gives it; the
-          // handle then signals the process through whichever execution driver spawned it.
-          const exit = yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE)
-          if (exit._tag === "Some") return
-          const terminated = yield* Effect.timeoutOption(handle.kill({ killSignal: "SIGTERM" }), FORCE_KILL_AFTER)
-          if (terminated._tag === "None") yield* handle.kill({ killSignal: "SIGKILL" })
-        }).pipe(Effect.ensuring(Effect.sync(() => buffer.clear())), Effect.ignore),
+          state.handle = undefined
+          yield* stop(handle)
+        }).pipe(Effect.ensuring(Effect.sync(() => buffer.clear()))),
       ),
   }
 
@@ -128,22 +141,25 @@ export const make = Effect.fnUntraced(function* (options: Options) {
           Effect.ignore,
           // stdout ending means the server is gone; the SDK transport reports that the same way.
           Effect.ensuring(
-            Effect.sync(() => {
-              if (Deferred.doneUnsafe(closed, Exit.void)) transport.onclose?.()
+            Effect.gen(function* () {
+              const unexpected = state.phase !== "closed"
+              state.phase = "closed"
+              if (unexpected) yield* stop(handle)
+              transport.onclose?.()
             }),
           ),
         ),
       )
 
-      // StdioClientTransport pipes stderr into a stream nobody reads, which both hides server
-      // diagnostics and lets a chatty server stall on backpressure. Draining it into the debug log
-      // keeps the pipe moving and makes the output reachable.
+      // StdioClientTransport pipes stderr into a stream nobody reads. Drain chunks into the debug
+      // log so chatty servers cannot stall and newline-free output is not buffered without bound.
       yield* Effect.forkScoped(
         handle.stderr.pipe(
           Stream.decodeText(),
-          Stream.splitLines,
-          Stream.runForEach((line) =>
-            line.trim() === "" ? Effect.void : Effect.logDebug("mcp server stderr", { server: options.server, line }),
+          Stream.runForEach((output) =>
+            output.trim() === ""
+              ? Effect.void
+              : Effect.logDebug("mcp server stderr", { server: options.server, output }),
           ),
           Effect.ignore,
         ),

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -14,6 +14,7 @@ const CLOSE_GRACE = Duration.seconds(2)
 /** Mirrors StdioClientTransport: escalate SIGTERM to SIGKILL after this long. */
 const FORCE_KILL_AFTER = Duration.seconds(2)
 const OUTGOING_CAPACITY = 64
+const MAX_FRAME_BYTES = 16 * 1024 * 1024
 
 export interface Options {
   /** Server name; only used to attribute logs. */
@@ -42,26 +43,42 @@ export interface Options {
  */
 export const make = Effect.fnUntraced(function* (options: Options) {
   const environment = yield* Environment.Service
-  const context = yield* Effect.context<Scope.Scope>()
+  const scope = yield* Effect.scope
   // Outgoing frames are queued rather than written to `handle.stdin` directly: the sink closes the
   // stream it is run with, and stdin must stay open across the whole session.
   const outgoing = yield* Queue.bounded<string, Cause.Done>(OUTGOING_CAPACITY)
   const buffer = new ReadBuffer()
   const state: { phase: "ready" | "starting" | "open" | "closed"; handle?: ChildProcessHandle } = { phase: "ready" }
+  let startup: Promise<void> | undefined
+  let closing: Promise<void> | undefined
+  let trailingBytes = 0
 
   const stop = (handle: ChildProcessHandle) =>
     Effect.gen(function* () {
-      Queue.endUnsafe(outgoing)
       const exit = yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE)
       if (exit._tag === "Some") return
-      yield* handle.kill({ killSignal: "SIGTERM", forceKillAfter: FORCE_KILL_AFTER })
+      const terminated = yield* Effect.timeoutOption(handle.kill({ killSignal: "SIGTERM" }), FORCE_KILL_AFTER)
+      if (terminated._tag === "None") yield* handle.kill({ killSignal: "SIGKILL" })
     }).pipe(Effect.ignore)
+
+  const close = () =>
+    (closing ??= Effect.runPromise(
+      Effect.gen(function* () {
+        state.phase = "closed"
+        Queue.endUnsafe(outgoing)
+        if (startup) yield* Effect.promise(() => startup!.catch(() => undefined))
+        const handle = state.handle
+        if (!handle) return
+        state.handle = undefined
+        yield* stop(handle)
+      }).pipe(Effect.ensuring(Queue.shutdown(outgoing)), Effect.ensuring(Effect.sync(() => buffer.clear()))),
+    ))
 
   const transport: Transport = {
     start: () => {
       if (state.phase !== "ready") return Promise.reject(new Error("Stdio transport already started"))
       state.phase = "starting"
-      return Effect.runPromiseWith(context)(
+      startup = Effect.runPromise(
         Effect.gen(function* () {
           const handle = yield* environment.spawner.spawn(
             ChildProcess.make(options.command, [...options.args], {
@@ -81,8 +98,9 @@ export const make = Effect.fnUntraced(function* (options: Options) {
           }
           state.phase = "open"
           yield* startOutput(handle)
-        }),
+        }).pipe(Scope.provide(scope)),
       )
+      return startup
     },
     send: (message: JSONRPCMessage) =>
       state.phase !== "open"
@@ -92,21 +110,15 @@ export const make = Effect.fnUntraced(function* (options: Options) {
               Effect.flatMap((offered) => (offered ? Effect.void : Effect.fail(new Error("Not connected")))),
             ),
           ),
-    close: () =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          state.phase = "closed"
-          Queue.endUnsafe(outgoing)
-          const handle = state.handle
-          if (!handle) return
-          state.handle = undefined
-          yield* stop(handle)
-        }).pipe(Effect.ensuring(Effect.sync(() => buffer.clear()))),
-      ),
+    close,
   }
 
   const deliver = (chunk: Uint8Array) =>
     Effect.gen(function* () {
+      for (const byte of chunk) {
+        trailingBytes = byte === 10 ? 0 : trailingBytes + 1
+        if (trailingBytes > MAX_FRAME_BYTES) return yield* Effect.fail(new Error("MCP stdio frame exceeded 16 MiB"))
+      }
       buffer.append(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
       while (true) {
         // `undefined` means the frame failed to parse: the buffer has already advanced past it, so
@@ -143,8 +155,7 @@ export const make = Effect.fnUntraced(function* (options: Options) {
           Effect.ensuring(
             Effect.gen(function* () {
               const unexpected = state.phase !== "closed"
-              state.phase = "closed"
-              if (unexpected) yield* stop(handle)
+              if (unexpected) yield* Effect.promise(close)
               transport.onclose?.()
             }),
           ),

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -1,0 +1,154 @@
+export * as MCPStdio from "./stdio.js"
+
+import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js"
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Deferred, Duration, Effect, Exit, Queue, Scope, Stream } from "effect"
+import { ChildProcess } from "effect/unstable/process"
+import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
+import { Environment } from "../environment/index.js"
+
+/** Mirrors StdioClientTransport: wait this long for a graceful exit after stdin closes. */
+const CLOSE_GRACE = Duration.seconds(2)
+
+/** Mirrors StdioClientTransport: escalate SIGTERM to SIGKILL after this long. */
+const FORCE_KILL_AFTER = Duration.seconds(2)
+
+export interface Options {
+  /** Server name; only used to attribute logs. */
+  readonly server: string
+  readonly command: string
+  readonly args: ReadonlyArray<string>
+  readonly cwd: string
+  /**
+   * Environment declared by the server config, and nothing else.
+   *
+   * The host environment is merged in by the spawner via `extendEnv`, which keeps the merge on the
+   * side that actually runs the process: the local driver extends with the host's `process.env`
+   * (what the MCP SDK's transport did), while a workspace driver extends with the sandbox's own
+   * environment. Host variables therefore never cross the seam into a remote workspace.
+   */
+  readonly environment: Record<string, string>
+}
+
+/**
+ * MCP stdio transport that spawns its server through the location's `Environment` instead of the
+ * SDK's host-bound `StdioClientTransport`, so a workspace-backed location runs its MCP servers
+ * wherever the rest of its execution happens.
+ *
+ * The process is acquired in the calling scope: closing the scope kills it (the spawner kills the
+ * whole process group, so descendants go too) regardless of whether the transport was closed.
+ */
+export const make = Effect.fnUntraced(function* (options: Options) {
+  const environment = yield* Environment.Service
+  const context = yield* Effect.context<Scope.Scope>()
+  // Outgoing frames are queued rather than written to `handle.stdin` directly: the sink closes the
+  // stream it is run with, and stdin must stay open across the whole session.
+  const outgoing = yield* Queue.unbounded<Uint8Array, Cause.Done>()
+  const encoder = new TextEncoder()
+  const buffer = new ReadBuffer()
+  const closed = Deferred.makeUnsafe<void>()
+  const state: { started: boolean; handle?: ChildProcessHandle } = { started: false }
+
+  const transport: Transport = {
+    start: () => {
+      if (state.started) return Promise.reject(new Error("Stdio transport already started"))
+      state.started = true
+      return Effect.runPromiseWith(context)(
+        Effect.gen(function* () {
+          const handle = yield* environment.spawner.spawn(
+            ChildProcess.make(options.command, [...options.args], {
+              cwd: options.cwd,
+              env: options.environment,
+              extendEnv: true,
+              stdin: { stream: Stream.fromQueue(outgoing), endOnDone: true },
+              stdout: "pipe",
+              stderr: "pipe",
+              forceKillAfter: FORCE_KILL_AFTER,
+            }),
+          )
+          state.handle = handle
+          yield* startOutput(handle)
+        }),
+      )
+    },
+    send: (message: JSONRPCMessage) =>
+      Queue.offerUnsafe(outgoing, encoder.encode(serializeMessage(message)))
+        ? Promise.resolve()
+        : Promise.reject(new Error("Not connected")),
+    close: () =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          Queue.endUnsafe(outgoing)
+          const handle = state.handle
+          if (!handle) return
+          // Give the server the same chance to exit on its own that the SDK transport gives it; the
+          // handle then signals the process through whichever execution driver spawned it.
+          const exit = yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE)
+          if (exit._tag === "Some") return
+          const terminated = yield* Effect.timeoutOption(handle.kill({ killSignal: "SIGTERM" }), FORCE_KILL_AFTER)
+          if (terminated._tag === "None") yield* handle.kill({ killSignal: "SIGKILL" })
+        }).pipe(Effect.ensuring(Effect.sync(() => buffer.clear())), Effect.ignore),
+      ),
+  }
+
+  const deliver = (chunk: Uint8Array) =>
+    Effect.gen(function* () {
+      buffer.append(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+      while (true) {
+        // `undefined` means the frame failed to parse: the buffer has already advanced past it, so
+        // keep draining. `null` means the buffer holds no complete frame yet.
+        const message = yield* Effect.try({
+          try: () => buffer.readMessage(),
+          catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => {
+              transport.onerror?.(error)
+              return undefined
+            }),
+          ),
+        )
+        if (message === undefined) continue
+        if (message === null) return
+        transport.onmessage?.(message)
+      }
+    })
+
+  const startOutput = (handle: ChildProcessHandle) =>
+    Effect.gen(function* () {
+      yield* Effect.forkScoped(
+        Stream.runForEach(handle.stdout, deliver).pipe(
+          Effect.tapCause((cause) =>
+            Effect.sync(() => {
+              const error = Cause.squash(cause)
+              transport.onerror?.(error instanceof Error ? error : new Error(String(error)))
+            }),
+          ),
+          Effect.ignore,
+          // stdout ending means the server is gone; the SDK transport reports that the same way.
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (Deferred.doneUnsafe(closed, Exit.void)) transport.onclose?.()
+            }),
+          ),
+        ),
+      )
+
+      // StdioClientTransport pipes stderr into a stream nobody reads, which both hides server
+      // diagnostics and lets a chatty server stall on backpressure. Draining it into the debug log
+      // keeps the pipe moving and makes the output reachable.
+      yield* Effect.forkScoped(
+        handle.stderr.pipe(
+          Stream.decodeText(),
+          Stream.splitLines,
+          Stream.runForEach((line) =>
+            line.trim() === "" ? Effect.void : Effect.logDebug("mcp server stderr", { server: options.server, line }),
+          ),
+          Effect.ignore,
+        ),
+      )
+    })
+
+  return transport
+})

--- a/packages/core/test/fixture/environment.ts
+++ b/packages/core/test/fixture/environment.ts
@@ -1,7 +1,42 @@
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Environment } from "@opencode-ai/core/environment/index"
 import { Location } from "@opencode-ai/core/location"
+import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Effect, Layer } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+
+/**
+ * The host environment, without the workspace machinery: what a location with no `workspaceID`
+ * resolves to.
+ */
+export const hostEnvironmentLayer = Layer.effect(
+  Environment.Service,
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    const driver = Environment.makeLocalDriver(spawner)
+    return Environment.Service.of({ files: Environment.makeFiles(driver), spawner: driver.spawner })
+  }),
+).pipe(Layer.provide(LayerNode.compile(CrossSpawnSpawner.node)))
+
+/**
+ * The host environment with its spawner wrapped so a test can assert on every command that crosses
+ * the seam. Spawning still really happens, so the process under test behaves normally.
+ */
+export const recordingEnvironmentLayer = (spawns: Array<ChildProcess.Command>) =>
+  Layer.effect(
+    Environment.Service,
+    Effect.gen(function* () {
+      const environment = yield* Environment.Service
+      return Environment.Service.of({
+        ...environment,
+        spawner: ChildProcessSpawner.make((command) => {
+          spawns.push(command)
+          return environment.spawner.spawn(command)
+        }),
+      })
+    }),
+  ).pipe(Layer.provide(hostEnvironmentLayer))
 
 export type EnvironmentFilesTransform = (files: Environment.Files) => Partial<Environment.Files>
 

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -22,6 +22,7 @@ import { Bus } from "@opencode-ai/core/bus"
 import { ID, type Payload } from "@opencode-ai/schema/event"
 import { Form } from "@opencode-ai/core/form"
 import { Integration } from "@opencode-ai/core/integration"
+import { Environment } from "@opencode-ai/core/environment/index"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { MCPClient } from "@opencode-ai/core/mcp/client"
@@ -31,10 +32,12 @@ import { Session } from "@opencode-ai/core/session"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
 import { Tool } from "@opencode-ai/core/tool"
 import { DateTime, Deferred, Effect, Exit, Fiber, Layer, PubSub, Schedule, Schema, Stream } from "effect"
+import { ChildProcess } from "effect/unstable/process"
 import { Image } from "@opencode-ai/core/image"
 import { testEffect } from "./lib/effect"
 import { imagePassthrough } from "./lib/image"
 import { location } from "./fixture/location"
+import { hostEnvironmentLayer, recordingEnvironmentLayer } from "./fixture/environment"
 import { executeTool, toolDefinitions, toolIdentity, waitForCodeModeTool, waitForTool } from "./lib/tool"
 
 let assertion: Deferred.Deferred<Permission.AssertInput> | undefined
@@ -167,6 +170,7 @@ function resourceMcpLayer(
   overrides?: {
     entries?: Config.Interface["entries"]
     subscribe?: Bus.Interface["subscribe"]
+    environment?: Layer.Layer<Environment.Service>
   },
 ) {
   const directory = AbsolutePath.make(import.meta.dir)
@@ -229,10 +233,14 @@ function resourceMcpLayer(
           },
         }),
         Layer.mock(Credential.Service, {}),
+        overrides?.environment ?? hostEnvironmentLayer,
       ),
     ),
   )
 }
+
+const connect = (server: string, config: typeof ConfigMCP.Server.Type, directory: string) =>
+  MCPClient.connect(server, config, directory).pipe(Effect.provide(hostEnvironmentLayer))
 
 const mcp = Layer.mock(MCP.Service, {
   tools: () =>
@@ -407,7 +415,7 @@ test("retains output schemas across paginated MCP discovery", async () => {
   const tools = await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "pagination",
           new ConfigMCP.Local({
             type: "local",
@@ -440,11 +448,41 @@ test("retains output schemas across paginated MCP discovery", async () => {
   ])
 })
 
+test("spawns local MCP servers through the location environment", async () => {
+  const spawns: Array<ChildProcess.Command> = []
+  const cwd = path.join(import.meta.dir, "fixture")
+  const config = new ConfigMCP.Local({
+    type: "local",
+    command: [process.execPath, path.join(import.meta.dir, "fixture/mcp-output-schema.ts")],
+    cwd: "fixture",
+    environment: { MCP_LOCATION_TEST: "configured" },
+  })
+
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const connection = yield* MCPClient.connect("environment", config, import.meta.dir)
+        yield* connection.tools()
+      }),
+    ).pipe(Effect.provide(recordingEnvironmentLayer(spawns))),
+  )
+
+  expect(spawns).toHaveLength(1)
+  const command = spawns[0]
+  expect(command?._tag).toBe("StandardCommand")
+  if (!command || !ChildProcess.isStandardCommand(command)) throw new Error("Expected a standard process command")
+  expect(command.command).toBe(process.execPath)
+  expect(command.options.cwd).toBe(cwd)
+  expect(command.options.extendEnv).toBe(true)
+  expect(command.options.env).toEqual({ MCP_LOCATION_TEST: "configured" })
+  expect(command.options.env).not.toHaveProperty("HOME")
+})
+
 test("applies the configured MCP catalog timeout", async () => {
   const result = Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "catalog-timeout",
           new ConfigMCP.Local({
             type: "local",
@@ -466,7 +504,7 @@ test("applies the configured MCP execution timeout", async () => {
   const result = Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "execution-timeout",
           new ConfigMCP.Local({
             type: "local",
@@ -487,7 +525,7 @@ test("applies the configured MCP execution timeout to prompts", async () => {
   const result = Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "prompt-timeout",
           new ConfigMCP.Local({
             type: "local",
@@ -508,7 +546,7 @@ test("applies configured MCP timeouts to resource operations", async () => {
   const catalog = Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "resource-catalog-timeout",
           new ConfigMCP.Local({
             type: "local",
@@ -527,7 +565,7 @@ test("applies configured MCP timeouts to resource operations", async () => {
   const read = Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "resource-read-timeout",
           new ConfigMCP.Local({
             type: "local",
@@ -562,7 +600,7 @@ test("lists, reads, and reports MCP resource changes", async () => {
           },
           "templates-2": { items: [{ name: "Issue", uriTemplate: "issue://{id}", description: "Issue" }] },
         }
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "resources",
           new ConfigMCP.Remote({ type: "remote", url: server.url, oauth: false }),
           import.meta.dir,
@@ -633,7 +671,7 @@ test("skips MCP resource requests when the capability is absent", async () => {
     Effect.scoped(
       Effect.gen(function* () {
         const server = yield* resourceServer({ resources: false })
-        const connection = yield* MCPClient.connect(
+        const connection = yield* connect(
           "resources",
           new ConfigMCP.Remote({ type: "remote", url: server.url, oauth: false }),
           import.meta.dir,

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -26,6 +26,7 @@ import { Environment } from "@opencode-ai/core/environment/index"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { MCPClient } from "@opencode-ai/core/mcp/client"
+import { MCPStdio } from "@opencode-ai/core/mcp/stdio"
 import { Permission } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
@@ -476,6 +477,29 @@ test("spawns local MCP servers through the location environment", async () => {
   expect(command.options.extendEnv).toBe(true)
   expect(command.options.env).toEqual({ MCP_LOCATION_TEST: "configured" })
   expect(command.options.env).not.toHaveProperty("HOME")
+})
+
+test("rejects sends before the stdio transport is started", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const transport = yield* MCPStdio.make({
+          server: "not-started",
+          command: process.execPath,
+          args: [path.join(import.meta.dir, "fixture/mcp-output-schema.ts")],
+          cwd: import.meta.dir,
+          environment: {},
+        })
+        yield* Effect.tryPromise({
+          try: () => transport.send({ jsonrpc: "2.0", method: "notifications/initialized" }),
+          catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+        }).pipe(
+          Effect.flip,
+          Effect.tap((error) => Effect.sync(() => expect(error.message).toBe("Not connected"))),
+        )
+      }).pipe(Effect.provide(hostEnvironmentLayer)),
+    ),
+  )
 })
 
 test("applies the configured MCP catalog timeout", async () => {

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -32,8 +32,9 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
 import { Tool } from "@opencode-ai/core/tool"
-import { DateTime, Deferred, Effect, Exit, Fiber, Layer, PubSub, Schedule, Schema, Stream } from "effect"
-import { ChildProcess } from "effect/unstable/process"
+import { DateTime, Deferred, Effect, Exit, Fiber, Layer, PubSub, Schedule, Schema, Sink, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { ExitCode, makeHandle, ProcessId } from "effect/unstable/process/ChildProcessSpawner"
 import { Image } from "@opencode-ai/core/image"
 import { testEffect } from "./lib/effect"
 import { imagePassthrough } from "./lib/image"
@@ -470,13 +471,11 @@ test("spawns local MCP servers through the location environment", async () => {
 
   expect(spawns).toHaveLength(1)
   const command = spawns[0]
-  expect(command?._tag).toBe("StandardCommand")
   if (!command || !ChildProcess.isStandardCommand(command)) throw new Error("Expected a standard process command")
   expect(command.command).toBe(process.execPath)
   expect(command.options.cwd).toBe(cwd)
   expect(command.options.extendEnv).toBe(true)
   expect(command.options.env).toEqual({ MCP_LOCATION_TEST: "configured" })
-  expect(command.options.env).not.toHaveProperty("HOME")
 })
 
 test("rejects sends before the stdio transport is started", async () => {
@@ -500,6 +499,83 @@ test("rejects sends before the stdio transport is started", async () => {
       }).pipe(Effect.provide(hostEnvironmentLayer)),
     ),
   )
+})
+
+test("joins concurrent stdio transport closes", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const transport = yield* MCPStdio.make({
+          server: "concurrent-close",
+          command: "unused",
+          args: [],
+          cwd: import.meta.dir,
+          environment: {},
+        })
+        const first = transport.close()
+        expect(transport.close()).toBe(first)
+        yield* Effect.promise(() => first)
+      }).pipe(Effect.provide(hostEnvironmentLayer)),
+    ),
+  )
+})
+
+test("closes a stdio process that finishes spawning after close", async () => {
+  const spawning = Deferred.makeUnsafe<void>()
+  const release = Deferred.makeUnsafe<void>()
+  const exited = Deferred.makeUnsafe<ExitCode>()
+  const signals: Array<string> = []
+  const driver = Environment.makeMemoryDriver()
+  const environment = Layer.succeed(
+    Environment.Service,
+    Environment.Service.of({
+      files: Environment.makeFiles(driver),
+      spawner: ChildProcessSpawner.make(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(spawning, undefined)
+          yield* Deferred.await(release)
+          return makeHandle({
+            pid: ProcessId(1),
+            exitCode: Deferred.await(exited),
+            isRunning: Deferred.isDone(exited).pipe(Effect.map((done) => !done)),
+            kill: (options) =>
+              Effect.gen(function* () {
+                signals.push(options?.killSignal ?? "SIGTERM")
+                yield* Deferred.succeed(exited, ExitCode(143))
+              }),
+            stdin: Sink.drain,
+            stdout: Stream.never,
+            stderr: Stream.empty,
+            all: Stream.never,
+            getInputFd: () => Sink.drain,
+            getOutputFd: () => Stream.empty,
+            unref: Effect.succeed(Effect.void),
+          })
+        }),
+      ),
+    }),
+  )
+
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const transport = yield* MCPStdio.make({
+          server: "close-during-spawn",
+          command: "unused",
+          args: [],
+          cwd: import.meta.dir,
+          environment: {},
+        })
+        const start = transport.start()
+        yield* Deferred.await(spawning)
+        const close = transport.close()
+        yield* Deferred.succeed(release, undefined)
+        yield* Effect.promise(() => Promise.all([start, close]))
+      }).pipe(Effect.provide(environment)),
+    ),
+  )
+
+  expect(signals).toEqual(["SIGTERM"])
 })
 
 test("applies the configured MCP catalog timeout", async () => {


### PR DESCRIPTION
## What

Route local/stdio MCP server processes through each location's `Environment.spawner` instead of the MCP SDK's host-bound `StdioClientTransport`.

MCP is already location-scoped, but stdio servers were host-ambient. A workspace-backed location could run Shell and Ripgrep inside its sandbox while its MCP servers still ran on the OpenCode host. After this change, stdio MCP follows the same execution seam as the rest of the location.

## Before / After

**Before:** `MCPClient.connect` constructed `StdioClientTransport`, which spawned on the host with host environment values and used host-only `pgrep` cleanup. Workspace placement had no effect on stdio MCP execution.

**After:** the location MCP layer supplies its `Environment`; transport startup calls `Environment.spawner.spawn`, so local locations use the host driver and workspace locations use their sandbox driver. Process shutdown goes through the returned handle.

## How

- `packages/core/src/mcp/stdio.ts` implements the MCP `Transport` contract over an Effect `ChildProcessHandle`.
- JSON-RPC framing reuses the SDK's newline-delimited `ReadBuffer` and `serializeMessage`.
- The process is spawned in `start()`, keeping workspace wake/spawn inside the MCP startup timeout and preserving the SDK callback-ordering contract.
- Stderr is continuously drained and attributed to the MCP server in debug logs.
- Only configured environment overrides cross the Environment boundary. `extendEnv` is resolved by the selected driver: the local driver inherits host env as before, while workspace drivers inherit inside the sandbox, preventing host env leakage.
- Close ends stdin, waits for a graceful exit, sends `SIGTERM` through the handle, then escalates to `SIGKILL`; scoped process cleanup remains the final backstop. Local handles kill detached process groups, preserving descendant cleanup without host `pgrep`; workspace handles use their driver-specific kill protocol.
- `MCP.node` now depends on the location's `Environment.node`.

```mermaid
sequenceDiagram
  participant MCP as Location MCP
  participant Env as Environment.spawner
  participant Driver as Local or workspace driver
  participant Server as stdio MCP server
  MCP->>Env: spawn(command, cwd, configured env)
  Env->>Driver: route for location
  Driver->>Server: start process
  MCP->>Server: newline-delimited JSON-RPC over stdin
  Server-->>MCP: newline-delimited JSON-RPC over stdout
  MCP->>Driver: close stdin / SIGTERM / SIGKILL via handle
```

## Scope

No option or flag is added. Availability is determined by whether the location's Environment spawner works.

Follow-up: the workerd profile in #41918 will gain working stdio MCP through this seam once its Environment fallback is replaced.

## Testing

- `cd packages/core && bun run test`: 1,688 passed, 16 skipped, 0 failed on the first full run.
- A later full run hit two unrelated existing 5s timing failures (`Snapshot` interruption and Config command rename); both pass in isolation. The Config rename case was rerun twice during investigation and then passed when isolated.
- `cd packages/core && bun test test/mcp.test.ts`: 26 passed, including real stdio fixtures and a recording Environment spawner assertion.
- `bun run typecheck`: all 32 typecheck tasks succeeded across 38 packages, including a clean push-hook run.
- Prettier and `git diff --check` pass.
