### PR TITLE
docs: fix grammar in sdk and models pages

### DIFF
--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -60,7 +60,7 @@ OpenCode config.
 
 Here the full ID is `provider_id/model_id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
-If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
+If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is the key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
 
 ---
 

--- a/packages/web/src/content/docs/sdk.mdx
+++ b/packages/web/src/content/docs/sdk.mdx
@@ -119,7 +119,7 @@ try {
 
 ## Structured Output
 
-You can request structured JSON output from the model by specifying an `format` with a JSON schema. The model will use a `StructuredOutput` tool to return validated JSON matching your schema.
+You can request structured JSON output from the model by specifying a `format` with a JSON schema. The model will use a `StructuredOutput` tool to return validated JSON matching your schema.
 
 ### Basic Usage
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (docs grammar)
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes two English grammar mistakes in the docs:

1. `packages/web/src/content/docs/sdk.mdx` — "specifying an `format`" → "specifying a `format`" (`format` starts with a consonant, so "a" is correct).

2. `packages/web/src/content/docs/models.mdx` — "the `provider_id` is key from" → "the `provider_id` is the key from" (missing article; the second half of the same sentence already reads "is the key from `provider.models`").

### How did you verify your code works?

These are pure doc text changes. `bun typecheck` (30/30 packages) passed via the pre-push hook.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR