### PR TITLE
docs: add @oyadotai/opencode-plugin to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [@oyadotai/opencode-plugin](https://github.com/OyaAIProd/oya-plugins/tree/main/opencode)          | Build, deploy, and manage Oya AI agents, skills, and routines via the Oya MCP server               |
 
 ---
 


### PR DESCRIPTION
Adds [@oyadotai/opencode-plugin](https://www.npmjs.com/package/@oyadotai/opencode-plugin) to the plugins table on the ecosystem page.

The plugin lets OpenCode build, deploy, and manage [Oya](https://getoya.ai) AI agents via the Oya MCP server: create agents with skills and scheduled routines, deploy them to a sandboxed cloud runtime, connect gateways (Slack, Gmail, LinkedIn, and more), trigger runs, and inspect traces without leaving the editor.

- Source: https://github.com/OyaAIProd/oya-plugins (plugin in `opencode/`, MIT)
- npm: `@oyadotai/opencode-plugin` v0.3.0, built on `@opencode-ai/plugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)