### PR TITLE
fix: preserve trailing blank line in apply_patch

### DIFF
--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -71,11 +71,14 @@ export function parse(patchText: string): ReadonlyArray<Hunk> {
 export function derive(path: string, chunks: ReadonlyArray<UpdateFileChunk>, original: string): FileUpdate {
   const source = splitBom(original)
   const lines = source.text.split("\n")
-  if (lines.at(-1) === "") lines.pop()
+  // Remember whether the sentinel from split("\n") was popped: a genuinely blank
+  // last line also leaves "" at the end, so re-checking at(-1) would drop it.
+  const trailing = lines.at(-1) === ""
+  if (trailing) lines.pop()
   const replacements = computeReplacements(lines, path, chunks)
   const updated = [...lines]
   for (const [start, remove, insert] of replacements.toReversed()) updated.splice(start, remove, ...insert)
-  if (updated.at(-1) !== "") updated.push("")
+  if (trailing || updated.at(-1) !== "") updated.push("")
   const next = splitBom(updated.join("\n"))
   return { content: next.text, bom: source.bom || next.bom }
 }

--- a/packages/core/test/tool-apply-patch.test.ts
+++ b/packages/core/test/tool-apply-patch.test.ts
@@ -202,6 +202,37 @@ describe("ApplyPatchTool", () => {
     ),
   )
 
+  it.live("preserves a trailing blank line when updating other lines", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const update = path.join(tmp.path, "update.txt")
+        return Effect.promise(() => fs.writeFile(update, "alpha\nbeta\n\n")).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              Effect.gen(function* () {
+                const settled = yield* settleTool(
+                  registry,
+                  call("*** Begin Patch\n*** Update File: update.txt\n@@\n-alpha\n+ALPHA\n*** End Patch"),
+                )
+                expect(settled.result).toEqual({
+                  type: "text",
+                  value: "Applied patch sequentially:\nM update.txt",
+                })
+                expect(settled.output?.structured).toMatchObject({
+                  files: [{ file: "update.txt", status: "modified", additions: 1, deletions: 1 }],
+                })
+                expect(yield* Effect.promise(() => fs.readFile(update, "utf8"))).toBe("ALPHA\nbeta\n\n")
+              }),
+            ),
+          ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects moves before applying any hunk", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -313,8 +313,11 @@ export function deriveNewContentsFromChunks(
 
   let originalLines = originalContent.text.split("\n")
 
-  // Drop trailing empty element for consistent line counting
-  if (originalLines.length > 0 && originalLines[originalLines.length - 1] === "") {
+  // Drop trailing empty element for consistent line counting. Remember it was
+  // dropped: a genuinely blank last line also leaves "" at the end, so
+  // re-checking the last element below would drop that blank line instead.
+  const trailing = originalLines.length > 0 && originalLines[originalLines.length - 1] === ""
+  if (trailing) {
     originalLines.pop()
   }
 
@@ -322,7 +325,7 @@ export function deriveNewContentsFromChunks(
   let newLines = applyReplacements(originalLines, replacements)
 
   // Ensure trailing newline
-  if (newLines.length === 0 || newLines[newLines.length - 1] !== "") {
+  if (trailing || newLines.length === 0 || newLines[newLines.length - 1] !== "") {
     newLines.push("")
   }
 

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -356,6 +356,26 @@ PATCH`
       }),
     )
 
+    it.live("should preserve a trailing blank line when updating other lines", () =>
+      Effect.gen(function* () {
+        const filePath = path.join(tempDir, "trailing-blank.txt")
+        yield* Effect.promise(() => fs.writeFile(filePath, "line 1\nline 2\n\n"))
+
+        const patchText = `*** Begin Patch
+*** Update File: ${filePath}
+@@
+-line 1
++LINE 1
+*** End Patch`
+
+        const result = yield* Patch.applyPatch(patchText)
+        expect(result.modified).toHaveLength(1)
+
+        const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
+        expect(content).toBe("LINE 1\nline 2\n\n")
+      }),
+    )
+
     it.live("should handle multiple update chunks in single file", () =>
       Effect.gen(function* () {
         const filePath = path.join(tempDir, "multi-chunk.txt")


### PR DESCRIPTION
### Issue for this PR

Fixes #42081

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` silently deletes the final blank line of any file ending with `\n\n`, even when the patch doesn't touch it (#42081).

Both patch implementations pop the sentinel `""` that `split("\n")` produces when content ends with a newline, then later re-check "is the last element empty" to decide whether to push the sentinel back. A genuinely blank last line also leaves `""` at the end, so the sentinel is never restored and one `\n` is lost on every edit.

The fix records whether the sentinel was actually popped and reuses that on the way out instead of re-inferring it. Applied to `derive()` in `packages/core/src/patch.ts` and `deriveNewContentsFromChunks()` in `packages/opencode/src/patch/index.ts`. Files without a trailing newline keep the existing "always add one" behavior; this PR only fixes the unrequested deletion.

Disclosure: developed with AI assistance; I reviewed and verified everything locally.

### How did you verify your code works?

Added one regression test per implementation, next to the existing cases; both fail before the fix and pass after:

- `packages/core/test/tool-apply-patch.test.ts`: end-to-end through the tool. File `alpha\nbeta\n\n`, patch changes only `alpha`; asserts `ALPHA\nbeta\n\n` on disk and a 1 addition / 1 deletion diff (before the fix: `ALPHA\nbeta\n` and 1/2).
- `packages/opencode/test/patch/patch.test.ts`: same scenario through `Patch.applyPatch`.

Test runs:

- `packages/core`: full `bun test` — 1081 tests, 1079 pass; the 2 failures are pre-existing flaky `Npm.add` timeouts unrelated to this change (they pass when the file is run individually, both before and after the fix).
- `packages/opencode`: `bun test test/patch/patch.test.ts test/tool/apply_patch.test.ts` — 48 pass. I did not run this package's full suite.
- `bun typecheck` passes in both packages.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
