### PR TITLE
fix(tui): stabilize repeated open menu

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -69,7 +69,7 @@ import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
-import { DialogOpen } from "./component/dialog-open"
+import { DialogOpen, DialogOpenKey, loadDialogOpen } from "./component/dialog-open"
 import { SessionTabs } from "./component/session-tabs"
 import { sessionTabsFitVertically } from "./ui/layout"
 import { ThemeErrorToast } from "./component/theme-error-toast"
@@ -682,19 +682,13 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "Session",
         slash: { name: "open", aliases: ["projects", "project"] },
         run: async () => {
-          if (dialog.key === "open" || openingOpen) return
+          if (dialog.key === DialogOpenKey || openingOpen) return
           const previous = dialog.stack.at(-1)
-          openingOpen = Promise.all([
-            data.project.sync().catch(() => {}),
-            client.api.session
-              .list({ limit: 50, order: "desc", parentID: null })
-              .then((response) => response.data)
-              .catch(() => [] as SessionInfo[]),
-          ]).then(([, sessions]) => sessions)
+          openingOpen = loadDialogOpen(data, client)
           const sessions = await openingOpen
           openingOpen = undefined
           if (dialog.stack.at(-1) !== previous) return
-          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: "open", size: "large" })
+          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: DialogOpenKey, size: "large" })
         },
       },
       ...Array.from({ length: 9 }, (_, i) => ({

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -681,7 +681,8 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "Session",
         slash: { name: "open", aliases: ["projects", "project"] },
         run: () => {
-          dialog.replace(() => <DialogOpen />)
+          if (dialog.key === "open") return
+          dialog.replace(() => <DialogOpen />, undefined, { key: "open", size: "large" })
         },
       },
       ...Array.from({ length: 9 }, (_, i) => ({

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -2,7 +2,7 @@ import { render, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { registerOpencodeSpinner } from "./component/register-spinner"
 import { Deferred, Effect } from "effect"
 import { Service, type Endpoint } from "@opencode-ai/client/effect/service"
-import { OpenCode } from "@opencode-ai/client"
+import { OpenCode, type SessionInfo } from "@opencode-ai/client"
 import { Global } from "@opencode-ai/util/global"
 import { ClipboardProvider, useClipboard } from "./context/clipboard"
 import { LogProvider, useLog, type LogSink } from "./context/log"
@@ -478,6 +478,7 @@ function App(props: { pair?: DialogPairCredentials }) {
   const promptRef = usePromptRef()
   const plugins = usePlugin()
   const clipboard = useClipboard()
+  let openingOpen: Promise<SessionInfo[]> | undefined
   // Toast once when an MCP server enters a failed or needs-auth state so the user knows to act,
   // without having to open the status panel. Tracking the last alerted status avoids re-toasting
   // the same problem on every refresh while still re-alerting if the state changes.
@@ -680,9 +681,20 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "Open session or project",
         category: "Session",
         slash: { name: "open", aliases: ["projects", "project"] },
-        run: () => {
-          if (dialog.key === "open") return
-          dialog.replace(() => <DialogOpen />, undefined, { key: "open", size: "large" })
+        run: async () => {
+          if (dialog.key === "open" || openingOpen) return
+          const previous = dialog.stack.at(-1)
+          openingOpen = Promise.all([
+            data.project.sync().catch(() => {}),
+            client.api.session
+              .list({ limit: 50, order: "desc", parentID: null })
+              .then((response) => response.data)
+              .catch(() => [] as SessionInfo[]),
+          ]).then(([, sessions]) => sessions)
+          const sessions = await openingOpen
+          openingOpen = undefined
+          if (dialog.stack.at(-1) !== previous) return
+          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: "open", size: "large" })
         },
       },
       ...Array.from({ length: 9 }, (_, i) => ({

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -20,8 +20,20 @@ import { Spinner } from "./spinner"
 import { projectName } from "../util/project"
 
 const RECENT_LIMIT = 8
+export const DialogOpenKey = Symbol("DialogOpen")
 
 type OpenTarget = { type: "session"; sessionID: string } | { type: "project"; directory: string }
+
+export async function loadDialogOpen(data: ReturnType<typeof useData>, client: ReturnType<typeof useClient>) {
+  const [, sessions] = await Promise.all([
+    data.project.sync().catch(() => {}),
+    client.api.session
+      .list({ limit: 50, order: "desc", parentID: null })
+      .then((response) => response.data)
+      .catch(() => [] as SessionInfo[]),
+  ])
+  return sessions
+}
 
 export function DialogOpen(props: { sessions: SessionInfo[] }) {
   const dialog = useDialog()

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -23,7 +23,7 @@ const RECENT_LIMIT = 8
 
 type OpenTarget = { type: "session"; sessionID: string } | { type: "project"; directory: string }
 
-export function DialogOpen() {
+export function DialogOpen(props: { sessions: SessionInfo[] }) {
   const dialog = useDialog()
   const route = useRoute()
   const data = useData()
@@ -39,18 +39,6 @@ export function DialogOpen() {
   const [filter, setFilter] = createSignal("")
   const [selectionMoved, setSelectionMoved] = createSignal(false)
 
-  void data.project.sync().catch(() => {})
-
-  // One background fetch fills in recent sessions from other projects; the menu renders
-  // immediately from the local store and never blocks on the network.
-  const [fetched] = createResource(
-    () =>
-      client.api.session
-        .list({ limit: 50, order: "desc", parentID: null })
-        .then((response) => response.data)
-        .catch(() => [] as SessionInfo[]),
-    { initialValue: [] },
-  )
   const [matched] = createResource(
     () => {
       const value = filter().trim()
@@ -72,7 +60,7 @@ export function DialogOpen() {
   const sessions = createMemo(() => {
     const seen = new Set<string>()
     const match = matched()
-    return [...data.session.list(), ...fetched(), ...(match ? [match] : [])]
+    return [...data.session.list(), ...props.sessions, ...(match ? [match] : [])]
       .filter((session) => {
         if (session.parentID || seen.has(session.id)) return false
         seen.add(session.id)

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, createSignal, onMount } from "solid-js"
+import { createMemo, createResource, createSignal } from "solid-js"
 import type { SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
 import { dialogWidth, useDialog } from "../ui/dialog"
@@ -141,8 +141,6 @@ export function DialogOpen() {
 
     return [...sessionOptions, ...projectOptions]
   })
-
-  onMount(() => dialog.setSize("large"))
 
   return (
     <DialogSelect

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -75,7 +75,7 @@ function init() {
     stack: [] as {
       element: JSX.Element
       onClose?: () => void
-      key?: string
+      key?: unknown
     }[],
     size: "medium" as DialogSize,
     centered: false,
@@ -156,7 +156,7 @@ function init() {
       })
       refocus()
     },
-    replace(input: any, onClose?: () => void, options?: { key?: string; size?: DialogSize }) {
+    replace(input: any, onClose?: () => void, options?: { key?: unknown; size?: DialogSize }) {
       if (store.stack.length === 0) {
         focus = renderer.currentFocusedRenderable
         focus?.blur()

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -75,6 +75,7 @@ function init() {
     stack: [] as {
       element: JSX.Element
       onClose?: () => void
+      key?: string
     }[],
     size: "medium" as DialogSize,
     centered: false,
@@ -155,7 +156,7 @@ function init() {
       })
       refocus()
     },
-    replace(input: any, onClose?: () => void) {
+    replace(input: any, onClose?: () => void, options?: { key?: string; size?: DialogSize }) {
       if (store.stack.length === 0) {
         focus = renderer.currentFocusedRenderable
         focus?.blur()
@@ -163,14 +164,17 @@ function init() {
       for (const item of store.stack) {
         if (item.onClose) item.onClose()
       }
-      setStore("size", "medium")
-      setStore("centered", false)
-      setStore("stack", [
-        {
-          element: input,
-          onClose,
-        },
-      ])
+      batch(() => {
+        setStore("size", options?.size ?? "medium")
+        setStore("centered", false)
+        setStore("stack", [
+          {
+            element: input,
+            onClose,
+            key: options?.key,
+          },
+        ])
+      })
     },
     get stack() {
       return store.stack
@@ -180,6 +184,9 @@ function init() {
     },
     get centered() {
       return store.centered
+    },
+    get key() {
+      return store.stack.at(-1)?.key
     },
     setSize(size: "medium" | "large" | "xlarge") {
       setStore("size", size)

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -4,7 +4,7 @@ import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
 import { DialogOpen } from "../../../src/component/dialog-open"
 import { ConfigProvider } from "../../../src/config"
-import { ClientProvider } from "../../../src/context/client"
+import { ClientProvider, useClient } from "../../../src/context/client"
 import { DataProvider, useData } from "../../../src/context/data"
 import { Keymap } from "../../../src/context/keymap"
 import { LocationProvider, useLocation } from "../../../src/context/location"
@@ -157,8 +157,8 @@ test("preserves a moved project when sessions arrive", async () => {
   })
 
   try {
-    await fixture.app.waitForFrame((frame) => frame.includes("Second project"))
-    fixture.app.mockInput.pressArrow("down")
+    await fixture.app.renderOnce()
+    expect(fixture.app.captureCharFrame()).not.toContain("Search sessions and projects")
 
     resolveSessions(
       json({
@@ -176,7 +176,9 @@ test("preserves a moved project when sessions arrive", async () => {
         cursor: {},
       }),
     )
-    await fixture.app.waitForFrame((frame) => frame.includes("Recent session"))
+    await fixture.app.waitForFrame((frame) => frame.includes("Recent session") && frame.includes("Second project"))
+    fixture.app.mockInput.pressArrow("down")
+    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressEnter()
     await fixture.app.waitFor(() => fixture.route.data.type === "home")
 
@@ -292,14 +294,22 @@ async function renderOpen(
 
   function Probe() {
     const dialog = useDialog()
+    const client = useClient()
     route = useRoute()
     location = useLocation()
     data = useData()
     storage = useStorage()
     onMount(
       () =>
-        void Promise.resolve(beforeOpen?.({ data, location })).then(() =>
-          dialog.replace(() => <DialogOpen />, undefined, { key: "open", size: "large" }),
+        void Promise.all([
+          beforeOpen?.({ data, location }),
+          data.project.sync().catch(() => {}),
+          client.api.session
+            .list({ limit: 50, order: "desc", parentID: null })
+            .then((response) => response.data)
+            .catch(() => []),
+        ]).then(([, , sessions]) =>
+          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: "open", size: "large" }),
         ),
     )
     return null

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -2,7 +2,7 @@
 import { expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
-import { DialogOpen } from "../../../src/component/dialog-open"
+import { DialogOpen, DialogOpenKey, loadDialogOpen } from "../../../src/component/dialog-open"
 import { ConfigProvider } from "../../../src/config"
 import { ClientProvider, useClient } from "../../../src/context/client"
 import { DataProvider, useData } from "../../../src/context/data"
@@ -131,7 +131,7 @@ test("shows the current project and opens its root", async () => {
   }
 })
 
-test("preserves a moved project when sessions arrive", async () => {
+test("waits for sessions before showing the populated picker", async () => {
   let resolveSessions!: (response: Response) => void
   const sessions = new Promise<Response>((resolve) => (resolveSessions = resolve))
   const fixture = await renderOpen((url) => {
@@ -301,15 +301,8 @@ async function renderOpen(
     storage = useStorage()
     onMount(
       () =>
-        void Promise.all([
-          beforeOpen?.({ data, location }),
-          data.project.sync().catch(() => {}),
-          client.api.session
-            .list({ limit: 50, order: "desc", parentID: null })
-            .then((response) => response.data)
-            .catch(() => []),
-        ]).then(([, , sessions]) =>
-          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: "open", size: "large" }),
+        void Promise.all([beforeOpen?.({ data, location }), loadDialogOpen(data, client)]).then(([, sessions]) =>
+          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: DialogOpenKey, size: "large" }),
         ),
     )
     return null

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -297,7 +297,10 @@ async function renderOpen(
     data = useData()
     storage = useStorage()
     onMount(
-      () => void Promise.resolve(beforeOpen?.({ data, location })).then(() => dialog.replace(() => <DialogOpen />)),
+      () =>
+        void Promise.resolve(beforeOpen?.({ data, location })).then(() =>
+          dialog.replace(() => <DialogOpen />, undefined, { key: "open", size: "large" }),
+        ),
     )
     return null
   }


### PR DESCRIPTION
## What

Keep the populated Control-O session/project picker stable when it opens, reopens, or receives the shortcut repeatedly.

## Before / After

**Before:** Opening reset the shared dialog to medium width, mounted a partial picker from local state, then resized it and inserted projects and cross-project recents as two asynchronous requests completed. This produced a visible flash while loading. Pressing Control-O while open also remounted the picker and restarted those requests.

**After:** Project and recent-session data load before the picker is mounted. Its first visible frame is already populated and large. Repeated Control-O presses leave the active picker mounted, preserving its content, filter, and selection.

## How

- `packages/tui/src/app.tsx` loads projects and recent sessions before installing the picker, coalesces concurrent opens, and ignores `open.menu` while the picker is active.
- `packages/tui/src/ui/dialog.tsx` lets replacements declare their initial size and identity in one batched update.
- `packages/tui/src/component/dialog-open.tsx` receives loaded sessions and no longer fetches or resizes after mounting.
- `packages/tui/test/cli/tui/dialog-open.test.tsx` verifies no picker frame appears while recents are pending, then verifies the first picker frame contains both sessions and projects.

## Scope

This only changes loading, repeated invocation, and initial sizing for the Control-O picker. Other dialogs keep their existing replacement behavior.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/cli/tui/dialog-open.test.tsx` (6 passing, 13 assertions)
- Push hook workspace typecheck (32 packages successful)
- Live V2 TUI against the elected service: captured populated first open, Escape, populated reopen, and repeated Control-O presses while open

## Demo

Real live-service data, not an isolated fixture. The picker appears fully populated on both opens, and repeated Control-O presses do not remount it.

https://github.com/user-attachments/assets/6a5a7754-6640-41af-8b16-b54cebc1cc21
