### PR TITLE
fix(tui): consolidate developer tools controls

### DIFF
--- a/packages/tui/src/component/devtools-bar.tsx
+++ b/packages/tui/src/component/devtools-bar.tsx
@@ -429,6 +429,7 @@ export function DevToolsBar() {
 function BarItem(props: ParentProps<{ active: boolean; onClick: () => void }>) {
   const theme = useTheme()
   const renderer = useRenderer()
+  const [hovered, setHovered] = createSignal(false)
   return (
     <box
       position="relative"
@@ -437,7 +438,15 @@ function BarItem(props: ParentProps<{ active: boolean; onClick: () => void }>) {
       flexDirection="row"
       paddingLeft={1}
       paddingRight={1}
-      backgroundColor={props.active ? theme.background.action.primary.focused : undefined}
+      backgroundColor={
+        props.active
+          ? theme.background.action.primary.focused
+          : hovered()
+            ? theme.background.action.primary.hovered
+            : undefined
+      }
+      onMouseOver={() => setHovered(true)}
+      onMouseOut={() => setHovered(false)}
       onMouseUp={() => {
         if (renderer.getSelection()?.getSelectedText()) return
         props.onClick()

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -283,22 +283,13 @@ export const settings: Setting[] = [
     keywords: ["selection", "clipboard"],
   },
   {
-    title: "DevTools",
+    title: "Developer tools",
     category: "Debug",
     path: ["debug", "devtools"],
     default: false,
     values: [false, true],
     labels: ["off", "on"],
     keywords: ["debug bar", "developer tools"],
-  },
-  {
-    title: "Turn token usage",
-    category: "Debug",
-    path: ["debug", "turn_tokens"],
-    default: false,
-    values: [false, true, "verbose"],
-    labels: ["off", "on", "verbose"],
-    keywords: ["tokens", "usage", "debug"],
   },
 ]
 

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -180,6 +180,11 @@ test("uses ctrl+z for input undo when terminal suspend is unavailable", () => {
   expect(overridden.keybinds.get("input.undo")).toMatchObject([{ key: "ctrl+u" }])
 })
 
+test("keeps turn token usage inside developer tools", () => {
+  expect(settings.find((setting) => setting.path.join(".") === "debug.devtools")?.title).toBe("Developer tools")
+  expect(settings.some((setting) => setting.path.join(".") === "debug.turn_tokens")).toBe(false)
+})
+
 test("provides config and its host interface", async () => {
   const config = resolve({}, { terminalSuspend: true })
   let current = {}


### PR DESCRIPTION
## What

Use **Developer tools** as the user-facing command name and keep turn token usage controls inside the developer tools bar instead of exposing them as a separate command.

Clickable sections in the developer tools bar now use the theme's brighter hover background so they read as interactive before selection.

## Before / After

**Before:** The command palette exposed both `DevTools` and `Turn token usage`, splitting one developer-tools surface into two settings. The bar's top-level sections had no hover feedback.

**After:** The command palette exposes one `Developer tools` setting. Searching for `Turn token usage` returns no command, while its controls remain available in the Tools panel. Hovering a bar section applies the existing themed hover treatment.

## How

- `packages/tui/src/component/dialog-config.tsx` renames the visible setting and removes the standalone token-usage setting.
- `packages/tui/src/component/devtools-bar.tsx` tracks hover state for top-level bar items and applies the existing action hover color.
- `packages/tui/test/config-v2.test.tsx` covers the consolidated settings surface.

## Scope

Internal `DevTools` names and the persisted `debug.turn_tokens` configuration remain unchanged.

## Testing

- `bun run test test/config-v2.test.tsx` (14 tests, 100 assertions)
- `bun run typecheck`
- OpenCode Drive against this checkout, verifying the renamed command, absence of the standalone token command, and presence of token controls in the Tools panel

## Demo

Recorded with OpenCode Drive against this branch. The flow searches for `developer`, searches for `turn token usage`, then opens the Tools panel.

https://github.com/user-attachments/assets/53a55378-ba0f-4b24-ad70-29ff0661ad5c
