### PR TITLE
fix(tool): skip plugin tools without descriptions

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -194,6 +194,7 @@ const layer = Layer.effect(
         const plugins = yield* plugin.list()
         for (const p of plugins) {
           for (const [id, def] of Object.entries(p.tool ?? {})) {
+            if (!isPluginTool(def)) continue
             custom.push(fromPlugin(id, def))
           }
         }
@@ -348,7 +349,14 @@ function isZodType(value: unknown): value is z.ZodType {
 }
 
 function isPluginTool(value: unknown): value is ToolDefinition {
-  return typeof value === "object" && value !== null && "args" in value && "description" in value && "execute" in value
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "args" in value &&
+    "execute" in value &&
+    "description" in value &&
+    typeof value.description === "string"
+  )
 }
 
 function isJsonSchemaDefinition(value: unknown): value is JSONSchema7Definition {

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -50,6 +50,27 @@ const brokenPluginLayer = Layer.succeed(
   }),
 )
 
+const missingDescriptionPluginLayer = Layer.succeed(
+  Plugin.Service,
+  Plugin.Service.of({
+    init: () => Effect.void,
+    trigger: ((_name: unknown, _input: unknown, output: unknown) =>
+      Effect.succeed(output)) as Plugin.Interface["trigger"],
+    list: () =>
+      Effect.succeed([
+        {
+          tool: {
+            broken_description_tool: {
+              description: undefined as unknown as string,
+              args: {},
+              execute: async () => "ok",
+            },
+          },
+        },
+      ]),
+  }),
+)
+
 const root = LayerNode.group([ToolRegistry.node, Agent.node])
 const replacements = [
   [Config.node, configLayer],
@@ -94,6 +115,9 @@ const withEmptyCodeMode = testEffect(
   ]),
 )
 const withBrokenPlugin = testEffect(LayerNode.compile(root, [...replacements, [Plugin.node, brokenPluginLayer]]))
+const withMissingDescriptionPlugin = testEffect(
+  LayerNode.compile(root, [...replacements, [Plugin.node, missingDescriptionPluginLayer]]),
+)
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -269,6 +293,23 @@ describe("tool.registry", () => {
       const ids = yield* registry.ids()
       expect(ids).toContain("read")
       expect(ids).toContain("broken_plugin_tool")
+    }),
+  )
+
+  withMissingDescriptionPlugin.instance("skips plugin tools with missing descriptions", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const agents = yield* Agent.Service
+      const ids = yield* registry.ids()
+      const tools = yield* registry.tools({
+        providerID: ProviderV2.ID.opencode,
+        modelID: ModelV2.ID.make("test"),
+        agent: yield* agents.defaultInfo(),
+      })
+
+      expect(ids).toContain("read")
+      expect(ids).not.toContain("broken_description_tool")
+      expect(tools.map((tool) => tool.id)).not.toContain("broken_description_tool")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Refs #42026

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skips plugin tool definitions whose `description` field is not a string before they enter the tool registry.

The file-scanned tool path already guarded malformed exports with `isPluginTool(...)`, but the `plugin.list()` path accepted every entry and forwarded it into `fromPlugin(...)`. A plugin tool with `description: undefined` could then be surfaced to the model tool catalog and fail later during request/schema preparation.

This keeps valid plugin tools and built-in tools available while isolating the malformed tool definition.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/registry.test.ts --test-name-pattern 'skips plugin tools with missing descriptions' --timeout 30000`
- `cd packages/opencode && bun test test/tool/registry.test.ts --timeout 60000`
- `cd packages/opencode && bun typecheck`
- `bun run lint packages/opencode/src/tool/registry.ts packages/opencode/test/tool/registry.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A; this is a registry validation fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
