### PR TITLE
fix(tui): restore tab marquee hover

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -121,7 +121,7 @@ export function createMarquee(animations: () => boolean) {
   return { offset, active, enter, leave, reset, leading: () => leading.value().opacity }
 }
 
-function createTabMarquee(animations: () => boolean) {
+export function createTabMarquee(animations: () => boolean) {
   const [hovered, setHovered] = createSignal<string>()
   const marquee = createMarquee(animations)
   let hoverClear: ReturnType<typeof setTimeout> | undefined
@@ -139,6 +139,10 @@ function createTabMarquee(animations: () => boolean) {
       marquee.leave(sessionID)
     })
   }
+  const leaveHovered = () => {
+    const sessionID = hovered()
+    if (sessionID) leave(sessionID)
+  }
   const reset = () => {
     if (hoverClear) clearTimeout(hoverClear)
     hoverClear = undefined
@@ -149,7 +153,7 @@ function createTabMarquee(animations: () => boolean) {
     if (hoverClear) clearTimeout(hoverClear)
   })
 
-  return { ...marquee, hovered, enter, leave, reset }
+  return { ...marquee, hovered, enter, leave, leaveHovered, reset }
 }
 
 function TabContextMenu(props: { state: TabContextMenuState; tabs: SessionTabsController; onClose: () => void }) {
@@ -334,6 +338,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
       position="relative"
       paddingTop={1}
       backgroundColor={theme.background.default}
+      onMouseOut={marquee.leaveHovered}
     >
       <scrollbox ref={(element) => (scroll = element)} flexGrow={1} scrollbarOptions={{ visible: false }}>
         <box flexShrink={0} flexDirection="column" gap={1}>
@@ -833,6 +838,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
       position="relative"
       flexDirection="row"
       zIndex={1}
+      onMouseOut={marquee.leaveHovered}
       renderAfter={function (buffer) {
         const x = Math.max(0, this.screenX)
         const y = this.screenY + this.height

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -92,16 +92,17 @@ export function createMarquee(animations: () => boolean) {
     interval = setInterval(() => setOffset((value) => (value + 1) % cycleWidth), MARQUEE_INTERVAL)
   }
   const enter = (sessionID: string, title: string, width: number) => {
+    if (!marqueeOverflows(title, width)) {
+      const current = active()
+      if (current) leave(current)
+      return
+    }
     if (active() === sessionID && !returning) return
     clear()
     if (active() === sessionID) {
       returning = false
       leading.animate({ opacity: 1 })
       return scroll()
-    }
-    if (!marqueeOverflows(title, width)) {
-      reset()
-      return
     }
     cycleWidth = marqueeCycleWidth(title)
     setActive(sessionID)
@@ -368,6 +369,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const selected = () => activeID() === tab.sessionID
               const status = createMemo(() => itemStatus(tab))
               const [sweepLevel, setSweepLevel] = createSignal(0)
+              const [closeHovered, setCloseHovered] = createSignal(false)
               const session = createMemo(() => data.session.get(tab.sessionID))
               const project = createMemo(() => {
                 const value = session()
@@ -598,8 +600,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                         right={1}
                         zIndex={2}
                         width={1}
-                        fg={theme.text.subdued}
+                        fg={closeHovered() ? theme.text.default : theme.text.subdued}
                         selectable={false}
+                        onMouseOver={() => setCloseHovered(true)}
+                        onMouseOut={() => setCloseHovered(false)}
                         onMouseUp={(event) => {
                           if (event.button === RIGHT_MOUSE_BUTTON) return
                           if (hovered() !== tab.sessionID) return
@@ -607,7 +611,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                           tabs.close(tab.sessionID)
                         }}
                       >
-                        {hovered() === tab.sessionID ? "×" : ""}
+                        {hovered() === tab.sessionID ? "✕" : ""}
                       </text>
                     </box>
                   </box>
@@ -945,6 +949,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           }
           // The running sweep's level under the number cell, reported by the pulse renderable.
           const [sweepLevel, setSweepLevel] = createSignal(0)
+          const [closeHovered, setCloseHovered] = createSignal(false)
           const numberColor = () => {
             const feedback = feedbackColor()
             if (feedback) return feedback
@@ -1042,8 +1047,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   right={1}
                   zIndex={2}
                   width={1}
-                  fg={closeColor()}
+                  fg={closeHovered() ? theme.text.default : closeColor()}
                   selectable={false}
+                  onMouseOver={() => setCloseHovered(true)}
+                  onMouseOut={() => setCloseHovered(false)}
                   onMouseUp={(event) => {
                     if (event.button === RIGHT_MOUSE_BUTTON) return
                     // The close mark only renders while hovered; without motion events a click can
@@ -1053,7 +1060,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                     tabs.close(tab === NEW_SESSION_TAB ? undefined : tab.sessionID)
                   }}
                 >
-                  {hovered() === tab.sessionID ? "×" : ""}
+                  {hovered() === tab.sessionID ? "✕" : ""}
                 </text>
               </box>
             </box>

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -72,7 +72,7 @@ function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: nu
   return opacity === 0 ? color : tint(color, background, opacity)
 }
 
-function createMarquee(animations: () => boolean) {
+export function createMarquee(animations: () => boolean) {
   const [offset, setOffset] = createSignal(0)
   const [active, setActive] = createSignal<string>()
   const leading = createAnimatable({ opacity: 0 }, { enabled: animations, transition: tween({ duration: 0.25 }) })
@@ -97,7 +97,10 @@ function createMarquee(animations: () => boolean) {
       returning = false
       return scroll()
     }
-    if (!marqueeOverflows(title, width)) return
+    if (!marqueeOverflows(title, width)) {
+      reset()
+      return
+    }
     cycleWidth = marqueeCycleWidth(title)
     setActive(sessionID)
     setOffset(0)
@@ -363,7 +366,9 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               })
               const numberWidth = () => 2
               const restingTitleWidth = () => Math.max(1, width() - numberWidth() - 2)
-              const titleWidth = () => Math.max(1, restingTitleWidth() - (hovered() === tab.sessionID ? 1 : 0))
+              const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 1)
+              const titleWidth = () =>
+                hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth()
               const title = () => tab.title ?? "Untitled session"
               const scrolling = () => marquee.active() === tab.sessionID && marquee.offset() > 0
               const visibleTitle = createMemo(() =>
@@ -373,7 +378,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               )
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
               const titleFades = createMemo(
-                () => marqueeOverflows(title(), restingTitleWidth()) && titleWidth() > FADE_WIDTH,
+                () => marqueeOverflows(title(), titleWidth()) && titleWidth() > FADE_WIDTH,
               )
               const detail = createMemo(() => {
                 const value = session()
@@ -456,7 +461,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   position="relative"
                   flexDirection="column"
                   backgroundColor={background()}
-                  onMouseOver={() => marquee.enter(tab.sessionID, title(), restingTitleWidth())}
+                  onMouseOver={() => marquee.enter(tab.sessionID, title(), hoveredTitleWidth())}
                   onMouseOut={() => marquee.leave(tab.sessionID)}
                   onMouseDown={(event) => {
                     if (event.button === RIGHT_MOUSE_BUTTON) {
@@ -472,7 +477,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       event.stopPropagation()
                       return
                     }
-                    marquee.enter(tab.sessionID, title(), restingTitleWidth())
+                    marquee.enter(tab.sessionID, title(), hoveredTitleWidth())
                     setDragging(tab.sessionID)
                   }}
                   onMouseUp={(event) => {
@@ -897,7 +902,9 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const numberWidth = () => 2
           // Hovering reveals the close mark, so the title's right bound shifts left of it.
           const restingTitleWidth = () => Math.max(1, width() - 1 - numberWidth())
-          const availableTitleWidth = () => Math.max(1, restingTitleWidth() - (hovered() === tab.sessionID ? 2 : 0))
+          const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 2)
+          const availableTitleWidth = () =>
+            hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth()
           const scrolling = () => marquee.active() === tab.sessionID && marquee.offset() > 0
           const visibleTitle = createMemo(() =>
             scrolling()
@@ -906,7 +913,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           )
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
           const titleFades = createMemo(
-            () => marqueeOverflows(title(), restingTitleWidth()) && availableTitleWidth() > FADE_WIDTH,
+            () => marqueeOverflows(title(), availableTitleWidth()) && availableTitleWidth() > FADE_WIDTH,
           )
           const foreground = () => {
             if (hovered() === tab.sessionID) return theme.text.default
@@ -957,7 +964,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
               position="relative"
               flexDirection="row"
               backgroundColor={background()}
-              onMouseOver={() => marquee.enter(tab.sessionID, title(), restingTitleWidth())}
+              onMouseOver={() => marquee.enter(tab.sessionID, title(), hoveredTitleWidth())}
               onMouseOut={() => marquee.leave(tab.sessionID)}
               onMouseDown={(event) => {
                 if (event.button === RIGHT_MOUSE_BUTTON) {
@@ -972,7 +979,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   event.stopPropagation()
                   return
                 }
-                marquee.enter(tab.sessionID, title(), restingTitleWidth())
+                marquee.enter(tab.sessionID, title(), hoveredTitleWidth())
                 setDragging(tab.sessionID)
               }}
               onMouseUp={(event) => {

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -34,7 +34,6 @@ const FADE_WIDTH = 4
 const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
 const MARQUEE_INTERVAL = 100
-const MARQUEE_FADE_DURATION = 250
 const CONTEXT_MENU_WIDTH = 16
 const RIGHT_MOUSE_BUTTON = 2
 
@@ -80,7 +79,6 @@ export function createMarquee(animations: () => boolean) {
   let delay: ReturnType<typeof setTimeout> | undefined
   let interval: ReturnType<typeof setInterval> | undefined
   let cycleWidth = 0
-  let returning = false
 
   const clear = () => {
     if (delay) clearTimeout(delay)
@@ -93,21 +91,14 @@ export function createMarquee(animations: () => boolean) {
   }
   const enter = (sessionID: string, title: string, width: number) => {
     if (!marqueeOverflows(title, width)) {
-      const current = active()
-      if (current) leave(current)
+      reset()
       return
     }
-    if (active() === sessionID && !returning) return
+    if (active() === sessionID) return
     clear()
-    if (active() === sessionID) {
-      returning = false
-      leading.animate({ opacity: 1 })
-      return scroll()
-    }
     cycleWidth = marqueeCycleWidth(title)
     setActive(sessionID)
     setOffset(0)
-    returning = false
     leading.jump({ opacity: 0 })
     delay = setTimeout(() => {
       setOffset(1)
@@ -117,34 +108,10 @@ export function createMarquee(animations: () => boolean) {
   }
   const leave = (sessionID: string) => {
     if (active() !== sessionID) return
-    clear()
-    if (offset() === 0) {
-      returning = true
-      leading.animate({ opacity: 0 })
-      delay = setTimeout(() => {
-        returning = false
-        setActive(undefined)
-      }, MARQUEE_FADE_DURATION)
-      return
-    }
-    returning = true
-    interval = setInterval(() => {
-      setOffset((value) => {
-        const next = (value + 1) % cycleWidth
-        if (next !== 0) return next
-        clear()
-        leading.animate({ opacity: 0 })
-        delay = setTimeout(() => {
-          returning = false
-          setActive(undefined)
-        }, MARQUEE_FADE_DURATION)
-        return 0
-      })
-    }, MARQUEE_INTERVAL)
+    reset()
   }
   const reset = () => {
     clear()
-    returning = false
     setActive(undefined)
     setOffset(0)
     leading.jump({ opacity: 0 })
@@ -172,11 +139,17 @@ function createTabMarquee(animations: () => boolean) {
       marquee.leave(sessionID)
     })
   }
+  const reset = () => {
+    if (hoverClear) clearTimeout(hoverClear)
+    hoverClear = undefined
+    setHovered(undefined)
+    marquee.reset()
+  }
   onCleanup(() => {
     if (hoverClear) clearTimeout(hoverClear)
   })
 
-  return { ...marquee, hovered, enter, leave }
+  return { ...marquee, hovered, enter, leave, reset }
 }
 
 function TabContextMenu(props: { state: TabContextMenuState; tabs: SessionTabsController; onClose: () => void }) {

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -34,6 +34,7 @@ const FADE_WIDTH = 4
 const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
 const MARQUEE_INTERVAL = 100
+const MARQUEE_FADE_DURATION = 250
 const CONTEXT_MENU_WIDTH = 16
 const RIGHT_MOUSE_BUTTON = 2
 
@@ -95,6 +96,7 @@ export function createMarquee(animations: () => boolean) {
     clear()
     if (active() === sessionID) {
       returning = false
+      leading.animate({ opacity: 1 })
       return scroll()
     }
     if (!marqueeOverflows(title, width)) {
@@ -116,7 +118,12 @@ export function createMarquee(animations: () => boolean) {
     if (active() !== sessionID) return
     clear()
     if (offset() === 0) {
-      setActive(undefined)
+      returning = true
+      leading.animate({ opacity: 0 })
+      delay = setTimeout(() => {
+        returning = false
+        setActive(undefined)
+      }, MARQUEE_FADE_DURATION)
       return
     }
     returning = true
@@ -125,9 +132,11 @@ export function createMarquee(animations: () => boolean) {
         const next = (value + 1) % cycleWidth
         if (next !== 0) return next
         clear()
-        returning = false
-        setActive(undefined)
         leading.animate({ opacity: 0 })
+        delay = setTimeout(() => {
+          returning = false
+          setActive(undefined)
+        }, MARQUEE_FADE_DURATION)
         return 0
       })
     }, MARQUEE_INTERVAL)
@@ -370,7 +379,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const titleWidth = () =>
                 hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth()
               const title = () => tab.title ?? "Untitled session"
-              const scrolling = () => marquee.active() === tab.sessionID && marquee.offset() > 0
+              const scrolling = () => marquee.active() === tab.sessionID
               const visibleTitle = createMemo(() =>
                 scrolling()
                   ? marqueeText(title(), titleWidth(), marquee.offset())
@@ -905,7 +914,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 2)
           const availableTitleWidth = () =>
             hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth()
-          const scrolling = () => marquee.active() === tab.sessionID && marquee.offset() > 0
+          const scrolling = () => marquee.active() === tab.sessionID
           const visibleTitle = createMemo(() =>
             scrolling()
               ? marqueeText(title(), availableTitleWidth(), marquee.offset())

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, jest, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createMarquee } from "../../src/component/session-tabs"
+
+afterEach(() => jest.useRealTimers())
+
+describe("session tab marquee", () => {
+  test("starts for the hovered width and resets when the next tab fits", () => {
+    jest.useFakeTimers()
+    const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
+
+    scope.marquee.enter("first", "opencode", 6)
+    expect(scope.marquee.active()).toBe("first")
+    expect(scope.marquee.offset()).toBe(0)
+
+    jest.advanceTimersByTime(600)
+    expect(scope.marquee.offset()).toBe(1)
+
+    scope.marquee.enter("second", "short", 6)
+    expect(scope.marquee.active()).toBeUndefined()
+    expect(scope.marquee.offset()).toBe(0)
+
+    jest.advanceTimersByTime(1_000)
+    expect(scope.marquee.offset()).toBe(0)
+    scope.dispose()
+  })
+
+  test("finishes the current cycle after leaving", () => {
+    jest.useFakeTimers()
+    const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
+
+    scope.marquee.enter("first", "opencode", 6)
+    jest.advanceTimersByTime(700)
+    scope.marquee.leave("first")
+    jest.advanceTimersByTime(1_000)
+
+    expect(scope.marquee.active()).toBeUndefined()
+    expect(scope.marquee.offset()).toBe(0)
+    scope.dispose()
+  })
+})

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -5,7 +5,7 @@ import { createMarquee } from "../../src/component/session-tabs"
 afterEach(() => jest.useRealTimers())
 
 describe("session tab marquee", () => {
-  test("starts for the hovered width and resets when the next tab fits", () => {
+  test("starts for the hovered width and returns when the next tab fits", () => {
     jest.useFakeTimers()
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
@@ -17,11 +17,15 @@ describe("session tab marquee", () => {
     expect(scope.marquee.offset()).toBe(1)
 
     scope.marquee.enter("second", "short", 6)
-    expect(scope.marquee.active()).toBeUndefined()
-    expect(scope.marquee.offset()).toBe(0)
+    expect(scope.marquee.active()).toBe("first")
+    expect(scope.marquee.offset()).toBe(1)
 
     jest.advanceTimersByTime(1_000)
+    expect(scope.marquee.active()).toBe("first")
     expect(scope.marquee.offset()).toBe(0)
+
+    jest.advanceTimersByTime(250)
+    expect(scope.marquee.active()).toBeUndefined()
     scope.dispose()
   })
 

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -25,6 +25,19 @@ describe("session tab marquee", () => {
     scope.dispose()
   })
 
+  test("keeps the leading fade through a natural loop boundary", () => {
+    jest.useFakeTimers()
+    const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
+
+    scope.marquee.enter("first", "opencode", 6)
+    jest.advanceTimersByTime(1_600)
+
+    expect(scope.marquee.active()).toBe("first")
+    expect(scope.marquee.offset()).toBe(0)
+    expect(scope.marquee.leading()).toBe(1)
+    scope.dispose()
+  })
+
   test("finishes the current cycle after leaving", () => {
     jest.useFakeTimers()
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
@@ -32,8 +45,12 @@ describe("session tab marquee", () => {
     scope.marquee.enter("first", "opencode", 6)
     jest.advanceTimersByTime(700)
     scope.marquee.leave("first")
-    jest.advanceTimersByTime(1_000)
+    jest.advanceTimersByTime(900)
 
+    expect(scope.marquee.active()).toBe("first")
+    expect(scope.marquee.offset()).toBe(0)
+
+    jest.advanceTimersByTime(250)
     expect(scope.marquee.active()).toBeUndefined()
     expect(scope.marquee.offset()).toBe(0)
     scope.dispose()

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, jest, test } from "bun:test"
 import { createRoot } from "solid-js"
-import { createMarquee } from "../../src/component/session-tabs"
+import { createMarquee, createTabMarquee } from "../../src/component/session-tabs"
 
 afterEach(() => jest.useRealTimers())
 
@@ -47,6 +47,21 @@ describe("session tab marquee", () => {
     expect(scope.marquee.active()).toBeUndefined()
     expect(scope.marquee.offset()).toBe(0)
     expect(scope.marquee.leading()).toBe(0)
+    scope.dispose()
+  })
+
+  test("resets when the pointer leaves the tab rail", () => {
+    jest.useFakeTimers()
+    const scope = createRoot((dispose) => ({ marquee: createTabMarquee(() => false), dispose }))
+
+    scope.marquee.enter("first", "opencode", 6)
+    jest.advanceTimersByTime(700)
+    scope.marquee.leaveHovered()
+    jest.advanceTimersByTime(0)
+
+    expect(scope.marquee.hovered()).toBeUndefined()
+    expect(scope.marquee.active()).toBeUndefined()
+    expect(scope.marquee.offset()).toBe(0)
     scope.dispose()
   })
 })

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -5,7 +5,7 @@ import { createMarquee } from "../../src/component/session-tabs"
 afterEach(() => jest.useRealTimers())
 
 describe("session tab marquee", () => {
-  test("starts for the hovered width and returns when the next tab fits", () => {
+  test("starts for the hovered width and resets when the next tab fits", () => {
     jest.useFakeTimers()
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
@@ -17,15 +17,9 @@ describe("session tab marquee", () => {
     expect(scope.marquee.offset()).toBe(1)
 
     scope.marquee.enter("second", "short", 6)
-    expect(scope.marquee.active()).toBe("first")
-    expect(scope.marquee.offset()).toBe(1)
-
-    jest.advanceTimersByTime(1_000)
-    expect(scope.marquee.active()).toBe("first")
-    expect(scope.marquee.offset()).toBe(0)
-
-    jest.advanceTimersByTime(250)
     expect(scope.marquee.active()).toBeUndefined()
+    expect(scope.marquee.offset()).toBe(0)
+    expect(scope.marquee.leading()).toBe(0)
     scope.dispose()
   })
 
@@ -42,21 +36,17 @@ describe("session tab marquee", () => {
     scope.dispose()
   })
 
-  test("finishes the current cycle after leaving", () => {
+  test("resets immediately after leaving", () => {
     jest.useFakeTimers()
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
     scope.marquee.enter("first", "opencode", 6)
     jest.advanceTimersByTime(700)
     scope.marquee.leave("first")
-    jest.advanceTimersByTime(900)
 
-    expect(scope.marquee.active()).toBe("first")
-    expect(scope.marquee.offset()).toBe(0)
-
-    jest.advanceTimersByTime(250)
     expect(scope.marquee.active()).toBeUndefined()
     expect(scope.marquee.offset()).toBe(0)
+    expect(scope.marquee.leading()).toBe(0)
     scope.dispose()
   })
 })


### PR DESCRIPTION
## What

Restore session tab marquee behavior when hover reveals the close control, and prevent a previous tab's marquee from remaining active after the pointer moves to a title that fits.

## Before / After

**Before**

A title could fit the resting tab width but become clipped when hover reserved cells for the close control. Overflow eligibility still used the resting width, so the clipped title never rotated. Moving from an active marquee to a fitting tab cleared its timer but retained the old active tab and offset, leaving the marquee visually stuck.

**After**

Hover eligibility uses the actual hovered title viewport. Entering a fitting tab explicitly resets any previous marquee, so no stale active tab or interval survives the transition. Leaving an overflowing tab still completes the current ` · ` cycle before settling at its beginning.

## How

- `packages/tui/src/component/session-tabs.tsx` computes explicit hovered title widths for horizontal and vertical tabs and passes them to the marquee controller.
- The controller resets when the entered title fits instead of only clearing its timer.
- `packages/tui/test/component/session-tabs-marquee.test.ts` covers delayed hover start, transition to a fitting tab, stale interval prevention, and forward settling after leave.

## Scope

This changes only session tab marquee eligibility and lifecycle. Tab sizing, close-button behavior, drag behavior, and title generation are unchanged.

## Testing

- `bun run test test/component/session-tabs-marquee.test.ts test/util/marquee.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- Pre-push `bun turbo typecheck --concurrency=3`
