### PR TITLE
fix(desktop): stop sidecar before quitting

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -168,6 +168,7 @@ const main = Effect.gen(function* () {
     await killSidecar()
     wslServers.stopAll()
   }
+  let stoppingForQuit = false
   const relaunch = () => {
     setAppQuitting()
     void stopSidecars().finally(() => {
@@ -221,9 +222,16 @@ const main = Effect.gen(function* () {
     emitDeepLinks([url])
   })
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
     setAppQuitting()
-    void stopSidecars()
+    if (!server && !stoppingForQuit) return
+    event.preventDefault()
+    if (stoppingForQuit) return
+    stoppingForQuit = true
+    void stopSidecars().finally(() => {
+      stoppingForQuit = false
+      app.quit()
+    })
   })
 
   app.on("will-quit", () => {

--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -82,6 +82,9 @@ export async function spawnLocalServer(
     options.onExit?.(code)
     exit.resolve(code)
   })
+  child.on("message", (message: SidecarMessage) => {
+    if (message.type === "stopped") child.kill()
+  })
   child.on("error", (error) => options.onStderr?.(`utility process error: ${serializeError(error).message}`))
 
   child.stdout?.on("data", (chunk: Buffer) => options.onStdout?.(chunk.toString("utf8").trimEnd()))

--- a/packages/desktop/src/main/sidecar.ts
+++ b/packages/desktop/src/main/sidecar.ts
@@ -76,7 +76,6 @@ async function stop() {
   } finally {
     listener = undefined
     parentPort.postMessage({ type: "stopped" })
-    setImmediate(() => process.exit(0))
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #42097

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Linux, closing the desktop app could terminate the Electron NodeService utility process with SIGABRT while local server cleanup was still running. That could trigger systemd-coredump and consume several gigabytes while collecting the dump.

This waits for sidecar cleanup before allowing the app to quit. The sidecar reports that cleanup completed instead of exiting itself, and the parent then uses Electron's UtilityProcess.kill() so the process that spawned the utility process also terminates and reaps it.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/desktop`.
- Ran `bun test src/main/index.test.ts src/main/window-registry.test.ts` (9 passed).
- Ran `bun run build` in `packages/desktop`.
- Ran the repository-wide pre-push typecheck (30 tasks passed).
- Closed the running Linux desktop app and waited 45 seconds; the sidecar exited cleanly and neither `journalctl` nor `coredumpctl` reported a new coredump.

### Screenshots / recordings

Not applicable; this is a process lifecycle fix with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._