### PR TITLE
fix(tui): move debug overlay into developer tools

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -993,6 +993,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         name: "app.debug",
         title: "Toggle debug panel",
         category: "System",
+        palette: undefined,
         run: () => {
           renderer.toggleDebugOverlay()
           dialog.clear()

--- a/packages/tui/src/component/devtools-bar.tsx
+++ b/packages/tui/src/component/devtools-bar.tsx
@@ -1,4 +1,4 @@
-import { TextAttributes, type Renderable } from "@opentui/core"
+import { CliRenderEvents, TextAttributes, type Renderable } from "@opentui/core"
 import { TimeToFirstDraw, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { open } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -45,6 +45,7 @@ export function DevToolsBar() {
   const [dumpPath, setDumpPath] = createSignal<string>()
   const [dumpError, setDumpError] = createSignal<string>()
   const [frontendSamples, setFrontendSamples] = createSignal<readonly ProcessSample[]>([])
+  const [debugOverlay, setDebugOverlay] = createSignal(renderer.debugOverlay.enabled)
   let focus: Renderable | null
   const connected = createMemo(() => client.connection.status() === "connected")
   const serverIndicator = createMemo(() => connectionIndicator(client.connection.status(), client.connection.attempt()))
@@ -93,6 +94,10 @@ export function DevToolsBar() {
     { priority: 10 },
   )
   onCleanup(offEscape)
+
+  const onDebugOverlayToggle = (enabled: boolean) => setDebugOverlay(enabled)
+  renderer.on(CliRenderEvents.DEBUG_OVERLAY_TOGGLE, onDebugOverlayToggle)
+  onCleanup(() => renderer.off(CliRenderEvents.DEBUG_OVERLAY_TOGGLE, onDebugOverlayToggle))
 
   onMount(() => {
     const eventLoop = monitorEventLoopDelay({ resolution: 20 })
@@ -319,6 +324,9 @@ export function DevToolsBar() {
               unit=" MB"
               decimals={0}
             />
+            <Action onClick={() => renderer.toggleDebugOverlay()} hoverBackground>
+              {debugOverlay() ? "[x]" : "[ ]"} Debug overlay
+            </Action>
           </PanelBox>
         </Show>
       </BarItem>


### PR DESCRIPTION
## What

Move the OpenTUI renderer debug overlay behind the TUI's Developer Tools surface.

The Developer Tools **UI** pane now exposes a `Debug overlay` checkbox that stays synchronized with the renderer. The existing `app.debug` command remains available to explicit keybindings, but is no longer globally discoverable in the command palette.

## Before / After

**Before:** Searching the global command palette for `debug` exposed `Toggle debug panel` to every user, separate from the developer tools UI.

**After:** The command palette no longer lists the renderer overlay. Users who enable Developer Tools can toggle it from **UI → Debug overlay**, while configured `app.debug` keybindings continue to work and update the checkbox state.

## How

- `packages/tui/src/app.tsx` marks `app.debug` as hidden from the command palette without removing its keybinding command.
- `packages/tui/src/component/devtools-bar.tsx` adds the UI-pane toggle and follows OpenTUI's `DEBUG_OVERLAY_TOGGLE` event so UI state stays accurate regardless of how the overlay changes.

## Scope

- Does not persist the overlay across TUI launches.
- Does not remove backward compatibility for existing `app.debug` keybindings.

## Testing

- `bun run typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (683 passed, 5 skipped)
- `bun run lint packages/tui/src/app.tsx packages/tui/src/component/devtools-bar.tsx` (0 errors; existing warnings only)
- Push hook: full workspace `bun turbo typecheck --concurrency=3` (32 packages passed)
- Real PTY at 120×36 and 80×24 with Developer Tools enabled:
  - searching `debug` omitted `Toggle debug panel`
  - **UI → Debug overlay** rendered unchecked
  - toggling showed the renderer stats overlay and checked state
  - toggling again hid the overlay and restored unchecked state
