### PR TITLE
fix(console): add cors to zen responses

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -52,6 +52,7 @@ import { createProviderBudgetTracker } from "./providerBudgetTracker"
 import { accumulateUsage, HOT_WORKSPACES } from "./usageBatcher"
 import { Workspace } from "@opencode-ai/console-core/workspace.js"
 import { countryFromRequest } from "~/lib/request-country"
+import { withCorsHeaders } from "./modelsHandler"
 
 type ZenData = Awaited<ReturnType<typeof ZenData.list>>
 type RetryOptions = {
@@ -308,7 +309,7 @@ export async function handler(
     const resStatus = res.status === 404 ? 400 : res.status
 
     // Scrub response headers
-    const resHeaders = new Headers()
+    const resHeaders = withCorsHeaders()
     const keepHeaders = ["content-type", "cache-control"]
     for (const [k, v] of res.headers.entries()) {
       if (keepHeaders.includes(k.toLowerCase())) {

--- a/packages/console/app/src/routes/zen/util/modelsHandler.ts
+++ b/packages/console/app/src/routes/zen/util/modelsHandler.ts
@@ -1,11 +1,20 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+}
+
+export function withCorsHeaders(headers?: HeadersInit) {
+  return new Headers({
+    ...corsHeaders,
+    ...Object.fromEntries(new Headers(headers).entries()),
+  })
+}
+
 export async function buildOptionsResponse() {
   return new Response(null, {
     status: 200,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
+    headers: corsHeaders,
   })
 }
 
@@ -23,9 +32,9 @@ export async function buildModelsResponse(models: string[]) {
         })),
     }),
     {
-      headers: {
+      headers: withCorsHeaders({
         "Content-Type": "application/json",
-      },
+      }),
     },
   )
 }

--- a/packages/console/app/test/zenCors.test.ts
+++ b/packages/console/app/test/zenCors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { buildModelsResponse, buildOptionsResponse } from "../src/routes/zen/util/modelsHandler"
+
+describe("Zen CORS responses", () => {
+  test("includes CORS headers on actual model list responses", async () => {
+    const response = await buildModelsResponse(["model-a"])
+
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+    expect(response.headers.get("access-control-allow-methods")).toContain("GET")
+    expect(response.headers.get("access-control-allow-methods")).toContain("POST")
+    expect(response.headers.get("access-control-allow-headers")).toContain("Authorization")
+  })
+
+  test("keeps CORS headers on preflight responses", async () => {
+    const response = await buildOptionsResponse()
+
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41224

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds CORS headers to actual Zen model-list responses, not only OPTIONS preflight responses. The shared helper is also used by the main Zen chat handler response headers so normal GET/POST responses include `Access-Control-Allow-Origin` as browsers require after a successful preflight.

This keeps the existing permissive preflight policy (`*`, `GET, POST, OPTIONS`, `Content-Type, Authorization`) and applies it to actual API responses.

### How did you verify your code works?

- `cd packages/console/app && bun test test/zenCors.test.ts --timeout 30000`
- `cd packages/console/app && bun run typecheck`
- `bunx oxlint packages/console/app/src/routes/zen/util/modelsHandler.ts packages/console/app/src/routes/zen/util/handler.ts packages/console/app/test/zenCors.test.ts`
- `git diff --check`

### Screenshots / recordings

N/A; this is a response-header fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
