### PR TITLE
fix(llm): preserve nested OpenAI stream errors

### DIFF
--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -198,11 +198,11 @@ const OpenAIResponsesStreamItem = Schema.Struct({
 })
 type OpenAIResponsesStreamItem = Schema.Schema.Type<typeof OpenAIResponsesStreamItem>
 
-// OpenAI Responses surfaces provider failures in two related shapes. The
-// streaming `error` event carries the details at the top level
-// (`{ type: "error", code, message, param, sequence_number }`), while
-// `response.failed` carries them under `response.error`. We capture both so
-// the parser can surface a useful provider-error message in either path.
+// The Responses schema puts streaming error details at the top level and
+// response failures under `response.error`. The official SDK also recognizes
+// an event-level HTTP-style `error` envelope, so accept all three shapes here.
+// https://github.com/openai/openai-openapi/blob/5162af98d3147432c14680df789e8e12d4891e6b/openapi.yaml#L67234-L67382
+// https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/core/streaming.ts#L58-L85
 const OpenAIResponsesErrorPayload = Schema.Struct({
   code: optionalNull(Schema.String),
   message: optionalNull(Schema.String),
@@ -227,9 +227,10 @@ const OpenAIResponsesEvent = Schema.Struct({
       [Schema.Record(Schema.String, Schema.Unknown)],
     ),
   ),
-  code: Schema.optional(Schema.String),
+  code: optionalNull(Schema.String),
   message: Schema.optional(Schema.String),
-  param: Schema.optional(Schema.String),
+  param: optionalNull(Schema.String),
+  error: optionalNull(OpenAIResponsesErrorPayload),
 })
 type OpenAIResponsesEvent = Schema.Schema.Type<typeof OpenAIResponsesEvent>
 
@@ -894,7 +895,7 @@ const onResponseFinish = (state: ParserState, event: OpenAIResponsesEvent): Step
 // the bare message — production rate limits and context-length failures used
 // to be indistinguishable from generic stream drops.
 const providerErrorMessage = (event: OpenAIResponsesEvent, fallback: string): string => {
-  const nested = event.response?.error ?? undefined
+  const nested = event.error ?? event.response?.error ?? undefined
   const message = event.message || nested?.message || undefined
   const code = event.code || nested?.code || undefined
   if (message && code) return `${code}: ${message}`
@@ -902,7 +903,7 @@ const providerErrorMessage = (event: OpenAIResponsesEvent, fallback: string): st
 }
 
 const providerError = (event: OpenAIResponsesEvent, fallback: string) => {
-  const code = event.code || event.response?.error?.code || undefined
+  const code = event.code || event.error?.code || event.response?.error?.code || undefined
   const message = providerErrorMessage(event, fallback)
   return LLMEvent.providerError({
     message,

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1404,7 +1404,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("surfaces error event details even when they arrive nested under response.error", () =>
+  it.effect("surfaces error event details nested under response.error", () =>
     Effect.gen(function* () {
       // Some OpenAI-compatible proxies and older SDK versions wrap the
       // top-level error fields into a nested `response.error` payload
@@ -1429,6 +1429,65 @@ describe("OpenAI Responses route", () => {
           classification: "context-overflow",
         },
       ])
+    }),
+  )
+
+  it.effect("surfaces error event details nested under error", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              type: "error",
+              sequence_number: 2,
+              error: {
+                type: "invalid_request_error",
+                code: "context_length_exceeded",
+                message: "prompt too long",
+                param: "input",
+              },
+            }),
+          ),
+        ),
+      )
+
+      expect(response.events).toEqual([
+        {
+          type: "provider-error",
+          message: "context_length_exceeded: prompt too long",
+          classification: "context-overflow",
+        },
+      ])
+    }),
+  )
+
+  it.effect("accepts nullable fields in spec-compliant error events", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              type: "error",
+              code: null,
+              message: "Something went wrong",
+              param: null,
+              sequence_number: 1,
+            }),
+          ),
+        ),
+      )
+
+      expect(response.events).toEqual([{ type: "provider-error", message: "Something went wrong" }])
+    }),
+  )
+
+  it.effect("falls back to a stable default when error is null", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(fixedResponse(sseEvents({ type: "error", error: null }))),
+      )
+
+      expect(response.events).toEqual([{ type: "provider-error", message: "OpenAI Responses stream error" }])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #42007

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The nested OpenAI Responses SSE error handling from #36130 (commit bd0dffd) is missing from `dev`. The fix was merged to `v2` but lost during the branch transition — `git merge-base --is-ancestor bd0dffd78 HEAD` returns false on `dev`.

OpenAI Responses can deliver stream errors in three shapes: top-level fields (`type`, `code`, `message`), nested under `response.error`, or nested under a top-level `error` envelope. The current `dev` code only handles the first two. When an OpenAI-compatible proxy sends an event-level `error` object (as the official SDK recognizes), the nested `code` and `message` are silently dropped and the user sees a generic "OpenAI Responses stream error" instead of the actual cause (e.g. `context_length_exceeded: prompt too long`).

This restores the three-shape handling from #36130:
- Adds `error: optionalNull(OpenAIResponsesErrorPayload)` to `OpenAIResponsesEvent`
- Widens `code` and `param` to `optionalNull` to accept spec-compliant nullable fields
- Updates `providerErrorMessage` and `providerError` to check `event.error` before `event.response?.error`

Credit to @harshmathurx and @aidenpcline who authored the original fix in #36130.

### How did you verify your code works?

- 57 tests pass in `packages/llm/test/provider/openai-responses.test.ts` (0 fail), including three new cases that cover the `event.error` envelope, nullable `code`/`param` fields, and `error: null` fallback
- `packages/llm` typecheck clean
- Prettier clean on both changed files

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR