### PR TITLE
fix(tui): render Mermaid rich labels compactly

### DIFF
--- a/packages/merman/src/core/render-grid.ts
+++ b/packages/merman/src/core/render-grid.ts
@@ -5,13 +5,21 @@ export function renderDiagramGridStyledText<Style extends string, Metadata exten
   grid: DiagramCanvas<Style, Metadata>,
   fg: (run: DiagramCanvasRun<Style, Metadata>) => TextChunk["fg"],
   bg?: (run: DiagramCanvasRun<Style, Metadata>) => TextChunk["bg"],
-  options?: DiagramCanvasRunOptions<Style, Metadata>,
+  options?: DiagramCanvasRunOptions<Style, Metadata> & {
+    attributes?: (run: DiagramCanvasRun<Style, Metadata>) => TextChunk["attributes"]
+  },
 ): StyledText {
   const chunks: TextChunk[] = []
 
   grid.forEachRun(
     (run) => {
-      chunks.push({ __isChunk: true, text: run.text, fg: fg(run), bg: bg?.(run) })
+      chunks.push({
+        __isChunk: true,
+        text: run.text,
+        fg: fg(run),
+        bg: bg?.(run),
+        attributes: options?.attributes?.(run),
+      })
     },
     () => {
       chunks.push({ __isChunk: true, text: "\n" })

--- a/packages/merman/src/core/text-lines.ts
+++ b/packages/merman/src/core/text-lines.ts
@@ -1,3 +1,32 @@
+export interface DiagramTextRun {
+  text: string
+  italic: boolean
+}
+
+export interface DiagramTextLine {
+  text: string
+  runs: DiagramTextRun[]
+}
+
+export function parseDiagramTextLines(value: string): DiagramTextLine[] {
+  return value.split(/<br\s*\/?>/i).map((line) => {
+    const runs: DiagramTextRun[] = []
+    const source = line.trim()
+    const tag = /<\/?(?:i|em)\s*>/gi
+    let italic = false
+    let offset = 0
+
+    for (const match of source.matchAll(tag)) {
+      if (match.index > offset) runs.push({ text: source.slice(offset, match.index), italic })
+      italic = !match[0].startsWith("</")
+      offset = match.index + match[0].length
+    }
+    if (offset < source.length) runs.push({ text: source.slice(offset), italic })
+
+    return { text: runs.map((run) => run.text).join(""), runs }
+  })
+}
+
 export function splitDiagramLines(value: string): string[] {
-  return value.split(/<br\s*\/?>/i).map((line) => line.trim())
+  return parseDiagramTextLines(value).map((line) => line.text)
 }

--- a/packages/merman/src/core/text.test.ts
+++ b/packages/merman/src/core/text.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, test } from "bun:test"
-import { diagramTextWidth, measureDiagramTextBox, splitDiagramLines } from "./text.js"
+import { diagramTextWidth, measureDiagramTextBox, parseDiagramTextLines, splitDiagramLines } from "./text.js"
 
 describe("diagram text helpers", () => {
   test("splits Mermaid-style line breaks", () => {
     expect(splitDiagramLines("one<br/> two <br>three")).toEqual(["one", "two", "three"])
+  })
+
+  test("extracts Mermaid italic markup from visible text", () => {
+    expect(parseDiagramTextLines("plain <i>italic</i><br/><em>again</em>")).toEqual([
+      {
+        text: "plain italic",
+        runs: [
+          { text: "plain ", italic: false },
+          { text: "italic", italic: true },
+        ],
+      },
+      { text: "again", runs: [{ text: "again", italic: true }] },
+    ])
   })
 
   test("measures padded text boxes", () => {

--- a/packages/merman/src/core/text.ts
+++ b/packages/merman/src/core/text.ts
@@ -1,7 +1,7 @@
 import stringWidth from "string-width"
 import { splitDiagramLines } from "./text-lines.js"
 
-export { splitDiagramLines } from "./text-lines.js"
+export { parseDiagramTextLines, splitDiagramLines } from "./text-lines.js"
 
 export interface DiagramTextBoxSize {
   width: number

--- a/packages/merman/src/flowchart/drawing.ts
+++ b/packages/merman/src/flowchart/drawing.ts
@@ -1,7 +1,8 @@
-import { BorderChars, type BorderCharacters, type BorderStyle } from "@opentui/core"
+import { BorderChars, TextAttributes, type BorderCharacters, type BorderStyle } from "@opentui/core"
 import { walkOrthogonalSegment } from "../core/geometry.js"
 import { DiagramCanvas, type DiagramCanvasCell } from "../core/canvas.js"
-import { splitDiagramLines } from "../core/text.js"
+import { parseDiagramTextLines } from "../core/text.js"
+import type { DiagramTextRun } from "../core/text-lines.js"
 import {
   DIAGRAM_ARROW_HEADS,
   diagramArrowHeadBetween,
@@ -21,6 +22,7 @@ import {
   DATABASE_EDGE_FADE_STYLES,
   NODE_EDGE_FADE_STYLES,
   type FlowchartCellStyle,
+  type FlowchartCellMetadata,
   type FlowchartEdgeFadeStyle,
   type FlowchartGrid,
 } from "./style.js"
@@ -50,8 +52,19 @@ function mergeFlowchartCell(
   } as DiagramCanvasCell<FlowchartCellStyle>
 }
 
-function setNodeText(grid: FlowchartGrid, x: number, y: number, text: string, style: FlowchartCellStyle): void {
-  grid.setText(x, y, text, style)
+function setRichText(
+  grid: FlowchartGrid,
+  x: number,
+  y: number,
+  runs: readonly DiagramTextRun[],
+  style: FlowchartCellStyle,
+): number {
+  let offset = 0
+  for (const run of runs) {
+    grid.setText(x + offset, y, run.text, style, run.italic ? { attributes: TextAttributes.ITALIC } : undefined)
+    offset += visualLength(run.text)
+  }
+  return offset
 }
 
 function drawNode(
@@ -86,12 +99,13 @@ function drawNode(
       : node.shape === "database"
         ? bounds.top + 2
         : bounds.top + 1
+  const lines = parseDiagramTextLines(node.label)
   for (const [index, line] of bounds.lines.entries()) {
     const lineX =
       node.shape === "subroutine"
         ? bounds.left + 3
         : bounds.left + Math.max(1, Math.floor((bounds.width - visualLength(line)) / 2))
-    setNodeText(grid, lineX, textTop + index, line, style)
+    setRichText(grid, lineX, textTop + index, lines[index]!.runs, style)
   }
 }
 
@@ -139,18 +153,22 @@ function drawSubgraphFrame(grid: FlowchartGrid, bounds: FlowchartSubgraphBounds,
 
 function drawSubgraphLabel(grid: FlowchartGrid, bounds: FlowchartSubgraphBounds): void {
   if (bounds.label) {
-    const lines = splitDiagramLines(bounds.label)
+    const lines = parseDiagramTextLines(bounds.label)
     const labelY = bounds.labelSide === "top" ? bounds.top : bounds.top + bounds.height - lines.length
     for (const [index, line] of lines.entries()) {
-      grid.setText(bounds.left + 2, labelY + index, ` ${line} `, "group")
+      grid.setText(bounds.left + 2, labelY + index, " ", "group")
+      const width = setRichText(grid, bounds.left + 3, labelY + index, line.runs, "group")
+      grid.setText(bounds.left + width + 3, labelY + index, " ", "group")
     }
   }
 }
 
 function drawEdgeLabel(grid: FlowchartGrid, route: FlowchartEdgeRoute, style: FlowchartCellStyle): void {
   const label = flowchartEdgeLabelLayout(route.points, route.edge.label, visualLength, route.labelAxis)
-  for (const [index, line] of label.lines.entries()) {
-    grid.setText(label.point.x, label.point.y + index, line, style)
+  for (const [index, line] of parseDiagramTextLines(route.edge.label).entries()) {
+    grid.setText(label.point.x, label.point.y + index, " ", style)
+    const width = setRichText(grid, label.point.x + 1, label.point.y + index, line.runs, style)
+    grid.setText(label.point.x + width + 1, label.point.y + index, " ", style)
   }
 }
 
@@ -276,7 +294,7 @@ export function drawFlowchartDiagramGrid(
   const layout = layoutFlowchartDiagram(diagram, options)
   const { bounds, routes, subgraphBounds, width, height } = layout
   diagram = layout.diagram
-  const grid = new DiagramCanvas<FlowchartCellStyle>(width, height, {
+  const grid = new DiagramCanvas<FlowchartCellStyle, FlowchartCellMetadata>(width, height, {
     mergeCell: mergeFlowchartCell,
   })
   for (const subgraph of diagram.subgraphs ?? []) {

--- a/packages/merman/src/flowchart/flowchart.test.ts
+++ b/packages/merman/src/flowchart/flowchart.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { parseColor } from "@opentui/core"
+import { parseColor, TextAttributes } from "@opentui/core"
 import stringWidth from "string-width"
 import { expectDiagram } from "../test/diagram.js"
 import { drawFlowchartDiagramGrid as drawParsedFlowchartDiagramGrid } from "./drawing.js"
@@ -545,6 +545,19 @@ flowchart TD
     expect(diagram.edges[0]?.label).toBe("result ≥ 1")
   })
 
+  test("preserves quoted multiline edge labels", () => {
+    const diagram = parseMermaidFlowchartDiagram(`flowchart TD
+  A -->|"fs: watcher/fff off<br/>events.persist: true<br/>mcp.stdio: false<br/>A --> B"| B`)
+
+    expect(diagram.edges).toEqual([
+      {
+        from: "A",
+        to: "B",
+        label: "fs: watcher/fff off<br/>events.persist: true<br/>mcp.stdio: false<br/>A --> B",
+      },
+    ])
+  })
+
   test("parses and renders each edge in a chained flowchart statement", () => {
     const content = `flowchart LR
   API --> Worker --> DB[(Database)]`
@@ -911,6 +924,61 @@ flowchart LR
     expect(output).toContain("second line")
     expect(output.indexOf("first")).toBeLessThan(output.indexOf("second line"))
     expect(output).not.toContain("<br")
+  })
+
+  test("keeps quoted multiline labels compact and renders italic node text", () => {
+    const source = `flowchart TB
+  DO["ServerWorkerd.create({ storage, config })"]
+  DO --> SO["serverOptions()<br/><i>option flags</i>"]
+  DO --> RP["replacements()<br/><i>layer overrides</i>"]
+  SO -->|"fs: watcher/fff off<br/>events.persist: true<br/>mcp.stdio: false<br/>config as string"| SF["ServerFetch.make(options, { overrides })"]
+  RP -->|"Database → DO-SQLite<br/>Shell/FS/Pty → typed-unavailable<br/>Snapshot/Vcs → no-op<br/>plugins → precompiled only"| SF
+  SF --> GRAPH["LayerNode graph<br/>(core builds normally,<br/>swapped nodes substituted)"]`
+    const grid = drawFlowchartDiagramGrid(source)
+    const output = grid.toString({ trimTop: true, trimBottom: true })
+    const styled = renderGridStyledText(grid, resolveFlowchartStyleColors())
+
+    expect(Math.max(...output.split("\n").map((line) => stringWidth(line)))).toBeLessThan(140)
+    expect(output).not.toMatch(/<\/?i>|<br|events persist|mcp stdio|^[^\n]*"fs:/)
+    expect(
+      styled.chunks.some((chunk) => chunk.text.includes("option flags") && chunk.attributes === TextAttributes.ITALIC),
+    ).toBe(true)
+  })
+
+  test("keeps quoted architecture labels from distorting subgraph routes", () => {
+    const source = `flowchart TB
+    subgraph consumer["Durable Object"]
+        DO["ServerWorkerd.create({ storage, config })"]
+    end
+
+    DO --> SO["serverOptions()<br/><i>option flags</i>"]
+    DO --> RP["replacements()<br/><i>layer overrides</i>"]
+
+    SO -->|"fs: watcher/fff off<br/>events.persist: true<br/>mcp.stdio: false<br/>config as string"| SF["ServerFetch.make(options, { overrides })"]
+    RP -->|"Database → DO-SQLite<br/>Shell/FS/Pty → typed-unavailable<br/>Snapshot/Vcs → no-op<br/>plugins → precompiled only"| SF
+
+    SF --> GRAPH["LayerNode graph<br/>(core builds normally,<br/>swapped nodes substituted)"]
+
+    subgraph bundle["3rd mechanism: bundle conditions (build time)"]
+        COND["--conditions=workerd<br/>pty / fff / photon / shell-parser<br/>native modules → inert stubs<br/>#global-roots → workerd path rooting"]
+    end
+    COND -.->|import resolution| GRAPH`
+    const output = renderFlowchartDiagram(source)
+
+    expect(Math.max(...output.split("\n").map((line) => stringWidth(line)))).toBeLessThan(130)
+    expect(output).not.toMatch(/<\/?i>|<br|^[^\n]*"(?:fs:|Database)/)
+    for (const label of [
+      "fs: watcher/fff off",
+      "events.persist: true",
+      "mcp.stdio: false",
+      "config as string",
+      "Database → DO-SQLite",
+      "Shell/FS/Pty → typed-unavailable",
+      "Snapshot/Vcs → no-op",
+      "plugins → precompiled only",
+    ]) {
+      expect(output).toContain(label)
+    }
   })
 
   test("keeps tall multiline branch labels out of sibling nodes", () => {

--- a/packages/merman/src/flowchart/layout.ts
+++ b/packages/merman/src/flowchart/layout.ts
@@ -354,11 +354,6 @@ function layoutRankedNodes(
   requestedMinRankGap: number,
 ): Map<string, FlowchartNodeBounds> {
   const horizontal = isHorizontalDirection(direction)
-  let widestPaddedEdgeLabel = 0
-  for (const edge of diagram.edges) {
-    if (edge.label)
-      widestPaddedEdgeLabel = Math.max(widestPaddedEdgeLabel, flowchartLabelWidth(edge.label, visualLength))
-  }
   const ranks = rankNodes(diagram)
   const maxRank = Math.max(0, ...ranks.values())
   const ranksByIndex = new Map<number, FlowchartNode[]>()
@@ -382,13 +377,18 @@ function layoutRankedNodes(
         Math.max(0, nodes.length - 1) * spaciousNodeGap,
     ),
   )
-  const rankNodeGap = horizontal
-    ? minNodeGap
-    : widestPaddedEdgeLabel > 0
-      ? Math.max(spaciousNodeGap, flowchartVerticalBranchLabelGap(widestPaddedEdgeLabel))
-      : widestUnlabeledRank > DEFAULT_MAX_UNLABELED_RANK_WIDTH
-        ? minNodeGap
-        : spaciousNodeGap
+  const verticalNodeGap = (rank: number): number => {
+    const widestLabel = Math.max(
+      0,
+      ...diagram.edges
+        .filter(
+          (edge) => edge.label && (normalizedRanks.get(edge.from) === rank || normalizedRanks.get(edge.to) === rank),
+        )
+        .map((edge) => flowchartLabelWidth(edge.label, visualLength)),
+    )
+    if (widestLabel > 0) return Math.max(spaciousNodeGap, flowchartVerticalBranchLabelGap(widestLabel))
+    return widestUnlabeledRank > DEFAULT_MAX_UNLABELED_RANK_WIDTH ? minNodeGap : spaciousNodeGap
+  }
 
   const rankKeys = [...ranksByIndex.keys()].sort((a, b) => a - b)
   const horizontalGaps = horizontal ? horizontalRankGaps(diagram, normalizedRanks, rankKeys, requestedMinRankGap) : []
@@ -403,7 +403,7 @@ function layoutRankedNodes(
       const nodes = ranksByIndex.get(rank)!
       return (
         nodes.reduce((total, node) => total + sizes.get(node.id)!.height, 0) +
-        Math.max(0, nodes.length - 1) * rankNodeGap
+        Math.max(0, nodes.length - 1) * minNodeGap
       )
     })
     const canvasHeight = Math.max(1, ...columnHeights)
@@ -425,7 +425,7 @@ function layoutRankedNodes(
           centerX: left + Math.floor(size.width / 2),
           centerY: y + Math.floor(size.height / 2),
         })
-        y += size.height + rankNodeGap
+        y += size.height + minNodeGap
       }
       x += columnWidth + (horizontalGaps[rankIndex] ?? 0)
     }
@@ -437,7 +437,7 @@ function layoutRankedNodes(
       const nodes = ranksByIndex.get(rank)!
       return (
         nodes.reduce((total, node) => total + sizes.get(node.id)!.width, 0) +
-        Math.max(0, nodes.length - 1) * rankNodeGap
+        Math.max(0, nodes.length - 1) * verticalNodeGap(rank)
       )
     })
     const canvasWidth = Math.max(1, ...rowWidths)
@@ -446,6 +446,7 @@ function layoutRankedNodes(
       const rank = rankKeys[rankIndex]!
       const nodes = ranksByIndex.get(rank)!
       const rowHeight = rowHeights[rankIndex]!
+      const nodeGap = verticalNodeGap(rank)
       let x = Math.floor((canvasWidth - rowWidths[rankIndex]!) / 2)
       for (const node of nodes) {
         const size = sizes.get(node.id)!
@@ -458,7 +459,7 @@ function layoutRankedNodes(
           centerX: x + Math.floor(size.width / 2),
           centerY: top + Math.floor(size.height / 2),
         })
-        x += size.width + rankNodeGap
+        x += size.width + nodeGap
       }
       y += rowHeight + (verticalGaps[rankIndex] ?? 0)
     }

--- a/packages/merman/src/flowchart/parser.ts
+++ b/packages/merman/src/flowchart/parser.ts
@@ -31,7 +31,7 @@ const ID_ONLY_RE = new RegExp(`^${ID_RE}$`)
 const EXPLICIT_NODE_SHAPE_RE = new RegExp(`^${ID_RE}(?:\\[|\\(|\\{)`)
 const CIRCLE_NODE_RE = new RegExp(`^${ID_RE}\\(\\(.+\\)\\)$`)
 const EDGE_OPERATOR_RE =
-  /(-\.(?!->)(.+?)\.(?:->|-))|(--|==|-\.)\s+(.+?)\s+(-->|==>|\.->|-\.->|\.-)|(<-->|-->|==>|-\.->|---|~~~)\s*(?:\|([^|]*)\|\s*)?/g
+  /(-\.(?!->)(.+?)\.(?:->|-))|(--|==|-\.)\s+(.+?)\s+(-->|==>|\.->|-\.->|\.-)|(<-->|-->|==>|-\.->|---|~~~)\s*(?:\|([^|]*)\|\s*)?/dg
 
 function normalizeDirection(value?: string): FlowchartDirection {
   const upper = value?.toUpperCase()
@@ -161,10 +161,12 @@ function parseEdgeOperators(line: string): ParsedEdgeOperator[] {
     const inlineDashedArrow = match[1]
     const startArrow = inlineDashedArrow ?? match[3] ?? match[6]!
     const endArrow = inlineDashedArrow ?? match[5] ?? match[6]!
+    const labelGroup = match[2] ? 2 : match[4] ? 4 : match[7] ? 7 : undefined
+    const labelRange = labelGroup === undefined ? undefined : match.indices?.[labelGroup]
     return {
       index: match.index,
       end: match.index + match[0].length,
-      label: decodeMermaidText((match[2] ?? match[4] ?? match[7] ?? "").trim()),
+      label: stripQuotes(labelRange ? line.slice(labelRange[0], labelRange[1]) : ""),
       style: edgeStyleFromArrow(startArrow, endArrow),
       arrowhead: endArrow === "~~~" || endArrow.endsWith(">"),
       sourceArrowhead: startArrow.startsWith("<"),

--- a/packages/merman/src/flowchart/style.ts
+++ b/packages/merman/src/flowchart/style.ts
@@ -15,7 +15,10 @@ export type FlowchartNodeEdgeFadeStyle = `nodeEdgeFade${DiagramFadeStep}`
 export type FlowchartDatabaseEdgeFadeStyle = `databaseEdgeFade${DiagramFadeStep}`
 export type FlowchartEdgeFadeStyle = FlowchartNodeEdgeFadeStyle | FlowchartDatabaseEdgeFadeStyle
 export type FlowchartCellStyle = FlowchartBaseCellStyle | FlowchartEdgeFadeStyle
-export type FlowchartGrid = DiagramCanvas<FlowchartCellStyle>
+export interface FlowchartCellMetadata {
+  attributes?: number
+}
+export type FlowchartGrid = DiagramCanvas<FlowchartCellStyle, FlowchartCellMetadata>
 export type FlowchartStyleColors = Required<Record<FlowchartCellStyle, RGBA>>
 export const DEFAULT_THEME_RGB = {
   node: [228, 239, 232],
@@ -47,6 +50,8 @@ export function resolveFlowchartStyleColors(
 
 export function renderGridStyledText(grid: FlowchartGrid, colors: FlowchartStyleColors): StyledText {
   return renderDiagramGridStyledText(grid, (run) => (run.style ? colors[run.style] : undefined), undefined, {
+    key: (cell) => [cell.style, cell.attributes],
+    attributes: (run) => run.cell.attributes,
     trimTop: true,
     trimBottom: true,
   })

--- a/packages/merman/src/test/markdown.test.ts
+++ b/packages/merman/src/test/markdown.test.ts
@@ -250,6 +250,45 @@ sequenceDiagram
   expect(diagram.scrollX).toBeGreaterThan(0)
 })
 
+test("keeps surrounding Markdown anchored around a wide flowchart", async () => {
+  const testRenderer = await createTestRenderer({ width: 100, height: 40 })
+  renderer = testRenderer.renderer
+  const markdown = new MarkdownRenderable(renderer, {
+    id: "markdown-wide-flowchart",
+    content: `## Architecture — the profile is three mechanisms
+
+\`\`\`mermaid
+flowchart TB
+  subgraph consumer["Durable Object"]
+    DO["ServerWorkerd.create({ storage, config })"]
+  end
+  DO --> SO["serverOptions()<br/><i>option flags</i>"]
+  DO --> RP["replacements()<br/><i>layer overrides</i>"]
+  SO -->|"fs: watcher/fff off<br/>events.persist: true<br/>mcp.stdio: false<br/>config as string"| SF["ServerFetch.make(options, { overrides })"]
+  RP -->|"Database → DO-SQLite<br/>Shell/FS/Pty → typed-unavailable<br/>Snapshot/Vcs → no-op<br/>plugins → precompiled only"| SF
+  SF --> GRAPH["LayerNode graph<br/>(core builds normally,<br/>swapped nodes substituted)"]
+  subgraph bundle["3rd mechanism: bundle conditions (build time)"]
+    COND["--conditions=workerd<br/>pty / fff / photon / shell-parser<br/>native modules → inert stubs<br/>#global-roots → workerd path rooting"]
+  end
+  COND -.->|import resolution| GRAPH
+\`\`\``,
+    syntaxStyle,
+    treeSitterClient,
+    renderNode: createMermaidMarkdownRenderer(renderer),
+  })
+
+  renderer.root.add(markdown)
+  await renderMarkdown(markdown, testRenderer.renderOnce)
+
+  const frame = testRenderer.captureCharFrame()
+  const heading = frame.split("\n").find((line) => line.includes("Architecture"))
+  const diagram = markdown.getChildren().find((child) => child instanceof CodeRenderable) as CodeRenderable
+  expect(heading?.trimStart()).toStartWith("Architecture")
+  expect(diagram.scrollX).toBe(0)
+  expect(frame).toContain("Durable Object")
+  expect(frame).not.toMatch(/<\/?i>|<br|events persist|mcp stdio/)
+})
+
 test("renders a Mermaid state fence inside MarkdownRenderable", async () => {
   const testRenderer = await createTestRenderer({ width: 80, height: 14 })
   renderer = testRenderer.renderer


### PR DESCRIPTION
## What

Fixes terminal Mermaid flowcharts that use quoted multiline labels and inline italics. Valid labels now keep their punctuation, split on `<br/>`, render `<i>` / `<em>` as terminal italics, and reserve horizontal room only where that label is routed.

## Before / After

**Before:** the flowchart parser measured edge operators against a masked statement and also stored the masked label. A quoted label such as `"events.persist: true<br/>mcp.stdio: false"` became one long line like `"events persist: true br/ mcp stdio: false"`. That inflated every vertical rank, produced terminal-wide rails, exposed unrelated route/subgraph crossings, and printed `<i>` tags literally.

**After:** operator detection still uses the masked statement, but label text is recovered from the original source range. Rich text is normalized before measurement, `<br/>` creates rows, italic spans become OpenTUI text attributes, and multiline label clearance applies only to ranks touched by the labeled edge.

## How

- `packages/merman/src/flowchart/parser.ts` recovers quoted edge labels from original source indices without allowing arrow-like label text to become structural syntax.
- `packages/merman/src/core/text-lines.ts` exposes visible lines and italic runs for shared measurement and drawing.
- `packages/merman/src/flowchart/drawing.ts` writes rich text into canvas metadata; `style.ts` and `core/render-grid.ts` preserve those attributes in `StyledText`.
- `packages/merman/src/flowchart/layout.ts` computes vertical branch-label clearance per rank instead of applying the widest label globally.
- Flowchart and Markdown tests cover the complete reported architecture graph, narrow viewports, punctuation, line breaks, italics, and width.

## Scope

This supports Mermaid's existing `<br>`, `<br/>`, `<i>`, and `<em>` label presentation used by the terminal renderer. It does not add general HTML rendering or change non-flowchart diagram styling.

## Testing

- `cd packages/merman && bun run test` (`290` passing)
- `cd packages/merman && bun typecheck`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (`32` packages passing)
- OpenCode Drive against commit `b8d8911d7a`, simulated model response containing the complete reported diagram at a 200x44 viewport

## Demo

Exact reported diagram rendered by the OpenCode TUI through OpenCode Drive. Quoted labels are multiline, `option flags` and `layer overrides` are italic, and the graph stays compact.

![OpenCode Drive rendering the fixed Mermaid diagram](https://github.com/user-attachments/assets/92963553-c25a-4447-9559-c9d07a4dea1c)

## Flow

```mermaid
flowchart LR
    Source[Original Mermaid statement] --> Mask[Mask label syntax for edge detection]
    Mask --> Range[Recover label from original source range]
    Range --> Lines[Split visible lines and italic runs]
    Lines --> Layout[Measure rank-local clearance]
    Lines --> Canvas[Write text and attributes to canvas]
    Canvas --> Styled[Render OpenTUI StyledText]
```
