### PR TITLE
fix(tui): show worktree names in session list

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -141,11 +141,11 @@ export function DialogSessionList() {
     const option = (session: SessionInfo, category: string) => {
       const directory = session.location.directory
       const project = data.project.get(session.projectID)
-      const relative = path.relative(project?.canonical ?? directory, directory)
-      const footer = allProjects()
-        ? Locale.truncate(projectName(project, directory) ?? "", 20)
-        : relative.startsWith("..") || path.isAbsolute(relative)
-          ? Locale.truncate(path.basename(directory), 20)
+      const root = session.subpath ? path.resolve(directory, ...session.subpath.split("/").map(() => "..")) : directory
+      const relative = path.relative(project?.canonical ?? root, root)
+      const footer =
+        relative.startsWith("..") || path.isAbsolute(relative)
+          ? Locale.truncate(path.basename(relative), 25)
           : undefined
       const slot = sessionTabs.enabled() ? undefined : slotByID.get(session.id)
       const deleting = toDelete() === session.id


### PR DESCRIPTION
## Summary
- fix worktree names in the TUI session list dialog
- remove the session subpath before deriving the worktree name
- show linked worktree names instead of the nested session directory or project fallback
- truncate worktree labels to 25 terminal cells

## Verification
- reproduced with OpenCode Drive using two linked worktrees with sessions under `packages/cli`
- confirmed the dialog changed from `cli` for both rows to `worktree` and `worktree-two`
- `bun typecheck` in `packages/tui`
- full TUI suite: 683 passed, 5 skipped, 0 failed