### PR TITLE
refactor(codemode): route transpilation through a #transpile conditional import

### DIFF
--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -19,6 +19,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "imports": {
+    "#transpile": {
+      "workerd": "./src/interpreter/transpile.workerd.ts",
+      "default": "./src/interpreter/transpile.node.ts"
+    }
+  },
   "scripts": {
     "build": "bun run script/build.ts",
     "typecheck": "tsgo --noEmit",

--- a/packages/codemode/src/interpreter/execute.ts
+++ b/packages/codemode/src/interpreter/execute.ts
@@ -1,6 +1,8 @@
 import { parse } from "acorn"
 import { Cause, Effect, Scope } from "effect"
-import { DiagnosticCategory, ModuleKind, ScriptTarget, flattenDiagnosticMessageText, transpileModule } from "typescript"
+// #transpile: conditional import — full typescript on node/bun, an identity
+// pass-through on workerd (the compiler is ~11 MiB and can't init there).
+import { transpile } from "#transpile"
 import type { DataValue, Diagnostic, ExecuteOptions, ResolvedExecutionLimits, Result } from "../codemode.js"
 import { copyIn, copyOut, ToolRuntime, type Services } from "../tool-runtime.js"
 import type { Tools } from "../tools.js"
@@ -119,21 +121,10 @@ export const executeWithLimits = <const Provided extends Record<string, unknown>
 }
 
 const parseProgram = (code: string): ProgramNode => {
-  const transpiled = transpileModule(`async function __codemode__() {\n${code}\n}`, {
-    reportDiagnostics: true,
-    compilerOptions: {
-      target: ScriptTarget.ESNext,
-      module: ModuleKind.ESNext,
-    },
-  })
-  const diagnostic = transpiled.diagnostics?.find((item) => item.category === DiagnosticCategory.Error)
+  const transpiled = transpile(`async function __codemode__() {\n${code}\n}`)
 
-  if (diagnostic) {
-    throw new InterpreterRuntimeError(
-      `Failed to parse TypeScript: ${flattenDiagnosticMessageText(diagnostic.messageText, "\n")}`,
-      undefined,
-      "ParseError",
-    )
+  if (transpiled.error !== undefined) {
+    throw new InterpreterRuntimeError(`Failed to parse TypeScript: ${transpiled.error}`, undefined, "ParseError")
   }
 
   const bodyStart = transpiled.outputText.indexOf("{") + 1

--- a/packages/codemode/src/interpreter/transpile.node.ts
+++ b/packages/codemode/src/interpreter/transpile.node.ts
@@ -1,0 +1,25 @@
+import { DiagnosticCategory, ModuleKind, ScriptTarget, flattenDiagnosticMessageText, transpileModule } from "typescript"
+
+export interface TranspileResult {
+  readonly outputText: string
+  readonly error?: string
+}
+
+// Full TypeScript transpilation on node/bun runtimes.
+export const transpile = (source: string): TranspileResult => {
+  const transpiled = transpileModule(source, {
+    reportDiagnostics: true,
+    compilerOptions: {
+      target: ScriptTarget.ESNext,
+      module: ModuleKind.ESNext,
+    },
+  })
+  const diagnostic = transpiled.diagnostics?.find((item) => item.category === DiagnosticCategory.Error)
+  if (diagnostic) {
+    return {
+      outputText: transpiled.outputText,
+      error: flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    }
+  }
+  return { outputText: transpiled.outputText }
+}

--- a/packages/codemode/src/interpreter/transpile.workerd.ts
+++ b/packages/codemode/src/interpreter/transpile.workerd.ts
@@ -1,0 +1,11 @@
+export interface TranspileResult {
+  readonly outputText: string
+  readonly error?: string
+}
+
+// workerd profile: the typescript compiler is ~11 MiB and probes node
+// internals at module init, so codemode programs are passed through
+// untranspiled. Plain-JS programs (the overwhelmingly common case) parse
+// fine downstream via acorn; TypeScript-only syntax surfaces as a parse
+// error from the interpreter instead of a transpile diagnostic.
+export const transpile = (source: string): TranspileResult => ({ outputText: source })


### PR DESCRIPTION
## What / Why

Runtimes bundled with the `workerd` condition cannot carry the TypeScript transpiler dependency: the compiler is large and probes Node internals during module initialization.

Route interpreter transpilation through a `#transpile` conditional import. Node and Bun resolve the extracted TypeScript implementation, preserving the existing path byte-for-byte, while workerd bundles resolve an inert variant that passes JavaScript through without importing the compiler. TypeScript-only syntax then fails at the interpreter parse boundary with a clear parse error.

This follows the `#global-roots` conditional-import precedent in `packages/util` from #41918.

## Scope

- Adds the `#transpile` package imports map in `packages/codemode`.
- Extracts the existing Node/Bun transpilation implementation without changing its compiler options or diagnostic formatting.
- Adds the workerd pass-through implementation.
- Does not add TypeScript transpilation support to workerd.

## Testing

- `bun run typecheck` in `packages/codemode`
- `bun run test` in `packages/codemode` (1,089 passing)
- Push hook: `bun turbo typecheck --concurrency=3` (32 packages passing)