### PR TITLE
fix(core): resolve watcher binding require lazily

### DIFF
--- a/packages/core/src/filesystem/watcher-binding.ts
+++ b/packages/core/src/filesystem/watcher-binding.ts
@@ -2,9 +2,10 @@ import { createRequire } from "node:module"
 
 declare const OPENCODE_LIBC: string | undefined
 
-const require = createRequire(import.meta.url)
-
+// Lazy: on workerd import.meta.url is undefined and the watcher is never
+// loaded, so createRequire must not run at module scope.
 export default function load() {
+  const require = createRequire(import.meta.url)
   const libc = typeof OPENCODE_LIBC === "undefined" ? undefined : OPENCODE_LIBC
   return require(
     process.env.OPENCODE_PARCEL_WATCHER_PATH ??


### PR DESCRIPTION
## What / Why

Bundles using the `workerd` condition crash at import time because `import.meta.url` is undefined there and `createRequire(import.meta.url)` currently runs at module scope. The watcher is never loaded on that runtime, so resolving the require eagerly turns unreachable functionality into a bundle-wide startup failure.

Before, importing the bundle evaluated `createRequire` immediately and crashed. After, `createRequire` runs only when `load()` is called, preserving Node and Bun behavior while avoiding evaluation on workerd. This follows the same lazy resolution pattern used for `npmPath` in `packages/util/src/npm-config.ts`.

## Scope

One file: `packages/core/src/filesystem/watcher-binding.ts`.

## Testing

- `bun run typecheck`
- `bun run test test/filesystem/watcher.test.ts` from `packages/core` (11 passed)