### PR TITLE
fix(tui): continue pending work after interrupt

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -503,6 +503,7 @@ export function Prompt(props: PromptProps) {
           if (store.interrupt >= 2) {
             void client.api.session.interrupt({
               sessionID: props.sessionID,
+              continue: true,
             })
             setStore("interrupt", 0)
           }


### PR DESCRIPTION
## Summary
- pass `continue: true` when the main TUI interrupts a running session
- preserve explicit subagent cancellation behavior

## Testing
- `bun typecheck` (`packages/tui`)
- `bun test` (`packages/tui`): 688 passed, 5 skipped
- pre-push monorepo typecheck: 32 packages passed