### PR TITLE
fix(tui): improve selected spinner contrast

### DIFF
--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,6 +1,7 @@
 import { createMemo, createResource, createSignal } from "solid-js"
 import type { SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
+import type { RGBA } from "@opentui/core"
 import { dialogWidth, useDialog } from "../ui/dialog"
 import { DialogSelect, dialogSelectContentWidth } from "../ui/dialog-select"
 import { useRoute } from "../context/route"
@@ -105,7 +106,7 @@ export function DialogOpen(props: { sessions: SessionInfo[] }) {
         footer: `${name ? `${Locale.truncate(name, 20)} · ` : ""}${timeAgo(session.time.updated)}`,
         onSelect: () => location.set(session.location),
         gutter: running
-          ? () => <Spinner />
+          ? (color: RGBA) => <Spinner color={color} />
           : tabs.has(session.id)
             ? () => <text fg={theme.hue.accent[mode() === "light" ? 800 : 200]}>▪</text>
             : undefined,

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -2,6 +2,7 @@ import { createMemo, createResource, createSignal, onMount, Show } from "solid-j
 import path from "path"
 import type { SessionInfo } from "@opencode-ai/client"
 import { TextAttributes } from "@opentui/core"
+import type { RGBA } from "@opentui/core"
 import { useDialog } from "../ui/dialog"
 import { DialogSelect } from "../ui/dialog-select"
 import { useRoute } from "../context/route"
@@ -161,7 +162,7 @@ export function DialogSessionList() {
         gutter:
           data.session.status(session.id) === "running" ||
           data.session.family(session.id).some((id) => data.session.status(id) === "running")
-            ? () => <Spinner />
+            ? (color: RGBA) => <Spinner color={color} />
             : slot === undefined
               ? undefined
               : () => <text fg={theme.hue.accent[mode() === "light" ? 800 : 200]}>{slot}</text>,

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -80,7 +80,7 @@ export interface DialogSelectOption<T = any> {
   disabled?: boolean
   bg?: RGBA
   fg?: RGBA
-  gutter?: () => JSX.Element
+  gutter?: (color: RGBA) => JSX.Element
   margin?: JSX.Element
   onSelect?: (ctx: DialogContext) => void
 }
@@ -816,7 +816,7 @@ function Option(props: {
   footerColor?: RGBA
   titleWidth?: number
   truncateTitle?: boolean | "left"
-  gutter?: () => JSX.Element
+  gutter?: (color: RGBA) => JSX.Element
   activeColor?: RGBA
   onMouseOver?: () => void
 }) {
@@ -837,7 +837,7 @@ function Option(props: {
       </Show>
       <Show when={props.gutter}>
         <box flexShrink={0} marginRight={0}>
-          {props.gutter?.()}
+          {props.gutter?.(text())}
         </box>
       </Show>
       <text

--- a/packages/tui/test/cli/tui/dialog-select.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-select.test.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @opentui/solid */
-import { InputRenderable } from "@opentui/core"
+import { InputRenderable, type RGBA } from "@opentui/core"
 import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
@@ -194,6 +194,32 @@ test("renders actions with a current selection", async () => {
     await app.waitForFrame((frame) => frame.includes("delete"))
   } finally {
     app.renderer.destroy()
+  }
+})
+
+test("passes the row foreground color to gutters", async () => {
+  await using tmp = await tmpdir()
+  const colors = new Map<string, RGBA>()
+  const gutter = (item: string) => (color: RGBA) => {
+    colors.set(item, color)
+    return <text fg={color}>*</text>
+  }
+  const select = await mountSelect(tmp.path, [
+    { title: "Alpha", value: "alpha", gutter: gutter("alpha") },
+    { title: "Beta", value: "beta", gutter: gutter("beta") },
+  ])
+
+  try {
+    await select.app.waitFor(() => colors.size === 2)
+    const selected = colors.get("alpha")!.toInts()
+    const idle = colors.get("beta")!.toInts()
+    expect(selected).not.toEqual(idle)
+
+    select.app.mockInput.pressArrow("down")
+    await select.app.waitFor(() => colors.get("alpha")!.toInts().every((value, index) => value === idle[index]))
+    expect(colors.get("beta")!.toInts()).toEqual(selected)
+  } finally {
+    select.app.renderer.destroy()
   }
 })
 


### PR DESCRIPTION
## What

Make activity spinners readable when their session row is selected in the Open and Sessions pickers.

## Before / After

**Before:** activity spinners always used the default muted spinner color. On a selected row, that color had low contrast against the focused background and made the running state difficult to see.

**After:** gutter content receives the row's resolved foreground color. Activity spinners now use the same high-contrast foreground as the selected title, while unselected spinners remain muted.

## How

- `packages/tui/src/ui/dialog-select.tsx` passes each row's resolved foreground color to its gutter renderer.
- `packages/tui/src/component/dialog-open.tsx` and `dialog-session-list.tsx` apply that color to running-session spinners.
- `packages/tui/test/cli/tui/dialog-select.test.tsx` verifies the gutter color follows selection as it moves between rows.

## Scope

This only changes activity-spinner contrast in dialog rows. Other gutter markers keep their existing colors.

## Testing

- `bun run test test/cli/tui/dialog-select.test.tsx test/cli/tui/dialog-open.test.tsx` (20 passed)
- `bun typecheck` from `packages/tui`
- Repository pre-push typecheck (32 packages successful)
- OpenCode Drive: started an active session, opened the Sessions picker from a new session, and moved selection away from and back to the running row.

## Demo

OpenCode Drive recording. The spinner starts selected with the high-contrast row foreground, becomes muted when selection moves away, then regains contrast when selected again.

https://github.com/user-attachments/assets/76484285-3b0e-4573-b193-18abf3aa09a5
