### PR TITLE
feat(tui): refine session tab activity indicators

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1,5 +1,5 @@
 import { RGBA, ScrollBoxRenderable, TextAttributes, type MouseEvent } from "@opentui/core"
-import { For, Show, createComputed, createEffect, createMemo, createSignal, onCleanup, untrack } from "solid-js"
+import { For, Match, Show, Switch, createComputed, createEffect, createMemo, createSignal, onCleanup, untrack } from "solid-js"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useConfig } from "../config"
 import { useSessionTabs } from "../context/session-tabs"
@@ -57,12 +57,29 @@ export const EMPTY_SESSION_TAB_STATUS: SessionTabsStatus = {
 export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
   newTab?: () => boolean
   add?: () => void
+  detail?: (sessionID: string) => string | undefined
   status(sessionID: string): SessionTabsStatus
 }
-
 const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: NEW_SESSION_TAB_TITLE }
 const glowTextColor = (base: RGBA, glow: RGBA, index: number, width: number) =>
   tint(base, glow, 0.12 * unreadGlowIntensity(index, width))
+
+function createNumberIgnition(runs: () => boolean, prompt: () => number, animations: () => boolean) {
+  const ignition = createAnimatable({ level: 0 }, { enabled: animations, transition: tween({ duration: 0.7 }) })
+  let wasRunning = runs()
+  let promptPulse = prompt()
+  createEffect(() => {
+    const running = runs()
+    const nextPromptPulse = prompt()
+    if (running !== wasRunning || nextPromptPulse !== promptPulse) {
+      ignition.jump({ level: 0.85 })
+      ignition.animate({ level: 0 })
+    }
+    wasRunning = running
+    promptPulse = nextPromptPulse
+  })
+  return ignition
+}
 
 function fadeTitleColor(color: RGBA, background: RGBA, index: number, length: number, leading: number) {
   const fade = (position: number) => (position <= 0 ? 0 : 0.2 + 0.72 * ((position - 1) / Math.max(1, FADE_WIDTH - 1)))
@@ -247,15 +264,30 @@ function TabContextMenu(props: { state: TabContextMenuState; tabs: SessionTabsCo
 }
 
 export function SessionTabs(
-  props: { controller?: SessionTabsController; animations?: boolean; orientation?: "horizontal" | "vertical" } = {},
+  props: {
+    controller?: SessionTabsController
+    animations?: boolean
+    orientation?: "horizontal" | "vertical"
+  } = {},
 ) {
-  if (props.orientation === "vertical")
-    return <VerticalSessionTabs controller={props.controller} animations={props.animations} />
-  return <HorizontalSessionTabs controller={props.controller} animations={props.animations} />
+  return (
+    <Switch>
+      <Match when={props.orientation === "vertical"}>
+        <VerticalSessionTabs
+          controller={props.controller}
+          animations={props.animations}
+        />
+      </Match>
+      <Match when={true}>
+        <HorizontalSessionTabs controller={props.controller} animations={props.animations} />
+      </Match>
+    </Switch>
+  )
 }
 
 function VerticalSessionTabs(props: { controller?: SessionTabsController; animations?: boolean }) {
-  const tabs = props.controller ?? useSessionTabs()
+  const contextTabs = useSessionTabs()
+  const tabs: SessionTabsController = props.controller ?? contextTabs
   const data = useData()
   const theme = useTheme("elevated")
   const { mode } = useThemes()
@@ -367,6 +399,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
               const titleFades = createMemo(() => marqueeOverflows(title(), titleWidth()) && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
+                const fixture = tabs.detail?.(tab.sessionID)
+                if (fixture !== undefined) return Locale.takeWidth(fixture, titleWidth())
                 const value = session()
                 return Locale.takeWidth(projectName(project(), value?.location.directory) ?? "", titleWidth())
               })
@@ -377,15 +411,30 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 return theme.background.default
               })
               const pulseBackground = createMemo(() => tint(theme.background.default, background(), background().a))
+              const runs = () => status().runs
+              const numberIgnition = createNumberIgnition(runs, () => status().promptPulse, animations)
               const numberColor = () => {
-                if (status().attention) return theme.text.feedback.warning.default
-                if (status().unread === "error") return theme.text.feedback.error.default
                 const base =
                   hovered() === tab.sessionID && !selected()
                     ? foreground()
-                    : tint(idleNumber(), activeNumber(), Number(selected()))
-                const color = tint(base, accent(), Number(complete()))
-                return sweepLevel() === 0 ? color : tint(color, theme.text.default, 0.15 * sweepLevel())
+                    : tint(
+                        idleNumber(),
+                        tint(theme.text.default, pulseBackground(), 0.25),
+                        Number(selected()),
+                      )
+                const color = status().attention
+                  ? theme.text.feedback.warning.default
+                  : status().unread === "error"
+                    ? theme.text.feedback.error.default
+                    : tint(base, accent(), Number(complete()))
+                const runningColor = runs() ? activeNumber() : color
+                return sweepLevel() === 0
+                  ? tint(runningColor, theme.text.default, numberIgnition.value().level)
+                  : tint(
+                      runningColor,
+                      theme.text.default,
+                      Math.max(numberIgnition.value().level, 0.35 * sweepLevel()),
+                    )
               }
               const foreground = () => {
                 if (hovered() === tab.sessionID) return theme.text.default
@@ -398,8 +447,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 return accent()
               }
               const pulseColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.25))
+              const flashColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.7))
               const glowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.45))
               const detailPulseColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.13))
+              const detailFlashColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.42))
               const detailGlowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.25))
               const detailColor = createMemo(() => tint(theme.text.subdued, pulseBackground(), 0.35))
               const glows = () => status().glows
@@ -411,8 +462,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   : { ...EMPTY_SESSION_TAB_STATUS, complete: false, runs: false, glows: false }
               })
               const previousGlows = () => previousStatus().glows
-              const runs = () => status().runs
               const previousRuns = () => previousStatus().runs
+              const indicatorWidth = 10
               const previousGlowHue = () => {
                 if (previousStatus().attention) return theme.text.feedback.warning.default
                 if (previousStatus().unread === "error") return theme.text.feedback.error.default
@@ -499,7 +550,11 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                     breathe={status().attention}
                     outerBreathe={previousStatus().attention}
                     color={separatorLowerPulseColor()}
+                    width={indicatorWidth}
                     outerColor={separatorUpperPulseColor()}
+                    flashColor={tint(theme.background.default, theme.text.default, 0.22)}
+                    outerFlashColor={tint(theme.background.default, theme.text.default, 0.18)}
+                    flashTail={8}
                     glowColor={separatorLowerColor()}
                     outerGlowColor={separatorUpperColor()}
                     glowTail={8}
@@ -524,7 +579,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       breathe={status().attention}
                       outerBreathe={false}
                       color={tint(theme.background.default, theme.text.default, 0.04)}
+                      width={indicatorWidth}
                       outerColor={tint(theme.background.default, theme.text.default, 0.006)}
+                      flashColor={tint(theme.background.default, theme.text.default, 0.18)}
+                      flashTail={8}
                       glowColor={tint(theme.background.default, glowHue(), 0.1)}
                       outerGlowColor={theme.background.default}
                       glowTail={8}
@@ -543,7 +601,10 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       glow={glows()}
                       breathe={status().attention}
                       color={pulseColor()}
+                      width={indicatorWidth}
                       glowColor={glowColor()}
+                      flashColor={flashColor()}
+                      flashTail={8}
                       completionColor={glowColor()}
                       backgroundColor={pulseBackground()}
                       onLevel={setSweepLevel}
@@ -599,8 +660,11 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       glow={glows()}
                       breathe={status().attention}
                       color={detailPulseColor()}
+                      width={indicatorWidth}
                       glowColor={detailGlowColor()}
                       glowTail={10}
+                      flashColor={detailFlashColor()}
+                      flashTail={8}
                       completionColor={detailGlowColor()}
                       backgroundColor={pulseBackground()}
                     />
@@ -646,7 +710,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
             >
               <text
                 width={2}
-                fg={newTab() ? activeNumber() : addHovered() ? theme.text.default : idleNumber()}
+                fg={newTab() || addHovered() ? theme.text.default : idleNumber()}
                 selectable={false}
                 attributes={newTab() ? TextAttributes.BOLD : undefined}
               >
@@ -903,6 +967,8 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const titleFades = createMemo(
             () => marqueeOverflows(title(), availableTitleWidth()) && availableTitleWidth() > FADE_WIDTH,
           )
+          const runs = () => status().busy && !status().attention
+          const numberIgnition = createNumberIgnition(runs, () => status().promptPulse, animations)
           const foreground = () => {
             if (hovered() === tab.sessionID) return theme.text.default
             return tint(theme.text.subdued, theme.text.default, selection())
@@ -927,14 +993,17 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const [closeHovered, setCloseHovered] = createSignal(false)
           const numberColor = () => {
             const feedback = feedbackColor()
-            if (feedback) return feedback
             const base =
               hovered() === tab.sessionID && !selected()
                 ? foreground()
-                : tint(idleNumber(), activeNumber(), selection())
-            const color = tint(base, accent(), activity())
+                : tint(idleNumber(), tint(theme.text.default, background(), 0.25), selection())
+            const color = feedback ?? (runs() ? activeNumber() : tint(base, accent(), activity()))
             // The number brightens faintly as the running sweep passes beneath it.
-            return sweepLevel() === 0 ? color : tint(color, theme.text.default, 0.15 * sweepLevel())
+            return tint(
+              color,
+              theme.text.default,
+              Math.max(numberIgnition.value().level, 0.15 * sweepLevel()),
+            )
           }
           const bold = () => (selected() || dragged() ? TextAttributes.BOLD : undefined)
           const closeColor = () => tint(theme.text.subdued, theme.text.default, 0.6)

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -22,6 +22,8 @@ type TabPulseOptions = RenderableOptions<TabPulseRenderable> & {
   outerGlowTail?: number
   flashColor?: RGBA
   outerFlashColor?: RGBA
+  flashTail?: number
+  outerFlashTail?: number
   completionColor?: RGBA
   outerCompletionColor?: RGBA
   backgroundColor?: RGBA
@@ -72,6 +74,7 @@ export const completionPulseOpacity = (progress: number) => attackDecay(progress
 export const glowIgnitionLevel = (progress: number) =>
   attackDecay(progress, GLOW_IGNITION_ATTACK, GLOW_IGNITION_PEAK, 1)
 const glowIntensityAt = (index: number, tail: number) => smootherstep(clamp(1 - Math.max(0, index - 1) / tail))
+export const tabFlashIntensity = (index: number, tail: number) => glowIntensityAt(index, tail)
 export const unreadGlowIntensity = (index: number, width: number, maximumTail = GLOW_TAIL) => {
   const tail = Math.min(maximumTail, Math.max(1, width - 2))
   return glowIntensityAt(index, tail)
@@ -323,6 +326,8 @@ class TabPulseRenderable extends Renderable {
   private _edge: "above" | "below" | undefined
   private _flashColor: RGBA
   private _outerFlashColor: RGBA
+  private _flashTail: number | undefined
+  private _outerFlashTail: number | undefined
   private _completionColor: RGBA
   private _outerCompletionColor: RGBA
   private _backgroundColor: RGBA
@@ -373,6 +378,8 @@ class TabPulseRenderable extends Renderable {
     this._edge = edge
     this._flashColor = options.flashColor ?? this._color
     this._outerFlashColor = options.outerFlashColor ?? options.flashColor ?? this._outerColor
+    this._flashTail = options.flashTail
+    this._outerFlashTail = options.outerFlashTail ?? options.flashTail
     this._completionColor = options.completionColor ?? this._color
     this._outerCompletionColor = options.outerCompletionColor ?? options.completionColor ?? this._outerColor
     this._backgroundColor = options.backgroundColor ?? RGBA.defaultBackground()
@@ -501,6 +508,18 @@ class TabPulseRenderable extends Renderable {
     this.requestRender()
   }
 
+  set flashTail(value: number | undefined) {
+    if (value === this._flashTail) return
+    this._flashTail = value
+    this.requestRender()
+  }
+
+  set outerFlashTail(value: number | undefined) {
+    if (value === this._outerFlashTail) return
+    this._outerFlashTail = value
+    this.requestRender()
+  }
+
   set completionColor(value: RGBA) {
     if (value.equals(this._completionColor)) return
     this._completionColor = value
@@ -560,6 +579,9 @@ class TabPulseRenderable extends Renderable {
       )
     const glowTail = Math.min(this._glowTail, Math.max(1, this.width - 2))
     const outerGlowTail = Math.min(this._outerGlowTail, Math.max(1, this.width - 2))
+    const flashTail = this._flashTail === undefined ? undefined : Math.min(this._flashTail, Math.max(1, this.width - 2))
+    const outerFlashTail =
+      this._outerFlashTail === undefined ? undefined : Math.min(this._outerFlashTail, Math.max(1, this.width - 2))
     for (let index = 0; index < this.width; index++) {
       // Skip per-cell sweep and glow math when that stage is idle, e.g. a steady breathing glow.
       const sweep =
@@ -589,7 +611,7 @@ class TabPulseRenderable extends Renderable {
         this._completionColor,
         glowLevel === 0 ? 0 : glowIntensityAt(index, glowTail) * GLOW_OPACITY * glowLevel,
         sweep,
-        flash,
+        flashTail === undefined ? flash : flash * tabFlashIntensity(index, flashTail),
         completion,
       )
       if (!this._edge) {
@@ -605,7 +627,7 @@ class TabPulseRenderable extends Renderable {
         this._outerCompletionColor,
         outerGlowLevel === 0 ? 0 : glowIntensityAt(index, outerGlowTail) * GLOW_OPACITY * outerGlowLevel,
         outerSweep,
-        outerFlash,
+        outerFlashTail === undefined ? outerFlash : outerFlash * tabFlashIntensity(index, outerFlashTail),
         outerCompletion,
       )
       buffer.setCell(
@@ -650,6 +672,8 @@ export function TabPulse(props: {
   outerGlowTail?: number
   flashColor?: RGBA
   outerFlashColor?: RGBA
+  flashTail?: number
+  outerFlashTail?: number
   completionColor?: RGBA
   outerCompletionColor?: RGBA
   backgroundColor: RGBA
@@ -681,6 +705,8 @@ export function TabPulse(props: {
       outerGlowTail={props.outerGlowTail ?? props.glowTail ?? GLOW_TAIL}
       flashColor={props.flashColor ?? props.color}
       outerFlashColor={props.outerFlashColor ?? props.flashColor ?? props.outerColor ?? props.color}
+      flashTail={props.flashTail}
+      outerFlashTail={props.outerFlashTail ?? props.flashTail}
       completionColor={props.completionColor ?? props.color}
       outerCompletionColor={props.outerCompletionColor ?? props.completionColor ?? props.outerColor ?? props.color}
       backgroundColor={props.backgroundColor}

--- a/packages/tui/src/feature-plugins/system/storybook/footer.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/footer.tsx
@@ -1,0 +1,54 @@
+import type { Plugin } from "@opencode-ai/plugin/tui"
+import { For, Show } from "solid-js"
+
+export type StoryFooterControl = {
+  shortcut: string
+  label: string
+}
+
+export function StoryFooter(props: {
+  context: Plugin.Context
+  title: string
+  details?: readonly string[]
+  status?: string
+  message?: string
+  controls: readonly StoryFooterControl[]
+}) {
+  const theme = props.context.theme.contextual.elevated
+
+  return (
+    <box flexShrink={0} flexDirection="column" backgroundColor={theme.background.default}>
+      <box height={1} paddingLeft={1} paddingRight={1} flexDirection="row">
+        <text fg={theme.text.default}>{props.title}</text>
+        <Show when={props.details?.length}>
+          <text fg={theme.text.subdued}> · {props.details?.join(" · ")}</text>
+        </Show>
+      </box>
+      <Show when={props.status || props.message}>
+        <box height={1} paddingLeft={1} paddingRight={1} flexDirection="row">
+          <text fg={theme.text.default}>{props.status ?? ""}</text>
+          <Show when={props.status && props.message}>
+            <text fg={theme.text.subdued}> · </text>
+          </Show>
+          <text fg={theme.text.subdued}>{props.message ?? ""}</text>
+        </box>
+      </Show>
+      <box height={1} paddingLeft={1} paddingRight={1} flexDirection="row">
+        <text fg={theme.text.default} wrapMode="none">
+          <For each={props.controls}>
+            {(control, index) => (
+              <>
+                <Show when={index() > 0}>
+                  <span>  </span>
+                </Show>
+                {control.shortcut} <span style={{ fg: theme.text.subdued }}>{control.label}</span>
+              </>
+            )}
+          </For>
+        </text>
+      </box>
+      {/* The app-wide feature footer overlays the terminal's final row. */}
+      <box height={1} />
+    </box>
+  )
+}

--- a/packages/tui/src/feature-plugins/system/storybook/index.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/index.tsx
@@ -1,6 +1,7 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { createSignal, For, type JSX } from "solid-js"
+import { StoryFooter } from "./footer"
 import { sessionTabsStory } from "./session-tabs"
 
 /**
@@ -47,7 +48,6 @@ function Commands(props: { context: Plugin.Context }) {
 function StorybookIndex(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const theme = props.context.theme
-  const elevatedTheme = theme.contextual.elevated
   const [selected, setSelected] = createSignal(0)
   const open = (story: Story) =>
     props.context.ui.router.navigate({ type: "plugin", name: "storybook", data: { story: story.id } })
@@ -110,18 +110,15 @@ function StorybookIndex(props: { context: Plugin.Context }) {
         </For>
       </box>
       <box flexGrow={1} />
-      <box
-        height={1}
-        flexShrink={0}
-        backgroundColor={elevatedTheme.background.default}
-        paddingLeft={1}
-        paddingRight={1}
-        flexDirection="row"
-      >
-        <text fg={elevatedTheme.text.subdued}>storybook</text>
-        <box flexGrow={1} />
-        <text fg={elevatedTheme.text.subdued}>↑/↓ select | enter open | esc home</text>
-      </box>
+      <StoryFooter
+        context={props.context}
+        title="storybook"
+        controls={[
+          { shortcut: "↑/↓", label: "select" },
+          { shortcut: "enter", label: "open" },
+          { shortcut: "esc", label: "home" },
+        ]}
+      />
     </box>
   )
 }

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -1,30 +1,32 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
-import { batch, createSignal, For, onCleanup } from "solid-js"
+import { batch, createSignal, For } from "solid-js"
 import { createStore, reconcile } from "solid-js/store"
-import { EMPTY_SESSION_TAB_STATUS, SessionTabs, type SessionTabsController } from "../../../component/session-tabs"
-import { moveSessionTab } from "../../../context/session-tabs-model"
+import {
+  EMPTY_SESSION_TAB_STATUS,
+  SessionTabs,
+  type SessionTabsController,
+} from "../../../component/session-tabs"
+import { closeSessionTab, cycleSessionTab, moveSessionTab } from "../../../context/session-tabs-model"
+import { StoryFooter } from "./footer"
 import type { Story } from "./index"
 
 type FixtureStatus = ReturnType<SessionTabsController["status"]>
 
 const FIXTURE_TABS = [
-  { sessionID: "fixture-1", title: "Implement session tabs" },
-  { sessionID: "fixture-2", title: "Investigate rendering" },
-  { sessionID: "fixture-3", title: "A deliberately long session title for truncation" },
-  { sessionID: "fixture-4", title: "Fix provider state" },
-  { sessionID: "fixture-5", title: "Review animation" },
-  { sessionID: "fixture-6", title: "Untitled behavior" },
-  { sessionID: "fixture-7", title: "Queue follow-up work" },
-  { sessionID: "fixture-8", title: "Check narrow layout" },
-  { sessionID: "fixture-9", title: "Profile terminal output" },
-  { sessionID: "fixture-10", title: "Handle permission" },
-  { sessionID: "fixture-11", title: "Run focused tests" },
-  { sessionID: "fixture-12", title: "Prepare review" },
+  { sessionID: "fixture-1", title: "Implement session tabs", project: "opencode" },
+  { sessionID: "fixture-2", title: "Investigate rendering", project: "opencode" },
+  { sessionID: "fixture-3", title: "A deliberately long session title for truncation", project: "opencode-slack" },
+  { sessionID: "fixture-4", title: "Fix provider state", project: "opencode" },
+  { sessionID: "fixture-5", title: "Review animation", project: "opencode-slack" },
+  { sessionID: "fixture-6", title: "Untitled behavior", project: "opencode-drive" },
+  { sessionID: "fixture-7", title: "Queue follow-up work", project: "opencode" },
+  { sessionID: "fixture-8", title: "Check narrow layout", project: "opencode-drive" },
+  { sessionID: "fixture-9", title: "Profile terminal output", project: "opencode" },
+  { sessionID: "fixture-10", title: "Handle permission", project: "opencode-slack" },
+  { sessionID: "fixture-11", title: "Run focused tests", project: "opencode" },
+  { sessionID: "fixture-12", title: "Prepare review", project: "opencode-drive" },
 ]
-
-const RUN_DURATION = 1_800
-const RESUME_DURATION = 900
 
 // Plausible targets for the fake transcript's tool calls, picked per fixture index.
 const TRANSCRIPT_FILES = [
@@ -39,7 +41,6 @@ const TRANSCRIPT_FILES = [
 function SessionTabsStory(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const theme = props.context.theme
-  const elevatedTheme = theme.contextual.elevated
   // A keyed store mirrors production: retitles mutate rows in place instead of remounting them.
   const [tabStore, setTabStore] = createStore<{ items: { sessionID: string; title?: string }[] }>({
     items: FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })),
@@ -50,26 +51,14 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const [active, setActive] = createSignal<string | undefined>("fixture-1")
   const [lastEvent, setLastEvent] = createSignal("press space to start a random tab")
   const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>({})
+  const [orientation, setOrientation] = createSignal<"horizontal" | "vertical">("vertical")
   // Unread clears on select, so the transcript remembers how each session's last run ended.
   const [outcomes, setOutcomes] = createSignal<Record<string, "completed" | "failed">>({})
-  const runs = new Map<string, ReturnType<typeof setTimeout>>()
-  onCleanup(() => runs.forEach(clearTimeout))
-
   const number = (sessionID: string) => tabs().findIndex((tab) => tab.sessionID === sessionID) + 1
 
-  function finishRun(sessionID: string, resumed: boolean) {
-    runs.delete(sessionID)
+  function finishRun(sessionID: string) {
     if (!tabs().some((item) => item.sessionID === sessionID)) return
     const roll = Math.random()
-    // A permission request pauses the still-busy run until the tab is selected.
-    if (!resumed && roll < 0.25) {
-      setStatuses((current) => ({
-        ...current,
-        [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), attention: true },
-      }))
-      setLastEvent(`tab ${number(sessionID)} needs input; select it to resolve`)
-      return
-    }
     const failed = roll >= 0.75
     const unread = active() === sessionID ? undefined : failed ? ("error" as const) : ("activity" as const)
     batch(() => {
@@ -90,19 +79,11 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
 
   const select = (sessionID: string) => {
     const status = statuses()[sessionID]
-    const resumes = status !== undefined && status.attention && status.busy && !runs.has(sessionID)
     batch(() => {
       setActive(sessionID)
       if (status && (status.unread || status.attention))
         setStatuses((current) => ({ ...current, [sessionID]: { ...status, unread: undefined, attention: false } }))
     })
-    if (resumes) {
-      setLastEvent(`tab ${number(sessionID)} input resolved, resuming`)
-      runs.set(
-        sessionID,
-        setTimeout(() => finishRun(sessionID, true), RESUME_DURATION),
-      )
-    }
   }
 
   const addTab = () => {
@@ -120,6 +101,9 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     tabs,
     current: active,
     add: addTab,
+    detail(sessionID) {
+      return FIXTURE_TABS.find((tab) => tab.sessionID === sessionID)?.project
+    },
     status(sessionID) {
       return statuses()[sessionID] ?? EMPTY_SESSION_TAB_STATUS
     },
@@ -132,31 +116,24 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     close(sessionID?: string) {
       const target = sessionID ?? active()
       if (!target) return
-      const items = tabs()
-      const index = items.findIndex((tab) => tab.sessionID === target)
-      if (index === -1) return
-      const next = items.filter((tab) => tab.sessionID !== target).map((tab) => ({ ...tab }))
-      const selected = next[index]?.sessionID ?? next[index - 1]?.sessionID
-      clearTimeout(runs.get(target))
-      runs.delete(target)
+      const result = closeSessionTab(tabs(), target)
+      if (result.tabs === tabs()) return
       batch(() => {
-        setItems(next)
+        setItems(result.tabs.map((tab) => ({ ...tab })))
         setStatuses((current) => {
           const updated = { ...current }
           delete updated[target]
           return updated
         })
-        if (active() === target && selected) select(selected)
-        if (active() === target && !selected) setActive(undefined)
+        if (active() === target && result.next) select(result.next)
+        if (active() === target && !result.next) setActive(undefined)
       })
     },
   } satisfies SessionTabsController
 
   const cycle = (direction: 1 | -1) => {
-    const items = tabs()
-    if (items.length === 0) return
-    const index = items.findIndex((tab) => tab.sessionID === active())
-    select(items[(index + direction + items.length) % items.length].sessionID)
+    const tab = cycleSessionTab(tabs(), active(), direction)
+    if (tab) select(tab.sessionID)
   }
   const startRun = (sessionID: string) => {
     setStatuses((current) => ({
@@ -169,10 +146,22 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       return next
     })
     setLastEvent(`tab ${number(sessionID)} running`)
-    runs.set(
-      sessionID,
-      setTimeout(() => finishRun(sessionID, false), RUN_DURATION),
-    )
+  }
+  const prompt = (sessionID: string) => {
+    const wasBusy = controller.status(sessionID).busy
+    setStatuses((current) => {
+      const status = current[sessionID] ?? EMPTY_SESSION_TAB_STATUS
+      return {
+        ...current,
+        [sessionID]: {
+          ...status,
+          busy: true,
+          unread: undefined,
+          promptPulse: status.promptPulse + 1,
+        },
+      }
+    })
+    setLastEvent(`prompt sent to tab ${number(sessionID)}${wasBusy ? " while running" : ""}`)
   }
   const randomInactiveTab = () => {
     const candidates = tabs().filter((tab) => {
@@ -183,6 +172,10 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     const untitled = candidates.filter((tab) => tab.title === undefined)
     const pool = untitled.length > 0 ? untitled : candidates
     return pool[Math.floor(Math.random() * pool.length)]
+  }
+  const randomRunningTab = () => {
+    const candidates = tabs().filter((tab) => controller.status(tab.sessionID).busy)
+    return candidates[Math.floor(Math.random() * candidates.length)]
   }
   // A fake transcript for the selected session so tab switches feel like moving between real
   // sessions; the tail line tracks the live status of the current run.
@@ -213,12 +206,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       { text: `  ✱ Bash bun run test`, color: theme.text.subdued },
       { text: "", color: theme.text.default },
     )
-    if (status.attention)
-      lines.push({
-        text: "⚠ Permission required: Bash `bun run test` — select this tab to approve",
-        color: theme.text.feedback.warning.default,
-      })
-    else if (status.busy) lines.push({ text: "● Working…", color: theme.text.subdued })
+    if (status.busy) lines.push({ text: "● Working…", color: theme.text.subdued })
     else if (outcome === "failed")
       lines.push({
         text: `✗ bun run test failed — 3 tests failing in ${file}`,
@@ -232,17 +220,11 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     return lines
   }
 
-  const selectedState = () => {
-    const current = active()
-    const status = current ? controller.status(current) : EMPTY_SESSION_TAB_STATUS
-    const activity = status.busy
-      ? "running"
-      : status.unread === "activity"
-        ? "completed (unread)"
-        : status.unread === "error"
-          ? "failed (unread)"
-          : "read"
-    return status.attention ? `${activity} + needs input` : activity
+  const stateSummary = () => {
+    const values = tabs().map((tab) => controller.status(tab.sessionID))
+    const running = values.filter((status) => status.busy).length
+    const unread = values.filter((status) => status.unread !== undefined).length
+    return [`selected ${number(active() ?? "")}`, `${running} running`, `${unread} unread`].join("  ·  ")
   }
 
   props.context.keymap.layer(() => ({
@@ -255,8 +237,8 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           props.context.ui.router.navigate({ type: "plugin", name: "storybook" })
         },
       },
-      { bind: "left,h", title: "Previous tab", group: "Storybook", run: () => cycle(-1) },
-      { bind: "right,l", title: "Next tab", group: "Storybook", run: () => cycle(1) },
+      { bind: "up,k,left,h", title: "Previous tab", group: "Storybook", run: () => cycle(-1) },
+      { bind: "down,j,right,l", title: "Next tab", group: "Storybook", run: () => cycle(1) },
       ...Array.from({ length: 10 }, (_, index) => ({
         bind: String((index + 1) % 10),
         title: `Select tab ${index + 1}`,
@@ -280,6 +262,29 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         },
       },
       {
+        bind: "e",
+        title: "End a random running tab",
+        group: "Storybook",
+        run() {
+          const tab = randomRunningTab()
+          if (!tab) {
+            setLastEvent("no tabs are running; press space to start one")
+            return
+          }
+          finishRun(tab.sessionID)
+        },
+      },
+      {
+        bind: "p",
+        title: "Prompt selected tab",
+        group: "Storybook",
+        run() {
+          const current = active()
+          if (!current) return
+          prompt(current)
+        },
+      },
+      {
         // Random runs stay off the selected tab, so this is the way to watch the edge flash
         // and running sweep under the cursor.
         bind: "s",
@@ -298,12 +303,18 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       { bind: "t", title: "Add tab", group: "Storybook", run: addTab },
       { bind: "d", title: "Close tab", group: "Storybook", run: () => controller.close() },
       {
+        bind: "o",
+        title: "Toggle tab orientation",
+        group: "Storybook",
+        run() {
+          setOrientation((value) => (value === "vertical" ? "horizontal" : "vertical"))
+        },
+      },
+      {
         bind: "r",
         title: "Reset",
         group: "Storybook",
         run() {
-          runs.forEach(clearTimeout)
-          runs.clear()
           batch(() => {
             setItems(FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })))
             setStatuses({})
@@ -323,37 +334,34 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       flexDirection="column"
       backgroundColor={theme.background.default}
     >
-      <SessionTabs controller={controller} />
-      <box height={1} />
-      <box flexGrow={1} paddingLeft={2} paddingRight={2} flexDirection="column">
-        <For each={transcript()}>
-          {(line) => (
-            <text fg={line.color} wrapMode="none" selectable={false}>
-              {line.text || " "}
-            </text>
-          )}
-        </For>
+      <box flexGrow={1} flexDirection={orientation() === "vertical" ? "row" : "column"}>
+        <SessionTabs controller={controller} orientation={orientation()} />
+        <box flexGrow={1} paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
+          <For each={transcript()}>
+            {(line) => (
+              <text fg={line.color} wrapMode="none" selectable={false}>
+                {line.text || " "}
+              </text>
+            )}
+          </For>
+        </box>
       </box>
-      <box paddingLeft={2} flexDirection="column">
-        <text fg={theme.text.subdued}>
-          selected: {number(active() ?? "")} | state: {selectedState()}
-        </text>
-        <text fg={theme.text.subdued}>background: {lastEvent()}</text>
-      </box>
-      <box
-        height={1}
-        flexShrink={0}
-        backgroundColor={elevatedTheme.background.default}
-        paddingLeft={1}
-        paddingRight={1}
-        flexDirection="row"
-      >
-        <text fg={elevatedTheme.text.subdued}>storybook / tabs</text>
-        <box flexGrow={1} />
-        <text fg={elevatedTheme.text.subdued}>
-          space/s run | t add | d close | r reset | ←/→ 1-0 move | drag reorders | esc back
-        </text>
-      </box>
+      <StoryFooter
+        context={props.context}
+        title="storybook / tabs"
+        details={[orientation() === "vertical" ? "left rail" : "top strip"]}
+        status={stateSummary()}
+        message={lastEvent()}
+        controls={[
+          { shortcut: "space", label: "start" },
+          { shortcut: "p", label: "prompt" },
+          { shortcut: "e", label: "end" },
+          { shortcut: "↑/↓", label: "select" },
+          { shortcut: "o", label: "layout" },
+          { shortcut: "r", label: "reset" },
+          { shortcut: "esc", label: "back" },
+        ]}
+      />
     </box>
   )
 }

--- a/packages/tui/test/component/tab-pulse.test.tsx
+++ b/packages/tui/test/component/tab-pulse.test.tsx
@@ -4,6 +4,7 @@ import {
   blendTabPulseColor,
   completionPulseOpacity,
   glowIgnitionLevel,
+  tabFlashIntensity,
   unreadGlowIntensity,
 } from "../../src/component/tab-pulse"
 import { tint } from "../../src/theme/color"
@@ -37,6 +38,16 @@ test("unread glow peaks behind the tab number and fades to the normal background
 test("unread glow reaches the normal background on compact tabs", () => {
   expect(unreadGlowIntensity(0, 8)).toBe(1)
   expect(unreadGlowIntensity(7, 8)).toBe(0)
+})
+
+test("tab flash holds behind the shortcut then feathers to the background", () => {
+  const intensities = Array.from({ length: 10 }, (_, index) => tabFlashIntensity(index, 8))
+
+  expect(intensities[0]).toBe(1)
+  expect(intensities[1]).toBe(1)
+  expect(intensities[2]).toBeLessThan(1)
+  expect(intensities.slice(1)).toEqual(intensities.slice(1).sort((a, b) => b - a))
+  expect(intensities.at(-1)).toBe(0)
 })
 
 test("reuses a color while preserving the original glow and pulse blend stages", () => {


### PR DESCRIPTION
## What

Refines session-tab activity feedback in both layouts:

- vertical tabs use a compact 10-cell running sweep instead of washing the full row
- selected shortcuts stay neutral, while running shortcuts turn interactive blue
- start, reprompt, and completion brighten the shortcut, then settle into its durable state
- vertical flashes radiate from the shortcut with a feathered falloff
- top tabs adopt the same shortcut color and flash semantics without changing their background pulse
- the Tabs story can hold runs open, reprompt the selected session, end runs, and switch layouts

## How

- `packages/tui/src/component/session-tabs.tsx` shares a number-ignition primitive across vertical and horizontal tabs and applies the selected/running color semantics.
- `packages/tui/src/component/tab-pulse.tsx` adds an optional flash tail so localized flashes can fade spatially instead of ending as a hard block.
- `packages/tui/src/feature-plugins/system/storybook/` adds reusable footer chrome and richer manual controls for inspecting tab states.

## Scope

This does not change the horizontal tab background pulse geometry. It only aligns shortcut color and ignition behavior there.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 689 passed, 5 skipped
- push hook monorepo typecheck: 32 packages passed
- real PTY verification in both left-rail and top-strip layouts

## Demo

Real PTY recording with the `opencode-drive` fixture selected. It shows vertical start/reprompt, then top-tab reprompt/completion.

https://github.com/user-attachments/assets/07f18419-bea6-4c51-aaa3-0859e4be2725
