### PR TITLE
chore(ci): surface bun exit code with ::warning:: on failure

### DIFF
--- a/.github/workflows/close-prs.yml
+++ b/.github/workflows/close-prs.yml
@@ -47,4 +47,8 @@ jobs:
             args+=("--execute")
           fi
 
-          bun script/github/close-prs.ts "${args[@]}"
+          bun script/github/close-prs.ts "${args[@]}" || {
+            exit_code=$?
+            echo "::warning::close-prs.ts exited with code $exit_code — check logs for GraphQL/token-scope errors"
+            exit $exit_code
+          }


### PR DESCRIPTION
## Summary

Wrap the `bun script/github/close-prs.ts` invocation in `.github/workflows/close-prs.yml` so a non-zero exit code emits a `::warning::` annotation visible in the run log.

Fixes #42157

## Problem

When the close-prs bun script fails (GraphQL pagination error, token-scope error, unhandled exception), the workflow step fails silently — the error is buried in the full log with no visible annotation in the run summary. This makes diagnosing close-prs failures harder than necessary.

## Fix

```yaml
bun script/github/close-prs.ts "${args[@]}" || {
  exit_code=$?
  echo "::warning::close-prs.ts exited with code $exit_code — check logs for GraphQL/token-scope errors"
  exit $exit_code
}
```

The exit code is still propagated (`exit $exit_code`), so the workflow step still fails — but now the failure reason is visible at a glance in the run summary via the `::warning::` annotation.

## Verification

- Pre-commit hooks passed
- The change is in the workflow YAML, not the TypeScript script itself — no test changes needed
- Tested on the fork `niStee/opencode` (same workflow file, same failure mode observed in run #13)