### PR TITLE
docs: add Orshot to the MCP server examples

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,35 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Orshot
+
+Add the [Orshot MCP server](https://orshot.com/docs/integrations/mcp-server) to render images, PDFs, and video from your own templates.
+
+```json title="opencode.json" {4-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "orshot": {
+      "type": "remote",
+      "url": "https://mcp.orshot.com/mcp"
+    }
+  }
+}
+```
+
+The server supports dynamic client registration, so there is no key to paste — OpenCode opens the browser on first use. A free account comes with render credits.
+
+```txt "use the orshot tool"
+Render an OG image from my blog-post template with this title and set it as the og:image. use the orshot tool
+```
+
+Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/).
+
+```md title="AGENTS.md"
+When a task needs a social image, OG image, or a PDF rendered from a template, use `orshot` tools.
+```
+
+Orshot exposes a large tool surface, so it is a good candidate for [enabling per agent](#per-agent) rather than globally.

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -515,7 +515,7 @@ If you are unsure how to do something, use `gh_grep` to search code examples fro
 
 ### Orshot
 
-Add the [Orshot MCP server](https://orshot.com/docs/integrations/mcp-server) to render images, PDFs, and video from your own templates.
+Add the [Orshot MCP server](https://orshot.com/agents/opencode) to render images, PDFs, and video from your own templates.
 
 ```json title="opencode.json" {4-7}
 {


### PR DESCRIPTION
### Issue for this PR

Closes #

No issue — docs-only addition, under the "Documentation improvements" bullet in CONTRIBUTING.md. Happy to open one if you'd prefer.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Orshot to the MCP server examples, in the same shape as the Sentry / Context7 / Grep entries: one config snippet, a prompt, and an AGENTS.md rule.

Orshot renders images, PDFs and video from templates. The case this covers is an agent that just wrote a page and needs the OG image to go with it, without leaving the terminal.

Two things differ from the existing entries:

- No `oauth` block and no key in the snippet. The server does dynamic client registration, so the bare remote entry is enough — OpenCode runs the browser flow on first use.
- A link to [Per agent](#per-agent) at the end. Orshot exposes ~66 tools and the page already warns about MCP context cost up top, so it seemed worth pointing at the escape hatch from the example that most needs it.

Disclosure: I build Orshot, so this is a vendor-submitted entry. Fine by me if you'd rather keep the list to third-party examples — say so and I'll close it.

### How did you verify your code works?

Markdown only, so there was nothing to run. What I did check:

- The snippet matches the Remote schema documented higher on the same page (`type`, `url`).
- The `#per-agent` anchor resolves — the heading is at line 347 of the same file.
- The "no key needed" claim, by hand against the server:

```
$ curl -s -o /dev/null -w '%{http_code}' -X POST https://mcp.orshot.com/mcp -d '{...initialize...}'
401
$ curl -sI ... | grep -i www-authenticate
www-authenticate: Bearer resource_metadata="https://mcp.orshot.com/.well-known/oauth-protected-resource"
```

  The authorization server metadata advertises `registration_endpoint` and `code_challenge_methods_supported: ["S256"]`, which is the RFC 7591 path your OAuth handler takes.

I did not build the docs site, and I don't have opencode installed to run a live session against it. If you want that before merging, tell me and I'll do it.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally — to the extent above; no docs build
- [x] I have not included unrelated changes in this PR
