### PR TITLE
fix(opencode): bridge question tool to ACP elicitation

### DIFF
--- a/packages/opencode/specs/acp-elicitation.md
+++ b/packages/opencode/specs/acp-elicitation.md
@@ -1,0 +1,299 @@
+# ACP Elicitation for Questions
+
+## Problem
+
+The `question` tool can block indefinitely when opencode is used through ACP. The registered opencode tool currently uses the legacy question service and publishes `question.asked`; the core V2 question service publishes the equivalent `question.v2.asked` event. In both cases the tool creates a pending question request and then waits for the matching reply or reject.
+
+ACP has the matching protocol concept: the agent can call `elicitation/create` on the client and wait for an accept, decline, or cancel response. The ACP adapter should bridge opencode's `QuestionV2` event to ACP elicitation and then settle the original question request.
+
+## Current Shape
+
+The core question path is:
+
+```text
+LLM tool call
+  -> question tool execute
+  -> QuestionV2.ask(...)
+  -> publish question.asked or question.v2.asked
+  -> wait for reply/reject
+```
+
+The app and desktop clients handle this by consuming question events, adapting V2 events to the existing app state shape when needed, rendering `SessionQuestionDock`, then calling the question HTTP API with the real request ID.
+
+ACP already does a similar bridge for permissions:
+
+```text
+permission.asked
+  -> connection.requestPermission(...)
+  -> sdk.permission.reply(...)
+```
+
+Questions should follow the same pattern:
+
+```text
+question.asked / question.v2.asked
+  -> connection.unstable_createElicitation(...)
+  -> sdk.question.reply(...) or sdk.question.reject(...)
+```
+
+## Design
+
+`packages/opencode/src/acp/event.ts` should treat `question.asked` as the current source of truth for ACP elicitation and should also handle `question.v2.asked` defensively for the core V2 path.
+
+Do not derive elicitation from `message.part.updated` question tool parts. Tool parts describe projected transcript state; they do not carry the `QuestionV2` request ID needed to unblock the pending question. A tool part's `callID` is the model/tool call ID, not the question request ID.
+
+The event contains both identities needed by the bridge:
+
+- `event.properties.id`: the real question request ID. Use this for `sdk.question.reply` and `sdk.question.reject`.
+- `event.properties.tool?.callID`: the originating tool call ID. Use this as ACP `toolCallId` when present.
+
+The ACP event subscription should add handlers for both `question.asked` and `question.v2.asked`:
+
+```text
+on question.asked or question.v2.asked:
+  find ACP session by event.properties.sessionID
+  if session is unknown:
+    return
+
+  if the client did not advertise elicitation support:
+    reject event.properties.id
+    return
+
+  if connection.unstable_createElicitation is unavailable:
+    reject event.properties.id
+    return
+
+  call unstable_createElicitation({
+    mode: "form",
+    sessionId: event.properties.sessionID,
+    toolCallId: event.properties.tool?.callID,
+    message,
+    requestedSchema,
+  })
+
+  if response.action is "accept":
+    convert response.content to QuestionV2 answers
+    reply event.properties.id
+    return
+
+  reject event.properties.id
+```
+
+`initialize` should record whether the ACP client advertised elicitation support. The bridge should not infer support only from method presence because the ACP SDK type may expose optional methods that a client did not negotiate.
+
+## Schema Mapping
+
+Each `QuestionV2.Info` should become one property in the ACP form schema.
+
+Single-select question:
+
+```text
+type: "string"
+title: question.header
+description: question.question
+enum: question.options[].label
+```
+
+Multi-select question:
+
+```text
+type: "array"
+title: question.header
+description: question.question
+items.anyOf: question.options[].label as const/title entries
+```
+
+Use `question.header` as the property key because it is the short user-facing label already used by the question tool. Duplicate headers are ambiguous; the first implementation may preserve current behavior, but production code should either disambiguate duplicate keys or reject the elicitation safely.
+
+On accept, convert ACP response content back into `QuestionV2.Reply.answers` in the original question order:
+
+- string value -> single selected label
+- array value -> selected labels
+- missing or empty value -> empty answer array
+
+## Capability Behavior
+
+If a client does not advertise `clientCapabilities.elicitation`, opencode should not leave the tool blocked.
+
+The conservative behavior is to reject the pending question request. This matches the existing issue goal: clients that cannot answer questions should not hang the session. A rejection becomes a `QuestionV2.RejectedError`, which the runner can treat as a declined user interaction.
+
+## Event Ordering
+
+`question.asked` and `question.v2.asked` are emitted before the corresponding question service waits on its Deferred. The question event is the earliest reliable point where ACP can ask the user and settle the request.
+
+`message.part.updated` may arrive before, after, or not in time for this bridge depending on projection and stream timing. It is still useful for ACP `session_update` tool-call display, but it should not own question elicitation.
+
+## Implementation Plan
+
+### Production Code Changes
+
+`packages/opencode/src/acp/elicitation.ts`
+
+- Replace the current `QuestionToolPart` input type with a question request input type:
+
+  ```ts
+  type QuestionRequest = {
+    readonly id: string
+    readonly sessionID: string
+    readonly questions: ReadonlyArray<QuestionInfo>
+    readonly tool?: { readonly messageID: string; readonly callID: string }
+  }
+  ```
+
+- `Handler.handle(...)` should accept this question request shape, not a `ToolPart`.
+- `Handler.process(...)` should:
+  - look up the ACP session by `request.sessionID`
+  - return without action if the session is unknown
+  - reject `request.id` if the request has no questions
+  - reject `request.id` if elicitation is unsupported or unavailable
+  - call `unstable_createElicitation(buildRequest(request))` when supported
+  - reply `request.id` on `accept`
+  - reject `request.id` on `decline`, `cancel`, missing response, or client call failure
+- `buildRequest(...)` should set:
+  - `sessionId: request.sessionID`
+  - `toolCallId: request.tool?.callID`
+  - `requestedSchema` from `request.questions`
+- Remove every use of `part.callID` as a question request ID.
+
+`packages/opencode/src/acp/event.ts`
+
+- Add `question.asked` and `question.v2.asked` to the event switch in `Subscription.handle(...)`.
+- Route that event to `this.elicitation.handle(event.properties)`.
+- Do not invoke `this.elicitation.handle(...)` from the `message.part.updated` / `handleToolPart(...)` path.
+- Keep existing `toolStart(...)`, `runningTool(...)`, completed, and error updates for tool display. The question tool can still appear in ACP `session_update`; it just must not own the elicitation/reply flow.
+- Keep `enableElicitation()` as the capability toggle if the implementation keeps negotiation state inside `ACPElicitation.Handler`.
+
+`packages/opencode/src/acp/service.ts`
+
+- Keep the `initialize(...)` capability hook, but remove debug logging.
+- On initialize, call `events?.enableElicitation()` only when `params.clientCapabilities?.elicitation` is present.
+- Do not advertise or enable the question tool from ACP initialization as part of this bridge. Tool availability should remain controlled by the existing registry logic and tests should opt in explicitly when needed.
+
+### Cleanup Required Before Fixing Behavior
+
+Remove all temporary debug code from production files:
+
+- `packages/opencode/src/acp/elicitation.ts`
+  - remove dynamic `import("fs")`
+  - remove `/tmp/acp-debug.log` writes
+- `packages/opencode/src/acp/event.ts`
+  - remove dynamic `import("fs")`
+  - remove `/tmp/acp-debug.log` writes in `handle(...)` and `handleToolPart(...)`
+- `packages/opencode/src/acp/service.ts`
+  - remove dynamic `import("fs")`
+  - remove `/tmp/acp-debug.log` writes in `initialize(...)`
+- Delete the ad hoc debug entrypoint:
+  - `packages/opencode/debug_acp.ts`
+
+Do this before evaluating test results. The debug writes can hide timing problems, leave noisy side effects, and should not ship.
+
+### Hanging Prevention Rules
+
+Every code path that observes a `question.asked` or `question.v2.asked` event for a known ACP session must eventually settle the pending question unless the process is interrupted.
+
+The handler must call exactly one of:
+
+```ts
+sdk.question.reply({ requestID: request.id, directory: session.cwd, answers })
+sdk.question.reject({ requestID: request.id, directory: session.cwd })
+```
+
+for these cases:
+
+- client does not advertise elicitation support: reject
+- `connection.unstable_createElicitation` is missing: reject
+- question request contains no questions: reject
+- `unstable_createElicitation(...)` throws/rejects: reject
+- client returns `{ action: "accept" }`: reply
+- client returns `{ action: "decline" }`: reject
+- client returns `{ action: "cancel" }`: reject
+- client returns no response or an invalid response: reject
+
+The handler should catch reply/reject failures so ACP event processing does not crash, but tests should make those failures visible through assertions where possible.
+
+Do not use `tool.callID` or `part.callID` for `sdk.question.reply(...)` or `sdk.question.reject(...)`. That is the hanging bug. The only valid unblock ID is the question request ID from the question event.
+
+### Testing Changes
+
+`packages/opencode/test/acp/elicitation.test.ts`
+
+- Change the tests to emit `question.asked`, not synthetic `message.part.updated` tool parts.
+- Test data must use different IDs:
+
+  ```text
+  question request id: que_test
+  tool call id: call_test
+  ```
+
+- Assertions must verify:
+  - `unstable_createElicitation(...)` receives `toolCallId: "call_test"`
+  - `sdk.question.reply(...)` receives `requestID: "que_test"`
+  - `sdk.question.reject(...)` receives `requestID: "que_test"`
+- Keep coverage for:
+  - accept maps answers and replies
+  - decline rejects
+  - cancel rejects
+  - unsupported client auto-rejects
+  - `unstable_createElicitation` failure rejects
+  - multiple questions
+  - multi-select questions
+  - unknown ACP session does not call elicitation or reply/reject
+- Add a regression test that would fail if `tool.callID` is used as `requestID`.
+
+`packages/opencode/test/cli/acp/elicitation.test.ts`
+
+- Keep this as subprocess coverage, but make the test harness fail faster.
+- The test must explicitly enable the question tool for ACP. Normal ACP does not expose the question tool because `OPENCODE_CLIENT=acp`; the registry only includes it when `enableQuestionTool` is true.
+- Add one happy-path test:
+  - initialize with `clientCapabilities.elicitation`
+  - create a session
+  - model calls `question`
+  - test client receives `elicitation/create`
+  - test client returns `accept`
+  - `session/prompt` returns `stopReason: "end_turn"`
+- Add one unsupported-client test:
+  - initialize without elicitation support
+  - model calls `question`
+  - no `elicitation/create` is observed
+  - `session/prompt` still returns instead of timing out
+- Add one decline test if runtime cost is acceptable:
+  - client returns `decline`
+  - prompt returns instead of timing out
+- The per-test infrastructure timeout can remain high, but the harness should include shorter intent-specific waits. For example, after the model emits the question tool, fail within a few seconds if the expected `elicitation/create` request is not observed.
+- The JSON-RPC driver must keep serving inbound requests while `session/prompt` is pending. Do not use a receive loop that can be monopolized by the outbound prompt response wait.
+
+### Expected Diff Shape
+
+The final implementation should primarily touch:
+
+- `packages/opencode/src/acp/elicitation.ts`
+- `packages/opencode/src/acp/event.ts`
+- `packages/opencode/src/acp/service.ts`
+- `packages/opencode/test/acp/elicitation.test.ts`
+- `packages/opencode/test/cli/acp/elicitation.test.ts`
+
+It should delete:
+
+- `packages/opencode/debug_acp.ts`
+
+It should not require changes to:
+
+- `packages/core/src/question.ts`
+- `packages/core/src/tool/question.ts`
+- `packages/opencode/src/tool/registry.ts`
+- generated SDK files
+- Protocol or Server `HttpApi`
+
+## Non-Goals
+
+Do not teach ACP clients to call opencode's HTTP question API directly. That leaks opencode-specific control flow through the ACP boundary.
+
+Do not use a plugin to bridge question events to ACP. The ACP adapter already has the connection and the opencode SDK; this belongs in the adapter.
+
+Do not make `message.part.updated` the source of truth for replying to questions. It does not contain the request ID that `QuestionV2` requires.
+
+## Open Questions
+
+- Should duplicate question headers be rejected, disambiguated, or encoded under generated stable keys?
+- Should ACP advertise an agent capability for elicitation support in `initialize`, or is client capability negotiation sufficient for now?
+- Should the question tool remain disabled by default for ACP and only be enabled when the client advertises elicitation support, or should existing `enableQuestionTool` remain the only override?

--- a/packages/opencode/src/acp/elicitation.ts
+++ b/packages/opencode/src/acp/elicitation.ts
@@ -1,0 +1,117 @@
+import type { AgentSideConnection, CreateElicitationRequest, ElicitationPropertySchema } from "@agentclientprotocol/sdk"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { Effect } from "effect"
+import type { ACPSession } from "./session"
+
+type Connection = Partial<Pick<AgentSideConnection, "unstable_createElicitation">>
+
+type QuestionInfo = {
+  readonly question: string
+  readonly header: string
+  readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+  readonly multiple?: boolean
+}
+
+export type QuestionRequest = {
+  readonly id: string
+  readonly sessionID: string
+  readonly questions: ReadonlyArray<QuestionInfo>
+  readonly tool?: { readonly messageID: string; readonly callID: string }
+}
+
+export class Handler {
+  private supported = false
+
+  constructor(
+    private readonly input: {
+      sdk: OpencodeClient
+      connection: Connection
+      session: ACPSession.Interface
+    },
+  ) {}
+
+  enable() {
+    this.supported = true
+  }
+
+  handle(request: QuestionRequest) {
+    void this.process(request).catch(() => {})
+  }
+
+  private async process(request: QuestionRequest) {
+    const session = await Effect.runPromise(this.input.session.tryGet(request.sessionID))
+    if (!session) return
+
+    const questions = request.questions
+    if (!questions?.length) {
+      await this.input.sdk.question.reject({ requestID: request.id, directory: session.cwd }).catch(() => {})
+      return
+    }
+
+    if (!this.supported || !this.input.connection.unstable_createElicitation) {
+      await this.input.sdk.question.reject({ requestID: request.id, directory: session.cwd }).catch(() => {})
+      return
+    }
+
+    const response = await this.input.connection
+      .unstable_createElicitation(buildRequest(request))
+      .catch(() => undefined)
+
+    if (!response || response.action !== "accept") {
+      await this.input.sdk.question.reject({ requestID: request.id, directory: session.cwd }).catch(() => {})
+      return
+    }
+
+    const answers: string[][] = buildAnswers(questions, response.content ?? {}).map((a) => [...a])
+    await this.input.sdk.question.reply({ requestID: request.id, directory: session.cwd, answers }).catch(() => {})
+  }
+}
+
+function buildRequest(request: QuestionRequest): CreateElicitationRequest {
+  const properties: Record<string, ElicitationPropertySchema> = {}
+  const required: string[] = []
+
+  for (const q of request.questions) {
+    properties[q.header] = toPropertySchema(q)
+    required.push(q.header)
+  }
+
+  return {
+    mode: "form",
+    sessionId: request.sessionID,
+    toolCallId: request.tool?.callID,
+    message: request.questions.map((q) => q.question).join(" / "),
+    requestedSchema: { type: "object", properties, required },
+  }
+}
+
+function toPropertySchema(q: QuestionInfo): ElicitationPropertySchema {
+  if (q.multiple) {
+    return {
+      type: "array",
+      title: q.header,
+      description: q.question,
+      items: { anyOf: q.options.map((o) => ({ const: o.label, title: o.label })) },
+    }
+  }
+  return {
+    type: "string",
+    title: q.header,
+    description: q.question,
+    enum: q.options.map((o) => o.label),
+  }
+}
+
+function buildAnswers(
+  questions: ReadonlyArray<QuestionInfo>,
+  content: Record<string, unknown>,
+): ReadonlyArray<ReadonlyArray<string>> {
+  return questions.map((q) => {
+    const value = content[q.header]
+    if (Array.isArray(value)) return value.map(String)
+    if (typeof value === "string" && value.length > 0) return [value]
+    return []
+  })
+}
+
+export * as ACPElicitation from "./elicitation"

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -11,6 +11,7 @@ import type {
 import { Effect } from "effect"
 import { ACPSession } from "./session"
 import { ACPPermission } from "./permission"
+import { ACPElicitation } from "./elicitation"
 import { partsToContentChunks, type ReplayPart } from "./content"
 import {
   duplicateRunningToolUpdate,
@@ -22,7 +23,7 @@ import {
 } from "./tool"
 
 type Connection = Pick<AgentSideConnection, "sessionUpdate"> &
-  Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
+  Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile" | "unstable_createElicitation">>
 type GlobalEventEnvelope = {
   payload?: Event
 }
@@ -43,6 +44,7 @@ export class Subscription {
   private readonly connectionWaiters = new Set<() => void>()
   private readonly idleWaiters = new Map<string, Set<ReturnType<typeof signal>>>()
   private readonly permission: ACPPermission.Handler
+  private readonly elicitation: ACPElicitation.Handler
   private connected = false
   private started = false
 
@@ -54,6 +56,7 @@ export class Subscription {
     },
   ) {
     this.permission = new ACPPermission.Handler(input)
+    this.elicitation = new ACPElicitation.Handler(input)
   }
 
   start() {
@@ -69,6 +72,10 @@ export class Subscription {
     this.disconnected()
     for (const resolve of this.connectionWaiters) resolve()
     this.connectionWaiters.clear()
+  }
+
+  enableElicitation() {
+    this.elicitation.enable()
   }
 
   async runUntilIdle<A>(sessionId: string, request: () => Promise<A>) {
@@ -97,6 +104,12 @@ export class Subscription {
         return
       case "permission.asked":
         this.permission.handle(event)
+        return
+      case "question.asked":
+        this.elicitation.handle(event.properties)
+        return
+      case "question.v2.asked":
+        this.elicitation.handle(event.properties)
         return
       case "message.part.updated":
         return this.handlePartUpdated(event)

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -50,7 +50,7 @@ export const AuthMethodID = "opencode-login"
 
 export type Error = ACPError.Error
 type ServiceConnection = Pick<AgentSideConnection, "sessionUpdate"> &
-  Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
+  Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile" | "unstable_createElicitation">>
 
 export type Interface = {
   readonly initialize: (input: InitializeRequest) => Effect.Effect<InitializeResponse, Error>
@@ -107,6 +107,10 @@ export function make(input: {
           label: "OpenCode Login",
         },
       }
+    }
+
+    if (params.clientCapabilities?.elicitation) {
+      events?.enableElicitation()
     }
 
     const response = {

--- a/packages/opencode/test/acp/elicitation.test.ts
+++ b/packages/opencode/test/acp/elicitation.test.ts
@@ -1,0 +1,456 @@
+import { describe, expect, it } from "bun:test"
+import type { AgentSideConnection, CreateElicitationRequest, CreateElicitationResponse } from "@agentclientprotocol/sdk"
+import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, ManagedRuntime } from "effect"
+import { ACPEvent } from "@/acp/event"
+import { ACPSession } from "@/acp/session"
+
+type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
+type QuestionReplyParams = Parameters<OpencodeClient["question"]["reply"]>[0]
+type QuestionRejectParams = Parameters<OpencodeClient["question"]["reject"]>[0]
+
+const pollUntil = async (
+  check: () => boolean | Promise<boolean>,
+  message: string,
+  opts?: { timeoutMs?: number; intervalMs?: number },
+) => {
+  const started = Date.now()
+  while (true) {
+    if (await check()) return
+    if (Date.now() - started > (opts?.timeoutMs ?? 2000)) throw new Error(message)
+    await new Promise((resolve) => setTimeout(resolve, opts?.intervalMs ?? 5))
+  }
+}
+
+function makeSessionService() {
+  return ManagedRuntime.make(LayerNode.compile(ACPSession.node)).runSync(
+    ACPSession.Service.use((service) => Effect.succeed(service)),
+  )
+}
+
+type QuestionOption = { label: string; description: string }
+
+function questionAsked(overrides: {
+  sessionID: string
+  requestID: string
+  toolCallID?: string
+  type?: "question.asked" | "question.v2.asked"
+  questions?: Array<{ question: string; header: string; options: QuestionOption[]; multiple?: boolean }>
+}): Event {
+  return {
+    id: `evt_${overrides.requestID}`,
+    type: overrides.type ?? "question.asked",
+    properties: {
+      id: overrides.requestID,
+      sessionID: overrides.sessionID,
+      tool: {
+        messageID: `msg_${overrides.toolCallID ?? "call_q"}`,
+        callID: overrides.toolCallID ?? "call_q",
+      },
+      questions:
+        overrides.questions ?? [
+          {
+            question: "Which environment?",
+            header: "Environment",
+            options: [
+              { label: "staging", description: "Staging environment" },
+              { label: "production", description: "Production environment" },
+            ],
+          },
+        ],
+    },
+  } as Event
+}
+
+function questionAskedWithoutTool(overrides: {
+  sessionID: string
+  requestID: string
+  questions?: Array<{ question: string; header: string; options: QuestionOption[]; multiple?: boolean }>
+}): Event {
+  return {
+    id: `evt_${overrides.requestID}`,
+    type: "question.asked",
+    properties: {
+      id: overrides.requestID,
+      sessionID: overrides.sessionID,
+      questions:
+        overrides.questions ?? [
+          {
+            question: "Which environment?",
+            header: "Environment",
+            options: [
+              { label: "staging", description: "Staging environment" },
+              { label: "production", description: "Production environment" },
+            ],
+          },
+        ],
+    },
+  } as Event
+}
+
+function toolUpdatedQuestion(overrides: {
+  sessionID: string
+  callID: string
+  questions?: Array<{ question: string; header: string; options: QuestionOption[]; multiple?: boolean }>
+}): Event {
+  return {
+    id: `evt_${overrides.callID}`,
+    type: "message.part.updated",
+    properties: {
+      sessionID: overrides.sessionID,
+      time: Date.now(),
+      part: {
+        id: `part_${overrides.callID}`,
+        sessionID: overrides.sessionID,
+        messageID: `msg_${overrides.callID}`,
+        type: "tool",
+        callID: overrides.callID,
+        tool: "question",
+        state: {
+          status: "running",
+          input: {
+            questions:
+              overrides.questions ?? [
+                {
+                  question: "Which environment?",
+                  header: "Environment",
+                  options: [
+                    { label: "staging", description: "Staging environment" },
+                    { label: "production", description: "Production environment" },
+                  ],
+                },
+              ],
+          },
+          title: "question",
+          time: { start: Date.now() },
+        },
+      },
+    },
+  } as Event
+}
+
+function createHarness(createElicitation?: (params: CreateElicitationRequest) => Promise<CreateElicitationResponse>) {
+  const replies: QuestionReplyParams[] = []
+  const rejects: QuestionRejectParams[] = []
+  const elicitations: CreateElicitationRequest[] = []
+  const updates: SessionUpdateParams[] = []
+  const session = makeSessionService()
+
+  const sdk = {
+    global: {
+      event: () => Promise.resolve({ stream: (async function* () {})() }),
+    },
+    session: {
+      message: () => Promise.resolve({ data: undefined }),
+    },
+    question: {
+      reply: (params: QuestionReplyParams) => {
+        replies.push(params)
+        return Promise.resolve({ data: undefined })
+      },
+      reject: (params: QuestionRejectParams) => {
+        rejects.push(params)
+        return Promise.resolve({ data: undefined })
+      },
+    },
+  } as unknown as OpencodeClient
+
+  const connection = {
+    sessionUpdate: (params: SessionUpdateParams) => {
+      updates.push(params)
+      return Promise.resolve()
+    },
+    ...(createElicitation
+      ? {
+          unstable_createElicitation: (params: CreateElicitationRequest) => {
+            elicitations.push(params)
+            return createElicitation(params)
+          },
+        }
+      : {}),
+  } satisfies Pick<AgentSideConnection, "sessionUpdate"> &
+    Partial<Pick<AgentSideConnection, "unstable_createElicitation">>
+
+  const subscription = new ACPEvent.Subscription({ sdk, connection, session })
+  if (createElicitation) subscription.enableElicitation()
+
+  return { elicitations, replies, rejects, session, subscription, updates }
+}
+
+async function createSession(session: ACPSession.Interface, sessionId: string, cwd = "/workspace") {
+  await Effect.runPromise(session.create({ id: sessionId, cwd }))
+}
+
+describe("acp elicitation", () => {
+  it("sends unstable_createElicitation and replies with accepted answers", async () => {
+    const harness = createHarness(() =>
+      Promise.resolve({ action: "accept", content: { Environment: "staging" } }),
+    )
+    await createSession(harness.session, "ses_q")
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_q", requestID: "que_q1", toolCallID: "call_q1" }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "question was never replied")
+
+    expect(harness.elicitations).toHaveLength(1)
+    expect(harness.elicitations[0]).toMatchObject({
+      mode: "form",
+      sessionId: "ses_q",
+      toolCallId: "call_q1",
+      message: "Which environment?",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          Environment: {
+            type: "string",
+            title: "Environment",
+            description: "Which environment?",
+            enum: ["staging", "production"],
+          },
+        },
+        required: ["Environment"],
+      },
+    })
+    expect(harness.replies[0]).toMatchObject({
+      requestID: "que_q1",
+      directory: "/workspace",
+      answers: [["staging"]],
+    })
+    expect(harness.rejects).toHaveLength(0)
+  })
+
+  it("rejects when client declines the elicitation", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "decline" }))
+    await createSession(harness.session, "ses_decline")
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_decline", requestID: "que_decline", toolCallID: "call_decline" }),
+    )
+
+    await pollUntil(() => harness.rejects.length === 1, "question was never rejected after decline")
+
+    expect(harness.rejects[0]).toMatchObject({ requestID: "que_decline", directory: "/workspace" })
+    expect(harness.replies).toHaveLength(0)
+  })
+
+  it("rejects when client cancels the elicitation", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "cancel" }))
+    await createSession(harness.session, "ses_cancel")
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_cancel", requestID: "que_cancel", toolCallID: "call_cancel" }),
+    )
+
+    await pollUntil(() => harness.rejects.length === 1, "question was never rejected after cancel")
+
+    expect(harness.rejects[0]).toMatchObject({ requestID: "que_cancel", directory: "/workspace" })
+    expect(harness.replies).toHaveLength(0)
+  })
+
+  it("auto-rejects when client does not advertise elicitation support", async () => {
+    const harness = createHarness(undefined)
+    await createSession(harness.session, "ses_no_support")
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_no_support", requestID: "que_no_support", toolCallID: "call_no_support" }),
+    )
+
+    await pollUntil(() => harness.rejects.length === 1, "question was never auto-rejected for unsupported client")
+
+    expect(harness.elicitations).toHaveLength(0)
+    expect(harness.rejects[0]).toMatchObject({ requestID: "que_no_support", directory: "/workspace" })
+  })
+
+  it("rejects when unstable_createElicitation throws", async () => {
+    const harness = createHarness(() => Promise.reject(new Error("client elicitation UI failed")))
+    await createSession(harness.session, "ses_err")
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_err", requestID: "que_err", toolCallID: "call_err" }),
+    )
+
+    await pollUntil(() => harness.rejects.length === 1, "question was never rejected after elicitation error")
+
+    expect(harness.rejects[0]).toMatchObject({ requestID: "que_err" })
+    expect(harness.replies).toHaveLength(0)
+  })
+
+  it("maps multiple questions into a single elicitation form with one property per question", async () => {
+    const harness = createHarness(() =>
+      Promise.resolve({
+        action: "accept",
+        content: { Environment: "staging", Notify: "yes" },
+      }),
+    )
+    await createSession(harness.session, "ses_multi_q")
+
+    await harness.subscription.handle(
+      questionAsked({
+        sessionID: "ses_multi_q",
+        requestID: "que_multi_q",
+        toolCallID: "call_multi_q",
+        questions: [
+          {
+            question: "Which environment?",
+            header: "Environment",
+            options: [
+              { label: "staging", description: "Staging" },
+              { label: "production", description: "Production" },
+            ],
+          },
+          {
+            question: "Notify team?",
+            header: "Notify",
+            options: [
+              { label: "yes", description: "Yes" },
+              { label: "no", description: "No" },
+            ],
+          },
+        ],
+      }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "multi-question elicitation was never replied")
+
+    const schema = harness.elicitations[0]
+    expect(schema?.mode).toBe("form")
+    if (schema?.mode === "form") {
+      expect(schema.requestedSchema.properties).toMatchObject({
+        Environment: { type: "string", enum: ["staging", "production"] },
+        Notify: { type: "string", enum: ["yes", "no"] },
+      })
+    }
+    expect(harness.replies[0]).toMatchObject({
+      answers: [["staging"], ["yes"]],
+    })
+  })
+
+  it("maps multi-select questions to array schema with anyOf items", async () => {
+    const harness = createHarness(() =>
+      Promise.resolve({ action: "accept", content: { Regions: ["us-east-1", "eu-west-1"] } }),
+    )
+    await createSession(harness.session, "ses_multi")
+
+    await harness.subscription.handle(
+      questionAsked({
+        sessionID: "ses_multi",
+        requestID: "que_multi",
+        toolCallID: "call_multi",
+        questions: [
+          {
+            question: "Which regions?",
+            header: "Regions",
+            options: [
+              { label: "us-east-1", description: "US East" },
+              { label: "eu-west-1", description: "EU West" },
+            ],
+            multiple: true,
+          },
+        ],
+      }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "multi-select question was never replied")
+
+    const schema = harness.elicitations[0]
+    expect(schema?.mode).toBe("form")
+    if (schema?.mode === "form") {
+      expect(schema.requestedSchema.properties?.["Regions"]).toMatchObject({
+        type: "array",
+        items: { anyOf: [{ const: "us-east-1", title: "us-east-1" }, { const: "eu-west-1", title: "eu-west-1" }] },
+      })
+    }
+    expect(harness.replies[0]).toMatchObject({ answers: [["us-east-1", "eu-west-1"]] })
+  })
+
+  it("does not call elicitation for unknown sessions", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "accept", content: { Environment: "staging" } }))
+
+    await harness.subscription.handle(
+      questionAsked({ sessionID: "ses_missing", requestID: "que_missing", toolCallID: "call_missing" }),
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(harness.elicitations).toHaveLength(0)
+    expect(harness.replies).toHaveLength(0)
+    expect(harness.rejects).toHaveLength(0)
+  })
+
+  it("rejects empty question requests for known sessions", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "accept", content: {} }))
+    await createSession(harness.session, "ses_empty")
+
+    await harness.subscription.handle(
+      questionAsked({
+        sessionID: "ses_empty",
+        requestID: "que_empty",
+        toolCallID: "call_empty",
+        questions: [],
+      }),
+    )
+
+    await pollUntil(() => harness.rejects.length === 1, "empty question request was never rejected")
+
+    expect(harness.elicitations).toHaveLength(0)
+    expect(harness.replies).toHaveLength(0)
+    expect(harness.rejects[0]).toMatchObject({ requestID: "que_empty", directory: "/workspace" })
+  })
+
+  it("does not reply to question tool call IDs from message part updates", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "accept", content: { Environment: "staging" } }))
+    await createSession(harness.session, "ses_tool_part")
+
+    await harness.subscription.handle(toolUpdatedQuestion({ sessionID: "ses_tool_part", callID: "call_tool_part" }))
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(harness.elicitations).toHaveLength(0)
+    expect(harness.replies).toHaveLength(0)
+    expect(harness.rejects).toHaveLength(0)
+    expect(harness.updates).toHaveLength(2)
+    expect(harness.updates.map((item) => item.update.sessionUpdate)).toEqual(["tool_call", "tool_call_update"])
+  })
+
+  it("omits toolCallId when the question event is not tied to a tool", async () => {
+    const harness = createHarness(() =>
+      Promise.resolve({ action: "accept", content: { Environment: "production" } }),
+    )
+    await createSession(harness.session, "ses_no_tool")
+
+    await harness.subscription.handle(questionAskedWithoutTool({ sessionID: "ses_no_tool", requestID: "que_no_tool" }))
+
+    await pollUntil(() => harness.replies.length === 1, "question without tool metadata was never replied")
+
+    expect(harness.elicitations[0]).toMatchObject({
+      mode: "form",
+      sessionId: "ses_no_tool",
+    })
+    expect(Reflect.get(harness.elicitations[0] ?? {}, "toolCallId")).toBeUndefined()
+    expect(harness.replies[0]).toMatchObject({
+      requestID: "que_no_tool",
+      answers: [["production"]],
+    })
+  })
+
+  it("also handles v2 question events", async () => {
+    const harness = createHarness(() => Promise.resolve({ action: "accept", content: { Environment: "staging" } }))
+    await createSession(harness.session, "ses_v2")
+
+    await harness.subscription.handle(
+      questionAsked({
+        type: "question.v2.asked",
+        sessionID: "ses_v2",
+        requestID: "que_v2",
+        toolCallID: "call_v2",
+      }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "v2 question was never replied")
+
+    expect(harness.elicitations[0]).toMatchObject({ sessionId: "ses_v2", toolCallId: "call_v2" })
+    expect(harness.replies[0]).toMatchObject({ requestID: "que_v2", answers: [["staging"]] })
+  })
+})

--- a/packages/opencode/test/cli/acp/elicitation.test.ts
+++ b/packages/opencode/test/cli/acp/elicitation.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect } from "bun:test"
+import type { CreateElicitationRequest, InitializeResponse, NewSessionResponse, PromptResponse } from "@agentclientprotocol/sdk"
+import { Duration, Effect } from "effect"
+import { cliIt, type AcpHandle } from "../../lib/cli-process"
+import { verifierConfig } from "./helpers"
+
+// Minimal duplex JSON-RPC driver that handles inbound requests from opencode
+// (e.g. elicitation/create) without touching the shared AcpClient
+// infrastructure. Lives here only — no changes to shared test helpers.
+type InboundHandler = (params: unknown) => unknown | Promise<unknown>
+
+function makeDriver(acp: AcpHandle) {
+  let nextId = 1
+  const pending = new Map<number, (msg: unknown) => void>()
+  const inbound = new Map<string, InboundHandler>()
+
+  // Fan-out loop: response → resolve pending, inbound request → call handler, else discard.
+  async function loop() {
+    while (true) {
+      let msg: unknown
+      try {
+        msg = await Effect.runPromise(acp.receive)
+      } catch {
+        break
+      }
+      if (!msg || typeof msg !== "object") continue
+
+      const m = msg as Record<string, unknown>
+
+      // Inbound request from opencode: has id + method, no result/error
+      if ("id" in m && "method" in m && !("result" in m) && !("error" in m)) {
+        const handler = inbound.get(m.method as string)
+        if (handler) {
+          Promise.resolve(handler(m.params)).then((result) => {
+            void Effect.runPromise(acp.send({ jsonrpc: "2.0", id: m.id, result: result ?? {} }))
+          })
+        }
+        continue
+      }
+
+      // Response to one of our outbound requests
+      if ("id" in m && ("result" in m || "error" in m)) {
+        const resolve = pending.get(m.id as number)
+        if (resolve) {
+          pending.delete(m.id as number)
+          resolve(msg)
+        }
+      }
+    }
+  }
+
+  void loop()
+
+  function send<T>(method: string, params?: unknown): Promise<{ result?: T; error?: unknown }> {
+    return new Promise((resolve) => {
+      const id = nextId++
+      pending.set(id, (msg) => resolve(msg as { result?: T; error?: unknown }))
+      void Effect.runPromise(
+        acp.send(params !== undefined ? { jsonrpc: "2.0", id, method, params } : { jsonrpc: "2.0", id, method }),
+      )
+    })
+  }
+
+  function on(method: string, handler: InboundHandler) {
+    inbound.set(method, handler)
+    return () => inbound.delete(method)
+  }
+
+  return { send, on }
+}
+
+function ok<T>(response: { result?: T; error?: unknown }): T {
+  expect(response.error).toBeUndefined()
+  expect(response.result).toBeDefined()
+  return response.result as T
+}
+
+describe("opencode acp elicitation subprocess", () => {
+  cliIt.live(
+    "forwards question tool to elicitation/create and unblocks on accept",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const handle = yield* opencode.acp({
+          env: {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify(verifierConfig(llm.url)),
+            OPENCODE_ENABLE_QUESTION_TOOL: "1",
+          },
+        })
+        const driver = makeDriver(handle)
+
+        ok(
+          yield* Effect.promise(() =>
+            driver.send<InitializeResponse>("initialize", {
+              protocolVersion: 1,
+              clientCapabilities: { _meta: { "terminal-auth": true }, elicitation: { form: {} } },
+              clientInfo: { name: "opencode-elicitation-test", version: "0.1.0" },
+            }),
+          ),
+        )
+
+        const session = ok(
+          yield* Effect.promise(() => driver.send<NewSessionResponse>("session/new", { cwd: home, mcpServers: [] })),
+        )
+
+        const elicitations: CreateElicitationRequest[] = []
+        driver.on("elicitation/create", (params) => {
+          elicitations.push(params as CreateElicitationRequest)
+          return { action: "accept", content: { Environment: "staging" } }
+        })
+
+        // LLM turn 1: calls question tool. Turn 2: responds with the accepted answer.
+        yield* llm.tool("question", {
+          questions: [
+            {
+              question: "Which environment?",
+              header: "Environment",
+              options: [
+                { label: "staging", description: "Staging environment" },
+                { label: "production", description: "Production environment" },
+              ],
+            },
+          ],
+        })
+        yield* llm.text("Deploying to staging.")
+
+        const response = ok(
+          yield* Effect.promise(() =>
+            Promise.race([
+              driver.send<PromptResponse>("session/prompt", {
+                sessionId: session.sessionId,
+                prompt: [{ type: "text", text: "Which environment should I deploy to?" }],
+              }),
+              new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+            ]),
+          ),
+        )
+
+        expect(response.stopReason).toBe("end_turn")
+        expect(elicitations).toHaveLength(1)
+        expect(elicitations[0]).toMatchObject({
+          mode: "form",
+          sessionId: session.sessionId,
+          requestedSchema: {
+            type: "object",
+            properties: {
+              Environment: { type: "string", enum: ["staging", "production"] },
+            },
+          },
+        })
+      }),
+    60_000,
+  )
+
+  cliIt.live(
+    "auto-rejects question tool when client does not advertise elicitation support",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const handle = yield* opencode.acp({
+          env: {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify(verifierConfig(llm.url)),
+            OPENCODE_ENABLE_QUESTION_TOOL: "1",
+          },
+        })
+        const driver = makeDriver(handle)
+
+        ok(
+          yield* Effect.promise(() =>
+            driver.send<InitializeResponse>("initialize", {
+              protocolVersion: 1,
+              // No elicitation capability
+              clientCapabilities: { _meta: { "terminal-auth": true } },
+              clientInfo: { name: "opencode-no-elicitation-test", version: "0.1.0" },
+            }),
+          ),
+        )
+
+        const session = ok(
+          yield* Effect.promise(() => driver.send<NewSessionResponse>("session/new", { cwd: home, mcpServers: [] })),
+        )
+
+        const elicitations: unknown[] = []
+        driver.on("elicitation/create", (params) => {
+          elicitations.push(params)
+          return { action: "accept", content: {} }
+        })
+
+        yield* llm.tool("question", {
+          questions: [
+            { question: "Which env?", header: "Env", options: [{ label: "prod", description: "Prod" }] },
+          ],
+        })
+        yield* llm.text("Proceeding without answer.")
+
+        const response = ok(
+          yield* Effect.promise(() =>
+            Promise.race([
+              driver.send<PromptResponse>("session/prompt", {
+                sessionId: session.sessionId,
+                prompt: [{ type: "text", text: "Which environment?" }],
+              }),
+              new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+            ]),
+          ),
+        )
+
+        expect(response.stopReason).toBe("end_turn")
+        expect(elicitations).toHaveLength(0)
+      }),
+    60_000,
+  )
+
+  cliIt.live(
+    "continues session after client declines elicitation",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const handle = yield* opencode.acp({
+          env: {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify(verifierConfig(llm.url)),
+            OPENCODE_ENABLE_QUESTION_TOOL: "1",
+          },
+        })
+        const driver = makeDriver(handle)
+
+        ok(
+          yield* Effect.promise(() =>
+            driver.send<InitializeResponse>("initialize", {
+              protocolVersion: 1,
+              clientCapabilities: { _meta: { "terminal-auth": true }, elicitation: { form: {} } },
+              clientInfo: { name: "opencode-decline-test", version: "0.1.0" },
+            }),
+          ),
+        )
+
+        const session = ok(
+          yield* Effect.promise(() => driver.send<NewSessionResponse>("session/new", { cwd: home, mcpServers: [] })),
+        )
+
+        driver.on("elicitation/create", () => ({ action: "decline" }))
+
+        yield* llm.tool("question", {
+          questions: [
+            { question: "Which env?", header: "Env", options: [{ label: "prod", description: "Prod" }] },
+          ],
+        })
+        yield* llm.text("Understood, proceeding without input.")
+
+        const response = ok(
+          yield* Effect.promise(() =>
+            Promise.race([
+              driver.send<PromptResponse>("session/prompt", {
+                sessionId: session.sessionId,
+                prompt: [{ type: "text", text: "Which environment?" }],
+              }),
+              new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), 30_000)),
+            ]),
+          ),
+        )
+
+        expect(response.stopReason).toBe("end_turn")
+      }),
+    60_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #38121

### Type of change

- [x] Bug fix

### What does this PR do?

The `question` tool blocked indefinitely in ACP mode. The root cause: `question.asked` events carry a QuestionV2 request ID that must be passed to `sdk.question.reply/reject` to unblock the waiting deferred — but the event subscription never handled these events at all, so the deferred never settled.

The fix wires `question.asked` and `question.v2.asked` into the existing event handler switch and forwards them to a new `ACPElicitation.Handler`. The handler calls `unstable_createElicitation` when the connected client advertises elicitation support (set during `initialize`), and falls back to auto-reject otherwise — preserving current behaviour for non-elicitation clients.

### How did you verify your code works?

Unit tests cover: accept, decline, cancel, unsupported client auto-reject, elicitation error, multi-question form, multi-select array schema, empty question list, unknown session, `message.part.updated` not triggering elicitation, missing `toolCallId`, and `question.v2.asked`.

Integration tests (subprocess) cover the accept path end-to-end with a real opencode process, auto-reject when the client omits elicitation capability, and the decline path.

Also verified against a live Docker Compose environment with nsjail: `create_elicitation` arrives over the ACP wire with the correct schema, the form renders, and the accepted answer is injected back into the model turn.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
