### PR TITLE
fix(catalog): serve app shell at lab route

### DIFF
--- a/packages/lab/catalog/catalog/worker.test.ts
+++ b/packages/lab/catalog/catalog/worker.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import wrangler from "../wrangler.jsonc"
 import { assetPath } from "../worker"
 
 describe("catalog worker", () => {
@@ -11,5 +12,9 @@ describe("catalog worker", () => {
   test("strips the catalog prefix from assets", () => {
     expect(assetPath("/lab/catalog/catalog.json")).toBe("/catalog.json")
     expect(assetPath("/lab/catalog/captures/opencode/home.frame.json")).toBe("/captures/opencode/home.frame.json")
+  })
+
+  test("leaves HTML routing to the worker", () => {
+    expect(wrangler.assets.html_handling).toBe("none")
   })
 })

--- a/packages/lab/catalog/wrangler.jsonc
+++ b/packages/lab/catalog/wrangler.jsonc
@@ -8,6 +8,7 @@
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",
+    "html_handling": "none",
   },
   "routes": [
     {


### PR DESCRIPTION
## What
Serve the catalog app shell at `https://dev.opencode.ai/lab/catalog` and its client-side deep links.

## Before / After
**Before:** the Worker rewrote app routes to `/index.html`, then Cloudflare Assets applied its default HTML canonicalization and redirected that internal path to `https://dev.opencode.ai/`. The bare catalog route returned a redirect/404 instead of the catalog UI, while JSON assets remained available.

**After:** Cloudflare Assets performs no independent HTML path rewriting. The Worker remains the single owner of catalog-prefix stripping and SPA fallback routing, so `/lab/catalog`, `/lab/catalog/`, and deep links resolve to the catalog app shell.

## How
- Set `assets.html_handling` to `none` in `packages/lab/catalog/wrangler.jsonc`.
- Add a regression assertion in `catalog/worker.test.ts` so Assets cannot silently regain competing HTML route behavior.

## Scope
This changes only catalog HTML route handling. Capture JSON, the committed capture set, and the `dev.opencode.ai/lab/catalog*` route remain unchanged.

## Testing
- `bun run test`
- `bun typecheck`
- `bun run build`
- `bunx wrangler deploy --dry-run`
- Full monorepo typecheck from the push hook
