### PR TITLE
Rename 'frapper' to 'bash' in tools documentation

### DIFF
--- a/packages/web/src/content/docs/fr/tools.mdx
+++ b/packages/web/src/content/docs/fr/tools.mdx
@@ -45,7 +45,7 @@ Voici tous les outils intégrés disponibles dans OpenCode.
 
 ---
 
-### frapper
+### bash
 
 Exécutez des commandes shell dans votre environnement de projet.
 


### PR DESCRIPTION
frapper means "to hit"
