### PR TITLE
fix(core): conservative shell permission fallback when tree-sitter assets cannot load

### DIFF
--- a/packages/core/src/shell/parse.ts
+++ b/packages/core/src/shell/parse.ts
@@ -1,6 +1,6 @@
 export * as ShellParse from "./parse.js"
 
-import { Effect } from "effect"
+import { Effect, Exit } from "effect"
 import { fileURLToPath } from "url"
 import os from "os"
 import path from "path"
@@ -153,8 +153,15 @@ const ARITY: Record<string, number> = {
 }
 
 export const scan = Effect.fn("ShellParse.scan")(function* (command: string, shell: string, cwd: string) {
-  const parsers = yield* Effect.promise(load)
   const powershell = ShellSelect.ps(shell)
+  const loaded = yield* Effect.promise(load).pipe(Effect.exit)
+  // Workerd has no filesystem-backed tree-sitter assets. Preserve execution
+  // with one conservative permission resource instead of disabling shell.
+  if (Exit.isFailure(loaded)) {
+    const tokens = command.trim().split(/\s+/)
+    return { commands: [{ resource: command, save: `${prefix(tokens).join(" ")} *` }], directories: [] }
+  }
+  const parsers = loaded.value
   const tree = (powershell ? parsers.ps : parsers.bash).parse(command)
   if (!tree) return yield* Effect.fail(new Error("Failed to parse shell command"))
 


### PR DESCRIPTION
## What
Keep shell execution usable when tree-sitter parser assets cannot load, such as in workerd runtimes without filesystem-backed assets. Permission analysis falls back to one conservative command resource instead of failing the scan.

## How
Capture parser loading with `Effect.exit`. On failure, return the full command as the resource, derive the reusable save prefix from the existing token arity logic, and report no directories.

## Scope
Only changes the parser-load failure path in `packages/core/src/shell/parse.ts`. Successful parser loading and detailed command/directory extraction are unchanged.

## Testing
- `bun run test test/shell-parse.test.ts test/permission.test.ts` (16 passed)
- `bun typecheck` in `packages/core`
- Push hook workspace typecheck (34 tasks passed)

No direct failure-path test was added because the loader is a closed module-level singleton; injecting a load failure would require production refactoring beyond this focused fallback.
