### PR TITLE
fix(core): subagent sessions inherit ancestor deny rules

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -115,6 +115,11 @@ interface Pending {
   readonly deferred: Deferred.Deferred<void, DeclinedError | CorrectedError>
 }
 
+interface ConfiguredPermissions {
+  readonly own: Permission.Ruleset
+  readonly ancestors: ReadonlyArray<Permission.Ruleset>
+}
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -152,35 +157,47 @@ const layer = Layer.effect(
     function configuredPermissions(
       sessionID: SessionSchema.ID,
       agentID?: Agent.ID,
-    ): Effect.Effect<ReadonlyArray<Permission.Ruleset>, SessionErrors.NotFoundError> {
+    ): Effect.Effect<ConfiguredPermissions, SessionErrors.NotFoundError> {
       return Effect.gen(function* () {
         const session = yield* sessions.get(sessionID)
         if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
         const agent = yield* agents.resolve(agentID ?? session.agent)
         const own = agent?.permissions ?? missingAgentPermissions
+        if (!session.parentID) return { own, ancestors: [] }
+        return { own, ancestors: yield* ancestorPermissions(session.parentID) }
+      })
+    }
+
+    function ancestorPermissions(
+      sessionID: SessionSchema.ID,
+    ): Effect.Effect<ReadonlyArray<Permission.Ruleset>, SessionErrors.NotFoundError> {
+      return Effect.gen(function* () {
+        const session = yield* sessions.get(sessionID)
+        if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
+        const agent = yield* agents.resolve(session.agent)
+        const own = agent?.permissions ?? []
         if (!session.parentID) return [own]
-        return [...(yield* configuredPermissions(session.parentID)), own]
+        return [...(yield* ancestorPermissions(session.parentID)), own]
       })
     }
 
     function evaluateResource(
       input: AssertInput,
       resource: string,
-      rulesets: ReadonlyArray<Permission.Ruleset>,
+      rules: ConfiguredPermissions,
       remembered: Permission.Ruleset,
     ) {
-      const configured = rulesets.map((rules) => evaluate(input.action, resource, rules).effect)
-      if (configured.includes("deny")) return "deny"
-      const effective = rulesets.map((rules) => evaluate(input.action, resource, rules, remembered).effect)
-      return effective.includes("ask") ? "ask" : "allow"
+      if (rules.ancestors.some((ruleset) => evaluate(input.action, resource, ruleset).effect === "deny")) return "deny"
+      if (evaluate(input.action, resource, rules.own).effect === "deny") return "deny"
+      return evaluate(input.action, resource, rules.own, remembered).effect
     }
 
     function evaluateRules(
       input: AssertInput,
-      rulesets: ReadonlyArray<Permission.Ruleset>,
+      rules: ConfiguredPermissions,
       remembered: Permission.Ruleset,
     ) {
-      const effects = input.resources.map((resource) => evaluateResource(input, resource, rulesets, remembered))
+      const effects = input.resources.map((resource) => evaluateResource(input, resource, rules, remembered))
       const effect: Permission.Effect = effects.includes("deny") ? "deny" : effects.includes("ask") ? "ask" : "allow"
       return effect
     }
@@ -190,15 +207,18 @@ const layer = Layer.effect(
     }
 
     const evaluateInput = Effect.fnUntraced(function* (input: AssertInput) {
-      const rulesets = yield* configured(input.sessionID, input.agent)
+      const rules = yield* configured(input.sessionID, input.agent)
       const remembered = yield* savedRules()
-      const effect = evaluateRules(input, rulesets, remembered)
+      const effect = evaluateRules(input, rules, remembered)
       const denied = input.resources
-        .filter((resource) => evaluateResource(input, resource, rulesets, remembered) === "deny")
+        .filter((resource) => evaluateResource(input, resource, rules, remembered) === "deny")
         .map((resource): Permission.Rule => ({ action: input.action, resource, effect: "deny" }))
       return {
         effect,
-        rules: effect === "deny" ? [...rulesets.flat(), ...denied] : [...rulesets.flat(), ...remembered],
+        rules:
+          effect === "deny"
+            ? [...rules.ancestors.flat(), ...rules.own, ...denied]
+            : [...rules.own, ...remembered],
       }
     })
 

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -147,15 +147,42 @@ const layer = Layer.effect(
       )
     })
 
-    const configured = Effect.fn("Permission.configured")(function* (sessionID: SessionSchema.ID, agentID?: Agent.ID) {
-      const session = yield* sessions.get(sessionID)
-      if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
-      const agent = yield* agents.resolve(agentID ?? session.agent)
-      return agent?.permissions ?? missingAgentPermissions
-    })
+    const configured = Effect.fn("Permission.configured")(configuredPermissions)
 
-    function denied(input: AssertInput, rules: Permission.Ruleset) {
-      return input.resources.some((resource) => evaluate(input.action, resource, rules).effect === "deny")
+    function configuredPermissions(
+      sessionID: SessionSchema.ID,
+      agentID?: Agent.ID,
+    ): Effect.Effect<ReadonlyArray<Permission.Ruleset>, SessionErrors.NotFoundError> {
+      return Effect.gen(function* () {
+        const session = yield* sessions.get(sessionID)
+        if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
+        const agent = yield* agents.resolve(agentID ?? session.agent)
+        const own = agent?.permissions ?? missingAgentPermissions
+        if (!session.parentID) return [own]
+        return [...(yield* configuredPermissions(session.parentID)), own]
+      })
+    }
+
+    function evaluateResource(
+      input: AssertInput,
+      resource: string,
+      rulesets: ReadonlyArray<Permission.Ruleset>,
+      remembered: Permission.Ruleset,
+    ) {
+      const configured = rulesets.map((rules) => evaluate(input.action, resource, rules).effect)
+      if (configured.includes("deny")) return "deny"
+      const effective = rulesets.map((rules) => evaluate(input.action, resource, rules, remembered).effect)
+      return effective.includes("ask") ? "ask" : "allow"
+    }
+
+    function evaluateRules(
+      input: AssertInput,
+      rulesets: ReadonlyArray<Permission.Ruleset>,
+      remembered: Permission.Ruleset,
+    ) {
+      const effects = input.resources.map((resource) => evaluateResource(input, resource, rulesets, remembered))
+      const effect: Permission.Effect = effects.includes("deny") ? "deny" : effects.includes("ask") ? "ask" : "allow"
+      return effect
     }
 
     function relevant(input: AssertInput, rules: Permission.Ruleset) {
@@ -163,12 +190,16 @@ const layer = Layer.effect(
     }
 
     const evaluateInput = Effect.fnUntraced(function* (input: AssertInput) {
-      const rules = yield* configured(input.sessionID, input.agent)
-      if (denied(input, rules)) return { effect: "deny" as const, rules }
-      const all = [...rules, ...(yield* savedRules())]
-      const effects = input.resources.map((resource) => evaluate(input.action, resource, all).effect)
-      const effect: Permission.Effect = effects.includes("deny") ? "deny" : effects.includes("ask") ? "ask" : "allow"
-      return { effect, rules: all }
+      const rulesets = yield* configured(input.sessionID, input.agent)
+      const remembered = yield* savedRules()
+      const effect = evaluateRules(input, rulesets, remembered)
+      const denied = input.resources
+        .filter((resource) => evaluateResource(input, resource, rulesets, remembered) === "deny")
+        .map((resource): Permission.Rule => ({ action: input.action, resource, effect: "deny" }))
+      return {
+        effect,
+        rules: effect === "deny" ? [...rulesets.flat(), ...denied] : [...rulesets.flat(), ...remembered],
+      }
     })
 
     function request(input: AssertInput): Request {
@@ -283,14 +314,7 @@ const layer = Layer.effect(
               Effect.catchTag("Session.NotFoundError", () => Effect.succeed(undefined)),
             )
             if (!rules) continue
-            if (denied(input, rules)) continue
-            const effective = [...rules, ...rememberedRules]
-            if (
-              !item.request.resources.every(
-                (resource) => evaluate(item.request.action, resource, effective).effect === "allow",
-              )
-            )
-              continue
+            if (evaluateRules(input, rules, rememberedRules) !== "allow") continue
             yield* bus.publish(Permission.Event.Replied, {
               sessionID: item.request.sessionID,
               requestID: item.request.id,

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -171,8 +171,6 @@ export const Plugin = {
                   title: input.description,
                   agent: Agent.ID.make(input.agent),
                   model,
-                  // TODO(opencode kkdvxn): derive restricted subagent permissions from the parent
-                  // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
                 })
                 .pipe(
                   Effect.mapError(

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -135,6 +135,69 @@ describe("Permission", () => {
     }),
   )
 
+  it.effect("intersects subagent permissions with every ancestor", () =>
+    Effect.gen(function* () {
+      yield* setup([{ action: "read", resource: "*", effect: "allow" }])
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(SessionTable)
+        .values([
+          {
+            id: Session.ID.make("ses_child"),
+            project_id: Project.ID.global,
+            parent_id: Session.ID.make("ses_test"),
+            slug: "child",
+            directory: "/project",
+            title: "child",
+            version: "test",
+            agent: "child",
+          },
+          {
+            id: Session.ID.make("ses_grandchild"),
+            project_id: Project.ID.global,
+            parent_id: Session.ID.make("ses_child"),
+            slug: "grandchild",
+            directory: "/project",
+            title: "grandchild",
+            version: "test",
+            agent: "grandchild",
+          },
+        ])
+        .run()
+        .pipe(Effect.orDie)
+      const agents = yield* Agent.Service
+      yield* agents.transform((editor) => {
+        editor.update(Agent.ID.make("child"), (agent) => {
+          agent.permissions = [{ action: "read", resource: "*", effect: "allow" }]
+        })
+        editor.update(Agent.ID.make("grandchild"), (agent) => {
+          agent.permissions = [{ action: "read", resource: "*", effect: "allow" }]
+        })
+      })
+      const service = yield* Permission.Service
+      const child = assertion({ sessionID: Session.ID.make("ses_grandchild") })
+
+      expect(yield* service.ask(child)).toMatchObject({ effect: "allow" })
+      yield* setRules([{ action: "read", resource: "*", effect: "deny" }])
+      expect(yield* service.ask(child)).toMatchObject({ effect: "deny" })
+      yield* setRules([{ action: "read", resource: "*", effect: "allow" }])
+      yield* agents.transform((editor) =>
+        editor.update(Agent.ID.make("child"), (agent) => {
+          agent.permissions = []
+        }),
+      )
+      expect(yield* service.ask(child)).toMatchObject({ effect: "ask" })
+      const saved = yield* PermissionSaved.Service
+      yield* saved.add({ projectID: Project.ID.global, action: "read", resources: ["src/index.ts"] })
+      expect(yield* service.ask(child)).toMatchObject({ effect: "allow" })
+      yield* setRules([{ action: "read", resource: "*", effect: "deny" }])
+      const denied = yield* service.assert(child).pipe(Effect.flip)
+      expect(denied).toBeInstanceOf(Permission.BlockedError)
+      if (denied instanceof Permission.BlockedError)
+        expect(Permission.evaluate("read", "src/index.ts", denied.rules).effect).toBe("deny")
+    }),
+  )
+
   it.effect("allows and denies from explicit rules without asking", () =>
     Effect.gen(function* () {
       yield* setup([{ action: "read", resource: "*", effect: "allow" }])

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -135,9 +135,41 @@ describe("Permission", () => {
     }),
   )
 
-  it.effect("intersects subagent permissions with every ancestor", () =>
+  it.effect("does not inherit ancestor asks", () =>
     Effect.gen(function* () {
-      yield* setup([{ action: "read", resource: "*", effect: "allow" }])
+      yield* setup([])
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: Session.ID.make("ses_child"),
+          project_id: Project.ID.global,
+          parent_id: Session.ID.make("ses_test"),
+          slug: "child",
+          directory: "/project",
+          title: "child",
+          version: "test",
+          agent: "child",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const agents = yield* Agent.Service
+      yield* agents.transform((editor) =>
+        editor.update(Agent.ID.make("child"), (agent) => {
+          agent.permissions = [{ action: "read", resource: "*", effect: "allow" }]
+        }),
+      )
+      const service = yield* Permission.Service
+      const child = assertion({ sessionID: Session.ID.make("ses_child") })
+
+      expect(yield* service.ask(child)).toMatchObject({ effect: "allow" })
+      expect(yield* service.list()).toEqual([])
+    }),
+  )
+
+  it.effect("inherits denies from every ancestor and denies override remembered allows", () =>
+    Effect.gen(function* () {
+      yield* setup([{ action: "read", resource: "*", effect: "deny" }])
       const { db } = yield* Database.Service
       yield* db
         .insert(SessionTable)
@@ -175,26 +207,60 @@ describe("Permission", () => {
         })
       })
       const service = yield* Permission.Service
-      const child = assertion({ sessionID: Session.ID.make("ses_grandchild") })
+      const grandchild = assertion({ sessionID: Session.ID.make("ses_grandchild") })
 
-      expect(yield* service.ask(child)).toMatchObject({ effect: "allow" })
-      yield* setRules([{ action: "read", resource: "*", effect: "deny" }])
-      expect(yield* service.ask(child)).toMatchObject({ effect: "deny" })
-      yield* setRules([{ action: "read", resource: "*", effect: "allow" }])
-      yield* agents.transform((editor) =>
-        editor.update(Agent.ID.make("child"), (agent) => {
-          agent.permissions = []
-        }),
-      )
-      expect(yield* service.ask(child)).toMatchObject({ effect: "ask" })
+      expect(yield* service.ask(grandchild)).toMatchObject({ effect: "deny" })
       const saved = yield* PermissionSaved.Service
       yield* saved.add({ projectID: Project.ID.global, action: "read", resources: ["src/index.ts"] })
-      expect(yield* service.ask(child)).toMatchObject({ effect: "allow" })
-      yield* setRules([{ action: "read", resource: "*", effect: "deny" }])
-      const denied = yield* service.assert(child).pipe(Effect.flip)
+      expect(yield* service.ask(grandchild)).toMatchObject({ effect: "deny" })
+      const denied = yield* service.assert(grandchild).pipe(Effect.flip)
       expect(denied).toBeInstanceOf(Permission.BlockedError)
       if (denied instanceof Permission.BlockedError)
         expect(Permission.evaluate("read", "src/index.ts", denied.rules).effect).toBe("deny")
+    }),
+  )
+
+  it.effect("ignores a missing ancestor agent", () =>
+    Effect.gen(function* () {
+      yield* setup([{ action: "read", resource: "*", effect: "deny" }])
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: Session.ID.make("ses_child"),
+          project_id: Project.ID.global,
+          parent_id: Session.ID.make("ses_test"),
+          slug: "child",
+          directory: "/project",
+          title: "child",
+          version: "test",
+          agent: "child",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const agents = yield* Agent.Service
+      yield* agents.transform((editor) => {
+        editor.remove(Agent.ID.make("test"))
+        editor.update(Agent.ID.make("child"), (agent) => {
+          agent.permissions = [{ action: "read", resource: "*", effect: "allow" }]
+        })
+      })
+
+      const service = yield* Permission.Service
+      expect(yield* service.ask(assertion({ sessionID: Session.ID.make("ses_child") }))).toMatchObject({
+        effect: "allow",
+      })
+    }),
+  )
+
+  it.effect("denies all when the current session agent is missing", () =>
+    Effect.gen(function* () {
+      yield* setup([{ action: "read", resource: "*", effect: "allow" }])
+      const agents = yield* Agent.Service
+      yield* agents.transform((editor) => editor.remove(Agent.ID.make("test")))
+
+      const service = yield* Permission.Service
+      expect(yield* service.ask(assertion())).toMatchObject({ effect: "deny" })
     }),
   )
 


### PR DESCRIPTION
## What

Before, permission checks used only the current session's agent ruleset, so a subagent session escaped every configured deny in its ancestry.

After, denies are fences and asks are per-agent gates:

| Ancestor verdict | Current agent + remembered verdict | Result |
| --- | --- | --- |
| deny | any | deny |
| ask or allow | deny | deny |
| ask or allow | ask | ask |
| ask or allow | allow | allow |

Configured denies always win, including over remembered approvals. Ancestor asks and allows do not participate in the current session's gate.

V2 agent permissions are explicit per-agent configuration, so a broader child ruleset is deliberate user intent. This matches V1's documented philosophy that parent-agent restrictions govern that agent while a subagent's own permissions determine its capabilities, while improving on V1 by evaluating the live session ancestry instead of copying a spawn-time snapshot.

Embedded and headless hosts depend on ancestor deny fences to prevent a child from escaping explicit host restrictions, without introducing inherited asks that cannot be answered and can wedge a turn.

## How

- Walk the live session parent chain and collect configured ancestor rulesets.
- For each resource, deny if any ancestor or the current agent evaluates to deny; otherwise evaluate only the current agent's ruleset plus remembered approvals for ask/allow.
- Treat a missing ancestor agent as an empty ruleset, while a missing current agent remains deny-all.
- Reuse the same evaluator for live checks and the pending-request auto-reply loop.
- Remove the resolved subagent permission TODO.

## Scope

`external_directory` is the V2 equivalent of the V1 action that was copied into child snapshots. This PR inherits its configured denies through the same fence as every action, but does not inherit its asks or allows; the current agent's live `external_directory` rules remain its gate. No API or protocol changes.

## Testing

- `bun run test test/permission.test.ts` (15 passed)
- `bun run test test/tool-subagent.test.ts` (6 passed)
- `bun typecheck` in `packages/core`
- Pre-push monorepo typecheck (34 tasks passed)