### PR TITLE
fix(session): set finish status on halted assistant message

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -617,6 +617,7 @@ const layer = Layer.effect(
           return
         }
         ctx.assistantMessage.error = error
+        ctx.assistantMessage.finish = "error"
         yield* events.publish(Session.Event.Error, {
           sessionID: ctx.assistantMessage.sessionID,
           error: ctx.assistantMessage.error,

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -552,6 +552,7 @@ it.live("session.processor effect tests do not retry unknown json errors", () =>
         expect(value).toBe("stop")
         expect(yield* llm.calls).toBe(1)
         expect(handle.message.error?.name).toBe("APIError")
+        expect(handle.message.finish).toBe("error")
       }),
     { config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -558,6 +558,67 @@ it.live("session.processor effect tests do not retry unknown json errors", () =>
   ),
 )
 
+it.live("session.processor effect tests do not replay a failed compaction task on resume", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        yield* llm.error(400, { error: { message: "no_kv_space" } })
+
+        const chat = yield* session.create({})
+        const original = yield* user(chat.id, "keep this context")
+        const parent = yield* user(chat.id, "compact")
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: chat.id,
+          messageID: parent.id,
+          type: "compaction",
+          auto: true,
+        })
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        // Real compaction messages start unfinished; the shared helper does not.
+        delete msg.finish
+        msg.summary = true
+        msg.mode = "compaction"
+        msg.agent = "compaction"
+        yield* session.updateMessage(msg)
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const result = yield* handle.process({
+          user: parent,
+          sessionID: chat.id,
+          model: mdl,
+          agent: { ...agent(), name: "compaction" },
+          system: [],
+          messages: [{ role: "user", content: "summarize the conversation" }],
+          tools: {},
+        })
+
+        expect(result).toBe("stop")
+        const resumed = yield* user(chat.id, "continue after the provider recovers")
+        const messages = MessageV2.filterCompacted(yield* MessageV2.stream(chat.id))
+        const latest = MessageV2.latest(messages)
+        const failed = messages.find((message) => message.info.id === msg.id)?.info
+
+        expect(failed?.role).toBe("assistant")
+        if (failed?.role !== "assistant") throw new Error("Missing failed compaction message")
+        expect(failed.error?.name).toBe("APIError")
+        expect(messages.map((message) => message.info.id)).toContain(original.id)
+        expect(latest.user?.id).toBe(resumed.id)
+        // runLoop selects tasks from this persisted frontier on the next prompt.
+        expect(latest.tasks).toEqual([])
+        expect(latest.finished?.id).toBe(msg.id)
+        expect(failed.finish).toBe("error")
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests retry recognized structured json errors", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
@@ -670,6 +731,8 @@ it.live("session.processor effect tests compact on structured context overflow",
         const chat = yield* session.create({})
         const parent = yield* user(chat.id, "compact json")
         const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        delete msg.finish
+        yield* session.updateMessage(msg)
         const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
         const handle = yield* processors.create({
           assistantMessage: msg,
@@ -697,6 +760,7 @@ it.live("session.processor effect tests compact on structured context overflow",
         expect(value).toBe("compact")
         expect(yield* llm.calls).toBe(1)
         expect(handle.message.error).toBeUndefined()
+        expect(handle.message.finish).toBeUndefined()
       }),
     { config: (url) => providerCfg(url) },
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #42070

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the session processor halts due to an error that isn't a ContextOverflow (e.g. an API error from the model), the assistant message gets `error` set but `finish` stays undefined. The prompt loop checks `finish` to decide whether to exit — with it undefined, the loop never terminates and the session appears stuck in compaction.

The fix sets `finish = "error"` in the non-ContextOverflow branch of `halt()`, matching what the ContextOverflow branch already does. This is a one-line change in `processor.ts`.

### How did you verify your code works?

Added `expect(handle.message.finish).toBe("error")` to the existing test "do not retry unknown json errors" which exercises the exact error-halt path. 15/15 tests pass in `processor-effect.test.ts`, typecheck clean.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR