### PR TITLE
fix(cli): dispose all instances on command exit

### DIFF
--- a/packages/opencode/src/cli/effect-cmd.ts
+++ b/packages/opencode/src/cli/effect-cmd.ts
@@ -53,10 +53,10 @@ interface EffectCmdOpts<Args, A> {
  * Effect-native CLI command builder. Wraps yargs `cmd()` so the handler body is
  * an `Effect` with `InstanceRef` provided and any `AppServices` yieldable.
  *
- * The handler is wrapped in `Effect.ensuring(store.dispose(ctx))` so the loaded
- * InstanceContext is disposed (runDisposers + IPC `server.instance.disposed`)
- * on every Exit — success, typed failure, defect, or interruption. Matches the
- * legacy `bootstrap()` finally-disposal semantics without per-handler boilerplate.
+ * The handler is wrapped in a `finally` block that calls `store.disposeAll()` so
+ * all loaded InstanceContexts are disposed (runDisposers + IPC `server.instance.disposed`)
+ * on every Exit — success, typed failure, defect, or interruption. This covers
+ * instances loaded by server middleware for session resume with a different `--dir`.
  *
  * Errors propagate to the existing top-level handler in `src/index.ts`; use
  * `fail("...")` for user-visible domain failures (clean exit, formatted message).
@@ -90,7 +90,7 @@ export const effectCmd = <Args, A>(opts: EffectCmdOpts<Args, A>) =>
       try {
         await AppRuntime.runPromise(opts.handler(args).pipe(Effect.provideService(InstanceRef, ctx)))
       } finally {
-        await AppRuntime.runPromise(store.dispose(ctx))
+        await AppRuntime.runPromise(store.disposeAll().pipe(Effect.catchCause((cause) => Effect.logWarning("cli disposal failed", { cause }))))
       }
     },
   })


### PR DESCRIPTION
### Issue for this PR

Closes #41841

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --session <id> --dir <path>` can load a second InstanceContext via server middleware when the session's original directory differs from `--dir`. The CLI's finally block was calling `store.dispose(ctx)`, which only disposes the primary instance — the middleware-loaded instance is left running with its IPC server alive, so the process never exits.

Changed `store.dispose(ctx)` to `store.disposeAll()` with a `logWarning` on failure (matching the pattern in `global-lifecycle.ts`). This ensures all instances loaded during the command are cleaned up. The JSDoc comment is updated to reflect the new behavior.

`serve` and `web` commands are unaffected — they use `instance: false` and return before reaching the finally block. The TUI has its own disposal path.

### How did you verify your code works?

Typecheck clean. Existing tests for `disposeAll` semantics in `instance.test.ts` (dedup, re-arm) remain green. The source-string assertion in `effect-cmd-instance-als.test.ts` still passes.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR