### PR TITLE
fix(core): apply variable substitution to v2 config loading

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -22,6 +22,7 @@ import { ConfigPlugin } from "./config/plugin"
 import { ConfigProvider } from "./config/provider"
 import { ConfigReference } from "./config/reference"
 import { ConfigToolOutput } from "./config/tool-output"
+import { ConfigVariable } from "./config/variable"
 import { ConfigWatcher } from "./config/watcher"
 import { ConfigV1 } from "./v1/config/config"
 import { ConfigMigrateV1 } from "./v1/config/migrate"
@@ -148,8 +149,10 @@ const layer = Layer.effect(
       const text = yield* fs.readFileStringSafe(filepath)
       if (!text) return
 
+      const substituted = yield* ConfigVariable.substitute({ text, filepath })
+
       const errors: ParseError[] = []
-      const input: unknown = parse(text, errors, { allowTrailingComma: true })
+      const input: unknown = parse(substituted, errors, { allowTrailingComma: true })
       if (errors.length) return
 
       const info = Option.getOrUndefined(

--- a/packages/core/src/config/variable.ts
+++ b/packages/core/src/config/variable.ts
@@ -1,0 +1,69 @@
+export * as ConfigVariable from "./variable"
+
+import path from "path"
+import os from "os"
+import { Effect, Schema } from "effect"
+import { FSUtil } from "../fs-util"
+
+export class InvalidFileReferenceError extends Schema.TaggedErrorClass<InvalidFileReferenceError>()(
+  "ConfigVariable.InvalidFileReferenceError",
+  {
+    token: Schema.String,
+    resolvedPath: Schema.String,
+    filepath: Schema.String,
+  },
+) {}
+
+/** Apply {env:VAR} and {file:path} substitutions to config text before parsing. */
+export const substitute = Effect.fnUntraced(function* (input: {
+  text: string
+  filepath: string
+  missing?: "error" | "empty"
+}) {
+  const missing = input.missing ?? "error"
+  const text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => process.env[varName] ?? "")
+
+  const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
+  if (!fileMatches.length) return text
+
+  const configDir = path.dirname(input.filepath)
+  const fs = yield* FSUtil.Service
+  let out = ""
+  let cursor = 0
+
+  for (const match of fileMatches) {
+    const token = match[0]
+    const index = match.index!
+    out += text.slice(cursor, index)
+
+    const lineStart = text.lastIndexOf("\n", index - 1) + 1
+    const prefix = text.slice(lineStart, index).trimStart()
+    if (prefix.startsWith("//")) {
+      out += token
+      cursor = index + token.length
+      continue
+    }
+
+    let filePath = token.slice(6, -1)
+    if (filePath.startsWith("~/")) filePath = path.join(os.homedir(), filePath.slice(2))
+
+    const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
+    const content = yield* fs
+      .readFileStringSafe(resolvedPath)
+      .pipe(
+        Effect.flatMap((content) =>
+          content !== undefined
+            ? Effect.succeed(content.trim())
+            : missing === "empty"
+              ? Effect.succeed("")
+              : Effect.fail(new InvalidFileReferenceError({ token, resolvedPath, filepath: input.filepath })),
+        ),
+      )
+
+    out += JSON.stringify(content).slice(1, -1)
+    cursor = index + token.length
+  }
+
+  out += text.slice(cursor)
+  return out
+})

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -795,4 +795,133 @@ describe("Config", () => {
       }),
     ),
   )
+
+  it.live("substitutes {file:} references in config values", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              fs.writeFile(path.join(tmp.path, "api.key"), "sk-secret-key\n"),
+              fs.writeFile(path.join(tmp.path, "opencode.json"), JSON.stringify({ model: "{file:./api.key}" })),
+            ]),
+          )
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+            expect(documents[0]?.info.model).toBe("sk-secret-key")
+          }).pipe(Effect.provide(testLayer(tmp.path)))
+        }),
+      ),
+    ),
+  )
+
+  it.live("substitutes {env:} references in config values", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const previous = process.env.OPENCODE_TEST_MODEL
+          process.env.OPENCODE_TEST_MODEL = "anthropic/claude"
+          yield* Effect.promise(() =>
+            fs.writeFile(path.join(tmp.path, "opencode.json"), JSON.stringify({ model: "{env:OPENCODE_TEST_MODEL}" })),
+          )
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+            expect(documents[0]?.info.model).toBe("anthropic/claude")
+          }).pipe(
+            Effect.provide(testLayer(tmp.path)),
+            Effect.ensuring(
+              Effect.sync(() => {
+                if (previous === undefined) delete process.env.OPENCODE_TEST_MODEL
+                else process.env.OPENCODE_TEST_MODEL = previous
+              }),
+            ),
+          )
+        }),
+      ),
+    ),
+  )
+
+  it.live("does not substitute {file:} inside JSONC line comments", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              fs.writeFile(path.join(tmp.path, "api.key"), "sk-secret-key"),
+              fs.writeFile(
+                path.join(tmp.path, "opencode.jsonc"),
+                `{
+                  // "model": "{file:./api.key}"
+                  "model": "anthropic/claude"
+                }`,
+              ),
+            ]),
+          )
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+            expect(documents[0]?.info.model).toBe("anthropic/claude")
+          }).pipe(Effect.provide(testLayer(tmp.path)))
+        }),
+      ),
+    ),
+  )
+
+  it.live("substitutes {file:} with absolute paths", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const keyPath = path.join(tmp.path, "secret.key")
+          yield* Effect.promise(() =>
+            Promise.all([
+              fs.writeFile(keyPath, "sk-abs-key"),
+              fs.writeFile(path.join(tmp.path, "opencode.json"), JSON.stringify({ model: `{file:${keyPath}}` })),
+            ]),
+          )
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+            expect(documents[0]?.info.model).toBe("sk-abs-key")
+          }).pipe(Effect.provide(testLayer(tmp.path)))
+        }),
+      ),
+    ),
+  )
+
+  it.live("substitutes {file:} content with JSON-special characters", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              fs.writeFile(path.join(tmp.path, "api.key"), 'sk-"quote"\n\\backslash\t'),
+              fs.writeFile(path.join(tmp.path, "opencode.json"), JSON.stringify({ model: "{file:./api.key}" })),
+            ]),
+          )
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const documents = (yield* config.entries()).filter((entry) => entry.type === "document")
+            expect(documents[0]?.info.model).toBe('sk-"quote"\n\\backslash')
+          }).pipe(Effect.provide(testLayer(tmp.path)))
+        }),
+      ),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #41973

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The v2 config loading path in `packages/core/src/config.ts` reads config files and parses them as JSONC without applying `{file:}` and `{env:}` variable substitution. The v1 path in `packages/opencode/src/config/config.ts` calls `ConfigVariable.substitute()` on the raw text before parsing. Through `opencode run` and the TUI (v1 path), `{file:/tmp/demo.key}` is resolved and the provider authenticates. Through `opencode serve` (v2 path), the literal string `{file:/tmp/demo.key}` ends up as the API key, causing 401s.

This PR adds an Effect-based `substitute()` function in `packages/core/src/config/variable.ts` that handles `{env:VAR}` and `{file:path}` substitutions, and calls it in `loadFile()` before JSONC parsing. The implementation mirrors the v1 substitution logic: supports `~/` expansion, relative paths (relative to the config file), skips substitution inside `//` line comments, and trims file content.

### How did you verify your code works?

Added 5 tests to `config.test.ts` covering: `{file:}` with relative paths, `{env:}` substitution, `//` comment skipping, `{file:}` with absolute paths, and `{file:}` content containing JSON-special characters (quotes, backslashes, newlines). 20/20 tests pass, typecheck clean, prettier clean.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR