### PR TITLE
fix(client): prevent stale service replacement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -189,12 +189,14 @@
       "dependencies": {
         "@opencode-ai/protocol": "workspace:*",
         "@opencode-ai/schema": "workspace:*",
+        "semver": "catalog:",
       },
       "devDependencies": {
         "@effect/platform-node": "catalog:",
         "@opencode-ai/httpapi-codegen": "workspace:*",
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
+        "@types/semver": "catalog:",
         "@typescript/native-preview": "catalog:",
         "effect": "catalog:",
       },
@@ -6466,6 +6468,8 @@
     "@openauthjs/openauth/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
 
     "@opencode-ai/cli/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "@opencode-ai/client/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@opencode-ai/console-app/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.7", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DrpkEoM3j9cBBWhufqBwnbbn+3nf1N9FP6xuVJ+e220jbactKuQgaZwjwP5CP1t+O94brm2JgVMD2atMGX3xIQ=="],
 

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -103,7 +103,9 @@ export const options = Effect.fnUntraced(function* (input: { readonly checkVersi
   yield* Effect.forEach(legacyRegistrationFiles, (legacy) => migrateRegistration(legacy, file))
   return {
     file,
-    version: input.checkVersion ? OPENCODE_VERSION : undefined,
+    version: input.checkVersion
+      ? (version: string) => Service.isServiceVersionCompatible(version, OPENCODE_VERSION)
+      : undefined,
     command: [...selfCommand(), "serve", "--service"],
   }
 })

--- a/packages/cli/test/server-connection.test.ts
+++ b/packages/cli/test/server-connection.test.ts
@@ -64,7 +64,11 @@ test("service options only require a matching version when requested", async () 
 
   try {
     expect((await runPromise(ServiceConfig.options())).version).toBeUndefined()
-    expect((await runPromise(ServiceConfig.options({ checkVersion: true }))).version).toBe(OPENCODE_VERSION)
+    const version = (await runPromise(ServiceConfig.options({ checkVersion: true }))).version
+    expect(version).toBeFunction()
+    if (typeof version !== "function") throw new Error("Expected a service version predicate")
+    expect(version(OPENCODE_VERSION)).toBe(true)
+    expect(version("999.0.0")).toBe(true)
   } finally {
     await fs.rm(root, { recursive: true, force: true })
   }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@opencode-ai/schema": "workspace:*",
-    "@opencode-ai/protocol": "workspace:*"
+    "@opencode-ai/protocol": "workspace:*",
+    "semver": "catalog:"
   },
   "peerDependencies": {
     "effect": "4.0.0-beta.101"
@@ -48,6 +49,7 @@
     "@opencode-ai/httpapi-codegen": "workspace:*",
     "@tsconfig/bun": "catalog:",
     "@types/bun": "catalog:",
+    "@types/semver": "catalog:",
     "@typescript/native-preview": "catalog:",
     "effect": "catalog:"
   }

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -10,7 +10,7 @@ import {
   spawnServiceContender,
 } from "../service-contender.js"
 import { defaultEnsureTiming, ensureTiming, type EnsureTiming } from "../service-timing.js"
-import { matchesVersion } from "../service-version.js"
+import { isServiceVersionCompatible, matchesVersion } from "../service-version.js"
 
 export * from "../service.js"
 /** Contents of the local service registration file. */
@@ -325,4 +325,4 @@ const requestStop = Effect.fnUntraced(function* (service: LocalService, timeout 
 })
 
 /** Effect-based local service lifecycle operations. */
-export const Service = { discover, incumbent, ensure, stop, headers, Info }
+export const Service = { discover, incumbent, ensure, stop, headers, isServiceVersionCompatible, Info }

--- a/packages/client/src/promise/service.ts
+++ b/packages/client/src/promise/service.ts
@@ -9,7 +9,7 @@ import {
   spawnServiceContender,
 } from "../service-contender.js"
 import { defaultEnsureTiming, ensureTiming, type EnsureTiming } from "../service-timing.js"
-import { matchesVersion } from "../service-version.js"
+import { isServiceVersionCompatible, matchesVersion } from "../service-version.js"
 import type { ServiceHealth, ServiceStopResponse } from "./generated/types.js"
 
 export * from "../service.js"
@@ -278,4 +278,4 @@ function delay(milliseconds: number) {
 }
 
 /** Promise-based local service lifecycle operations. */
-export const Service = { discover, ensure, stop, headers }
+export const Service = { discover, ensure, stop, headers, isServiceVersionCompatible }

--- a/packages/client/src/service-version.ts
+++ b/packages/client/src/service-version.ts
@@ -1,8 +1,18 @@
 import type { DiscoverOptions } from "./service.js"
+import semver from "semver"
 
 export function matchesVersion(version: string | undefined, options: DiscoverOptions) {
   if (options.version === undefined) return true
   if (version === undefined) return false
   if (typeof options.version === "function") return options.version(version)
   return version === options.version
+}
+
+/** Whether a service is at least as new as its client. */
+export function isServiceVersionCompatible(serverVersion: string, clientVersion: string) {
+  if (serverVersion === clientVersion) return true
+  const server = serverVersion.replace(/^(0\.0\.0-.+)-(\d+(?:\.\d+)?)$/, "$1.$2")
+  const client = clientVersion.replace(/^(0\.0\.0-.+)-(\d+(?:\.\d+)?)$/, "$1.$2")
+  if (!semver.valid(server) || !semver.valid(client)) return true
+  return semver.gte(server, client)
 }

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -1,3 +1,5 @@
+export { isServiceVersionCompatible } from "./service-version.js"
+
 /** Connection details for a local OpenCode service. */
 export type Endpoint = {
   /** Base URL of the service. */

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -31,6 +31,7 @@ let version = "test"
 if (mode === "old" || mode === "reject-stop") version = "old"
 if (mode === "incompatible") version = "1.9.0"
 if (mode === "compatible" || mode === "delayed-compatible") version = "2.1.0-next.1"
+if (mode === "newer") version = "0.0.0-next-17272"
 const id = crypto.randomUUID()
 const server = Bun.serve({
   port: 0,

--- a/packages/client/test/service-version.test.ts
+++ b/packages/client/test/service-version.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { isServiceVersionCompatible } from "../src/service"
+
+test("accepts the same or a newer service version", () => {
+  expect(isServiceVersionCompatible("0.0.0-next-17272", "0.0.0-next-17272")).toBe(true)
+  expect(isServiceVersionCompatible("0.0.0-next-17272", "0.0.0-next-17271")).toBe(true)
+  expect(isServiceVersionCompatible("0.0.0-next-17271", "0.0.0-next-17272")).toBe(false)
+  expect(isServiceVersionCompatible("0.0.0-next-15000", "0.0.0-next-9999")).toBe(true)
+})
+
+test("accepts incomparable development versions", () => {
+  expect(isServiceVersionCompatible("development-a", "development-b")).toBe(true)
+})

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -68,6 +68,30 @@ test("reuses a compatible registered service", async () => {
   expect(existing.exitCode).toBe(null)
 })
 
+test("a stale client reuses a newer registered service", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const existing = spawn(registration, "newer")
+  await waitForFile(registration)
+  const original = await Bun.file(registration).json()
+
+  const starts: EnsureReason[] = []
+  const endpoint = await run(
+    ensure({
+      file: registration,
+      version: (version) => Service.isServiceVersionCompatible(version, "0.0.0-next-17271"),
+      command: [process.execPath, fixture, registration, "record-start"],
+      onStart: (reason) => starts.push(reason),
+    }),
+  )
+
+  expect(endpoint.url).toBe(original.url)
+  expect(starts).toEqual([])
+  expect(existing.exitCode).toBe(null)
+  expect(await Bun.file(registration).json()).toEqual(original)
+  expect(await Bun.file(registration + ".started").exists()).toBe(false)
+})
+
 test("replaces an incompatible registered service", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")

--- a/packages/desktop/src/main/background-cli.ts
+++ b/packages/desktop/src/main/background-cli.ts
@@ -29,7 +29,7 @@ export async function startBackgroundCli(logger: Logger) {
       isolated && process.env.OPENCODE_DESKTOP_SERVER_CHANNEL === "local"
         ? join(app.getPath("userData"), "opencode", "service-local.json")
         : undefined,
-    version,
+    version: (serverVersion) => Service.isServiceVersionCompatible(serverVersion, version),
     command: [binary, "serve", "--service"],
     onStart: (reason, previousVersion) => logger.log("v2 CLI background service starting", { reason, previousVersion }),
   })


### PR DESCRIPTION
## What

Prevent an older CLI or Desktop client from replacing a newer managed background service.

## Before / After

**Before**

A client required its exact installed version. After an update, an older client saw the newer service as incompatible and replaced it with the older binary. A newer client could then replace that service again.

**After**

CLI and Desktop accept a service at the same or a newer comparable version. A newer client still sees an older service as incompatible, so normal automatic upgrades continue.

```mermaid
flowchart TD
  A[Client discovers service] --> B{Service version >= client?}
  B -->|Yes| C[Reuse service]
  B -->|No| D[Existing replacement path]
```

## How

- `packages/client/src/service-version.ts` compares stable and numeric preview versions and conservatively accepts incomparable development versions.
- `packages/cli/src/services/service-config.ts` uses the compatibility predicate for managed startup.
- `packages/desktop/src/main/background-cli.ts` applies the same policy.
- Client tests verify numeric ordering and that a stale real child-process client neither stops nor replaces a newer service.

## Scope

This PR only changes version compatibility policy. It does not change stop authentication, PID signaling, Promise registration validation, migration polling, service election, or TUI presentation.

## Testing

- `cd packages/client && bun run test`
- `cd packages/client && bun typecheck`
- `cd packages/cli && bun run test test/server-connection.test.ts --test-name-pattern 'service options'`
- `cd packages/cli && bun typecheck`
- `cd packages/desktop && bun typecheck`
- Repository pre-push typecheck: 34 packages passed
