### PR TITLE
fix(tui): retry migration status transport errors

### DIFF
--- a/packages/tui/src/component/migration-overlay.tsx
+++ b/packages/tui/src/component/migration-overlay.tsx
@@ -1,3 +1,4 @@
+import { ClientError } from "@opencode-ai/client"
 import { createSignal, onCleanup, onMount, Show } from "solid-js"
 import { useClient } from "../context/client"
 import { useTheme } from "../context/theme"
@@ -16,9 +17,23 @@ export function MigrationOverlay() {
 
   onMount(async () => {
     await Bun.sleep(1_000)
+    if (abort.signal.aborted) return
     void (async () => {
       while (true) {
-        const status = await client.api.migration.v1.status({ signal: abort.signal })
+        const result = await client.api.migration.v1.status({ signal: abort.signal }).then(
+          (status) => ({ status }),
+          (error: unknown) => ({ error }),
+        )
+        if ("error" in result) {
+          if (result.error instanceof ClientError && result.error.reason === "Transport") {
+            if (abort.signal.aborted) return
+            await Bun.sleep(1_000)
+            if (abort.signal.aborted) return
+            continue
+          }
+          throw result.error
+        }
+        const status = result.status
         setProgress(status.status === "running" ? status.progress : undefined)
         if (status.status === "completed") return
         if (status.status === "error") throw new Error(status.error)


### PR DESCRIPTION
## What

Keep the migration status overlay polling through temporary server transport loss.

## Before / After

**Before**

A transient disconnect while the background service restarted ended migration polling and displayed a migration failure toast.

**After**

Transport errors retry after one second. Actual API or migration errors still surface, and unmount aborts polling without a stale toast.

## How

- Retries only `ClientError` transport failures in `packages/tui/src/component/migration-overlay.tsx`.
- Checks the abort signal before and after retry delays.
- Suppresses cleanup-triggered error presentation.

## Scope

This PR does not change service version policy, replacement, stop behavior, discovery validation, service election, or TUI layout.

## Testing

- `cd packages/tui && bun run test test/component` (10 passed)
- `cd packages/tui && bun typecheck`
- Repository pre-push typecheck: 34 packages passed
