### PR TITLE
fix(cli): inset update footer

### DIFF
--- a/packages/cli/src/services/update-preflight.tsx
+++ b/packages/cli/src/services/update-preflight.tsx
@@ -447,7 +447,7 @@ function UpdateFooter(props: {
   })
 
   return (
-    <box width="100%" height={4} flexDirection="row" gap={1} live={props.animating()}>
+    <box width="100%" height={4} flexDirection="row" gap={1} paddingLeft={1} live={props.animating()}>
       <Monogram ink={monogramInk} />
       <box flexDirection="column" flexGrow={1} overflow="hidden">
         <CellLine cells={header()} />


### PR DESCRIPTION
## What

Add one cell of left padding to the update preflight footer so its monogram no longer touches the terminal edge.

## Before / After

**Before:** The update monogram began in terminal column zero and appeared flush against the left edge.

**After:** The footer content starts one cell in, matching the intended visual inset while preserving the existing spacing between the monogram and status content.

## How

- Set `paddingLeft={1}` on the outer update footer row in `packages/cli/src/services/update-preflight.tsx`.

## Scope

- Only changes the update preflight footer layout.
- Does not change update behavior, timing, or service replacement logic.

## Testing

- `bun typecheck` from `packages/cli`
- Push hook: `bun turbo typecheck --concurrency=3` (34 tasks passed)
- `git diff --check`