### PR TITLE
fix(tui): truncate queued prompt preview

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2089,7 +2089,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
 
 function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOpen: () => void }) {
   const theme = useTheme("elevated")
-  const next = createMemo(() => props.prompts[0]?.text)
+  const next = createMemo(() => props.prompts[0]?.text.replaceAll("\n", " "))
 
   return (
     <box


### PR DESCRIPTION
**What**

Keep the queued-prompt dock to one terminal row when the next queued prompt contains multiple lines.

**Before / After**

**Before:** Queuing a multiline prompt preserved its newline characters in the dock preview. Although the text renderer used `wrapMode="none"` and `truncate`, explicit newlines expanded the dock and could consume much of the session viewport.

**After:** The dock replaces preview newlines with spaces before rendering. The existing single-line truncation then bounds the preview to one row, while the queued-prompts dialog retains the complete original text.

**How**

- `packages/tui/src/routes/session/index.tsx`: flatten newlines only in `QueuedPromptDock`'s derived preview text.

**Scope**

This does not alter queued prompt storage, delivery, or the full text shown in the queued-prompts dialog.

**Testing**

- `bun typecheck` in `packages/tui`
- Push hook: `bun turbo typecheck --concurrency=3` (34 packages passed)
- `opencode-drive check queued-prompt-drive.ts`
- Exercised multiline prompt entry and Alt+Enter through a development TUI with OpenCode Drive. The scripted queue capture wedged on its first UI RPC, and the live simulated response completed before queue admission, so no screenshot is attached as queue-dock evidence.
