### PR TITLE
fix(tui): repair baseline unit failures

### DIFF
--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -120,7 +120,9 @@ describe("opencode-drive", () => {
     expect(initStatus).toBe(0)
     const artifacts = initOutput.trim()
     expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).exists()).toBe(true)
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(
+      Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).text()),
+    ).toMatchObject({
       model: "simulation/gpt-sim-model",
       snapshots: false,
       permissions: [{ action: "*", resource: "*", effect: "allow" }],
@@ -765,13 +767,15 @@ describe("opencode-drive", () => {
       gitWriteError: expect.stringContaining("must not modify Git metadata"),
       matches: true,
     })
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(
+      Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).text()),
+    ).toMatchObject({
       autoupdate: false,
       model: "simulation/gpt-sim-model",
       providers: { simulation: { models: { "gpt-sim-model": {} } } },
       test: { declared: true, setup: true },
     })
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "tui.jsonc")).json()).toEqual({
+    expect(Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "tui.jsonc")).text())).toEqual({
       test: { declared: true, setup: true },
     })
     const backendEvents = (await Bun.file(join(artifacts, "backend-events.jsonl")).text())

--- a/packages/drive/test/instance/config.test.ts
+++ b/packages/drive/test/instance/config.test.ts
@@ -15,7 +15,7 @@ describe("instance configuration", () => {
     const root = await initializeInstance()
     artifacts.push(root)
 
-    expect(await Bun.file(join(root, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(Bun.JSONC.parse(await Bun.file(join(root, "files", ".opencode", "opencode.jsonc")).text())).toMatchObject({
       model: "simulation/gpt-sim-model",
       providers: {
         simulation: {

--- a/packages/tui/src/mini/mono.ts
+++ b/packages/tui/src/mini/mono.ts
@@ -91,7 +91,6 @@ function monoRenderable(renderable: Renderable): void {
 
 function monoCode(renderable: CodeRenderable): void {
   const onChunks = renderable.onChunks
-  const prose = renderable.filetype === "markdown" && onChunks !== undefined
   renderable.onChunks = async (chunks, context) => monoChunks((await onChunks?.(chunks, context)) ?? chunks)
   renderable.treeSitterClient = monoTreeSitter(renderable.treeSitterClient)
 
@@ -112,11 +111,11 @@ function monoCode(renderable: CodeRenderable): void {
     configurable: true,
     get: contentGetter,
     set(value: string) {
-      if (!prose || !isStyledText(Reflect.get(renderable, "_initialStyledText"))) {
+      if (renderable.filetype !== "markdown" || !isStyledText(Reflect.get(renderable, "_initialStyledText"))) {
         renderable.drawUnstyledText = true
         renderable.initialStyledText = stringToStyledText(value)
       }
-      contentSetter(value)
+      contentSetter(renderable.filetype === "markdown" ? value : monoText(value))
     },
   })
 


### PR DESCRIPTION
## What

Repair the deterministic Linux unit failures introduced by the current OpenTUI and Drive configuration baselines.

## Before / After

**Before**

- Monochrome fenced code could render Unicode source such as `Café → …` after a `CodeRenderable` was reused across Markdown block types.
- Drive tests parsed generated `.jsonc` files with strict JSON APIs and failed as soon as defaults contained comments.

**After**

- Non-Markdown code content is ASCII-normalized before OpenTUI refreshes its buffer, producing `Caf? -> ...`.
- Drive instance and CLI tests parse `.jsonc` files with `Bun.JSONC.parse`, matching production and the file format.

## How

- `packages/tui/src/mini/mono.ts` checks the renderable's current file type and normalizes non-Markdown code content.
- Drive test assertions read JSONC text and parse it with Bun's JSONC parser.

## Scope

Production Drive behavior is unchanged. This does not alter service lifecycle behavior. A one-off diff-viewer renderer timeout was not changed because it passed 20 focused runs and five complete TUI suites after these deterministic failures were removed.

## Testing

- `cd packages/tui && bun run test test/mini/footer.view.test.tsx` (42 passed, 4 skipped)
- `cd packages/tui && bun typecheck`
- `cd packages/drive && bun run test` (205 Effect tests and 58 CLI integration tests passed)
- `cd packages/drive && bun typecheck`
- Repository pre-push typecheck: 34 packages passed
