### PR TITLE
test(drive): parse generated JSONC config

### DIFF
--- a/packages/drive/test/cli/integration.test.ts
+++ b/packages/drive/test/cli/integration.test.ts
@@ -120,7 +120,9 @@ describe("opencode-drive", () => {
     expect(initStatus).toBe(0)
     const artifacts = initOutput.trim()
     expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).exists()).toBe(true)
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(
+      Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).text()),
+    ).toMatchObject({
       model: "simulation/gpt-sim-model",
       snapshots: false,
       permissions: [{ action: "*", resource: "*", effect: "allow" }],
@@ -765,13 +767,15 @@ describe("opencode-drive", () => {
       gitWriteError: expect.stringContaining("must not modify Git metadata"),
       matches: true,
     })
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(
+      Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "opencode.jsonc")).text()),
+    ).toMatchObject({
       autoupdate: false,
       model: "simulation/gpt-sim-model",
       providers: { simulation: { models: { "gpt-sim-model": {} } } },
       test: { declared: true, setup: true },
     })
-    expect(await Bun.file(join(artifacts, "files", ".opencode", "tui.jsonc")).json()).toEqual({
+    expect(Bun.JSONC.parse(await Bun.file(join(artifacts, "files", ".opencode", "tui.jsonc")).text())).toEqual({
       test: { declared: true, setup: true },
     })
     const backendEvents = (await Bun.file(join(artifacts, "backend-events.jsonl")).text())

--- a/packages/drive/test/instance/config.test.ts
+++ b/packages/drive/test/instance/config.test.ts
@@ -15,7 +15,7 @@ describe("instance configuration", () => {
     const root = await initializeInstance()
     artifacts.push(root)
 
-    expect(await Bun.file(join(root, "files", ".opencode", "opencode.jsonc")).json()).toMatchObject({
+    expect(Bun.JSONC.parse(await Bun.file(join(root, "files", ".opencode", "opencode.jsonc")).text())).toMatchObject({
       model: "simulation/gpt-sim-model",
       providers: {
         simulation: {


### PR DESCRIPTION
## What

Repair Drive tests so generated `opencode.jsonc` and `tui.jsonc` files are parsed as JSONC.

## Before / After

**Before**

Instance and CLI integration tests called `Bun.file(...).json()` on JSONC files. Once the default configuration included comments, Linux unit jobs failed with `SyntaxError: Failed to parse JSON` before checking the generated configuration.

**After**

Tests read the files as text and parse them with `Bun.JSONC.parse`, matching the production configuration reader and the files' declared format.

## How

Updates JSONC assertions in:

- `packages/drive/test/instance/config.test.ts`
- `packages/drive/test/cli/integration.test.ts`

Production behavior is unchanged.

## Scope

This does not change Drive configuration generation or provider configuration.

## Testing

- `cd packages/drive && bun run test` (205 Effect tests and 58 CLI integration tests passed)
- `cd packages/drive && bun typecheck`
- Repository pre-push typecheck: 34 packages passed
