### PR TITLE
fix(core): skip shell parsing when permissions allow all

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -99,6 +99,11 @@ export function merge(...rulesets: Permission.Ruleset[]): Permission.Ruleset {
 }
 
 export interface Interface {
+  readonly allowsAll: (input: {
+    readonly sessionID: SessionSchema.ID
+    readonly action: string
+    readonly agent?: Agent.ID
+  }) => Effect.Effect<boolean, SessionErrors.NotFoundError>
   readonly ask: (input: AssertInput) => Effect.Effect<AskResult, SessionErrors.NotFoundError>
   readonly assert: (input: AssertInput) => Effect.Effect<void, Error | SessionErrors.NotFoundError>
   readonly reply: (input: ReplyInput) => Effect.Effect<void, NotFoundError>
@@ -152,6 +157,24 @@ const layer = Layer.effect(
       if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
       const agent = yield* agents.resolve(agentID ?? session.agent)
       return agent?.permissions ?? missingAgentPermissions
+    })
+
+    const allowsAll = Effect.fn("Permission.allowsAll")(function* (input: {
+      readonly sessionID: SessionSchema.ID
+      readonly action: string
+      readonly agent?: Agent.ID
+    }) {
+      const rules = yield* configured(input.sessionID, input.agent)
+      const relevant = rules.filter((rule) => Wildcard.match(input.action, rule.action))
+      for (let index = relevant.length - 1; index >= 0; index--) {
+        const rule = relevant[index]
+        if (rule.resource !== "*") {
+          if (rule.effect !== "allow") return false
+          continue
+        }
+        return rule.effect === "allow"
+      }
+      return false
     })
 
     function denied(input: AssertInput, rules: Permission.Ruleset) {
@@ -315,7 +338,7 @@ const layer = Layer.effect(
       return Array.from(pending.values(), (item) => item.request).filter((request) => request.sessionID === sessionID)
     })
 
-    return Service.of({ ask, assert, reply, get, forSession, list })
+    return Service.of({ allowsAll, ask, assert, reply, get, forSession, list })
   }),
 )
 

--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -149,54 +149,49 @@ export const Plugin = {
                 (invocation) =>
                   Effect.gen(function* () {
                     const target = yield* mutation.resolve({ path: invocation.cwd, kind: "directory" })
-                    const unrestricted = yield* Effect.all([
-                      permission.allowsAll({ sessionID: context.sessionID, action: name, agent: context.agent }),
-                      permission.allowsAll({
+                    const unrestricted =
+                      (yield* permission.allowsAll({
+                        sessionID: context.sessionID,
+                        action: name,
+                        agent: context.agent,
+                      })) &&
+                      (yield* permission.allowsAll({
                         sessionID: context.sessionID,
                         action: "external_directory",
                         agent: context.agent,
-                      }),
-                    ]).pipe(Effect.map((allowed) => allowed.every(Boolean)))
+                      }))
                     invocation.cwd = target.absolute
                     finalTimeout = invocation.timeout
-                    if (unrestricted) {
-                      const workdir = yield* Environment.typeFollowing(environment.files, target.absolute).pipe(
-                        Effect.catchTag("Environment.NotFound", () =>
-                          Effect.fail(new Error(`Working directory does not exist: ${target.absolute}`)),
-                        ),
+                    if (!unrestricted) {
+                      const parsed = yield* ShellParse.scan(invocation.command, invocation.shell, target.absolute)
+                      const directories = yield* Effect.forEach(parsed.directories, (directory) =>
+                        mutation.resolve({ path: path.resolve(target.absolute, directory), kind: "directory" }),
                       )
-                      if (workdir !== "directory")
-                        return yield* Effect.fail(new Error(`Working directory is not a directory: ${target.absolute}`))
-                      return
+                      const external = [target, ...directories]
+                        .map((item) => item.externalDirectory)
+                        .filter((item) => item !== undefined)
+                        .filter(
+                          (item, index, items) => items.findIndex((other) => other.resource === item.resource) === index,
+                        )
+                      if (external.length > 0)
+                        yield* permission.assert({
+                          action: "external_directory",
+                          resources: external.map((item) => item.resource),
+                          save: external.map((item) => item.save),
+                          sessionID: context.sessionID,
+                          agent: context.agent,
+                          source,
+                        })
+                      if (parsed.commands.length > 0)
+                        yield* permission.assert({
+                          action: name,
+                          resources: parsed.commands.map((command) => command.resource),
+                          save: parsed.commands.map((command) => command.save),
+                          sessionID: context.sessionID,
+                          agent: context.agent,
+                          source,
+                        })
                     }
-                    const parsed = yield* ShellParse.scan(invocation.command, invocation.shell, target.absolute)
-                    const directories = yield* Effect.forEach(parsed.directories, (directory) =>
-                      mutation.resolve({ path: path.resolve(target.absolute, directory), kind: "directory" }),
-                    )
-                    const external = [target, ...directories]
-                      .map((item) => item.externalDirectory)
-                      .filter((item) => item !== undefined)
-                      .filter(
-                        (item, index, items) => items.findIndex((other) => other.resource === item.resource) === index,
-                      )
-                    if (external.length > 0)
-                      yield* permission.assert({
-                        action: "external_directory",
-                        resources: external.map((item) => item.resource),
-                        save: external.map((item) => item.save),
-                        sessionID: context.sessionID,
-                        agent: context.agent,
-                        source,
-                      })
-                    if (parsed.commands.length > 0)
-                      yield* permission.assert({
-                        action: name,
-                        resources: parsed.commands.map((command) => command.resource),
-                        save: parsed.commands.map((command) => command.save),
-                        sessionID: context.sessionID,
-                        agent: context.agent,
-                        source,
-                      })
                     const workdir = yield* Environment.typeFollowing(environment.files, target.absolute).pipe(
                       Effect.catchTag("Environment.NotFound", () =>
                         Effect.fail(new Error(`Working directory does not exist: ${target.absolute}`)),

--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -149,12 +149,30 @@ export const Plugin = {
                 (invocation) =>
                   Effect.gen(function* () {
                     const target = yield* mutation.resolve({ path: invocation.cwd, kind: "directory" })
+                    const unrestricted = yield* Effect.all([
+                      permission.allowsAll({ sessionID: context.sessionID, action: name, agent: context.agent }),
+                      permission.allowsAll({
+                        sessionID: context.sessionID,
+                        action: "external_directory",
+                        agent: context.agent,
+                      }),
+                    ]).pipe(Effect.map((allowed) => allowed.every(Boolean)))
+                    invocation.cwd = target.absolute
+                    finalTimeout = invocation.timeout
+                    if (unrestricted) {
+                      const workdir = yield* Environment.typeFollowing(environment.files, target.absolute).pipe(
+                        Effect.catchTag("Environment.NotFound", () =>
+                          Effect.fail(new Error(`Working directory does not exist: ${target.absolute}`)),
+                        ),
+                      )
+                      if (workdir !== "directory")
+                        return yield* Effect.fail(new Error(`Working directory is not a directory: ${target.absolute}`))
+                      return
+                    }
                     const parsed = yield* ShellParse.scan(invocation.command, invocation.shell, target.absolute)
                     const directories = yield* Effect.forEach(parsed.directories, (directory) =>
                       mutation.resolve({ path: path.resolve(target.absolute, directory), kind: "directory" }),
                     )
-                    invocation.cwd = target.absolute
-                    finalTimeout = invocation.timeout
                     const external = [target, ...directories]
                       .map((item) => item.externalDirectory)
                       .filter((item) => item !== undefined)

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -112,6 +112,31 @@ describe("Permission", () => {
     }),
   )
 
+  it.effect("proves only unconditional configured allows", () =>
+    Effect.gen(function* () {
+      const service = yield* Permission.Service
+      const input = { sessionID: Session.ID.make("ses_test"), action: "shell" }
+
+      yield* setup([{ action: "shell", resource: "*", effect: "allow" }])
+      expect(yield* service.allowsAll(input)).toBe(true)
+
+      yield* setRules([
+        { action: "shell", resource: "*", effect: "allow" },
+        { action: "shell", resource: "rm *", effect: "deny" },
+      ])
+      expect(yield* service.allowsAll(input)).toBe(false)
+
+      yield* setRules([{ action: "shell", resource: "git *", effect: "allow" }])
+      expect(yield* service.allowsAll(input)).toBe(false)
+
+      yield* setRules([
+        { action: "shell", resource: "rm *", effect: "deny" },
+        { action: "shell", resource: "*", effect: "allow" },
+      ])
+      expect(yield* service.allowsAll(input)).toBe(true)
+    }),
+  )
+
   it.effect("evaluates against an explicit provider-turn agent", () =>
     Effect.gen(function* () {
       yield* setup([{ action: "read", resource: "*", effect: "allow" }])

--- a/packages/core/test/session-instructions.test.ts
+++ b/packages/core/test/session-instructions.test.ts
@@ -61,6 +61,7 @@ const projects = Layer.succeed(
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: () => Effect.void,
     ask: () => Effect.die("unused"),
     reply: () => Effect.die("unused"),

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -58,6 +58,7 @@ const client = LLMClient.layer.pipe(Layer.provide(executor))
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: () => Effect.die("unused"),
     ask: () => Effect.die("unused"),
     reply: () => Effect.die("unused"),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -221,6 +221,7 @@ const permissionFail = {
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: () => Effect.die("unused"),
     ask: () => Effect.die("unused"),
     reply: () => Effect.die("unused"),

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -46,6 +46,7 @@ let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(fal
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) =>
       Effect.sync(() => assertions.push(input)).pipe(
         Effect.andThen(

--- a/packages/core/test/tool-patch.test.ts
+++ b/packages/core/test/tool-patch.test.ts
@@ -41,6 +41,7 @@ let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(fal
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) =>
       Effect.sync(() => {
         assertions.push(input)

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -31,6 +31,7 @@ const questionInput = {
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) =>
       Effect.sync(() => assertions.push(input)).pipe(
         Effect.andThen(

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -73,6 +73,7 @@ let allow = true
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) =>
       Effect.sync(() => {
         assertions.push(input)

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -52,6 +52,7 @@ const withTools = <A, E, R>(
           Layer.succeed(
             Permission.Service,
             Permission.Service.of({
+              allowsAll: () => Effect.succeed(false),
               assert: (input) =>
                 Effect.sync(() => {
                   assertions?.push(input)

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -44,12 +44,14 @@ import { toolIdentity, executeTool, registerToolPlugin, toolDefinitions } from "
 const sessionID = Session.ID.make("ses_shell_tool_test")
 const sessionModel = Model.Ref.make({ id: Model.ID.make("test"), providerID: Provider.ID.make("test") })
 const assertions: Permission.AssertInput[] = []
+const allowedActions = new Set<string>()
 let denyAction: string | undefined
 let afterPermission = (_input: Permission.AssertInput): Effect.Effect<void> => Effect.void
 
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: (input) => Effect.succeed(allowedActions.has(input.action)),
     assert: (input) =>
       Effect.sync(() => assertions.push(input)).pipe(
         Effect.andThen(Effect.suspend(() => afterPermission(input))),
@@ -75,6 +77,7 @@ const permission = Layer.succeed(
 
 const reset = () => {
   assertions.length = 0
+  allowedActions.clear()
   denyAction = undefined
   afterPermission = () => Effect.void
 }
@@ -328,6 +331,30 @@ describe("ShellTool", () => {
                   resources: ["printf one", "printf two"],
                   save: ["printf *", "printf *"],
                 })
+              }),
+            ),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 15_000 },
+  )
+
+  it.live(
+    "skips command decomposition when shell and external directories are unrestricted",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          allowedActions.add("shell")
+          allowedActions.add("external_directory")
+          return withSession(tmp.path, (registry) =>
+            executeTool(registry, call({ command: "printf one && printf two" }, "call-unrestricted")),
+          ).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                expect(assertions).toEqual([])
               }),
             ),
           )

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -55,6 +55,7 @@ describe("SkillTool", () => {
           const permission = Layer.succeed(
             Permission.Service,
             Permission.Service.of({
+              allowsAll: () => Effect.succeed(false),
               assert: (input) =>
                 Effect.sync(() => assertions.push(input)).pipe(
                   Effect.andThen(

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -39,6 +39,7 @@ const http = Layer.succeed(
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) => Effect.sync(() => assertions.push(input)),
     ask: () => Effect.die("unused"),
     reply: () => Effect.die("unused"),

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -69,6 +69,7 @@ beforeEach(() => {
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) => Effect.sync(() => assertions.push(input)),
     ask: () => Effect.die("unused"),
     reply: () => Effect.die("unused"),

--- a/packages/core/test/tool-write.test.ts
+++ b/packages/core/test/tool-write.test.ts
@@ -36,6 +36,7 @@ let denyAction: string | undefined
 const permission = Layer.succeed(
   Permission.Service,
   Permission.Service.of({
+    allowsAll: () => Effect.succeed(false),
     assert: (input) =>
       Effect.sync(() => assertions.push(input)).pipe(
         Effect.andThen(


### PR DESCRIPTION
## What

Skip shell command parsing when the effective agent configuration provably allows every shell command and every external directory.

This lets sandboxed runtimes with an unconditional shell policy execute without loading tree-sitter. Runtimes with granular asks or denies retain the existing parser-backed permission decomposition.

## Before / After

**Before:** the shell tool always loaded tree-sitter and parsed the command before checking permissions. A workerd runtime could not execute shell commands even when its agent configuration unconditionally allowed them, because tree-sitter's dynamically linked grammar WASM cannot load there.

**After:** the permission service first proves that both `shell` and `external_directory` are unconditionally allowed. If so, the tool validates the working directory and executes the raw command without loading the parser. Any ask, deny, scoped-only allow, or later scoped override keeps the existing parse-and-assert path.

## How

- `packages/core/src/permission.ts` adds `allowsAll`, a conservative configured-rule proof. It requires a matching `resource: \"*\"` allow and rejects any later matching scoped ask or deny.
- `packages/core/src/tool/plugin/shell.ts` skips `ShellParse.scan` only when both shell execution and external-directory access pass that proof.
- Permission and shell-tool tests cover blanket allows, scoped allows, later denies, later blanket overrides, parser bypass, and unchanged compound-command decomposition.

## Scope

This does not add a parser fallback or change granular shell permission semantics. Commands still parse whenever the configuration cannot prove unrestricted access.

This branch currently targets the permission model at `v2` HEAD. #42174 adds ancestor deny inheritance; after it merges, this PR will be rebased so inherited denies also prevent the fast path.

## Testing

- `cd packages/core && bun test test/permission.test.ts` (12 passed)
- `cd packages/core && bun test test/tool-shell.test.ts` (20 passed)
- `cd packages/core && bun run typecheck`
- Pre-push full workspace typecheck: 34 packages passed