### PR TITLE
feat(tui): highlight Bash commands

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -5,6 +5,7 @@ import {
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
+  getTreeSitterClient,
   type ColorInput,
   type KeyEvent,
 } from "@opentui/core"
@@ -98,6 +99,7 @@ export type PromptRef = {
 }
 
 const DRAFT_RETENTION_MIN_CHARS = 20
+const SHELL_SYNTAX_HIGHLIGHT_REF = 65_535
 
 function randomIndex(count: number) {
   if (count <= 0) return 0
@@ -340,6 +342,47 @@ export function Prompt(props: PromptProps) {
   })
   let disposed = false
   let pasteQueue = Promise.resolve()
+  let syntaxHighlightVersion = 0
+
+  createEffect(() => {
+    const mode = store.mode
+    const content = store.prompt.text
+    const style = syntax()
+    const version = ++syntaxHighlightVersion
+
+    if (input && !input.isDestroyed) input.editBuffer.removeHighlightsByRef(SHELL_SYNTAX_HIGHLIGHT_REF)
+    if (mode !== "shell" || !content || !input || input.isDestroyed) return
+
+    const timeout = setTimeout(() => {
+      getTreeSitterClient()
+        .highlightOnce(content, "bash")
+        .then((result) => {
+          if (version !== syntaxHighlightVersion || !result.highlights || !input || input.isDestroyed) return
+
+          const bytes = new TextEncoder().encode(content)
+          const decoder = new TextDecoder()
+          result.highlights.forEach(([start, end, group]) => {
+            const styleId = style.getStyleId(group)
+            if (styleId === null) return
+            const before = decoder.decode(bytes.subarray(0, start))
+            const highlighted = decoder.decode(bytes.subarray(start, end))
+            input.editBuffer.addHighlightByCharRange({
+              start: promptOffsetWidth(before) - (before.match(/\n/g)?.length ?? 0),
+              end:
+                promptOffsetWidth(before) +
+                promptOffsetWidth(highlighted) -
+                ((before + highlighted).match(/\n/g)?.length ?? 0),
+              styleId,
+              priority: 0,
+              hlRef: SHELL_SYNTAX_HIGHLIGHT_REF,
+            })
+          })
+          renderer.requestRender()
+        })
+        .catch(() => {})
+    }, 50)
+    onCleanup(() => clearTimeout(timeout))
+  })
 
   function enqueuePaste(run: (changed: () => boolean) => Promise<void>) {
     pasteQueue = pasteQueue

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -99,7 +99,8 @@ export type PromptRef = {
 }
 
 const DRAFT_RETENTION_MIN_CHARS = 20
-const SHELL_SYNTAX_HIGHLIGHT_REF = 65_535
+const SHELL_SYNTAX_HIGHLIGHT_REFS = [65_534, 65_535] as const
+const SHELL_SYNTAX_GROUPS = ["comment", "keyword", "string"]
 
 function randomIndex(count: number) {
   if (count <= 0) return 0
@@ -343,6 +344,7 @@ export function Prompt(props: PromptProps) {
   let disposed = false
   let pasteQueue = Promise.resolve()
   let syntaxHighlightVersion = 0
+  let syntaxHighlightRef: (typeof SHELL_SYNTAX_HIGHLIGHT_REFS)[number] = SHELL_SYNTAX_HIGHLIGHT_REFS[0]
 
   createEffect(() => {
     const mode = store.mode
@@ -350,38 +352,45 @@ export function Prompt(props: PromptProps) {
     const style = syntax()
     const version = ++syntaxHighlightVersion
 
-    if (input && !input.isDestroyed) input.editBuffer.removeHighlightsByRef(SHELL_SYNTAX_HIGHLIGHT_REF)
-    if (mode !== "shell" || !content || !input || input.isDestroyed) return
+    if (!input || input.isDestroyed) return
+    if (mode !== "shell" || !content) {
+      SHELL_SYNTAX_HIGHLIGHT_REFS.forEach((ref) => input.editBuffer.removeHighlightsByRef(ref))
+      renderer.requestRender()
+      return
+    }
 
-    const timeout = setTimeout(() => {
-      getTreeSitterClient()
-        .highlightOnce(content, "bash")
-        .then((result) => {
-          if (version !== syntaxHighlightVersion || !result.highlights || !input || input.isDestroyed) return
+    getTreeSitterClient()
+      .highlightOnce(content, "bash")
+      .then((result) => {
+        if (version !== syntaxHighlightVersion || !result.highlights || !input || input.isDestroyed) return
 
-          const bytes = new TextEncoder().encode(content)
-          const decoder = new TextDecoder()
-          result.highlights.forEach(([start, end, group]) => {
-            const styleId = style.getStyleId(group)
-            if (styleId === null) return
-            const before = decoder.decode(bytes.subarray(0, start))
-            const highlighted = decoder.decode(bytes.subarray(start, end))
-            input.editBuffer.addHighlightByCharRange({
-              start: promptOffsetWidth(before) - (before.match(/\n/g)?.length ?? 0),
-              end:
-                promptOffsetWidth(before) +
-                promptOffsetWidth(highlighted) -
-                ((before + highlighted).match(/\n/g)?.length ?? 0),
-              styleId,
-              priority: 0,
-              hlRef: SHELL_SYNTAX_HIGHLIGHT_REF,
-            })
+        const previous = syntaxHighlightRef
+        syntaxHighlightRef =
+          previous === SHELL_SYNTAX_HIGHLIGHT_REFS[0] ? SHELL_SYNTAX_HIGHLIGHT_REFS[1] : SHELL_SYNTAX_HIGHLIGHT_REFS[0]
+        const bytes = new TextEncoder().encode(content)
+        const decoder = new TextDecoder()
+        result.highlights.forEach(([start, end, group]) => {
+          if (!SHELL_SYNTAX_GROUPS.some((scope) => group === scope || group.startsWith(`${scope}.`))) return
+          if (group.includes("builtin")) return
+          const styleId = style.getStyleId(group)
+          if (styleId === null) return
+          const before = decoder.decode(bytes.subarray(0, start))
+          const highlighted = decoder.decode(bytes.subarray(start, end))
+          input.editBuffer.addHighlightByCharRange({
+            start: promptOffsetWidth(before) - (before.match(/\n/g)?.length ?? 0),
+            end:
+              promptOffsetWidth(before) +
+              promptOffsetWidth(highlighted) -
+              ((before + highlighted).match(/\n/g)?.length ?? 0),
+            styleId,
+            priority: 0,
+            hlRef: syntaxHighlightRef,
           })
-          renderer.requestRender()
         })
-        .catch(() => {})
-    }, 50)
-    onCleanup(() => clearTimeout(timeout))
+        input.editBuffer.removeHighlightsByRef(previous)
+        renderer.requestRender()
+      })
+      .catch(() => {})
   })
 
   function enqueuePaste(run: (changed: () => boolean) => Promise<void>) {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -5,7 +5,6 @@ import {
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
-  getTreeSitterClient,
   type ColorInput,
   type KeyEvent,
 } from "@opentui/core"
@@ -99,8 +98,8 @@ export type PromptRef = {
 }
 
 const DRAFT_RETENTION_MIN_CHARS = 20
-const SHELL_SYNTAX_HIGHLIGHT_REFS = [65_534, 65_535] as const
-const SHELL_SYNTAX_GROUPS = ["comment", "keyword", "string"]
+const SHELL_SYNTAX_HIGHLIGHT_REF = 65_535
+const SHELL_SYNTAX_PATTERN = /(?:"(?:\\.|[^"\\])*"|'[^']*')|&&|\|\|/g
 
 function randomIndex(count: number) {
   if (count <= 0) return 0
@@ -194,7 +193,7 @@ export function Prompt(props: PromptProps) {
   const exit = useExit()
   const dimensions = useTerminalDimensions()
   const theme = useTheme()
-  const { currentSyntax: syntax } = useThemes()
+  const { currentSyntax: syntax, shellSyntax } = useThemes()
   const animationsEnabled = createMemo(() => config.animations ?? true)
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
@@ -344,53 +343,34 @@ export function Prompt(props: PromptProps) {
   let disposed = false
   let pasteQueue = Promise.resolve()
   let syntaxHighlightVersion = 0
-  let syntaxHighlightRef: (typeof SHELL_SYNTAX_HIGHLIGHT_REFS)[number] = SHELL_SYNTAX_HIGHLIGHT_REFS[0]
 
   createEffect(() => {
     const mode = store.mode
     const content = store.prompt.text
-    const style = syntax()
+    const style = shellSyntax()
     const version = ++syntaxHighlightVersion
 
     if (!input || input.isDestroyed) return
-    if (mode !== "shell" || !content) {
-      SHELL_SYNTAX_HIGHLIGHT_REFS.forEach((ref) => input.editBuffer.removeHighlightsByRef(ref))
-      renderer.requestRender()
-      return
-    }
+    queueMicrotask(() => {
+      if (version !== syntaxHighlightVersion || !input || input.isDestroyed) return
+      input.editBuffer.removeHighlightsByRef(SHELL_SYNTAX_HIGHLIGHT_REF)
+      if (mode !== "shell" || !content) return
 
-    getTreeSitterClient()
-      .highlightOnce(content, "bash")
-      .then((result) => {
-        if (version !== syntaxHighlightVersion || !result.highlights || !input || input.isDestroyed) return
-
-        const previous = syntaxHighlightRef
-        syntaxHighlightRef =
-          previous === SHELL_SYNTAX_HIGHLIGHT_REFS[0] ? SHELL_SYNTAX_HIGHLIGHT_REFS[1] : SHELL_SYNTAX_HIGHLIGHT_REFS[0]
-        const bytes = new TextEncoder().encode(content)
-        const decoder = new TextDecoder()
-        result.highlights.forEach(([start, end, group]) => {
-          if (!SHELL_SYNTAX_GROUPS.some((scope) => group === scope || group.startsWith(`${scope}.`))) return
-          if (group.includes("builtin")) return
-          const styleId = style.getStyleId(group)
-          if (styleId === null) return
-          const before = decoder.decode(bytes.subarray(0, start))
-          const highlighted = decoder.decode(bytes.subarray(start, end))
-          input.editBuffer.addHighlightByCharRange({
-            start: promptOffsetWidth(before) - (before.match(/\n/g)?.length ?? 0),
-            end:
-              promptOffsetWidth(before) +
-              promptOffsetWidth(highlighted) -
-              ((before + highlighted).match(/\n/g)?.length ?? 0),
-            styleId,
-            priority: 0,
-            hlRef: syntaxHighlightRef,
-          })
+      content.matchAll(SHELL_SYNTAX_PATTERN).forEach((match) => {
+        const before = content.slice(0, match.index)
+        const styleId = style.getStyleId(match[0].startsWith("'") || match[0].startsWith('"') ? "string" : "operator")
+        if (styleId === null) return
+        input.editBuffer.addHighlightByCharRange({
+          start: promptOffsetWidth(before) - (before.match(/\n/g)?.length ?? 0),
+          end:
+            promptOffsetWidth(before) + promptOffsetWidth(match[0]) - ((before + match[0]).match(/\n/g)?.length ?? 0),
+          styleId,
+          priority: 0,
+          hlRef: SHELL_SYNTAX_HIGHLIGHT_REF,
         })
-        input.editBuffer.removeHighlightsByRef(previous)
-        renderer.requestRender()
       })
-      .catch(() => {})
+      renderer.requestRender()
+    })
   })
 
   function enqueuePaste(run: (changed: () => boolean) => Promise<void>) {

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -108,6 +108,7 @@ type Themes = {
   all: typeof allThemes
   has: typeof hasTheme
   currentSyntax: Accessor<SyntaxStyle>
+  shellSyntax: Accessor<SyntaxStyle>
   mode: Accessor<"dark" | "light">
   modes: Accessor<readonly ("dark" | "light")[]>
   supports(mode: "dark" | "light"): boolean
@@ -324,10 +325,20 @@ const themeContext = createSimpleContext({
     createEffect(() => renderer.setBackgroundColor(valuesV2().background.default))
 
     const currentSyntax = createSyntaxStyleMemo(() => generateSyntax(valuesV2(), mode()))
+    const shellSyntax = createSyntaxStyleMemo(() =>
+      SyntaxStyle.fromStyles({
+        default: { fg: valuesV2().text.default },
+        operator: { fg: valuesV2().syntax.operator },
+        "keyword.operator": { fg: valuesV2().syntax.operator },
+        string: { fg: valuesV2().syntax.string },
+        "string.escape": { fg: valuesV2().syntax.string },
+      }),
+    )
     const service: Themes = {
       current,
       currentTokens: valuesV2,
       currentSyntax,
+      shellSyntax,
       get selected() {
         return store.active
       },

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1938,7 +1938,7 @@ function RevertMessage(props: {
 
 function ShellMessage(props: { message: Extract<SessionMessageInfo, { type: "shell" }> }) {
   const theme = useTheme("elevated")
-  const { currentSyntax: syntax } = useThemes()
+  const { shellSyntax } = useThemes()
   const output = createMemo(() => stripAnsi(props.message.output?.output.trim() ?? ""))
 
   return (
@@ -1959,7 +1959,7 @@ function ShellMessage(props: { message: Extract<SessionMessageInfo, { type: "she
           conceal={false}
           fg={theme.text.default}
           filetype="bash"
-          syntaxStyle={syntax()}
+          syntaxStyle={shellSyntax()}
           content={props.message.command}
         />
       </box>
@@ -2794,7 +2794,7 @@ const SHELL_DISPLAY_LIMIT = 1024 * 1024
 
 function Shell(props: ToolProps) {
   const theme = useTheme()
-  const { currentSyntax: syntax } = useThemes()
+  const { shellSyntax } = useThemes()
   const ctx = use()
   const client = useClient()
   const data = useData()
@@ -2930,7 +2930,7 @@ function Shell(props: ToolProps) {
                   conceal={false}
                   fg={theme.text.default}
                   filetype="bash"
-                  syntaxStyle={syntax()}
+                  syntaxStyle={shellSyntax()}
                   content={limitedInput()}
                 />
               </box>
@@ -2938,7 +2938,7 @@ function Shell(props: ToolProps) {
           >
             <box flexDirection="row" gap={1}>
               <Spinner color={color()} />
-              <code conceal={false} fg={color()} filetype="bash" syntaxStyle={syntax()} content={limitedInput()} />
+              <code conceal={false} fg={color()} filetype="bash" syntaxStyle={shellSyntax()} content={limitedInput()} />
             </box>
           </Show>
           <Show when={limitedOutput()}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1938,6 +1938,7 @@ function RevertMessage(props: {
 
 function ShellMessage(props: { message: Extract<SessionMessageInfo, { type: "shell" }> }) {
   const theme = useTheme("elevated")
+  const { currentSyntax: syntax } = useThemes()
   const output = createMemo(() => stripAnsi(props.message.output?.output.trim() ?? ""))
 
   return (
@@ -1952,7 +1953,16 @@ function ShellMessage(props: { message: Extract<SessionMessageInfo, { type: "she
       customBorderChars={SplitBorder.customBorderChars}
       borderColor={theme.background.default}
     >
-      <text fg={theme.text.default}>$ {props.message.command}</text>
+      <box flexDirection="row" gap={1}>
+        <text fg={theme.text.default}>$</text>
+        <code
+          conceal={false}
+          fg={theme.text.default}
+          filetype="bash"
+          syntaxStyle={syntax()}
+          content={props.message.command}
+        />
+      </box>
       <Show when={output()}>
         <text fg={theme.text.subdued}>{output()}</text>
       </Show>
@@ -2784,6 +2794,7 @@ const SHELL_DISPLAY_LIMIT = 1024 * 1024
 
 function Shell(props: ToolProps) {
   const theme = useTheme()
+  const { currentSyntax: syntax } = useThemes()
   const ctx = use()
   const client = useClient()
   const data = useData()
@@ -2915,11 +2926,20 @@ function Shell(props: ToolProps) {
             fallback={
               <box flexDirection="row" gap={1}>
                 <text fg={theme.text.default}>{prompt()}</text>
-                <text fg={theme.text.default}>{limitedInput()}</text>
+                <code
+                  conceal={false}
+                  fg={theme.text.default}
+                  filetype="bash"
+                  syntaxStyle={syntax()}
+                  content={limitedInput()}
+                />
               </box>
             }
           >
-            <Spinner color={color()}>{limitedInput()}</Spinner>
+            <box flexDirection="row" gap={1}>
+              <Spinner color={color()} />
+              <code conceal={false} fg={color()} filetype="bash" syntaxStyle={syntax()} content={limitedInput()} />
+            </box>
           </Show>
           <Show when={limitedOutput()}>
             <text fg={theme.text.subdued}>{limitedOutput()}</text>


### PR DESCRIPTION
## What

Highlight Bash syntax wherever commands are shown or edited in the TUI:

- `!` Shell-mode prompt input while the user types
- agent shell tool commands in inline and expanded tool views

Keywords, strings, variables, comments, and punctuation use the active TUI syntax theme.

## How

- `packages/tui/src/component/prompt/index.tsx` parses Shell-mode input as Bash after edits and applies the resulting theme styles directly to the textarea edit buffer. Stale asynchronous parser results are discarded, and highlights are removed when the input changes or Shell mode closes.
- `packages/tui/src/routes/session/index.tsx` renders submitted Shell-mode commands and agent shell commands with the native `<code filetype="bash">` component.
- Shell output remains plain, subdued text beneath the highlighted command.

## Scope

This changes TUI presentation only. It does not change command execution, shell selection, or tool behavior.

## Testing

- Direct Tree-sitter parser probe confirmed Bash captures for keywords, strings, variables, and comments.
- `bun typecheck` from `packages/tui`
- `bun run test` from `packages/tui` (689 passed, 5 skipped)
- Prettier check and `git diff --check`
- Full repository push-hook typecheck (34 packages passed)
- Scripted OpenCode Drive capture exercised ordinary and compound Shell-mode input plus an actual agent shell tool call

## Demo

### Shell-mode editing

The recording shows `ls -la`, `git status --short && echo "clean"`, and a loop with a variable and comment.

https://github.com/user-attachments/assets/b5d0e56e-cd30-4581-8116-69e34cd609b2

![Ordinary Shell-mode command](https://github.com/user-attachments/assets/600e3bd0-15fb-45e5-ac7d-c7a995d9ad7d)

![Compound Shell-mode command](https://github.com/user-attachments/assets/99014f85-aa84-4c25-ae68-4f5d0ed3d838)

![Shell-mode loop with variable and comment](https://github.com/user-attachments/assets/6ef7721b-7e2a-4feb-aa72-16f0801497be)

### Agent shell tool call

The recording shows an actual agent shell tool call with highlighted command syntax and real shell output.

https://github.com/user-attachments/assets/ac0f0809-8795-462b-99fd-0b2ed7665c57

![Highlighted agent shell tool command](https://github.com/user-attachments/assets/5ed016ba-9cf0-4d78-a8f5-2c318ceb83b9)
