### PR TITLE
fix(tui): highlight queued prompts on hover

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2089,6 +2089,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
 
 function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOpen: () => void }) {
   const theme = useTheme("elevated")
+  const [hover, setHover] = createSignal(false)
   const next = createMemo(() => props.prompts[0]?.text.replaceAll("\n", " "))
 
   return (
@@ -2096,6 +2097,8 @@ function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOp
       border={["left"]}
       borderColor={theme.border.default}
       customBorderChars={SplitBorder.customBorderChars}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
       onMouseUp={props.onOpen}
     >
       <box
@@ -2104,7 +2107,7 @@ function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOp
         paddingBottom={1}
         paddingLeft={2}
         paddingRight={1}
-        backgroundColor={theme.background.default}
+        backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
         flexDirection="row"
       >
         <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1} minWidth={0}>


### PR DESCRIPTION
## What

Adds a subtle raised background when the queued-prompts dock is hovered, making its existing click behavior discoverable.

## Before / After

**Before:** The queued-prompts dock looked identical at rest and under the pointer, so it did not read as interactive.

**After:** Hovering raises the dock background using the existing elevated theme treatment. Clicking still opens the queued-prompts manager.

## How

- Tracks hover state in `QueuedPromptDock`.
- Uses `theme.raise(theme.background.default)` while hovered.
- Preserves the existing full-dock click target and layout.

## Scope

This only changes the V2 TUI queued-prompts dock hover styling.

## Testing

- `bun typecheck` from `packages/tui`
- Full repository pre-push typecheck (41 packages)
- OpenCode Drive end-to-end capture against this worktree

## Demo

OpenCode Drive capture with a seeded simulated queued prompt. The dock starts at its default background, raises visibly for two seconds on hover, then opens the matching `Queued prompts` dialog on click.

https://github.com/user-attachments/assets/3c25bc0e-5191-4f60-b9e2-341f532b7ce4
