### PR TITLE
refactor(util): replace xdg-basedir

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1036,7 +1036,6 @@
         "minimatch": "10.2.5",
         "npm-package-arg": "13.0.2",
         "resolve.exports": "catalog:",
-        "xdg-basedir": "5.1.0",
       },
       "devDependencies": {
         "@tsconfig/bun": "catalog:",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -52,8 +52,7 @@
     "mime-types": "3.0.2",
     "minimatch": "10.2.5",
     "npm-package-arg": "13.0.2",
-    "resolve.exports": "catalog:",
-    "xdg-basedir": "5.1.0"
+    "resolve.exports": "catalog:"
   },
   "devDependencies": {
     "@tsconfig/bun": "catalog:",

--- a/packages/util/src/global-roots.ts
+++ b/packages/util/src/global-roots.ts
@@ -1,14 +1,19 @@
 import os from "os"
 import path from "path"
-import { xdgCache, xdgConfig, xdgData, xdgState } from "xdg-basedir"
+
+const home = os.homedir()
+const data = process.env.XDG_DATA_HOME || (home ? path.join(home, ".local", "share") : undefined)
+const cache = process.env.XDG_CACHE_HOME || (home ? path.join(home, ".cache") : undefined)
+const config = process.env.XDG_CONFIG_HOME || (home ? path.join(home, ".config") : undefined)
+const state = process.env.XDG_STATE_HOME || (home ? path.join(home, ".local", "state") : undefined)
 
 /** The XDG base directories that root opencode's global paths. */
 export function roots(app: string) {
   return {
-    data: path.join(xdgData!, app),
-    cache: path.join(xdgCache!, app),
-    config: path.join(xdgConfig!, app),
-    state: path.join(xdgState!, app),
+    data: path.join(data!, app),
+    cache: path.join(cache!, app),
+    config: path.join(config!, app),
+    state: path.join(state!, app),
     tmp: path.join(os.tmpdir(), app),
   }
 }

--- a/packages/util/test/global-roots.test.ts
+++ b/packages/util/test/global-roots.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { pathToFileURL } from "url"
+
+const module = pathToFileURL(path.join(import.meta.dir, "../src/global-roots.ts")).href
+
+describe("global roots", () => {
+  test("uses XDG overrides", () => {
+    const root = path.join(os.tmpdir(), "opencode-xdg-overrides")
+    const env = {
+      XDG_DATA_HOME: path.join(root, "data"),
+      XDG_CACHE_HOME: path.join(root, "cache"),
+      XDG_CONFIG_HOME: path.join(root, "config"),
+      XDG_STATE_HOME: path.join(root, "state"),
+    }
+
+    expect(run(env)).toEqual({
+      data: path.join(env.XDG_DATA_HOME, "opencode"),
+      cache: path.join(env.XDG_CACHE_HOME, "opencode"),
+      config: path.join(env.XDG_CONFIG_HOME, "opencode"),
+      state: path.join(env.XDG_STATE_HOME, "opencode"),
+      tmp: path.join(os.tmpdir(), "opencode"),
+    })
+  })
+
+  test("empty XDG overrides use home directory defaults", () => {
+    const home = path.join(os.tmpdir(), "opencode-xdg-home")
+
+    expect(
+      run({
+        XDG_DATA_HOME: "",
+        XDG_CACHE_HOME: "",
+        XDG_CONFIG_HOME: "",
+        XDG_STATE_HOME: "",
+        ...(process.platform === "win32" ? { USERPROFILE: home } : { HOME: home }),
+      }),
+    ).toEqual({
+      data: path.join(home, ".local", "share", "opencode"),
+      cache: path.join(home, ".cache", "opencode"),
+      config: path.join(home, ".config", "opencode"),
+      state: path.join(home, ".local", "state", "opencode"),
+      tmp: path.join(os.tmpdir(), "opencode"),
+    })
+  })
+})
+
+function run(env: Record<string, string>) {
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "-e",
+      `const { roots } = await import(${JSON.stringify(module)}); console.log(JSON.stringify(roots("opencode")))`,
+    ],
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+
+  expect(result.exitCode, result.stderr.toString()).toBe(0)
+  return JSON.parse(result.stdout.toString())
+}


### PR DESCRIPTION
## What

Replace `@opencode-ai/util`'s single `xdg-basedir` use with a behavior-compatible local implementation, removing one direct runtime dependency (6,813 unpacked bytes across 5 files).

## How

- Preserve import-time XDG environment overrides and home-directory defaults in `global-roots.ts`.
- Preserve empty-value fallback behavior and platform-specific home resolution through `os.homedir()`.
- Cover overrides and empty/default behavior in isolated subprocess tests.

## Scope

Only `packages/util` is changed. The unrelated `packages/workerd-spike` dependency remains, so the shared lockfile retains the package entry.

## Testing

- `cd packages/util && bun run test` (9 passed)
- `cd packages/util && bun typecheck`
- Push hook workspace typecheck (34 tasks passed)
