### PR TITLE
fix(tui): correct working directory when continuing session in a new directory

### DIFF
--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -8,7 +8,7 @@ import { wrapClientError } from "../error-interceptor.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
 
 function pick(value: string | null, fallback?: string, encode?: (value: string) => string) {
-  if (!value) return
+  if (!value) return fallback
   if (!fallback) return value
   if (value === fallback) return fallback
   if (encode && value === encode(fallback)) return fallback

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -518,6 +518,13 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       } else {
         route.navigate({ type: "session", sessionID: match })
       }
+      return
+    }
+    // No matching session found. Once sync is fully complete, fall back to
+    // home instead of lingering on the placeholder "dummy" session route.
+    if (sync.status === "complete") {
+      continued = true
+      route.navigate({ type: "home" })
     }
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #42221
Also addresses #41562

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode -c` in a directory with no prior sessions showed an old directory instead of the current one. Two issues caused this:

1. **SDK `pick()` didn't fall back to `config.directory`** — When the `x-opencode-directory` header was missing from a request, `pick()` returned `undefined` instead of the configured directory. This meant the `directory` query param wasn't sent, so the server's `listGlobal` skipped its directory filter and returned sessions from all directories. The `-c` continue logic then resumed a session from the wrong directory.

   Fix: `pick()` now returns `fallback` when the header value is missing, so the configured directory is always sent as a query param.

2. **Continue effect didn't fall back to home** — When `-c` found no matching session in the blocking phase, it stayed on the placeholder `"dummy"` session route, producing a broken view.

   Fix: the continue effect now navigates to home once sync completes without a match.

### How did you verify your code works?

- Typecheck passes for both `packages/sdk/js` and `packages/tui`
- SDK tests pass (1/1), TUI session list tests pass (5/5)
- TUI full suite: 189 pass, 4 pre-existing failures (Windows path separator + KV state file — unrelated)
- Verified session DB stores forward-slash paths while `FSUtil.resolve` returns backslashes on Windows, confirming the filter mismatch path

### Screenshots / recordings

_N/A (logic fix, no visible UI change beyond correct directory display)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR