### PR TITLE
fix(tui): position composer top slot above queue

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1085,10 +1085,10 @@ export function Session() {
               </Show>
             </scrollbox>
             <box flexShrink={0}>
+              <Slot path="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                 <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>
-              <Slot path="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Composer
                 sessionID={route.sessionID}
                 open={composer.open || (!!session()?.parentID && forms().length === 0)}


### PR DESCRIPTION
## What

Render `session.composer.top` above the complete composer stack instead of between the queued-prompt rail and prompt.

This keeps additions such as session recaps above the composer as a whole, while the queued rail remains visually attached to the prompt it belongs to.

## Before / After

**Before**

The top slot split the two composer-owned sections.

```text
queued prompt rail
session.composer.top
prompt and footer
```

**After**

The top slot sits above the complete composer.

```text
session.composer.top

queued prompt rail
prompt and footer
```

## How

- `packages/tui/src/routes/session/index.tsx` mounts `session.composer.top` before `QueuedPromptDock`.
- The queued rail and prompt stay together in the existing fixed bottom stack.
- No plugin API or queued-prompt behavior changes.

## Scope

This only changes vertical render order. It does not change slot semantics, queued-prompt interactions, or prompt styling.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/plugin-structure.test.ts` in `packages/tui` (14 passing)
- Full workspace typecheck from the push hook (34 tasks passing)
- OpenCode Drive against this development checkout, with a queued prompt visible above the real prompt

## Demo

The Drive capture shows the queued rail directly attached to the prompt and its metadata. `session.composer.top` now mounts immediately above this complete bottom stack.

![OpenCode Drive capture showing the queued rail attached to the prompt](https://github.com/user-attachments/assets/c13b06e7-7cc1-4271-abb0-b0070dc72e7e)

The simulated response text is generated by OpenCode Drive; the queued rail and prompt are the real TUI surfaces from this branch.
