### PR TITLE
fix(core): reject inherited workspace providers

### DIFF
--- a/packages/core/src/workspace/driver.ts
+++ b/packages/core/src/workspace/driver.ts
@@ -55,7 +55,7 @@ export class RegistryService extends Context.Service<RegistryService, Registry>(
 
 export const registry = (drivers: Readonly<Record<string, Interface>>): Registry => ({
   get: (provider) => {
-    const driver = drivers[provider]
+    const driver = Object.hasOwn(drivers, provider) ? drivers[provider] : undefined
     return driver ? Effect.succeed(driver) : Effect.fail(new ProviderNotFound({ provider }))
   },
 })

--- a/packages/core/test/workspace.test.ts
+++ b/packages/core/test/workspace.test.ts
@@ -48,6 +48,18 @@ beforeEach(() => {
   failConnect = false
 })
 
+it.effect("rejects unregistered workspace providers", () =>
+  Effect.gen(function* () {
+    const registry = WorkspaceDriver.registry({ fake: driver })
+
+    for (const provider of ["missing", "constructor", "toString", "__proto__"]) {
+      expect(yield* registry.get(provider).pipe(Effect.flip)).toEqual(
+        new WorkspaceDriver.ProviderNotFound({ provider }),
+      )
+    }
+  }),
+)
+
 it.effect("persists the workspace lifecycle and reconnects after idle suspension", () =>
   Effect.gen(function* () {
     const workspace = yield* Workspace.Service


### PR DESCRIPTION
## What

Preserve the typed `WorkspaceDriver.ProviderNotFound` contract for every unregistered provider name after removing the built-in Modal workspace driver in #42142.

## Before / After

**Before:** the registry read `drivers[provider]` directly. Names inherited from `Object.prototype`, such as `constructor`, `toString`, and `__proto__`, resolved to unrelated values. Workspace creation then defected while trying to call the bogus driver's `create` method instead of returning `WorkspaceDriver.ProviderNotFound`.

**After:** the registry accepts only own properties of the externally supplied provider record. Ordinary missing names and prototype-inherited names all return the same typed `ProviderNotFound` error.

## How

- Guard the provider lookup in `packages/core/src/workspace/driver.ts` with `Object.hasOwn`.
- Add focused Core coverage for an ordinary missing provider and the inherited `constructor`, `toString`, and `__proto__` names.

## Scope

- V2 only; `packages/opencode` is unchanged.
- No change to the generic workspace driver interface or layer registration API.
- No built-in workspace provider is added.
- The Modal implementation, dependency, tests, and lock graph remain removed by #42142.

## Testing

- `cd packages/core && bun run test test/workspace.test.ts` (3 passed)
- `cd packages/core && bun typecheck`
- `cd packages/server && bun run test` (22 passed)
- `cd packages/server && bun typecheck`
- `cd packages/sdk-next && bun run test test/embedded.test.ts` (11 passed)
- `cd packages/sdk-next && bun typecheck`
- Push hook: `bun turbo typecheck --concurrency=3` (34 package tasks passed)
- `bunx prettier --check packages/core/src/workspace/driver.ts packages/core/test/workspace.test.ts`
- `git diff --check`

## Modal Removal Measurements

Measured across #42142 using identical `bun build src/routes.ts --target=bun` commands:

- Server JS bundle: 30,876,101 to 27,797,545 bytes, saving 3,078,556 bytes (9.97%).
- Gzipped server JS: saving 361,312 bytes (6.91%).
- Installed monorepo dependencies: saving 13,520 KiB (0.41%).
- Lockfile: 39 lines and 20 Modal-related package entries removed.
