### PR TITLE
fix(console): drop non-function tools when converting Responses to chat completions

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -1,4 +1,4 @@
-import { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
+import type { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
 
 type Usage = {
   prompt_tokens?: number
@@ -195,15 +195,24 @@ export function toOaCompatibleRequest(body: CommonRequest) {
     }
   }
 
+  // Chat-completions upstreams only accept function tools. Responses-API
+  // requests also carry non-function tools (e.g. web_search) that have no
+  // chat-completions equivalent; mapping them into a function tool yields an
+  // undefined function.name, which upstream serde rejects with
+  // `tools[N].function: missing field "name"` and 400s the whole request, so
+  // drop them. Accept both Responses-style (name at the top level) and
+  // chat-style (name nested under function) tools.
   const tools = Array.isArray(body.tools)
-    ? body.tools.map((tool: any) => ({
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-        },
-      }))
+    ? body.tools
+        .filter((tool: any) => tool && typeof tool === "object" && tool.type === "function")
+        .map((tool: any) => ({
+          type: "function",
+          function: {
+            name: tool.function?.name ?? tool.name,
+            description: tool.function?.description ?? tool.description,
+            parameters: tool.function?.parameters ?? tool.parameters,
+          },
+        }))
     : undefined
 
   return {

--- a/packages/console/app/test/openaiCompatibleRequest.test.ts
+++ b/packages/console/app/test/openaiCompatibleRequest.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { fromOpenaiRequest } from "../src/routes/zen/util/provider/openai"
+import { toOaCompatibleRequest } from "../src/routes/zen/util/provider/openai-compatible"
+
+describe("toOaCompatibleRequest tool conversion", () => {
+  test("drops non-function tools (web_search) and keeps Responses-style function tools with top-level name", () => {
+    // This is the shape Codex actually sends to /v1/responses: function tools
+    // carry `name` at the top level, and web_search has no name at all.
+    const common = fromOpenaiRequest({
+      model: "deepseek-v4-pro",
+      input: [{ role: "user", content: "hi" }],
+      tools: [
+        { type: "function", name: "shell_command", description: "run a shell command", parameters: { type: "object" } },
+        { type: "namespace", name: "mcp__node_repl", description: "mcp tools", tools: [] },
+        { type: "web_search", external_web_access: true },
+      ],
+    })
+
+    expect(toOaCompatibleRequest(common).tools).toEqual([
+      {
+        type: "function",
+        function: { name: "shell_command", description: "run a shell command", parameters: { type: "object" } },
+      },
+    ])
+  })
+
+  test("keeps chat-completions-style function tools with nested function.name", () => {
+    const common = fromOpenaiRequest({
+      model: "m",
+      input: [{ role: "user", content: "hi" }],
+      tools: [{ type: "function", function: { name: "get_weather", description: "x", parameters: { type: "object" } } }],
+    })
+
+    expect(toOaCompatibleRequest(common).tools).toEqual([
+      { type: "function", function: { name: "get_weather", description: "x", parameters: { type: "object" } } },
+    ])
+  })
+
+  test("omits tools when the request has none", () => {
+    const common = fromOpenaiRequest({ model: "m", input: [{ role: "user", content: "hi" }] })
+    expect(toOaCompatibleRequest(common).tools).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

Fixes the `tools[N].function: missing field "name"` 400 that Codex hits on
`/v1/responses` (OpenCode Go / Zen) when the upstream model speaks chat
completions instead of native Responses (e.g. `deepseek-v4-pro`).

## Why

Codex always sends a `web_search` tool on `/v1/responses`:

```json
{"type":"web_search","external_web_access":true}
```

It has no `name` field. `toOaCompatibleRequest` mapped **every** tool into
`{"type":"function","function":{...}}`, so `web_search` produced an undefined
`function.name`, which the upstream (DeepSeek) serde rejects with
`tools[N].function: missing field "name"` and 400s the whole request before
the model even runs.

Reproduced with the real Codex CLI (0.147.0, `wire_api = "responses"`):
the identical request body succeeds for `deepseek-v4-flash` (paid tier is
routed to DeepSeek's native `/v1/responses`) and fails for
`deepseek-v4-pro` (goes through the chat-completions conversion).

## Changes

- `toOaCompatibleRequest`: filter out non-function tools (`web_search`,
  namespaces, ...) before converting to chat completions, since
  chat-completions upstreams have no equivalent for them.
- Read the function name/description/parameters from both Responses-style
  tools (`name` at the top level, which Codex actually sends) and
  chat-style tools (`name` nested under `function`).
- Add regression tests using the real Codex `/v1/responses` tool shape
  (top-level name + namespace + `web_search`).

## Related

- #40171 (stream lifecycle for converted streams)
- #40210 (complements; its tool conversion only reads chat-style
  `tool.function?.name`, this also handles the Responses-style top-level
  `name` that Codex sends, and adds tests with the real shape)