### PR TITLE
fix(tui): detach clipboard helper processes to survive SIGTSTP

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -8,7 +8,15 @@ const exec = promisify(execFile)
 
 function command(command: string, args: string[] = [], input?: string) {
   return new Promise<Buffer>((resolve, reject) => {
-    const child = spawn(command, args, { stdio: [input === undefined ? "ignore" : "pipe", "pipe", "ignore"] })
+    // `detached: true` gives the child its own process group so clipboard helpers that
+    // fork into the background to keep serving a selection (e.g. `wl-copy`) are not
+    // suspended when the terminal sends SIGTSTP to opencode's foreground process group.
+    // Without this, Ctrl-Z stops the still-running helper along with opencode, and the
+    // next paste hangs waiting on a stopped clipboard provider.
+    const child = spawn(command, args, {
+      stdio: [input === undefined ? "ignore" : "pipe", "pipe", "ignore"],
+      detached: true,
+    })
     const output: Buffer[] = []
     child.on("error", reject)
     child.stdout?.on("data", (chunk: Buffer) => output.push(chunk))


### PR DESCRIPTION
## Bug

Clipboard helper processes spawned by `packages/tui/src/clipboard.ts` (e.g. `wl-copy` on Wayland) inherited opencode's process group. `wl-copy` forks into the background to keep serving the clipboard selection after the initiating process exits — but since it shares opencode's pgid, sending `Ctrl-Z` to the terminal delivers `SIGTSTP` to the whole foreground process group, suspending the still-running `wl-copy` along with opencode. Any subsequent paste then hangs indefinitely waiting on the stopped clipboard provider until it's manually resumed with `SIGCONT`.

## Fix

Pass `detached: true` when spawning the clipboard helper in the shared `command()` helper, giving it its own process group so it's unaffected by signals sent to opencode's foreground group.

## Verification

Reproduced the underlying mechanism locally (macOS, Node `child_process`) since I don't have a Wayland session on hand:

- Spawned a long-running child without `detached`: it shares the parent's pgid (`ps` shows same PGID as parent), and `kill -TSTP` on the parent's process group stops it too.
- Spawned the same child with `detached: true`: it gets its own pgid/session (`ps` shows `STAT=Ss`, distinct PGID), and is unaffected by `SIGTSTP` sent to the original parent's process group.

This is exactly the mechanism described in the report, so the fix directly addresses the root cause. Also ran the existing test suite and typecheck:

- `bun test` in `packages/tui`: 193 pass, 0 fail (existing `clipboard.test.ts` covers `copyCommand`, unaffected by this change)
- `bun turbo typecheck`: 30/30 packages pass

Small, isolated change — one spawn-option addition, no behavior change on macOS/Windows paths (`osascript`/`powershell.exe` are short-lived and exit on their own; `detached` is harmless for them too).

*Note: I'm Atlas, an AI agent operating under Gordon Lee's (@g0rdonL) direction, opening this PR on his behalf after independently verifying the fix.*
