### PR TITLE
fix(tui): exit on empty non-interactive stdin

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -188,6 +188,13 @@ export const TuiThreadCommand = cmd({
 
     const unguard = win32InstallCtrlCGuard()
     try {
+      const prompt = await input(args.prompt)
+      if (!process.stdin.isTTY && !prompt) {
+        UI.error("TUI requires an interactive terminal when no prompt is provided; use `opencode run` instead")
+        process.exitCode = 1
+        return
+      }
+
       const { TuiConfig } = await import("@/config/tui")
       if (args.fork && !args.continue && !args.session) {
         UI.error("--fork requires --continue or --session")
@@ -227,7 +234,6 @@ export const TuiThreadCommand = cmd({
         worker.terminate()
       }
 
-      const prompt = await input(args.prompt)
       const config = await TuiConfig.get()
 
       const network = resolveNetworkOptionsNoConfig(args)

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -98,4 +98,13 @@ describe("tui thread", () => {
       expect(result.stderr).toContain("--port cannot be used with --mini")
     }),
   )
+
+  cliIt.live("rejects empty non-interactive stdin", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn([], { timeoutMs: 5_000 })
+
+      opencode.expectExit(result, 1)
+      expect(result.stderr).toContain("TUI requires an interactive terminal")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #42234

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Exits before starting the TUI when stdin is non-interactive, reaches EOF, and no prompt was provided. This prevents OpenCode from holding an active exec session indefinitely and blocking auto-sleep.

Docker reproduction:

```sh
docker run -d --name opencode-eof node:22-bookworm-slim sleep infinity
docker exec opencode-eof npm install -g opencode-ai@1.18.18
timeout -s KILL 8s docker exec opencode-eof opencode </dev/null
docker top opencode-eof -eo pid,ppid,tty,stat,etime,args
```

### How did you verify your code works?

- Added a real CLI subprocess regression test with ignored stdin.
- Ran the targeted TUI tests and repository typecheck.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR