### PR TITLE
feat(merman): support cherry-pick in GitGraph diagrams

### DIFF
--- a/packages/merman/src/gitgraph/diagram.test.ts
+++ b/packages/merman/src/gitgraph/diagram.test.ts
@@ -62,6 +62,62 @@ describe("GitGraphDiagram", () => {
     ])
   })
 
+  test("parses cherry-pick onto the current branch inheriting message and tags", () => {
+    const diagram = parseMermaidGitGraphDiagram(`gitGraph
+      commit id: "base"
+      branch hotfix
+      commit id: "fix" msg: "Fix crash" tag: "v1.1"
+      checkout main
+      cherry-pick id: "fix"
+      cherry-pick id: "fix" tag: "backported"`)
+
+    expect(diagram.commits).toEqual([
+      { id: "base", tags: [], type: "NORMAL", branch: "main", parents: [] },
+      { id: "fix", message: "Fix crash", tags: ["v1.1"], type: "NORMAL", branch: "hotfix", parents: ["base"] },
+      {
+        id: "commit-1",
+        message: "Fix crash",
+        tags: ["v1.1"],
+        type: "CHERRY",
+        branch: "main",
+        parents: ["base"],
+        cherryPicked: "fix",
+      },
+      {
+        id: "commit-2",
+        message: "Fix crash",
+        tags: ["backported"],
+        type: "CHERRY",
+        branch: "main",
+        parents: ["commit-1"],
+        cherryPicked: "fix",
+      },
+    ])
+  })
+
+  test("rejects cherry-pick without an id or referencing an unknown commit", () => {
+    expect(() => parseMermaidGitGraphDiagram("gitGraph\n commit id: base\n cherry-pick")).toThrow(
+      "GitGraph cherry-pick requires an id",
+    )
+    expect(() => parseMermaidGitGraphDiagram("gitGraph\n commit id: base\n cherry-pick id: missing")).toThrow(
+      'cherry-pick references unknown commit "missing"',
+    )
+  })
+
+  test("renders cherry-picked commits with a hollow glyph", () => {
+    expect(
+      renderGitGraphDiagram(`gitGraph
+        commit id: base
+        branch hotfix
+        commit id: fix tag: "v1.1"
+        checkout main
+        cherry-pick id: fix`),
+    ).toBe(`●    base
+├─╮
+│ ●  fix  [hotfix] [v1.1]
+◌    commit-1  [main] [v1.1]`)
+  })
+
   test("supports shorthand messages and preserves branch heads without direct commits", () => {
     const diagram = parseMermaidGitGraphDiagram(`gitGraph
       commit "Initial release"
@@ -127,7 +183,7 @@ describe("GitGraphDiagram", () => {
       new MermaidSyntaxError("gitGraph", 2, "checkout missing", 'Unknown branch "missing"'),
     )
     expect(() => parseMermaidGitGraphDiagram("gitGraph\n cherry-pick id: one")).toThrow(
-      new MermaidSyntaxError("gitGraph", 2, "cherry-pick id: one", "Cherry-pick is not supported"),
+      new MermaidSyntaxError("gitGraph", 2, "cherry-pick id: one", 'cherry-pick references unknown commit "one"'),
     )
     expect(() => parseMermaidGitGraphDiagram("gitGraph\n commit id: same\n commit id: same")).toThrow(
       'Duplicate commit id "same"',
@@ -148,11 +204,14 @@ describe("GitGraphDiagram", () => {
         commit id: work type: REVERSE
         checkout main
         commit id: checkpoint type: HIGHLIGHT
-        merge feature id: done`),
+        merge feature id: done
+        cherry-pick id: checkpoint`),
     )
     const styles = new Set(grid.rows.flatMap((row) => row.map((cell) => cell.style).filter(Boolean)))
 
-    expect(styles).toEqual(new Set(["branch0", "branch1", "commit", "reverse", "highlight", "merge", "label"]))
+    expect(styles).toEqual(
+      new Set(["branch0", "branch1", "commit", "reverse", "highlight", "merge", "cherry", "label"]),
+    )
     expect(Object.keys(resolveGitGraphStyleColors()).sort()).toEqual(
       [
         "branch0",
@@ -163,6 +222,7 @@ describe("GitGraphDiagram", () => {
         "branch5",
         "branch6",
         "branch7",
+        "cherry",
         "commit",
         "highlight",
         "label",

--- a/packages/merman/src/gitgraph/drawing.ts
+++ b/packages/merman/src/gitgraph/drawing.ts
@@ -214,12 +214,14 @@ function isFork(
 function commitGlyph(commit: GitGraphCommit): string {
   if (commit.type === "REVERSE") return "⊗"
   if (commit.type === "HIGHLIGHT") return "◆"
+  if (commit.type === "CHERRY") return "◌"
   return commit.parents.length > 1 ? "◎" : "●"
 }
 
 function commitStyle(commit: GitGraphCommit): GitGraphCellStyle {
   if (commit.type === "REVERSE") return "reverse"
   if (commit.type === "HIGHLIGHT") return "highlight"
+  if (commit.type === "CHERRY") return "cherry"
   return commit.parents.length > 1 ? "merge" : "commit"
 }
 

--- a/packages/merman/src/gitgraph/parser.ts
+++ b/packages/merman/src/gitgraph/parser.ts
@@ -122,7 +122,28 @@ export function parseMermaidGitGraphDiagram(content: string): GitGraphDiagram {
     }
 
     if (operation === "cherry-pick") {
-      throw syntaxError(source.lineNumber, line, "Cherry-pick is not supported")
+      const attributes = parseAttributes(rest, source.lineNumber, line, ["id", "tag"])
+      const referenced = single(attributes, "id", source.lineNumber, line)
+      if (referenced === undefined)
+        throw syntaxError(source.lineNumber, line, "GitGraph cherry-pick requires an id")
+      const sourceCommit = commits.find((commit) => commit.id === referenced)
+      if (sourceCommit === undefined)
+        throw syntaxError(source.lineNumber, line, `cherry-pick references unknown commit "${referenced}"`)
+      const id = `commit-${generatedId++}`
+      const currentHead = heads.get(currentBranch)
+      const commit: GitGraphCommit = {
+        id,
+        message: sourceCommit.message,
+        tags: attributes.get("tag") ?? sourceCommit.tags,
+        type: "CHERRY",
+        branch: currentBranch,
+        parents: currentHead === undefined ? [] : [currentHead],
+        cherryPicked: referenced,
+      }
+      commits.push(commit)
+      ids.add(id)
+      heads.set(currentBranch, id)
+      continue
     }
     throw syntaxError(source.lineNumber, line)
   }

--- a/packages/merman/src/gitgraph/style.ts
+++ b/packages/merman/src/gitgraph/style.ts
@@ -32,6 +32,7 @@ export function resolveGitGraphStyleColors(
     merge: colors.secondary ?? rgba(BRANCH_RGB[2]),
     highlight: colors.warning ?? rgba(BRANCH_RGB[1]),
     reverse: colors.warning ?? rgba(BRANCH_RGB[5]),
+    cherry: colors.muted ?? rgba(BRANCH_RGB[6]),
     label: colors.text ?? rgba([228, 239, 232]),
   }
 }

--- a/packages/merman/src/gitgraph/types.ts
+++ b/packages/merman/src/gitgraph/types.ts
@@ -1,5 +1,5 @@
 export type GitGraphDirection = "LR" | "TB" | "BT"
-export type GitGraphCommitType = "NORMAL" | "REVERSE" | "HIGHLIGHT"
+export type GitGraphCommitType = "NORMAL" | "REVERSE" | "HIGHLIGHT" | "CHERRY"
 
 export interface GitGraphBranch {
   name: string
@@ -14,6 +14,8 @@ export interface GitGraphCommit {
   type: GitGraphCommitType
   branch: string
   parents: string[]
+  /** Source commit id for cherry-picked commits. */
+  cherryPicked?: string
 }
 
 export interface GitGraphDiagram {
@@ -33,4 +35,5 @@ export type GitGraphCellStyle =
   | "merge"
   | "highlight"
   | "reverse"
+  | "cherry"
   | "label"

--- a/packages/merman/src/test/diagnostics.test.ts
+++ b/packages/merman/src/test/diagnostics.test.ts
@@ -114,7 +114,7 @@ describe("parser diagnostics", () => {
 
   test("reports unsupported GitGraph operations with source diagnostics", () => {
     expect(() => renderGitGraphDiagram("gitGraph\n  cherry-pick id: missing")).toThrow(
-      'Cherry-pick is not supported in gitGraph diagram at line 2: "cherry-pick id: missing"',
+      'cherry-pick references unknown commit "missing" in gitGraph diagram at line 2: "cherry-pick id: missing"',
     )
   })
 


### PR DESCRIPTION
### Issue for this PR

N/A — feat PR (feature PRs skip issue requirement per contributing guidelines)

### Type of change

- [x] New feature

### What does this PR do?

Completes the GitGraph feature landed in #42179: the parser currently rejects `cherry-pick` with "Cherry-pick is not supported". This PR implements cherry-pick per Mermaid semantics:

- `cherry-pick id: "c1"` (optional `tag:` override) appends a cherry-picked commit to the current branch, inheriting the source commit's message and tags
- The source commit must already exist in the diagram; unknown references fail with a source diagnostic
- Cherry-picked commits use a generated id (so the `commitById` render map stays unambiguous) and render with a hollow `◌` glyph in a dedicated `cherry` cell style, echoing Mermaid's dashed-circle representation

### How did you verify your code works?

- Added tests in `packages/merman/src/gitgraph/diagram.test.ts`: parse + inherited message/tags + tag override, missing-id and unknown-reference errors, hollow-glyph rendering
- Updated the two pre-existing assertions that expected the "not supported" error
- `bun test` (packages/merman) — 327 pass
- `tsgo --noEmit` (packages/merman) — clean

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
