### PR TITLE
fix: deduplicate identical permission prompts in same session

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -83,6 +83,21 @@ const layer = Layer.effect(
 
       if (!needsAsk) return
 
+      // Deduplicate: if an identical permission request is already pending in
+      // the same session (same permission + patterns), wait on the existing
+      // deferred instead of creating a duplicate prompt. When the user
+      // responds, all waiters proceed together.
+      for (const entry of pending.values()) {
+        if (
+          entry.info.sessionID === request.sessionID &&
+          entry.info.permission === request.permission &&
+          entry.info.patterns.length === request.patterns.length &&
+          entry.info.patterns.every((p, i) => p === request.patterns[i])
+        ) {
+          return yield* Deferred.await(entry.deferred)
+        }
+      }
+
       const id = request.id ?? PermissionV1.ID.ascending()
       const info: PermissionV1.Request = {
         id,

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -850,7 +850,7 @@ it.instance(
         permission: "bash",
         patterns: ["ls"],
         metadata: {},
-        always: ["ls"],
+        always: ["*"],
         ruleset: [],
       }).pipe(Effect.forkScoped)
 
@@ -858,7 +858,7 @@ it.instance(
         id: PermissionV1.ID.make("per_test5b"),
         sessionID: SessionID.make("session_same"),
         permission: "bash",
-        patterns: ["ls"],
+        patterns: ["rm"],
         metadata: {},
         always: [],
         ruleset: [],
@@ -870,6 +870,84 @@ it.instance(
       yield* Fiber.join(a)
       yield* Fiber.join(b)
       expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - deduplicates identical permission requests in same session",
+  () =>
+    Effect.gen(function* () {
+      const a = yield* ask({
+        id: PermissionV1.ID.make("per_dedup_a"),
+        sessionID: SessionID.make("session_dedup"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      const b = yield* ask({
+        id: PermissionV1.ID.make("per_dedup_b"),
+        sessionID: SessionID.make("session_dedup"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      // Only one pending request should exist — b is deduplicated to a
+      yield* waitForPending(1)
+      expect((yield* list()).map((item) => item.id)).toEqual([PermissionV1.ID.make("per_dedup_a")])
+
+      yield* reply({ requestID: PermissionV1.ID.make("per_dedup_a"), reply: "once" })
+
+      // Both callers should succeed from a single reply
+      yield* Fiber.join(a)
+      yield* Fiber.join(b)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - does not deduplicate requests with different patterns",
+  () =>
+    Effect.gen(function* () {
+      const a = yield* ask({
+        id: PermissionV1.ID.make("per_nodedup_a"),
+        sessionID: SessionID.make("session_nodedup"),
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      const b = yield* ask({
+        id: PermissionV1.ID.make("per_nodedup_b"),
+        sessionID: SessionID.make("session_nodedup"),
+        permission: "bash",
+        patterns: ["rm"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      // Different patterns → both pending
+      yield* waitForPending(2)
+      expect((yield* list()).map((item) => item.id)).toEqual([
+        PermissionV1.ID.make("per_nodedup_a"),
+        PermissionV1.ID.make("per_nodedup_b"),
+      ])
+
+      // Rejecting one cascades to all pending in the same session
+      yield* reply({ requestID: PermissionV1.ID.make("per_nodedup_a"), reply: "reject" })
+      const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+      expect(Exit.isFailure(ea)).toBe(true)
+      expect(Exit.isFailure(eb)).toBe(true)
     }),
   { git: true },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #41849

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem:** When two identical permission requests (same `sessionID`, `permission`, and `patterns`) arrive within the same second, each creates an independent pending prompt. The user has to answer every duplicate individually — the reporter measured 141 groups of duplicates, worst case 5 identical prompts in a row.

**Root cause:** `Permission.ask` in `packages/opencode/src/permission/index.ts` generates a new unique request ID and adds it to the `pending` map on every call, without checking whether an equivalent request is already pending. Both prompts block independently, so answering one does not dismiss the other.

**Fix:** Before creating a new request, scan the `pending` map for an entry with the same `(sessionID, permission, patterns)`. If found, await the existing entry's `Deferred` instead of creating a duplicate. When the user responds — approve, reject, or "always" — all waiters proceed together via the shared deferred.

The dedup key is `(sessionID, permission, patterns)`. Requests with different patterns (e.g. `bash ["ls"]` vs `bash ["rm"]`) or from different sessions are not deduplicated.

### How did you verify your code works?

Ran `bun test test/permission/next.test.ts` — all 81 tests pass, including:

- **New:** `"ask - deduplicates identical permission requests in same session"` — two identical asks produce only 1 pending request; a single reply resolves both callers.
- **New:** `"ask - does not deduplicate requests with different patterns"` — two asks with different patterns (`["ls"]` vs `["rm"]`) produce 2 pending requests as before.
- **Updated:** `"reply - always resolves matching pending requests in same session"` — adjusted to use different patterns (`["ls"]` / `["rm"]`) so the cascade behavior is still tested without being deduplicated.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
