### PR TITLE
fix(opencode): skip tool files that fail to load

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -67,12 +67,14 @@ type State = {
   builtin: Tool.Def[]
   task: TaskDef
   read: ReadDef
+  skipped: Array<{ file: string; error: unknown }>
 }
 
 export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
   readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef }>
+  readonly skipped: () => Effect.Effect<Array<{ file: string; error: unknown }>>
   readonly tools: (model: {
     providerID: ProviderV2.ID
     modelID: ModelV2.ID
@@ -116,6 +118,7 @@ const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("ToolRegistry.state")(function* (ctx) {
         const custom: Tool.Def[] = []
+        const skipped: Array<{ file: string; error: unknown }> = []
 
         function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
           // Plugin tools still expose Zod args publicly; keep that compatibility
@@ -184,8 +187,24 @@ const layer = Layer.effect(
           const namespace = path.basename(match, path.extname(match))
           // `match` is an absolute filesystem path from `Glob.scanSync(..., { absolute: true })`.
           // Import it as `file://` so Node on Windows accepts the dynamic import.
-          const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
-          for (const [id, def] of Object.entries(mod)) {
+          //
+          // A failing tool file (e.g. its `@opencode-ai/plugin` dependency could not be
+          // installed) must not take down the whole registry — warn and skip instead.
+          const loaded = yield* Effect.promise(async () => {
+            try {
+              const mod = await import(pathToFileURL(match).href)
+              return { ok: true as const, mod }
+            } catch (error) {
+              return { ok: false as const, error }
+            }
+          })
+          if (!loaded.ok) {
+            const file = pathToFileURL(match).href
+            yield* Effect.logWarning("failed to load tool, skipping", { file, error: loaded.error })
+            skipped.push({ file, error: loaded.error })
+            continue
+          }
+          for (const [id, def] of Object.entries(loaded.mod)) {
             if (!isPluginTool(def)) continue
             custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
           }
@@ -223,6 +242,7 @@ const layer = Layer.effect(
 
         return {
           custom,
+          skipped,
           builtin: [
             tool.invalid,
             ...(questionEnabled ? [tool.question] : []),
@@ -251,6 +271,11 @@ const layer = Layer.effect(
     const all: Interface["all"] = Effect.fn("ToolRegistry.all")(function* () {
       const s = yield* InstanceState.get(state)
       return [...s.builtin, ...s.custom] as Tool.Def[]
+    })
+
+    const skipped: Interface["skipped"] = Effect.fn("ToolRegistry.skipped")(function* () {
+      const s = yield* InstanceState.get(state)
+      return s.skipped
     })
 
     const ids: Interface["ids"] = Effect.fn("ToolRegistry.ids")(function* () {
@@ -339,7 +364,7 @@ const layer = Layer.effect(
       return { task: s.task, read: s.read }
     })
 
-    return Service.of({ ids, all, named, tools })
+    return Service.of({ ids, all, named, skipped, tools })
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #42258

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom tool files (`.opencode/tool/*.{js,ts}`) are dynamically imported when building the tool registry. If one file throws on import (e.g. its `@opencode-ai/plugin` dependency couldn't be installed), the error propagates and kills the whole registry — taking down every session run in that project, including any valid sibling tool files.

This PR wraps the import in a `try/catch`. On failure it logs a warning, records the file in a new `skipped` list, and continues loading the remaining tools. A `skipped()` accessor exposes the list so callers can surface it.

The UI surfacing of these skips is handled in the companion PR #42253, which reads `registry.skipped()`.

### How did you verify your code works?

Reproduced with a project containing `.opencode/tool/broken.ts` that imports a nonexistent package. Before: any prompt in that project died with the `ResolveMessage` stack. After: the run proceeds and valid tools still load. Ran the registry tests and typechecks (`tsgo --noEmit` on the opencode package).

### Screenshots / recordings

Not applicable — no UI change in this PR.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Applies to the `2.0`/beta branch as well (identical code path); can port if you'd like.
