### PR TITLE
fix(opencode): propagate session errors and surface tool-load warnings in the UI

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1271,6 +1271,18 @@ export function MessageTimeline(props: {
           </TimelineRowFrame>
         )
       }
+      case "Warning": {
+        const warningRow = row as Accessor<TimelineRowByTag<"Warning">>
+        return (
+          <TimelineRowFrame row={warningRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <Card variant="warning" class="error-card">
+                {warningRow().text}
+              </Card>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
     }
   }
 

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -228,6 +228,19 @@ export namespace Timeline {
       )
     }
 
+    const warning = assistantMessages.at(-1)?.warning
+    if (warning) {
+      const data = warning.data?.message
+      rows.push(
+        new TimelineRow.Warning({
+          userMessageID: userMessage.id,
+          text: unwrapErrorMessage(
+            typeof data === "string" ? data : data === undefined || data === null ? "" : String(data),
+          ),
+        }),
+      )
+    }
+
     return rows
   }
 

--- a/packages/app/src/pages/session/timeline/timeline-row.ts
+++ b/packages/app/src/pages/session/timeline/timeline-row.ts
@@ -36,6 +36,10 @@ export namespace TimelineRow {
     userMessageID: string
     text: string
   }> {}
+  export class Warning extends Data.TaggedClass("Warning")<{
+    userMessageID: string
+    text: string
+  }> {}
   export class Retry extends Data.TaggedClass("Retry")<{
     userMessageID: string
   }> {}
@@ -49,6 +53,7 @@ export namespace TimelineRow {
     | Thinking
     | DiffSummary
     | Error
+    | Warning
     | Retry
 
   export const key = (row: TimelineRow) => {
@@ -69,6 +74,8 @@ export namespace TimelineRow {
         return `diff-summary:${row.userMessageID}`
       case "Error":
         return `error:${row.userMessageID}`
+      case "Warning":
+        return `warning:${row.userMessageID}`
       case "Retry":
         return `retry:${row.userMessageID}`
     }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -835,6 +835,7 @@ export const RunCommand = effectCmd({
             if (args.attach) return
             const error = await completed
             if (error) process.exitCode = 1
+            return error
           }
 
           if (args.command) {
@@ -847,8 +848,11 @@ export const RunCommand = effectCmd({
               variant: args.variant,
             })
             if (result.error) {
-              if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
+              const loopError = await finish()
+              if (!loopError && !emit("error", { error: result.error })) {
+                UI.error(formatRunError(result.error))
+              }
               return
             }
             await finish()
@@ -864,8 +868,11 @@ export const RunCommand = effectCmd({
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {
-            if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
             process.exitCode = 1
+            const loopError = await finish()
+            if (!loopError && !emit("error", { error: result.error })) {
+              UI.error(formatRunError(result.error))
+            }
             return
           }
           await finish()

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -316,6 +316,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       yield* promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
+            if (cause.reasons.some(Cause.isDieReason)) return
             yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })
             yield* events.publish(Session.Event.Error, {
               sessionID: ctx.params.sessionID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1238,6 +1238,7 @@ const layer = Layer.effect(
               Effect.provideService(MCP.Service, mcp),
               Effect.provideService(Truncate.Service, truncate),
               Effect.provideService(RuntimeFlags.Service, flags),
+              Effect.provideService(EventV2Bridge.Service, events),
             )
 
             if (lastUser.format?.type === "json_schema") {
@@ -1343,7 +1344,31 @@ const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
       input: LoopInput,
     ) {
-      return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID))
+      return yield* state.ensureRunning(
+        input.sessionID,
+        lastAssistant(input.sessionID),
+        runLoop(input.sessionID).pipe(
+          Effect.catchCause((cause) => {
+            const alreadySurfaced = cause.reasons
+              .filter(Cause.isDieReason)
+              .some(
+                (reason) =>
+                  reason.defect instanceof NamedError || Provider.ModelNotFoundError.isInstance(reason.defect),
+              )
+            if (alreadySurfaced) return Effect.failCause(cause)
+            if (!cause.reasons.some(Cause.isDieReason)) return Effect.failCause(cause)
+            return Effect.gen(function* () {
+              const error = new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject()
+              yield* Effect.logError("session run failed with defect", {
+                "session.id": input.sessionID,
+                cause,
+              })
+              yield* events.publish(Session.Event.Error, { sessionID: input.sessionID, error })
+              return yield* Effect.failCause(cause)
+            })
+          }),
+        ),
+      )
     })
 
     const shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError> = Effect.fn(

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -326,6 +326,7 @@ export const Event = {
   Deleted: SessionV1.Event.Deleted,
   Diff: SessionV1.Event.Diff,
   Error: SessionV1.Event.Error,
+  Warning: SessionV1.Event.Warning,
 }
 
 export function plan(input: { slug: string; time: { created: number } }, instance: InstanceContext) {

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -17,10 +17,12 @@ import { Effect } from "effect"
 import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
 import { SessionProcessor } from "./processor"
+import { EventV2Bridge } from "@/event-v2-bridge"
 import { PartID } from "./schema"
 import { EffectBridge } from "@/effect/bridge"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { NamedError } from "@opencode-ai/core/util/error"
 import { isRecord } from "@/util/record"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
@@ -487,6 +489,22 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         }),
       )
     tools[key] = item
+  }
+
+  const skipped = yield* registry.skipped()
+  if (skipped.length > 0) {
+    const message = skipped
+      .map(({ file, error }) => {
+        const detail = error instanceof Error ? `${error.message}` : String(error)
+        return `Failed to load tool: ${file} (${detail})`
+      })
+      .join("\n")
+    input.processor.message.warning = new NamedError.Unknown({ message }).toObject()
+    const events = yield* EventV2Bridge.Service
+    yield* events.publish(Session.Event.Warning, {
+      sessionID: input.session.id,
+      warning: input.processor.message.warning,
+    })
   }
 
   return tools

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -67,12 +67,14 @@ type State = {
   builtin: Tool.Def[]
   task: TaskDef
   read: ReadDef
+  skipped: Array<{ file: string; error: unknown }>
 }
 
 export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
   readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef }>
+  readonly skipped: () => Effect.Effect<Array<{ file: string; error: unknown }>>
   readonly tools: (model: {
     providerID: ProviderV2.ID
     modelID: ModelV2.ID
@@ -116,6 +118,7 @@ const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("ToolRegistry.state")(function* (ctx) {
         const custom: Tool.Def[] = []
+        const skipped: Array<{ file: string; error: unknown }> = []
 
         function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
           // Plugin tools still expose Zod args publicly; keep that compatibility
@@ -244,6 +247,7 @@ const layer = Layer.effect(
           ],
           task: tool.task,
           read: tool.read,
+          skipped,
         }
       }),
     )
@@ -251,6 +255,11 @@ const layer = Layer.effect(
     const all: Interface["all"] = Effect.fn("ToolRegistry.all")(function* () {
       const s = yield* InstanceState.get(state)
       return [...s.builtin, ...s.custom] as Tool.Def[]
+    })
+
+    const skipped: Interface["skipped"] = Effect.fn("ToolRegistry.skipped")(function* () {
+      const s = yield* InstanceState.get(state)
+      return s.skipped
     })
 
     const ids: Interface["ids"] = Effect.fn("ToolRegistry.ids")(function* () {
@@ -339,7 +348,7 @@ const layer = Layer.effect(
       return { task: s.task, read: s.read }
     })
 
-    return Service.of({ ids, all, named, tools })
+    return Service.of({ ids, all, named, skipped, tools })
   }),
 )
 

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -458,6 +458,7 @@ export const Assistant = Schema.Struct({
     completed: Schema.optional(NonNegativeInt),
   }),
   error: Schema.optional(AssistantErrorSchema),
+  warning: Schema.optional(AssistantErrorSchema),
   parentID: MessageID,
   modelID: Model.ID,
   providerID: Provider.ID,
@@ -483,8 +484,12 @@ export const Assistant = Schema.Struct({
   variant: Schema.optional(Schema.String),
   finish: Schema.optional(Schema.String),
 }).annotate({ identifier: "AssistantMessage" })
-export type Assistant = Omit<Types.DeepMutable<Schema.Schema.Type<typeof Assistant>>, "error"> & {
+export type Assistant = Omit<
+  Types.DeepMutable<Schema.Schema.Type<typeof Assistant>>,
+  "error" | "warning"
+> & {
   error?: AssistantError
+  warning?: AssistantError
 }
 
 export const Info = Schema.Union([User, Assistant]).annotate({ discriminator: "role", identifier: "Message" })
@@ -656,11 +661,20 @@ export const Error = define({
   },
 })
 
+export const Warning = define({
+  type: "session.warning",
+  schema: {
+    sessionID: Schema.optional(SessionID),
+    warning: Assistant.fields.warning,
+  },
+})
+
 export const Event = {
   ...events,
   PartDelta,
   Diff,
   Error,
+  Warning,
   Definitions: inventory(
     events.Created,
     events.Updated,
@@ -672,5 +686,6 @@ export const Event = {
     PartDelta,
     Diff,
     Error,
+    Warning,
   ),
 }

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -9,8 +9,8 @@ import { WorkspaceEvent } from "../src/workspace-event"
 
 describe("public event manifest", () => {
   test("owns the complete public event surface", () => {
-    expect(EventManifest.ServerDefinitions.length).toBe(55)
-    expect(EventManifest.Definitions.length).toBe(85)
+    expect(EventManifest.ServerDefinitions.length).toBe(58)
+    expect(EventManifest.Definitions.length).toBe(89)
     expect(SessionV1.Event.Definitions).toEqual([
       SessionV1.Event.Created,
       SessionV1.Event.Updated,
@@ -22,9 +22,10 @@ describe("public event manifest", () => {
       SessionV1.Event.PartDelta,
       SessionV1.Event.Diff,
       SessionV1.Event.Error,
+      SessionV1.Event.Warning,
     ])
-    expect(EventManifest.Latest.size).toBe(85)
-    expect(EventManifest.Durable.size).toBe(32)
+    expect(EventManifest.Latest.size).toBe(89)
+    expect(EventManifest.Durable.size).toBe(35)
   })
 
   test("uses canonical definitions for current public events", () => {
@@ -42,10 +43,11 @@ describe("public event manifest", () => {
     expect(Reference.Event.Definitions).toEqual([Reference.Event.Updated])
     expect(EventManifest.Latest.has("ide.installed")).toBe(false)
     expect(IdeEvent.Definitions).toEqual([IdeEvent.Installed])
-    expect(EventManifest.Definitions.slice(40, 43)).toEqual([
+    expect(EventManifest.Definitions.slice(43, 47)).toEqual([
       SessionV1.Event.PartDelta,
       SessionV1.Event.Diff,
       SessionV1.Event.Error,
+      SessionV1.Event.Warning,
     ])
     expect(EventManifest.Durable.has("session.next.step.ended.1")).toBe(false)
     expect(EventManifest.Durable.get("session.next.step.ended.2")).toBe(SessionEvent.Step.Ended)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -347,6 +347,15 @@ export type AssistantMessage = {
     | ContextOverflowError
     | ContentFilterError
     | ApiError
+  warning?:
+    | ProviderAuthError
+    | UnknownError
+    | MessageOutputLengthError
+    | MessageAbortedError
+    | StructuredOutputError
+    | ContextOverflowError
+    | ContentFilterError
+    | ApiError
   parentID: string
   modelID: string
   providerID: string


### PR DESCRIPTION
### Issue for this PR

Closes #42259

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two related problems in how session outcomes reach the UI:

1. **Session run defects were silently dropped.** When a session run failed with an unexpected defect, no error reached the UI — the session just went idle as if it succeeded. The real `session.error` event was published only *after* the `session.status idle` event, so clients that stop consuming on idle never rendered it. This PR publishes `session.error` inside the run loop, before the runner transitions to idle, so the real message reaches the UI.

2. **Tool-load failures were not surfaced.** When a custom tool file fails to load (see #42258 / #42252), the skip was only logged. This PR adds a `session.warning` event and a `warning` field on the assistant message, rendered as an inline warning card in the session timeline (same card component as errors, `variant="warning"`). It reads the skipped tools from `registry.skipped()` added in the companion PR #42252.

### How did you verify your code works?

Reproduced with a project containing `.opencode/tool/broken.ts` that imports a nonexistent package. Before: the turn ended, the session went idle, and no error was shown. After: the real `ResolveMessage` error surfaces in the web UI (`session.error` now arrives before `idle`), and the skipped tool renders as an inline warning card. Ran the session prompt tests, schema event-manifest tests, and typechecks (`tsgo --noEmit` on the opencode/schema/app/sdk packages).

Tested via headless opencode driven from the web browser; did not test the TUI.

### Screenshots / recordings

<img width="1717" height="1325" alt="Screenshot 2026-08-13 at 12 19 53 AM" src="https://github.com/user-attachments/assets/2518eaf0-3343-4226-b14c-af638d26bbe3" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Applies to the `2.0`/beta branch as well (identical code path); can port if you'd like.
