### PR TITLE
fix(opencode): persist Config.update to the loaded config file

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -621,10 +621,38 @@ const layer = Layer.effect(
       )
     })
 
+    const projectConfigFile = Effect.fnUntraced(function* (ctx: InstanceContext) {
+      // Write the project file the loader merges last so the mutation
+      // survives the instance reload the server performs after a PATCH.
+      // The user's home `.opencode` stays out of scope, like global and
+      // managed configs.
+      const opencodeDirs = (yield* fs
+        .up({ targets: [".opencode"], start: ctx.directory, stop: ctx.worktree })
+        .pipe(Effect.orDie)).toReversed()
+      for (const dir of opencodeDirs) {
+        if (dir === path.join(Global.Path.home, ".opencode")) continue
+        for (const name of ["opencode.jsonc", "opencode.json"]) {
+          const file = path.join(dir, name)
+          if (yield* fs.existsSafe(file)) return file
+        }
+      }
+      const plainFiles = (yield* fs
+        .up({ targets: ["opencode.jsonc", "opencode.json"], start: ctx.directory, stop: ctx.worktree })
+        .pipe(Effect.orDie)).toReversed()
+      return plainFiles.at(-1) ?? path.join(ctx.directory, "opencode.json")
+    })
+
     const update = Effect.fn("Config.update")(function* (config: Info) {
-      const dir = yield* InstanceState.directory
-      const file = path.join(dir, "config.json")
-      const existing = yield* loadFile(file)
+      const ctx = yield* InstanceState.context
+      const file = yield* projectConfigFile(ctx)
+      const before = (yield* readConfigFile(file)) ?? "{}"
+      if (file.endsWith(".jsonc")) {
+        yield* fs.writeFileString(file, patchJsonc(before, writable(config))).pipe(Effect.orDie)
+        return
+      }
+      // Parse the raw file text like updateGlobal so {env:}/{file:} tokens
+      // survive the rewrite instead of being baked to resolved values.
+      const existing = ConfigParse.schema(ConfigV1.Info, ConfigParse.jsonc(before, file), file)
       yield* fs
         .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))
         .pipe(Effect.orDie)

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -19,6 +19,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Env } from "../../src/env"
 import {
   provideTmpdirInstance,
+  reloadInstance,
   TestInstance,
   tmpdir,
   tmpdirScoped,
@@ -358,15 +359,14 @@ it.instance(
 it.instance("updates config and preserves empty shell sentinel", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance
-    yield* writeConfigEffect(
-      test.directory,
-      { $schema: "https://opencode.ai/config.json", shell: "bash" },
-      "config.json",
-    )
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      shell: "bash",
+    })
 
     yield* Config.Service.use((svc) => svc.update(ConfigParse.schema(ConfigV1.Info, { shell: "" }, "test:config")))
 
-    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "config.json"))
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
     expect(writtenConfig).toMatchObject({ shell: "" })
   }),
 )
@@ -897,9 +897,237 @@ it.instance("updates config and writes to file", () =>
       svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
     )
 
-    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "config.json"))
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
     expect(writtenConfig).toMatchObject({ model: "updated/model" })
   }),
+)
+
+// Config.update is the write path behind the SDK's PATCH /config endpoint.
+// The server disposes the instance after a PATCH, so the next GET reloads
+// config from disk. The mutation must land in a file the loader reads
+// (opencode.json / opencode.jsonc).
+
+it.instance("update writes to opencode.json, the file the loader reads", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      model: "base/model",
+      username: "testuser",
+    })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The mutation must be persisted to opencode.json
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
+    expect(writtenConfig).toMatchObject({ model: "updated/model" })
+    // merging pre-existing keys from that same file
+    expect(writtenConfig).toMatchObject({ username: "testuser" })
+  }),
+)
+
+it.instance("update survives instance reload, matching the server PATCH flow", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      model: "base/model",
+    })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The server disposes the instance after a PATCH, so the next GET reads
+    // config from disk again and must observe the mutation.
+    yield* reloadInstance({ directory: test.directory })
+    const config = yield* Config.use.get()
+    expect(config.model).toBe("updated/model")
+  }),
+)
+
+it.instance("update targets opencode.jsonc when that is the project config file", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, "opencode.jsonc"),
+      `{
+        // project config with comments
+        "$schema": "https://opencode.ai/config.json",
+        "model": "base/model"
+      }`,
+    )
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The mutation must be applied to the existing jsonc file
+    const writtenConfig = yield* FSUtil.use.readFileString(path.join(test.directory, "opencode.jsonc"))
+    expect(writtenConfig).toContain('"model": "updated/model"')
+    // keeping the file readable and its comments intact
+    expect(writtenConfig).toContain("// project config with comments")
+    const parsed = ConfigParse.schema(ConfigV1.Info, ConfigParse.jsonc(writtenConfig, path.join(test.directory, "opencode.jsonc")), path.join(test.directory, "opencode.jsonc"))
+    expect(parsed.model).toBe("updated/model")
+  }),
+)
+
+it.instance("update preserves env tokens in the target file", () =>
+  withProcessEnv(
+    "TEST_MODEL",
+    "token/model",
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* writeConfigEffect(test.directory, {
+        $schema: "https://opencode.ai/config.json",
+        model: "{env:TEST_MODEL}",
+        username: "testuser",
+      })
+
+      yield* Config.Service.use((svc) =>
+        svc.update(ConfigParse.schema(ConfigV1.Info, { username: "patched" }, "test:config")),
+      )
+
+      // The update rewrites the user-maintained file, so env tokens must
+      // survive as literals instead of being baked to their resolved values.
+      const writtenConfig = yield* FSUtil.use.readFileString(path.join(test.directory, "opencode.json"))
+      expect(writtenConfig).toContain("{env:TEST_MODEL}")
+      expect(writtenConfig).not.toContain("token/model")
+      expect(writtenConfig).toContain('"username": "patched"')
+
+      // The token still resolves on the next load.
+      yield* reloadInstance({ directory: test.directory })
+      const config = yield* Config.use.get()
+      expect(config.model).toBe("token/model")
+      expect(config.username).toBe("patched")
+    }),
+  ),
+)
+
+// The loader also reads project configs from .opencode/opencode.json(c) at
+// each level of the directory walk, after the plain opencode.json(c) files.
+// The last file the loader merges is the one an update must touch, otherwise
+// the mutation is shadowed once the instance reloads from disk.
+
+it.instance("update targets .opencode/opencode.json when that is the project config", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.ensureDir(path.join(test.directory, ".opencode"))
+    yield* writeConfigEffect(path.join(test.directory, ".opencode"), {
+      $schema: "https://opencode.ai/config.json",
+      model: "base/model",
+    })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The mutation must be persisted to the .opencode config…
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, ".opencode", "opencode.json"))
+    expect(writtenConfig).toMatchObject({ model: "updated/model" })
+    // …and must not create a plain opencode.json or legacy config.json.
+    expect(yield* FSUtil.use.existsSafe(path.join(test.directory, "opencode.json"))).toBe(false)
+    expect(yield* FSUtil.use.existsSafe(path.join(test.directory, "config.json"))).toBe(false)
+
+    yield* reloadInstance({ directory: test.directory })
+    const config = yield* Config.use.get()
+    expect(config.model).toBe("updated/model")
+  }),
+)
+
+it.instance("update prefers .opencode/opencode.jsonc over .opencode/opencode.json", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.ensureDir(path.join(test.directory, ".opencode"))
+    yield* writeConfigEffect(path.join(test.directory, ".opencode"), {
+      $schema: "https://opencode.ai/config.json",
+      model: "base/model",
+    })
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".opencode", "opencode.jsonc"),
+      JSON.stringify({ $schema: "https://opencode.ai/config.json", model: "base/model" }, null, 2),
+    )
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The loader merges jsonc after json within a directory, so the mutation
+    // must land in the jsonc file and leave the json file untouched.
+    const writtenConfig = yield* FSUtil.use.readFileString(path.join(test.directory, ".opencode", "opencode.jsonc"))
+    expect(writtenConfig).toContain('"model": "updated/model"')
+    const untouched = yield* FSUtil.use.readJson(path.join(test.directory, ".opencode", "opencode.json"))
+    expect(untouched).toMatchObject({ model: "base/model" })
+
+    yield* reloadInstance({ directory: test.directory })
+    const config = yield* Config.use.get()
+    expect(config.model).toBe("updated/model")
+  }),
+)
+
+it.instance("update targets .opencode config over the plain project opencode.json", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      model: "root/model",
+    })
+    yield* FSUtil.use.ensureDir(path.join(test.directory, ".opencode"))
+    yield* writeConfigEffect(path.join(test.directory, ".opencode"), {
+      $schema: "https://opencode.ai/config.json",
+      model: "local/model",
+    })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    // The .opencode config is merged after the plain file, so it must receive
+    // the mutation; the plain opencode.json must stay untouched.
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, ".opencode", "opencode.json"))
+    expect(writtenConfig).toMatchObject({ model: "updated/model" })
+    const untouched = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
+    expect(untouched).toMatchObject({ model: "root/model" })
+
+    yield* reloadInstance({ directory: test.directory })
+    const config = yield* Config.use.get()
+    expect(config.model).toBe("updated/model")
+  }),
+)
+
+it.effect("update targets the worktree-level .opencode config the loader merges last", () =>
+  Effect.gen(function* () {
+    const root = yield* tmpdirScoped({ git: true })
+    const sub = path.join(root, "sub")
+    yield* FSUtil.use.ensureDir(sub)
+    yield* FSUtil.use.ensureDir(path.join(root, ".opencode"))
+    yield* writeConfigEffect(path.join(root, ".opencode"), {
+      $schema: "https://opencode.ai/config.json",
+      model: "root/model",
+    })
+    yield* FSUtil.use.ensureDir(path.join(sub, ".opencode"))
+    yield* writeConfigEffect(path.join(sub, ".opencode"), {
+      $schema: "https://opencode.ai/config.json",
+      model: "sub/model",
+    })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    ).pipe(provideInstanceEffect(sub))
+
+    // The loader walks .opencode dirs nearest first and merges later entries
+    // on top, so the worktree-level config wins; the mutation must land there.
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(root, ".opencode", "opencode.json"))
+    expect(writtenConfig).toMatchObject({ model: "updated/model" })
+    const untouched = yield* FSUtil.use.readJson(path.join(sub, ".opencode", "opencode.json"))
+    expect(untouched).toMatchObject({ model: "sub/model" })
+
+    yield* reloadInstance({ directory: sub })
+    const config = yield* Config.use.get().pipe(provideInstanceEffect(sub))
+    expect(config.model).toBe("updated/model")
+  }).pipe(Effect.provide(testInstanceStoreLayer), Effect.provide(LayerNode.compile(CrossSpawnSpawner.node))),
 )
 
 it.instance("gets config directories", () =>

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { Server } from "../../src/server/server"
 import { Effect, Fiber } from "effect"
 import { resetDatabase } from "../fixture/db"
@@ -56,10 +57,70 @@ describe("config HttpApi", () => {
         lsp: false,
       })
       yield* Fiber.join(disposed)
-      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).json())).toMatchObject({
+      // The PATCH must persist to the project config file the loader reads,
+      // never the legacy config.json that is ignored on reload.
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "opencode.json")).json())).toMatchObject({
         username: "patched-user",
         formatter: false,
         lsp: false,
+      })
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).exists())).toBe(false)
+    }),
+  )
+
+  it.live(
+    "persists config update to the .opencode project config",
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirEffect({
+        init: async (dir) => {
+          await fs.mkdir(path.join(dir, ".opencode"))
+          await Bun.write(
+            path.join(dir, ".opencode", "opencode.json"),
+            JSON.stringify(
+              { $schema: "https://opencode.ai/config.json", username: "e2e-user", formatter: true },
+              null,
+              2,
+            ),
+          )
+        },
+      })
+      const disposed = yield* waitDisposed(tmp.path).pipe(Effect.forkScoped({ startImmediately: true }))
+
+      const response = yield* Effect.promise(() =>
+        Promise.resolve(
+          app().request("/config", {
+            method: "PATCH",
+            headers: {
+              "content-type": "application/json",
+              "x-opencode-directory": tmp.path,
+            },
+            body: JSON.stringify({ username: "patched-user", formatter: false }),
+          }),
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      yield* Fiber.join(disposed)
+      // The mutation must be persisted to the .opencode config the loader
+      // reads last, not to a plain opencode.json or legacy config.json.
+      const written = yield* Effect.promise(() => Bun.file(path.join(tmp.path, ".opencode", "opencode.json")).json())
+      expect(written).toMatchObject({ username: "patched-user", formatter: false })
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "opencode.json")).exists())).toBe(false)
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).exists())).toBe(false)
+
+      const getResponse = yield* Effect.promise(() =>
+        Promise.resolve(
+          app().request("/config", {
+            headers: {
+              "x-opencode-directory": tmp.path,
+            },
+          }),
+        ),
+      )
+      expect(getResponse.status).toBe(200)
+      expect(yield* Effect.promise(() => getResponse.json())).toMatchObject({
+        username: "patched-user",
+        formatter: false,
       })
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Fixes #42276 and #28966

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The SDK's `client.config.update` (PATCH `/config`) returned 200 but the mutation was silently lost: a follow-up GET returned the original config and the file on disk was untouched. Updates were written to `config.json`, a legacy filename the config loader ignores, so they vanished when the instance was disposed and reloaded after the PATCH.

After this change:

- The update persists to the project config file the loader reads last (existing `opencode.json` / `opencode.jsonc` or `.opencode/` overlay), merged with existing content
- A follow-up GET reflects the change
- Home (`~/.opencode`), global, and managed configs won't be written

### How did you verify your code works?

- Tests covering:
  - plain `opencode.json` / `opencode.jsonc` targets
  - `.opencode/` overlay preference
  - worktree-level precedence
  - token preservation
  - reload persistence
  - end-to-end HTTP tests through the real server app
- Built the server binary and tested with a real SDK client

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
