### PR TITLE
fix(tui): align skill descriptions with wide characters

### DIFF
--- a/packages/tui/src/component/dialog-skill.tsx
+++ b/packages/tui/src/component/dialog-skill.tsx
@@ -35,9 +35,9 @@ export function DialogSkill(props: DialogSkillProps) {
   const options = createMemo<DialogSelectOption<string>[]>(() => {
     if (showError()) return []
     const list = skills() ?? []
-    const maxWidth = Math.max(0, ...list.map((s) => s.name.length))
+    const maxWidth = Math.max(0, ...list.map((s) => Bun.stringWidth(s.name)))
     return list.map((skill) => ({
-      title: skill.name.padEnd(maxWidth),
+      title: skill.name.padEnd(skill.name.length + maxWidth - Bun.stringWidth(skill.name)),
       description: skill.description?.replace(/\s+/g, " ").trim(),
       value: skill.name,
       category: "Skills",


### PR DESCRIPTION
fix(tui): align skill descriptions with wide characters

### Issue for this PR

https://github.com/anomalyco/opencode/issues/40605
Closes #40605

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a skill's name contains wide characters (e.g. CJK), the `/skills`dialog padded titles with `String.prototype.padEnd` based on UTF-16 codeunit length (`s.name.length`). Chinese characters count as 1 code unit butoccupy 2 terminal cells, so titles with the same code-unit length ended atdifferent screen columns and the descriptions below them misaligned.

The fix measures the column width with `Bun.stringWidth` (already usedelsewhere in the TUI, e.g. `src/prompt/display.ts`) and pads each title upto the maximum display width instead of the maximum code-unit length:

```ts
const maxWidth = Math.max(0, ...list.map((s) => Bun.stringWidth(s.name)))
title: skill.name.padEnd(skill.name.length + maxWidth - Bun.stringWidth(skill.name))
```
### How did you verify your code works?
I created a Chinese title skill that describes normal alignment
### Screenshots / recordings
<img width="1085" height="413" alt="屏幕截图 2026-08-13 145422" src="https://github.com/user-attachments/assets/71f3f860-fd8d-4f8e-b6e3-f1555035d93d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._