### PR TITLE
fix(shell): encode PowerShell commands to preserve multi-line output

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -195,7 +195,7 @@ export function args(file: string, command: string, cwd: string) {
     ]
   }
   if (n === "cmd") return ["/c", command]
-  if (ps(file)) return ["-NoProfile", "-Command", command]
+  if (ps(file)) return ["-NoProfile", "-EncodedCommand", Buffer.from(command, "utf-16le").toString("base64")]
   return ["-c", command]
 }
 

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -153,6 +153,14 @@ export function ps(file: string) {
   return meta(file)?.ps === true
 }
 
+export function powershellCommand(file: string, command: string) {
+  const ext = path.win32.extname(FSUtil.windowsPath(file)).toLowerCase()
+  if (ext === ".cmd" || ext === ".bat") {
+    return ["-EncodedCommand", Buffer.from(command, "utf-16le").toString("base64")]
+  }
+  return ["-Command", command]
+}
+
 function info(file: string): Item {
   const item = full(file)
   const n = name(item)
@@ -195,7 +203,7 @@ export function args(file: string, command: string, cwd: string) {
     ]
   }
   if (n === "cmd") return ["/c", command]
-  if (ps(file)) return ["-NoProfile", "-EncodedCommand", Buffer.from(command, "utf-16le").toString("base64")]
+  if (ps(file)) return ["-NoProfile", ...powershellCommand(file, command)]
   return ["-c", command]
 }
 

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -63,6 +63,18 @@ describe("shell", () => {
     expect(zsh.at(-1)).toBe("/tmp")
   })
 
+  test("builds PowerShell command args per executable type", () => {
+    const command = 'echo "first"\necho "second"'
+    expect(Shell.powershellCommand("C:/tools/pwsh.exe", command)).toEqual(["-Command", command])
+    expect(Shell.args("/tools/pwsh", command, "/tmp")).toEqual(["-NoProfile", "-Command", command])
+
+    for (const shell of ["C:/tools/pwsh.cmd", "C:/tools/powershell.BAT"]) {
+      const args = Shell.powershellCommand(shell, command)
+      expect(args[0]).toBe("-EncodedCommand")
+      expect(Buffer.from(args[1], "base64").toString("utf-16le")).toBe(command)
+    }
+  })
+
   if (process.platform === "win32") {
     test("rejects blacklisted shells case-insensitively", async () => {
       await withShell("NU.EXE", async () => {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -292,7 +292,8 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
+    const encoded = Buffer.from(command, "utf-16le").toString("base64")
+    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], {
       cwd,
       env,
       stdin: "ignore",

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -292,13 +292,16 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
   if (process.platform === "win32" && Shell.ps(shell)) {
-    const encoded = Buffer.from(command, "utf-16le").toString("base64")
-    return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], {
-      cwd,
-      env,
-      stdin: "ignore",
-      detached: false,
-    })
+    return ChildProcess.make(
+      shell,
+      ["-NoLogo", "-NoProfile", "-NonInteractive", ...Shell.powershellCommand(shell, command)],
+      {
+        cwd,
+        env,
+        stdin: "ignore",
+        detached: false,
+      },
+    )
   }
 
   return ChildProcess.make(command, [], {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -209,6 +209,33 @@ describe("tool.shell", () => {
     ),
   )
 
+  if (process.platform === "win32") {
+    it.live("captures multi-line output through a PowerShell cmd wrapper", () =>
+      Effect.gen(function* () {
+        const shell = Bun.which("pwsh") || Bun.which("powershell")
+        if (!shell) return
+        const tmp = yield* tmpdirScoped()
+        const wrapper = path.join(tmp, "pwsh.cmd")
+        yield* Effect.promise(() => Bun.write(wrapper, `@"${shell}" %*\r\n`))
+        yield* withShell(
+          { label: "pwsh", shell: wrapper },
+          runIn(
+            projectRoot,
+            Effect.gen(function* () {
+              const result = yield* run({
+                command: 'echo "first"\necho "second"\necho "third"',
+              })
+              expect(result.metadata.exit).toBe(0)
+              expect(result.output).toContain("first")
+              expect(result.output).toContain("second")
+              expect(result.output).toContain("third")
+            }),
+          ),
+        )
+      }),
+    )
+  }
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -194,6 +194,21 @@ describe("tool.shell", () => {
     ),
   )
 
+  each("multi-line commands capture all output", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const result = yield* run({
+          command: 'echo "first"\necho "second"\necho "third"',
+        })
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("first")
+        expect(result.output).toContain("second")
+        expect(result.output).toContain("third")
+      }),
+    ),
+  )
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
### Issue for this PR

Closes #41983

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, a configured PowerShell `.cmd` or `.bat` wrapper passes through `cmd.exe`, which treats newlines in a `-Command` argument as command separators. Only the first line can reach PowerShell.

This uses PowerShell's UTF-16LE `-EncodedCommand` form for wrapper scripts, while preserving `-Command` for direct `powershell.exe` and `pwsh.exe` executables. That keeps multiline wrapper commands intact without reducing the command-line budget for direct executables.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/shell.test.ts` — 24 pass, 0 fail
- `cd packages/core && bun test test/shell.test.ts` — 7 pass, 0 fail
- `cd packages/opencode && bun typecheck`
- `cd packages/core && bun typecheck`

Portable tests verify the exact argument form and UTF-16LE round trip. A Windows-only test creates a real `pwsh.cmd` wrapper and verifies all three lines of a multiline command reach PowerShell.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
