### PR TITLE
fix(core): resolve child process exit signal on exit event

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -275,6 +275,9 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        if (end) return
+        end = true
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("close", (...args) => {
         if (end) return

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -269,12 +269,10 @@ export const make = Effect.gen(function* () {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
       let end = false
-      let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
       proc.on("exit", (...args) => {
-        exit = args
         if (end) return
         end = true
         Deferred.doneUnsafe(signal, Exit.succeed(args))
@@ -282,7 +280,7 @@ export const make = Effect.gen(function* () {
       proc.on("close", (...args) => {
         if (end) return
         end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
       })
       proc.on("spawn", () => {
         resume(Effect.succeed([proc, signal]))

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -59,6 +59,19 @@ async function gone(pid: number, timeout = 5_000) {
   return !alive(pid)
 }
 
+async function waitForFile(file: string, timeout = 5_000) {
+  const end = Date.now() + timeout
+  while (Date.now() < end) {
+    try {
+      return await fs.readFile(file, "utf8")
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  throw new Error(`timed out waiting for ${file}`)
+}
+
 describe("cross-spawn spawner", () => {
   describe("basic spawning", () => {
     fx.effect(
@@ -376,14 +389,48 @@ describe("cross-spawn spawner", () => {
     )
   })
 
-  describe("exit reaping", () => {
+  describe("exit signal", () => {
     fx.effect(
-      "exit code resolves before stream ends",
+      "exit code resolves while a descendant keeps stdout open",
       Effect.gen(function* () {
-        const handle = yield* js('process.stdout.write("ok"); process.exit(0)')
-        const code = yield* handle.exitCode
+        const tmp = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+        )
+        const stop = path.join(tmp.path, "stop")
+        const done = path.join(tmp.path, "done")
+        const descendant = [
+          'const fs = require("node:fs")',
+          `const stop = ${JSON.stringify(stop)}`,
+          "const timer = setInterval(() => {",
+          "  if (!fs.existsSync(stop)) return",
+          "  clearInterval(timer)",
+          `  fs.writeFileSync(${JSON.stringify(done)}, "done")`,
+          "}, 10)",
+        ].join("\n")
+        const parent = [
+          'const { spawn } = require("node:child_process")',
+          `const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendant)}], {`,
+          '  stdio: ["ignore", "inherit", "inherit"],',
+          "})",
+          "child.unref()",
+        ].join("\n")
+
+        const handle = yield* js(parent)
+        const cleanup = Effect.promise(async () => {
+          await fs.writeFile(stop, "stop")
+          await waitForFile(done)
+        })
+        const code = yield* handle.exitCode.pipe(
+          Effect.timeoutOrElse({
+            duration: "1 second",
+            orElse: () => Effect.die(new Error("exit code did not resolve after the parent exited")),
+          }),
+          Effect.ensuring(cleanup),
+        )
         expect(code).toBe(ChildProcessSpawner.ExitCode(0))
       }),
+      10_000,
     )
   })
 

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -376,6 +376,17 @@ describe("cross-spawn spawner", () => {
     )
   })
 
+  describe("exit reaping", () => {
+    fx.effect(
+      "exit code resolves before stream ends",
+      Effect.gen(function* () {
+        const handle = yield* js('process.stdout.write("ok"); process.exit(0)')
+        const code = yield* handle.exitCode
+        expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
+  })
+
   describe("Windows-specific", () => {
     fx.effect(
       "uses shell routing on Windows",


### PR DESCRIPTION
### Issue for this PR

Fixes #41806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ChildProcessHandle.exitCode` was settled from Node's `close` event, which waits for stdio to close after the direct child exits. A descendant that inherits one of those pipes can therefore keep the direct child's exit signal pending.

This settles the signal from `exit` instead and retains `close` as a fallback. The change is intentionally limited to the handle lifecycle; callers that separately collect streams continue to wait for stream completion.

### How did you verify your code works?

- `cd packages/core && bun test test/effect/cross-spawn-spawner.test.ts` — 25 pass, 0 fail
- `cd packages/core && bun typecheck`

The regression starts a parent that spawns a descendant with inherited stdout, records readiness, and exits. The descendant holds the pipe open until the test releases it, proving that `exitCode` settles from the direct child's exit rather than the later stream close.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
