### PR TITLE
fix(opencode): keep shell tail when oversized line ends with newline

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -236,7 +236,7 @@ function tail(text: string, maxLines: number, maxBytes: number) {
   for (let i = lines.length - 1; i >= 0 && out.length < maxLines; i--) {
     const size = Buffer.byteLength(lines[i], "utf-8") + (out.length > 0 ? 1 : 0)
     if (bytes + size > maxBytes) {
-      if (out.length === 0) {
+      if (bytes === 0) {
         const buf = Buffer.from(lines[i], "utf-8")
         let start = buf.length - maxBytes
         if (start < 0) start = 0

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -113,11 +113,13 @@ const cmdShell = shells.find((item) => item.label === "cmd")
 const sh = () => Shell.name(Shell.acceptable())
 const evalarg = (text: string) => (sh() === "cmd" ? quote(text) : squote(text))
 
-const fill = (mode: "lines" | "bytes", n: number) => {
+const fill = (mode: "lines" | "bytes" | "bytes-newline", n: number) => {
   const code =
     mode === "lines"
       ? "console.log(Array.from({length:Number(Bun.argv[1])},(_,i)=>i+1).join(String.fromCharCode(10)))"
-      : "process.stdout.write(String.fromCharCode(97).repeat(Number(Bun.argv[1])))"
+      : mode === "bytes-newline"
+        ? "process.stdout.write(String.fromCharCode(97).repeat(Number(Bun.argv[1]))+String.fromCharCode(10))"
+        : "process.stdout.write(String.fromCharCode(97).repeat(Number(Bun.argv[1])))"
   const text = `${bin} -e ${evalarg(code)} ${n}`
   if (PS.has(sh())) return `& ${text}`
   return text
@@ -1158,6 +1160,22 @@ describe("tool.shell truncation", () => {
         mustTruncate(result)
         expect(result.output).toMatch(/\.\.\.output truncated\.\.\./)
         expect(result.output).toMatch(/Full output saved to:\s+\S+/)
+      }),
+    ),
+  )
+
+  it.live("keeps a tail when the oversized line ends with a newline", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const byteCount = Truncate.MAX_BYTES + 10000
+        const result = yield* run({
+          command: fill("bytes-newline", byteCount),
+        })
+        mustTruncate(result)
+        expect(result.output).toMatch(/\.\.\.output truncated\.\.\./)
+        expect(result.output).not.toContain("(no output)")
+        expect(result.output).toContain("a".repeat(1000))
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #42277

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tail()` walks the output lines backwards and, when even the last line on its own exceeds `max_bytes`, byte-slices that line so the model still gets a tail. The fallback is guarded by `out.length === 0`. For output ending in a newline, `split("\n")` produces a trailing empty sentinel that gets unshifted into `out` first — it costs 0 bytes, but it makes the guard false, so the fallback never runs and `tail()` returns an empty string. The model then receives the "output truncated" banner followed by `(no output)`.

The guard now checks `bytes === 0`, which is what it meant to express ("nothing emitted yet"), since the sentinel contributes no bytes. Multi-line output is unaffected — it never reached the fallback. The branch was unreachable for newline-terminated output before, so this only turns dead code back on.

### How did you verify your code works?

Added `keeps a tail when the oversized line ends with a newline` beside the existing byte-limit test, reusing the same `fill()` generator with a trailing newline.

- On `dev` it fails: `Expected to not contain: "(no output)"`, received the banner plus `(no output)`
- With the fix it passes and the body carries the last 50 KB
- `bun test test/tool/` from `packages/opencode`: 339 pass, 0 fail
- `bun typecheck` from `packages/opencode`, and the pre-push `bun turbo typecheck`: 30/30 packages

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Disclosure: found and fixed with AI assistance; I reviewed and verified every claim locally.
