### PR TITLE
fix(core): apply external plugin changes after startup batch commits

### DIFF
--- a/packages/core/src/config/plugin/external.ts
+++ b/packages/core/src/config/plugin/external.ts
@@ -2,7 +2,7 @@ export * as ConfigExternalPlugin from "./external"
 
 import type { Plugin as EffectPlugin } from "@opencode-ai/plugin/v2/effect"
 import type { Plugin as PromisePlugin } from "@opencode-ai/plugin/v2/promise"
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Schema } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Config } from "../../config"
@@ -11,6 +11,7 @@ import { Location } from "../../location"
 import { Npm } from "../../npm"
 import { define } from "../../plugin/internal"
 import { PluginPromise } from "../../plugin/promise"
+import { State } from "../../state"
 
 const PluginModule = Schema.Struct({
   default: Schema.Union([
@@ -36,56 +37,68 @@ export const Plugin = define({
     const fs = yield* FSUtil.Service
     const location = yield* Location.Service
     const npm = yield* Npm.Service
-    yield* Effect.gen(function* () {
-      const configured: { package: string; options?: Record<string, any> }[] = []
+    yield* State.unbatched(
+      Effect.gen(function* () {
+        const configured: { package: string; options?: Record<string, any> }[] = []
 
-      for (const entry of yield* config.entries()) {
-        if (entry.type === "document") {
-          const directory = entry.path ? path.dirname(entry.path) : location.directory
-          for (const item of entry.info.plugins ?? []) {
-            const ref = typeof item === "string" ? { package: item } : item
-            const packageName = (() => {
-              if (ref.package.startsWith("file://")) return fileURLToPath(ref.package)
-              if (ref.package.startsWith("./") || ref.package.startsWith("../")) {
-                return path.resolve(directory, ref.package)
-              }
-              return ref.package
-            })()
-            configured.push({ package: packageName, options: ref.options })
+        for (const entry of yield* config.entries()) {
+          if (entry.type === "document") {
+            const directory = entry.path ? path.dirname(entry.path) : location.directory
+            for (const item of entry.info.plugins ?? []) {
+              const ref = typeof item === "string" ? { package: item } : item
+              const packageName = (() => {
+                if (ref.package.startsWith("file://")) return fileURLToPath(ref.package)
+                if (ref.package.startsWith("./") || ref.package.startsWith("../")) {
+                  return path.resolve(directory, ref.package)
+                }
+                return ref.package
+              })()
+              configured.push({ package: packageName, options: ref.options })
+            }
+          }
+
+          if (entry.type === "directory") {
+            const files = yield* fs
+              .glob("{plugin,plugins}/*.{ts,js}", {
+                cwd: entry.path,
+                absolute: true,
+                include: "file",
+                dot: true,
+                symlink: true,
+              })
+              .pipe(Effect.orElseSucceed(() => []))
+            files.sort()
+            for (const file of files) configured.push({ package: file })
           }
         }
 
-        if (entry.type === "directory") {
-          const files = yield* fs
-            .glob("{plugin,plugins}/*.{ts,js}", {
-              cwd: entry.path,
-              absolute: true,
-              include: "file",
-              dot: true,
-              symlink: true,
+        yield* Effect.logInfo("external plugin discovery", {
+          entries: configured.map((item) => item.package),
+        })
+
+        for (const ref of configured) {
+          yield* Effect.logInfo("external plugin load", { package: ref.package })
+          yield* Effect.gen(function* () {
+            const entrypoint = path.isAbsolute(ref.package)
+              ? pathToFileURL(ref.package).href
+              : (yield* npm.add(ref.package)).entrypoint
+            if (!entrypoint) return
+
+            const mod = yield* Effect.promise(() => import(entrypoint))
+            const value = (yield* Schema.decodeUnknownEffect(PluginModule)(mod)).default
+            const plugin = "effect" in value ? value : PluginPromise.fromPromise(value)
+            yield* ctx.plugin.add({
+              id: plugin.id,
+              effect: (host) => plugin.effect({ ...host, options: ref.options ?? {} }),
             })
-            .pipe(Effect.orElseSucceed(() => []))
-          files.sort()
-          for (const file of files) configured.push({ package: file })
+          }).pipe(
+            Effect.tapCause((cause) =>
+              Effect.logError("failed to load external plugin", { package: ref.package, cause: Cause.pretty(cause) }),
+            ),
+            Effect.ignoreCause,
+          )
         }
-      }
-
-      for (const ref of configured) {
-        yield* Effect.gen(function* () {
-          const entrypoint = path.isAbsolute(ref.package)
-            ? pathToFileURL(ref.package).href
-            : (yield* npm.add(ref.package)).entrypoint
-          if (!entrypoint) return
-
-          const mod = yield* Effect.promise(() => import(entrypoint))
-          const value = (yield* Schema.decodeUnknownEffect(PluginModule)(mod)).default
-          const plugin = "effect" in value ? value : PluginPromise.fromPromise(value)
-          yield* ctx.plugin.add({
-            id: plugin.id,
-            effect: (host) => plugin.effect({ ...host, options: ref.options ?? {} }),
-          })
-        }).pipe(Effect.ignoreCause)
-      }
-    }).pipe(Effect.forkScoped({ startImmediately: true }))
+      }),
+    ).pipe(Effect.forkScoped({ startImmediately: true }))
   }),
 })

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -41,6 +41,15 @@ export function batch<A, E, R>(effect: Effect.Effect<A, E, R>) {
   })
 }
 
+/**
+ * Runs an effect outside any ambient batch. Forked fibers inherit the batching
+ * context of their parent; a batch that has already committed would silently
+ * drop their reloads, so async plugin loads must opt out explicitly.
+ */
+export function unbatched<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return Effect.provideService(effect, CurrentBatch, undefined)
+}
+
 export interface Options<State, DraftApi> {
   /** Creates the base value for initial state and every scoped-transform reload. */
   readonly initial: () => State

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -10,6 +10,7 @@ import { Npm } from "@opencode-ai/core/npm"
 import { PluginV2 } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { State } from "@opencode-ai/core/state"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "../plugin/fixture"
 
@@ -99,6 +100,51 @@ describe("ConfigExternalPlugin", () => {
 
       expect(yield* waitForAgent(agents, "effect-configured")).toMatchObject({
         description: "Effect plugin from config",
+        mode: "subagent",
+      })
+    }),
+  )
+
+  it.live("applies plugin changes that land after the startup batch commits", () =>
+    Effect.gen(function* () {
+      const plugins = yield* PluginV2.Service
+      const agents = yield* AgentV2.Service
+      const fs = yield* FSUtil.Service
+      const location = yield* Location.Service
+      const npm = yield* Npm.Service
+      const host = yield* PluginHost.make(plugins)
+
+      yield* State.batch(
+        ConfigExternalPlugin.Plugin.effect(host).pipe(
+          Effect.provideService(PluginV2.Service, plugins),
+          Effect.provideService(FSUtil.Service, fs),
+          Effect.provideService(Location.Service, location),
+          Effect.provideService(Npm.Service, npm),
+          Effect.provideService(
+            Config.Service,
+            Config.Service.of({
+              entries: () =>
+                Effect.succeed([
+                  new Config.Document({
+                    type: "document",
+                    path: path.join(import.meta.dir, "opencode.json"),
+                    info: decode({
+                      plugins: [
+                        {
+                          package: "../plugin/fixtures/config-effect-plugin.ts",
+                          options: { description: "Loaded after batch commit" },
+                        },
+                      ],
+                    }),
+                  }),
+                ]),
+            }),
+          ),
+        ),
+      )
+
+      expect(yield* waitForAgent(agents, "effect-configured")).toMatchObject({
+        description: "Loaded after batch commit",
         mode: "subagent",
       })
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #42280

### Type of change

- [x] Bug fix

### What does this PR do?

`ConfigExternalPlugin` loads plugins in a `forkScoped` fiber, which inherits the ambient `State` batch. Startup wraps loading in `State.batch(...)`, so once the startup effect returns, the batch is drained and gone — but the async plugin load finishes later, and its `transform()` calls enqueue their reloads into that dead set. The plugin's agents/tools/skills never materialize, with no error.

The fix adds `State.unbatched(effect)`, which clears the inherited `CurrentBatch` so transforms reload immediately, and wraps the forked loader in it. Also replaces the silent `Effect.ignoreCause` with discovery/load/error logs so a failing plugin is visible instead of vanishing.

### How did you verify your code works?

Added a regression test in `packages/core/test/config/plugin.test.ts` that wraps the plugin effect in `State.batch`, matching the real startup path. It times out waiting for the plugin-registered agent without the fix and passes with it. `bun test test/config/ test/plugin/` (281 tests) and `bun typecheck` pass in `packages/core`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

(Recreated from #42245, which was auto-closed by the compliance check before the description was updated.)