### PR TITLE
fix(cli): stop `run` from sleeping through an exhausted quota

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -87,6 +87,13 @@ function formatRunError(error: unknown) {
   return FormatError(error) ?? FormatUnknownError(error)
 }
 
+// Retry reasons that will not clear on their own within a run. The session retry
+// schedule honors the provider's retry-after for these, which for an exhausted
+// quota is measured in days, so a non-interactive run reports and stops instead
+// of sleeping through it. Every other retryable failure is transient and keeps
+// its existing wait-and-retry behavior.
+const NON_TRANSIENT_RETRY_REASONS = new Set(["free_tier_limit", "account_rate_limit"])
+
 async function tool(part: ToolPart) {
   try {
     const { toolInlineInfo } = await import("./run/tool")
@@ -783,6 +790,28 @@ export const RunCommand = effectCmd({
               error = error ? error + EOL + err : err
               if (emit("error", { error: props.error })) continue
               UI.error(err)
+            }
+
+            // Retries are invisible here otherwise: the session stays busy, no
+            // session.error is published, and idle only arrives once the retry
+            // schedule finishes. A transient retry (429/5xx, short retry-after)
+            // is worth waiting out, but quota exhaustion carries a retry-after
+            // measured in days, which an unattended run must not sleep through.
+            if (event.type === "session.status" && event.properties.sessionID === sessionID) {
+              const status = event.properties.status
+              if (status.type === "retry") {
+                if (!emit("retry", { attempt: status.attempt, message: status.message, next: status.next })) {
+                  UI.error(`${status.message} (attempt ${status.attempt})`)
+                }
+                if (NON_TRANSIENT_RETRY_REASONS.has(status.action?.reason ?? "")) {
+                  error = error ? error + EOL + status.message : status.message
+                  // The schedule is already sleeping on the provider's retry-after.
+                  // Abort so that pending wait cannot hold the process open after
+                  // this loop stops reading events.
+                  await client.session.abort({ sessionID }).catch(() => {})
+                  break
+                }
+              }
             }
 
             if (

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -328,4 +328,30 @@ describe("opencode run (non-interactive subprocess)", () => {
       }),
     30_000,
   )
+
+  // An exhausted quota answers with a retry-after measured in days, which the
+  // session retry schedule honors. A non-interactive run has nowhere to show a
+  // pending retry, so it must report the limit and stop rather than sleep on it.
+  cliIt.concurrent(
+    "reports and exits non-zero instead of waiting out an exhausted quota",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.error(
+          429,
+          {
+            name: "GoUsageLimitError",
+            message: "Monthly usage limit reached.",
+            metadata: { workspace: "wrk_test", limitName: "Monthly" },
+          },
+          { "retry-after": "345600" },
+        )
+
+        const result = yield* opencode.run("say hi")
+
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stderr).toContain("usage limit reached")
+        expect(result.durationMs).toBeLessThan(30_000)
+      }),
+    60_000,
+  )
 })

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -46,6 +46,7 @@ type HttpError = {
   type: "http-error"
   status: number
   body: unknown
+  headers?: Record<string, string>
 }
 
 export type Item = Sse | HttpError
@@ -446,6 +447,7 @@ function fail(item: HttpError) {
   return HttpServerResponse.text(JSON.stringify(item.body), {
     status: item.status,
     contentType: "application/json",
+    headers: item.headers,
   })
 }
 
@@ -565,11 +567,12 @@ export function reply() {
   return new Reply()
 }
 
-export function httpError(status: number, body: unknown): Item {
+export function httpError(status: number, body: unknown, headers?: Record<string, string>): Item {
   return {
     type: "http-error",
     status,
     body,
+    headers,
   }
 }
 
@@ -621,7 +624,7 @@ namespace TestLLMServer {
     readonly toolHang: (name: string, input: unknown) => Effect.Effect<void>
     readonly reason: (value: string, opts?: { text?: string; usage?: Usage }) => Effect.Effect<void>
     readonly fail: (message?: unknown) => Effect.Effect<void>
-    readonly error: (status: number, body: unknown) => Effect.Effect<void>
+    readonly error: (status: number, body: unknown, headers?: Record<string, string>) => Effect.Effect<void>
     readonly hang: Effect.Effect<void>
     readonly hold: (value: string, wait: PromiseLike<unknown>) => Effect.Effect<void>
     readonly reset: Effect.Effect<void>
@@ -747,8 +750,8 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
         fail: Effect.fn("TestLLMServer.fail")(function* (message: unknown = "boom") {
           queue(reply().streamError(message).item())
         }),
-        error: Effect.fn("TestLLMServer.error")(function* (status: number, body: unknown) {
-          queue(httpError(status, body))
+        error: Effect.fn("TestLLMServer.error")(function* (status: number, body: unknown, headers?: Record<string, string>) {
+          queue(httpError(status, body, headers))
         }),
         hang: Effect.gen(function* () {
           queue(reply().hang().item())


### PR DESCRIPTION
Fixes #40747 — `opencode run` produces no output and never returns when a model's quota is exhausted.

It isn't wedged, it's sleeping. The quota error is classified as retryable, and `delay()` honors the provider's `retry-after`, which for a monthly limit is days. While the schedule sleeps, `halt()` never runs, so no `session.error` and no `idle` are published, and `loop()` in `cli/cmd/run.ts` breaks only on `idle` and has no branch for `retry` status. The TUI is unaffected because it shows the retry in its footer; a headless run has nowhere to show it.

I left the retry timing alone — honoring long `retry-after` values was deliberate in 0a2d7af17, and waiting out a short rate limit is useful. The change is only in the non-interactive loop:

- print the retry status, which today prints nothing at all in headless runs
- exit non-zero when `action.reason` is `free_tier_limit` / `account_rate_limit`; transient retries (429/5xx) carry no `action.reason` and still wait and retry as before
- abort the session before returning, because breaking out of the loop isn't enough to end the process — the sleeping schedule holds the in-process server open, and without the abort it still has to be killed

## How I verified it

New test in `test/cli/run/run-process.test.ts`: the test provider returns a 429 carrying `GoUsageLimitError` with `retry-after: 345600`, and the run must exit non-zero and mention the limit on stderr. On unmodified `dev` it hangs until the harness kills it at 30 s; with this change it passes in ~2 s.

Setting that header needed an optional `headers` argument on `httpError()` / `llm.error()` in the test harness — `retry-after` drives the delay and there was no way to set it before.

`bun test test/session/retry.test.ts test/cli/run/` → 250 pass, 5 skip, 0 fail. `tsc --noEmit` matches the `dev` baseline.
