### PR TITLE
fix(app): scope review panel to the session's own file changes

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -96,6 +96,7 @@ import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
 import { diffs as list } from "@/utils/diffs"
+import { sessionTouchedFiles } from "@/utils/session-files"
 import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { formatServerError, isLocalSessionNotFoundError, isSessionNotFoundError } from "@/utils/server-errors"
@@ -650,6 +651,10 @@ export default function Page() {
   }, desktopReviewOpen())
 
   const turnDiffs = createMemo(() => list(lastUserMessage()?.summary?.diffs))
+  // Files changed by this session across all its turns. The working tree is
+  // shared by every session in the same directory, so the review panel must
+  // be scoped to these files to avoid leaking other sessions' changes.
+  const sessionFiles = createMemo(() => sessionTouchedFiles(messages()))
   const nogit = createMemo(() => {
     const project = sync().project
     return !!project && project.vcs !== "git"
@@ -678,7 +683,13 @@ export default function Page() {
   })
   const vcsKey = createMemo(
     () =>
-      ["session-vcs", sdk().directory, sync().data.vcs?.branch ?? "", sync().data.vcs?.default_branch ?? ""] as const,
+      [
+        "session-vcs",
+        params.id,
+        sdk().directory,
+        sync().data.vcs?.branch ?? "",
+        sync().data.vcs?.default_branch ?? "",
+      ] as const,
   )
   const vcsQuery = createQuery(() => {
     const mode = vcsMode()
@@ -701,9 +712,15 @@ export default function Page() {
   })
   const refreshVcs = debounce(() => void queryClient.invalidateQueries({ queryKey: vcsKey() }), 100)
   const reviewDiffs = () => {
-    if (reviewMode() === "git" || reviewMode() === "branch")
+    if (reviewMode() === "git" || reviewMode() === "branch") {
       // avoids suspense
-      return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
+      const diffs = vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
+      // The working-tree diff is shared by all sessions in this directory;
+      // only surface changes this session actually made.
+      const files = sessionFiles()
+      if (files.size === 0) return []
+      return diffs.filter((diff) => diff.file !== undefined && files.has(diff.file))
+    }
     return turnDiffs()
   }
   const activeReviewFile = () => {

--- a/packages/app/src/utils/session-files.test.ts
+++ b/packages/app/src/utils/session-files.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import { sessionTouchedFiles } from "./session-files"
+
+function message(id: string, summary?: unknown, role: Message["role"] = "user"): Message {
+  return {
+    id,
+    role,
+    sessionID: "session-1",
+    time: { created: 0 },
+    version: 1,
+    info: {},
+    ...(summary === undefined ? {} : { summary }),
+  } as unknown as Message
+}
+
+describe("sessionTouchedFiles", () => {
+  test("collects files from user message diff summaries", () => {
+    const messages = [
+      message("m1", {
+        diffs: [
+          { file: "src/a.ts", patch: "", additions: 1, deletions: 0, status: "modified" },
+          { file: "src/b.ts", patch: "", additions: 1, deletions: 0, status: "added" },
+        ],
+      }),
+      message("m2", {
+        diffs: [{ file: "src/c.ts", patch: "", additions: 1, deletions: 0, status: "modified" }],
+      }),
+    ]
+    expect([...sessionTouchedFiles(messages)].sort()).toEqual(["src/a.ts", "src/b.ts", "src/c.ts"])
+  })
+
+  test("skips assistant messages", () => {
+    const messages = [
+      message(
+        "m1",
+        { diffs: [{ file: "src/a.ts", patch: "", additions: 1, deletions: 0 }] },
+        "assistant",
+      ),
+    ]
+    expect(sessionTouchedFiles(messages).size).toBe(0)
+  })
+
+  test("deduplicates files across turns", () => {
+    const diff = { file: "src/a.ts", patch: "", additions: 1, deletions: 0, status: "modified" as const }
+    const messages = [message("m1", { diffs: [diff] }), message("m2", { diffs: [diff] })]
+    expect([...sessionTouchedFiles(messages)]).toEqual(["src/a.ts"])
+  })
+
+  test("returns empty set for messages without summaries", () => {
+    const messages = [message("m1"), message("m2")]
+    expect(sessionTouchedFiles(messages).size).toBe(0)
+  })
+
+  test("tolerates malformed diff payloads", () => {
+    const messages = [
+      message("m1", {
+        diffs: [
+          { file: "src/ok.ts", patch: "p", additions: 1, deletions: 0 },
+          "garbage",
+          null,
+          { patch: "missing file field" },
+        ],
+      }),
+    ]
+    expect([...sessionTouchedFiles(messages)]).toEqual(["src/ok.ts"])
+  })
+})

--- a/packages/app/src/utils/session-files.ts
+++ b/packages/app/src/utils/session-files.ts
@@ -1,0 +1,21 @@
+import type { Message } from "@opencode-ai/sdk/v2/client"
+import { diffs } from "./diffs"
+
+/**
+ * Collects the set of file paths that this session's own turns have changed,
+ * based on the per-message diff summaries computed by the server.
+ *
+ * The working tree is shared by every session in the same directory, so the
+ * review panel must be scoped to these files to avoid leaking changes made by
+ * other concurrent sessions (see anomalyco/opencode#40736, #41399).
+ */
+export function sessionTouchedFiles(messages: readonly Message[]): Set<string> {
+  const files = new Set<string>()
+  for (const msg of messages) {
+    if (msg.role !== "user") continue
+    for (const diff of diffs(msg.summary?.diffs)) {
+      if (diff.file) files.add(diff.file)
+    }
+  }
+  return files
+}


### PR DESCRIPTION
### Issue for this PR

Closes #41399

### Type of change

- [x] Bug fix

### What does this PR do?

The Review / Files Changed panel in a session shows the full working-tree diff of the project directory. The working tree is shared by every session in the same folder, so a clean session B displays files that a concurrent session A is actively writing (#41399, #40736).

The panel was not scoped to what this session actually changed, and the VCS query cache key (`["session-vcs", directory, branch, default_branch]`) contained no session ID, so cache entries were shared across sessions.

Changes:
- Add a `sessionTouchedFiles()` helper (with unit tests) that collects the files this session's own turns changed, from the per-message diff summaries the server stores.
- In `git`/`branch` review mode, intersect the working-tree diff with that set, so the panel only shows changes this session made (empty for sessions that wrote nothing).
- Add `params.id` to the `session-vcs` cache key so each session's VCS state is cached separately.

The server-side snapshot scoping is tracked separately (#40736, complementary PR #40821); this PR fixes the app-layer symptom and works regardless of server behaviour.

### How did you verify your code works?

- `bun run test:unit` in `packages/app`: 503 pass / 0 fail (includes 5 new unit tests for `sessionTouchedFiles`)
- `bun run typecheck`: green
- Live functional check against a real server + real model turns: a clean session shows an empty Review panel while another session's changes exist in the working tree; the session's own writes appear in its per-message diff (data verified server-side).

### Screenshots / recordings

No screenshot included — verification was done via the automated suite and the live functional negative control described above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
