### PR TITLE
fix(session): recover orphaned task runs

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -3,9 +3,11 @@ import { Cause, Deferred, Effect, Exit, Fiber, Latch, Schema, Scope, Synchronize
 export interface Runner<A, E = never> {
   readonly state: State<A, E>
   readonly busy: boolean
+  readonly admit: (work: Effect.Effect<A, E>) => Effect.Effect<Effect.Effect<A, E>>
   readonly ensureRunning: (work: Effect.Effect<A, E>) => Effect.Effect<A, E>
+  readonly admitShell: (work: Effect.Effect<A, E>, ready?: Latch.Latch) => Effect.Effect<Effect.Effect<A, E | Busy>>
   readonly startShell: (work: Effect.Effect<A, E>, ready?: Latch.Latch) => Effect.Effect<A, E | Busy>
-  readonly cancel: Effect.Effect<void>
+  readonly cancel: Effect.Effect<boolean>
 }
 
 export class Cancelled extends Schema.TaggedErrorClass<Cancelled>()("RunnerCancelled", {}) {}
@@ -112,7 +114,7 @@ export const make = <A, E = never>(
       yield* Fiber.interrupt(shell.fiber)
     })
 
-  const ensureRunning = (work: Effect.Effect<A, E>) =>
+  const admit = (work: Effect.Effect<A, E>) =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
@@ -135,9 +137,11 @@ export const make = <A, E = never>(
           }
         }
       }),
-    ).pipe(Effect.flatten)
+    )
 
-  const startShell = (work: Effect.Effect<A, E>, ready?: Latch.Latch): Effect.Effect<A, E | Busy> =>
+  const ensureRunning = (work: Effect.Effect<A, E>) => admit(work).pipe(Effect.flatten)
+
+  const admitShell = (work: Effect.Effect<A, E>, ready?: Latch.Latch) =>
     SynchronizedRef.modifyEffect(
       ref,
       Effect.fnUntraced(function* (st) {
@@ -166,19 +170,22 @@ export const make = <A, E = never>(
           { _tag: "Shell", shell },
         ] as const
       }),
-    ).pipe(Effect.flatten)
+    )
+
+  const startShell = (work: Effect.Effect<A, E>, ready?: Latch.Latch): Effect.Effect<A, E | Busy> =>
+    admitShell(work, ready).pipe(Effect.flatten)
 
   const cancel = SynchronizedRef.modify(ref, (st) => {
     switch (st._tag) {
       case "Idle":
-        return [Effect.void, st] as const
+        return [Effect.succeed(false), st] as const
       case "Running":
         return [
           Effect.gen(function* () {
             yield* Fiber.interrupt(st.run.fiber)
             yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
             yield* idleIfCurrent()
-          }),
+          }).pipe(Effect.as(true)),
           { _tag: "Idle" } as const,
         ] as const
       case "Shell":
@@ -186,7 +193,7 @@ export const make = <A, E = never>(
           Effect.gen(function* () {
             yield* stopShell(st.shell)
             yield* idleIfCurrent()
-          }),
+          }).pipe(Effect.as(true)),
           { _tag: "Idle" } as const,
         ] as const
       case "ShellThenRun":
@@ -195,7 +202,7 @@ export const make = <A, E = never>(
             yield* stopShell(st.shell)
             yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
             yield* idleIfCurrent()
-          }),
+          }).pipe(Effect.as(true)),
           { _tag: "Idle" } as const,
         ] as const
     }
@@ -208,7 +215,9 @@ export const make = <A, E = never>(
     get busy() {
       return state()._tag !== "Idle"
     },
+    admit,
     ensureRunning,
+    admitShell,
     startShell,
     cancel,
   }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -235,22 +235,15 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])),
       )
       const end = Date.now()
-      const interrupted = messages.filter((message) => {
-        if (message.info.role !== "assistant") return false
-        return message.parts.some(
-          (part): part is SessionV1.ToolPart & { state: SessionV1.ToolStatePending | SessionV1.ToolStateRunning } =>
-            part.type === "tool" &&
-            part.tool === "task" &&
-            (part.state.status === "pending" || part.state.status === "running"),
-        )
-      })
-      for (const message of interrupted) {
+      for (const message of messages) {
+        if (message.info.role !== "assistant") continue
         const tasks = message.parts.filter(
           (part): part is SessionV1.ToolPart & { state: SessionV1.ToolStatePending | SessionV1.ToolStateRunning } =>
             part.type === "tool" &&
             part.tool === "task" &&
             (part.state.status === "pending" || part.state.status === "running"),
         )
+        if (tasks.length === 0) continue
         for (const part of tasks) {
           yield* session.updatePart({
             ...part,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -13,6 +13,7 @@ import { SessionRevert } from "@/session/revert"
 import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
+import { NotFoundError } from "@/storage/storage"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
@@ -229,8 +230,55 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* fork({ params: ctx.params, payload })
     })
 
+    const settleOrphanedTaskParts = Effect.fn("SessionHttpApi.settleOrphanedTaskParts")(function* (sessionID: SessionID) {
+      const messages = yield* session.messages({ sessionID }).pipe(
+        Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])),
+      )
+      const end = Date.now()
+      const interrupted = messages.filter((message) => {
+        if (message.info.role !== "assistant") return false
+        return message.parts.some(
+          (part): part is SessionV1.ToolPart & { state: SessionV1.ToolStatePending | SessionV1.ToolStateRunning } =>
+            part.type === "tool" &&
+            part.tool === "task" &&
+            (part.state.status === "pending" || part.state.status === "running"),
+        )
+      })
+      for (const message of interrupted) {
+        const tasks = message.parts.filter(
+          (part): part is SessionV1.ToolPart & { state: SessionV1.ToolStatePending | SessionV1.ToolStateRunning } =>
+            part.type === "tool" &&
+            part.tool === "task" &&
+            (part.state.status === "pending" || part.state.status === "running"),
+        )
+        for (const part of tasks) {
+          yield* session.updatePart({
+            ...part,
+            state: {
+              status: "error",
+              input: part.state.input,
+              error: "Tool execution aborted",
+              metadata: { ...(part.state.status === "running" ? part.state.metadata : {}), interrupted: true },
+              time: { start: part.state.status === "running" ? part.state.time.start : end, end },
+            },
+          } satisfies SessionV1.ToolPart)
+        }
+        if (message.info.time.completed) continue
+        yield* session.updateMessage({
+          ...message.info,
+          error:
+            message.info.error ??
+            MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
+              providerID: message.info.providerID,
+              aborted: true,
+            }),
+          time: { ...message.info.time, completed: end },
+        })
+      }
+    })
+
     const abort = Effect.fn("SessionHttpApi.abort")(function* (ctx: { params: { sessionID: SessionID } }) {
-      yield* promptSvc.cancel(ctx.params.sessionID)
+      yield* runState.cancelOr(ctx.params.sessionID, settleOrphanedTaskParts(ctx.params.sessionID))
       return true
     })
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { KeyedMutex } from "@opencode-ai/core/effect/keyed-mutex"
 import { InstanceState } from "@/effect/instance-state"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Runner } from "@/effect/runner"
@@ -10,7 +11,11 @@ import { SessionStatus } from "./status"
 
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
-  readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly cancel: (sessionID: SessionID) => Effect.Effect<boolean>
+  readonly cancelOr: <A, E, R>(
+    sessionID: SessionID,
+    onIdle: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<CancelResult<A>, E, R>
   readonly ensureRunning: (
     sessionID: SessionID,
     onInterrupt: Effect.Effect<SessionV1.WithParts>,
@@ -23,6 +28,8 @@ export interface Interface {
     ready?: Latch.Latch,
   ) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
 }
+
+type CancelResult<A> = { readonly _tag: "cancelled" } | { readonly _tag: "idle"; readonly value: A }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRunState") {}
 
@@ -45,7 +52,7 @@ const layer = Layer.effect(
             runners.clear()
           }),
         )
-        return { runners, scope }
+        return { runners, scope, locks: KeyedMutex.makeUnsafe<SessionID>() }
       }),
     )
 
@@ -56,14 +63,17 @@ const layer = Layer.effect(
       const data = yield* InstanceState.get(state)
       const existing = data.runners.get(sessionID)
       if (existing) return existing
+      const current = {} as { runner: Runner.Runner<SessionV1.WithParts> }
       const next = Runner.make<SessionV1.WithParts>(data.scope, {
         onIdle: Effect.gen(function* () {
+          if (data.runners.get(sessionID) !== current.runner || current.runner.busy) return
           data.runners.delete(sessionID)
           yield* status.set(sessionID, { type: "idle" })
         }),
         onBusy: status.set(sessionID, { type: "busy" }),
         onInterrupt,
       })
+      current.runner = next
       data.runners.set(sessionID, next)
       return next
     })
@@ -74,15 +84,27 @@ const layer = Layer.effect(
       if (existing?.busy) yield* busyError(sessionID)
     })
 
-    const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
-      yield* cancelBackgroundJobs(background, sessionID)
+    const cancelOr = Effect.fn("SessionRunState.cancelOr")(function* <A, E, R>(
+      sessionID: SessionID,
+      onIdle: Effect.Effect<A, E, R>,
+    ): Effect.Effect<CancelResult<A>, E, R> {
       const data = yield* InstanceState.get(state)
-      const existing = data.runners.get(sessionID)
-      if (!existing) {
-        yield* status.set(sessionID, { type: "idle" })
-        return
-      }
-      yield* existing.cancel
+      return yield* data.locks.withLock(sessionID)(
+        Effect.gen(function* () {
+          yield* cancelBackgroundJobs(background, sessionID)
+          const existing = data.runners.get(sessionID)
+          if (existing && (yield* existing.cancel)) {
+            return { _tag: "cancelled" } as const
+          }
+          yield* status.set(sessionID, { type: "idle" })
+          return { _tag: "idle", value: yield* onIdle } as const
+        }),
+      )
+    })
+
+    const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
+      const result = yield* cancelOr(sessionID, Effect.void)
+      return result._tag === "cancelled"
     })
 
     const ensureRunning = Effect.fn("SessionRunState.ensureRunning")(function* (
@@ -90,7 +112,13 @@ const layer = Layer.effect(
       onInterrupt: Effect.Effect<SessionV1.WithParts>,
       work: Effect.Effect<SessionV1.WithParts>,
     ) {
-      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
+      const data = yield* InstanceState.get(state)
+      const run = yield* data.locks.withLock(sessionID)(
+        Effect.gen(function* () {
+          return yield* (yield* runner(sessionID, onInterrupt)).admit(work)
+        }),
+      )
+      return yield* run
     })
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
@@ -99,12 +127,16 @@ const layer = Layer.effect(
       work: Effect.Effect<SessionV1.WithParts>,
       ready?: Latch.Latch,
     ) {
-      return yield* (yield* runner(sessionID, onInterrupt))
-        .startShell(work, ready)
-        .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
+      const data = yield* InstanceState.get(state)
+      const run = yield* data.locks.withLock(sessionID)(
+        Effect.gen(function* () {
+          return yield* (yield* runner(sessionID, onInterrupt)).admitShell(work, ready)
+        }),
+      )
+      return yield* run.pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, cancelOr, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -14,7 +14,7 @@ export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<boolean>
   readonly cancelOr: <A, E, R>(
     sessionID: SessionID,
-    onIdle: Effect.Effect<A, E, R>,
+    onStopped: Effect.Effect<A, E, R>,
   ) => Effect.Effect<CancelResult<A>, E, R>
   readonly ensureRunning: (
     sessionID: SessionID,
@@ -86,18 +86,18 @@ const layer = Layer.effect(
 
     const cancelOr = Effect.fn("SessionRunState.cancelOr")(function* <A, E, R>(
       sessionID: SessionID,
-      onIdle: Effect.Effect<A, E, R>,
+      onStopped: Effect.Effect<A, E, R>,
     ): Effect.Effect<CancelResult<A>, E, R> {
       const data = yield* InstanceState.get(state)
+      yield* cancelBackgroundJobs(background, sessionID)
       return yield* data.locks.withLock(sessionID)(
         Effect.gen(function* () {
-          yield* cancelBackgroundJobs(background, sessionID)
           const existing = data.runners.get(sessionID)
-          if (existing && (yield* existing.cancel)) {
-            return { _tag: "cancelled" } as const
-          }
-          yield* status.set(sessionID, { type: "idle" })
-          return { _tag: "idle", value: yield* onIdle } as const
+          const cancelled = existing ? yield* existing.cancel : false
+          if (!cancelled) yield* status.set(sessionID, { type: "idle" })
+          const value = yield* onStopped
+          if (cancelled) return { _tag: "cancelled" } as const
+          return { _tag: "idle", value } as const
         }),
       )
     })

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -87,7 +87,7 @@ const layer = Layer.effect(
     const cancelOr = Effect.fn("SessionRunState.cancelOr")(function* <A, E, R>(
       sessionID: SessionID,
       onStopped: Effect.Effect<A, E, R>,
-    ): Effect.Effect<CancelResult<A>, E, R> {
+    ) {
       const data = yield* InstanceState.get(state)
       yield* cancelBackgroundJobs(background, sessionID)
       return yield* data.locks.withLock(sessionID)(

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -133,7 +133,7 @@ describe("Runner", () => {
       expect(runner.busy).toBe(true)
       expect(runner.state._tag).toBe("Running")
 
-      yield* runner.cancel
+      expect(yield* runner.cancel).toBe(true)
       expect(runner.busy).toBe(false)
 
       const exit = yield* Fiber.await(fiber)
@@ -146,8 +146,22 @@ describe("Runner", () => {
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
-      yield* runner.cancel
+      expect(yield* runner.cancel).toBe(false)
       expect(runner.busy).toBe(false)
+    }),
+  )
+
+  it.live(
+    "admit reserves a run before returning control",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const admitted = yield* runner.admit(Effect.never.pipe(Effect.as("never")))
+
+      expect(runner.busy).toBe(true)
+      expect(yield* runner.cancel).toBe(true)
+      const exit = yield* admitted.pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -4,7 +4,7 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { Cause, Config, Effect, Exit, Layer } from "effect"
+import { Cause, Config, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse, HttpRouter, HttpServer } from "effect/unstable/http"
 import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -24,6 +24,7 @@ import * as HttpSessionError from "../../src/server/routes/instance/httpapi/hand
 import { ExperimentalPaths } from "../../src/server/routes/instance/httpapi/groups/experimental"
 import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { Session } from "@/session/session"
+import { SessionRunState } from "@/session/run-state"
 import { MessageID, PartID, SessionID, type SessionID as SessionIDType } from "../../src/session/schema"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
@@ -88,6 +89,63 @@ function createTextMessage(sessionID: SessionIDType, text: string) {
       text,
     })
     return { info, part }
+  })
+}
+
+function createAssistantWithTask(sessionID: SessionIDType, directory: string, status: "pending" | "running" = "running") {
+  return Effect.gen(function* () {
+    const svc = yield* Session.Service
+    const user = yield* createTextMessage(sessionID, "hello")
+    const assistant = yield* svc.updateMessage({
+      id: MessageID.ascending(),
+      parentID: user.info.id,
+      role: "assistant",
+      sessionID,
+      mode: "build",
+      agent: "build",
+      path: { cwd: directory, root: directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ModelV2.ID.make("test"),
+      providerID: ProviderV2.ID.make("test"),
+      time: { created: Date.now() },
+    })
+    const taskState =
+      status === "running"
+        ? ({
+            status: "running",
+            input: { description: "stale task", prompt: "do work", subagent_type: "general" },
+            metadata: { sessionId: "ses_stale" },
+            time: { start: Date.now() },
+          } satisfies SessionV1.ToolStateRunning)
+        : ({
+            status: "pending",
+            input: { description: "stale task", prompt: "do work", subagent_type: "general" },
+            raw: "",
+          } satisfies SessionV1.ToolStatePending)
+    const task = yield* svc.updatePart({
+      id: PartID.ascending(),
+      sessionID,
+      messageID: assistant.id,
+      type: "tool",
+      callID: "call_orphaned_task",
+      tool: "task",
+      state: taskState,
+    } satisfies SessionV1.ToolPart)
+    const unrelated = yield* svc.updatePart({
+      id: PartID.ascending(),
+      sessionID,
+      messageID: assistant.id,
+      type: "tool",
+      callID: "call_active_bash",
+      tool: "bash",
+      state: {
+        status: "running",
+        input: { command: "sleep 1" },
+        time: { start: Date.now() },
+      },
+    } satisfies SessionV1.ToolPart)
+    return { assistant, task, unrelated }
   })
 }
 
@@ -790,6 +848,121 @@ describe("session HttpApi", () => {
         ).toBe(true)
       }),
     { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
+  )
+
+  it.instance(
+    "settles orphaned task parts when aborting an idle session",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const session = yield* createSession({ title: "orphaned task" })
+        const svc = yield* Session.Service
+        const { assistant, task, unrelated } = yield* createAssistantWithTask(session.id, test.directory)
+
+        expect(
+          yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: session.id }), {
+            method: "POST",
+            headers,
+          }),
+        ).toBe(true)
+
+        const restored = (yield* svc.messages({ sessionID: session.id })).find(
+          (message) => message.info.id === assistant.id,
+        )
+        expect(restored?.info.role).toBe("assistant")
+        if (!restored || restored.info.role !== "assistant") return
+
+        expect(restored.info.time.completed).toBeDefined()
+        expect(restored.info.error?.name).toBe("MessageAbortedError")
+
+        const restoredTask = restored.parts.find((part) => part.id === task.id)
+        expect(restoredTask?.type).toBe("tool")
+        if (restoredTask?.type === "tool") {
+          expect(restoredTask.state.status).toBe("error")
+          if (restoredTask.state.status === "error") {
+            expect(restoredTask.state.error).toBe("Tool execution aborted")
+            expect(restoredTask.state.metadata?.interrupted).toBe(true)
+            expect(restoredTask.state.time.end).toBeDefined()
+          }
+        }
+
+        const restoredUnrelated = restored.parts.find((part) => part.id === unrelated.id)
+        expect(restoredUnrelated?.type).toBe("tool")
+        if (restoredUnrelated?.type === "tool") expect(restoredUnrelated.state.status).toBe("running")
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "leaves task cleanup to an active session runner",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const session = yield* createSession({ title: "active task" })
+        const svc = yield* Session.Service
+        const { assistant, task } = yield* createAssistantWithTask(session.id, test.directory)
+        const result = { info: assistant, parts: [] } satisfies SessionV1.WithParts
+        const started = yield* Deferred.make<void>()
+        const runState = yield* SessionRunState.Service
+        const fiber = yield* runState
+          .ensureRunning(
+            session.id,
+            Effect.succeed(result),
+            Effect.gen(function* () {
+              yield* Deferred.succeed(started, undefined)
+              return yield* Effect.never
+            }),
+          )
+          .pipe(Effect.forkChild)
+
+        yield* Deferred.await(started)
+        expect(
+          yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: session.id }), {
+            method: "POST",
+            headers,
+          }),
+        ).toBe(true)
+        expect(Exit.isSuccess(yield* Fiber.await(fiber))).toBe(true)
+
+        const restored = (yield* svc.messages({ sessionID: session.id })).find(
+          (message) => message.info.id === assistant.id,
+        )
+        const restoredTask = restored?.parts.find((part) => part.id === task.id)
+        expect(restored?.info.time.completed).toBeUndefined()
+        expect(restoredTask?.type).toBe("tool")
+        if (restoredTask?.type === "tool") expect(restoredTask.state.status).toBe("running")
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "settles pending orphaned task parts when aborting an idle session",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* createSession({ title: "pending orphaned task" })
+        const svc = yield* Session.Service
+        const { assistant, task } = yield* createAssistantWithTask(session.id, test.directory, "pending")
+
+        yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: session.id }), {
+          method: "POST",
+          headers: { "x-opencode-directory": test.directory },
+        })
+
+        const restored = (yield* svc.messages({ sessionID: session.id })).find(
+          (message) => message.info.id === assistant.id,
+        )
+        const restoredTask = restored?.parts.find((part) => part.id === task.id)
+        expect(restored?.info.time.completed).toBeDefined()
+        expect(restoredTask?.type).toBe("tool")
+        if (restoredTask?.type === "tool") {
+          expect(restoredTask.state.status).toBe("error")
+          if (restoredTask.state.status === "error") expect(restoredTask.state.metadata?.interrupted).toBe(true)
+        }
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
   )
 
   it.instance(

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -45,7 +45,15 @@ const noopBootstrapLayer = Layer.succeed(
   InstanceBootstrapService.Service.of({ run: Effect.void }),
 )
 const appLayer = AppNodeBuilder.build(
-  LayerNode.group([InstanceStore.node, Project.node, Session.node, Workspace.node, Database.node, Ripgrep.node]),
+  LayerNode.group([
+    InstanceStore.node,
+    Project.node,
+    Session.node,
+    SessionRunState.node,
+    Workspace.node,
+    Database.node,
+    Ripgrep.node,
+  ]),
   [[InstanceStore.bootstrapNode, noopBootstrapLayer]],
 )
 const servedRoutes: Layer.Layer<never, Config.ConfigError, HttpServer.HttpServer> = HttpRouter.serve(
@@ -929,8 +937,11 @@ describe("session HttpApi", () => {
         const restored = (yield* svc.messages({ sessionID: session.id })).find(
           (message) => message.info.id === assistant.id,
         )
+        expect(restored?.info.role).toBe("assistant")
+        if (!restored || restored.info.role !== "assistant") return
+
         const restoredTask = restored?.parts.find((part) => part.id === task.id)
-        expect(restored?.info.time.completed).toBeDefined()
+        expect(restored.info.time.completed).toBeDefined()
         expect(restoredTask?.type).toBe("tool")
         if (restoredTask?.type === "tool") expect(restoredTask.state.status).toBe("error")
         const restoredUnrelated = restored?.parts.find((part) => part.id === unrelated.id)
@@ -957,8 +968,11 @@ describe("session HttpApi", () => {
         const restored = (yield* svc.messages({ sessionID: session.id })).find(
           (message) => message.info.id === assistant.id,
         )
-        const restoredTask = restored?.parts.find((part) => part.id === task.id)
-        expect(restored?.info.time.completed).toBeDefined()
+        expect(restored?.info.role).toBe("assistant")
+        if (!restored || restored.info.role !== "assistant") return
+
+        const restoredTask = restored.parts.find((part) => part.id === task.id)
+        expect(restored.info.time.completed).toBeDefined()
         expect(restoredTask?.type).toBe("tool")
         if (restoredTask?.type === "tool") {
           expect(restoredTask.state.status).toBe("error")

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -895,14 +895,14 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
-    "leaves task cleanup to an active session runner",
+    "settles orphaned task parts after aborting an active unrelated run",
     () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
         const headers = { "x-opencode-directory": test.directory }
         const session = yield* createSession({ title: "active task" })
         const svc = yield* Session.Service
-        const { assistant, task } = yield* createAssistantWithTask(session.id, test.directory)
+        const { assistant, task, unrelated } = yield* createAssistantWithTask(session.id, test.directory)
         const result = { info: assistant, parts: [] } satisfies SessionV1.WithParts
         const started = yield* Deferred.make<void>()
         const runState = yield* SessionRunState.Service
@@ -930,9 +930,12 @@ describe("session HttpApi", () => {
           (message) => message.info.id === assistant.id,
         )
         const restoredTask = restored?.parts.find((part) => part.id === task.id)
-        expect(restored?.info.time.completed).toBeUndefined()
+        expect(restored?.info.time.completed).toBeDefined()
         expect(restoredTask?.type).toBe("tool")
-        if (restoredTask?.type === "tool") expect(restoredTask.state.status).toBe("running")
+        if (restoredTask?.type === "tool") expect(restoredTask.state.status).toBe("error")
+        const restoredUnrelated = restored?.parts.find((part) => part.id === unrelated.id)
+        expect(restoredUnrelated?.type).toBe("tool")
+        if (restoredUnrelated?.type === "tool") expect(restoredUnrelated.state.status).toBe("running")
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -954,6 +954,46 @@ describe("tool.task", () => {
     }),
   )
 
+  background.instance("cancelling a child task run does not deadlock", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const runState = yield* SessionRunState.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const started = yield* Deferred.make<void>()
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          background: true,
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {
+            promptOps: {
+              cancel: (sessionID) => runState.cancel(sessionID).pipe(Effect.asVoid),
+              resolvePromptParts: (template) => Effect.succeed([{ type: "text", text: template }]),
+              prompt: () => Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+            } satisfies TaskPromptOps,
+          },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      yield* Deferred.await(started)
+      yield* runState.cancel(result.metadata.sessionId).pipe(Effect.timeout("1 second"))
+      expect((yield* jobs.get(result.metadata.sessionId))?.status).toBe("cancelled")
+    }),
+  )
+
   it.instance("cancelling a parent run recursively cancels descendant background tasks", () =>
     Effect.gen(function* () {
       const jobs = yield* BackgroundJob.Service

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -285,12 +285,14 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                 <ToastProvider>
                                   <RouteProvider
                                     initialRoute={
-                                      input.args.continue
-                                        ? {
-                                            type: "session",
-                                            sessionID: "dummy",
-                                          }
-                                        : undefined
+                                      input.args.fork && (input.args.continue || input.args.sessionID)
+                                        ? { type: "loading" }
+                                        : input.args.continue
+                                          ? {
+                                              type: "session",
+                                              sessionID: "dummy",
+                                            }
+                                          : undefined
                                     }
                                   >
                                     <TuiConfigProvider config={input.config}>
@@ -476,6 +478,14 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   })
 
   const args = useArgs()
+  const forkFailed = (message: string) => {
+    route.navigate({
+      type: "home",
+      prompt: args.prompt ? { input: args.prompt, parts: [] } : undefined,
+      skipInitialPrompt: true,
+    })
+    toast.show({ message, variant: "error" })
+  }
   onMount(() => {
     batch(() => {
       if (args.agent) local.agent.set(args.agent)
@@ -501,24 +511,32 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   let continued = false
   createEffect(() => {
     // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
-    if (continued || sync.status === "loading" || !args.continue) return
+    if (continued || sync.status === "loading" || !args.continue || args.sessionID) return
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined)?.id
-    if (match) {
+    if (!match) {
+      if (sync.status !== "complete") return
+      if (!args.fork) return
       continued = true
-      if (args.fork) {
-        void sdk.client.session.fork({ sessionID: match }).then((result) => {
+      forkFailed("No session to fork")
+      return
+    }
+    continued = true
+    if (args.fork) {
+      void sdk.client.session
+        .fork({ sessionID: match })
+        .then((result) => {
           if (result.data?.id) {
             route.navigate({ type: "session", sessionID: result.data.id })
-          } else {
-            toast.show({ message: "Failed to fork session", variant: "error" })
+            return
           }
+          forkFailed("Failed to fork session")
         })
-      } else {
-        route.navigate({ type: "session", sessionID: match })
-      }
+        .catch(() => forkFailed("Failed to fork session"))
+      return
     }
+    route.navigate({ type: "session", sessionID: match })
   })
 
   // Handle --session with --fork: wait for sync to be fully complete before forking
@@ -528,13 +546,16 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   createEffect(() => {
     if (forked || sync.status !== "complete" || !args.sessionID || !args.fork) return
     forked = true
-    void sdk.client.session.fork({ sessionID: args.sessionID }).then((result) => {
-      if (result.data?.id) {
-        route.navigate({ type: "session", sessionID: result.data.id })
-      } else {
-        toast.show({ message: "Failed to fork session", variant: "error" })
-      }
-    })
+    void sdk.client.session
+      .fork({ sessionID: args.sessionID })
+      .then((result) => {
+        if (result.data?.id) {
+          route.navigate({ type: "session", sessionID: result.data.id })
+          return
+        }
+        forkFailed("Failed to fork session")
+      })
+      .catch(() => forkFailed("Failed to fork session"))
   })
 
   createEffect(
@@ -1110,6 +1131,11 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       <Show when={ready()}>
         <box flexGrow={1} minHeight={0} flexDirection="column">
           <Switch>
+            <Match when={route.data.type === "loading"}>
+              <box flexGrow={1} alignItems="center" justifyContent="center">
+                <text fg={theme.textMuted}>Forking session...</text>
+              </box>
+            </Match>
             <Match when={route.data.type === "home"}>
               <Home />
             </Match>

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -516,7 +516,6 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined)?.id
     if (!match) {
-      if (sync.status !== "complete") return
       if (!args.fork) return
       continued = true
       forkFailed("No session to fork")

--- a/packages/tui/src/context/route.tsx
+++ b/packages/tui/src/context/route.tsx
@@ -6,6 +6,11 @@ import { useTuiStartup } from "./runtime"
 export type HomeRoute = {
   type: "home"
   prompt?: PromptInfo
+  skipInitialPrompt?: boolean
+}
+
+export type LoadingRoute = {
+  type: "loading"
 }
 
 export type SessionRoute = {
@@ -20,7 +25,7 @@ export type PluginRoute = {
   data?: Record<string, unknown>
 }
 
-export type Route = HomeRoute | SessionRoute | PluginRoute
+export type Route = HomeRoute | LoadingRoute | SessionRoute | PluginRoute
 
 export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
   name: "Route",

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -55,7 +55,7 @@ function routeNavigate(route: ReturnType<typeof useRoute>, name: string, params?
 }
 
 function routeCurrent(route: ReturnType<typeof useRoute>): TuiPluginApi["route"]["current"] {
-  if (route.data.type === "home") return { name: "home" }
+  if (route.data.type === "home" || route.data.type === "loading") return { name: "home" }
   if (route.data.type === "session") {
     return {
       name: "session",

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -50,6 +50,7 @@ export function Home() {
       once = true
       return
     }
+    if (route.skipInitialPrompt) return
     if (!args.prompt) return
     r.set({ input: args.prompt, parts: [] })
     once = true
@@ -61,6 +62,7 @@ export function Home() {
     if (sent) return
     if (!r) return
     if (!sync.ready || !local.model.ready) return
+    if (route.skipInitialPrompt) return
     if (!args.prompt) return
     if (r.current.input !== args.prompt) return
     sent = true

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -126,3 +126,54 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
     mock.restore()
   }
 })
+
+test("continue fork returns home when the blocking session list is empty", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  let commandStarted!: () => void
+  const command = new Promise<void>((resolve) => {
+    commandStarted = resolve
+  })
+  const calls = createFetch((url) => {
+    if (url.pathname === "/command") {
+      commandStarted()
+      return new Promise<Response>(() => {})
+    }
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: { continue: true, fork: true },
+        pluginHost: {
+          async start() {
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node))),
+    )
+
+    await Promise.all([ready, command])
+    const frame = await setup.waitForFrame((frame) => frame.includes("No session to fork"))
+    expect(frame).toContain("No session to fork")
+
+    setup.renderer.destroy()
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #42286

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a persisted `task` call outlives its in-memory session runner, abort now marks the stale task part and its parent assistant message as aborted instead of leaving both unfinished. It also avoids the `dummy` session route during `--continue --fork` startup and returns to home when no session is available.

### How did you verify your code works?

- Ran native `tsgo --noEmit` in `packages/opencode` and `packages/tui`.
- Ran focused runner, task, orphan-recovery HTTP, and TUI lifecycle tests.

### Screenshots / recordings

Not applicable: terminal startup behavior is covered by a lifecycle test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR