### PR TITLE
fix(session-ui): preserve caret after prompt editor rebuild

### DIFF
--- a/packages/app/e2e/regression/prompt-caret-after-mention.spec.ts
+++ b/packages/app/e2e/regression/prompt-caret-after-mention.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test"
+import type { Page } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+// Family of #37037 / #36210: the caret position in the prompt input must survive
+// external prompt edits. In the v2 composer, inserting a @mention mid-text used to
+// rebuild the editor DOM and collapse the caret to the END of the prompt, discarding
+// the stored cursor position.
+
+async function editorCursorOffset(page: Page) {
+  return page.evaluate(() => {
+    const editor = document.querySelector('[data-component="prompt-input"]')
+    if (!(editor instanceof HTMLElement)) throw new Error("editor not found")
+    const selection = window.getSelection()
+    if (!selection?.rangeCount) throw new Error("no selection")
+    const range = selection.getRangeAt(0).cloneRange()
+    range.selectNodeContents(editor)
+    range.setEnd(selection.anchorNode!, selection.anchorOffset)
+    return range.toString().length
+  })
+}
+
+test("keeps the caret right after a mention inserted mid-prompt", async ({ page }) => {
+  test.setTimeout(240_000)
+  await mockOpenCodeServer(page, {
+    sessions: fixture.sessions,
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages,
+    findFiles: () => ["src/index.ts"],
+  })
+  await page.goto(`/${base64Encode(fixture.directory)}/session/${fixture.targetID}`)
+
+  const editor = page.getByRole("textbox", { name: "Prompt" })
+  await expectAppVisible(editor)
+  await editor.click()
+  await page.keyboard.type("please fix the bug")
+  await page.evaluate(() => {
+    const el = document.querySelector('[data-component="prompt-input"]')
+    el?.focus()
+    const sel = window.getSelection()
+    const range = document.createRange()
+    range.setStart(el?.firstChild!, 7)
+    range.collapse(true)
+    sel?.removeAllRanges()
+    sel?.addRange(range)
+  })
+  await page.keyboard.type("@src")
+
+  const suggestion = page.locator('[data-suggestion-id="file:src/index.ts"]')
+  await expect(suggestion).toBeVisible()
+  await suggestion.click()
+  await page.waitForTimeout(100)
+
+  const text = await page.evaluate(
+    () => document.querySelector('[data-component="prompt-input"]')?.textContent ?? "",
+  )
+  // "please " (7) + "@src/index.ts" (13) + " fix the bug" (12) = 33 chars
+  expect(text).toBe("please @src/index.ts fix the bug")
+  // The caret must sit right after the mention (7 + 13 + 1 trailing space = 21),
+  // not at the end of the whole prompt (33).
+  expect(await editorCursorOffset(page)).toBe(21)
+})

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -70,7 +70,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
       localInput = false
       return
     }
-    renderPromptInputV2Editor(editor, parts)
+    renderPromptInputV2Editor(editor, parts, props.controller.cursor())
   })
 
   return (
@@ -269,8 +269,9 @@ export function PromptInputV2(props: PromptInputV2Props) {
   )
 }
 
-function renderPromptInputV2Editor(editor: HTMLDivElement, prompt: PromptInputV2Prompt) {
+function renderPromptInputV2Editor(editor: HTMLDivElement, prompt: PromptInputV2Prompt, cursor?: number) {
   const active = document.activeElement === editor
+  const previous = cursor ?? promptInputV2Cursor(editor)
   editor.replaceChildren(
     ...prompt.flatMap<Node>((part) => {
       if (part.type === "image") return []
@@ -290,10 +291,50 @@ function renderPromptInputV2Editor(editor: HTMLDivElement, prompt: PromptInputV2
     }),
   )
   if (!active) return
-  const selection = window.getSelection()
+  setPromptInputV2Cursor(editor, previous)
+}
+
+// Restores the caret at a prompt character offset after the editor DOM is rebuilt.
+// Mentions are uneditable spans that still occupy their text length, so the caret
+// is placed before or after a mention, never inside it.
+function setPromptInputV2Cursor(editor: HTMLDivElement, position: number) {
+  let remaining = position
+  let node = editor.firstChild
+  while (node) {
+    const isText = node.nodeType === Node.TEXT_NODE
+    const isMention =
+      node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.mention !== undefined
+    const length = isText
+      ? (node.textContent ?? "").replace(/\u200B/g, "").length
+      : isMention
+        ? (node.textContent ?? "").length
+        : 0
+    if (isText && remaining <= length) {
+      const range = document.createRange()
+      range.setStart(node, Math.max(0, remaining))
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      return
+    }
+    if (isMention && remaining <= length) {
+      const range = document.createRange()
+      if (remaining === 0) range.setStartBefore(node)
+      else range.setStartAfter(node)
+      range.collapse(true)
+      const selection = window.getSelection()
+      selection?.removeAllRanges()
+      selection?.addRange(range)
+      return
+    }
+    remaining -= length
+    node = node.nextSibling
+  }
   const range = document.createRange()
   range.selectNodeContents(editor)
   range.collapse(false)
+  const selection = window.getSelection()
   selection?.removeAllRanges()
   selection?.addRange(range)
 }

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -301,6 +301,9 @@ export function createPromptInputV2Controller(input: {
     parts() {
       return draft.state.prompt
     },
+    cursor() {
+      return draft.state.cursor
+    },
     addPart,
     contextItem(id: string) {
       return draft.state.context.items.find((item) => item.key === id)


### PR DESCRIPTION
### Issue for this PR

Fixes #42335

Related to #37037 / #36210 (caret jumps around in the prompt input while the
session updates). This PR fixes the variant I could reproduce and verify on the
current v2 composer: inserting a @mention mid-text on the **session page**
collapses the caret to the END of the prompt instead of keeping it right after
the mention. I could not reproduce the streaming-output case from #37037 on
current `dev`, so I only claim the mention-insertion scenario here.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`renderPromptInputV2Editor` rebuilds the editor DOM (`replaceChildren`) whenever
the prompt store changes outside a local input (mention insertion, history
navigation, followup edit). After the rebuild it always collapsed the caret to
the end of the editor, ignoring the cursor position stored in the prompt store.
Reproduced on the session page: after inserting `@src/index.ts` mid-text, the
caret lands at offset 32 (end of a 32-char prompt) instead of 21 (right after
the mention).

Changes in `packages/session-ui/src/v2/components/prompt-input`:

- `interaction.ts`: expose `cursor()` on the controller so the editor can read
  the authoritative stored caret position.
- `index.tsx`: restore the caret from the stored cursor after a rebuild, falling
  back to the pre-rebuild DOM caret when no cursor is stored. Mentions are
  uneditable spans that still occupy their text length, so
  `setPromptInputV2Cursor` places the caret before/after a mention, never inside
  it.

### How did you verify your code works?

- New e2e regression test `packages/app/e2e/regression/prompt-caret-after-mention.spec.ts`:
  types "please fix the bug", moves the caret to offset 7, inserts
  `@src/index.ts` mid-text on a session page, and asserts the caret lands at
  offset 21. It failed before the fix (caret at 32) and passes after.
  Run with: `bunx playwright test e2e/regression/prompt-caret-after-mention.spec.ts`
- `bun run typecheck` in `packages/session-ui` passes.
- `bun test src` in `packages/session-ui`: 83 tests pass.
- Existing prompt e2e (`prompt-input-v2-command-draft`) still passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
