### PR TITLE
fix(opencode): clarify possible tool argument truncation

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -301,11 +301,14 @@ const live: Layer.Layer<
                 toolName: lower,
               }
             }
+            const error = failed.error.message.includes("Unterminated string in JSON")
+              ? `Tool call arguments were truncated before the model finished generating them. This typically happens when the output token limit (${prepared.params.maxOutputTokens}) is reached mid-generation. Increase OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX or reduce the argument size. Original error: ${failed.error.message}`
+              : failed.error.message
             return {
               ...failed.toolCall,
               input: JSON.stringify({
                 tool: failed.toolCall.toolName,
-                error: failed.error.message,
+                error,
               }),
               toolName: "invalid",
             }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -301,9 +301,11 @@ const live: Layer.Layer<
                 toolName: lower,
               }
             }
-            const error = failed.error.message.includes("Unterminated string in JSON")
-              ? `Tool call arguments were truncated before the model finished generating them. This typically happens when the output token limit (${prepared.params.maxOutputTokens}) is reached mid-generation. Increase OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX or reduce the argument size. Original error: ${failed.error.message}`
-              : failed.error.message
+            const error =
+              failed.error.message.includes("JSON parsing failed") &&
+              failed.error.message.includes("Unterminated string")
+                ? `Tool call arguments may have been truncated before the model finished generating them. This can happen when the output token limit (${prepared.params.maxOutputTokens}) is reached mid-generation. Increase OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX or reduce the argument size. Original error: ${failed.error.message}`
+                : failed.error.message
             return {
               ...failed.toolCall,
               input: JSON.stringify({
@@ -317,7 +319,6 @@ const live: Layer.Layer<
           topP: prepared.params.topP,
           topK: prepared.params.topK,
           providerOptions: ProviderTransform.providerOptions(input.model, prepared.params.options),
-          activeTools: Object.keys(prepared.tools).filter((x) => x !== "invalid"),
           tools: prepared.tools,
           toolChoice: input.toolChoice,
           maxOutputTokens: prepared.params.maxOutputTokens,
@@ -332,6 +333,12 @@ const live: Layer.Layer<
                 specificationVersion: "v3" as const,
                 async transformParams(args) {
                   if (args.type === "stream") {
+                    // Keep the invalid tool available to AI SDK's repair pass without exposing it to the model.
+                    args.params.tools = args.params.tools?.filter((tool) => tool.name !== "invalid")
+                    if (args.params.tools?.length === 0) {
+                      args.params.tools = undefined
+                      args.params.toolChoice = undefined
+                    }
                     // @ts-expect-error
                     args.params.prompt = ProviderTransform.message(
                       args.params.prompt,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -443,6 +443,14 @@ const layer = Layer.effect(
             ctx.assistantMessage.finish = value.reason
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
+            if (value.reason === "length") {
+              yield* Effect.logWarning("output token limit reached", {
+                "session.id": ctx.sessionID,
+                messageID: ctx.assistantMessage.id,
+                "model.id": ctx.model.id,
+                "provider.id": ctx.model.providerID,
+              })
+            }
             yield* session.updatePart({
               id: PartID.ascending(),
               reason: value.reason,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -57,6 +57,14 @@ const it = testEffect(AppNodeBuilder.build(LayerNode.group([LLM.node, Provider.n
 // LLM.stream returns a Stream, not an Effect, so we can't use the serviceUse proxy.
 const drain = (input: LLM.StreamInput) => LLM.Service.use((svc) => svc.stream(input).pipe(Stream.runDrain))
 
+const collect = (input: LLM.StreamInput) =>
+  LLM.Service.use((svc) =>
+    svc.stream(input).pipe(
+      Stream.runCollect,
+      Effect.map((events) => Array.from(events)),
+    ),
+  )
+
 // drainWith builds an isolated runtime so custom replacements fully own LLM and
 // its transitive deps.
 const drainWith = (layer: Layer.Layer<LLM.Service>, input: LLM.StreamInput) =>
@@ -1067,6 +1075,122 @@ describe("session.llm.stream", () => {
           expect(Cause.hasInterrupts(inner.cause)).toBe(true)
         }
         yield* Effect.promise(() => Promise.race([pending.requestAborted, timeout(500)]).catch(() => undefined))
+      }),
+    {
+      config: () => ({
+        enabled_providers: [alibabaQwenFixture.providerID],
+        provider: {
+          [alibabaQwenFixture.providerID]: {
+            options: { apiKey: "test-key", baseURL: `${state.server!.url.origin}/v1` },
+          },
+        },
+      }),
+    },
+  )
+
+  it.instance(
+    "qualifies truncated tool argument diagnostics and preserves other parse errors",
+    () =>
+      Effect.gen(function* () {
+        const fixture = loadFixture(alibabaQwenFixture.providerID, alibabaQwenFixture.modelID)
+        const resolved = yield* Provider.use.getModel(
+          ProviderV2.ID.make(alibabaQwenFixture.providerID),
+          ModelV2.ID.make(fixture.model.id),
+        )
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        } satisfies Agent.Info
+
+        const invalidCall = (id: string, input: string) =>
+          Effect.gen(function* () {
+            const sessionID = SessionID.make(`session-test-tool-parse-${id}`)
+            const request = waitRequest(
+              "/chat/completions",
+              createEventResponse(
+                [
+                  {
+                    id: `chatcmpl-${id}`,
+                    object: "chat.completion.chunk",
+                    choices: [{ delta: { role: "assistant" } }],
+                  },
+                  {
+                    id: `chatcmpl-${id}`,
+                    object: "chat.completion.chunk",
+                    choices: [
+                      {
+                        delta: {
+                          tool_calls: [
+                            {
+                              index: 0,
+                              id: `call-${id}`,
+                              type: "function",
+                              function: { name: "lookup", arguments: input },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    id: `chatcmpl-${id}`,
+                    object: "chat.completion.chunk",
+                    choices: [{ delta: {}, finish_reason: "stop" }],
+                  },
+                ],
+                true,
+              ),
+            )
+
+            const events = yield* collect({
+              user: {
+                id: MessageID.make(`msg_user-tool-parse-${id}`),
+                sessionID,
+                role: "user",
+                time: { created: Date.now() },
+                agent: agent.name,
+                model: { providerID: ProviderV2.ID.make(alibabaQwenFixture.providerID), modelID: resolved.id },
+              },
+              sessionID,
+              model: resolved,
+              agent,
+              system: [],
+              messages: [{ role: "user", content: "Use lookup" }],
+              tools: {
+                invalid: tool({
+                  description: "Do not use",
+                  inputSchema: z.object({ tool: z.string(), error: z.string() }),
+                  execute: async () => ({ output: "invalid input" }),
+                }),
+                lookup: tool({
+                  description: "Lookup data",
+                  inputSchema: z.object({ query: z.string() }),
+                }),
+              },
+            })
+            const capture = yield* Effect.promise(() => request)
+            expect(JSON.stringify(capture.body.tools)).not.toContain('"name":"invalid"')
+            const call = events.find((event) => event.type === "tool-call" && event.name === "invalid")
+            if (call?.type !== "tool-call") throw new Error("invalid tool call event not found")
+            if (!call.input || typeof call.input !== "object" || !("error" in call.input)) {
+              throw new Error("invalid tool call diagnostic not found")
+            }
+            if (typeof call.input.error !== "string") throw new Error("invalid tool call diagnostic is not a string")
+            return call.input.error
+          })
+
+        const truncated = yield* invalidCall("truncated", '{"query":"unfinished')
+        expect(truncated).toContain("may have been truncated")
+        expect(truncated).toContain("This can happen when the output token limit")
+        expect(truncated).toContain("Original error:")
+        expect(truncated).toContain("Unterminated string")
+
+        const malformed = yield* invalidCall("malformed", '{"query":}')
+        expect(malformed).not.toContain("may have been truncated")
+        expect(malformed).not.toContain("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX")
+        expect(malformed).toContain("JSON")
       }),
     {
       config: () => ({


### PR DESCRIPTION
### Issue for this PR

Closes #42224

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Large tool arguments can end in an unterminated JSON string when generation stops before the model emits the closing syntax. The resulting parser error does not explain the likely cause or how to adjust the configured output limit.

This PR makes that failure actionable without treating every unterminated string as proof of token-limit truncation. For an unterminated tool-call JSON parse, the invalid-tool result says the arguments may have been truncated, names the configured output token limit, points to `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`, and preserves the original parser error. Other malformed tool inputs keep their original diagnostics.

The internal `invalid` repair tool remains available to the AI SDK parser but is removed from the provider request, so the repaired diagnostic reaches the user without advertising an implementation-only tool to the model. A direct `finish_reason: "length"` also emits a structured warning with the session, message, model, and provider IDs.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/llm.test.ts` — verifies the qualified truncation diagnostic, the unchanged non-truncation parse error, and that the internal repair tool is absent from the provider request
- `cd packages/opencode && bun test test/session/processor-effect.test.ts` — verifies the processor path
- `cd packages/opencode && bun typecheck`
- Changed-file Prettier and `git diff --check`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
