### PR TITLE
fix(opencode): include agent identity in system prompt

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1256,7 +1256,7 @@ const layer = Layer.effect(
 
             const [skills, env, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
-              sys.environment(model),
+              sys.environment(model, agent),
               instruction.system().pipe(Effect.orDie),
               sys.mcp(agent, session.permission),
               MessageV2.toModelMessagesEffect(msgs, model),

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -42,7 +42,7 @@ export function provider(model: Provider.Model) {
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model) => Effect.Effect<string[]>
+  readonly environment: (model: Provider.Model, agent: Agent.Info) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
   readonly mcp: (agent: Agent.Info, permission?: PermissionV1.Ruleset) => Effect.Effect<string | undefined>
 }
@@ -57,7 +57,7 @@ const layer = Layer.effect(
     const locations = yield* LocationServiceMap.Service
 
     return Service.of({
-      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
+      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, agent: Agent.Info) {
         const ctx = yield* InstanceState.context
         const references = yield* Effect.gen(function* () {
           return (yield* (yield* Reference.Service).list()).filter((reference) => reference.description !== undefined)
@@ -72,6 +72,7 @@ const layer = Layer.effect(
             `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
             `  Today's date: ${new Date().toDateString()}`,
+            `  Agent: ${agent.name}`,
             `</env>`,
           ].join("\n"),
           references.length === 0

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -130,6 +130,23 @@ describe("session.system", () => {
     }),
   )
 
+  it.instance("environment includes the agent name", () =>
+    Effect.gen(function* () {
+      const prompt = yield* SystemPrompt.Service
+      const env = yield* prompt.environment({ api: { id: "test-model" }, providerID: "test" } as Provider.Model, build)
+      expect(env[0]).toContain("Agent: build")
+    }),
+  )
+
+  it.instance("environment reflects a custom agent name", () =>
+    Effect.gen(function* () {
+      const prompt = yield* SystemPrompt.Service
+      const custom: Agent.Info = { name: "reviewer", mode: "subagent", permission: Permission.fromConfig({ "*": "allow" }), options: {} }
+      const env = yield* prompt.environment({ api: { id: "test-model" }, providerID: "test" } as Provider.Model, custom)
+      expect(env[0]).toContain("Agent: reviewer")
+    }),
+  )
+
   it.effect("MCP output omits servers when all advertised tools are denied", () =>
     Effect.gen(function* () {
       const prompt = yield* SystemPrompt.Service


### PR DESCRIPTION
### Issue for this PR

Fixes #42125

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The model does not know which agent it is running as because the agent identity is not included in the system prompt. The `<env>` block already contains model ID, working directory, platform, and date — this adds `Agent: ${agent.name}`.

The `environment` function signature changes from `(model)` to `(model, agent)`, consistent with `sys.skills(agent)` and `sys.mcp(agent)` which already receive the agent.

### How did you verify your code works?

Two tests in `test/session/system.test.ts` verify the agent name appears in the environment output — one with the built-in `build` agent and one with a custom `reviewer` agent. `bun typecheck` passes clean. Only one caller of `sys.environment` exists in the codebase (`prompt.ts:1259`), updated.

### Checklist

- [x] I have read the contributing guide
- [x] I have verified my code works on the target platform
