### PR TITLE
fix(core): recover corrupt snapshot index

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -141,6 +141,8 @@ export interface Interface {
       repository: Repository
       scopes: readonly RelativePath[]
       ignores?: Repository
+      /** Recover an invalid private index only when the repository is contained by `root`. */
+      repairIndex?: { readonly root: AbsolutePath; readonly source: Repository }
       maximumUntrackedFileBytes?: number
     }) => Effect.Effect<TreeID, OperationError>
     readonly write: (repository: Repository) => Effect.Effect<TreeID, OperationError>
@@ -531,18 +533,89 @@ const layer = Layer.effect(
       return TreeID.make((yield* repositoryOperation("write_tree", repository, ["write-tree"])).text.trim())
     })
 
+    const repairIndex = Effect.fnUntraced(function* (repository: Repository, source: Repository) {
+      if (repository.gitDirectory === source.gitDirectory)
+        return yield* new OperationError({
+          operation: "refresh",
+          directory: repository.gitDirectory,
+          message: "Refusing to repair a source repository index",
+        })
+
+      const index = path.join(repository.gitDirectory, "index")
+      const current = yield* fs.readFile(index).pipe(
+        Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
+        Effect.mapError(
+          (cause) =>
+            new OperationError({
+              operation: "refresh",
+              directory: repository.gitDirectory,
+              message: "Failed to inspect snapshot index",
+              cause,
+            }),
+        ),
+      )
+      if (!current || hasIndexSignature(current)) return false
+
+      const seed = yield* fs.readFile(path.join(source.gitDirectory, "index")).pipe(
+        Effect.mapError(
+          (cause) =>
+            new OperationError({
+              operation: "refresh",
+              directory: repository.gitDirectory,
+              message: "Failed to read source index for snapshot recovery",
+              cause,
+            }),
+        ),
+      )
+      if (!hasIndexSignature(seed))
+        return yield* new OperationError({
+          operation: "refresh",
+          directory: repository.gitDirectory,
+          message: "Cannot recover snapshot from an invalid source index",
+        })
+
+      const recovery = path.join(repository.gitDirectory, `index.recovery-${randomUUID()}`)
+      yield* fs.writeFile(recovery, seed).pipe(
+        Effect.andThen(fs.rename(recovery, index)),
+        Effect.ensuring(fs.remove(recovery).pipe(Effect.catch(() => Effect.void))),
+        Effect.mapError(
+          (cause) =>
+            new OperationError({
+              operation: "refresh",
+              directory: repository.gitDirectory,
+              message: "Failed to replace corrupt snapshot index",
+              cause,
+            }),
+        ),
+      )
+      return true
+    })
+
     const captureTree = Effect.fn("Git.tree.capture")(
       (input: {
         repository: Repository
         scopes: readonly RelativePath[]
         ignores?: Repository
+        repairIndex?: { readonly root: AbsolutePath; readonly source: Repository }
         maximumUntrackedFileBytes?: number
       }) =>
         locked(
           input.repository,
           Effect.gen(function* () {
-            yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }), { discard: true })
-            return yield* writeTree(input.repository)
+            const capture = Effect.gen(function* () {
+              yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }), { discard: true })
+              return yield* writeTree(input.repository)
+            })
+            return yield* capture.pipe(
+              Effect.catch((cause) =>
+                Effect.gen(function* () {
+                  if (!input.repairIndex) return yield* cause
+                  if (!FSUtil.contains(input.repairIndex.root, input.repository.gitDirectory)) return yield* cause
+                  if (!(yield* repairIndex(input.repository, input.repairIndex.source))) return yield* cause
+                  return yield* capture
+                }),
+              ),
+            )
           }),
         ),
     )
@@ -984,4 +1057,9 @@ function resolvePath(cwd: string, value: string) {
   const normalized = FSUtil.windowsPath(trimmed)
   if (path.isAbsolute(normalized)) return path.normalize(normalized)
   return path.resolve(cwd, normalized)
+}
+
+// Git index files always start with the ASCII signature "DIRC".
+function hasIndexSignature(index: Uint8Array) {
+  return index[0] === 0x44 && index[1] === 0x49 && index[2] === 0x52 && index[3] === 0x43
 }

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -95,7 +95,8 @@ const layer = Layer.effect(
     const worktree = source
       ? AbsolutePath.make(yield* fs.realPath(source.worktree).pipe(Effect.orDie))
       : location.project.directory
-    const gitDirectory = AbsolutePath.make(path.join(global.data, "snapshot", location.project.id, Hash.fast(worktree)))
+    const snapshotDirectory = AbsolutePath.make(path.join(global.data, "snapshot"))
+    const gitDirectory = AbsolutePath.make(path.join(snapshotDirectory, location.project.id, Hash.fast(worktree)))
 
     const scope = Effect.fnUntraced(function* () {
       const relative = path.relative(worktree, location.directory)
@@ -135,6 +136,7 @@ const layer = Layer.effect(
             repository: repo,
             scopes: [yield* scope()],
             ignores: source,
+            repairIndex: source ? { root: snapshotDirectory, source } : undefined,
             maximumUntrackedFileBytes: 2 * 1024 * 1024,
           }),
         )
@@ -195,6 +197,7 @@ const layer = Layer.effect(
           repository: repo,
           scopes: Array.from(files.keys()),
           ignores: source,
+          repairIndex: source ? { root: snapshotDirectory, source } : undefined,
           maximumUntrackedFileBytes: 2 * 1024 * 1024,
         })
         .pipe(Effect.mapError((cause) => failure("preview", cause)))

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -83,6 +83,61 @@ describe("Snapshot", () => {
     ),
   )
 
+  testEffect(Layer.empty).live("recovers a corrupt snapshot index without losing captured trees", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await $`git init`.cwd(project).quiet()
+            await $`git config core.fsmonitor false`.cwd(project).quiet()
+            await $`git config commit.gpgsign false`.cwd(project).quiet()
+            await $`git config user.email test@opencode.test`.cwd(project).quiet()
+            await $`git config user.name Test`.cwd(project).quiet()
+            await $`git add .`.cwd(project).quiet()
+            await $`git commit -m initial`.cwd(project).quiet()
+          })
+
+          const projectID = yield* Effect.gen(function* () {
+            return (yield* Location.Service).project.id
+          }).pipe(
+            Effect.provide(
+              AppNodeBuilder.build(Location.boundNode(Location.Ref.make({ directory: AbsolutePath.make(project) }))),
+            ),
+          )
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            const before = yield* snapshot.capture()
+            expect(before).toBeDefined()
+            if (!before) return
+
+            const gitDirectory = path.join(tmp.path, "snapshot", projectID, Hash.fast(project))
+            const sourceIndex = path.join(project, ".git", "index")
+            const sourceBefore = yield* Effect.promise(() => fs.readFile(sourceIndex))
+            yield* Effect.promise(async () => {
+              await fs.writeFile(path.join(project, "tracked.txt"), "changed\n")
+              await fs.writeFile(path.join(gitDirectory, "index"), new Uint8Array(4))
+            })
+
+            const [first, second] = yield* Effect.all([snapshot.capture(), snapshot.capture()], { concurrency: 2 })
+            expect(first).toBeDefined()
+            expect(second).toBe(first)
+            if (!first) return
+            expect(yield* snapshot.files({ from: before, to: first })).toEqual([RelativePath.make("tracked.txt")])
+            expect(yield* Effect.promise(() => fs.readFile(sourceIndex))).toEqual(sourceBefore)
+
+            yield* snapshot.restore({ files: new Map([[RelativePath.make("tracked.txt"), before]]) })
+            expect(yield* read(path.join(project, "tracked.txt"))).toBe("one\n")
+          }).pipe(Effect.provide(snapshotLayer(tmp.path, project)))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   testEffect(Layer.empty).live("isolates snapshot indexes by canonical Git worktree", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #42237

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Snapshot capture now recovers an invalid private Git index after a failed capture. Recovery is restricted to OpenCode snapshot storage, replaces only the index from the source repository, and retries once under the existing repository lock. Historical objects and tree IDs remain available.

### How did you verify your code works?

- bun test test/git.test.ts test/snapshot.test.ts — 9 passed
- Corrupt-index regression with --rerun-each 10 — 10 passed
- bun typecheck
- Prettier and Oxlint — 0 errors

The full Core suite passed 1076 tests with 7 unrelated Windows/npm environment failures.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR