### PR TITLE
fix(opencode): accumulate step tokens instead of overwriting

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -442,7 +442,21 @@ const layer = Layer.effect(
             })
             ctx.assistantMessage.finish = value.reason
             ctx.assistantMessage.cost += usage.cost
-            ctx.assistantMessage.tokens = usage.tokens
+            // Multi-step messages report usage per step. Output tokens are
+            // produced per step and accumulate, while input and cache reads
+            // measure the request sent in the final step (which already
+            // includes all prior steps), so the last step's values are kept.
+            const previous = ctx.assistantMessage.tokens
+            ctx.assistantMessage.tokens = {
+              total: usage.tokens.total,
+              input: usage.tokens.input,
+              output: (previous?.output ?? 0) + usage.tokens.output,
+              reasoning: (previous?.reasoning ?? 0) + usage.tokens.reasoning,
+              cache: {
+                read: usage.tokens.cache.read,
+                write: (previous?.cache.write ?? 0) + usage.tokens.cache.write,
+              },
+            }
             yield* session.updatePart({
               id: PartID.ascending(),
               reason: value.reason,

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -226,6 +226,50 @@ const fragmentFailureLLM = Layer.succeed(
 const fragmentFailureEnv = LayerNode.compile(root, [...replacements, [LLM.node, fragmentFailureLLM]])
 const itFragmentFailure = testEffect(fragmentFailureEnv)
 
+const multiStepLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "text-1" }),
+        LLMEvent.textDelta({ id: "text-1", text: "first" }),
+        LLMEvent.textEnd({ id: "text-1" }),
+        LLMEvent.stepFinish({
+          index: 0,
+          reason: "tool-calls",
+          usage: {
+            inputTokens: 100,
+            outputTokens: 50,
+            reasoningTokens: 10,
+            cacheReadInputTokens: 2,
+            cacheWriteInputTokens: 5,
+            totalTokens: 167,
+          },
+        }),
+        LLMEvent.stepStart({ index: 1 }),
+        LLMEvent.textStart({ id: "text-2" }),
+        LLMEvent.textDelta({ id: "text-2", text: "second" }),
+        LLMEvent.textEnd({ id: "text-2" }),
+        LLMEvent.stepFinish({
+          index: 1,
+          reason: "stop",
+          usage: {
+            inputTokens: 200,
+            outputTokens: 60,
+            reasoningTokens: 20,
+            cacheReadInputTokens: 3,
+            cacheWriteInputTokens: 7,
+            totalTokens: 290,
+          },
+        }),
+        LLMEvent.finish({ reason: "stop" }),
+      ),
+  }),
+)
+const multiStepEnv = LayerNode.compile(root, [...replacements, [LLM.node, multiStepLLM]])
+const itMultiStep = testEffect(multiStepEnv)
+
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
   const session = yield* Session.Service
@@ -1108,6 +1152,48 @@ itFragmentFailure.live("session.processor effect tests retain partial legacy par
         expect(seen).toContain(MessageV2.Event.PartUpdated.type)
         expect(seen).toContain(Session.Event.Error.type)
         expect(seen.filter((type) => type.startsWith("session.next."))).toEqual([])
+      }),
+    { config: cfg },
+  ),
+)
+
+itMultiStep.live("session.processor effect tests accumulate tokens across steps", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "multi step")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "multi step" }],
+          tools: {},
+        })
+
+        expect(value).toBe("continue")
+        expect(msg.tokens).toEqual({
+          total: 290,
+          input: 190,
+          output: 80,
+          reasoning: 30,
+          cache: { read: 3, write: 12 },
+        })
       }),
     { config: cfg },
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #42324

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In multi-step tool-call messages, `processor.ts` overwrites `assistantMessage.tokens` on every `step-finish` event, so only the last step's output, reasoning, and cache.write survive — while `cost` already accumulates with `+=`.

This change accumulates the additive fields (output, reasoning, cache.write) across steps. `input` and `cache.read` keep the final step's values, because the final step's request already includes all prior steps and accumulating those would double-count. `total` keeps the final step's value as before.

This fixes under-reported context metrics and delayed auto-compaction for multi-step messages.

### How did you verify your code works?

- Added a two-step test in `packages/opencode/test/session/processor-effect.test.ts` with distinct per-step usage, asserting the accumulated message tokens.
- `bun typecheck` passes.
- `bun test --timeout 30000 test/session/processor-effect.test.ts` passes (one pre-existing failure unrelated to this change, reproducible on clean dev).
- `bun test --timeout 30000 test/session/compaction.test.ts` passes.

### Screenshots / recordings

_This is not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
