### PR TITLE
fix(app): register direct session projects

### DIFF
--- a/packages/app/e2e/regression/direct-new-session.spec.ts
+++ b/packages/app/e2e/regression/direct-new-session.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/OpenCode/DirectNewSession"
+
+test("registers a directly opened new-session directory", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: "proj_direct_new_session",
+      worktree: directory,
+      vcs: "git",
+      name: "direct-new-session",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: [],
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+    localStorage.setItem("opencode.global.dat:server", JSON.stringify({ projects: {}, lastProject: {} }))
+  })
+
+  await page.goto(`/${base64Encode(directory)}/session`)
+
+  await expect(page).toHaveURL(/\/new-session\?draftId=/)
+  await expect(page.locator('[data-component="prompt-input"]')).toBeVisible()
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const value = localStorage.getItem("opencode.global.dat:server")
+        if (!value) return
+        return JSON.parse(value) as {
+          projects?: Record<string, { worktree: string }[]>
+          lastProject?: Record<string, string>
+        }
+      }),
+    )
+    .toMatchObject({
+      projects: { local: [{ worktree: directory }] },
+      lastProject: { local: directory },
+    })
+})

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -97,7 +97,10 @@ const SessionRoute = () => {
     if (!settings.general.newLayoutDesigns()) return
     if (params.id || search.draftId) return
     if (!tabs.ready() || !sdk().directory) return
-    tabs.newDraft({ server: server.key, directory: sdk().directory }, search.prompt)
+    const directory = sdk().directory
+    server.projects.open(directory)
+    server.projects.touch(directory)
+    void tabs.newDraft({ server: server.key, directory }, search.prompt)
   })
 
   return (


### PR DESCRIPTION
### Issue for this PR

Closes #42265

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Direct visits to `/:dir/session` in the new layout created a draft without adding the directory to the current server's project state. Register and touch the directory before creating the draft, matching the existing new-session entry points.

The regression test starts with empty project state, opens the encoded directory route, and verifies both the draft redirect and the persisted project/last-project state.

### How did you verify your code works?

- `bun run typecheck`
- `bun run typecheck:e2e`
- `bun run test:unit` (722 passed)
- `bun run test:browser` (41 passed)
- `bun run test:e2e -- e2e/regression/direct-new-session.spec.ts` (1 passed)
- `bun run build`
- Repository pre-push monorepo typecheck (30 tasks passed)

### Screenshots / recordings

Not applicable; this changes route state registration without changing the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
