### PR TITLE
fix(app): size update pill to label

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -618,16 +618,19 @@ function TitlebarV2Right(props: { state: TitlebarV2RightState }) {
 
 function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
   return (
-    <div class="group relative mr-3 h-5 w-5 shrink-0 rounded-full bg-v2-background-bg-deep transition-[width] duration-150 ease-out hover:z-30 hover:w-[68px] focus-within:z-30 focus-within:w-[68px] motion-reduce:transition-none">
+    <div
+      data-slot="titlebar-update-pill"
+      class="group relative mr-3 flex h-5 w-max max-w-5 shrink-0 justify-end overflow-hidden rounded-full bg-v2-background-bg-deep transition-[max-width] duration-150 ease-out hover:z-30 hover:max-w-48 focus-within:z-30 focus-within:max-w-48 motion-reduce:transition-none"
+    >
       <button
         type="button"
-        class="absolute right-0 top-0 z-10 flex h-5 w-5 items-center justify-end overflow-hidden rounded-full bg-v2-icon-icon-accent/20 text-v2-icon-icon-accent transition-[width,background-color] duration-150 ease-out group-hover:w-[68px] group-hover:bg-[color-mix(in_srgb,var(--v2-icon-icon-accent)_20%,var(--v2-background-bg-deep))] group-focus-within:w-[68px] group-focus-within:bg-[color-mix(in_srgb,var(--v2-icon-icon-accent)_20%,var(--v2-background-bg-deep))] focus-visible:outline-none disabled:opacity-60 motion-reduce:transition-none"
+        class="z-10 flex h-5 w-max shrink-0 items-center justify-end rounded-full bg-v2-icon-icon-accent/20 text-v2-icon-icon-accent transition-[background-color] duration-150 ease-out group-hover:bg-[color-mix(in_srgb,var(--v2-icon-icon-accent)_20%,var(--v2-background-bg-deep))] group-focus-within:bg-[color-mix(in_srgb,var(--v2-icon-icon-accent)_20%,var(--v2-background-bg-deep))] focus-visible:outline-none disabled:opacity-60 motion-reduce:transition-none"
         onClick={props.state.onInstall}
         disabled={props.state.installing}
         aria-busy={props.state.installing}
         aria-label={props.state.ariaLabel}
       >
-        <span class="shrink-0 ml-[8px] mr-px text-[11px] text-v2-text-text-accent [font-weight:530] opacity-0 translate-x-2 motion-safe:transition-all duration-150 ease-out group-hover:opacity-100 group-hover:translate-x-0 group-focus-within:opacity-100 group-focus-within:translate-x-0 motion-reduce:translate-x-0">
+        <span class="ml-[8px] mr-px shrink-0 whitespace-nowrap text-[11px] text-v2-text-text-accent [font-weight:530] opacity-0 translate-x-2 motion-safe:transition-all duration-150 ease-out group-hover:opacity-100 group-hover:translate-x-0 group-focus-within:opacity-100 group-focus-within:translate-x-0 motion-reduce:translate-x-0">
           {props.state.label}
         </span>
         <span class="flex size-5 shrink-0 items-center justify-center">


### PR DESCRIPTION
### Issue for this PR

Closes #42232

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The titlebar update pill used a fixed 68px expanded width, leaving excess space around short translations such as Chinese and constraining longer labels.

Size the expanded pill from its label's intrinsic width while preserving the 20px collapsed circle, right-aligned icon, focus/hover animation, and a 192px maximum for unusually long translations.

### How did you verify your code works?

- `bun run typecheck`
- `bun run test:unit` (722 passed)
- `bun run test:browser` (41 passed)
- `bun run build`
- Repository pre-push monorepo typecheck (30 tasks passed)
- Browser layout check: 20px collapsed; 51px Chinese, 65.5px English, and 94.52px French when expanded

### Screenshots / recordings

Before, from the issue report:

![Chinese update pill with fixed-width spacing](https://github.com/user-attachments/assets/721f7745-7fa2-4c06-98ab-3639213a2d4e)

After the fix, the focused Chinese pill measures 51px instead of the fixed 68px. English and French expand to 65.5px and 94.52px respectively, while every collapsed pill remains 20px.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
