### PR TITLE
fix(app): enable directory auto-accept settings

### DIFF
--- a/packages/app/e2e/regression/remote-session-settings.spec.ts
+++ b/packages/app/e2e/regression/remote-session-settings.spec.ts
@@ -7,9 +7,52 @@ const serverA = "http://127.0.0.1:4096"
 const serverB = "http://127.0.0.1:4097"
 const directoryA = "C:/server-a"
 const directoryB = "/home/server-b"
+const draftID = "draft_remote_settings_directory"
 const sessionA = session("ses_server_a", directoryA, "Server A session")
 const childSessionA = { ...session("ses_server_a_child", directoryA, "Server A child session"), parentID: sessionA.id }
 const sessionB = session("ses_server_b", directoryB, "Server B session")
+
+test("draft settings use directory auto-accept", async ({ page }) => {
+  const permissionRequests: string[] = []
+  await mockServers(page, permissionRequests)
+  await configureServers(page, [{ type: "draft", server: serverB, draftID, directory: directoryB }])
+
+  await page.goto(`/new-session?draftId=${draftID}`)
+  await page.keyboard.press("Control+,")
+
+  const autoAccept = page.locator(".settings-v2-dialog").locator('[data-action="settings-auto-accept-permissions"]')
+  const input = autoAccept.getByRole("switch")
+  await expect(autoAccept).toBeVisible()
+  await expect(input).toBeEnabled()
+  permissionRequests.length = 0
+  await autoAccept.locator('[data-slot="switch-control"]').click()
+  await expect(input).toBeChecked()
+  await expect
+    .poll(() =>
+      permissionRequests.some((request) => {
+        const url = new URL(request)
+        return url.origin === serverB && url.searchParams.get("directory") === directoryB
+      }),
+    )
+    .toBe(true)
+  expect(permissionRequests.every((request) => new URL(request).origin === serverB)).toBe(true)
+})
+
+test("settings without active scope keep auto-accept disabled", async ({ page }) => {
+  const permissionRequests: string[] = []
+  await mockServers(page, permissionRequests)
+  await configureServers(page)
+
+  await page.goto("/")
+  await page.keyboard.press("Control+,")
+
+  const autoAccept = page.locator(".settings-v2-dialog").locator('[data-action="settings-auto-accept-permissions"]')
+  const input = autoAccept.getByRole("switch")
+  await expect(autoAccept).toBeVisible()
+  await expect(input).toBeDisabled()
+  await expect(input).not.toBeChecked()
+  expect(permissionRequests).toEqual([])
+})
 
 test("session settings use the remote server context", async ({ page }) => {
   const permissionRequests: string[] = []
@@ -150,7 +193,11 @@ type PermissionResponse = {
   body: unknown
 }
 
-async function configureServers(page: Page, tabs: { type: "session"; server: string; sessionId: string }[] = []) {
+type StoredTab =
+  | { type: "session"; server: string; sessionId: string }
+  | { type: "draft"; server: string; draftID: string; directory: string }
+
+async function configureServers(page: Page, tabs: StoredTab[] = []) {
   await page.addInitScript(
     ({ serverB, tabs }) => {
       localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))

--- a/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
@@ -94,7 +94,7 @@ export const DialogSettings: Component<{
           </div>
         </TabsV2.List>
         <TabsV2.Content value="general" class="settings-v2-panel">
-          <SettingsGeneralV2 sessionID={props.sessionID} />
+          <SettingsGeneralV2 sessionID={props.sessionID} directory={directory} />
         </TabsV2.Content>
         <TabsV2.Content value="shortcuts" class="settings-v2-panel">
           <SettingsKeybinds v2 />

--- a/packages/app/src/components/settings-v2/general-controllers.ts
+++ b/packages/app/src/components/settings-v2/general-controllers.ts
@@ -22,12 +22,15 @@ import { createSoundPreviewController, type ShellOption } from "./general-contro
 export { createShellOptions, createSoundPreviewController } from "./general-controller-behavior"
 export type { ShellOption, ShellSelectOption } from "./general-controller-behavior"
 
-export function createPermissionScopeController(sessionID: Accessor<string | undefined>) {
+export function createPermissionScopeController(
+  sessionID: Accessor<string | undefined>,
+  activeDirectory: Accessor<string | undefined> = () => undefined,
+) {
   const permission = usePermission()
   const serverSync = useServerSync()
   const directory = createMemo(() => {
     const id = sessionID()
-    if (!id) return undefined
+    if (!id) return activeDirectory()
     return serverSync().session.lineage.peek(id)?.session.directory
   })
 
@@ -35,14 +38,20 @@ export function createPermissionScopeController(sessionID: Accessor<string | und
     accepting: createMemo(() => {
       const id = sessionID()
       const dir = directory()
-      if (!id || !dir) return false
+      if (!dir) return false
+      if (!id) return permission.isAutoAcceptingDirectory(dir)
       return permission.isAutoAccepting(id, dir)
     }),
     enabled: createMemo(() => !!directory()),
     set: (checked: boolean) => {
       const id = sessionID()
       const dir = directory()
-      if (!id || !dir) return
+      if (!dir) return
+      if (!id) {
+        if (permission.isAutoAcceptingDirectory(dir) === checked) return
+        permission.toggleAutoAcceptDirectory(dir)
+        return
+      }
       if (checked) return permission.enableAutoAccept(id, dir)
       permission.disableAutoAccept(id, dir)
     },

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, createResource } from "solid-js"
+import { Component, Show, createMemo, createResource, type Accessor } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { SelectV2 } from "@opencode-ai/ui/v2/select-v2"
@@ -273,6 +273,7 @@ const LanguageSetting = () => {
 
 export const SettingsGeneralV2: Component<{
   sessionID?: string
+  directory?: Accessor<string | undefined>
 }> = (props) => {
   const language = useLanguage()
   const platform = usePlatform()
@@ -280,7 +281,7 @@ export const SettingsGeneralV2: Component<{
   const settings = useSettings()
   const mobile = createMediaQuery("(max-width: 767px)")
   const updater = useUpdaterAction()
-  const permissionScope = createPermissionScopeController(() => props.sessionID)
+  const permissionScope = createPermissionScopeController(() => props.sessionID, props.directory)
   const shell = createShellSettingsController()
   const appearance = createAppearanceSettingsController()
   const sounds = createSoundSettingsController()


### PR DESCRIPTION
### Issue for this PR

Fixes #31137

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 Settings already receives a session ID for active sessions, but draft and directory-backed new-session routes have no session ID even though the layout knows their active directory. That leaves the auto-accept switch disabled in those routes.

This passes the active route directory into General Settings and uses the existing directory-scoped auto-accept API when there is no session ID. Existing session behavior is unchanged. Settings with no active directory remains disabled and sends no permission request.

This does not add a global default or change auto-accept persistence or precedence. #39328 proposes that broader behavior separately.

### How did you verify your code works?

- `PLAYWRIGHT_WORKERS=1 bun run test:e2e e2e/regression/remote-session-settings.spec.ts --grep "draft settings use directory auto-accept|settings without active scope keep auto-accept disabled|session settings use the remote server context"` — 3 passed
- `bun run typecheck:e2e` — passed
- `bun run build` — passed
- Repository pre-push `bun typecheck` with Bun 1.3.14 — 30/30 packages passed

The remote draft regression verifies the switch enables, toggles, and sends the permission request only to the correct server and directory. The no-active-scope regression verifies the switch remains disabled and sends no permission request.

### Screenshots / recordings

No visual styling changes. The new Playwright coverage exercises the rendered Settings switch and its before/after enabled state; manual Chromium QA also covered 768×900 and 1280×720.

**Before**

<img width="1280" height="720" alt="draft-1280x720-before" src="https://github.com/user-attachments/assets/24229894-e1b1-4914-9f0d-65ab20ef20db" />

**After**

<img width="1280" height="720" alt="draft-1280x720-after" src="https://github.com/user-attachments/assets/efcff8c5-39b3-479c-b913-80b7c3cd292e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
