### PR TITLE
fix(skills): Update global config path in documentation

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -40,7 +40,7 @@ already-loaded config until then.
 | Scope                         | Path                                                                                                                      |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | Project config                | `./opencode.json`, `./opencode.jsonc`, or `.opencode/opencode.json` (opencode walks up from the cwd to the worktree root) |
-| Global config                 | `~/.config/opencode/opencode.json` or `~/.config/opencode/opencode.jsonc` (NOT `~/.opencode/`)                                                                   |
+| Global config                 | `~/.config/opencode/opencode.json` or `~/.config/opencode/opencode.jsonc` (NOT `~/.opencode/`) |
 | Project agents                | `.opencode/agent/<name>.md` or `.opencode/agents/<name>.md`                                                               |
 | Global agents                 | `~/.config/opencode/agent(s)/<name>.md`                                                                                   |
 | Project commands              | `.opencode/command/<name>.md` or `.opencode/commands/<name>.md`                                                           |

--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -40,7 +40,7 @@ already-loaded config until then.
 | Scope                         | Path                                                                                                                      |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | Project config                | `./opencode.json`, `./opencode.jsonc`, or `.opencode/opencode.json` (opencode walks up from the cwd to the worktree root) |
-| Global config                 | `~/.config/opencode/opencode.json` (NOT `~/.opencode/`)                                                                   |
+| Global config                 | `~/.config/opencode/opencode.json` or `~/.config/opencode/opencode.jsonc` (NOT `~/.opencode/`)                                                                   |
 | Project agents                | `.opencode/agent/<name>.md` or `.opencode/agents/<name>.md`                                                               |
 | Global agents                 | `~/.config/opencode/agent(s)/<name>.md`                                                                                   |
 | Project commands              | `.opencode/command/<name>.md` or `.opencode/commands/<name>.md`                                                           |


### PR DESCRIPTION
Clarified the global config path to include both JSON and JSONC formats.

### Issue for this PR

Closes #32717

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an issue where AI agents almost always miss out on looking for opencode.jsonc file and assumes the global config file is missing

### How did you verify your code works?

Gave a prompt "use customize-opencode skill and tell me where is global config" and I got response:

I'll load the skill.
→Skill "customize-opencode"
Global config lives at:
- ~/.config/opencode/opencode.json (or opencode.jsonc)
- On your machine: C:\Users\Aditya\.config\opencode\opencode.json
Note it's not ~/.opencode/. Other global items sit alongside it:
- Agents: ~/.config/opencode/agent/<name>.md
- Commands: ~/.config/opencode/command/<name>.md
- Skills: ~/.config/opencode/skill/<name>/SKILL.md
Project config (./opencode.json or .opencode/opencode.json) deep-merges over global.

### Screenshots / recordings

<img width="2560" height="1524" alt="image" src="https://github.com/user-attachments/assets/def8a86a-6562-4fda-baf3-61e57fe08acf" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR