### PR TITLE
fix(tui): stop disabled tab pulse rendering

### DIFF
--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -190,7 +190,7 @@ class PulseState {
   }
 
   get live() {
-    return this.active || this.breathing || this.envelopes.some(envelopeActive)
+    return this.enabled && (this.active || this.breathing || this.envelopes.some(envelopeActive))
   }
 
   get running() {

--- a/packages/tui/test/component/tab-pulse.test.tsx
+++ b/packages/tui/test/component/tab-pulse.test.tsx
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test"
+/** @jsxImportSource @opentui/solid */
 import { RGBA } from "@opentui/core"
+import { testRender } from "@opentui/solid"
+import { createSignal } from "solid-js"
 import {
+  TabPulse,
   blendTabPulseColor,
   completionPulseOpacity,
   glowIgnitionLevel,
@@ -8,6 +12,26 @@ import {
   unreadGlowIntensity,
 } from "../../src/component/tab-pulse"
 import { tint } from "../../src/theme/color"
+
+test("a disabled pulse stays idle when it becomes active", async () => {
+  const background = RGBA.fromHex("#101010")
+  const [active, setActive] = createSignal(false)
+  const app = await testRender(
+    () => <TabPulse enabled={false} active={active()} color={background} backgroundColor={background} />,
+    { width: 8, height: 1 },
+  )
+
+  try {
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+
+    setActive(true)
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
 
 test("completion pulse rises quickly and fades over the remaining duration", () => {
   expect(completionPulseOpacity(0)).toBe(0)


### PR DESCRIPTION
## What

Prevent disabled tab pulses from keeping the OpenTUI renderer live after their session becomes active.

Enabled running sweeps, breathing, flashes, and completion animations are unchanged.

## Before / After

**Before**

1. A tab pulse mounted with animations disabled.
2. Its session later transitioned to active.
3. `PulseState.live` returned `true` from `active` without considering `enabled`.
4. The invisible pulse propagated liveness to the renderer root, producing continuous frames despite no visual changes.

In the reproduced TUI, four disabled pulses held the renderer at 53–57 FPS while native stats reported zero changed cells.

**After**

`PulseState.live` is gated by `enabled`. A disabled pulse remains non-live through later activity transitions, so it cannot start an invisible render loop.

## How

- `packages/tui/src/component/tab-pulse.tsx`: require the pulse to be enabled before any active, breathing, or finite envelope state contributes liveness.
- `packages/tui/test/component/tab-pulse.test.tsx`: mount a disabled pulse, transition it to active, and assert root liveness remains zero.

## Scope

This PR only fixes disabled-animation liveness. It does not change the frame rate or appearance of enabled animations, and it does not address full-root rendering costs while legitimate animations are active.

## Testing

- `cd packages/tui && bun run test test/component/tab-pulse.test.tsx` — 7 passed
- `cd packages/tui && bun typecheck`
- Repository pre-push hook: all 34 package typechecks passed
- Diagnostic TUI verification: `rootLiveCount` dropped from 4 to 0 and frame count stopped advancing after hydration when animations were disabled
