### PR TITLE
fix(core): refresh fallback file search

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -22,7 +22,7 @@ export type Options = typeof Options.Type
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/FileSystem/Search") {}
 
-const REFRESH_INTERVAL = Duration.toMillis("2 seconds")
+const REFRESH_INTERVAL = Duration.toMillis("10 seconds")
 
 export const ripgrepLayer = Layer.effect(
   Service,
@@ -34,7 +34,7 @@ export const ripgrepLayer = Layer.effect(
     const home = Protected.isHome(location.directory)
     let index = { files: [] as string[], directories: new Set<string>() }
     let initialized = false
-    let refreshedAt = 0
+    let settledAt = Number.NEGATIVE_INFINITY
     let refreshing = false
     const scan = Effect.gen(function* () {
       const next = { files: [] as string[], directories: new Set<string>() }
@@ -55,13 +55,17 @@ export const ripgrepLayer = Layer.effect(
       })
       index = next
       initialized = true
-      refreshedAt = clock.currentTimeMillisUnsafe()
     }).pipe(
       Effect.orDie,
-      Effect.ensuring(Effect.sync(() => (refreshing = false))),
+      Effect.ensuring(
+        Effect.sync(() => {
+          settledAt = clock.currentTimeMillisUnsafe()
+          refreshing = false
+        }),
+      ),
     )
     const refresh = Effect.sync(() => {
-      if (refreshing || (initialized && clock.currentTimeMillisUnsafe() < refreshedAt + REFRESH_INTERVAL)) return
+      if (refreshing || clock.currentTimeMillisUnsafe() < settledAt + REFRESH_INTERVAL) return
       refreshing = true
       return scan
     }).pipe(Effect.flatMap((effect) => (effect ? effect.pipe(Effect.forkIn(scope)) : Effect.void)))

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -2,7 +2,7 @@ export * as FileSystemSearch from "./search.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Context, Effect, Layer, Schema, Scope } from "effect"
+import { Clock, Context, Duration, Effect, Layer, Schema, Scope } from "effect"
 import { Fff } from "#fff"
 import fuzzysort from "fuzzysort"
 import { FileSystem } from "../filesystem.js"
@@ -22,38 +22,60 @@ export type Options = typeof Options.Type
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/FileSystem/Search") {}
 
+const REFRESH_INTERVAL = Duration.toMillis("2 seconds")
+
 export const ripgrepLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const location = yield* Location.Service
     const ripgrep = yield* Ripgrep.Service
     const scope = yield* Scope.Scope
-    const files: string[] = []
-    const directories = new Set<string>()
+    const clock = yield* Clock.Clock
     const home = Protected.isHome(location.directory)
-    yield* ripgrep
-      .find({
+    let index = { files: [] as string[], directories: new Set<string>() }
+    let initialized = false
+    let refreshedAt = 0
+    let refreshing = false
+    const scan = Effect.gen(function* () {
+      const next = { files: [] as string[], directories: new Set<string>() }
+      if (!initialized) index = next
+      yield* ripgrep.find({
         cwd: location.directory,
         pattern: "*",
         limit: location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000,
         exclude: home ? [...Protected.names()].map((name) => `${name}/**`) : undefined,
         onEntry: (entry) =>
           Effect.sync(() => {
-            files.push(entry.path)
+            next.files.push(entry.path)
             const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
+            parts.slice(0, -1).forEach((_, offset) =>
+              next.directories.add(parts.slice(0, offset + 1).join("/") + path.sep),
+            )
           }),
       })
-      .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
+      index = next
+      initialized = true
+      refreshedAt = clock.currentTimeMillisUnsafe()
+    }).pipe(
+      Effect.orDie,
+      Effect.ensuring(Effect.sync(() => (refreshing = false))),
+    )
+    const refresh = Effect.sync(() => {
+      if (refreshing || (initialized && clock.currentTimeMillisUnsafe() < refreshedAt + REFRESH_INTERVAL)) return
+      refreshing = true
+      return scan
+    }).pipe(Effect.flatMap((effect) => (effect ? effect.pipe(Effect.forkIn(scope)) : Effect.void)))
+    yield* refresh
     return Service.of({
       find: (input) =>
         Effect.gen(function* () {
+          yield* refresh
           const items =
             input.type === "file"
-              ? files
+              ? index.files
               : input.type === "directory"
-                ? Array.from(directories)
-                : [...files, ...directories]
+                ? Array.from(index.directories)
+                : [...index.files, ...index.directories]
           return fuzzysort.go(input.query, items, { limit: input.limit ?? 50 }).map((item) => {
             const relative = item.target
             const type = relative.endsWith(path.sep) ? ("directory" as const) : ("file" as const)

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import os from "os"
 import path from "path"
-import { Effect, Layer } from "effect"
+import { Deferred, Effect, Layer } from "effect"
+import { TestClock } from "effect/testing"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { Protected } from "@opencode-ai/core/filesystem/protected"
@@ -54,6 +55,70 @@ describe("FileSystemSearch", () => {
           RelativePath.make(`src${path.sep}`),
         )
       }).pipe(Effect.provide(layer), Effect.scoped),
+    )
+  })
+
+  test("refreshes a stale ripgrep index atomically without blocking search", async () => {
+    let scans = 0
+    const initial = Effect.runSync(Deferred.make<void>())
+    const started = Effect.runSync(Deferred.make<void>())
+    const release = Effect.runSync(Deferred.make<void>())
+    const layer = AppNodeBuilder.build(FileSystemSearch.node, [
+      [
+        Location.node,
+        Layer.succeed(
+          Location.Service,
+          Location.Service.of(location({ directory: AbsolutePath.make(path.join(os.tmpdir(), "opencode-search-atomic")) })),
+        ),
+      ],
+      [
+        Ripgrep.node,
+        Layer.succeed(
+          Ripgrep.Service,
+          Ripgrep.Service.of({
+            find: (input) =>
+              Effect.gen(function* () {
+                scans++
+                if (scans > 1) {
+                  yield* Deferred.succeed(started, undefined)
+                  yield* Deferred.await(release)
+                }
+                const entry = FileSystem.Entry.make({
+                  path: RelativePath.make(scans === 1 ? "src/old.ts" : "src/new.ts"),
+                  type: "file",
+                })
+                if (input.onEntry) yield* input.onEntry(entry)
+                if (scans === 1) yield* Deferred.succeed(initial, undefined)
+                return [entry]
+              }),
+            glob: () => Effect.succeed([]),
+            grep: () => Effect.succeed([]),
+          }),
+        ),
+      ],
+    ])
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const search = yield* FileSystemSearch.Service
+        yield* Deferred.await(initial)
+        expect((yield* search.find({ query: "old", type: "file" }))[0]?.path).toBe(RelativePath.make("src/old.ts"))
+        expect(scans).toBe(1)
+
+        yield* TestClock.adjust("2 seconds")
+        yield* search.find({ query: "old", type: "file" })
+        yield* Deferred.await(started)
+
+        expect((yield* search.find({ query: "old", type: "file" }))[0]?.path).toBe(RelativePath.make("src/old.ts"))
+        expect(scans).toBe(2)
+        yield* Deferred.succeed(release, undefined)
+        const refreshed = yield* Effect.gen(function* () {
+          yield* Effect.yieldNow
+          return yield* search.find({ query: "new", type: "file" })
+        }).pipe(Effect.repeat({ until: (entries) => entries.length > 0 }))
+        expect(refreshed[0]?.path).toBe(RelativePath.make("src/new.ts"))
+        expect(scans).toBe(2)
+      }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()), Effect.scoped),
     )
   })
 })

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -105,7 +105,7 @@ describe("FileSystemSearch", () => {
         expect((yield* search.find({ query: "old", type: "file" }))[0]?.path).toBe(RelativePath.make("src/old.ts"))
         expect(scans).toBe(1)
 
-        yield* TestClock.adjust("2 seconds")
+        yield* TestClock.adjust("10 seconds")
         yield* search.find({ query: "old", type: "file" })
         yield* Deferred.await(started)
 


### PR DESCRIPTION
## What

Keep the ripgrep-backed filename index fresh without restoring a recursive project filesystem watch.

Fallback file search now serves its current index immediately and starts at most one background refresh when the last completed scan is 10 seconds old. A completed refresh atomically replaces the prior index.

## Before / After

**Before**

The fallback ran ripgrep once when a Location started. Files created, deleted, or renamed afterward remained absent or stale for the lifetime of that Location service.

A recursive root watcher can detect those changes, but that topology was deliberately removed in #41096 because large projects consume an unbounded number of native watches. It is also broader than the bounded search scan for home and aggregate Locations.

**After**

A search always reads the current index without waiting. If that index is stale, the same request starts one scoped background ripgrep scan. Requests arriving during that scan keep using the prior complete index and do not start more scans. The next request after completion sees the refreshed paths.

The initial scan retains the existing incremental behavior, so file search remains usable while a Location first indexes.

## How

- `packages/core/src/filesystem/search.ts` tracks refresh completion time and one in-flight scan inside the existing Location-scoped search module.
- Initial scan entries remain visible incrementally.
- Later scans build a private file/directory index and publish it atomically on completion.
- The implementation adds no watcher dependency, protocol change, or client-specific behavior. Desktop, web, and TUI continue consuming `GET /api/fs/find` unchanged.
- `packages/core/test/filesystem/search.test.ts` verifies bounded refresh, non-blocking stale reads, atomic replacement, and scan deduplication with `TestClock` and explicit scan gates.

## Scope

- This provides bounded eventual freshness for arbitrary external changes; it does not promise instantaneous updates.
- This does not add exact create/delete/move hints from OpenCode-owned file mutations.
- FFF-backed VCS Locations retain their existing native indexing behavior.

## Testing

- `cd packages/core && bun run test test/filesystem/search.test.ts`
- `cd packages/core && bun typecheck`
- Repository pre-push typecheck: 34 tasks passed
- `git diff --check`

## Flow

```mermaid
sequenceDiagram
    participant UI as Desktop / Web / TUI
    participant Search as FileSystemSearch
    participant RG as Ripgrep

    UI->>Search: GET /api/fs/find
    Search-->>UI: Current fuzzy results
    alt Last scan is stale and no refresh is running
        Search->>RG: Start background scan
        UI->>Search: Next query
        Search-->>UI: Prior complete results
        RG-->>Search: Complete updated index
        Search->>Search: Atomically replace index
        UI->>Search: Subsequent query
        Search-->>UI: Refreshed results
    end
```