### PR TITLE
docs(ecosystem): add opencode-obvious-grid plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,6 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                       |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
+| [opencode-obvious-grid](https://github.com/ray062/opencode-obvious-grid)                           | Status dashboard for all opencode instances: tokens, cost, graphs, ntfy/alarm alerts               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
[Opencode Obvious Grid](https://github.com/ray062/opencode-obvious-grid)
Adds opencode-obvious-grid to the Plugins table — a self-contained very visible and bold status-page plugin (aggregate view of every opencode session tokens/cost/graphs, ntfy + alarm notifications). Published on npm, cross-platform (WSL/Linux/macOS/Windows).

### How did you verify your code works?
The added line matches the surrounding table's column alignment; no other changes in the diff.

### Screenshots / recordings
<img width="3828" height="2328" alt="image" src="https://github.com/user-attachments/assets/ceec97cc-e736-4ed1-be40-3045f9a1fb7c" />

<img width="3817" height="2385" alt="image" src="https://github.com/user-attachments/assets/b13ab366-e59a-4dbc-9ba4-ff203adb7964" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

