### PR TITLE
feat(core): add automatic web search routing

### DIFF
--- a/packages/core/src/config/plugin/websearch.ts
+++ b/packages/core/src/config/plugin/websearch.ts
@@ -3,6 +3,7 @@ export * as ConfigWebSearchPlugin from "./websearch.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
+import { WebSearch } from "../../websearch.js"
 
 export const Plugin = define({
   id: "opencode.config.websearch",
@@ -11,7 +12,7 @@ export const Plugin = define({
     const loaded = { entries: yield* config.entries() }
     yield* ctx.websearch.transform((websearch) => {
       const providerID = Config.latest(loaded.entries, "websearch")?.provider
-      if (providerID) websearch.default.set(providerID)
+      if (providerID) websearch.default.set(providerID === WebSearch.AUTO ? providerID : WebSearch.ID.make(providerID))
     })
     yield* ctx.event.subscribe().pipe(
       Stream.filter((event) => event.type === "config.updated"),

--- a/packages/core/src/config/plugin/websearch.ts
+++ b/packages/core/src/config/plugin/websearch.ts
@@ -3,7 +3,6 @@ export * as ConfigWebSearchPlugin from "./websearch.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
-import { WebSearch } from "../../websearch.js"
 
 export const Plugin = define({
   id: "opencode.config.websearch",
@@ -12,7 +11,7 @@ export const Plugin = define({
     const loaded = { entries: yield* config.entries() }
     yield* ctx.websearch.transform((websearch) => {
       const providerID = Config.latest(loaded.entries, "websearch")?.provider
-      if (providerID) websearch.default.set(providerID === WebSearch.AUTO ? providerID : WebSearch.ID.make(providerID))
+      if (providerID) websearch.default.set(providerID)
     })
     yield* ctx.event.subscribe().pipe(
       Stream.filter((event) => event.type === "config.updated"),

--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -55,7 +55,7 @@ export const Plugin = {
               const search = (): Effect.Effect<Effect.Success<ReturnType<typeof ctx.websearch.query>>, unknown> =>
                 websearch.default().pipe(
                   Effect.flatMap((provider) => {
-                    if (!provider) return ctx.websearch.query(input)
+                    if (!provider || provider === WebSearch.AUTO) return ctx.websearch.query(input)
                     return context
                       .progress({ provider: provider.id })
                       .pipe(Effect.andThen(ctx.websearch.query({ ...input, providerID: provider.id })))
@@ -67,8 +67,7 @@ export const Plugin = {
                         Effect.gen(function* () {
                           if (yield* websearch.default()) return yield* Effect.void
                           const providers = (yield* ctx.websearch.providers()).data
-                          const defaultProvider = providers[0]
-                          if (!defaultProvider) return yield* new WebSearch.ProviderRequiredError()
+                          if (!providers.length) return yield* new WebSearch.ProviderRequiredError()
                           const response = yield* forms.ask({
                             sessionID: context.sessionID,
                             title: "Web Search",
@@ -83,11 +82,11 @@ export const Plugin = {
                                 options: [
                                   {
                                     value: "allow",
-                                    label: `Allow web search via ${defaultProvider.name}`,
+                                    label: "Allow web search with automatic provider selection",
                                   },
                                   {
                                     value: "choose",
-                                    label: "Choose another provider",
+                                    label: "Choose a specific provider",
                                   },
                                   { value: "disable", label: "Disable web search" },
                                 ],
@@ -123,10 +122,10 @@ export const Plugin = {
                               : undefined
                           if (selection?.status === "cancelled")
                             return yield* Effect.fail(new Error("Web search cancelled"))
-                          const providerID = selection?.answer.provider ?? defaultProvider.id
+                          const providerID = selection?.answer.provider ?? WebSearch.AUTO
                           if (
                             typeof providerID !== "string" ||
-                            !providers.some((provider) => provider.id === providerID)
+                            (providerID !== WebSearch.AUTO && !providers.some((provider) => provider.id === providerID))
                           )
                             return yield* new WebSearch.ProviderRequiredError()
                           return yield* kv.set("websearch:provider", providerID)

--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -82,7 +82,7 @@ export const Plugin = {
                                 options: [
                                   {
                                     value: "allow",
-                                    label: "Allow web search with automatic provider selection",
+                                    label: "Allow web search",
                                   },
                                   {
                                     value: "choose",

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -128,17 +128,6 @@ const layer = Layer.effect(
       return new Response({ providerID: provider.id, results })
     })
 
-    const executeAutomatic = Effect.fn("WebSearch.executeAutomatic")(function* (
-      providers: readonly ProviderImplementation[],
-      input: Input,
-    ) {
-      const attempt = (index: number): Effect.Effect<Response, RequestError> =>
-        execute(providers[index]!, input).pipe(
-          Effect.catch((error) => (index === providers.length - 1 ? Effect.fail(error) : attempt(index + 1))),
-        )
-      return yield* attempt(0)
-    })
-
     return Service.of({
       transform: state.transform,
       reload: state.reload,
@@ -155,7 +144,7 @@ const layer = Layer.effect(
       }),
       query: Effect.fn("WebSearch.query")(function* (input) {
         const route = yield* resolve(input)
-        if (Array.isArray(route)) return yield* executeAutomatic(route, input)
+        if (Array.isArray(route)) return yield* Effect.firstSuccessOf(route.map((provider) => execute(provider, input)))
         return yield* execute(route, input)
       }),
     })

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -1,7 +1,7 @@
 export * as WebSearch from "./websearch.js"
 
 import { WebSearch } from "@opencode-ai/schema/websearch"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Random, Schema } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "./bus.js"
 import { KV } from "./kv.js"
@@ -9,6 +9,8 @@ import { State } from "./state.js"
 
 export const ID = WebSearch.ID
 export type ID = WebSearch.ID
+
+export const AUTO = WebSearch.AUTO
 
 export const Provider = WebSearch.Provider
 export type Provider = WebSearch.Provider
@@ -52,7 +54,7 @@ export type Error = ProviderRequiredError | ProviderNotFoundError | DisabledErro
 
 export interface Interface extends State.Transformable<Draft> {
   readonly providers: () => Effect.Effect<readonly Provider[]>
-  readonly default: () => Effect.Effect<Provider | undefined, DisabledError>
+  readonly default: () => Effect.Effect<Provider | typeof AUTO | undefined, DisabledError>
   readonly query: (input: Input) => Effect.Effect<Response, Error>
 }
 
@@ -60,14 +62,14 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/We
 
 type Data = {
   readonly providers: Map<ID, ProviderImplementation>
-  defaultProviderID?: ID
+  defaultProviderID?: WebSearch.Selection
 }
 
 export type Draft = {
   add: (provider: ProviderImplementation) => void
   default: {
-    get: () => ID | undefined
-    set: (providerID: ID) => void
+    get: () => WebSearch.Selection | undefined
+    set: (providerID: WebSearch.Selection) => void
   }
 }
 
@@ -96,11 +98,13 @@ const layer = Layer.effect(
 
     const defaultProvider = Effect.fn("WebSearch.default")(function* () {
       const data = state.get()
+      if (data.defaultProviderID === AUTO) return AUTO
       const configured = data.defaultProviderID ? data.providers.get(data.defaultProviderID) : undefined
       if (configured) return configured
       const stored = yield* kv.get("websearch:provider")
       if (stored === false) return yield* new DisabledError()
       if (typeof stored !== "string") return
+      if (stored === AUTO) return AUTO
       return data.providers.get(ID.make(stored))
     })
 
@@ -109,7 +113,30 @@ const layer = Layer.effect(
       if (input.providerID) return yield* requireProvider(providers, input.providerID)
       const provider = yield* defaultProvider()
       if (!provider) return yield* new ProviderRequiredError()
+      if (provider === AUTO) {
+        if (!providers.size) return yield* new ProviderRequiredError()
+        return yield* Random.shuffle(providers.values())
+      }
       return provider
+    })
+
+    const execute = Effect.fn("WebSearch.execute")(function* (provider: ProviderImplementation, input: Input) {
+      const results = yield* provider.execute({ query: input.query }).pipe(
+        Effect.flatMap(decodeResults),
+        Effect.mapError((cause) => new RequestError({ providerID: provider.id, cause })),
+      )
+      return new Response({ providerID: provider.id, results })
+    })
+
+    const executeAutomatic = Effect.fn("WebSearch.executeAutomatic")(function* (
+      providers: readonly ProviderImplementation[],
+      input: Input,
+    ) {
+      const attempt = (index: number): Effect.Effect<Response, RequestError> =>
+        execute(providers[index]!, input).pipe(
+          Effect.catch((error) => (index === providers.length - 1 ? Effect.fail(error) : attempt(index + 1))),
+        )
+      return yield* attempt(0)
     })
 
     return Service.of({
@@ -123,15 +150,13 @@ const layer = Layer.effect(
       }),
       default: Effect.fn("WebSearch.defaultInfo")(function* () {
         const provider = yield* defaultProvider()
+        if (provider === AUTO) return AUTO
         return provider && { id: provider.id, name: provider.name }
       }),
       query: Effect.fn("WebSearch.query")(function* (input) {
-        const provider = yield* resolve(input)
-        const results = yield* provider.execute({ query: input.query }).pipe(
-          Effect.flatMap(decodeResults),
-          Effect.mapError((cause) => new RequestError({ providerID: provider.id, cause })),
-        )
-        return new Response({ providerID: provider.id, results })
+        const route = yield* resolve(input)
+        if (Array.isArray(route)) return yield* executeAutomatic(route, input)
+        return yield* execute(route, input)
       }),
     })
   }),

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -266,7 +266,7 @@ describe("WebSearchTool registration", () => {
               options: [
                 {
                   value: "allow",
-                  label: "Allow web search with automatic provider selection",
+                  label: "Allow web search",
                 },
                 {
                   value: "choose",

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -80,6 +80,7 @@ const websearch = Layer.succeed(
       Effect.gen(function* () {
         const stored = values.get("websearch:provider")
         if (stored === false) return yield* new WebSearch.DisabledError()
+        if (stored === WebSearch.AUTO) return WebSearch.AUTO
         return typeof stored === "string" ? providers.find((provider) => provider.id === stored) : undefined
       }),
     query: (input) =>
@@ -93,6 +94,7 @@ const websearch = Layer.succeed(
         }
         if (queryError) return yield* queryError
         if (providerRequired && typeof stored !== "string") return yield* new WebSearch.ProviderRequiredError()
+        if (stored === WebSearch.AUTO) return result
         if (typeof stored === "string")
           return new WebSearch.Response({ providerID: WebSearch.ID.make(stored), results: result.results })
         return result
@@ -234,7 +236,7 @@ describe("WebSearchTool registration", () => {
     }),
   )
 
-  it.effect("asks once and uses the default provider when web search is first enabled", () =>
+  it.effect("asks once and enables automatic provider selection", () =>
     Effect.gen(function* () {
       providerRequired = true
       formResponse = { status: "answered", answer: { choice: "allow" } }
@@ -247,7 +249,7 @@ describe("WebSearchTool registration", () => {
           call: { type: "tool-call", id: "call-enable", name: "websearch", input: { query: "effect" } },
         }),
       ).toMatchObject({ status: "completed", metadata: { provider: "exa" } })
-      expect(values.get("websearch:provider")).toBe("exa")
+      expect(values.get("websearch:provider")).toBe(WebSearch.AUTO)
       expect(queries).toHaveLength(2)
       expect(formRequests).toEqual([
         {
@@ -264,11 +266,11 @@ describe("WebSearchTool registration", () => {
               options: [
                 {
                   value: "allow",
-                  label: "Allow web search via Exa",
+                  label: "Allow web search with automatic provider selection",
                 },
                 {
                   value: "choose",
-                  label: "Choose another provider",
+                  label: "Choose a specific provider",
                 },
                 { value: "disable", label: "Disable web search" },
               ],
@@ -353,7 +355,7 @@ describe("WebSearchTool registration", () => {
 
       expect(results.every((item) => item.status === "completed")).toBe(true)
       expect(formRequests).toHaveLength(1)
-      expect(values.get("websearch:provider")).toBe("exa")
+      expect(values.get("websearch:provider")).toBe(WebSearch.AUTO)
     }),
   )
 

--- a/packages/core/test/websearch.test.ts
+++ b/packages/core/test/websearch.test.ts
@@ -72,7 +72,7 @@ describe("WebSearch", () => {
       const exa = yield* register("exa", "fail")
       const parallel = yield* register("parallel")
       const websearch = yield* WebSearch.Service
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
 
       const error = yield* websearch.query({ query: "strict", providerID: exa.providerID }).pipe(Effect.flip)
 
@@ -170,7 +170,7 @@ describe("WebSearch", () => {
       const empty = yield* register("empty", "empty")
       const fallback = yield* register("fallback")
       const websearch = yield* WebSearch.Service
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
 
       const response = yield* websearch.query({ query: "empty" }).pipe(Random.withSeed("empty-first"))
 
@@ -185,7 +185,7 @@ describe("WebSearch", () => {
       const exa = yield* register("exa", "fail")
       const parallel = yield* register("parallel", "fail")
       const websearch = yield* WebSearch.Service
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
       const expected = yield* Random.shuffle([exa.providerID, parallel.providerID]).pipe(Random.withSeed("all-fail"))
 
       const error = yield* websearch.query({ query: "failure" }).pipe(Random.withSeed("all-fail"), Effect.flip)
@@ -199,7 +199,7 @@ describe("WebSearch", () => {
   it.effect("supports zero and one registered provider in automatic mode", () =>
     Effect.gen(function* () {
       const websearch = yield* WebSearch.Service
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
       expect((yield* websearch.query({ query: "zero" }).pipe(Effect.flip))._tag).toBe("WebSearch.ProviderRequired")
 
       const only = yield* register("only")
@@ -215,7 +215,7 @@ describe("WebSearch", () => {
       const websearch = yield* WebSearch.Service
       const kv = yield* KV.Service
       yield* kv.set("websearch:provider", fixed.providerID)
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
 
       expect((yield* websearch.query({ query: "config" })).providerID).toBe(fallback.providerID)
       expect(fixed.calls.length).toBeLessThanOrEqual(1)
@@ -229,7 +229,7 @@ describe("WebSearch", () => {
       const exa = yield* register("exa")
       const parallel = yield* register("parallel")
       const websearch = yield* WebSearch.Service
-      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.AUTO))
 
       const selected = yield* Effect.forEach(["a", "b", "c", "d", "e", "f"], (seed) =>
         websearch.query({ query: seed }).pipe(

--- a/packages/core/test/websearch.test.ts
+++ b/packages/core/test/websearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Effect, Exit, Scope } from "effect"
+import { Effect, Exit, Random, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
@@ -9,7 +9,7 @@ import { testEffect } from "./lib/effect"
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([WebSearch.node, Bus.node, KV.node])))
 
-const register = (id: string) =>
+const register = (id: string, behavior: "results" | "empty" | "fail" = "results") =>
   Effect.gen(function* () {
     const websearch = yield* WebSearch.Service
     const providerID = WebSearch.ID.make(id)
@@ -19,17 +19,24 @@ const register = (id: string) =>
         id: providerID,
         name: id.toUpperCase(),
         execute: (input) =>
-          Effect.sync(() => {
-            calls.push(input)
-            return [
-              {
-                url: `https://${id}.example.com`,
-                title: input.query,
-                content: `${id}: ${input.query}`,
-                time: {},
-              },
-            ]
-          }),
+          Effect.sync(() => calls.push(input)).pipe(
+            Effect.andThen(
+              behavior === "fail"
+                ? Effect.fail(new Error(`${id} failed`))
+                : Effect.succeed(
+                    behavior === "empty"
+                      ? []
+                      : [
+                          {
+                            url: `https://${id}.example.com`,
+                            title: input.query,
+                            content: `${id}: ${input.query}`,
+                            time: {},
+                          },
+                        ],
+                  ),
+            ),
+          ),
       })
     })
     return { providerID, calls }
@@ -60,6 +67,21 @@ describe("WebSearch", () => {
     }),
   )
 
+  it.effect("keeps explicit providers strict when automatic selection is enabled", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa", "fail")
+      const parallel = yield* register("parallel")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+
+      const error = yield* websearch.query({ query: "strict", providerID: exa.providerID }).pipe(Effect.flip)
+
+      expect(error).toMatchObject({ _tag: "WebSearch.Request", providerID: exa.providerID })
+      expect(exa.calls).toEqual([{ query: "strict" }])
+      expect(parallel.calls).toEqual([])
+    }),
+  )
+
   it.effect("requires a provider when no default is set", () =>
     Effect.gen(function* () {
       yield* register("exa")
@@ -81,6 +103,20 @@ describe("WebSearch", () => {
     }),
   )
 
+  it.effect("keeps fixed configured providers strict", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa", "fail")
+      const parallel = yield* register("parallel")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(exa.providerID))
+
+      const error = yield* websearch.query({ query: "configured" }).pipe(Effect.flip)
+
+      expect(error).toMatchObject({ _tag: "WebSearch.Request", providerID: exa.providerID })
+      expect(parallel.calls).toEqual([])
+    }),
+  )
+
   it.effect("uses the provider stored in KV", () =>
     Effect.gen(function* () {
       yield* register("exa")
@@ -91,6 +127,118 @@ describe("WebSearch", () => {
 
       expect((yield* websearch.query({ query: "stored" })).providerID).toBe(parallel.providerID)
       yield* kv.remove("websearch:provider")
+    }),
+  )
+
+  it.effect("keeps fixed KV providers strict", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa", "fail")
+      const parallel = yield* register("parallel")
+      const websearch = yield* WebSearch.Service
+      const kv = yield* KV.Service
+      yield* kv.set("websearch:provider", exa.providerID)
+
+      const error = yield* websearch.query({ query: "fixed" }).pipe(Effect.flip)
+
+      expect(error).toMatchObject({ _tag: "WebSearch.Request", providerID: exa.providerID })
+      expect(parallel.calls).toEqual([])
+      yield* kv.remove("websearch:provider")
+    }),
+  )
+
+  it.effect("automatically tries each provider at most once until one succeeds", () =>
+    Effect.gen(function* () {
+      const order = yield* Random.shuffle(["exa", "parallel", "firecrawl"]).pipe(Random.withSeed("fallback"))
+      const registered = yield* Effect.forEach(["exa", "parallel", "firecrawl"], (id) =>
+        register(id, id === order.at(-1) ? "results" : "fail"),
+      )
+      const websearch = yield* WebSearch.Service
+      const kv = yield* KV.Service
+      yield* kv.set("websearch:provider", WebSearch.AUTO)
+
+      const response = yield* websearch.query({ query: "automatic" }).pipe(Random.withSeed("fallback"))
+
+      expect(response.providerID).toBe(WebSearch.ID.make(order.at(-1)!))
+      expect(registered.flatMap((provider) => provider.calls)).toHaveLength(3)
+      expect(registered.every((provider) => provider.calls.length === 1)).toBe(true)
+      yield* kv.remove("websearch:provider")
+    }),
+  )
+
+  it.effect("stops automatic fallback on empty results", () =>
+    Effect.gen(function* () {
+      const empty = yield* register("empty", "empty")
+      const fallback = yield* register("fallback")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+
+      const response = yield* websearch.query({ query: "empty" }).pipe(Random.withSeed("empty-first"))
+
+      expect(response.results).toEqual([])
+      expect(empty.calls).toHaveLength(1)
+      expect(fallback.calls).toHaveLength(0)
+    }),
+  )
+
+  it.effect("returns the final request error when every automatic provider fails", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa", "fail")
+      const parallel = yield* register("parallel", "fail")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      const expected = yield* Random.shuffle([exa.providerID, parallel.providerID]).pipe(Random.withSeed("all-fail"))
+
+      const error = yield* websearch.query({ query: "failure" }).pipe(Random.withSeed("all-fail"), Effect.flip)
+
+      expect(error).toMatchObject({ _tag: "WebSearch.Request", providerID: expected.at(-1) })
+      expect(exa.calls).toHaveLength(1)
+      expect(parallel.calls).toHaveLength(1)
+    }),
+  )
+
+  it.effect("supports zero and one registered provider in automatic mode", () =>
+    Effect.gen(function* () {
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+      expect((yield* websearch.query({ query: "zero" }).pipe(Effect.flip))._tag).toBe("WebSearch.ProviderRequired")
+
+      const only = yield* register("only")
+      expect((yield* websearch.query({ query: "one" })).providerID).toBe(only.providerID)
+      expect(only.calls).toHaveLength(1)
+    }),
+  )
+
+  it.effect("lets an automatic configured default override a fixed KV provider", () =>
+    Effect.gen(function* () {
+      const fixed = yield* register("fixed", "fail")
+      const fallback = yield* register("fallback")
+      const websearch = yield* WebSearch.Service
+      const kv = yield* KV.Service
+      yield* kv.set("websearch:provider", fixed.providerID)
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+
+      expect((yield* websearch.query({ query: "config" })).providerID).toBe(fallback.providerID)
+      expect(fixed.calls.length).toBeLessThanOrEqual(1)
+      expect(fallback.calls).toHaveLength(1)
+      yield* kv.remove("websearch:provider")
+    }),
+  )
+
+  it.effect("can start automatic selection with any registered provider", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa")
+      const parallel = yield* register("parallel")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.transform((draft) => draft.default.set(WebSearch.ID.make(WebSearch.AUTO)))
+
+      const selected = yield* Effect.forEach(["a", "b", "c", "d", "e", "f"], (seed) =>
+        websearch.query({ query: seed }).pipe(
+          Random.withSeed(seed),
+          Effect.map((response) => response.providerID),
+        ),
+      )
+
+      expect(new Set(selected)).toEqual(new Set([exa.providerID, parallel.providerID]))
     }),
   )
 

--- a/packages/schema/src/config/websearch.ts
+++ b/packages/schema/src/config/websearch.ts
@@ -4,5 +4,5 @@ import { Schema } from "effect"
 import { WebSearch } from "../websearch.js"
 
 export class Info extends Schema.Class<Info>("ConfigWebSearch.Info")({
-  provider: WebSearch.ID,
+  provider: WebSearch.Selection,
 }) {}

--- a/packages/schema/src/websearch.ts
+++ b/packages/schema/src/websearch.ts
@@ -7,6 +7,11 @@ import { optional } from "./schema.js"
 export const ID = Schema.String.pipe(Schema.brand("WebSearch.ID"))
 export type ID = typeof ID.Type
 
+export const AUTO = "auto" as const
+
+export const Selection = Schema.Union([Schema.Literal(AUTO), ID])
+export type Selection = typeof Selection.Type
+
 export interface Provider extends Schema.Schema.Type<typeof Provider> {}
 export const Provider = Schema.Struct({
   id: ID,

--- a/packages/schema/test/config.test.ts
+++ b/packages/schema/test/config.test.ts
@@ -6,8 +6,14 @@ import { ConfigMCP } from "../src/config/mcp.js"
 import { ConfigProvider } from "../src/config/provider.js"
 import { Mcp } from "../src/mcp.js"
 import { AbsolutePath } from "../src/schema.js"
+import { WebSearch } from "../src/websearch.js"
 
 describe("Config.Entry", () => {
+  test("accepts automatic web search provider selection", () => {
+    const config = new Config.Info({ websearch: { provider: WebSearch.AUTO } })
+    expect(config.websearch?.provider).toBe(WebSearch.AUTO)
+  })
+
   test("round-trips every configuration entry type", () => {
     const entries = [
       new Config.Document({


### PR DESCRIPTION
## What

Add automatic provider selection and failover for V2 web search.

Users can configure `websearch.provider` as `"auto"`, or select **Allow web search** on first use. Each search snapshots the currently registered providers, shuffles them once, and tries each provider at most once until one succeeds.

Fixed provider selections and explicit request provider IDs remain strict and never fall back.

## How

- `packages/schema` defines `WebSearch.AUTO` and the typed `WebSearch.Selection` config value.
- `packages/core/src/websearch.ts` resolves explicit, fixed, and automatic routes. Automatic routes use Effect's seedable `Random.shuffle` and `Effect.firstSuccessOf` over existing `WebSearch.Request` failures.
- `packages/core/src/tool/plugin/websearch.ts` updates first-use consent to persist `"auto"` while preserving fixed-provider and disabled choices.
- Existing response, tool metadata, and server error contracts remain unchanged and expose only the provider that succeeded.

## Scope

- No provider ranking, load measurement, retry delays, backoff, or per-provider retries.
- Empty result sets remain successful and do not trigger fallback.
- Existing persisted fixed-provider choices are not migrated.
- No public attempted-provider list or new exhaustion error.

## Testing

- `bun run test test/websearch.test.ts test/tool-websearch.test.ts` in `packages/core` (24 tests)
- `bun typecheck` in `packages/core`
- `bun run test test/config.test.ts` in `packages/schema`
- `bun typecheck` in `packages/schema`
- `bun typecheck` in `packages/plugin`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (34 packages)

## Flow

```mermaid
flowchart TD
  Q[Web search query] --> E{Explicit provider?}
  E -- Yes --> S[Attempt explicit provider once]
  E -- No --> D{Configured or stored selection}
  D -- Fixed provider --> F[Attempt fixed provider once]
  D -- auto --> H[Snapshot and shuffle registered providers]
  H --> A[Attempt next provider]
  A -- Success, including empty results --> R[Return winning provider and results]
  A -- WebSearch.Request and providers remain --> A
  A -- Final WebSearch.Request --> X[Return final existing error]
```
