### PR TITLE
fix(config): tolerate missing file variables in config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -219,8 +219,8 @@ const layer = Layer.effect(
       const expanded = yield* Effect.promise(() =>
         ConfigVariable.substitute(
           "path" in options
-            ? { text, type: "path", path: options.path, env }
-            : { text, type: "virtual", ...options, env },
+            ? { text, type: "path", path: options.path, env, missing: "empty" }
+            : { text, type: "virtual", ...options, env, missing: "empty" },
         ),
       )
       const parsed = ConfigParse.jsonc(expanded, source)

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -66,10 +66,9 @@ export async function substitute(input: SubstituteInput) {
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
     const fileContent = (
       await Filesystem.readText(resolvedPath).catch((error: NodeJS.ErrnoException) => {
-        if (missing === "empty") return ""
-
         const errMsg = `bad file reference: "${token}"`
         if (error.code === "ENOENT") {
+          if (missing === "empty") return ""
           throw new InvalidError(
             {
               path: configSource,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -531,13 +531,51 @@ it.instance("preserves env variables when adding $schema to config", () =>
 it.instance("handles file inclusion substitution", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance
-    yield* FSUtil.use.writeWithDirs(path.join(test.directory, "included.txt"), "test-user")
+    yield* FSUtil.use.writeWithDirs(path.join(test.directory, "included.txt"), "  test-user\n")
     yield* writeConfigEffect(test.directory, {
       $schema: "https://opencode.ai/config.json",
       username: "{file:included.txt}",
     })
     const config = yield* Config.use.get()
     expect(config.username).toBe("test-user")
+  }),
+)
+
+it.instance("resolves missing file inclusion substitution to empty string", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      model: "{file:missing.txt}",
+    })
+    const config = yield* Config.use.get()
+    expect(config.model).toBe("")
+  }),
+)
+
+it.instance("handles mixed existing and missing file inclusion substitutions", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(path.join(test.directory, "included.txt"), "test-user")
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      username: "{file:included.txt}{file:missing.txt}",
+    })
+    const config = yield* Config.use.get()
+    expect(config.username).toBe("test-user")
+  }),
+)
+
+it.instance("keeps non-missing file inclusion read errors fatal", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* Effect.promise(() => fs.mkdir(path.join(test.directory, "included-dir")))
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      username: "{file:included-dir}",
+    })
+    const exit = yield* Config.use.get().pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
   }),
 )
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -940,6 +940,8 @@ File paths can be:
 - Relative to the config file directory
 - Or absolute paths starting with `/` or `~`
 
+If the referenced file does not exist, the variable resolves to an empty string. Other file read errors still fail config loading.
+
 These are useful for:
 
 - Keeping sensitive data like API keys in separate files.


### PR DESCRIPTION
### Issue for this PR

Fixes/Closes #15033

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes missing `{file:...}` config variables resolve to an empty string instead of failing opencode start when file is not present.

Existing file references are still read normally, and non-missing file read errors remain fatal (eg permissions problems).

### How did you verify your code works?

- Ran: `bun test --timeout 30000 test/config/config.test.ts` — passed
- Ran: `bun typecheck` — passed
- Ran dev TUI: `bun dev /home/myuser/myproject` where project-local `opencode.json` has missing file from `{file:path}` in MCP section. Command succeeded, opencode loaded, MCPs were off (not all config entries properly set). Compared with `opencode /home/myuser/myproject` and it fails to start (treats missing files as fatal).

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._

