### PR TITLE
fix(core): preserve unicode in grep previews

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -264,7 +264,10 @@ const layer = Layer.effect(
                 }),
                 line: match.line_number,
                 offset: match.absolute_offset,
-                text: match.lines.text.length > 2_000 ? match.lines.text.slice(0, 2_000) + "..." : match.lines.text,
+                text:
+                  match.lines.text.length > 2_000
+                    ? match.lines.text.slice(0, 2_000).replace(/[\uD800-\uDBFF]$/, "") + "..."
+                    : match.lines.text,
                 submatches: match.submatches.map((submatch) => ({
                   text: submatch.match.text,
                   start: submatch.start,

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -62,4 +62,24 @@ describe("Ripgrep", () => {
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
+  it.live("does not split surrogate pairs in oversized line previews", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            fs.writeFile(path.join(tmp.path, "unicode.txt"), `needle${"x".repeat(1_993)}😀\n`),
+          )
+
+          const matches = yield* (yield* Ripgrep.Service).grep({
+            cwd: tmp.path,
+            pattern: "needle",
+            limit: 10,
+          })
+
+          expect(matches[0]?.text).toBe(`needle${"x".repeat(1_993)}...`)
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
 })


### PR DESCRIPTION
## What

Prevent oversized Ripgrep line previews from persisting half of a Unicode character. A malformed preview could display as `�` and poison subsequent provider requests.

## Before / After

**Before**

A grep match longer than 2,000 JavaScript string units could place an emoji across the preview boundary. `slice(0, 2_000)` retained only the emoji's first UTF-16 code unit, which JSON serialized as an unpaired `\ud83d`. The TUI displayed a replacement character, and OpenAI rejected later requests with HTTP 400 because the request body was not valid Unicode JSON.

**After**

When the preview cutoff lands after the first half of a Unicode character, Ripgrep drops that incomplete code unit before appending the truncation marker. Persisted tool output remains valid Unicode and can be submitted to providers.

## How

- `packages/core/src/ripgrep.ts`: remove a trailing unmatched high-surrogate code unit from truncated line previews.
- `packages/core/test/ripgrep.test.ts`: cover an emoji crossing the exact 2,000-unit preview boundary.

## Scope

This fixes the producer that created the malformed durable tool output. It does not add a provider-request sanitizer or rewrite existing session history.

## Testing

- `bun run test test/ripgrep.test.ts` from `packages/core`: 3 passed
- `bun typecheck` from `packages/core`: passed
- Push hook workspace typecheck: 30 packages passed
- End-to-end A/B replay against OpenAI:
  - original exported history containing one unpaired `\ud83d`: HTTP 400 `Invalid body: failed to parse JSON value`
  - identical history with only that unpaired code unit removed: normal assistant response
