### PR TITLE
fix(app): navigate into directories in the open project dialog

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -1,5 +1,6 @@
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
+import { Button } from "@opencode-ai/ui/button"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
@@ -8,8 +9,14 @@ import { createMemo, createResource, createSignal } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { useGlobal } from "@/context/global"
-import { cleanPickerInput, createDirectorySearch, displayPickerPath } from "./directory-picker-domain"
 import type { Path } from "@opencode-ai/sdk/v2/client"
+import {
+  cleanPickerInput,
+  createDirectorySearch,
+  displayPickerPath,
+  pickerAbsoluteInput,
+  pickerRoot,
+} from "./directory-picker-domain"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -128,6 +135,25 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     dialog.close()
   }
 
+  // Navigate into the highlighted item (append "/" and refetch suggestions)
+  function navigateInto(item: Row) {
+    const value = displayPickerPath(item.absolute, filter(), home())
+    list?.setFilter(value.endsWith("/") ? value : value + "/")
+  }
+
+  // Resolve the current filter path as the selection
+  const resolvedPath = createMemo(() => {
+    const base = start() ?? home()
+    const absolute = filter() ? pickerAbsoluteInput(filter(), home(), base) : base
+    return absolute && pickerRoot(absolute) ? absolute : undefined
+  })
+
+  function confirmFilter() {
+    const absolute = resolvedPath()
+    if (!absolute) return
+    resolve(absolute)
+  }
+
   return (
     <Dialog title={props.title ?? language.t("command.project.open")}>
       <List
@@ -149,19 +175,27 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
         ref={(r) => (list = r)}
         onFilter={(value) => setFilter(cleanPickerInput(value))}
         onKeyEvent={(e, item) => {
-          if (e.key !== "Tab") return
-          if (e.shiftKey) return
-          if (!item) return
-
-          e.preventDefault()
-          e.stopPropagation()
-
-          const value = displayPickerPath(item.absolute, filter(), home())
-          list?.setFilter(value.endsWith("/") ? value : value + "/")
+          // Ctrl+Enter or Meta+Enter: confirm the current filter path
+          if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault()
+            e.stopPropagation()
+            confirmFilter()
+            return
+          }
+          // Tab or Enter: navigate into highlighted directory, or confirm filter if nothing highlighted
+          if (e.key === "Tab" || e.key === "Enter") {
+            if (e.shiftKey) return
+            e.preventDefault()
+            e.stopPropagation()
+            if (item) navigateInto(item)
+            else confirmFilter()
+            return
+          }
         }}
         onSelect={(path) => {
+          // Clicking an item navigates into it; use the Open button to confirm
           if (!path) return
-          resolve(path.absolute)
+          navigateInto(path)
         }}
       >
         {(item) => {
@@ -195,6 +229,14 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           )
         }}
       </List>
+      <div class="px-3 pb-3 pt-2 flex justify-end gap-2">
+        <Button variant="ghost" onClick={() => dialog.close()}>
+          {language.t("common.cancel")}
+        </Button>
+        <Button variant="primary" disabled={!resolvedPath()} onClick={confirmFilter}>
+          {language.t("dialog.directory.action.selectFolder")}
+        </Button>
+      </div>
     </Dialog>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #38338

Rebase of #38345 by @razzeee onto current `dev`, opened with their permission
(https://github.com/anomalyco/opencode/pull/38345#issuecomment-5280628324).
Original commit and authorship preserved.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Open Project dialog immediately resolved and closed when clicking a
suggestion or pressing Enter, making it impossible to navigate into a
subdirectory and continue. There was also no explicit confirm action.

- Tab and Enter now navigate into the highlighted directory (appends `/` and
  refetches) instead of confirming
- Clicking an item also navigates in rather than immediately opening the project
- Added Cancel and Select Folder buttons in the footer
- Ctrl/Cmd+Enter or the button confirms the current path
- Enter with no item highlighted confirms the current filter path directly

**This also fixes opencode web, not just desktop.** Both go through the same
`DialogSelectDirectory` (`directory-picker.tsx` falls through to the legacy
picker for web), so before this change the only way to descend on web was the
undiscoverable Tab shortcut — and on touch devices there was no way at all
short of typing the full absolute path. The scope in the title is `app` rather
than `desktop` for that reason.

Rebase notes: the only conflict was the import hunk, resolved by keeping both
the `Path` type import and the expanded `directory-picker-domain` import.
`onSelect` had not changed upstream since the original branch point.

### How did you verify your code works?

Tested locally on `opencode web` in a browser: clicked into nested directories,
navigated with Enter and Tab, went back up, confirmed with both the Select
Folder button and Ctrl+Enter. Verified backspace still works normally in the
input, and checked the footer at a narrow (mobile) viewport.

### Screenshots / recordings


https://github.com/user-attachments/assets/79b5a3a8-3457-4102-9b1b-dd0b65a9d0f4


https://github.com/user-attachments/assets/4c9a8308-fb97-4537-9616-f4f93aa8d42f



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR