### PR TITLE
fix(drive): serialize unfocused UI state

### DIFF
--- a/packages/simulation/src/frontend/actions.ts
+++ b/packages/simulation/src/frontend/actions.ts
@@ -115,9 +115,10 @@ export function elements(renderer: CliRenderer): Element[] {
 }
 
 export function state(harness: Harness) {
+  const renderable = harness.renderer.currentFocusedRenderable?.num
   return {
     focused: {
-      renderable: harness.renderer.currentFocusedRenderable?.num,
+      ...(renderable === undefined ? {} : { renderable }),
       editor: Boolean(harness.renderer.currentFocusedEditor),
     },
     elements: elements(harness.renderer),

--- a/packages/simulation/test/actions.test.ts
+++ b/packages/simulation/test/actions.test.ts
@@ -14,6 +14,18 @@ test("matches literal screen text", () => {
   expect(matches(harness, "opencode")).toBe(false)
 })
 
+test("omits an absent focused renderable from state", () => {
+  const harness = {
+    renderer: {
+      root: { getChildren: () => [] },
+      currentFocusedRenderable: undefined,
+      currentFocusedEditor: undefined,
+    },
+  } as unknown as Harness
+
+  expect(state(harness)).toEqual({ focused: { editor: false }, elements: [] })
+})
+
 test("normalizes named keys for OpenTUI", async () => {
   const pressed: Array<readonly [string, object | undefined]> = []
   const harness = {


### PR DESCRIPTION
## What

Keep OpenCode Drive responsive when the TUI has no focused renderable.

Drive currently hangs on its first `ui.state` request for full-screen plugin routes such as Storybook. The state object includes `focused.renderable: undefined`, which cannot be encoded as JSON. Encoding defects the control-server response fiber, so the client waits until its 30-second timeout.

## Before / After

**Before**

1. Drive launches a headless TUI with no focused renderable.
2. The client sends `ui.state` after the simulation handshake.
3. The server builds a state containing nested `undefined`.
4. `JsonRpc.success` rejects the non-JSON value and sends no response.
5. Drive exits with `ui.state timed out after 30000ms`.

**After**

1. An absent focused renderable is omitted from the state object.
2. The state remains valid against the existing optional protocol field.
3. JSON-RPC encoding succeeds and Drive can continue controlling the TUI.

## How

- `packages/simulation/src/frontend/actions.ts` conditionally includes `focused.renderable` only when one exists.
- `packages/simulation/test/actions.test.ts` covers the unfocused state shape.

## Testing

- `bun test test/actions.test.ts test/frontend-server.test.ts` from `packages/simulation` (10 passing)
- `bun typecheck` from `packages/simulation`
- Commit hook: `bun turbo typecheck --concurrency=3` (34 tasks passing)
- End-to-end: the previously failing Drive script completed and produced the recovery-panel recording attached to #42353.
