### PR TITLE
feat(tui): prototype tab scroll controls

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -48,6 +48,7 @@ export const Flag = {
 
   OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
   OPENCODE_EXPERIMENTAL_WORKSPACES: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),
+  OPENCODE_EXPERIMENTAL_TAB_SCROLL: enabledByExperimental("OPENCODE_EXPERIMENTAL_TAB_SCROLL"),
 
   // Evaluated at access time (not module load) because tests, the CLI, and
   // external tooling set these env vars at runtime.

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -489,6 +489,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               ? sessionStore.pinned.filter((x) => x !== sessionID)
               : [...sessionStore.pinned, sessionID]
             setSessionStore("pinned", next)
+            if (exists) state.scroll.delete(sessionID)
             save()
           })
         },
@@ -499,9 +500,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           route.navigate({ type: "session", sessionID: target })
         },
         scrollPosition(sessionID: string) {
+          if (!slots().includes(sessionID)) return
           return state.scroll.get(sessionID)
         },
-        setScrollPosition(sessionID: string, position: number) {
+        setScrollPosition(sessionID: string, position: number | undefined) {
+          if (position === undefined || !slots().includes(sessionID)) {
+            state.scroll.delete(sessionID)
+            return
+          }
           state.scroll.set(sessionID, position)
         },
       }

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -417,6 +417,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const filePath = path.join(paths.state, "session.json")
       const state = {
         pending: false,
+        scroll: new Map<string, number>(),
       }
 
       function save() {
@@ -455,6 +456,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       function prune(sessionID: string) {
         batch(() => {
+          state.scroll.delete(sessionID)
           if (sessionStore.pinned.includes(sessionID)) {
             setSessionStore(
               "pinned",
@@ -495,6 +497,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!target) return
           if (route.data.type === "session" && route.data.sessionID === target) return
           route.navigate({ type: "session", sessionID: target })
+        },
+        scrollPosition(sessionID: string) {
+          return state.scroll.get(sessionID)
+        },
+        setScrollPosition(sessionID: string, position: number) {
+          state.scroll.set(sessionID, position)
         },
       }
     }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -81,6 +81,7 @@ import { getRevertDiffFiles } from "../../util/revert-diff"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { LocationProvider } from "../../context/location"
+import { Flag } from "@opencode-ai/core/flag/flag"
 
 addDefaultParsers(parsers.parsers)
 
@@ -258,6 +259,11 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [jumpBottomPosition, setJumpBottomPosition] = kv.signal<"center" | "right">(
+    "experimental_jump_bottom_position",
+    "center",
+  )
+  const [awayFromBottom, setAwayFromBottom] = createSignal(false)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -306,7 +312,12 @@ export function Session() {
       await sync.session.sync(sessionID)
       setTimeout(() => {
         if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
-        scroll.scrollTo(local.session.scrollPosition(sessionID) ?? scroll.scrollHeight)
+        scroll.scrollTo(
+          Flag.OPENCODE_EXPERIMENTAL_TAB_SCROLL
+            ? (local.session.scrollPosition(sessionID) ?? scroll.scrollHeight)
+            : scroll.scrollHeight,
+        )
+        updateAwayFromBottom()
       }, 50)
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
@@ -340,7 +351,10 @@ export function Session() {
   let scroll: ScrollBoxRenderable
   onCleanup(() => {
     if (!scroll || scroll.isDestroyed) return
-    local.session.setScrollPosition(route.sessionID, scroll.scrollTop)
+    local.session.setScrollPosition(
+      route.sessionID,
+      Flag.OPENCODE_EXPERIMENTAL_TAB_SCROLL && isAwayFromBottom() ? scroll.scrollTop : undefined,
+    )
   })
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
@@ -411,16 +425,34 @@ export function Session() {
 
     if (!targetID) {
       scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
+      updateAwayFromBottom()
       dialog.clear()
       return
     }
 
     const child = scroll.getChildren().find((c) => c.id === targetID)
     if (child) scroll.scrollBy(child.y - scroll.y - 1)
+    updateAwayFromBottom()
     dialog.clear()
   }
 
+  function isAwayFromBottom() {
+    return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height) - 1
+  }
+
+  function updateAwayFromBottom() {
+    if (!Flag.OPENCODE_EXPERIMENTAL_TAB_SCROLL) return
+    setTimeout(() => {
+      if (!scroll || scroll.isDestroyed) return
+      const away = isAwayFromBottom()
+      setAwayFromBottom(away)
+      if (!away) local.session.setScrollPosition(route.sessionID, undefined)
+    })
+  }
+
   function toBottom() {
+    setAwayFromBottom(false)
+    local.session.setScrollPosition(route.sessionID, undefined)
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)
@@ -527,6 +559,7 @@ export function Session() {
                 return child.id === messageID
               })
               if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              updateAwayFromBottom()
             }}
             sessionID={route.sessionID}
             setPrompt={(promptInfo) => prompt?.set(promptInfo)}
@@ -550,6 +583,7 @@ export function Session() {
                 return child.id === messageID
               })
               if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              updateAwayFromBottom()
             }}
             sessionID={route.sessionID}
           />
@@ -748,12 +782,26 @@ export function Session() {
       },
     },
     {
+      title: `Move jump-to-bottom button ${jumpBottomPosition() === "center" ? "right" : "to center"}`,
+      value: "session.jump_bottom.position",
+      category: "Session",
+      hidden: !Flag.OPENCODE_EXPERIMENTAL_TAB_SCROLL,
+      slash: {
+        name: "jump-bottom-position",
+      },
+      run: () => {
+        setJumpBottomPosition((position) => (position === "center" ? "right" : "center"))
+        dialog.clear()
+      },
+    },
+    {
       title: "Page up",
       value: "session.page.up",
       category: "Session",
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 2)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -764,6 +812,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(scroll.height / 2)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -774,6 +823,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(-1)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -784,6 +834,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(1)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -794,6 +845,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(-scroll.height / 4)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -804,6 +856,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollBy(scroll.height / 4)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -814,6 +867,7 @@ export function Session() {
       hidden: true,
       run: () => {
         scroll.scrollTo(0)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -823,7 +877,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollTo(scroll.scrollHeight)
+        toBottom()
         dialog.clear()
       },
     },
@@ -853,6 +907,7 @@ export function Session() {
               return child.id === message.id
             })
             if (child) scroll.scrollBy(child.y - scroll.y - 1)
+            updateAwayFromBottom()
             break
           }
         }
@@ -1184,6 +1239,7 @@ export function Session() {
                 stickyStart="bottom"
                 flexGrow={1}
                 scrollAcceleration={scrollAcceleration()}
+                onMouseScroll={updateAwayFromBottom}
               >
                 <box height={1} />
                 <For each={messages()}>
@@ -1282,6 +1338,18 @@ export function Session() {
                 </For>
               </scrollbox>
               <box flexShrink={0}>
+                <Show when={Flag.OPENCODE_EXPERIMENTAL_TAB_SCROLL && awayFromBottom()}>
+                  <box
+                    height={1}
+                    flexDirection="row"
+                    justifyContent={jumpBottomPosition() === "center" ? "center" : "flex-end"}
+                    paddingRight={jumpBottomPosition() === "right" ? 1 : 0}
+                  >
+                    <text fg={theme.textMuted} onMouseUp={toBottom}>
+                      ↓ Bottom
+                    </text>
+                  </box>
+                </Show>
                 <Show when={permissions().length > 0}>
                   <PermissionPrompt
                     request={permissions()[0]}

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -6,7 +6,6 @@ import {
   createSignal,
   For,
   Match,
-  on,
   onCleanup,
   onMount,
   Show,
@@ -275,6 +274,7 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
   const editor = useEditorContext()
+  const local = useLocal()
 
   createEffect(() => {
     const sessionID = route.sessionID
@@ -304,7 +304,10 @@ export function Session() {
       }
       editor.reconnect(result.data.directory)
       await sync.session.sync(sessionID)
-      if (route.sessionID === sessionID && scroll) scroll.scrollBy(100_000)
+      setTimeout(() => {
+        if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+        scroll.scrollTo(local.session.scrollPosition(sessionID) ?? scroll.scrollHeight)
+      }, 50)
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
       toast.show({
@@ -335,6 +338,10 @@ export function Session() {
 
   let seeded = false
   let scroll: ScrollBoxRenderable
+  onCleanup(() => {
+    if (!scroll || scroll.isDestroyed) return
+    local.session.setScrollPosition(route.sessionID, scroll.scrollTop)
+  })
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
     prompt = r
@@ -419,8 +426,6 @@ export function Session() {
       scroll.scrollTo(scroll.scrollHeight)
     }, 50)
   }
-
-  const local = useLocal()
 
   function enterChild(sessionID: string) {
     navigate({
@@ -1138,9 +1143,6 @@ export function Session() {
       diffFiles: revertDiffFiles(),
     }
   })
-
-  // snap to bottom when session changes
-  createEffect(on(() => route.sessionID, toBottom))
 
   return (
     <LocationProvider location={location()}>


### PR DESCRIPTION
## What

Add an opt-in TUI experiment for preserving reading position across visible quick-slot tabs and returning to the latest transcript content.

Run it with:

```sh
OPENCODE_EXPERIMENTAL_TAB_SCROLL=1 bun dev
```

When a visible tab is scrolled away from the bottom, switching away remembers its offset. Returning restores that reading position and shows a clickable `↓ Bottom` affordance above the composer.

Use `/jump-bottom-position` to compare centered and right-aligned placement. Centered is the default.

## Before / After

**Before:** Switching away from a session unmounted its view. Returning always snapped the transcript to the bottom, even when the user had been reading earlier messages. There was no visible way to return to the latest content after scrolling upward.

**After:** Only sessions in the nine visible quick slots retain an in-memory offset, and only while they are away from the bottom. Returning to one restores its position. Clicking `↓ Bottom`, scrolling back to the bottom, unpinning the tab, or leaving the visible slots clears the saved offset.

## How

- `packages/core/src/flag/flag.ts` adds the `OPENCODE_EXPERIMENTAL_TAB_SCROLL` experiment flag.
- `packages/tui/src/context/local.tsx` keeps transient offsets scoped to visible quick slots and clears them when a tab leaves that set.
- `packages/tui/src/routes/session/index.tsx` tracks whether the viewport is away from the bottom, restores eligible offsets after sync, and renders the jump control above the composer.
- `/jump-bottom-position` toggles the affordance between centered and right-aligned layouts for evaluation.

## Scope

- Disabled by default.
- Scroll positions last only for the current TUI process.
- Sessions outside the nine visible quick slots do not retain positions.
- This does not change transcript content or server-side session state.

## Testing

- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 191 passed, 1 skipped
- Push hook `bun turbo typecheck`: 29 packages passed

## States

**1. At the latest content**

No affordance appears and no offset is retained.

```text
Latest transcript content

┃ Prompt
```

**2. Reading history**

The current quick-slot tab retains its offset and offers a return path.

```text
Earlier transcript content

                 ↓ Bottom
┃ Prompt
```

**3. Comparing placement**

Run `/jump-bottom-position` to move the same control to the right edge.

```text
Earlier transcript content

                                      ↓ Bottom
┃ Prompt
```

## Flow

```mermaid
flowchart TD
  A[Visible quick-slot tab] --> B{At bottom?}
  B -->|Yes| C[Clear saved offset and hide control]
  B -->|No| D[Save offset when leaving and show Bottom]
  D --> E[Switch back to tab]
  E --> F[Restore saved offset]
  D -->|Click Bottom| C
  D -->|Tab leaves visible slots| C
```
