### PR TITLE
fix(tui): restore composer shell kill shortcut

### DIFF
--- a/packages/tui/src/routes/session/composer/shell-tab.tsx
+++ b/packages/tui/src/routes/session/composer/shell-tab.tsx
@@ -23,6 +23,19 @@ export function ShellTab(props: { sessionID: string }) {
 
   const selectedEntry = createMemo(() => entries()[store.selected])
 
+  const keymap = Keymap.use()
+  createEffect(() => {
+    if (!composer.active("shell")) return
+    const cleanup = keymap.intercept("key", ({ event, consume }) => {
+      if (event.name !== "d" || !event.ctrl) return
+      if (!shortcuts.list("composer.shell.kill").includes("ctrl+d")) return
+      if (!selectedEntry()) return
+      consume()
+      keymap.dispatch("composer.shell.kill")
+    })
+    onCleanup(cleanup)
+  })
+
   createEffect(() => {
     if (store.selected >= entries().length) setStore("selected", Math.max(0, entries().length - 1))
   })

--- a/packages/tui/test/cli/tui/composer-keymap.test.tsx
+++ b/packages/tui/test/cli/tui/composer-keymap.test.tsx
@@ -23,7 +23,11 @@ const sessions = {
 
 const shells = [shell("sh-a", "bun test"), shell("sh-b", "bun dev")]
 
-async function renderComposer(defaultTab: "subagents" | "shell", keybinds: Partial<TuiKeybind.Keybinds>) {
+async function renderComposer(
+  defaultTab: "subagents" | "shell",
+  keybinds: Partial<TuiKeybind.Keybinds>,
+  focusedTextarea = false,
+) {
   const events = createEventStream()
   const interrupted: string[] = []
   const removed: string[] = []
@@ -69,7 +73,21 @@ async function renderComposer(defaultTab: "subagents" | "shell", keybinds: Parti
         .then(() => wait(() => data.session.status("child-a") === "running"))
         .then(() => ready.resolve(), ready.reject)
     })
-    return <Composer sessionID="parent" open={true} defaultTab={defaultTab} onClose={() => closed++} />
+    return (
+      <>
+        {focusedTextarea && <textarea focused={true} initialValue="draft" />}
+        <Composer sessionID="parent" open={true} defaultTab={defaultTab} onClose={() => closed++} />
+      </>
+    )
+  }
+
+  function AppExit() {
+    Keymap.createLayer(() => ({
+      mode: "global",
+      commands: [{ id: "app.exit", title: "Exit", group: "System", run: () => {} }],
+    }))
+    Keymap.createLayer(() => ({ bindings: ["app.exit"] }))
+    return null
   }
 
   const app = await testRender(
@@ -77,6 +95,7 @@ async function renderComposer(defaultTab: "subagents" | "shell", keybinds: Parti
       <TestTuiContexts directory={directory}>
         <ConfigProvider config={createTuiResolvedConfig({ keybinds })}>
           <Keymap.Provider>
+            <AppExit />
             <ClientProvider api={createApi(calls.fetch)}>
               <DataProvider>
                 <LocationProvider>
@@ -147,6 +166,18 @@ test("disabled shell bindings have no component fallbacks", async () => {
 
     composer.app.mockInput.pressArrow("down")
     composer.dispatch("composer.shell.kill")
+    await wait(() => composer.removed.length === 1)
+    expect(composer.removed).toEqual(["sh-a"])
+  } finally {
+    composer.app.renderer.destroy()
+  }
+})
+
+test("shell kill binding overrides app exit", async () => {
+  const composer = await renderComposer("shell", {}, true)
+  try {
+    expect(composer.app.captureCharFrame()).toContain("bun test")
+    composer.app.mockInput.pressKey("d", { ctrl: true })
     await wait(() => composer.removed.length === 1)
     expect(composer.removed).toEqual(["sh-a"])
   } finally {


### PR DESCRIPTION
## What

Restore `Ctrl+D` shell termination from the TUI composer Shell tab when a global binding also recognizes the key.

## Before / After

**Before:** The Shell tab rendered `kill ctrl+d`, but the key could be consumed before `composer.shell.kill`, so no `DELETE /api/shell/:id` request was sent and the background process continued running.

**After:** While the Shell tab is active, its configured `Ctrl+D` binding gets first refusal and dispatches the existing `composer.shell.kill` command. The server removes the shell and terminates its process group.

## How

- `packages/tui/src/routes/session/composer/shell-tab.tsx` intercepts the configured `Ctrl+D` shell-kill shortcut while the Shell tab is active, then dispatches the existing command.
- `packages/tui/test/cli/tui/composer-keymap.test.tsx` covers a focused textarea plus the global `app.exit` collision and verifies the shell DELETE request.

## Scope

This does not change composer focus, the shell API, or process lifecycle. The existing `shell.remove` path already terminates the detached process group; the bug was that the TUI never invoked it.

## Testing

- `bun run test test/cli/tui/composer-keymap.test.tsx` from `packages/tui`: 3 passed
- `bun typecheck` from `packages/tui`: passed
- Push hook repository typecheck: 34 packages passed
- `bun run test test/tool-shell.test.ts` from `packages/core`: 20 passed
- Live PTY verification with `termctrl` against the elected OpenCode service: opened the Shell tab, pressed `Ctrl+D`, observed the shell disappear, and confirmed the shell API no longer returned its ID

## Flow

```mermaid
sequenceDiagram
    participant User
    participant ShellTab
    participant Server
    participant Process

    User->>ShellTab: Press Ctrl+D
    ShellTab->>ShellTab: Dispatch composer.shell.kill
    ShellTab->>Server: DELETE /api/shell/:id
    Server->>Process: Terminate process group
    Server-->>ShellTab: shell.deleted
```
