### PR TITLE
feat(app): show tokens-per-second in context usage indicator

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -133,36 +133,45 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
         name={language.t("context.usage.tokens")}
         value={context()?.total.toLocaleString(language.intl()) ?? "0"}
       />
+      <ContextTooltipRow
+        name="TPS"
+        value={context()?.tps !== undefined ? `${context()?.tps} t/s` : "–"}
+      />
     </div>
   )
 
   return (
     <Show when={params.id}>
       <TooltipV2 value={tooltipValue()} placement={props.placement ?? "top"} shift={-8}>
-        <Switch>
-          <Match when={variant() === "indicator"}>{circle()}</Match>
-          <Match when={buttonAppearance() === "v2"}>
-            <IconButtonV2
-              type="button"
-              variant="ghost-muted"
-              size="large"
-              icon={circleV2()}
-              onClick={openContext}
-              aria-label={language.t("context.usage.view")}
-            />
-          </Match>
-          <Match when={true}>
-            <Button
-              type="button"
-              variant="ghost"
-              class="size-6"
-              onClick={openContext}
-              aria-label={language.t("context.usage.view")}
-            >
-              {circle()}
-            </Button>
-          </Match>
-        </Switch>
+        <div class="flex min-w-0 items-center gap-1">
+          <Switch>
+            <Match when={variant() === "indicator"}>{circle()}</Match>
+            <Match when={buttonAppearance() === "v2"}>
+              <IconButtonV2
+                type="button"
+                variant="ghost-muted"
+                size="large"
+                icon={circleV2()}
+                onClick={openContext}
+                aria-label={language.t("context.usage.view")}
+              />
+            </Match>
+            <Match when={true}>
+              <Button
+                type="button"
+                variant="ghost"
+                class="size-6"
+                onClick={openContext}
+                aria-label={language.t("context.usage.view")}
+              >
+                {circle()}
+              </Button>
+            </Match>
+          </Switch>
+          <span class="shrink-0 text-[10px] leading-none tabular-nums text-v2-text-text-muted">
+            {context()?.tps !== undefined ? `${context()?.tps}` : ""}
+          </span>
+        </div>
       </TooltipV2>
     </Show>
   )

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -96,4 +96,29 @@ describe("getSessionContext", () => {
 
     expect(ctx).toBeUndefined()
   })
+
+  test("computes tps from output tokens and turn duration", () => {
+    const messages = [
+      assistant("a1", { input: 100, output: 120, reasoning: 0, read: 0, write: 0 }, 0.1),
+    ] as unknown as Message[]
+    messages[0].time = { created: 1_000, completed: 4_000 }
+    const ctx = getSessionContext(messages, [])
+
+    expect(ctx?.tps).toBe(40)
+  })
+
+  test("leaves tps undefined without completed time or output tokens", () => {
+    const noCompleted = getSessionContext(
+      [assistant("a1", { input: 100, output: 120, reasoning: 0, read: 0, write: 0 }, 0.1)] as unknown as Message[],
+      [],
+    )
+    expect(noCompleted?.tps).toBeUndefined()
+
+    const zeroOutput = [
+      assistant("a2", { input: 100, output: 0, reasoning: 0, read: 0, write: 0 }, 0.1),
+    ] as unknown as Message[]
+    zeroOutput[0].time = { created: 1_000, completed: 4_000 }
+    const ctx = getSessionContext(zeroOutput, [])
+    expect(ctx?.tps).toBeUndefined()
+  })
 })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -23,6 +23,7 @@ type Context = {
   input: number
   total: number
   usage: number | null
+  tps: number | undefined
 }
 
 const tokenTotal = (msg: AssistantMessage) => {
@@ -47,6 +48,13 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
   const limit = model?.limit.context
   const total = tokenTotal(message)
 
+  const elapsedMs =
+    message.time.completed !== undefined ? message.time.completed - message.time.created : undefined
+  const tps =
+    elapsedMs !== undefined && elapsedMs > 0 && message.tokens.output > 0
+      ? Math.round((message.tokens.output / elapsedMs) * 1000)
+      : undefined
+
   return {
     message,
     provider,
@@ -57,6 +65,7 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
     input: message.tokens.input,
     total,
     usage: limit ? Math.round((total / limit) * 100) : null,
+    tps,
   }
 }
 


### PR DESCRIPTION
### Issue for this PR

No issue filed; small UX addition to the existing context usage indicator.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The context usage indicator (progress circle shown in the session header and message timeline) already shows cost, context usage % and total tokens on hover. This PR adds a tokens-per-second metric:

- \getSessionContext\ now also computes \	ps\ for the last assistant message: output tokens divided by turn duration (\	ime.completed - time.created\). It stays \undefined\ when the turn has no completion time or no output tokens, and the UI renders \–\ in that case.
- The hover tooltip gains a \TPS\ row next to the existing cost / usage / tokens rows.
- A small TPS number is rendered beside the circle.

I chose message-level timing (the whole assistant turn) over text-part timing because the component only has message data; this keeps the metric consistent with the other per-message rows and needs no extra data fetching.

### How did you verify your code works?

- Added 2 unit tests for \getSessionContext\ (6 pass total), covering the TPS math and the undefined fallbacks.
- Built the desktop app locally (v1.18.5) and smoke-tested: server sidecar boots and the renderer loads with the change.

### Screenshots / recordings

None — no screenshot tooling on my machine. Verified by unit tests and a local desktop build.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR