### PR TITLE
feat(tui): prototype tab scroll memory

### DIFF
--- a/packages/tui/src/component/dialog-experiments.tsx
+++ b/packages/tui/src/component/dialog-experiments.tsx
@@ -13,7 +13,13 @@ type Experiment = {
 // In-flight features anyone can opt into. Each entry is temporary: an
 // experiment either graduates (delete the entry, make the behavior
 // unconditional) or dies (delete the entry and the branch it gated).
-export const experiments: Experiment[] = []
+export const experiments: Experiment[] = [
+  {
+    id: "tab_scroll",
+    title: "Remember tab scroll",
+    description: "Keep each open tab's reading position and show a shortcut back to the bottom.",
+  },
+]
 
 export function DialogExperiments() {
   const config = useConfig()

--- a/packages/tui/src/component/dialog-experiments.tsx
+++ b/packages/tui/src/component/dialog-experiments.tsx
@@ -33,7 +33,6 @@ export function DialogExperiments() {
   const options = createMemo(() =>
     experiments.map((experiment) => ({
       title: experiment.title,
-      category: "Experiments",
       searchText: experiment.description,
       footer: enabled(experiment) ? "on" : "off",
       value: experiment,

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -66,6 +66,12 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     let history: SessionTabHistory = { entries: [], index: -1 }
     // User-closed tabs eligible for reopening; in-memory like history, deleted sessions pruned.
     let closedTabs: ClosedSessionTab[] = []
+    const scrollPositions = new Map<string, number>()
+
+    createEffect(() => {
+      if (config.experimental?.tab_scroll === true) return
+      scrollPositions.clear()
+    })
 
     function state() {
       if (config.tabs.scope === "cwd") return store.cwd[paths.cwd] ?? fallback
@@ -231,6 +237,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
 
     function remove(sessionID: string, navigate: boolean) {
       const target = root(sessionID)
+      scrollPositions.delete(target)
       const closed = closeSessionTab(state().tabs, target)
       const selected = navigate && current() === target
       if (closed.tabs === state().tabs && !selected) return
@@ -262,6 +269,19 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       },
       current,
       status,
+      scrollPosition(sessionID: string) {
+        const target = root(sessionID)
+        if (!state().tabs.some((tab) => tab.sessionID === target)) return
+        return scrollPositions.get(target)
+      },
+      setScrollPosition(sessionID: string, position: number | undefined) {
+        const target = root(sessionID)
+        if (position === undefined || !state().tabs.some((tab) => tab.sessionID === target)) {
+          scrollPositions.delete(target)
+          return
+        }
+        scrollPositions.set(target, position)
+      },
       select(sessionID: string) {
         if (!enabled()) return
         route.navigate({ type: "session", sessionID: root(sessionID) })

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1124,9 +1124,9 @@ export function Session() {
                 {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
               </Show>
             </scrollbox>
-            <box flexShrink={0}>
+            <box flexShrink={0} position="relative">
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <box height={1} flexDirection="row" justifyContent="flex-end">
+                <box position="absolute" top={-1} right={0} height={1} zIndex={1}>
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>
                     Latest ↓
                   </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1082,7 +1082,6 @@ export function Session() {
           paddingBottom={1}
           paddingLeft={dimensions().width < 44 ? 1 : 2}
           paddingRight={dimensions().width < 44 ? 1 : 2}
-          gap={1}
         >
           <Show when={session()}>
             <box flexGrow={1} minHeight={0} position="relative">
@@ -1125,21 +1124,12 @@ export function Session() {
                   {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
                 </Show>
               </scrollbox>
+            </box>
+            <box height={1} flexShrink={0} flexDirection="row" justifyContent="flex-end">
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <box
-                  position="absolute"
-                  bottom={0}
-                  left={0}
-                  width="100%"
-                  height={1}
-                  zIndex={2000}
-                  flexDirection="row"
-                  justifyContent="flex-end"
-                >
-                  <text fg={theme.text.subdued} onMouseUp={toBottom}>
-                    Latest ↓
-                  </text>
-                </box>
+                <text fg={theme.text.subdued} onMouseUp={toBottom}>
+                  Latest ↓
+                </text>
               </Show>
             </box>
             <box flexShrink={0}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1128,7 +1128,7 @@ export function Session() {
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
                 <box height={1} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>
-                    ↓ Bottom
+                    ↓ Latest
                   </text>
                 </box>
               </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1126,7 +1126,16 @@ export function Session() {
                 </Show>
               </scrollbox>
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <box position="absolute" bottom={0} right={0} height={1} zIndex={1}>
+                <box
+                  position="absolute"
+                  bottom={0}
+                  left={0}
+                  right={0}
+                  height={1}
+                  zIndex={1}
+                  flexDirection="row"
+                  justifyContent="flex-end"
+                >
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>
                     Latest ↓
                   </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -274,6 +274,7 @@ export function Session() {
   const [navigationSlack, setNavigationSlack] = createSignal(0)
   const [synced, setSynced] = createSignal(false)
   const sessionTabs = useSessionTabs()
+  const [awayFromBottom, setAwayFromBottom] = createSignal(false)
 
   const clearMessageNavigation = () => {
     setNavigationSlack(0)
@@ -319,7 +320,7 @@ export function Session() {
         return
       }
       editor.reconnect(info.location.directory)
-      if (route.sessionID === sessionID && scroll) scroll.scrollBy(100_000)
+      if (route.sessionID === sessionID && scroll) restoreScrollPosition(sessionID)
       setSynced(true)
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
@@ -335,6 +336,13 @@ export function Session() {
   let seeded = false
   let sent = false
   let scroll: ScrollBoxRenderable
+  onCleanup(() => {
+    if (!scroll || scroll.isDestroyed) return
+    sessionTabs.setScrollPosition(
+      route.sessionID,
+      config.experimental?.tab_scroll === true && isAwayFromBottom() ? scroll.scrollTop : undefined,
+    )
+  })
   const [prompt, setPrompt] = createSignal<PromptRef>()
   const bind = (r: PromptRef | undefined) => {
     setPrompt(r)
@@ -385,6 +393,31 @@ export function Session() {
     if (hidden() === 0) return continuation()
     setHiddenRows(0)
     afterLayout(continuation)
+  }
+
+  function isAwayFromBottom() {
+    return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height) - 1
+  }
+  function updateAwayFromBottom() {
+    if (config.experimental?.tab_scroll !== true) return
+    setTimeout(() => {
+      if (!scroll || scroll.isDestroyed) return
+      const away = isAwayFromBottom()
+      setAwayFromBottom(away)
+      if (!away) sessionTabs.setScrollPosition(route.sessionID, undefined)
+    })
+  }
+  function restoreScrollPosition(sessionID: string) {
+    const position = config.experimental?.tab_scroll === true ? sessionTabs.scrollPosition(sessionID) : undefined
+    if (position === undefined) {
+      scroll.scrollTo(scroll.scrollHeight)
+      setAwayFromBottom(false)
+      return
+    }
+    ensureAllRows(() => {
+      scroll.scrollTo(position)
+      updateAwayFromBottom()
+    })
   }
 
   createEffect(() => {
@@ -495,6 +528,8 @@ export function Session() {
 
   function toBottom() {
     clearMessageNavigation()
+    setAwayFromBottom(false)
+    sessionTabs.setScrollPosition(route.sessionID, undefined)
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)
@@ -510,6 +545,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-scroll.height / 2)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -521,6 +557,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(scroll.height / 2)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -532,6 +569,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-1)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -543,6 +581,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(1)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -554,6 +593,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(-scroll.height / 4)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -565,6 +605,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollBy(scroll.height / 4)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -579,6 +620,7 @@ export function Session() {
       run: () => {
         clearMessageNavigation()
         scroll.scrollTo(0)
+        updateAwayFromBottom()
         dialog.clear()
       },
     },
@@ -588,8 +630,7 @@ export function Session() {
       group: "Session",
       palette: undefined,
       run: () => {
-        clearMessageNavigation()
-        scroll.scrollTo(scroll.scrollHeight)
+        toBottom()
         dialog.clear()
       },
     },
@@ -1006,8 +1047,6 @@ export function Session() {
     bindings: [...baseAndUnfocusedCommands, ...baseCommands()].map((command) => command.id),
   }))
 
-  // snap to bottom when session changes
-  createEffect(on(() => route.sessionID, toBottom))
   createEffect(
     on(
       () => route.sessionID,
@@ -1063,6 +1102,7 @@ export function Session() {
               stickyStart="bottom"
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}
+              onMouseScroll={updateAwayFromBottom}
             >
               <For each={visibleRows()}>
                 {(row, index) => (
@@ -1085,6 +1125,13 @@ export function Session() {
               </Show>
             </scrollbox>
             <box flexShrink={0}>
+              <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
+                <box height={1} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
+                  <text fg={theme.text.subdued} onMouseUp={toBottom}>
+                    ↓ Bottom
+                  </text>
+                </box>
+              </Show>
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                 <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1085,53 +1085,55 @@ export function Session() {
           gap={1}
         >
           <Show when={session()}>
-            <scrollbox
-              ref={(r) => (scroll = r)}
-              viewportOptions={{
-                paddingRight: showScrollbar() ? 1 : 0,
-              }}
-              verticalScrollbarOptions={{
-                paddingLeft: 1,
-                visible: showScrollbar(),
-                trackOptions: {
-                  backgroundColor: theme.raise(theme.background.surface.offset),
-                  foregroundColor: theme.border.default,
-                },
-              }}
-              stickyScroll={!navigationMessage()}
-              stickyStart="bottom"
-              flexGrow={1}
-              scrollAcceleration={scrollAcceleration()}
-              onMouseScroll={updateAwayFromBottom}
-            >
-              <For each={visibleRows()}>
-                {(row, index) => (
-                  <SessionRowView
-                    row={row}
-                    message={(messageID) => data.session.message.get(route.sessionID, messageID)}
-                    boundaryID={boundaries()[index() + hidden()]}
+            <box flexGrow={1} minHeight={0} position="relative">
+              <scrollbox
+                ref={(r) => (scroll = r)}
+                viewportOptions={{
+                  paddingRight: showScrollbar() ? 1 : 0,
+                }}
+                verticalScrollbarOptions={{
+                  paddingLeft: 1,
+                  visible: showScrollbar(),
+                  trackOptions: {
+                    backgroundColor: theme.raise(theme.background.surface.offset),
+                    foregroundColor: theme.border.default,
+                  },
+                }}
+                stickyScroll={!navigationMessage()}
+                stickyStart="bottom"
+                flexGrow={1}
+                scrollAcceleration={scrollAcceleration()}
+                onMouseScroll={updateAwayFromBottom}
+              >
+                <For each={visibleRows()}>
+                  {(row, index) => (
+                    <SessionRowView
+                      row={row}
+                      message={(messageID) => data.session.message.get(route.sessionID, messageID)}
+                      boundaryID={boundaries()[index() + hidden()]}
+                    />
+                  )}
+                </For>
+                <BackgroundToolHint messages={messages()} />
+                <Show when={session()?.revert?.messageID}>
+                  <RevertMessage
+                    count={messagesFromRevert().filter((message) => message.type === "user").length}
+                    files={session()!.revert!.files ?? []}
                   />
-                )}
-              </For>
-              <BackgroundToolHint messages={messages()} />
-              <Show when={session()?.revert?.messageID}>
-                <RevertMessage
-                  count={messagesFromRevert().filter((message) => message.type === "user").length}
-                  files={session()!.revert!.files ?? []}
-                />
-              </Show>
-              <Show when={navigationSlack()}>
-                {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
-              </Show>
-            </scrollbox>
-            <box flexShrink={0} position="relative" overflow="visible">
+                </Show>
+                <Show when={navigationSlack()}>
+                  {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
+                </Show>
+              </scrollbox>
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <box position="absolute" top={-1} right={0} height={1} zIndex={1}>
+                <box position="absolute" bottom={0} right={0} height={1} zIndex={1}>
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>
                     Latest ↓
                   </text>
                 </box>
               </Show>
+            </box>
+            <box flexShrink={0}>
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
                 <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1130,9 +1130,9 @@ export function Session() {
                   position="absolute"
                   bottom={0}
                   left={0}
-                  right={0}
+                  width="100%"
                   height={1}
-                  zIndex={1}
+                  zIndex={2000}
                   flexDirection="row"
                   justifyContent="flex-end"
                 >

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1126,9 +1126,9 @@ export function Session() {
             </scrollbox>
             <box flexShrink={0}>
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <box height={1} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
+                <box height={1} flexDirection="row" justifyContent="flex-end">
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>
-                    ↓ Latest
+                    Latest ↓
                   </text>
                 </box>
               </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1124,7 +1124,7 @@ export function Session() {
                 {(height) => <box id={NAVIGATION_SLACK_ID} height={height()} flexShrink={0} />}
               </Show>
             </scrollbox>
-            <box flexShrink={0} position="relative">
+            <box flexShrink={0} position="relative" overflow="visible">
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
                 <box position="absolute" top={-1} right={0} height={1} zIndex={1}>
                   <text fg={theme.text.subdued} onMouseUp={toBottom}>


### PR DESCRIPTION
## What

Add an opt-in V2 TUI experiment that remembers the reading position of each open session tab and provides a direct return to the latest transcript content.

Enable **Remember tab scroll** from the DevTools **Experiments** dialog.

## Before / After

**Before:** Switching away from a session tab unmounted its transcript. Returning always snapped to the bottom, even when reading earlier output. Scrolling upward also had no visible return action.

**After:** A tab away from the bottom retains its in-memory scroll offset. Returning restores that position and shows `Latest ↓` flush with the composer's right edge. The action uses the existing fixed spacer above the composer, so appearing or disappearing does not move the transcript or composer. Tabs at the bottom retain no offset.

## How

- `packages/tui/src/component/dialog-experiments.tsx` registers **Remember tab scroll** in V2's config-native Experiments dialog and removes the redundant list category heading.
- `packages/tui/src/context/session-tabs.tsx` owns transient positions for open tabs, clearing them when tabs close or the experiment is disabled.
- `packages/tui/src/routes/session/index.tsx` captures positions on unmount, restores them after transcript layout, and renders the jump control only while away from the bottom.
- The transcript/composer gap is a permanent one-row spacer; `Latest ↓` paints into that row without changing layout geometry.
- Restoring a position mounts the full transcript first; first visits and bottom-position tabs retain the existing tail-first fast path.

## Scope

- V2 only, based on `v2`.
- Disabled by default.
- Positions last only for the current TUI process.
- Only open tabs retain positions.
- No server-side or durable session state changes.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test --runInBand` in `packages/tui`: 689 passed, 5 skipped
- Push hook `bun turbo typecheck --concurrency=3`: 34 packages passed

## Flow

```mermaid
flowchart TD
  A[Open session tab] --> B{At bottom?}
  B -->|Yes| C[Clear offset and hide action]
  B -->|No| D[Keep offset and show Latest]
  D --> E[Switch tabs]
  E --> F[Restore offset after transcript layout]
  D -->|Click Latest| C
  D -->|Close tab| C
  D -->|Disable experiment| C
```
