### PR TITLE
fix(core): render granular instruction updates

### DIFF
--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -2,6 +2,7 @@ export * as InstructionDiscovery from "./instruction-discovery.js"
 
 import { Context, Effect, Layer, Schema, Types } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { createPatch } from "diff"
 import { Bus } from "./bus.js"
 import { Instructions } from "./instructions/index.js"
 import { AbsolutePath } from "./schema.js"
@@ -81,8 +82,7 @@ export const layer = (options?: Options) =>
           read: Effect.succeed(value),
           render: {
             initial: render,
-            changed: (_previous, current) =>
-              `These instructions replace all previously loaded ambient instructions.\n\n${render(current)}`,
+            changed: renderUpdate,
             removed: () => "Previously loaded instructions no longer apply.",
           },
         })
@@ -119,4 +119,29 @@ export const node = configured()
 
 function render(files: ReadonlyArray<File>) {
   return files.map((file) => `Instructions from: ${file.path}\n${file.content}`).join("\n\n")
+}
+
+function renderUpdate(previous: ReadonlyArray<File>, current: ReadonlyArray<File>) {
+  const changes = Instructions.diffByKey(
+    previous,
+    current,
+    (file) => file.path,
+    (before, after) => before.content !== after.content,
+  )
+  const order = current.map((file) => file.path)
+  const reordered = previous.length !== current.length || previous.some((file, index) => file.path !== order[index])
+  return [
+    ...changes.removed.map((file) => `The ambient instruction file at ${file.path} no longer applies.`),
+    ...changes.added.map((file) => `A new ambient instruction file now applies:\n${render([file])}`),
+    ...(reordered ? [`Ambient instruction files now apply in this order:\n${order.join("\n")}`] : []),
+    ...changes.changed.map(({ previous: before, current: after }) => {
+      const patch = createPatch(after.path, before.content, after.content, "", "", { context: 3 })
+      return [
+        `The ambient instructions in ${after.path} changed. Apply this patch to the previously loaded version:`,
+        "```diff",
+        patch.slice(patch.indexOf("@@")).trimEnd(),
+        "```",
+      ].join("\n")
+    }),
+  ].join("\n\n")
 }

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -134,7 +134,7 @@ function renderUpdate(previous: ReadonlyArray<File>, current: ReadonlyArray<File
     ...changes.changed.map(({ previous: before, current: after }) => {
       const patch = createPatch(after.path, before.content, after.content, "", "", { context: 3 })
       return [
-        `The instructions from ${after.path} changed. Apply this patch to the previously loaded version:`,
+        `The instructions from ${after.path} changed. Here's the diff:`,
         "```diff",
         patch.slice(patch.indexOf("@@")).trimEnd(),
         "```",

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -133,12 +133,14 @@ function renderUpdate(previous: ReadonlyArray<File>, current: ReadonlyArray<File
     ...changes.added.map((file) => `New instructions apply from:\n${render([file])}`),
     ...changes.changed.map(({ previous: before, current: after }) => {
       const patch = createPatch(after.path, before.content, after.content, "", "", { context: 3 })
-      return [
+      const diff = [
         `The instructions from ${after.path} changed. Here's the diff:`,
         "```diff",
         patch.slice(patch.indexOf("@@")).trimEnd(),
         "```",
       ].join("\n")
+      const replacement = `The instructions changed:\n${render([after])}`
+      return diff.length < replacement.length ? diff : replacement
     }),
   ].join("\n\n")
 }

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -128,16 +128,13 @@ function renderUpdate(previous: ReadonlyArray<File>, current: ReadonlyArray<File
     (file) => file.path,
     (before, after) => before.content !== after.content,
   )
-  const order = current.map((file) => file.path)
-  const reordered = previous.length !== current.length || previous.some((file, index) => file.path !== order[index])
   return [
-    ...changes.removed.map((file) => `The ambient instruction file at ${file.path} no longer applies.`),
-    ...changes.added.map((file) => `A new ambient instruction file now applies:\n${render([file])}`),
-    ...(reordered ? [`Ambient instruction files now apply in this order:\n${order.join("\n")}`] : []),
+    ...changes.removed.map((file) => `The instructions from ${file.path} no longer apply.`),
+    ...changes.added.map((file) => `New instructions apply from:\n${render([file])}`),
     ...changes.changed.map(({ previous: before, current: after }) => {
       const patch = createPatch(after.path, before.content, after.content, "", "", { context: 3 })
       return [
-        `The ambient instructions in ${after.path} changed. Apply this patch to the previously loaded version:`,
+        `The instructions from ${after.path} changed. Apply this patch to the previously loaded version:`,
         "```diff",
         patch.slice(patch.indexOf("@@")).trimEnd(),
         "```",

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -112,7 +112,7 @@ describe("InstructionDiscovery", () => {
     }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
   )
 
-  it.effect("renders granular updates for ambient instruction files", () =>
+  it.effect("renders granular instruction updates", () =>
     Effect.gen(function* () {
       const discovery = yield* InstructionDiscovery.Service
       yield* discovery.transform((draft) => {
@@ -127,7 +127,7 @@ describe("InstructionDiscovery", () => {
         })
       })
       const modified = (yield* readUpdate(yield* discovery.load(), initial)).text
-      expect(modified).toContain("The ambient instructions in /repo/AGENTS.md changed")
+      expect(modified).toContain("The instructions from /repo/AGENTS.md changed")
       expect(modified).toContain("-old\n+new")
       expect(modified).not.toContain("global")
 
@@ -136,13 +136,8 @@ describe("InstructionDiscovery", () => {
         draft.add(file("/repo/packages/AGENTS.md", "package"))
       })
       const structural = (yield* readUpdate(yield* discovery.load(), initial)).text
-      expect(structural).toContain("The ambient instruction file at /global/AGENTS.md no longer applies.")
-      expect(structural).toContain(
-        "A new ambient instruction file now applies:\nInstructions from: /repo/packages/AGENTS.md\npackage",
-      )
-      expect(structural).toContain(
-        "Ambient instruction files now apply in this order:\n/repo/AGENTS.md\n/repo/packages/AGENTS.md",
-      )
+      expect(structural).toContain("The instructions from /global/AGENTS.md no longer apply.")
+      expect(structural).toContain("New instructions apply from:\nInstructions from: /repo/packages/AGENTS.md\npackage")
       expect(structural).not.toContain("Instructions from: /global/AGENTS.md\nglobal")
     }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
   )
@@ -204,17 +199,14 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           yield* Effect.promise(() => fs.writeFile(packageFile, "changed"))
           yield* emitAndWait({ type: "update", path: packageFile })
           const changed = (yield* readUpdate(yield* discovery.load(), initialized)).text
-          expect(changed).toContain(`The ambient instructions in ${packageFile} changed`)
+          expect(changed).toContain(`The instructions from ${packageFile} changed`)
           expect(changed).toContain("-package\n\\ No newline at end of file\n+changed")
           expect(changed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 
           yield* Effect.promise(() => fs.rm(packageFile))
           yield* emitAndWait({ type: "delete", path: packageFile })
           const removed = (yield* readUpdate(yield* discovery.load(), initialized)).text
-          expect(removed).toContain(`The ambient instruction file at ${packageFile} no longer applies.`)
-          expect(removed).toContain(
-            `Ambient instruction files now apply in this order:\n${globalFile}\n${projectFile}\n${sharedFile}`,
-          )
+          expect(removed).toContain(`The instructions from ${packageFile} no longer apply.`)
           expect(removed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 
           yield* Effect.promise(() => fs.rm(globalFile))

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -117,13 +117,15 @@ describe("InstructionDiscovery", () => {
       const discovery = yield* InstructionDiscovery.Service
       yield* discovery.transform((draft) => {
         draft.add(file("/global/AGENTS.md", "global"))
-        draft.add(file("/repo/AGENTS.md", "old\nkeep"))
+        draft.add(
+          file("/repo/AGENTS.md", ["old", ...Array.from({ length: 20 }, (_, index) => `keep ${index}`)].join("\n")),
+        )
       })
       const initial = yield* readInitial(yield* discovery.load())
 
       yield* discovery.transform((draft) => {
         draft.update("/repo/AGENTS.md", (current) => {
-          current.content = "new\nkeep"
+          current.content = ["new", ...Array.from({ length: 20 }, (_, index) => `keep ${index}`)].join("\n")
         })
       })
       const modified = (yield* readUpdate(yield* discovery.load(), initial)).text
@@ -131,8 +133,20 @@ describe("InstructionDiscovery", () => {
       expect(modified).toContain("-old\n+new")
       expect(modified).not.toContain("global")
 
+      const rewritten = state({
+        "core/instructions": [{ path: "/repo/AGENTS.md", content: "old one\nold two\nold three\nold four" }],
+      })
       yield* discovery.transform((draft) => {
         draft.remove("/global/AGENTS.md")
+        draft.update("/repo/AGENTS.md", (current) => {
+          current.content = "new"
+        })
+      })
+      expect((yield* readUpdate(yield* discovery.load(), rewritten)).text).toBe(
+        "The instructions changed:\nInstructions from: /repo/AGENTS.md\nnew",
+      )
+
+      yield* discovery.transform((draft) => {
         draft.add(file("/repo/packages/AGENTS.md", "package"))
       })
       const structural = (yield* readUpdate(yield* discovery.load(), initial)).text
@@ -199,8 +213,7 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           yield* Effect.promise(() => fs.writeFile(packageFile, "changed"))
           yield* emitAndWait({ type: "update", path: packageFile })
           const changed = (yield* readUpdate(yield* discovery.load(), initialized)).text
-          expect(changed).toContain(`The instructions from ${packageFile} changed. Here's the diff:`)
-          expect(changed).toContain("-package\n\\ No newline at end of file\n+changed")
+          expect(changed).toContain(`The instructions changed:\nInstructions from: ${packageFile}\nchanged`)
           expect(changed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 
           yield* Effect.promise(() => fs.rm(packageFile))

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -111,6 +111,41 @@ describe("InstructionDiscovery", () => {
       ).toBe(false)
     }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
   )
+
+  it.effect("renders granular updates for ambient instruction files", () =>
+    Effect.gen(function* () {
+      const discovery = yield* InstructionDiscovery.Service
+      yield* discovery.transform((draft) => {
+        draft.add(file("/global/AGENTS.md", "global"))
+        draft.add(file("/repo/AGENTS.md", "old\nkeep"))
+      })
+      const initial = yield* readInitial(yield* discovery.load())
+
+      yield* discovery.transform((draft) => {
+        draft.update("/repo/AGENTS.md", (current) => {
+          current.content = "new\nkeep"
+        })
+      })
+      const modified = (yield* readUpdate(yield* discovery.load(), initial)).text
+      expect(modified).toContain("The ambient instructions in /repo/AGENTS.md changed")
+      expect(modified).toContain("-old\n+new")
+      expect(modified).not.toContain("global")
+
+      yield* discovery.transform((draft) => {
+        draft.remove("/global/AGENTS.md")
+        draft.add(file("/repo/packages/AGENTS.md", "package"))
+      })
+      const structural = (yield* readUpdate(yield* discovery.load(), initial)).text
+      expect(structural).toContain("The ambient instruction file at /global/AGENTS.md no longer applies.")
+      expect(structural).toContain(
+        "A new ambient instruction file now applies:\nInstructions from: /repo/packages/AGENTS.md\npackage",
+      )
+      expect(structural).toContain(
+        "Ambient instruction files now apply in this order:\n/repo/AGENTS.md\n/repo/packages/AGENTS.md",
+      )
+      expect(structural).not.toContain("Instructions from: /global/AGENTS.md\nglobal")
+    }).pipe(Effect.provide(AppNodeBuilder.build(LayerNode.group([InstructionDiscovery.node, Bus.node])))),
+  )
 })
 
 describe("ConfigInstructionPlugin.Plugin", () => {
@@ -168,20 +203,19 @@ describe("ConfigInstructionPlugin.Plugin", () => {
 
           yield* Effect.promise(() => fs.writeFile(packageFile, "changed"))
           yield* emitAndWait({ type: "update", path: packageFile })
-          expect((yield* readUpdate(yield* discovery.load(), initialized)).text).toContain(
-            `Instructions from: ${packageFile}\nchanged`,
-          )
+          const changed = (yield* readUpdate(yield* discovery.load(), initialized)).text
+          expect(changed).toContain(`The ambient instructions in ${packageFile} changed`)
+          expect(changed).toContain("-package\n\\ No newline at end of file\n+changed")
+          expect(changed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 
           yield* Effect.promise(() => fs.rm(packageFile))
           yield* emitAndWait({ type: "delete", path: packageFile })
-          expect((yield* readUpdate(yield* discovery.load(), initialized)).text).toBe(
-            [
-              "These instructions replace all previously loaded ambient instructions.",
-              `Instructions from: ${globalFile}\nglobal`,
-              `Instructions from: ${projectFile}\nproject`,
-              `Instructions from: ${sharedFile}\nshared`,
-            ].join("\n\n"),
+          const removed = (yield* readUpdate(yield* discovery.load(), initialized)).text
+          expect(removed).toContain(`The ambient instruction file at ${packageFile} no longer applies.`)
+          expect(removed).toContain(
+            `Ambient instruction files now apply in this order:\n${globalFile}\n${projectFile}\n${sharedFile}`,
           )
+          expect(removed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 
           yield* Effect.promise(() => fs.rm(globalFile))
           yield* emitAndWait({ type: "delete", path: globalFile })

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -127,7 +127,7 @@ describe("InstructionDiscovery", () => {
         })
       })
       const modified = (yield* readUpdate(yield* discovery.load(), initial)).text
-      expect(modified).toContain("The instructions from /repo/AGENTS.md changed")
+      expect(modified).toContain("The instructions from /repo/AGENTS.md changed. Here's the diff:")
       expect(modified).toContain("-old\n+new")
       expect(modified).not.toContain("global")
 
@@ -199,7 +199,7 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           yield* Effect.promise(() => fs.writeFile(packageFile, "changed"))
           yield* emitAndWait({ type: "update", path: packageFile })
           const changed = (yield* readUpdate(yield* discovery.load(), initialized)).text
-          expect(changed).toContain(`The instructions from ${packageFile} changed`)
+          expect(changed).toContain(`The instructions from ${packageFile} changed. Here's the diff:`)
           expect(changed).toContain("-package\n\\ No newline at end of file\n+changed")
           expect(changed).not.toContain(`Instructions from: ${globalFile}\nglobal`)
 


### PR DESCRIPTION
## What

Instruction changes now append only the affected file deltas instead of repeating every loaded `AGENTS.md` file in full.

For each modified file, OpenCode renders both a three-context unified diff and the complete new instructions, then uses whichever final message is shorter. Added and removed files use explicit messages.

## Before / After

**Before:** Editing one line in one instruction file appended a complete replacement containing every global and project instruction file. The session learned the correct new state, but paid the token cost of unrelated unchanged files.

**After:** Unchanged files are omitted. A localized edit usually appends a small diff, while a rewrite or tiny file appends the complete new instructions when that is shorter. Additions and removals remain explicit.

## How

- `packages/core/src/instruction-discovery.ts` compares the previous and current file arrays by path.
- Modified files use the existing `diff` dependency to produce unified patches with three lines of context.
- The renderer compares the complete diff and replacement messages and emits the shorter one.
- Added files include their complete contents; removed files name the source that no longer applies.
- `packages/core/test/instruction-discovery.test.ts` covers diff selection, replacement selection, and the real watcher-driven update/delete flow.

## Scope

This does not attempt to attribute file changes to the session that made them or suppress self-authored updates. Durable instruction state, chronological updates, and compaction behavior are unchanged.

## Testing

- `bun run test` in `packages/core`: 1,709 passed, 16 skipped
- `bun run test test/instruction-discovery.test.ts` in `packages/core`: 10 passed
- `bun typecheck` in `packages/core`
- Repository pre-push typecheck: 34 tasks passed
- `bunx prettier --check packages/core/src/instruction-discovery.ts packages/core/test/instruction-discovery.test.ts`
- `git diff --check`

## Flow

```mermaid
flowchart LR
  A[Read instruction files] --> B[Compare with admitted values]
  B --> C{Change type}
  C -->|Modified| D[Render diff and replacement]
  D --> E[Append shorter message]
  C -->|Added| F[Append new instructions]
  C -->|Removed| G[Append removal notice]
  E --> H[Durable chronological update]
  F --> H
  G --> H
```
