### PR TITLE
fix(tui): load transcript history on demand

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -534,84 +534,57 @@ export function Session() {
     }, 50)
   }
 
+  function moveTranscript(delta: number) {
+    clearMessageNavigation()
+    if (delta >= 0 || !revealOlderRows(delta)) {
+      scroll.scrollBy(delta)
+      updateAwayFromBottom()
+    }
+    dialog.clear()
+  }
+
   const globalCommands = [
     {
       id: "session.page.up",
       title: "Page up",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        if (!revealOlderRows(-scroll.height / 2)) {
-          scroll.scrollBy(-scroll.height / 2)
-          updateAwayFromBottom()
-        }
-        dialog.clear()
-      },
+      run: () => moveTranscript(-scroll.height / 2),
     },
     {
       id: "session.page.down",
       title: "Page down",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        scroll.scrollBy(scroll.height / 2)
-        updateAwayFromBottom()
-        dialog.clear()
-      },
+      run: () => moveTranscript(scroll.height / 2),
     },
     {
       id: "session.line.up",
       title: "Line up",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        if (!revealOlderRows(-1)) {
-          scroll.scrollBy(-1)
-          updateAwayFromBottom()
-        }
-        dialog.clear()
-      },
+      run: () => moveTranscript(-1),
     },
     {
       id: "session.line.down",
       title: "Line down",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        scroll.scrollBy(1)
-        updateAwayFromBottom()
-        dialog.clear()
-      },
+      run: () => moveTranscript(1),
     },
     {
       id: "session.half.page.up",
       title: "Half page up",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        if (!revealOlderRows(-scroll.height / 4)) {
-          scroll.scrollBy(-scroll.height / 4)
-          updateAwayFromBottom()
-        }
-        dialog.clear()
-      },
+      run: () => moveTranscript(-scroll.height / 4),
     },
     {
       id: "session.half.page.down",
       title: "Half page down",
       group: "Session",
       palette: undefined,
-      run: () => {
-        clearMessageNavigation()
-        scroll.scrollBy(scroll.height / 4)
-        updateAwayFromBottom()
-        dialog.clear()
-      },
+      run: () => moveTranscript(scroll.height / 4),
     },
   ]
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -115,12 +115,9 @@ addDefaultParsers(parsers.parsers)
 const NAVIGATION_SLACK_ID = "session-navigation-slack"
 const BACKGROUND_TOOL_HINT_DELAY = 1_000
 
-// Tail-first transcript mounting: rows mounted with the session, then backfill cadence.
-// The tail comfortably overfills a tall viewport; backfill drains a 200-message transcript
-// in a few hundred milliseconds without a perceptible pause.
+// The tail comfortably overfills a tall viewport; older rows mount as the reader approaches them.
 const TRANSCRIPT_TAIL_ROWS = 40
 const TRANSCRIPT_BACKFILL_CHUNK = 60
-const TRANSCRIPT_BACKFILL_DELAY = 120
 type PendingAction = "steer" | "queue" | "cancel"
 
 const context = createContext<{
@@ -362,32 +359,33 @@ export function Session() {
     })
   }
 
-  // Tail-first transcript mounting: only the newest rows mount when the session opens, and the
-  // rest backfill in chunks shortly after, so switching to a long session costs the visible tail
-  // instead of the whole transcript. Until backfill pins the count, the hidden span derives from
-  // the row count, so it needs no effect ordering; the clamp keeps at least a tail visible when a
-  // re-reduce shrinks the transcript. Streaming appends land at the end of the visible slice.
+  // Tail-first transcript mounting: only the newest rows mount when the session opens. Older rows
+  // mount on demand near the top, keeping inactive tabs cheap to tear down. Until the first chunk
+  // pins the count, the hidden span derives from the row count, so streaming appends remain visible.
   const [hiddenRows, setHiddenRows] = createSignal<number>()
   const hidden = createMemo(() => Math.max(0, Math.min(hiddenRows() ?? Infinity, rows.length - TRANSCRIPT_TAIL_ROWS)))
   const visibleRows = createMemo(() => (hidden() === 0 ? rows : rows.slice(hidden())))
-  createEffect(() => {
+  let revealingOlderRows = false
+  const revealOlderRows = (scrollBy = 0) => {
     const current = hidden()
-    if (current === 0) return
-    // Until the first chunk pins hiddenRows, appends change hidden() and reset this timer, so
-    // backfill waits for a pause in streaming before starting. Once pinned, it drains on a fixed
-    // cadence undisturbed by appends.
-    const timer = setTimeout(() => {
-      const before = scroll && !scroll.isDestroyed ? scroll.scrollHeight : undefined
-      const viewportBottom = before === undefined ? 0 : scroll.scrollTop + scroll.viewport.height
-      setHiddenRows(Math.max(0, current - TRANSCRIPT_BACKFILL_CHUNK))
-      if (before === undefined) return
-      // Sticky scroll holds bottom-anchored readers through the mount; compensation is only for
-      // readers who have scrolled up.
-      if (viewportBottom >= before - 1) return
-      afterLayout(() => scroll.scrollBy(scroll.scrollHeight - before))
-    }, TRANSCRIPT_BACKFILL_DELAY)
-    onCleanup(() => clearTimeout(timer))
-  })
+    if (
+      revealingOlderRows ||
+      current === 0 ||
+      !scroll ||
+      scroll.isDestroyed ||
+      scroll.scrollTop > scroll.viewport.height
+    )
+      return false
+    revealingOlderRows = true
+    const before = scroll.scrollHeight
+    setHiddenRows(Math.max(0, current - TRANSCRIPT_BACKFILL_CHUNK))
+    afterLayout(() => {
+      revealingOlderRows = false
+      scroll.scrollBy(scroll.scrollHeight - before + scrollBy)
+      updateAwayFromBottom()
+    })
+    return true
+  }
   /** Message navigation needs the full transcript mounted before walking or jumping. */
   const ensureAllRows = (continuation: () => void) => {
     if (hidden() === 0) return continuation()
@@ -544,8 +542,10 @@ export function Session() {
       palette: undefined,
       run: () => {
         clearMessageNavigation()
-        scroll.scrollBy(-scroll.height / 2)
-        updateAwayFromBottom()
+        if (!revealOlderRows(-scroll.height / 2)) {
+          scroll.scrollBy(-scroll.height / 2)
+          updateAwayFromBottom()
+        }
         dialog.clear()
       },
     },
@@ -568,8 +568,10 @@ export function Session() {
       palette: undefined,
       run: () => {
         clearMessageNavigation()
-        scroll.scrollBy(-1)
-        updateAwayFromBottom()
+        if (!revealOlderRows(-1)) {
+          scroll.scrollBy(-1)
+          updateAwayFromBottom()
+        }
         dialog.clear()
       },
     },
@@ -592,8 +594,10 @@ export function Session() {
       palette: undefined,
       run: () => {
         clearMessageNavigation()
-        scroll.scrollBy(-scroll.height / 4)
-        updateAwayFromBottom()
+        if (!revealOlderRows(-scroll.height / 4)) {
+          scroll.scrollBy(-scroll.height / 4)
+          updateAwayFromBottom()
+        }
         dialog.clear()
       },
     },
@@ -619,8 +623,10 @@ export function Session() {
       palette: undefined,
       run: () => {
         clearMessageNavigation()
-        scroll.scrollTo(0)
-        updateAwayFromBottom()
+        ensureAllRows(() => {
+          scroll.scrollTo(0)
+          updateAwayFromBottom()
+        })
         dialog.clear()
       },
     },
@@ -1102,7 +1108,10 @@ export function Session() {
                 stickyStart="bottom"
                 flexGrow={1}
                 scrollAcceleration={scrollAcceleration()}
-                onMouseScroll={updateAwayFromBottom}
+                onMouseScroll={(event) => {
+                  if (event.scroll?.direction === "up" && revealOlderRows()) return
+                  updateAwayFromBottom()
+                }}
               >
                 <For each={visibleRows()}>
                   {(row, index) => (


### PR DESCRIPTION
## What

Keep long session tabs cheap to switch by mounting older transcript rows only when the reader scrolls toward them.

The newest 40 rows still mount immediately. Older rows now mount in 60-row chunks on upward keyboard or mouse scrolling instead of automatically mounting the complete transcript shortly after every tab visit.

## Before / After

**Before**

1. Opening a session mounted its newest 40 transcript rows.
2. A 120 ms timer repeatedly mounted 60 older rows until the complete cached transcript was mounted.
3. Visiting several long-session tabs left each active tab's session tree expensive to tear down.
4. Switching tabs synchronously destroyed the current tree and constructed the next one, producing a visible pause even though only one viewport was visible.

**After**

1. Opening a session mounts its newest 40 rows.
2. The transcript remains bounded at that tail while the reader stays near the bottom.
3. Upward keyboard or mouse scrolling mounts one older 60-row chunk and compensates for its inserted height after layout.
4. Explicit message navigation and `First message` still mount the complete transcript when required.

## How

- `packages/tui/src/routes/session/index.tsx`
- Remove timed transcript backfill.
- Reveal older chunks when Page Up, Line Up, Half Page Up, or upward mouse scrolling approaches the mounted top.
- Combine requested movement with post-layout height compensation so chunk insertion does not move the reader's content unexpectedly.
- Guard against overlapping reveals while layout is settling.
- Preserve complete mounting for message jumps and first-message navigation.

## Scope

This addresses transcript mount and teardown cost during tab switching. It is separate from #42346, which fixes disabled tab pulse animations keeping the renderer continuously live.

It does not retain mounted session panes or introduce generic retained rendering.

## Testing

- `cd packages/tui && bun typecheck`
- `cd packages/tui && bun run test` - 690 passed, 5 skipped
- `cd packages/tui && bunx prettier --check src/routes/session/index.tsx`
- `git diff --check`
- Repository pre-push hook - all 34 package typechecks passed
- Live V2 TUI against the elected service via `bun run dev:live`, driven in a real PTY with `termctrl`: switched repeatedly among large sessions and verified upward history navigation

## Diagnostic Evidence

The cached page for the reported large session contained 200 messages, 574 assistant parts, and 3.15 MB of projected message data. Pure row reduction plus boundary construction measured about 1 ms cold and under 0.2 ms warm, ruling it out as the visible pause. The unbounded timed mounting and subsequent render-tree teardown were the actionable switch-path cost.
