### PR TITLE
fix(core): isolate opencode2 database

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -5,7 +5,7 @@ import { layer as sqliteLayer } from "#sqlite"
 import { Context, Effect, Layer } from "effect"
 import { Global } from "../global"
 import { Flag } from "../flag/flag"
-import { isAbsolute, join } from "path"
+import { basename, isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
 import { makeGlobalNode } from "../effect/app-node"
@@ -40,18 +40,33 @@ export function layerFromPath(filename: string) {
   return layer.pipe(Layer.provide(sqliteLayer({ filename })))
 }
 
+export function defaultPath(input: {
+  data: string
+  channel: string
+  executable: string
+  disableChannelDb?: string
+}) {
+  if (input.disableChannelDb === "1" || input.disableChannelDb === "true") {
+    return join(input.data, "opencode.db")
+  }
+  if (basename(input.executable).toLowerCase().replace(/\.exe$/, "") === "opencode2") {
+    return join(input.data, "opencode2.db")
+  }
+  if (["latest", "beta", "prod"].includes(input.channel)) return join(input.data, "opencode.db")
+  return join(input.data, `opencode-${input.channel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+}
+
 export function path() {
   if (Flag.OPENCODE_DB) {
     if (Flag.OPENCODE_DB === ":memory:" || isAbsolute(Flag.OPENCODE_DB)) return Flag.OPENCODE_DB
     return join(Global.Path.data, Flag.OPENCODE_DB)
   }
-  if (
-    ["latest", "beta", "prod"].includes(InstallationChannel) ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
-  )
-    return join(Global.Path.data, "opencode.db")
-  return join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
+  return defaultPath({
+    data: Global.Path.data,
+    channel: InstallationChannel,
+    executable: process.execPath,
+    disableChannelDb: process.env.OPENCODE_DISABLE_CHANNEL_DB,
+  })
 }
 
 export const node = makeGlobalNode({ service: Service, layer: layerFromPath(path()), deps: [] })

--- a/packages/core/test/database-path.test.ts
+++ b/packages/core/test/database-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Database } from "@opencode-ai/core/database/database"
+
+const data = path.join("home", "data", "opencode")
+
+describe("database path", () => {
+  test("isolates the opencode2 preview from the stable database", () => {
+    for (const executable of [path.join("usr", "local", "bin", "opencode2"), path.join("tmp", "opencode2.exe")]) {
+      expect(Database.defaultPath({ data, channel: "latest", executable })).toBe(path.join(data, "opencode2.db"))
+    }
+  })
+
+  test("keeps stable release channels on the production database", () => {
+    for (const channel of ["latest", "beta", "prod"]) {
+      expect(Database.defaultPath({ data, channel, executable: "/usr/local/bin/opencode" })).toBe(
+        path.join(data, "opencode.db"),
+      )
+    }
+  })
+
+  test("keeps named preview channels isolated", () => {
+    expect(Database.defaultPath({ data, channel: "feature/test", executable: "/usr/local/bin/opencode" })).toBe(
+      path.join(data, "opencode-feature-test.db"),
+    )
+  })
+
+  test("allows an explicit opt-in to the shared database", () => {
+    expect(
+      Database.defaultPath({
+        data,
+        channel: "latest",
+        executable: "/usr/local/bin/opencode2",
+        disableChannelDb: "true",
+      }),
+    ).toBe(path.join(data, "opencode.db"))
+  })
+})


### PR DESCRIPTION
### Issue for this PR

#42260

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This draft keeps the separately named `opencode2` preview from opening the stable `opencode.db` by default. It derives `opencode2.db` from the running executable name before applying the existing release-channel fallback.

The patch deliberately does not migrate, copy, or repair an existing database. Explicit `OPENCODE_DB` and `OPENCODE_DISABLE_CHANNEL_DB` overrides keep their current behavior, so sharing remains an opt-in escape hatch.

Assumption for review: the `opencode2` executable name is the compatibility boundary. A broader alternative would isolate the complete XDG data/state/config namespace or copy stable data into a preview namespace. This draft uses the smaller database-only boundary because it prevents incompatible migrations while leaving unrelated paths unchanged.

### How did you verify your code works?

- `bun test test/database-path.test.ts` from `packages/core`: 4 passed
- `bun typecheck` from `packages/core`: passed
- Full `packages/core` test run: 1081 passed, 7 skipped, with 6 unrelated Windows failures in existing npm-config and cross-spawn tests

### Screenshots / recordings

Not applicable; this changes database path selection.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
