### PR TITLE
feat(go): add Gemini 3.7 Flash

### DIFF
--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -25,6 +25,7 @@ const checkLoggedIn = query(async () => {
 const models = [
   { name: "Grok 4.5", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention30" },
   { name: "GPT 5.6 Luna", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention30" },
+  { name: "Gemini 3.7 Flash", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "GLM-5.2", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "GLM-5.1", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "Kimi K3", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
@@ -69,6 +70,7 @@ function LimitsGraph(props: { href: string }) {
     { id: "grok-4.5", name: "Grok 4.5", req: 120, d: "50ms" },
     { id: "kimi-k3", name: "Kimi K3", req: 110, d: "75ms" },
     { id: "qwen3.8-max", name: "Qwen3.8 Max", req: 160, d: "90ms" },
+    { id: "gemini-3.7-flash", name: "Gemini 3.7 Flash", req: 440, baseReq: 220, d: "95ms" },
     { id: "glm-5.2", name: "GLM-5.2", req: 880, d: "100ms" },
     { id: "minimax-m3", name: "MiniMax M3", req: 3200, d: "210ms" },
     { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", req: 3450, d: "270ms" },

--- a/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
@@ -306,6 +306,7 @@ export function LiteSection(props: { lite: LiteSubscription | undefined }) {
           <ul data-slot="promo-models">
             <li>Grok 4.5</li>
             <li>GPT 5.6 Luna</li>
+            <li>Gemini 3.7 Flash</li>
             <li>GLM-5.2</li>
             <li>GLM-5.1</li>
             <li>Kimi K3</li>

--- a/packages/console/app/src/routes/zen/go/v1/models/[model].ts
+++ b/packages/console/app/src/routes/zen/go/v1/models/[model].ts
@@ -1,0 +1,15 @@
+import type { APIEvent } from "@solidjs/start/server"
+import { handler } from "~/routes/zen/util/handler"
+import { parseGoogleVariant } from "~/routes/zen/util/variant"
+
+export function POST(input: APIEvent) {
+  return handler(input, {
+    format: "google",
+    modelList: "lite",
+    parseApiKey: (headers: Headers) => headers.get("x-goog-api-key") ?? undefined,
+    parseModel: (url: string, _body: any) => url.split("/").pop()?.split(":")?.[0] ?? "",
+    parseVariant: (url: string, body: any) => parseGoogleVariant(body),
+    parseIsStream: (url: string, _body: any) =>
+      url.split("/").pop()?.split(":")?.[1]?.startsWith("streamGenerateContent") ?? false,
+  })
+}

--- a/packages/web/src/content/docs/ar/go.mdx
+++ b/packages/web/src/content/docs/ar/go.mdx
@@ -53,6 +53,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | GPT 5.6 Luna      | 2,050               | 5,100              | 10,250           |
 | GLM-5.2           | 880                 | 2,150              | 4,300            |
 | GLM-5.1           | 880                 | 2,150              | 4,300            |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                 | 250                | 490              |
 | Kimi K2.7 Code    | 1,350               | 3,380              | 6,750            |
 | Kimi K2.6         | 1,150               | 2,880              | 5,750            |
@@ -110,6 +112,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - Grok 4.5 — ‏1,100 input، و71,500 cached، و220 output tokens لكل طلب
 - GLM-5.2/5.1 — ‏700 input، و52,000 cached، و150 output tokens لكل طلب
 - GPT 5.6 Luna — ‏1,000 توكن إدخال، و50,000 توكن مخزّن مؤقتًا، و220 توكن إخراج لكل طلب
+- Gemini 3.7 Flash — ‏1,050 input، و76,500 cached، و300 output tokens لكل طلب
 - Kimi K3 — ‏1,050 input، و76,500 cached، و300 output tokens لكل طلب
 - Kimi K2.7/K2.6 — ‏870 input، و55,000 cached، و200 output tokens لكل طلب
 - DeepSeek V4 Pro — ‏750 input، و82,000 cached، و290 output tokens لكل طلب
@@ -133,6 +136,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | GPT 5.6 Luna (> 272K tokens) | $0.40   | $1.80   | $0.04           | $0.50           | $15       |
 | GLM-5.2                      | $1.40   | $4.40   | $0.26           | -               | $60       |
 | GLM-5.1                      | $1.40   | $4.40   | $0.26           | -               | $60       |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00   | $15.00  | $0.30           | -               | $15       |
 | Kimi K2.7 Code               | $0.95   | $4.00   | $0.19           | -               | $60       |
 | Kimi K2.6                    | $0.95   | $4.00   | $0.16           | -               | $60       |
@@ -189,6 +193,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | غير مستخدَمة  | 30 يومًا           |
 | GLM-5.2           | غير مستخدَمة  | 0 أيام             |
 | GLM-5.1           | غير مستخدَمة  | 0 أيام             |
+| Gemini 3.7 Flash           | غير مستخدَمة  | 0 أيام             |
 | Kimi K3           | غير مستخدَمة  | 0 أيام             |
 | Kimi K2.7 Code    | غير مستخدَمة  | 0 أيام             |
 | Kimi K2.6         | غير مستخدَمة  | 0 أيام             |

--- a/packages/web/src/content/docs/ar/zen.mdx
+++ b/packages/web/src/content/docs/ar/zen.mdx
@@ -86,6 +86,7 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -172,6 +173,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60           | $7.50           |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10           | $1.25           |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15           | -               |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15           | -               |
 | Gemini 3.5 Flash Lite             | $0.30   | $2.50   | $0.03           | -               |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00   | $12.00  | $0.20           | -               |

--- a/packages/web/src/content/docs/bs/go.mdx
+++ b/packages/web/src/content/docs/bs/go.mdx
@@ -63,6 +63,7 @@ Trenutna lista modela uključuje:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ Tabela ispod pruža procijenjeni broj zahtjeva na osnovu tipičnih obrazaca kori
 | GPT 5.6 Luna      | 2,050              | 5,100             | 10,250            |
 | GLM-5.2           | 880                | 2,150             | 4,300             |
 | GLM-5.1           | 880                | 2,150             | 4,300             |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                | 250               | 490               |
 | Kimi K2.7 Code    | 1,350              | 3,380             | 6,750             |
 | Kimi K2.6         | 1,150              | 2,880             | 5,750             |
@@ -120,6 +122,7 @@ Procjene se zasnivaju na zapaženim obrascima zahtjeva:
 - Grok 4.5 — 1,100 ulaznih, 71,500 keširanih, 220 izlaznih tokena po zahtjevu
 - GLM-5.2/5.1 — 700 ulaznih (input), 52,000 keširanih, 150 izlaznih (output) tokena po zahtjevu
 - GPT 5.6 Luna — 1,000 ulaznih, 50,000 keširanih, 220 izlaznih tokena po zahtjevu
+- Gemini 3.7 Flash — 1,050 ulaznih, 76,500 keširanih, 300 izlaznih tokena po zahtjevu
 - Kimi K3 — 1,050 ulaznih, 76,500 keširanih, 300 izlaznih tokena po zahtjevu
 - Kimi K2.7/K2.6 — 870 ulaznih, 55,000 keširanih, 200 izlaznih tokena po zahtjevu
 - DeepSeek V4 Pro — 750 ulaznih, 82,000 keširanih, 290 izlaznih tokena po zahtjevu
@@ -143,6 +146,7 @@ Procjene se također zasnivaju na sljedećim cijenama po 1M tokena i mjesečnoj 
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15       |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60       |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60       |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15       |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60       |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60       |
@@ -201,6 +205,7 @@ Također možete pristupiti Go modelima putem sljedećih API endpointa.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Ne koristi se     | 30 dana              |
 | GLM-5.2           | Ne koristi se     | 0 dana               |
 | GLM-5.1           | Ne koristi se     | 0 dana               |
+| Gemini 3.7 Flash           | Ne koristi se     | 0 dana               |
 | Kimi K3           | Ne koristi se     | 0 dana               |
 | Kimi K2.7 Code    | Ne koristi se     | 0 dana               |
 | Kimi K2.6         | Ne koristi se     | 0 dana               |

--- a/packages/web/src/content/docs/bs/zen.mdx
+++ b/packages/web/src/content/docs/bs/zen.mdx
@@ -91,6 +91,7 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/da/go.mdx
+++ b/packages/web/src/content/docs/da/go.mdx
@@ -63,6 +63,7 @@ Den nuværende liste over modeller inkluderer:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ Tabellen nedenfor giver et estimeret antal anmodninger baseret på typiske Go-fo
 | GPT 5.6 Luna      | 2,050                   | 5,100               | 10,250                |
 | GLM-5.2           | 880                     | 2,150               | 4,300                 |
 | GLM-5.1           | 880                     | 2,150               | 4,300                 |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                     | 250                 | 490                   |
 | Kimi K2.7 Code    | 1,350                   | 3,380               | 6,750                 |
 | Kimi K2.6         | 1,150                   | 2,880               | 5,750                 |
@@ -120,6 +122,7 @@ Estimaterne er baseret på observerede anmodningsmønstre:
 - Grok 4.5 — 1.100 input, 71.500 cachelagrede, 220 output-tokens pr. anmodning
 - GLM-5.2/5.1 — 700 input, 52.000 cachelagrede, 150 output-tokens pr. anmodning
 - GPT 5.6 Luna — 1.000 input, 50.000 cachelagrede, 220 output-tokens pr. anmodning
+- Gemini 3.7 Flash — 1.050 input, 76.500 cachelagrede, 300 output-tokens pr. anmodning
 - Kimi K3 — 1.050 input, 76.500 cachelagrede, 300 output-tokens pr. anmodning
 - Kimi K2.7/K2.6 — 870 input, 55.000 cachelagrede, 200 output-tokens pr. anmodning
 - DeepSeek V4 Pro — 750 input, 82.000 cachelagrede, 290 output-tokens pr. anmodning
@@ -143,6 +146,7 @@ Estimaterne er også baseret på følgende priser pr. 1M tokens og det månedlig
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15     |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60     |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60     |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15     |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60     |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60     |
@@ -201,6 +205,7 @@ Du kan også få adgang til Go-modeller gennem følgende API-endpoints.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Ikke brugt   | 30 dage        |
 | GLM-5.2           | Ikke brugt   | 0 dage         |
 | GLM-5.1           | Ikke brugt   | 0 dage         |
+| Gemini 3.7 Flash           | Ikke brugt   | 0 dage         |
 | Kimi K3           | Ikke brugt   | 0 dage         |
 | Kimi K2.7 Code    | Ikke brugt   | 0 dage         |
 | Kimi K2.6         | Ikke brugt   | 0 dage         |

--- a/packages/web/src/content/docs/da/zen.mdx
+++ b/packages/web/src/content/docs/da/zen.mdx
@@ -91,6 +91,7 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/de/go.mdx
+++ b/packages/web/src/content/docs/de/go.mdx
@@ -55,6 +55,7 @@ Die aktuelle Liste der Modelle umfasst:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -92,6 +93,7 @@ Die folgende Tabelle zeigt eine geschätzte Anzahl von Anfragen basierend auf ty
 | GPT 5.6 Luna      | 2,050                  | 5,100              | 10,250             |
 | GLM-5.2           | 880                    | 2,150              | 4,300              |
 | GLM-5.1           | 880                    | 2,150              | 4,300              |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                    | 250                | 490                |
 | Kimi K2.7 Code    | 1,350                  | 3,380              | 6,750              |
 | Kimi K2.6         | 1,150                  | 2,880              | 5,750              |
@@ -112,6 +114,7 @@ Die Schätzungen basieren auf beobachteten Anfragemustern:
 - Grok 4.5 — 1.100 Input-, 71.500 Cached-, 220 Output-Tokens pro Anfrage
 - GLM-5.2/5.1 — 700 Input-, 52.000 Cached-, 150 Output-Tokens pro Anfrage
 - GPT 5.6 Luna — 1.000 Input-, 50.000 Cached-, 220 Output-Tokens pro Anfrage
+- Gemini 3.7 Flash — 1.050 Input-, 76.500 Cached-, 300 Output-Tokens pro Anfrage
 - Kimi K3 — 1.050 Input-, 76.500 Cached-, 300 Output-Tokens pro Anfrage
 - Kimi K2.7/K2.6 — 870 Input-, 55.000 Cached-, 200 Output-Tokens pro Anfrage
 - DeepSeek V4 Pro — 750 Input-, 82.000 Cached-, 290 Output-Tokens pro Anfrage
@@ -135,6 +138,7 @@ Die Schätzungen basieren außerdem auf den folgenden Preisen pro 1M Tokens und 
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15     |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60     |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60     |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15     |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60     |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60     |
@@ -191,6 +195,7 @@ Du kannst auf die Go-Modelle auch über die folgenden API-Endpunkte zugreifen.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -229,6 +234,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Nicht verwendet | 30 Tage           |
 | GLM-5.2           | Nicht verwendet | 0 Tage            |
 | GLM-5.1           | Nicht verwendet | 0 Tage            |
+| Gemini 3.7 Flash           | Nicht verwendet | 0 Tage            |
 | Kimi K3           | Nicht verwendet | 0 Tage            |
 | Kimi K2.7 Code    | Nicht verwendet | 0 Tage            |
 | Kimi K2.6         | Nicht verwendet | 0 Tage            |

--- a/packages/web/src/content/docs/de/zen.mdx
+++ b/packages/web/src/content/docs/de/zen.mdx
@@ -82,6 +82,7 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/es/go.mdx
+++ b/packages/web/src/content/docs/es/go.mdx
@@ -63,6 +63,7 @@ La lista actual de modelos incluye:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ La siguiente tabla proporciona una cantidad estimada de peticiones basada en los
 | GPT 5.6 Luna      | 2,050                  | 5,100                 | 10,250             |
 | GLM-5.2           | 880                    | 2,150                 | 4,300              |
 | GLM-5.1           | 880                    | 2,150                 | 4,300              |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                    | 250                   | 490                |
 | Kimi K2.7 Code    | 1,350                  | 3,380                 | 6,750              |
 | Kimi K2.6         | 1,150                  | 2,880                 | 5,750              |
@@ -120,6 +122,7 @@ Las estimaciones se basan en los patrones de peticiones observados:
 - Grok 4.5 — 1,100 tokens de entrada, 71,500 en caché, 220 tokens de salida por petición
 - GLM-5.2/5.1 — 700 tokens de entrada, 52,000 en caché, 150 tokens de salida por petición
 - GPT 5.6 Luna — 1,000 tokens de entrada, 50,000 en caché, 220 tokens de salida por petición
+- Gemini 3.7 Flash — 1,050 tokens de entrada, 76,500 en caché, 300 tokens de salida por petición
 - Kimi K3 — 1,050 tokens de entrada, 76,500 en caché, 300 tokens de salida por petición
 - Kimi K2.7/K2.6 — 870 tokens de entrada, 55,000 en caché, 200 tokens de salida por petición
 - DeepSeek V4 Pro — 750 tokens de entrada, 82,000 en caché, 290 tokens de salida por petición
@@ -143,6 +146,7 @@ Las estimaciones también se basan en los siguientes precios por 1M tokens y en 
 | GPT 5.6 Luna (> 272K tokens) | $0.40   | $1.80  | $0.04            | $0.50              | $15 |
 | GLM-5.2                      | $1.40   | $4.40  | $0.26            | -                  | $60 |
 | GLM-5.1                      | $1.40   | $4.40  | $0.26            | -                  | $60 |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00   | $15.00 | $0.30            | -                  | $15 |
 | Kimi K2.7 Code               | $0.95   | $4.00  | $0.19            | -                  | $60 |
 | Kimi K2.6                    | $0.95   | $4.00  | $0.16            | -                  | $60 |
@@ -201,6 +205,7 @@ También puedes acceder a los modelos de Go a través de los siguientes endpoint
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | No utilizado             | 30 días            |
 | GLM-5.2           | No utilizado             | 0 días             |
 | GLM-5.1           | No utilizado             | 0 días             |
+| Gemini 3.7 Flash           | No utilizado             | 0 días             |
 | Kimi K3           | No utilizado             | 0 días             |
 | Kimi K2.7 Code    | No utilizado             | 0 días             |
 | Kimi K2.6         | No utilizado             | 0 días             |

--- a/packages/web/src/content/docs/es/zen.mdx
+++ b/packages/web/src/content/docs/es/zen.mdx
@@ -91,6 +91,7 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60            | $7.50              |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10            | $1.25              |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15            | -                  |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15            | -                  |
 | Gemini 3.5 Flash Lite             | $0.30   | $2.50   | $0.03            | -                  |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00   | $12.00  | $0.20            | -                  |

--- a/packages/web/src/content/docs/fr/go.mdx
+++ b/packages/web/src/content/docs/fr/go.mdx
@@ -53,6 +53,7 @@ La liste actuelle des modèles comprend :
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ Le tableau ci-dessous fournit une estimation du nombre de requêtes basée sur d
 | GPT 5.6 Luna      | 2,050                 | 5,100                | 10,250            |
 | GLM-5.2           | 880                   | 2,150                | 4,300             |
 | GLM-5.1           | 880                   | 2,150                | 4,300             |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                   | 250                  | 490               |
 | Kimi K2.7 Code    | 1,350                 | 3,380                | 6,750             |
 | Kimi K2.6         | 1,150                 | 2,880                | 5,750             |
@@ -110,6 +112,7 @@ Les estimations sont basées sur les schémas de requêtes observés :
 - Grok 4.5 — 1,100 tokens en entrée, 71,500 en cache, 220 tokens en sortie par requête
 - GLM-5.2/5.1 — 700 tokens en entrée, 52,000 en cache, 150 tokens en sortie par requête
 - GPT 5.6 Luna — 1,000 tokens en entrée, 50,000 en cache, 220 tokens en sortie par requête
+- Gemini 3.7 Flash — 1,050 tokens en entrée, 76,500 en cache, 300 tokens en sortie par requête
 - Kimi K3 — 1,050 tokens en entrée, 76,500 en cache, 300 tokens en sortie par requête
 - Kimi K2.7/K2.6 — 870 tokens en entrée, 55,000 en cache, 200 tokens en sortie par requête
 - DeepSeek V4 Pro — 750 tokens en entrée, 82,000 en cache, 290 tokens en sortie par requête
@@ -133,6 +136,7 @@ Les estimations sont également basées sur les prix suivants par 1M tokens et s
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15         |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60         |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60         |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15         |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60         |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60         |
@@ -189,6 +193,7 @@ Vous pouvez également accéder aux modèles Go via les points de terminaison d'
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Non utilisé              | 30 jours                 |
 | GLM-5.2           | Non utilisé              | 0 jour                   |
 | GLM-5.1           | Non utilisé              | 0 jour                   |
+| Gemini 3.7 Flash           | Non utilisé              | 0 jour                   |
 | Kimi K3           | Non utilisé              | 0 jour                   |
 | Kimi K2.7 Code    | Non utilisé              | 0 jour                   |
 | Kimi K2.6         | Non utilisé              | 0 jour                   |

--- a/packages/web/src/content/docs/fr/zen.mdx
+++ b/packages/web/src/content/docs/fr/zen.mdx
@@ -82,6 +82,7 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -63,6 +63,7 @@ The current list of models includes:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ The table below provides an estimated request count based on typical Go usage pa
 | GPT 5.6 Luna      | 2,050               | 5,100             | 10,250             |
 | GLM-5.2           | 880                 | 2,150             | 4,300              |
 | GLM-5.1           | 880                 | 2,150             | 4,300              |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                 | 250               | 490                |
 | Kimi K2.7 Code    | 1,350               | 3,380             | 6,750              |
 | Kimi K2.6         | 1,150               | 2,880             | 5,750              |
@@ -120,6 +122,7 @@ The estimates are based on observed request patterns:
 - Grok 4.5 — 1,100 input, 71,500 cached, 220 output tokens per request
 - GLM-5.2/5.1 — 700 input, 52,000 cached, 150 output tokens per request
 - GPT 5.6 Luna — 1,000 input, 50,000 cached, 220 output tokens per request
+- Gemini 3.7 Flash — 1,050 input, 76,500 cached, 300 output tokens per request
 - Kimi K3 — 1,050 input, 76,500 cached, 300 output tokens per request
 - Kimi K2.7/K2.6 — 870 input, 55,000 cached, 200 output tokens per request
 - DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens per request
@@ -143,6 +146,7 @@ The estimates are also based on the following prices per 1M tokens and the month
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15   |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60   |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60   |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15   |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60   |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60   |
@@ -201,6 +205,7 @@ You can also access Go models through the following API endpoints.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Not used       | 30 days        |
 | GLM-5.2           | Not used       | 0 days         |
 | GLM-5.1           | Not used       | 0 days         |
+| Gemini 3.7 Flash           | Not used       | 0 days         |
 | Kimi K3           | Not used       | 0 days         |
 | Kimi K2.7 Code    | Not used       | 0 days         |
 | Kimi K2.6         | Not used       | 0 days         |

--- a/packages/web/src/content/docs/it/go.mdx
+++ b/packages/web/src/content/docs/it/go.mdx
@@ -61,6 +61,7 @@ L'elenco attuale dei modelli include:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -98,6 +99,7 @@ La tabella seguente fornisce una stima del conteggio delle richieste in base a p
 | GPT 5.6 Luna      | 2,050                | 5,100                 | 10,250            |
 | GLM-5.2           | 880                  | 2,150                 | 4,300             |
 | GLM-5.1           | 880                  | 2,150                 | 4,300             |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                  | 250                   | 490               |
 | Kimi K2.7 Code    | 1,350                | 3,380                 | 6,750             |
 | Kimi K2.6         | 1,150                | 2,880                 | 5,750             |
@@ -118,6 +120,7 @@ Le stime si basano sui pattern di richieste osservati:
 - Grok 4.5 — 1.100 di input, 71.500 in cache, 220 token di output per richiesta
 - GLM-5.2/5.1 — 700 di input, 52.000 in cache, 150 token di output per richiesta
 - GPT 5.6 Luna — 1.000 token di input, 50.000 in cache, 220 token di output per richiesta
+- Gemini 3.7 Flash — 1.050 di input, 76.500 in cache, 300 token di output per richiesta
 - Kimi K3 — 1.050 di input, 76.500 in cache, 300 token di output per richiesta
 - Kimi K2.7/K2.6 — 870 di input, 55.000 in cache, 200 token di output per richiesta
 - DeepSeek V4 Pro — 750 di input, 82.000 in cache, 290 token di output per richiesta
@@ -141,6 +144,7 @@ Le stime si basano anche sui seguenti prezzi per 1M token e sull'utilizzo mensil
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15      |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60      |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60      |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15      |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60      |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60      |
@@ -199,6 +203,7 @@ Puoi anche accedere ai modelli Go tramite i seguenti endpoint API.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -239,6 +244,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Non utilizzato            | 30 giorni              |
 | GLM-5.2           | Non utilizzato            | 0 giorni               |
 | GLM-5.1           | Non utilizzato            | 0 giorni               |
+| Gemini 3.7 Flash           | Non utilizzato            | 0 giorni               |
 | Kimi K3           | Non utilizzato            | 0 giorni               |
 | Kimi K2.7 Code    | Non utilizzato            | 0 giorni               |
 | Kimi K2.6         | Non utilizzato            | 0 giorni               |

--- a/packages/web/src/content/docs/it/zen.mdx
+++ b/packages/web/src/content/docs/it/zen.mdx
@@ -91,6 +91,7 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/ja/go.mdx
+++ b/packages/web/src/content/docs/ja/go.mdx
@@ -53,6 +53,7 @@ OpenCode Goをサブスクライブできるのは、1つのワークスペー�
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Goには以下の制限が含まれています：
 | GPT 5.6 Luna      | 2,050                     | 5,100            | 10,250           |
 | GLM-5.2           | 880                       | 2,150            | 4,300            |
 | GLM-5.1           | 880                       | 2,150            | 4,300            |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                       | 250              | 490              |
 | Kimi K2.7 Code    | 1,350                     | 3,380            | 6,750            |
 | Kimi K2.6         | 1,150                     | 2,880            | 5,750            |
@@ -110,6 +112,7 @@ OpenCode Goには以下の制限が含まれています：
 - Grok 4.5 — リクエストあたり 入力 1,100トークン、キャッシュ 71,500トークン、出力 220トークン
 - GLM-5.2/5.1 — リクエストあたり 入力 700トークン、キャッシュ 52,000トークン、出力 150トークン
 - GPT 5.6 Luna — リクエストあたり 入力 1,000トークン、キャッシュ 50,000トークン、出力 220トークン
+- Gemini 3.7 Flash — リクエストあたり 入力 1,050トークン、キャッシュ 76,500トークン、出力 300トークン
 - Kimi K3 — リクエストあたり 入力 1,050トークン、キャッシュ 76,500トークン、出力 300トークン
 - Kimi K2.7/K2.6 — リクエストあたり 入力 870トークン、キャッシュ 55,000トークン、出力 200トークン
 - DeepSeek V4 Pro — リクエストあたり 入力 750トークン、キャッシュ 82,000トークン、出力 290トークン
@@ -133,6 +136,7 @@ OpenCode Goには以下の制限が含まれています：
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15   |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60   |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60   |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15   |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60   |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60   |
@@ -189,6 +193,7 @@ Goでは月額$10を支払い、その6倍の利用枠を提供することを�
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | 使用なし             | 30日       |
 | GLM-5.2           | 使用なし             | 0日        |
 | GLM-5.1           | 使用なし             | 0日        |
+| Gemini 3.7 Flash           | 使用なし             | 0日        |
 | Kimi K3           | 使用なし             | 0日        |
 | Kimi K2.7 Code    | 使用なし             | 0日        |
 | Kimi K2.6         | 使用なし             | 0日        |

--- a/packages/web/src/content/docs/ja/zen.mdx
+++ b/packages/web/src/content/docs/ja/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/ko/go.mdx
+++ b/packages/web/src/content/docs/ko/go.mdx
@@ -53,6 +53,7 @@ workspace당 한 명의 멤버만 OpenCode Go를 구독할 수 있습니다.
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | GPT 5.6 Luna      | 2,050             | 5,100          | 10,250         |
 | GLM-5.2           | 880               | 2,150          | 4,300          |
 | GLM-5.1           | 880               | 2,150          | 4,300          |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110               | 250            | 490            |
 | Kimi K2.7 Code    | 1,350             | 3,380          | 6,750          |
 | Kimi K2.6         | 1,150             | 2,880          | 5,750          |
@@ -110,6 +112,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 - Grok 4.5 — 요청당 입력 1,100, 캐시 71,500, 출력 토큰 220
 - GLM-5.2/5.1 — 요청당 입력 700, 캐시 52,000, 출력 토큰 150
 - GPT 5.6 Luna — 요청당 입력 토큰 1,000개, 캐시 토큰 50,000개, 출력 토큰 220개
+- Gemini 3.7 Flash — 요청당 입력 1,050, 캐시 76,500, 출력 토큰 300
 - Kimi K3 — 요청당 입력 1,050, 캐시 76,500, 출력 토큰 300
 - Kimi K2.7/K2.6 — 요청당 입력 870, 캐시 55,000, 출력 토큰 200
 - DeepSeek V4 Pro — 요청당 입력 750, 캐시 82,000, 출력 토큰 290
@@ -133,6 +136,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15   |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60   |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60   |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15   |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60   |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60   |
@@ -189,6 +193,7 @@ Go에서는 월 $10를 지불하며, 저희는 그 6배의 사용량을 제공�
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | 사용되지 않음 | 30일        |
 | GLM-5.2           | 사용되지 않음 | 0일         |
 | GLM-5.1           | 사용되지 않음 | 0일         |
+| Gemini 3.7 Flash           | 사용되지 않음 | 0일         |
 | Kimi K3           | 사용되지 않음 | 0일         |
 | Kimi K2.7 Code    | 사용되지 않음 | 0일         |
 | Kimi K2.6         | 사용되지 않음 | 0일         |

--- a/packages/web/src/content/docs/ko/zen.mdx
+++ b/packages/web/src/content/docs/ko/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/nb/go.mdx
+++ b/packages/web/src/content/docs/nb/go.mdx
@@ -63,6 +63,7 @@ Den nåværende listen over modeller inkluderer:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ Tabellen nedenfor gir et estimert antall forespørsler basert på typiske bruksm
 | GPT 5.6 Luna      | 2,050                    | 5,100                | 10,250                 |
 | GLM-5.2           | 880                      | 2,150                | 4,300                  |
 | GLM-5.1           | 880                      | 2,150                | 4,300                  |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                      | 250                  | 490                    |
 | Kimi K2.7 Code    | 1,350                    | 3,380                | 6,750                  |
 | Kimi K2.6         | 1,150                    | 2,880                | 5,750                  |
@@ -120,6 +122,7 @@ Estimatene er basert på observerte forespørselsmønstre:
 - Grok 4.5 — 1 100 input, 71 500 bufret, 220 output-tokens per forespørsel
 - GLM-5.2/5.1 — 700 input, 52 000 bufret, 150 output-tokens per forespørsel
 - GPT 5.6 Luna — 1 000 input, 50 000 bufret, 220 output-tokens per forespørsel
+- Gemini 3.7 Flash — 1 050 input, 76 500 bufret, 300 output-tokens per forespørsel
 - Kimi K3 — 1 050 input, 76 500 bufret, 300 output-tokens per forespørsel
 - Kimi K2.7/K2.6 — 870 input, 55 000 bufret, 200 output-tokens per forespørsel
 - DeepSeek V4 Pro — 750 input, 82 000 bufret, 290 output-tokens per forespørsel
@@ -143,6 +146,7 @@ Estimatene er også basert på følgende priser per 1M tokens og den månedlige 
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15  |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60  |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60  |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15  |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60  |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60  |
@@ -201,6 +205,7 @@ Du kan også få tilgang til Go-modeller gjennom følgende API-endepunkter.
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Brukes ikke   | 30 dager        |
 | GLM-5.2           | Brukes ikke   | 0 dager         |
 | GLM-5.1           | Brukes ikke   | 0 dager         |
+| Gemini 3.7 Flash           | Brukes ikke   | 0 dager         |
 | Kimi K3           | Brukes ikke   | 0 dager         |
 | Kimi K2.7 Code    | Brukes ikke   | 0 dager         |
 | Kimi K2.6         | Brukes ikke   | 0 dager         |

--- a/packages/web/src/content/docs/nb/zen.mdx
+++ b/packages/web/src/content/docs/nb/zen.mdx
@@ -91,6 +91,7 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60         | $7.50           |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10         | $1.25           |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15         | -               |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15         | -               |
 | Gemini 3.5 Flash Lite             | $0.30   | $2.50   | $0.03         | -               |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00   | $12.00  | $0.20         | -               |

--- a/packages/web/src/content/docs/pl/go.mdx
+++ b/packages/web/src/content/docs/pl/go.mdx
@@ -57,6 +57,7 @@ Obecna lista modeli obejmuje:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -94,6 +95,7 @@ Poniższa tabela przedstawia szacunkową liczbę żądań na podstawie typowych 
 | GPT 5.6 Luna      | 2,050               | 5,100              | 10,250             |
 | GLM-5.2           | 880                 | 2,150              | 4,300              |
 | GLM-5.1           | 880                 | 2,150              | 4,300              |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                 | 250                | 490                |
 | Kimi K2.7 Code    | 1,350               | 3,380              | 6,750              |
 | Kimi K2.6         | 1,150               | 2,880              | 5,750              |
@@ -114,6 +116,7 @@ Szacunki te opierają się na zaobserwowanych wzorcach żądań:
 - Grok 4.5 — 1 100 tokenów wejściowych, 71 500 w pamięci podręcznej, 220 tokenów wyjściowych na żądanie
 - GLM-5.2/5.1 — 700 tokenów wejściowych, 52 000 w pamięci podręcznej, 150 tokenów wyjściowych na żądanie
 - GPT 5.6 Luna — 1 000 tokenów wejściowych, 50 000 w pamięci podręcznej, 220 tokenów wyjściowych na żądanie
+- Gemini 3.7 Flash — 1 050 tokenów wejściowych, 76 500 w pamięci podręcznej, 300 tokenów wyjściowych na żądanie
 - Kimi K3 — 1 050 tokenów wejściowych, 76 500 w pamięci podręcznej, 300 tokenów wyjściowych na żądanie
 - Kimi K2.7/K2.6 — 870 tokenów wejściowych, 55 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
 - DeepSeek V4 Pro — 750 tokenów wejściowych, 82 000 w pamięci podręcznej, 290 tokenów wyjściowych na żądanie
@@ -137,6 +140,7 @@ Szacunki opierają się również na następujących cenach za 1M tokenów oraz 
 | GPT 5.6 Luna (> 272K tokens) | $0.40   | $1.80   | $0.04          | $0.50          | $15    |
 | GLM-5.2                      | $1.40   | $4.40   | $0.26          | -              | $60    |
 | GLM-5.1                      | $1.40   | $4.40   | $0.26          | -              | $60    |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00   | $15.00  | $0.30          | -              | $15    |
 | Kimi K2.7 Code               | $0.95   | $4.00   | $0.19          | -              | $60    |
 | Kimi K2.6                    | $0.95   | $4.00   | $0.16          | -              | $60    |
@@ -193,6 +197,7 @@ Możesz również uzyskać dostęp do modeli Go za pośrednictwem następującyc
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -233,6 +238,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Niewykorzystywane | 30 dni          |
 | GLM-5.2           | Niewykorzystywane | 0 dni           |
 | GLM-5.1           | Niewykorzystywane | 0 dni           |
+| Gemini 3.7 Flash           | Niewykorzystywane | 0 dni           |
 | Kimi K3           | Niewykorzystywane | 0 dni           |
 | Kimi K2.7 Code    | Niewykorzystywane | 0 dni           |
 | Kimi K2.6         | Niewykorzystywane | 0 dni           |

--- a/packages/web/src/content/docs/pl/zen.mdx
+++ b/packages/web/src/content/docs/pl/zen.mdx
@@ -91,6 +91,7 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60          | $7.50          |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10          | $1.25          |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15          | -              |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15          | -              |
 | Gemini 3.5 Flash Lite             | $0.30   | $2.50   | $0.03          | -              |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00   | $12.00  | $0.20          | -              |

--- a/packages/web/src/content/docs/pt-br/go.mdx
+++ b/packages/web/src/content/docs/pt-br/go.mdx
@@ -63,6 +63,7 @@ A lista atual de modelos inclui:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ A tabela abaixo fornece uma contagem estimada de requisições com base nos padr
 | GPT 5.6 Luna      | 2,050                   | 5,100                  | 10,250              |
 | GLM-5.2           | 880                     | 2,150                  | 4,300               |
 | GLM-5.1           | 880                     | 2,150                  | 4,300               |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                     | 250                    | 490                 |
 | Kimi K2.7 Code    | 1,350                   | 3,380                  | 6,750               |
 | Kimi K2.6         | 1,150                   | 2,880                  | 5,750               |
@@ -120,6 +122,7 @@ As estimativas se baseiam nos padrões de requisições observados:
 - Grok 4.5 — 1.100 tokens de entrada, 71.500 em cache, 220 tokens de saída por requisição
 - GLM-5.2/5.1 — 700 tokens de entrada, 52.000 em cache, 150 tokens de saída por requisição
 - GPT 5.6 Luna — 1.000 tokens de entrada, 50.000 em cache, 220 tokens de saída por requisição
+- Gemini 3.7 Flash — 1.050 tokens de entrada, 76.500 em cache, 300 tokens de saída por requisição
 - Kimi K3 — 1.050 tokens de entrada, 76.500 em cache, 300 tokens de saída por requisição
 - Kimi K2.7/K2.6 — 870 tokens de entrada, 55.000 em cache, 200 tokens de saída por requisição
 - DeepSeek V4 Pro — 750 tokens de entrada, 82.000 em cache, 290 tokens de saída por requisição
@@ -143,6 +146,7 @@ As estimativas também se baseiam nos seguintes preços por 1M tokens e no uso m
 | GPT 5.6 Luna (> 272K tokens) | $0.40   | $1.80  | $0.04            | $0.50            | $15 |
 | GLM-5.2                      | $1.40   | $4.40  | $0.26            | -                | $60 |
 | GLM-5.1                      | $1.40   | $4.40  | $0.26            | -                | $60 |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00   | $15.00 | $0.30            | -                | $15 |
 | Kimi K2.7 Code               | $0.95   | $4.00  | $0.19            | -                | $60 |
 | Kimi K2.6                    | $0.95   | $4.00  | $0.16            | -                | $60 |
@@ -201,6 +205,7 @@ Você também pode acessar os modelos do Go através dos seguintes endpoints de 
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Não usado              | 30 dias           |
 | GLM-5.2           | Não usado              | 0 dias            |
 | GLM-5.1           | Não usado              | 0 dias            |
+| Gemini 3.7 Flash           | Não usado              | 0 dias            |
 | Kimi K3           | Não usado              | 0 dias            |
 | Kimi K2.7 Code    | Não usado              | 0 dias            |
 | Kimi K2.6         | Não usado              | 0 dias            |

--- a/packages/web/src/content/docs/pt-br/zen.mdx
+++ b/packages/web/src/content/docs/pt-br/zen.mdx
@@ -82,6 +82,7 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60            | $7.50            |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10            | $1.25            |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15            | -                |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15            | -                |
 | Gemini 3.5 Flash Lite             | $0.30   | $2.50   | $0.03            | -                |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00   | $12.00  | $0.20            | -                |

--- a/packages/web/src/content/docs/ru/go.mdx
+++ b/packages/web/src/content/docs/ru/go.mdx
@@ -63,6 +63,7 @@ OpenCode Go работает так же, как и любой другой пр
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -100,6 +101,7 @@ OpenCode Go включает следующие лимиты:
 | GPT 5.6 Luna      | 2,050               | 5,100             | 10,250           |
 | GLM-5.2           | 880                 | 2,150             | 4,300            |
 | GLM-5.1           | 880                 | 2,150             | 4,300            |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                 | 250               | 490              |
 | Kimi K2.7 Code    | 1,350               | 3,380             | 6,750            |
 | Kimi K2.6         | 1,150               | 2,880             | 5,750            |
@@ -120,6 +122,7 @@ OpenCode Go включает следующие лимиты:
 - Grok 4.5 — 1,100 входных, 71,500 кешированных, 220 выходных токенов на запрос
 - GLM-5.2/5.1 — 700 входных, 52,000 кешированных, 150 выходных токенов на запрос
 - GPT 5.6 Luna — 1,000 входных, 50,000 кешированных, 220 выходных токенов на запрос
+- Gemini 3.7 Flash — 1,050 входных, 76,500 кешированных, 300 выходных токенов на запрос
 - Kimi K3 — 1,050 входных, 76,500 кешированных, 300 выходных токенов на запрос
 - Kimi K2.7/K2.6 — 870 входных, 55,000 кешированных, 200 выходных токенов на запрос
 - DeepSeek V4 Pro — 750 входных, 82,000 кешированных, 290 выходных токенов на запрос
@@ -143,6 +146,7 @@ OpenCode Go включает следующие лимиты:
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15           |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60           |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60           |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15           |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60           |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60           |
@@ -201,6 +205,7 @@ OpenCode Go включает следующие лимиты:
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -241,6 +246,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Не используется  | 30 дней         |
 | GLM-5.2           | Не используется  | 0 дней          |
 | GLM-5.1           | Не используется  | 0 дней          |
+| Gemini 3.7 Flash           | Не используется  | 0 дней          |
 | Kimi K3           | Не используется  | 0 дней          |
 | Kimi K2.7 Code    | Не используется  | 0 дней          |
 | Kimi K2.6         | Не используется  | 0 дней          |

--- a/packages/web/src/content/docs/ru/zen.mdx
+++ b/packages/web/src/content/docs/ru/zen.mdx
@@ -91,6 +91,7 @@ OpenCode Zen работает как любой другой провайдер 
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/th/go.mdx
+++ b/packages/web/src/content/docs/th/go.mdx
@@ -53,6 +53,7 @@ OpenCode Go ทำงานเหมือนกับผู้ให้บร�
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | GPT 5.6 Luna      | 2,050                  | 5,100               | 10,250            |
 | GLM-5.2           | 880                    | 2,150               | 4,300             |
 | GLM-5.1           | 880                    | 2,150               | 4,300             |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                    | 250                 | 490               |
 | Kimi K2.7 Code    | 1,350                  | 3,380               | 6,750             |
 | Kimi K2.6         | 1,150                  | 2,880               | 5,750             |
@@ -110,6 +112,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 - Grok 4.5 — 1,100 input, 71,500 cached, 220 output tokens ต่อ request
 - GLM-5.2/5.1 — 700 input, 52,000 cached, 150 output tokens ต่อ request
 - GPT 5.6 Luna — 1,000 input, 50,000 cached, 220 output tokens ต่อ request
+- Gemini 3.7 Flash — 1,050 input, 76,500 cached, 300 output tokens ต่อ request
 - Kimi K3 — 1,050 input, 76,500 cached, 300 output tokens ต่อ request
 - Kimi K2.7/K2.6 — 870 input, 55,000 cached, 200 output tokens ต่อ request
 - DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens ต่อ request
@@ -133,6 +136,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15   |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60   |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60   |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15   |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60   |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60   |
@@ -189,6 +193,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | ไม่นำไปใช้  | 30 วัน             |
 | GLM-5.2           | ไม่นำไปใช้  | 0 วัน              |
 | GLM-5.1           | ไม่นำไปใช้  | 0 วัน              |
+| Gemini 3.7 Flash           | ไม่นำไปใช้  | 0 วัน              |
 | Kimi K3           | ไม่นำไปใช้  | 0 วัน              |
 | Kimi K2.7 Code    | ไม่นำไปใช้  | 0 วัน              |
 | Kimi K2.6         | ไม่นำไปใช้  | 0 วัน              |

--- a/packages/web/src/content/docs/th/zen.mdx
+++ b/packages/web/src/content/docs/th/zen.mdx
@@ -84,6 +84,7 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -170,6 +171,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/tr/go.mdx
+++ b/packages/web/src/content/docs/tr/go.mdx
@@ -53,6 +53,7 @@ Mevcut model listesi şunları içerir:
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ Aşağıdaki tablo, tipik Go kullanım modellerine dayalı tahmini bir istek say
 | GPT 5.6 Luna      | 2,050              | 5,100          | 10,250      |
 | GLM-5.2           | 880                | 2,150          | 4,300       |
 | GLM-5.1           | 880                | 2,150          | 4,300       |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110                | 250            | 490         |
 | Kimi K2.7 Code    | 1,350              | 3,380          | 6,750       |
 | Kimi K2.6         | 1,150              | 2,880          | 5,750       |
@@ -110,6 +112,7 @@ Tahminler, gözlemlenen istek modellerine dayanır:
 - Grok 4.5 — İstek başına 1.100 girdi, 71.500 önbelleğe alınmış, 220 çıktı token'ı
 - GLM-5.2/5.1 — İstek başına 700 girdi, 52.000 önbelleğe alınmış, 150 çıktı token'ı
 - GPT 5.6 Luna — İstek başına 1.000 girdi, 50.000 önbelleğe alınmış, 220 çıktı token'ı
+- Gemini 3.7 Flash — İstek başına 1.050 girdi, 76.500 önbelleğe alınmış, 300 çıktı token'ı
 - Kimi K3 — İstek başına 1.050 girdi, 76.500 önbelleğe alınmış, 300 çıktı token'ı
 - Kimi K2.7/K2.6 — İstek başına 870 girdi, 55.000 önbelleğe alınmış, 200 çıktı token'ı
 - DeepSeek V4 Pro — İstek başına 750 girdi, 82.000 önbelleğe alınmış, 290 çıktı token'ı
@@ -133,6 +136,7 @@ Tahminler ayrıca 1M token başına aşağıdaki fiyatlara ve her modelle birlik
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04       | $0.50        | $15      |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26       | -            | $60      |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26       | -            | $60      |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30       | -            | $15      |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19       | -            | $60      |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16       | -            | $60      |
@@ -189,6 +193,7 @@ Go modellerine aşağıdaki API uç noktaları aracılığıyla da erişebilirsi
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | Kullanılmaz   | 30 gün       |
 | GLM-5.2           | Kullanılmaz   | 0 gün        |
 | GLM-5.1           | Kullanılmaz   | 0 gün        |
+| Gemini 3.7 Flash           | Kullanılmaz   | 0 gün        |
 | Kimi K3           | Kullanılmaz   | 0 gün        |
 | Kimi K2.7 Code    | Kullanılmaz   | 0 gün        |
 | Kimi K2.6         | Kullanılmaz   | 0 gün        |

--- a/packages/web/src/content/docs/tr/zen.mdx
+++ b/packages/web/src/content/docs/tr/zen.mdx
@@ -82,6 +82,7 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -91,6 +91,7 @@ You can also access our models through the following API endpoints.
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -179,6 +180,7 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03       | -            |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20       | -            |

--- a/packages/web/src/content/docs/zh-cn/go.mdx
+++ b/packages/web/src/content/docs/zh-cn/go.mdx
@@ -53,6 +53,7 @@ OpenCode Go 的工作方式与 OpenCode 中的其他提供商一样。
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna      | 2,050           | 5,100      | 10,250     |
 | GLM-5.2           | 880             | 2,150      | 4,300      |
 | GLM-5.1           | 880             | 2,150      | 4,300      |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110             | 250        | 490        |
 | Kimi K2.7 Code    | 1,350           | 3,380      | 6,750      |
 | Kimi K2.6         | 1,150           | 2,880      | 5,750      |
@@ -110,6 +112,7 @@ OpenCode Go 包含以下限制：
 - Grok 4.5 — 每次请求 1,100 个输入 token，71,500 个缓存 token，220 个输出 token
 - GLM-5.2/5.1 — 每次请求 700 个输入 token，52,000 个缓存 token，150 个输出 token
 - GPT 5.6 Luna — 每次请求 1,000 个输入 token，50,000 个缓存 token，220 个输出 token
+- Gemini 3.7 Flash — 每次请求 1,050 个输入 token，76,500 个缓存 token，300 个输出 token
 - Kimi K3 — 每次请求 1,050 个输入 token，76,500 个缓存 token，300 个输出 token
 - Kimi K2.7/K2.6 — 每次请求 870 个输入 token，55,000 个缓存 token，200 个输出 token
 - DeepSeek V4 Pro — 每次请求 750 个输入 token，82,000 个缓存 token，290 个输出 token
@@ -133,6 +136,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04     | $0.50    | $15      |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26     | -        | $60      |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26     | -        | $60      |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30     | -        | $15      |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19     | -        | $60      |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16     | -        | $60      |
@@ -189,6 +193,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | 不使用   | 30 天    |
 | GLM-5.2           | 不使用   | 0 天     |
 | GLM-5.1           | 不使用   | 0 天     |
+| Gemini 3.7 Flash           | 不使用   | 0 天     |
 | Kimi K3           | 不使用   | 0 天     |
 | Kimi K2.7 Code    | 不使用   | 0 天     |
 | Kimi K2.6         | 不使用   | 0 天     |

--- a/packages/web/src/content/docs/zh-cn/zen.mdx
+++ b/packages/web/src/content/docs/zh-cn/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -168,6 +169,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60    | $7.50    |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10    | $1.25    |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15    | -        |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15    | -        |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03    | -        |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20    | -        |

--- a/packages/web/src/content/docs/zh-tw/go.mdx
+++ b/packages/web/src/content/docs/zh-tw/go.mdx
@@ -53,6 +53,7 @@ OpenCode Go 的運作方式與 OpenCode 中的任何其他供應商相同。
 - **GLM-5.2**
 - **GLM-5.1**
 - **GPT 5.6 Luna**
+- **Gemini 3.7 Flash**
 - **Kimi K3**
 - **Kimi K2.7 Code**
 - **Kimi K2.6**
@@ -90,6 +91,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna      | 2,050           | 5,100      | 10,250     |
 | GLM-5.2           | 880             | 2,150      | 4,300      |
 | GLM-5.1           | 880             | 2,150      | 4,300      |
+| Gemini 3.7 Flash | 220 | 500 | 980 |
 | Kimi K3           | 110             | 250        | 490        |
 | Kimi K2.7 Code    | 1,350           | 3,380      | 6,750      |
 | Kimi K2.6         | 1,150           | 2,880      | 5,750      |
@@ -110,6 +112,7 @@ OpenCode Go 包含以下限制：
 - Grok 4.5 — 每次請求 1,100 個輸入 token、71,500 個快取 token、220 個輸出 token
 - GLM-5.2/5.1 — 每次請求 700 個輸入 token、52,000 個快取 token、150 個輸出 token
 - GPT 5.6 Luna — 每次請求 1,000 個輸入 token、50,000 個快取 token、220 個輸出 token
+- Gemini 3.7 Flash — 每次請求 1,050 個輸入 token、76,500 個快取 token、300 個輸出 token
 - Kimi K3 — 每次請求 1,050 個輸入 token、76,500 個快取 token、300 個輸出 token
 - Kimi K2.7/K2.6 — 每次請求 870 個輸入 token、55,000 個快取 token、200 個輸出 token
 - DeepSeek V4 Pro — 每次請求 750 個輸入 token、82,000 個快取 token、290 個輸出 token
@@ -133,6 +136,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna (> 272K tokens) | $0.40  | $1.80  | $0.04     | $0.50    | $15    |
 | GLM-5.2                      | $1.40  | $4.40  | $0.26     | -        | $60    |
 | GLM-5.1                      | $1.40  | $4.40  | $0.26     | -        | $60    |
+| Gemini 3.7 Flash | $1.50 | $7.50 | $0.15 | - | $15 |
 | Kimi K3                      | $3.00  | $15.00 | $0.30     | -        | $15    |
 | Kimi K2.7 Code               | $0.95  | $4.00  | $0.19     | -        | $60    |
 | Kimi K2.6                    | $0.95  | $4.00  | $0.16     | -        | $60    |
@@ -189,6 +193,7 @@ OpenCode Go 包含以下限制：
 | GPT 5.6 Luna      | gpt-5.6-luna      | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | GLM-5.2           | glm-5.2           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Gemini 3.7 Flash | gemini-3.7-flash | `https://opencode.ai/zen/go/v1/models/gemini-3.7-flash` | `@ai-sdk/google` |
 | Kimi K3           | kimi-k3           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
@@ -227,6 +232,7 @@ https://opencode.ai/zen/go/v1/models
 | GPT 5.6 Luna      | 不使用   | 30 天    |
 | GLM-5.2           | 不使用   | 0 天     |
 | GLM-5.1           | 不使用   | 0 天     |
+| Gemini 3.7 Flash           | 不使用   | 0 天     |
 | Kimi K3           | 不使用   | 0 天     |
 | Kimi K2.7 Code    | 不使用   | 0 天     |
 | Kimi K2.6         | 不使用   | 0 天     |

--- a/packages/web/src/content/docs/zh-tw/zen.mdx
+++ b/packages/web/src/content/docs/zh-tw/zen.mdx
@@ -86,6 +86,7 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | Claude Sonnet 4.5           | claude-sonnet-4-5           | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5            | claude-haiku-4-5            | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Gemini 3.6 Flash            | gemini-3.6-flash            | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
+| Gemini 3.7 Flash            | gemini-3.7-flash            | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash            | gemini-3.5-flash            | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash Lite       | gemini-3.5-flash-lite       | `https://opencode.ai/zen/v1/models/gemini-3.5-flash-lite` | `@ai-sdk/google`            |
 | Gemini 3.1 Pro              | gemini-3.1-pro              | `https://opencode.ai/zen/v1/models/gemini-3.1-pro`        | `@ai-sdk/google`            |
@@ -173,6 +174,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60    | $7.50    |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10    | $1.25    |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15    | -        |
+| Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15    | -        |
 | Gemini 3.5 Flash Lite             | $0.30  | $2.50   | $0.03    | -        |
 | Gemini 3.1 Pro (≤ 200K tokens)    | $2.00  | $12.00  | $0.20    | -        |


### PR DESCRIPTION
## Summary
- add Gemini 3.7 Flash to Zen and Go
- 2x usage promo in Go

## Testing
- `bun run build` in `packages/web`
- `bun typecheck` in `packages/console`
- `git diff --check`