### PR TITLE
fix: preserve PDF filenames from tool output

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -146,8 +146,8 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
   // otherwise unsupportedParts() will turn it into a user-visible error.
   const supportsMediaInToolResult = (attachment: { mime: string }) => {
     if (model.api.npm === "@ai-sdk/anthropic") return true
-    if (model.api.npm === "@ai-sdk/openai") return true
-    if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true
+    if (model.api.npm === "@ai-sdk/openai") return attachment.mime.startsWith("image/")
+    if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return attachment.mime.startsWith("image/")
     if (model.api.npm === "@ai-sdk/amazon-bedrock") return attachment.mime.startsWith("image/")
     if (model.api.npm === "@ai-sdk/xai") return attachment.mime.startsWith("image/")
     if (model.api.npm === "@ai-sdk/google-vertex/anthropic") return true

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -601,6 +601,131 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("moves pdf media out of OpenAI-compatible tool results", async () => {
+    const openAIModel: Provider.Model = {
+      ...model,
+      capabilities: {
+        ...model.capabilities,
+        attachment: true,
+        input: {
+          ...model.capabilities.input,
+          pdf: true,
+        },
+      },
+    }
+    const pdf = Buffer.from("%PDF-1.4\n").toString("base64")
+    const userID = "m-user-openai-pdf"
+    const assistantID = "m-assistant-openai-pdf"
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1-openai-pdf"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-openai-pdf"),
+            type: "tool",
+            callID: "call-openai-pdf-1",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/example.pdf" },
+              output: "PDF read successfully",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [
+                {
+                  ...basePart(assistantID, "file-openai-pdf-1"),
+                  type: "file",
+                  mime: "application/pdf",
+                  filename: "example.pdf",
+                  url: `data:application/pdf;base64,${pdf}`,
+                },
+              ],
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, openAIModel)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-openai-pdf-1",
+            toolName: "read",
+            input: { filePath: "/tmp/example.pdf" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-openai-pdf-1",
+            toolName: "read",
+            output: { type: "text", value: "PDF read successfully" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Attached media from tool result:" },
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "example.pdf",
+            data: `data:application/pdf;base64,${pdf}`,
+          },
+        ],
+      },
+    ])
+
+    const unsupportedModel: Provider.Model = {
+      ...openAIModel,
+      capabilities: {
+        ...openAIModel.capabilities,
+        input: {
+          ...openAIModel.capabilities.input,
+          pdf: false,
+        },
+      },
+    }
+    const unsupported = ProviderTransform.message(
+      await MessageV2.toModelMessages(input, unsupportedModel),
+      unsupportedModel,
+      {},
+    )
+    expect(unsupported.at(-1)).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "Attached media from tool result:" },
+        {
+          type: "text",
+          text: 'ERROR: Cannot read "example.pdf" (this model does not support pdf input). Inform the user.',
+        },
+      ],
+    })
+  })
+
   test("omits provider metadata when assistant model differs", async () => {
     const userID = "m-user"
     const assistantID = "m-assistant"


### PR DESCRIPTION
Prevent PDF tool results from poisoning sessions on OpenAI-compatible provider transports.

The AI SDK turns media embedded in a tool result into an `input_file` with a fallback filename when the stored attachment filename is unavailable. Providers that validate the filename reject that replay, and every later request in the session fails on the same history. OpenCode now moves PDFs into a normal user message, where it preserves the filename and applies the existing model capability guard.

### Changes
- Treat images as the only inline tool-result media for OpenAI and Bedrock Mantle transports.
- Move PDF tool-result attachments into the existing synthetic user media message.
- Preserve the attachment filename when a PDF-capable model receives the replay.
- Replace the PDF with the existing actionable error text when the model lacks PDF input capability.
- Add a regression test for both supported and unsupported PDF-capability paths.

### Effects
- Existing sessions with stored PDF tool attachments can replay without resending an extensionless `data` file inside a tool result.
- Direct OpenAI and Mantle models still receive supported PDFs as normal user file input.
- Unsupported models receive text that directs the agent to inform the user instead of a provider rejection.

Verified with all 40 `message-v2` tests, package typecheck, repository pre-push typecheck, Prettier, and Oxlint.

Closes #21908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
