### PR TITLE
feat(tui): allow prompting subagent sessions

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -210,7 +210,6 @@ export function Prompt(props: PromptProps) {
   const workspace = usePromptWorkspace(props.sessionID)
   const move = usePromptMove({ projectID: project.project, sessionID: () => props.sessionID })
   const [cursorVersion, setCursorVersion] = createSignal(0)
-  const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const hasRightContent = createMemo(() => Boolean(props.right))
 
   function promptModelWarning() {
@@ -259,6 +258,32 @@ export function Prompt(props: PromptProps) {
     const messages = sync.data.message[props.sessionID]
     if (!messages) return undefined
     return messages.findLast((m): m is UserMessage => m.role === "user")
+  })
+  const promptIdentity = createMemo(() => {
+    const current = {
+      agent: local.agent.current(),
+      model: local.model.current(),
+      variant: local.model.variant.current(),
+    }
+    const session = props.sessionID ? sync.session.get(props.sessionID) : undefined
+    if (!session?.parentID) return current
+    const previous = lastUserMessage()
+    const model = session.model
+    const variant = model?.variant ?? previous?.model.variant
+    return {
+      agent: sync.data.agent.find((item) => item.name === (session.agent ?? previous?.agent)) ?? current.agent,
+      model: model ? { providerID: model.providerID, modelID: model.id } : (previous?.model ?? current.model),
+      variant: variant === "default" ? undefined : variant,
+    }
+  })
+  const modelInfo = createMemo(() => {
+    const model = promptIdentity().model
+    const provider = sync.data.provider.find((item) => item.id === model?.providerID)
+    return {
+      provider: provider?.name ?? model?.providerID ?? "Connect a provider",
+      model: (model && provider?.models[model.modelID]?.name) ?? model?.modelID ?? "No provider selected",
+      variants: (model && provider?.models[model.modelID]?.variants) ?? {},
+    }
   })
 
   const usage = createMemo(() => {
@@ -958,15 +983,15 @@ export function Prompt(props: PromptProps) {
     if (workspace.creating() || move.creating()) return false
     if (auto()?.visible) return false
     if (!store.prompt.input) return false
-    const agent = local.agent.current()
+    const agent = promptIdentity().agent
     if (!agent) return false
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       void exit()
       return true
     }
-    const selectedModel = local.model.current()
-    if (!selectedModel) {
+    const model = promptIdentity().model
+    if (!model) {
       void promptModelWarning()
       return false
     }
@@ -986,7 +1011,7 @@ export function Prompt(props: PromptProps) {
       return false
     }
 
-    const variant = local.model.variant.current()
+    const variant = promptIdentity().variant
     let sessionID = props.sessionID
     let finishMoveProgress = false
     if (sessionID == null) {
@@ -1002,8 +1027,8 @@ export function Prompt(props: PromptProps) {
         workspace: workspaceID,
         agent: agent.name,
         model: {
-          providerID: selectedModel.providerID,
-          id: selectedModel.modelID,
+          providerID: model.providerID,
+          id: model.modelID,
           variant,
         },
       })
@@ -1062,8 +1087,8 @@ export function Prompt(props: PromptProps) {
         sessionID,
         agent: agent.name,
         model: {
-          providerID: selectedModel.providerID,
-          modelID: selectedModel.modelID,
+          providerID: model.providerID,
+          modelID: model.modelID,
         },
         command: inputText,
       })
@@ -1085,7 +1110,7 @@ export function Prompt(props: PromptProps) {
         command: command.slice(1),
         arguments: args,
         agent: agent.name,
-        model: `${selectedModel.providerID}/${selectedModel.modelID}`,
+        model: `${model.providerID}/${model.modelID}`,
         variant,
         parts: nonTextParts.filter((x) => x.type === "file"),
       })
@@ -1095,9 +1120,9 @@ export function Prompt(props: PromptProps) {
         .prompt(
           {
             sessionID,
-            ...selectedModel,
+            ...model,
             agent: agent.name,
-            model: selectedModel,
+            model,
             variant,
             parts: [
               ...editorParts,
@@ -1288,22 +1313,20 @@ export function Prompt(props: PromptProps) {
   const highlight = createMemo(() => {
     if (leader()) return theme.border
     if (store.mode === "shell") return theme.primary
-    const agent = local.agent.current()
+    const agent = promptIdentity().agent
     if (!agent) return theme.border
     return local.agent.color(agent.name)
   })
 
   const showVariant = createMemo(() => {
-    const variants = local.model.variant.list()
-    if (variants.length === 0) return false
-    const current = local.model.variant.current()
-    return !!current
+    if (Object.keys(modelInfo().variants).length === 0) return false
+    return !!promptIdentity().variant
   })
 
-  const agentMetaAlpha = createFadeIn(() => !!local.agent.current(), animationsEnabled)
-  const modelMetaAlpha = createFadeIn(() => !!local.agent.current() && store.mode === "normal", animationsEnabled)
+  const agentMetaAlpha = createFadeIn(() => !!promptIdentity().agent, animationsEnabled)
+  const modelMetaAlpha = createFadeIn(() => !!promptIdentity().agent && store.mode === "normal", animationsEnabled)
   const variantMetaAlpha = createFadeIn(
-    () => !!local.agent.current() && store.mode === "normal" && showVariant(),
+    () => !!promptIdentity().agent && store.mode === "normal" && showVariant(),
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border, highlight(), agentMetaAlpha()))
@@ -1322,8 +1345,8 @@ export function Prompt(props: PromptProps) {
   const spinnerDef = createMemo(() => {
     const agent =
       status().type !== "idle"
-        ? (local.agent.list().find((a) => a.name === lastUserMessage()?.agent) ?? local.agent.current())
-        : local.agent.current()
+        ? (sync.data.agent.find((item) => item.name === lastUserMessage()?.agent) ?? promptIdentity().agent)
+        : promptIdentity().agent
     const color = agent ? local.agent.color(agent.name) : theme.border
     return {
       frames: createFrames({
@@ -1443,7 +1466,7 @@ export function Prompt(props: PromptProps) {
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
               <box flexDirection="row" gap={1}>
-                <Show when={local.agent.current()} fallback={<box height={1} />}>
+                <Show when={promptIdentity().agent} fallback={<box height={1} />}>
                   {(agent) => (
                     <>
                       <text fg={fadeColor(highlight(), agentMetaAlpha())}>
@@ -1459,14 +1482,14 @@ export function Prompt(props: PromptProps) {
                             flexShrink={0}
                             fg={fadeColor(leader() ? theme.textMuted : theme.text, modelMetaAlpha())}
                           >
-                            {local.model.parsed().model}
+                            {modelInfo().model}
                           </text>
-                          <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>{currentProviderLabel()}</text>
+                          <text fg={fadeColor(theme.textMuted, modelMetaAlpha())}>{modelInfo().provider}</text>
                           <Show when={showVariant()}>
                             <text fg={fadeColor(theme.textMuted, variantMetaAlpha())}>·</text>
                             <text>
                               <span style={{ fg: fadeColor(theme.warning, variantMetaAlpha()), bold: true }}>
-                                {local.model.variant.current()}
+                                {promptIdentity().variant}
                               </span>
                             </text>
                           </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -231,14 +231,14 @@ export function Session() {
       : [],
   )
   const permissions = createMemo(() => {
-    if (session()?.parentID) return []
+    if (session()?.parentID) return sync.data.permission[route.sessionID] ?? []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
   })
   const questions = createMemo(() => {
-    if (session()?.parentID) return []
+    if (session()?.parentID) return sync.data.question[route.sessionID] ?? []
     return children().flatMap((x) => sync.data.question[x.id] ?? [])
   })
-  const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
+  const visible = createMemo(() => permissions().length === 0 && questions().length === 0)
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
 
   const pending = createMemo(() => {

--- a/packages/tui/test/session-child-prompt.test.tsx
+++ b/packages/tui/test/session-child-prompt.test.tsx
@@ -1,0 +1,213 @@
+import { expect, mock, test } from "bun:test"
+import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import { createTestRenderer } from "@opentui/core/testing"
+import { Effect } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Global } from "@opencode-ai/core/global"
+import { createTuiResolvedConfig } from "./fixture/tui-runtime"
+import { createEventSource, createFetch, directory, json } from "./fixture/tui-sdk"
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+test("child sessions submit prompts with their own agent and model", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false })
+  const core = await import("@opentui/core")
+  void mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const parent = {
+    id: "ses_parent",
+    slug: "parent",
+    projectID: "proj_test",
+    directory,
+    title: "Parent session",
+    version: "0.0.0-test",
+    time: { created: 0, updated: 0 },
+  }
+  const child = {
+    id: "ses_child",
+    slug: "child",
+    projectID: "proj_test",
+    directory,
+    parentID: parent.id,
+    title: "Child session",
+    agent: "general",
+    model: { providerID: "openai", id: "child-model", variant: "xhigh" },
+    version: "0.0.0-test",
+    time: { created: 1, updated: 1 },
+  }
+  const model = (id: string, name: string, variants: Record<string, object> = {}) => ({
+    id,
+    providerID: "openai",
+    api: { id, url: "https://example.com", npm: "@ai-sdk/openai" },
+    name,
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 100_000, output: 8_000 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+    variants,
+  })
+  const provider = {
+    id: "openai",
+    name: "OpenAI",
+    source: "custom",
+    env: [],
+    options: {},
+    models: {
+      "primary-model": model("primary-model", "Primary Model"),
+      "child-model": model("child-model", "Child Model", { xhigh: {} }),
+    },
+  }
+  const calls = createFetch((url) => {
+    if (url.pathname === "/agent")
+      return json([
+        {
+          name: "build",
+          mode: "primary",
+          permission: [],
+          options: {},
+          model: { providerID: "openai", modelID: "primary-model" },
+        },
+        {
+          name: "general",
+          mode: "subagent",
+          permission: [],
+          options: {},
+          model: { providerID: "openai", modelID: "child-model" },
+        },
+      ])
+    if (url.pathname === "/config/providers")
+      return json({ providers: [provider], default: { openai: "primary-model" } })
+    if (url.pathname === "/provider")
+      return json({ all: [provider], default: { openai: "primary-model" }, connected: ["openai"] })
+    if (url.pathname === "/session") return json([parent, child])
+    if (url.pathname === `/session/${child.id}`) return json(child)
+    if (url.pathname === `/session/${child.id}/message`) return json([])
+    if (url.pathname === `/session/${child.id}/todo` || url.pathname === `/session/${child.id}/diff`) return json([])
+    if (url.pathname === "/project/proj_test/directories") return json([{ directory }])
+    return undefined
+  })
+  let prompt: unknown
+  const fetch = Object.assign(
+    async (input: Parameters<typeof calls.fetch>[0], init?: Parameters<typeof calls.fetch>[1]) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const url = new URL(request.url)
+      if (request.method === "POST" && url.pathname === `/session/${child.id}/message`) {
+        prompt = await request.json()
+        return json({})
+      }
+      return calls.fetch(input, init)
+    },
+    {
+      preconnect: (...args: Parameters<typeof calls.fetch.preconnect>) => calls.fetch.preconnect(...args),
+    },
+  )
+  let api: TuiPluginApi | undefined
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  let disposeSlots = () => {}
+  const events = createEventSource()
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch,
+        events: events.source,
+        args: { sessionID: child.id },
+        pluginHost: {
+          async start(input) {
+            api = input.api
+            disposeSlots = input.runtime.setupSlots(input.api).dispose
+            started()
+          },
+          async dispose() {
+            disposeSlots()
+          },
+        },
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node))),
+    )
+
+    await ready
+    await Promise.race([
+      wait(() => setup.renderer.currentFocusedEditor instanceof core.TextareaRenderable),
+      task.then(() => {
+        throw new Error("app exited before child prompt rendered")
+      }),
+    ])
+    await setup.renderOnce()
+    const frame = setup.captureCharFrame()
+    expect(frame).toContain("General")
+    expect(frame).toContain("Child Model")
+    expect(frame).toContain("OpenAI")
+    expect(frame).toContain("xhigh")
+
+    events.emit({
+      directory,
+      project: "proj_test",
+      payload: {
+        id: "evt_permission",
+        type: "permission.asked",
+        properties: {
+          id: "per_child",
+          sessionID: child.id,
+          permission: "bash",
+          patterns: ["git status"],
+          metadata: {},
+          always: [],
+        },
+      },
+    })
+    await wait(() => !(setup.renderer.currentFocusedEditor instanceof core.TextareaRenderable))
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain("Allow once")
+
+    events.emit({
+      directory,
+      project: "proj_test",
+      payload: {
+        id: "evt_permission_replied",
+        type: "permission.replied",
+        properties: { sessionID: child.id, requestID: "per_child", reply: "once" },
+      },
+    })
+    await wait(() => setup.renderer.currentFocusedEditor instanceof core.TextareaRenderable)
+
+    await setup.mockInput.typeText("Continue this task")
+    setup.mockInput.pressEnter()
+    await wait(() => prompt !== undefined)
+
+    expect(prompt).toMatchObject({
+      agent: "general",
+      model: { providerID: "openai", modelID: "child-model" },
+      variant: "xhigh",
+      parts: [{ type: "text", text: "Continue this task" }],
+    })
+
+    api?.keymap.dispatchCommand("app.exit")
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41667

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TUI child sessions currently omit the composer. This renders it and submits follow-up prompts with the agent, model, and variant recorded on the child session instead of the active parent/global selection. Child-local permission and question requests still block the composer until answered.

Web/desktop counterpart: #40804.

### How did you verify your code works?

- TUI typecheck
- Targeted child-session integration test covering rendering, permission blocking, and prompt payload identity
- Full TUI suite: 195 passed, 1 skipped, 0 failed
- Full repository pre-push typecheck: 30 tasks passed

### Screenshots / recordings

![Before and after child-session composer](https://raw.githubusercontent.com/SamuelZ12/opencode/tui-subagent-prompt-assets/before-after.png)

_Sanitized before/after comparison using integration-test fixture data._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR