### PR TITLE
fix(opencode): correct PowerShell 5.1 quoting guidance

### DIFF
--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -57,7 +57,8 @@ function powershellNotes(name: string) {
 - Prefer full cmdlet names like \`Get-ChildItem\`, \`Set-Content\`, \`Remove-Item\`, and \`New-Item\` over aliases.
 - Use \`$(...)\` for subexpressions. Use \`@(...)\` for array expressions.
 - To call a native executable whose path contains spaces, use the call operator: \`& "path/to/exe" args\`.
-- Escape special characters with the PowerShell backtick character.`
+- Escape characters inside PowerShell strings with the backtick; it does NOT protect quotes passed to an external program.
+- PowerShell 5.1 strips double quotes when building an external program's command line, silently splitting the argument. Use single quotes inside it: \`ssh host 'grep -E ''a|b'' file'\`. If double quotes are required, backslash-escape them: \`ssh host 'sed -i \\"s/\\r$//\\" file'\`. For longer scripts, write to a file and run the file.`
   }
   return ""
 }

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,5 +1,5 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Cause, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
@@ -8,6 +8,7 @@ import path from "path"
 import { Config } from "@/config/config"
 import { Shell } from "@opencode-ai/core/shell"
 import { ShellTool } from "../../src/tool/shell"
+import { ShellPrompt } from "../../src/tool/shell/prompt"
 import { Filesystem } from "@/util/filesystem"
 import { provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import type { Permission } from "../../src/permission"
@@ -1197,3 +1198,84 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+// The quoting forms recommended in the Windows PowerShell 5.1 shell notes. Each is asserted
+// to appear in the notes and is separately executed through powershell.exe below, so the
+// advice cannot drift away from what actually survives the shell.
+const RECOMMENDED = [
+  {
+    label: "single quotes for the inner argument",
+    payload: `'grep -E ''a|b'' file'`,
+    argv: `grep -E 'a|b' file`,
+  },
+  {
+    label: "backslash-escaped double quotes",
+    payload: String.raw`'sed -i \"s/\r$//\" file'`,
+    argv: String.raw`sed -i "s/\r$//" file`,
+  },
+]
+
+describe("windows powershell quoting guidance", () => {
+  const notesFor = (name: string) =>
+    ShellPrompt.render(name, "win32", { maxLines: 100, maxBytes: 10_000 }, 60_000).description
+
+  test("5.1 notes recommend only forms that survive native argument passing", () => {
+    const notes = notesFor("powershell")
+    for (const item of RECOMMENDED) expect(notes).toContain(item.payload)
+  })
+
+  test("5.1 notes drop the backtick advice that makes this worse", () => {
+    const notes = notesFor("powershell")
+    expect(notes).not.toContain("- Escape special characters with the PowerShell backtick character.")
+    // the backtick is still correct for escaping inside PowerShell's own strings
+    expect(notes).toContain("backtick")
+  })
+
+  test("pwsh notes are untouched, 7.3+ does not have this defect", () => {
+    expect(notesFor("pwsh")).toContain("- Escape special characters with the PowerShell backtick character.")
+  })
+})
+
+// Documents the Windows PowerShell 5.1 native argument passing defect and proves the
+// workarounds recommended in the shell notes actually survive it. PowerShell 5.1 does not
+// escape double quotes when building the command line for an external program, so a quoted
+// segment loses its quotes and can split into several arguments. Fixed in 7.3 via
+// $PSNativeCommandArgumentPassing = 'Standard', which does not exist in 5.1.
+const powershell51 = shells.find((item) => item.label === "powershell")
+if (process.platform === "win32" && powershell51) {
+  describe("windows powershell 5.1 native argument passing", () => {
+    const probe = `& ${bin} -e ${squote("console.log(JSON.stringify(Bun.argv.slice(1)))")}`
+    const argvOf = (payload: string) => {
+      const proc = Bun.spawnSync([
+        powershell51.shell,
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `${probe} ${payload}`,
+      ])
+      return JSON.parse(proc.stdout.toString().trim()) as string[]
+    }
+
+    test("plain double quotes are stripped and the argument splits", () => {
+      expect(argvOf(`'a "b c" d'`)).toEqual(["a b", "c d"])
+    })
+
+    for (const item of RECOMMENDED) {
+      test(`the notes recommend a form that survives: ${item.label}`, () => {
+        expect(argvOf(item.payload)).toEqual([item.argv])
+      })
+    }
+
+    test("backslash-escaped quotes keep a quoted segment containing spaces intact", () => {
+      expect(argvOf(String.raw`'a \"b c\" d'`)).toEqual([`a "b c" d`])
+    })
+
+    test("backslash-escaped quotes keep a shell metacharacter intact", () => {
+      expect(argvOf(String.raw`'grep -E \"a|b\" file'`)).toEqual([`grep -E "a|b" file`])
+    })
+
+    test("single quotes are unaffected", () => {
+      expect(argvOf(String.raw`"echo 'a\nb'"`)).toEqual([String.raw`echo 'a\nb'`])
+    })
+  })
+}


### PR DESCRIPTION
### Issue for this PR

Closes #42402

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PowerShell 5.1 doesn't escape double quotes when it builds the command line for an
external program. `ssh host 'sed -i "s/\r$//" file'` reaches the remote unquoted, does
the wrong thing, and still exits 0.

The 5.1 shell notes told the agent to escape with the backtick, which makes it worse:

    plain            ["a b","c d"]      2 args
    backtick         ["a ","b","c d"]   3 args
    backslash \"     ["a \"b c\" d"]    correct
    single quotes    ["a 'b c' d"]      correct

Replaced that line with the caveat and the two forms that survive. Only the 5.1 notes;
pwsh 7.3+ has $PSNativeCommandArgumentPassing = 'Standard' and isn't affected.

Not fixable in code: a PowerShell variable holding the correct string is still split
when passed to a native program, and -EncodedCommand doesn't help either.

### How did you verify your code works?

    node -e "console.log(JSON.stringify(process.argv.slice(1)))" 'a "b c" d'
    # ["a b","c d"]   expected ["a \"b c\" d"]

The recommended forms are defined once in the test, then asserted to appear in the notes
and executed through powershell.exe, so the advice can't drift from what survives.
Verified on PowerShell 5.1.19041.7663. Windows only, skipped elsewhere.

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
