### PR TITLE
feat(tui): add interactive toast actions

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -497,12 +497,14 @@ function App(props: { pair?: DialogPairCredentials }) {
           variant: "warning",
           title: "MCP server needs authentication",
           message: `Connect "${server.name}" to use its tools.`,
+          action: { label: "Open MCP servers", run: () => keymap.dispatch("mcp.list") },
         })
       else
         toast.show({
           variant: "error",
           title: `MCP server failed: ${server.name}`,
           message: "Run /mcps to view details.",
+          action: { label: "Open MCP servers", run: () => keymap.dispatch("mcp.list") },
         })
     }
   })

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -395,6 +395,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageResolver; d
           variant: "error",
           title: `Plugin failed: ${state.target}`,
           message: "Run /plugins to view details.",
+          action: { label: "Open plugins", run: () => host.keymap.dispatch("plugins.list") },
         })
     setStore("states", reconcileStore(states))
   }

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -42,7 +42,7 @@ function ToastSurface(props: {
       paddingRight={2}
       paddingTop={1}
       paddingBottom={1}
-      backgroundColor={hovered() ? theme.background.action.primary.hovered : theme.background.default}
+      backgroundColor={hovered() ? theme.raise(theme.background.default) : theme.background.default}
       borderColor={theme.text.feedback[props.toast.variant].default}
       border={["left", "right"]}
       customBorderChars={SplitBorder.customBorderChars}

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -52,7 +52,7 @@ function ToastSurface(props: {
         paddingRight={2}
         paddingTop={1}
         paddingBottom={1}
-        backgroundColor={hovered() ? tint(theme.background.default, theme.text.default, 0.1) : theme.background.default}
+        backgroundColor={hovered() ? tint(theme.background.default, theme.text.default, 0.04) : theme.background.default}
       >
         <Show
           when={props.toast.title}

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -42,7 +42,7 @@ function ToastSurface(props: {
       paddingRight={2}
       paddingTop={1}
       paddingBottom={1}
-      backgroundColor={hovered() ? theme.raise(theme.background.default) : theme.background.default}
+      backgroundColor={theme.background.default}
       borderColor={theme.text.feedback[props.toast.variant].default}
       border={["left", "right"]}
       customBorderChars={SplitBorder.customBorderChars}

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, type ParentProps, Show } from "solid-js"
+import { createContext, createSignal, onCleanup, useContext, type ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
@@ -9,42 +9,112 @@ export type ToastOptions = {
   message: string
   variant: "info" | "success" | "warning" | "error"
   duration: number
+  action?: {
+    label: string
+    run: () => void
+  }
 }
 type ToastInput = Omit<ToastOptions, "duration"> & { duration?: number }
 
-export function Toast() {
-  const toast = useToast()
+function ToastSurface(props: {
+  toast: ToastOptions
+  pending?: number
+  onHover?: (hovered: boolean) => void
+  onActivate: () => void
+}) {
   const theme = useTheme("overlay")
   const dimensions = useTerminalDimensions()
+  const [hovered, setHovered] = createSignal(false)
+  const hover = (value: boolean) => {
+    setHovered(value)
+    props.onHover?.(value)
+  }
+
+  return (
+    <box
+      position="absolute"
+      top={1}
+      right={2}
+      maxWidth={Math.min(60, dimensions().width - 6)}
+      justifyContent="center"
+      alignItems="flex-start"
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      backgroundColor={hovered() ? theme.background.action.primary.hovered : theme.background.default}
+      borderColor={theme.text.feedback[props.toast.variant].default}
+      border={["left", "right"]}
+      customBorderChars={SplitBorder.customBorderChars}
+      onMouseOver={() => hover(true)}
+      onMouseOut={() => hover(false)}
+      onMouseUp={props.onActivate}
+    >
+      <Show
+        when={props.toast.title}
+        fallback={
+          <box flexDirection="row" width="100%">
+            <text fg={theme.text.default} wrapMode="word" flexGrow={1}>
+              {props.toast.message}
+            </text>
+            <Show when={props.toast.action || hovered()}>
+              <text
+                flexShrink={0}
+                marginLeft={2}
+                wrapMode="none"
+                attributes={hovered() ? TextAttributes.BOLD : undefined}
+                fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+              >
+                {hovered() ? "› " : ""}
+                {props.toast.action?.label ?? "Dismiss"}
+              </text>
+            </Show>
+          </box>
+        }
+      >
+        <box flexDirection="row" width="100%" marginBottom={1}>
+          <text attributes={TextAttributes.BOLD} fg={theme.text.default}>
+            {props.toast.title}
+          </text>
+          <box flexGrow={1} />
+          <Show when={props.toast.action || hovered()}>
+            <text
+              flexShrink={0}
+              marginLeft={2}
+              wrapMode="none"
+              attributes={hovered() ? TextAttributes.BOLD : undefined}
+              fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+            >
+              {hovered() ? "› " : ""}
+              {props.toast.action?.label ?? "Dismiss"}
+            </text>
+          </Show>
+        </box>
+        <text fg={theme.text.default} wrapMode="word" width="100%">
+          {props.toast.message}
+        </text>
+      </Show>
+      <Show when={props.pending}>
+        <text fg={theme.text.subdued} marginTop={1}>
+          +{props.pending} more
+        </text>
+      </Show>
+    </box>
+  )
+}
+
+export function Toast() {
+  const toast = useToast()
 
   return (
     <Show when={toast.currentToast}>
       {(current) => (
-        <box
-          position="absolute"
-          justifyContent="center"
-          alignItems="flex-start"
-          top={1}
-          right={2}
-          maxWidth={Math.min(60, dimensions().width - 6)}
-          paddingLeft={2}
-          paddingRight={2}
-          paddingTop={1}
-          paddingBottom={1}
-          backgroundColor={theme.background.default}
-          borderColor={theme.text.feedback[current().variant].default}
-          border={["left", "right"]}
-          customBorderChars={SplitBorder.customBorderChars}
-        >
-          <Show when={current().title}>
-            <text attributes={TextAttributes.BOLD} marginBottom={1} fg={theme.text.default}>
-              {current().title}
-            </text>
-          </Show>
-          <text fg={theme.text.default} wrapMode="word" width="100%">
-            {current().message}
-          </text>
-        </box>
+        <ToastSurface
+          toast={current()}
+          pending={toast.pending}
+          onHover={(hovered) => (hovered ? toast.pause() : toast.resume())}
+          onActivate={toast.activate}
+        />
       )}
     </Show>
   )
@@ -53,18 +123,45 @@ export function Toast() {
 function init() {
   const [store, setStore] = createStore({
     currentToast: null as ToastOptions | null,
+    queue: [] as ToastOptions[],
   })
 
   let timeoutHandle: NodeJS.Timeout | null = null
+  let startedAt = 0
+  let remaining = 0
+  let paused = false
+
+  const clear = () => {
+    if (!timeoutHandle) return
+    clearTimeout(timeoutHandle)
+    timeoutHandle = null
+  }
+
+  const start = (duration: number) => {
+    clear()
+    remaining = duration
+    startedAt = Date.now()
+    timeoutHandle = setTimeout(() => dismiss(), duration).unref()
+  }
+
+  const dismiss = () => {
+    clear()
+    paused = false
+    const next = store.queue[0]
+    setStore("queue", (queue) => queue.slice(1))
+    setStore("currentToast", next ?? null)
+    if (next) start(next.duration)
+  }
 
   const toast = {
     show(options: ToastInput) {
       const toastOptions = { ...options, duration: options.duration ?? 5000 }
+      if (store.currentToast && (paused || store.queue.length > 0)) {
+        setStore("queue", (queue) => [...queue, toastOptions])
+        return
+      }
       setStore("currentToast", toastOptions)
-      if (timeoutHandle) clearTimeout(timeoutHandle)
-      timeoutHandle = setTimeout(() => {
-        setStore("currentToast", null)
-      }, toastOptions.duration).unref()
+      start(toastOptions.duration)
     },
     error: (err: any) => {
       if (err instanceof Error)
@@ -77,10 +174,31 @@ function init() {
         message: "An unknown error has occurred",
       })
     },
+    pause() {
+      if (!store.currentToast || paused) return
+      paused = true
+      remaining = Math.max(0, remaining - (Date.now() - startedAt))
+      clear()
+    },
+    resume() {
+      if (!store.currentToast || !paused) return
+      paused = false
+      start(remaining)
+    },
+    dismiss,
+    activate() {
+      const action = store.currentToast?.action
+      dismiss()
+      action?.run()
+    },
     get currentToast(): ToastOptions | null {
       return store.currentToast
     },
+    get pending() {
+      return store.queue.length
+    },
   }
+  onCleanup(clear)
   return toast
 }
 

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -66,7 +66,7 @@ function ToastSurface(props: {
                 fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
               >
                 {hovered() ? "› " : ""}
-                {props.toast.action?.label ?? "Dismiss"}
+                {props.toast.action?.label ?? "x"}
               </text>
             </Show>
           </box>
@@ -86,7 +86,7 @@ function ToastSurface(props: {
               fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
             >
               {hovered() ? "› " : ""}
-              {props.toast.action?.label ?? "Dismiss"}
+              {props.toast.action?.label ?? "x"}
             </text>
           </Show>
         </box>

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -65,7 +65,7 @@ function ToastSurface(props: {
                 attributes={hovered() ? TextAttributes.BOLD : undefined}
                 fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
               >
-                {hovered() ? "› " : ""}
+                {hovered() && props.toast.action ? "› " : ""}
                 {props.toast.action?.label ?? "x"}
               </text>
             </Show>
@@ -85,7 +85,7 @@ function ToastSurface(props: {
               attributes={hovered() ? TextAttributes.BOLD : undefined}
               fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
             >
-              {hovered() ? "› " : ""}
+              {hovered() && props.toast.action ? "› " : ""}
               {props.toast.action?.label ?? "x"}
             </text>
           </Show>

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "../context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "./border"
 import { TextAttributes } from "@opentui/core"
+import { tint } from "../theme/color"
 export type ToastOptions = {
   title?: string
   message: string
@@ -38,11 +39,6 @@ function ToastSurface(props: {
       maxWidth={Math.min(60, dimensions().width - 6)}
       justifyContent="center"
       alignItems="flex-start"
-      paddingLeft={2}
-      paddingRight={2}
-      paddingTop={1}
-      paddingBottom={1}
-      backgroundColor={theme.background.default}
       borderColor={theme.text.feedback[props.toast.variant].default}
       border={["left", "right"]}
       customBorderChars={SplitBorder.customBorderChars}
@@ -50,13 +46,41 @@ function ToastSurface(props: {
       onMouseOut={() => hover(false)}
       onMouseUp={props.onActivate}
     >
-      <Show
-        when={props.toast.title}
-        fallback={
-          <box flexDirection="row" width="100%">
-            <text fg={theme.text.default} wrapMode="word" flexGrow={1}>
-              {props.toast.message}
+      <box
+        width="100%"
+        paddingLeft={2}
+        paddingRight={2}
+        paddingTop={1}
+        paddingBottom={1}
+        backgroundColor={hovered() ? tint(theme.background.default, theme.text.default, 0.1) : theme.background.default}
+      >
+        <Show
+          when={props.toast.title}
+          fallback={
+            <box flexDirection="row" width="100%">
+              <text fg={theme.text.default} wrapMode="word" flexGrow={1}>
+                {props.toast.message}
+              </text>
+              <Show when={props.toast.action || hovered()}>
+                <text
+                  flexShrink={0}
+                  marginLeft={2}
+                  wrapMode="none"
+                  attributes={hovered() ? TextAttributes.BOLD : undefined}
+                  fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+                >
+                  {hovered() && props.toast.action ? "› " : ""}
+                  {props.toast.action?.label ?? "x"}
+                </text>
+              </Show>
+            </box>
+          }
+        >
+          <box flexDirection="row" width="100%" marginBottom={1}>
+            <text attributes={TextAttributes.BOLD} fg={theme.text.default}>
+              {props.toast.title}
             </text>
+            <box flexGrow={1} />
             <Show when={props.toast.action || hovered()}>
               <text
                 flexShrink={0}
@@ -70,35 +94,16 @@ function ToastSurface(props: {
               </text>
             </Show>
           </box>
-        }
-      >
-        <box flexDirection="row" width="100%" marginBottom={1}>
-          <text attributes={TextAttributes.BOLD} fg={theme.text.default}>
-            {props.toast.title}
+          <text fg={theme.text.default} wrapMode="word" width="100%">
+            {props.toast.message}
           </text>
-          <box flexGrow={1} />
-          <Show when={props.toast.action || hovered()}>
-            <text
-              flexShrink={0}
-              marginLeft={2}
-              wrapMode="none"
-              attributes={hovered() ? TextAttributes.BOLD : undefined}
-              fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
-            >
-              {hovered() && props.toast.action ? "› " : ""}
-              {props.toast.action?.label ?? "x"}
-            </text>
-          </Show>
-        </box>
-        <text fg={theme.text.default} wrapMode="word" width="100%">
-          {props.toast.message}
-        </text>
-      </Show>
-      <Show when={props.pending}>
-        <text fg={theme.text.subdued} marginTop={1}>
-          +{props.pending} more
-        </text>
-      </Show>
+        </Show>
+        <Show when={props.pending}>
+          <text fg={theme.text.subdued} marginTop={1}>
+            +{props.pending} more
+          </text>
+        </Show>
+      </box>
     </box>
   )
 }

--- a/packages/tui/test/cli/tui/toast.test.tsx
+++ b/packages/tui/test/cli/tui/toast.test.tsx
@@ -1,0 +1,65 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { onMount } from "solid-js"
+import { ToastProvider, useToast, type ToastContext } from "../../../src/ui/toast"
+
+function captureToast(setToast: (toast: ToastContext) => void) {
+  return function Capture() {
+    const toast = useToast()
+    onMount(() => setToast(toast))
+    return null
+  }
+}
+
+test("clicking runs an action and advances a queued toast", async () => {
+  let toast: ToastContext | undefined
+  const Capture = captureToast((value) => (toast = value))
+  const app = await testRender(() => (
+    <ToastProvider>
+      <Capture />
+    </ToastProvider>
+  ))
+
+  try {
+    await app.waitFor(() => toast !== undefined)
+    let activated = false
+    toast!.show({
+      message: "Plugin failed",
+      variant: "error",
+      action: { label: "Open plugins", run: () => (activated = true) },
+    })
+    toast!.pause()
+    toast!.show({ message: "Copied", variant: "success" })
+
+    expect(toast!.currentToast?.message).toBe("Plugin failed")
+    expect(toast!.pending).toBe(1)
+
+    toast!.activate()
+
+    expect(activated).toBe(true)
+    expect(toast!.currentToast?.message).toBe("Copied")
+    expect(toast!.pending).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("clicking a toast without an action dismisses it", async () => {
+  let toast: ToastContext | undefined
+  const Capture = captureToast((value) => (toast = value))
+  const app = await testRender(() => (
+    <ToastProvider>
+      <Capture />
+    </ToastProvider>
+  ))
+
+  try {
+    await app.waitFor(() => toast !== undefined)
+    toast!.show({ message: "Copied", variant: "success" })
+    toast!.activate()
+    expect(toast!.currentToast).toBeNull()
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What

TUI toasts now pause while hovered and use the whole card as a single click target:

- actionable toasts dismiss and run their action
- ordinary toasts dismiss without another effect
- notifications arriving during a hover wait instead of replacing what the user is reading
- plugin and MCP failures link directly to their existing management dialogs

The header shows the destination subtly at rest and highlights the whole-card action on hover.

## How

- `packages/tui/src/ui/toast.tsx` tracks remaining timeout duration, pauses/resumes it across hover, queues notifications while a toast is held, and activates or dismisses on click.
- `packages/tui/src/plugin/context.tsx` dispatches `plugins.list` from plugin failure toasts.
- `packages/tui/src/app.tsx` dispatches `mcp.list` from failed and unauthenticated MCP toasts.
- Focused provider tests cover action activation, queued progression, and plain dismissal.

## Scope

Actions are local TUI callbacks. This does not add arbitrary plugin-defined actions or change the public toast protocol.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/tui/toast.test.tsx test/plugin-hot-reload.test.tsx` from `packages/tui` (9 passed)
- Push hook workspace typecheck (34 packages passed)
- Live `bun run dev:live` verification with a real failed plugin: hover kept the toast visible beyond five seconds, and clicking opened Plugins

## Demo

The recording uses a real plugin failure in the live V2 TUI. The first segment is accelerated while the pointer holds the toast beyond its timeout.

https://github.com/user-attachments/assets/02317256-a971-4ccb-8334-63f624f40c56

## Flow

```mermaid
flowchart TD
  A[Toast appears] --> B{Pointer enters?}
  B -- no --> C[Timer expires]
  C --> D[Dismiss]
  B -- yes --> E[Pause remaining time]
  E --> F{Card clicked?}
  F -- actionable --> G[Dismiss and run action]
  F -- ordinary --> D
  F -- no, pointer leaves --> H[Resume remaining time]
  H --> C
  E --> I[New toast arrives]
  I --> J[Queue behind held toast]
```
