### PR TITLE
fix(tui): persist plugin activation toggles

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -1,4 +1,5 @@
 export * as Config from "."
+export * as ConfigPlugin from "./plugin"
 
 import { createBindingLookup } from "@opentui/keymap/extras"
 import { Schema } from "effect"

--- a/packages/tui/src/config/plugin.ts
+++ b/packages/tui/src/config/plugin.ts
@@ -1,0 +1,5 @@
+export function setEnabled(draft: { plugins?: unknown[] }, id: string, enabled: boolean) {
+  const plugins = Array.isArray(draft.plugins) ? draft.plugins : []
+  draft.plugins = plugins.filter((entry) => entry !== id && entry !== `-${id}`)
+  draft.plugins.push(enabled ? id : `-${id}`)
+}

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -4,6 +4,7 @@ import { usePlugin } from "../../plugin/context"
 import { DialogSelect, type DialogSelectOption } from "../../ui/dialog-select"
 import { useDialog } from "../../ui/dialog"
 import { DialogErrorDetails } from "../../component/dialog-error-details"
+import { ConfigPlugin, useConfig } from "../../config"
 
 const id = "opencode.plugins"
 
@@ -12,6 +13,7 @@ function View(props: { context: Plugin.Context; plugins: ReturnType<typeof usePl
   const [focused, setFocused] = createSignal<string>()
   const [detail, setDetail] = createSignal<{ title: string; error: string }>()
   const dialog = useDialog()
+  const config = useConfig()
   const options = createMemo(() => {
     const builtins = props.plugins
       .registered()
@@ -65,10 +67,9 @@ function View(props: { context: Plugin.Context; plugins: ReturnType<typeof usePl
     const current = props.plugins.registered().find((item) => item.id === plugin.value)
     if (!current) return
     setLocked(true)
-    void (current.active ? props.plugins.deactivate(current.id) : props.plugins.activate(current.id))
-      .then((ok) => {
-        if (ok) return
-        props.context.ui.toast.show({ variant: "error", message: `Failed to update plugin ${current.id}` })
+    void config
+      .update((draft) => {
+        ConfigPlugin.setEnabled(draft, current.id, !current.active)
       })
       .catch((error) => {
         props.context.ui.toast.show({

--- a/packages/tui/test/plugin-hot-reload.test.tsx
+++ b/packages/tui/test/plugin-hot-reload.test.tsx
@@ -30,7 +30,7 @@ async function until(read: () => Promise<string>, expected: (value: string | und
   return value
 }
 
-async function bootApp(directory: string) {
+async function bootApp(directory: string, config: Record<string, unknown> = {}) {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
   const core = await import("@opentui/core")
   mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
@@ -53,7 +53,13 @@ async function bootApp(directory: string) {
     run({
       app: { name: "test", version: "test", channel: "test" },
       server: { endpoint: { url: server.url.toString() } },
-      config: { get: async () => ({}), update: async () => ({}) },
+      config: {
+        get: async () => config,
+        update: async (update) => {
+          update(config)
+          return config
+        },
+      },
       packages: { resolve: async () => undefined },
       args: {},
       log: () => {},
@@ -212,6 +218,29 @@ test("editing one plugin leaves others untouched and a broken save keeps the las
     "b1:setup\nb1:cleanup\nb2:setup\nb2:cleanup\nb3:setup\n",
   )
   expect(await readA()).toBe("a1:setup\na1:cleanup\na2:setup\n")
+
+  process.emit("SIGHUP")
+  await app.task
+})
+
+test("editing one plugin does not reactivate a plugin disabled by configuration", async () => {
+  await using tmp = await tmpdir()
+  const directory = path.join(tmp.path, ".opencode", "plugins", "tui")
+  await mkdir(directory, { recursive: true })
+  const markerA = path.join(tmp.path, "a.txt")
+  const markerB = path.join(tmp.path, "b.txt")
+  await writeFile(path.join(directory, "a.ts"), lifecycleSource(markerA, "test.a", "a1"))
+  const sourceB = path.join(directory, "b.ts")
+  await writeFile(sourceB, lifecycleSource(markerB, "test.b", "b1"))
+
+  await using app = await bootApp(tmp.path, { plugins: ["-test.a"] })
+  const readB = () => readFile(markerB, "utf8")
+  expect(await until(readB, (value) => value === "b1:setup\n")).toBe("b1:setup\n")
+  expect(await readFile(markerA, "utf8").catch(() => undefined)).toBeUndefined()
+
+  await writeFile(sourceB, lifecycleSource(markerB, "test.b", "b2"))
+  expect(await until(readB, (value) => value?.includes("b2:setup") ?? false)).toBe("b1:setup\nb1:cleanup\nb2:setup\n")
+  expect(await readFile(markerA, "utf8").catch(() => undefined)).toBeUndefined()
 
   process.emit("SIGHUP")
   await app.task

--- a/packages/tui/test/plugin-toggle.test.ts
+++ b/packages/tui/test/plugin-toggle.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+import { ConfigPlugin } from "../src/config"
+
+test("plugin toggles replace exact directives without disturbing source declarations", () => {
+  const source = { package: "/tmp/recap.ts", options: { compact: true } }
+  const config = { plugins: [source, "kit.session-recap", "-kit.session-recap", "other"] }
+
+  ConfigPlugin.setEnabled(config, "kit.session-recap", false)
+  expect(config.plugins).toEqual([source, "other", "-kit.session-recap"])
+
+  ConfigPlugin.setEnabled(config, "kit.session-recap", true)
+  expect(config.plugins).toEqual([source, "other", "kit.session-recap"])
+})


### PR DESCRIPTION
## What

Persist activation changes made through `/plugins` so manually disabled plugins stay disabled across unrelated plugin source reloads and TUI restarts.

## Before / After

**Before**

1. Disable plugin A through `/plugins`.
2. Edit plugin B's source.
3. Source reconciliation rebuilds desired state from config.
4. Plugin A is declared normally in config, so it is activated again.

**After**

1. Disable plugin A through `/plugins`.
2. The TUI writes a trailing `-plugin.a` directive to the configured plugin list.
3. Edit plugin B's source or restart the TUI.
4. Reconciliation applies the persisted directive and plugin A remains inactive.

## How

- `packages/tui/src/config/plugin.ts` normalizes exact activation directives and appends the selected final state.
- `packages/tui/src/feature-plugins/system/plugins.tsx` updates host configuration instead of mutating only the current in-memory registration.
- Existing reconciliation remains the single lifecycle path that activates or deactivates registrations after the config update.

```mermaid
sequenceDiagram
  participant User
  participant Dialog as /plugins
  participant Config
  participant Reconciler

  User->>Dialog: disable plugin A
  Dialog->>Config: append -plugin.a
  Config->>Reconciler: configuration changed
  Reconciler->>Reconciler: deactivate plugin A
  User->>Reconciler: edit plugin B source
  Reconciler->>Config: read ordered directives
  Reconciler->>Reconciler: reload B; keep A inactive
```

## Scope

This does not change plugin discovery, source watching, matching semantics, or failure fallback behavior. It only makes dialog activation changes durable through the existing ordered plugin directives.

## Testing

- `bun run test test/plugin-hot-reload.test.tsx test/plugin-toggle.test.ts` from `packages/tui`: 9 passed.
- `bun typecheck` from `packages/tui`.
- Push hook repository typecheck: 34 packages passed.
- Live V2 TUI: disabled `kit.session-recap` through `/plugins`, confirmed `-kit.session-recap` was persisted, edited `pr-tracker`, and confirmed `kit.session-recap` remained inactive. Restored it to active afterward.
