### PR TITLE
fix(cli): mark lightningcss as external in the compiled build

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -66,7 +66,9 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts"],
     tsconfig: "./tsconfig.json",
     plugins: [plugin],
-    external: ["node-gyp"],
+    // lightningcss (via ui -> tailwind) has a conditional native-binding require the bundler
+    // cannot resolve; the TUI never runs that path, so it stays external.
+    external: ["node-gyp", "lightningcss"],
     format: "esm",
     minify: true,
     sourcemap: sourcemapsFlag ? "linked" : "none",


### PR DESCRIPTION
### Issue for this PR

Closes # (no issue filed; the repro is below)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`bun run --cwd packages/cli build --single` fails from a fresh clone:

```
    error: Could not resolve: "../pkg"
    at node_modules/.bun/lightningcss@1.30.1/node_modules/lightningcss/node/index.js:17:28
```

`lightningcss` comes in via `@opencode-ai/ui` -> tailwind. Its `node/index.js` has a conditional `require("../pkg")` for the wasm variant, and `Bun.build` tries to resolve that path even though the branch never runs. Marking `lightningcss` external skips the resolution. It is safe because nothing in the TUI calls lightningcss at runtime; if something ever did, the require would fail loudly instead of silently bundling wrong.

Seen with bun 1.3.14 on macOS arm64. Your release CI presumably builds under a configuration where this doesn't trigger, but a fresh local clone hits it every time.

### How did you verify your code works?

Before the change: the build fails with the error above, repeatably. After: the build completes and I exercised the compiled binary end to end: TUI boot, daemon spawn via `serve --register`, sessions served over the API.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR