### PR TITLE
fix(cli): defer update check until service resolves

### DIFF
--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -15,8 +15,6 @@ export default Runtime.handler(Commands, (input) =>
   Effect.gen(function* () {
     const requestedDirectory = Option.getOrUndefined(input.directory)
     if (requestedDirectory !== undefined) process.chdir(requestedDirectory)
-    const updater = yield* Updater.Service
-    yield* updater.check().pipe(Effect.forkScoped)
     const preflight = UpdatePreflight.make()
     yield* Effect.addFinalizer(() => Effect.promise(() => preflight.close()))
     const server = yield* ServerConnection.resolve({
@@ -36,6 +34,8 @@ export default Runtime.handler(Commands, (input) =>
         Effect.promise(() => preflight.fail("OpenCode update could not start the new background service")),
       ),
     )
+    const updater = yield* Updater.Service
+    yield* updater.check().pipe(Effect.forkScoped)
     preflight.loading()
     const config = yield* Config.Service
     const npm = yield* Npm.Service


### PR DESCRIPTION
## Summary

- resolve the current CLI version's background service before starting the asynchronous auto-update
- prevent a running old client from repeatedly rejecting newly installed server contenders as version mismatches
- extract the fix from closed, unmerged PR #42025 into a focused change

## Reproduction

A `0.0.0-next-17428` client began service resolution and auto-updated the executable to `0.0.0-next-17430` concurrently. The still-running `17428` process then spawned `17430` servers, rejected each one as incompatible, stopped it, and retried until the old client was killed.

## Testing

- `bun typecheck` (`packages/cli`)
- `bun test src/services/updater.test.ts` (`packages/cli`)
- workspace pre-push typecheck (35 tasks)