### PR TITLE
refactor(util): remove unused npm install

### DIFF
--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -55,7 +55,6 @@ const integrations = Layer.mock(Integration.Service, {
 })
 const npm = Layer.mock(Npm.Service, {
   add: () => Effect.die("unused"),
-  install: () => Effect.die("unused"),
   which: () => Effect.die("unused"),
 })
 const aisdk = Layer.mock(AISDK.Service, {

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -29,7 +29,6 @@ const npmLayer = Layer.succeed(
   Npm.Service,
   Npm.Service.of({
     add: () => Effect.succeed({ directory: "", entrypoint: undefined }),
-    install: () => Effect.void,
     which: () => Effect.succeed(undefined),
   }),
 )

--- a/packages/core/test/plugin/provider-dynamic.test.ts
+++ b/packages/core/test/plugin/provider-dynamic.test.ts
@@ -23,7 +23,6 @@ const itWithAISDK = testEffect(Layer.mergeAll(PluginTestLayer, AppNodeBuilder.bu
 function npmEntrypoint(entrypoint?: string) {
   return Npm.Service.of({
     add: () => Effect.succeed({ directory: "", entrypoint }),
-    install: () => Effect.void,
     which: () => Effect.succeed(undefined),
   })
 }

--- a/packages/core/test/plugin/provider-sap-ai-core.test.ts
+++ b/packages/core/test/plugin/provider-sap-ai-core.test.ts
@@ -14,7 +14,6 @@ const fixtureProvider = new URL("./fixtures/provider-factory.ts", import.meta.ur
 const it = testEffect(PluginTestLayer)
 const npm = Npm.Service.of({
   add: () => Effect.succeed({ directory: "", entrypoint: undefined }),
-  install: () => Effect.void,
   which: () => Effect.succeed(undefined),
 })
 

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -30,15 +30,6 @@ export interface Interface {
     pkg: string,
     options?: { readonly subpaths?: readonly string[] },
   ) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
-  readonly install: (
-    dir: string,
-    input?: {
-      add: {
-        name: string
-        version?: string
-      }[]
-    },
-  ) => Effect.Effect<void, EffectFlock.LockError | InstallFailedError>
   readonly which: (pkg: string, bin?: string) => Effect.Effect<string | undefined>
 }
 
@@ -143,59 +134,6 @@ const layer = Layer.effect(
       return resolveEntryPoint(first.name, first.path, options?.subpaths)
     }, Effect.scoped)
 
-    const install: Interface["install"] = Effect.fn("Npm.install")(function* (dir, input) {
-      const canWrite = yield* afs.access(dir, { writable: true }).pipe(
-        Effect.as(true),
-        Effect.orElseSucceed(() => false),
-      )
-      if (!canWrite) return
-
-      const add = input?.add.map((pkg) => [pkg.name, pkg.version].filter(Boolean).join("@")) ?? []
-      if (
-        yield* Effect.gen(function* () {
-          const nodeModulesExists = yield* afs.existsSafe(path.join(dir, "node_modules"))
-          if (!nodeModulesExists) {
-            yield* reify({ add, dir })
-            return true
-          }
-          return false
-        }).pipe(Effect.withSpan("Npm.checkNodeModules"))
-      )
-        return
-
-      yield* Effect.gen(function* () {
-        const pkg = yield* afs.readJson(path.join(dir, "package.json")).pipe(Effect.orElseSucceed(() => ({})))
-        const lock = yield* afs.readJson(path.join(dir, "package-lock.json")).pipe(Effect.orElseSucceed(() => ({})))
-
-        const pkgAny = pkg as any
-        const lockAny = lock as any
-        const declared = new Set([
-          ...Object.keys(pkgAny?.dependencies || {}),
-          ...Object.keys(pkgAny?.devDependencies || {}),
-          ...Object.keys(pkgAny?.peerDependencies || {}),
-          ...Object.keys(pkgAny?.optionalDependencies || {}),
-          ...(input?.add || []).map((pkg) => pkg.name),
-        ])
-
-        const root = lockAny?.packages?.[""] || {}
-        const locked = new Set([
-          ...Object.keys(root?.dependencies || {}),
-          ...Object.keys(root?.devDependencies || {}),
-          ...Object.keys(root?.peerDependencies || {}),
-          ...Object.keys(root?.optionalDependencies || {}),
-        ])
-
-        for (const name of declared) {
-          if (!locked.has(name)) {
-            yield* reify({ dir, add })
-            return
-          }
-        }
-      }).pipe(Effect.withSpan("Npm.checkDirty"))
-
-      return
-    }, Effect.scoped)
-
     const which = Effect.fn("Npm.which")(function* (pkg: string, bin?: string) {
       const dir = directory(pkg)
       const binDir = path.join(dir, "node_modules", ".bin")
@@ -249,7 +187,6 @@ const layer = Layer.effect(
 
     return Service.of({
       add,
-      install,
       which,
     })
   }),
@@ -262,10 +199,6 @@ export const node = makeGlobalNode({
 })
 
 const { runPromise } = makeRuntime(Service, LayerNode.compile(node))
-
-export async function install(...args: Parameters<Interface["install"]>) {
-  return runPromise((svc) => svc.install(...args))
-}
 
 export async function add(...args: Parameters<Interface["add"]>) {
   return runPromise((svc) => svc.add(...args))


### PR DESCRIPTION
## What

Remove the unused V2 `Npm.install` capability, which performed arbitrary-project dependency synchronization but has no production callers. Remove the corresponding stale fields from core test service fixtures.

## Impact

| Measure | Consequence |
| --- | --- |
| Code | 71 lines deleted across 5 files |
| Service surface | Removes 1 unused operation and 4 stale test placeholders |
| Runtime | No production behavior or startup change; there are zero production callers |
| Dependencies | No package removed; Arborist remains used by `Npm.add` |
| Compatibility | External deep-import consumers of `@opencode-ai/util/npm` can no longer call or implement `Npm.install` |
| Importance | Narrows the npm service to operations OpenCode actually supports and exercises |

## How

- Remove `install` from the npm service interface, implementation, service object, and Promise convenience exports in `packages/util/src/npm.ts`.
- Remove now-unnecessary `install` placeholders from V2 core tests.

## Scope

This does not remove Arborist or change npm configuration behavior. `Npm.add`, `Npm.which`, and their shared `reify` path remain unchanged, so plugin, provider, and formatter installs are unaffected.

## Testing

- `cd packages/util && bun typecheck`
- `cd packages/core && bun typecheck`
- `cd packages/core && bun run test test/npm.test.ts` (3 passed)
- `cd packages/core && bun run test test/generate.test.ts test/plugin/provider-dynamic.test.ts test/plugin/provider-sap-ai-core.test.ts` (15 passed)
- Push hook: `bun turbo typecheck --concurrency=3` (35 tasks passed)
- Prettier reported all changed files unchanged
