### PR TITLE
fix(tui): recover sessions from missing locations

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -741,21 +741,48 @@ const layer = Layer.effect(
         if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
         const project = yield* projects.resolve(directory)
         yield* persistProject(project)
-        const item = SessionInbox.Item.make({
-          type: "move",
-          payload: {
-            location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
-            projectID: project.id,
-            subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
-          },
-          delivery: input.delivery ?? "steer",
-        })
-        const inboxID = SessionMessage.ID.create()
-        yield* SessionInbox.admit(db, bus, {
-          id: inboxID,
+        const payload = {
           sessionID: input.sessionID,
-          item,
-        })
+          location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
+          projectID: project.id,
+          subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
+        }
+        const recovered = yield* SessionInbox.serialized(
+          input.sessionID,
+          Effect.gen(function* () {
+            const source = yield* fs
+              .stat(current.location.directory)
+              .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (!source || source.type !== "Directory") {
+              const pending = (yield* SessionInbox.list(db, input.sessionID)).filter((item) => item.type === "move")
+              const cancellations = pending.map(
+                (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
+              )
+              const first = cancellations[0]
+              if (!first) {
+                yield* bus.publish(SessionEvent.Moved, payload)
+                return true
+              }
+              yield* bus.publishAll([first, ...cancellations.slice(1), [SessionEvent.Moved, payload]])
+              return true
+            }
+            yield* SessionInbox.admit(db, bus, {
+              id: SessionMessage.ID.create(),
+              sessionID: input.sessionID,
+              item: SessionInbox.Item.make({
+                type: "move",
+                payload: {
+                  location: payload.location,
+                  projectID: payload.projectID,
+                  subpath: payload.subpath,
+                },
+                delivery: input.delivery ?? "steer",
+              }),
+            })
+            return false
+          }),
+        )
+        if (recovered) return
         yield* execution.wake(input.sessionID)
       }),
       compact: Effect.fn("Session.compact")(function* (input) {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -741,43 +741,38 @@ const layer = Layer.effect(
         if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
         const project = yield* projects.resolve(directory)
         yield* persistProject(project)
-        const payload = {
-          sessionID: input.sessionID,
+        const payload: SessionInbox.MovePayload = {
           location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
           projectID: project.id,
           subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
         }
+        const item = SessionInbox.Item.make({
+          type: "move",
+          payload,
+          delivery: input.delivery ?? "steer",
+        })
         const recovered = yield* SessionInbox.serialized(
           input.sessionID,
           Effect.gen(function* () {
-            const source = yield* fs
-              .stat(current.location.directory)
-              .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            const latest = yield* result.get(input.sessionID)
+            const source = yield* fs.stat(latest.location.directory).pipe(Effect.catch(() => Effect.succeed(undefined)))
             if (!source || source.type !== "Directory") {
-              const pending = (yield* SessionInbox.list(db, input.sessionID)).filter((item) => item.type === "move")
-              const cancellations = pending.map(
+              const cancellations = (yield* SessionInbox.moveIDs(db, input.sessionID)).map(
                 (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
               )
+              const moved = [SessionEvent.Moved, { sessionID: input.sessionID, ...payload }] as const
               const first = cancellations[0]
               if (!first) {
-                yield* bus.publish(SessionEvent.Moved, payload)
+                yield* bus.publish(...moved)
                 return true
               }
-              yield* bus.publishAll([first, ...cancellations.slice(1), [SessionEvent.Moved, payload]])
+              yield* bus.publishAll([first, ...cancellations.slice(1), moved])
               return true
             }
             yield* SessionInbox.admit(db, bus, {
               id: SessionMessage.ID.create(),
               sessionID: input.sessionID,
-              item: SessionInbox.Item.make({
-                type: "move",
-                payload: {
-                  location: payload.location,
-                  projectID: payload.projectID,
-                  subpath: payload.subpath,
-                },
-                delivery: input.delivery ?? "steer",
-              }),
+              item,
             })
             return false
           }),

--- a/packages/core/src/session/inbox.ts
+++ b/packages/core/src/session/inbox.ts
@@ -309,6 +309,16 @@ export const list = Effect.fn("SessionInbox.list")(function* (db: DatabaseServic
   return rows.map(fromRow)
 })
 
+export const moveIDs = Effect.fn("SessionInbox.moveIDs")(function* (db: DatabaseService, sessionID: SessionSchema.ID) {
+  return yield* db
+    .select({ id: SessionInboxTable.id })
+    .from(SessionInboxTable)
+    .where(and(eq(SessionInboxTable.session_id, sessionID), eq(SessionInboxTable.type, "move")))
+    .orderBy(asc(SessionInboxTable.enqueued_seq))
+    .all()
+    .pipe(Effect.orDie)
+})
+
 export const nextQueued = Effect.fn("SessionInbox.nextQueued")(function* (
   db: DatabaseService,
   sessionID: SessionSchema.ID,

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
 import path from "path"
+import { mkdir, rm } from "fs/promises"
 import { Effect } from "effect"
 import { Worktree } from "@opencode-ai/schema/worktree"
 import { Bus } from "@opencode-ai/core/bus"
@@ -29,7 +30,7 @@ const it = testEffect(
 )
 
 describe("Session.move", () => {
-  it.effect("enqueues one move when the source directory no longer exists", () =>
+  it.effect("applies a move immediately when the source directory no longer exists", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
@@ -38,29 +39,26 @@ describe("Session.move", () => {
         Effect.gen(function* () {
           const session = yield* Session.Service
           const destination = AbsolutePath.make(tmp.path)
+          const source = path.join(tmp.path, "source")
+          yield* Effect.promise(() => mkdir(source))
           const created = yield* session.create({
-            location: Location.Ref.make({ directory: AbsolutePath.make(path.join(tmp.path, "deleted")) }),
+            location: Location.Ref.make({ directory: AbsolutePath.make(source) }),
           })
 
           yield* session.move({ sessionID: created.id, directory: destination })
+          expect((yield* session.get(created.id)).location.directory).toBe(AbsolutePath.make(source))
+          expect(yield* session.inbox(created.id)).toHaveLength(1)
 
-          expect((yield* session.get(created.id)).location.directory).toBe(
-            AbsolutePath.make(path.join(tmp.path, "deleted")),
-          )
-          expect(yield* session.inbox(created.id)).toMatchObject([
-            {
-              type: "move",
-              delivery: "steer",
-              payload: {
-                location: { directory: destination },
-                projectID: Project.ID.global,
-              },
-            },
-          ])
+          yield* Effect.promise(() => rm(source, { recursive: true }))
+          yield* session.move({ sessionID: created.id, directory: destination })
+
+          expect((yield* session.get(created.id)).location.directory).toBe(destination)
+          expect(yield* session.inbox(created.id)).toEqual([])
 
           yield* session.move({ sessionID: created.id, directory: destination })
-          expect(yield* session.inbox(created.id)).toHaveLength(2)
+          expect(yield* session.inbox(created.id)).toHaveLength(1)
 
+          yield* Effect.promise(() => mkdir(path.join(tmp.path, "other")))
           const steered = yield* session.create({
             location: Location.Ref.make({ directory: AbsolutePath.make(path.join(tmp.path, "other")) }),
           })

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -665,14 +665,17 @@ function App(props: { pair?: DialogPairCredentials }) {
         category: "Session",
         slash: { name: "new", aliases: ["clear"] },
         run: () => {
+          const current =
+            route.data.type === "session"
+              ? (data.session.get(route.data.sessionID)?.location ?? location.ref)
+              : undefined
           route.navigate({
             type: "home",
             location: newSessionLocation(
               config.data.session.new_location,
               paths.cwd,
-              route.data.type === "session"
-                ? (data.session.get(route.data.sessionID)?.location ?? location.ref)
-                : undefined,
+              current,
+              location.error?.location,
             ),
           })
           dialog.clear()

--- a/packages/tui/src/config/new-session-location.ts
+++ b/packages/tui/src/config/new-session-location.ts
@@ -4,7 +4,13 @@ export function newSessionLocation(
   mode: "launch" | "inherit",
   launchDirectory: string,
   current?: LocationRef,
+  unavailable?: LocationRef,
 ): LocationRef {
-  if (mode === "inherit" && current) return current
+  if (
+    mode === "inherit" &&
+    current &&
+    (current.directory !== unavailable?.directory || current.workspaceID !== unavailable.workspaceID)
+  )
+    return current
   return { directory: launchDirectory }
 }

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -10,6 +10,7 @@ import { useConfig } from "../config"
 import { useLocation } from "./location"
 import { useStorage } from "./storage"
 import { useTuiPaths } from "./runtime"
+import { newSessionLocation } from "../config/new-session-location"
 import {
   closeSessionTab,
   cycleSessionTab,
@@ -289,9 +290,15 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       add() {
         if (!enabled()) return
         const sessionID = current()
+        const currentLocation = (sessionID ? data.session.get(sessionID)?.location : undefined) ?? location.ref
         route.navigate({
           type: "home",
-          location: (sessionID ? data.session.get(sessionID)?.location : undefined) ?? location.ref,
+          location: newSessionLocation(
+            config.session.new_location,
+            paths.cwd,
+            currentLocation,
+            location.error?.location,
+          ),
         })
       },
       close(sessionID?: string) {

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -4,7 +4,6 @@ import { useTheme } from "../context/theme"
 import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "./border"
 import { TextAttributes } from "@opentui/core"
-import { tint } from "../theme/color"
 export type ToastOptions = {
   title?: string
   message: string
@@ -56,9 +55,7 @@ function ToastSurface(props: {
         paddingRight={2}
         paddingTop={1}
         paddingBottom={1}
-        backgroundColor={
-          hovered() ? tint(theme.background.default, theme.text.default, 0.04) : theme.background.default
-        }
+        backgroundColor={theme.background.default}
       >
         <Show
           when={props.toast.title}
@@ -67,7 +64,18 @@ function ToastSurface(props: {
               <text fg={theme.text.default} wrapMode="word" flexGrow={1}>
                 {props.toast.message}
               </text>
-              <Show when={props.toast.action || hovered()}>
+              <Show
+                when={props.toast.action}
+                fallback={
+                  <text
+                    flexShrink={0}
+                    marginLeft={2}
+                    fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+                  >
+                    x
+                  </text>
+                }
+              >
                 <text
                   flexShrink={0}
                   marginLeft={2}
@@ -75,8 +83,7 @@ function ToastSurface(props: {
                   attributes={hovered() ? TextAttributes.BOLD : undefined}
                   fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
                 >
-                  {hovered() && props.toast.action ? "› " : ""}
-                  {props.toast.action?.label ?? "x"}
+                  › {props.toast.action?.label}
                 </text>
               </Show>
             </box>
@@ -87,7 +94,18 @@ function ToastSurface(props: {
               {props.toast.title}
             </text>
             <box flexGrow={1} />
-            <Show when={props.toast.action || hovered()}>
+            <Show
+              when={props.toast.action}
+              fallback={
+                <text
+                  flexShrink={0}
+                  marginLeft={2}
+                  fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+                >
+                  x
+                </text>
+              }
+            >
               <text
                 flexShrink={0}
                 marginLeft={2}
@@ -95,8 +113,7 @@ function ToastSurface(props: {
                 attributes={hovered() ? TextAttributes.BOLD : undefined}
                 fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
               >
-                {hovered() && props.toast.action ? "› " : ""}
-                {props.toast.action?.label ?? "x"}
+                › {props.toast.action?.label}
               </text>
             </Show>
           </box>

--- a/packages/tui/src/ui/toast.tsx
+++ b/packages/tui/src/ui/toast.tsx
@@ -30,6 +30,17 @@ function ToastSurface(props: {
     setHovered(value)
     props.onHover?.(value)
   }
+  const affordance = () => (
+    <text
+      flexShrink={0}
+      marginLeft={2}
+      wrapMode="none"
+      attributes={hovered() && props.toast.action ? TextAttributes.BOLD : undefined}
+      fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
+    >
+      {props.toast.action ? `› ${props.toast.action.label}` : "x"}
+    </text>
+  )
 
   return (
     <box
@@ -64,28 +75,7 @@ function ToastSurface(props: {
               <text fg={theme.text.default} wrapMode="word" flexGrow={1}>
                 {props.toast.message}
               </text>
-              <Show
-                when={props.toast.action}
-                fallback={
-                  <text
-                    flexShrink={0}
-                    marginLeft={2}
-                    fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
-                  >
-                    x
-                  </text>
-                }
-              >
-                <text
-                  flexShrink={0}
-                  marginLeft={2}
-                  wrapMode="none"
-                  attributes={hovered() ? TextAttributes.BOLD : undefined}
-                  fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
-                >
-                  › {props.toast.action?.label}
-                </text>
-              </Show>
+              {affordance()}
             </box>
           }
         >
@@ -94,28 +84,7 @@ function ToastSurface(props: {
               {props.toast.title}
             </text>
             <box flexGrow={1} />
-            <Show
-              when={props.toast.action}
-              fallback={
-                <text
-                  flexShrink={0}
-                  marginLeft={2}
-                  fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
-                >
-                  x
-                </text>
-              }
-            >
-              <text
-                flexShrink={0}
-                marginLeft={2}
-                wrapMode="none"
-                attributes={hovered() ? TextAttributes.BOLD : undefined}
-                fg={hovered() ? theme.text.action.primary.default : theme.text.subdued}
-              >
-                › {props.toast.action?.label}
-              </text>
-            </Show>
+            {affordance()}
           </box>
           <text fg={theme.text.default} wrapMode="word" width="100%">
             {props.toast.message}

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -35,6 +35,7 @@ async function renderSessionTabs(
     persisted?: string[]
     sessionGate?: Promise<void>
     sessionDirectories?: Record<string, string>
+    newLocation?: "launch" | "inherit"
   },
 ) {
   const temporary = options?.state ? undefined : await tmpdir()
@@ -106,7 +107,12 @@ async function renderSessionTabs(
     <TestTuiContexts paths={{ state }}>
       <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
         <StorageProvider>
-          <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
+          <ConfigProvider
+            config={createTuiResolvedConfig({
+              tabs: { enabled: true },
+              session: { new_location: options?.newLocation ?? "launch" },
+            })}
+          >
             <RouteProvider
               initialRoute={options?.home ? { type: "home" } : { type: "session", sessionID: initialSessionID }}
             >
@@ -319,8 +325,8 @@ test("tracks a temporary new session tab across close and creation", async () =>
   }
 })
 
-test("add opens the new session tab carrying the current session's location", async () => {
-  const setup = await renderSessionTabs("first")
+test("add opens the new session tab in the launch directory by default", async () => {
+  const setup = await renderSessionTabs("first", { sessionDirectories: { first: `${directory}/worktree` } })
 
   try {
     await wait(() => setup.tabs.current() === "first" && setup.data.session.get("first") !== undefined)
@@ -328,6 +334,22 @@ test("add opens the new session tab carrying the current session's location", as
     expect(setup.route.data).toEqual({ type: "home", location: { directory } })
     await wait(() => setup.tabs.newTab())
     expect(setup.tabs.tabs().map((tab) => tab.sessionID)).toEqual(["first"])
+  } finally {
+    await setup.destroy()
+  }
+})
+
+test("add inherits the current session location when configured", async () => {
+  const worktree = `${directory}/worktree`
+  const setup = await renderSessionTabs("first", {
+    newLocation: "inherit",
+    sessionDirectories: { first: worktree },
+  })
+
+  try {
+    await wait(() => setup.tabs.current() === "first" && setup.data.session.get("first") !== undefined)
+    setup.tabs.add()
+    expect(setup.route.data).toEqual({ type: "home", location: { directory: worktree } })
   } finally {
     await setup.destroy()
   }

--- a/packages/tui/test/new-session-location.test.ts
+++ b/packages/tui/test/new-session-location.test.ts
@@ -17,3 +17,14 @@ test("inherits the active session location when configured", () => {
 test("falls back to the launch directory without an active session", () => {
   expect(newSessionLocation("inherit", "/launch")).toEqual({ directory: "/launch" })
 })
+
+test("does not inherit an unavailable active location", () => {
+  expect(
+    newSessionLocation(
+      "inherit",
+      "/launch",
+      { directory: "/deleted", workspaceID: "work-1" },
+      { directory: "/deleted", workspaceID: "work-1" },
+    ),
+  ).toEqual({ directory: "/launch" })
+})


### PR DESCRIPTION
## What

Recover sessions whose working directory has been deleted, without requiring the broken location runner to start.

This also keeps new sessions out of unavailable inherited locations, makes the tab plus action respect `session.new_location`, and stabilizes toast rendering while hovered.

## Before / After

**Before**

1. Opening a session backed by a deleted temporary directory showed “Session location unavailable.”
2. Choosing a valid replacement admitted a move into the session inbox.
3. Applying that move required starting the runner at the deleted source directory, so the move remained pending forever and prompts failed with `UnexpectedStatus`.
4. New session actions could inherit the same deleted directory.
5. Hovering an error toast changed its surface background and inserted its close affordance, producing a visible flash.

**After**

1. A move from an unavailable source validates the destination and applies the location change immediately.
2. Any stale pending moves are cancelled in the same durable publish batch before the recovery move.
3. Normal moves from healthy locations retain their existing inbox and safe-boundary semantics.
4. New session entry points fall back to the launch directory when the inherited location is unavailable; tab plus now follows the configured launch/inherit mode.
5. Toast geometry and background remain stable while hover only changes affordance emphasis.

## How

- `packages/core/src/session.ts`: serializes move admission per session and uses immediate durable recovery only when the current source is no longer a directory.
- `packages/tui/src/config/new-session-location.ts`: centralizes unavailable-location fallback.
- `packages/tui/src/app.tsx` and `packages/tui/src/context/session-tabs.tsx`: use the same location policy for command and tab entry points.
- `packages/tui/src/ui/toast.tsx`: keeps the close/action affordance mounted and removes whole-surface hover tinting.

## Scope

- Does not change normal healthy-session move delivery semantics.
- Does not change the public HTTP API or generated clients.

## Testing

- `cd packages/core && bun run test test/session-move.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/tui && bun run test test/new-session-location.test.ts test/context/session-tabs.test.tsx test/cli/tui/toast.test.tsx`
- `cd packages/tui && bun typecheck`
- Push hook: workspace-wide `bun turbo typecheck --concurrency=3` (35 tasks passed)
- `git diff --check` and Prettier check on all changed files

## Flow

```mermaid
flowchart TD
  A[Move requested] --> B{Source directory available?}
  B -- Yes --> C[Admit move to session inbox]
  C --> D[Apply at safe runner boundary]
  B -- No --> E[Cancel stale pending moves]
  E --> F[Publish recovery move immediately]
  F --> G[Session resolves at destination]
```
