### PR TITLE
fix(tui): isolate tab scroll state

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -285,6 +285,8 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
           scrollAnchors.delete(target)
           return
         }
+        const current = scrollAnchors.get(target)
+        if (current?.messageID === anchor.messageID && current.screenY === anchor.screenY) return
         scrollAnchors.set(target, anchor)
       },
       select(sessionID: string) {

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -36,6 +36,11 @@ type PersistedState = {
   cwd: Record<string, TabsState>
 }
 
+type ScrollAnchor = {
+  messageID: string
+  screenY: number
+}
+
 const empty = (): TabsState => ({ tabs: [], unread: {} })
 
 // Deliberately after connect settles: the visible session's mount syncs win the first slots.
@@ -66,11 +71,11 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     let history: SessionTabHistory = { entries: [], index: -1 }
     // User-closed tabs eligible for reopening; in-memory like history, deleted sessions pruned.
     let closedTabs: ClosedSessionTab[] = []
-    const scrollOffsets = new Map<string, number>()
+    const scrollAnchors = new Map<string, ScrollAnchor>()
 
     createEffect(() => {
       if (config.experimental?.tab_scroll === true) return
-      scrollOffsets.clear()
+      scrollAnchors.clear()
     })
 
     function state() {
@@ -237,7 +242,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
 
     function remove(sessionID: string, navigate: boolean) {
       const target = root(sessionID)
-      scrollOffsets.delete(target)
+      scrollAnchors.delete(target)
       const closed = closeSessionTab(state().tabs, target)
       const selected = navigate && current() === target
       if (closed.tabs === state().tabs && !selected) return
@@ -269,18 +274,18 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       },
       current,
       status,
-      scrollOffset(sessionID: string) {
+      scrollAnchor(sessionID: string) {
         const target = root(sessionID)
         if (!state().tabs.some((tab) => tab.sessionID === target)) return
-        return scrollOffsets.get(target)
+        return scrollAnchors.get(target)
       },
-      setScrollOffset(sessionID: string, offset: number | undefined) {
+      setScrollAnchor(sessionID: string, anchor: ScrollAnchor | undefined) {
         const target = root(sessionID)
-        if (offset === undefined || !state().tabs.some((tab) => tab.sessionID === target)) {
-          scrollOffsets.delete(target)
+        if (anchor === undefined || !state().tabs.some((tab) => tab.sessionID === target)) {
+          scrollAnchors.delete(target)
           return
         }
-        scrollOffsets.set(target, offset)
+        scrollAnchors.set(target, anchor)
       },
       select(sessionID: string) {
         if (!enabled()) return

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -66,11 +66,11 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     let history: SessionTabHistory = { entries: [], index: -1 }
     // User-closed tabs eligible for reopening; in-memory like history, deleted sessions pruned.
     let closedTabs: ClosedSessionTab[] = []
-    const scrollPositions = new Map<string, number>()
+    const scrollOffsets = new Map<string, number>()
 
     createEffect(() => {
       if (config.experimental?.tab_scroll === true) return
-      scrollPositions.clear()
+      scrollOffsets.clear()
     })
 
     function state() {
@@ -237,7 +237,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
 
     function remove(sessionID: string, navigate: boolean) {
       const target = root(sessionID)
-      scrollPositions.delete(target)
+      scrollOffsets.delete(target)
       const closed = closeSessionTab(state().tabs, target)
       const selected = navigate && current() === target
       if (closed.tabs === state().tabs && !selected) return
@@ -269,18 +269,18 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       },
       current,
       status,
-      scrollPosition(sessionID: string) {
+      scrollOffset(sessionID: string) {
         const target = root(sessionID)
         if (!state().tabs.some((tab) => tab.sessionID === target)) return
-        return scrollPositions.get(target)
+        return scrollOffsets.get(target)
       },
-      setScrollPosition(sessionID: string, position: number | undefined) {
+      setScrollOffset(sessionID: string, offset: number | undefined) {
         const target = root(sessionID)
-        if (position === undefined || !state().tabs.some((tab) => tab.sessionID === target)) {
-          scrollPositions.delete(target)
+        if (offset === undefined || !state().tabs.some((tab) => tab.sessionID === target)) {
+          scrollOffsets.delete(target)
           return
         }
-        scrollPositions.set(target, position)
+        scrollOffsets.set(target, offset)
       },
       select(sessionID: string) {
         if (!enabled()) return

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -338,12 +338,7 @@ export function Session() {
   let scroll: ScrollBoxRenderable
   onCleanup(() => {
     if (!scroll || scroll.isDestroyed) return
-    sessionTabs.setScrollOffset(
-      sessionID,
-      config.experimental?.tab_scroll === true && isAwayFromBottom()
-        ? scroll.scrollHeight - scroll.viewport.height - scroll.scrollTop
-        : undefined,
-    )
+    saveScrollAnchor()
   })
   const [prompt, setPrompt] = createSignal<PromptRef>()
   const bind = (r: PromptRef | undefined) => {
@@ -368,8 +363,10 @@ export function Session() {
   // mount on demand near the top, keeping inactive tabs cheap to tear down. Until the first chunk
   // pins the count, the hidden span derives from the row count, so streaming appends remain visible.
   const [hiddenRows, setHiddenRows] = createSignal<number>()
+  const [visibleRowsEnd, setVisibleRowsEnd] = createSignal<number>()
   const hidden = createMemo(() => Math.max(0, Math.min(hiddenRows() ?? Infinity, rows.length - TRANSCRIPT_TAIL_ROWS)))
-  const visibleRows = createMemo(() => (hidden() === 0 ? rows : rows.slice(hidden())))
+  const visibleEnd = createMemo(() => Math.max(hidden(), Math.min(visibleRowsEnd() ?? rows.length, rows.length)))
+  const visibleRows = createMemo(() => rows.slice(hidden(), visibleEnd()))
   let revealingOlderRows = false
   const revealOlderRows = (scrollBy = 0) => {
     const current = hidden()
@@ -391,14 +388,37 @@ export function Session() {
     })
     return true
   }
+  let revealingNewerRows = false
+  const revealNewerRows = (scrollBy = 0) => {
+    const current = visibleEnd()
+    if (
+      revealingNewerRows ||
+      current === rows.length ||
+      !scroll ||
+      scroll.isDestroyed ||
+      scroll.scrollTop + scroll.viewport.height < scroll.scrollHeight - scroll.viewport.height
+    )
+      return false
+    revealingNewerRows = true
+    const next = Math.min(rows.length, current + TRANSCRIPT_BACKFILL_CHUNK)
+    setVisibleRowsEnd(next === rows.length ? undefined : next)
+    afterLayout(() => {
+      revealingNewerRows = false
+      scroll.scrollBy(scrollBy)
+      updateAwayFromBottom()
+    })
+    return true
+  }
   /** Message navigation needs the full transcript mounted before walking or jumping. */
   const ensureAllRows = (continuation: () => void) => {
-    if (hidden() === 0) return continuation()
+    if (hidden() === 0 && visibleEnd() === rows.length) return continuation()
     setHiddenRows(0)
+    setVisibleRowsEnd(undefined)
     afterLayout(continuation)
   }
 
   function isAwayFromBottom() {
+    if (visibleEnd() < rows.length) return true
     return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height) - 1
   }
   function updateAwayFromBottom() {
@@ -407,23 +427,51 @@ export function Session() {
       if (!scroll || scroll.isDestroyed) return
       const away = isAwayFromBottom()
       setAwayFromBottom(away)
-      sessionTabs.setScrollOffset(
-        sessionID,
-        away ? scroll.scrollHeight - scroll.viewport.height - scroll.scrollTop : undefined,
-      )
+      saveScrollAnchor()
     })
   }
+  function saveScrollAnchor() {
+    if (config.experimental?.tab_scroll !== true || !isAwayFromBottom()) {
+      sessionTabs.setScrollAnchor(sessionID, undefined)
+      return
+    }
+    const boundaryIDs = new Set(boundaries().filter((id) => id !== undefined))
+    const visible = scroll
+      .getChildren()
+      .filter((child) => child.id && boundaryIDs.has(child.id))
+      .map((child) => ({ messageID: child.id!, screenY: child.y - scroll.viewport.y }))
+    const anchor = visible.findLast((item) => item.screenY <= 0) ?? visible[0]
+    if (anchor) sessionTabs.setScrollAnchor(sessionID, anchor)
+  }
   function restoreScrollPosition(sessionID: string) {
-    const offset = config.experimental?.tab_scroll === true ? sessionTabs.scrollOffset(sessionID) : undefined
-    if (offset === undefined) {
+    const anchor = config.experimental?.tab_scroll === true ? sessionTabs.scrollAnchor(sessionID) : undefined
+    const index = anchor ? boundaries().indexOf(anchor.messageID) : -1
+    if (!anchor || index === -1) {
       scroll.scrollTo(scroll.scrollHeight)
       setAwayFromBottom(false)
       return
     }
-    ensureAllRows(() => {
-      scroll.scrollTo(scroll.scrollHeight - scroll.viewport.height - offset)
-      updateAwayFromBottom()
-    })
+    setHiddenRows(Math.max(0, index - TRANSCRIPT_BACKFILL_CHUNK))
+    const end = Math.min(rows.length, index + TRANSCRIPT_BACKFILL_CHUNK)
+    setVisibleRowsEnd(end === rows.length ? undefined : end)
+    scroll.stickyScroll = false
+    const restore = () =>
+      afterLayout(() => {
+        const boundary = scroll.getRenderable(anchor.messageID)
+        if (!boundary) return
+        const contentY = scroll.scrollTop + boundary.y - scroll.viewport.y
+        const target = contentY - anchor.screenY
+        const maximum = Math.max(0, scroll.scrollHeight - scroll.viewport.height)
+        if (target > maximum && visibleEnd() < rows.length) {
+          const next = Math.min(rows.length, visibleEnd() + TRANSCRIPT_BACKFILL_CHUNK)
+          setVisibleRowsEnd(next === rows.length ? undefined : next)
+          restore()
+          return
+        }
+        scroll.scrollTo(target)
+        updateAwayFromBottom()
+      })
+    restore()
   }
 
   createEffect(() => {
@@ -535,19 +583,28 @@ export function Session() {
   function toBottom() {
     clearMessageNavigation()
     setAwayFromBottom(false)
-    sessionTabs.setScrollOffset(route.sessionID, undefined)
+    sessionTabs.setScrollAnchor(route.sessionID, undefined)
+    setHiddenRows(undefined)
+    setVisibleRowsEnd(undefined)
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
+      scroll.stickyScroll = true
       scroll.scrollTo(scroll.scrollHeight)
     }, 50)
   }
 
   function moveTranscript(delta: number) {
     clearMessageNavigation()
-    if (delta >= 0 || !revealOlderRows(delta)) {
-      scroll.scrollBy(delta)
-      updateAwayFromBottom()
+    if (delta < 0 && revealOlderRows(delta)) {
+      dialog.clear()
+      return
     }
+    if (delta > 0 && revealNewerRows(delta)) {
+      dialog.clear()
+      return
+    }
+    scroll.scrollBy(delta)
+    updateAwayFromBottom()
     dialog.clear()
   }
 
@@ -1091,6 +1148,7 @@ export function Session() {
                 scrollAcceleration={scrollAcceleration()}
                 onMouseScroll={(event) => {
                   if (event.scroll?.direction === "up" && revealOlderRows()) return
+                  if (event.scroll?.direction === "down" && revealNewerRows()) return
                   updateAwayFromBottom()
                 }}
               >

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -149,6 +149,7 @@ export function Session() {
     await writeFile(file, content)
   }
   const route = useRouteData("session")
+  const sessionID = route.sessionID
   const { navigate } = useRoute()
   const data = useData()
   const local = useLocal()
@@ -336,9 +337,11 @@ export function Session() {
   let scroll: ScrollBoxRenderable
   onCleanup(() => {
     if (!scroll || scroll.isDestroyed) return
-    sessionTabs.setScrollPosition(
-      route.sessionID,
-      config.experimental?.tab_scroll === true && isAwayFromBottom() ? scroll.scrollTop : undefined,
+    sessionTabs.setScrollOffset(
+      sessionID,
+      config.experimental?.tab_scroll === true && isAwayFromBottom()
+        ? scroll.scrollHeight - scroll.viewport.height - scroll.scrollTop
+        : undefined,
     )
   })
   const [prompt, setPrompt] = createSignal<PromptRef>()
@@ -403,18 +406,21 @@ export function Session() {
       if (!scroll || scroll.isDestroyed) return
       const away = isAwayFromBottom()
       setAwayFromBottom(away)
-      if (!away) sessionTabs.setScrollPosition(route.sessionID, undefined)
+      sessionTabs.setScrollOffset(
+        sessionID,
+        away ? scroll.scrollHeight - scroll.viewport.height - scroll.scrollTop : undefined,
+      )
     })
   }
   function restoreScrollPosition(sessionID: string) {
-    const position = config.experimental?.tab_scroll === true ? sessionTabs.scrollPosition(sessionID) : undefined
-    if (position === undefined) {
+    const offset = config.experimental?.tab_scroll === true ? sessionTabs.scrollOffset(sessionID) : undefined
+    if (offset === undefined) {
       scroll.scrollTo(scroll.scrollHeight)
       setAwayFromBottom(false)
       return
     }
     ensureAllRows(() => {
-      scroll.scrollTo(position)
+      scroll.scrollTo(scroll.scrollHeight - scroll.viewport.height - offset)
       updateAwayFromBottom()
     })
   }
@@ -528,7 +534,7 @@ export function Session() {
   function toBottom() {
     clearMessageNavigation()
     setAwayFromBottom(false)
-    sessionTabs.setScrollPosition(route.sessionID, undefined)
+    sessionTabs.setScrollOffset(route.sessionID, undefined)
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -274,6 +274,7 @@ export function Session() {
   const [synced, setSynced] = createSignal(false)
   const sessionTabs = useSessionTabs()
   const [awayFromBottom, setAwayFromBottom] = createSignal(false)
+  const [latestHovered, setLatestHovered] = createSignal(false)
 
   const clearMessageNavigation = () => {
     setNavigationSlack(0)
@@ -1116,7 +1117,12 @@ export function Session() {
             </box>
             <box height={1} flexShrink={0} flexDirection="row" justifyContent="flex-end">
               <Show when={config.experimental?.tab_scroll === true && awayFromBottom()}>
-                <text fg={theme.text.subdued} onMouseUp={toBottom}>
+                <text
+                  fg={latestHovered() ? theme.text.default : theme.text.subdued}
+                  onMouseOver={() => setLatestHovered(true)}
+                  onMouseOut={() => setLatestHovered(false)}
+                  onMouseUp={toBottom}
+                >
                   Latest ↓
                 </text>
               </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -267,8 +267,15 @@ export function Session() {
     })
   })
   const editor = useEditorContext()
-  const rows = createSessionRows(() => route.sessionID)
+  const [rowsSynced, setRowsSynced] = createSignal(false)
+  const rows = createSessionRows(
+    () => route.sessionID,
+    (id) => {
+      if (id === sessionID) setRowsSynced(true)
+    },
+  )
   const boundaries = createMemo(() => messageBoundaryIDs(rows, messages()))
+  const boundaryIDs = createMemo(() => new Set(boundaries().filter((id) => id !== undefined)))
   const [navigationMessage, setNavigationMessage] = createSignal<string>()
   const [navigationSlack, setNavigationSlack] = createSignal(0)
   const [synced, setSynced] = createSignal(false)
@@ -320,7 +327,6 @@ export function Session() {
         return
       }
       editor.reconnect(info.location.directory)
-      if (route.sessionID === sessionID && scroll) restoreScrollPosition(sessionID)
       setSynced(true)
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
@@ -335,8 +341,16 @@ export function Session() {
 
   let seeded = false
   let sent = false
+  let restored = false
   let scroll: ScrollBoxRenderable
+  createEffect(() => {
+    if (restored || !synced() || !rowsSynced() || !scroll || scroll.isDestroyed) return
+    restored = true
+    restoreScrollPosition()
+  })
+  let awayTimer: ReturnType<typeof setTimeout> | undefined
   onCleanup(() => {
+    if (awayTimer) clearTimeout(awayTimer)
     if (!scroll || scroll.isDestroyed) return
     saveScrollAnchor()
   })
@@ -423,7 +437,9 @@ export function Session() {
   }
   function updateAwayFromBottom() {
     if (config.experimental?.tab_scroll !== true) return
-    setTimeout(() => {
+    if (awayTimer) clearTimeout(awayTimer)
+    awayTimer = setTimeout(() => {
+      awayTimer = undefined
       if (!scroll || scroll.isDestroyed) return
       const away = isAwayFromBottom()
       setAwayFromBottom(away)
@@ -435,15 +451,19 @@ export function Session() {
       sessionTabs.setScrollAnchor(sessionID, undefined)
       return
     }
-    const boundaryIDs = new Set(boundaries().filter((id) => id !== undefined))
-    const visible = scroll
-      .getChildren()
-      .filter((child) => child.id && boundaryIDs.has(child.id))
-      .map((child) => ({ messageID: child.id!, screenY: child.y - scroll.viewport.y }))
-    const anchor = visible.findLast((item) => item.screenY <= 0) ?? visible[0]
+    let first: { messageID: string; screenY: number } | undefined
+    let anchor: { messageID: string; screenY: number } | undefined
+    for (const child of scroll.getChildren()) {
+      if (!child.id || !boundaryIDs().has(child.id)) continue
+      const item = { messageID: child.id, screenY: child.y - scroll.viewport.y }
+      first ??= item
+      if (item.screenY <= 0) anchor = item
+    }
+    anchor ??= first
     if (anchor) sessionTabs.setScrollAnchor(sessionID, anchor)
+    else sessionTabs.setScrollAnchor(sessionID, undefined)
   }
-  function restoreScrollPosition(sessionID: string) {
+  function restoreScrollPosition() {
     const anchor = config.experimental?.tab_scroll === true ? sessionTabs.scrollAnchor(sessionID) : undefined
     const index = anchor ? boundaries().indexOf(anchor.messageID) : -1
     if (!anchor || index === -1) {
@@ -458,7 +478,13 @@ export function Session() {
     const restore = () =>
       afterLayout(() => {
         const boundary = scroll.getRenderable(anchor.messageID)
-        if (!boundary) return
+        if (!boundary) {
+          sessionTabs.setScrollAnchor(sessionID, undefined)
+          scroll.stickyScroll = true
+          scroll.scrollTo(scroll.scrollHeight)
+          setAwayFromBottom(false)
+          return
+        }
         const contentY = scroll.scrollTop + boundary.y - scroll.viewport.y
         const target = contentY - anchor.screenY
         const maximum = Math.max(0, scroll.scrollHeight - scroll.viewport.height)
@@ -582,6 +608,8 @@ export function Session() {
 
   function toBottom() {
     clearMessageNavigation()
+    if (awayTimer) clearTimeout(awayTimer)
+    awayTimer = undefined
     setAwayFromBottom(false)
     sessionTabs.setScrollAnchor(route.sessionID, undefined)
     setHiddenRows(undefined)

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -35,7 +35,7 @@ export type SessionRow =
   | { type: "assistant-footer"; messageID: string }
   | { type: "turn-usage"; messageIDs: string[]; previousCache?: CacheUsage }
 
-export function createSessionRows(sessionID: Accessor<string>) {
+export function createSessionRows(sessionID: Accessor<string>, onSynced?: (sessionID: string) => void) {
   const data = useData()
   const client = useClient()
   const config = useConfig()
@@ -95,6 +95,7 @@ export function createSessionRows(sessionID: Accessor<string>) {
         () => {
           if (sessionID() !== id) return
           setRows(reconcile(reduce()))
+          onSynced?.(id)
         },
         () => undefined,
       )


### PR DESCRIPTION
## What

Keep each session tab at its own transcript reading position when the `tab_scroll` experiment is enabled.

## Before / After

**Before**

1. Scroll upward in tab A.
2. Switch to tab B.
3. Tab A's cleanup could save its position under B because the route had already advanced.
4. The saved absolute `scrollTop` also became stale when older transcript rows mounted above the visible tail.
5. Switching back could show another tab's position or unrelated transcript content.

**After**

1. Each mounted session captures its own session ID.
2. Scrolling records that tab's distance from the transcript bottom while the renderable is live.
3. Switching back mounts older rows, then restores the same bottom-relative offset.
4. Tabs retain independent reading positions as transcript history mounts or grows.

## How

- `packages/tui/src/routes/session/index.tsx` captures the mounted session ID instead of reading the advanced route during cleanup.
- Scroll state is updated during transcript scrolling, before OpenTUI destroys the scrollbox.
- Restoration uses distance from the bottom rather than absolute `scrollTop`, so prepending lazily mounted history does not change the remembered location.
- `packages/tui/src/context/session-tabs.tsx` stores per-session bottom offsets and clears them when the experiment is disabled or a tab closes.

## Scope

- Applies only when the existing `tab_scroll` experiment is enabled.
- Scroll state remains in-memory for open tabs; this does not persist positions across TUI restarts.

## Testing

- `cd packages/tui && bun run test` (694 passed, 5 skipped)
- `cd packages/tui && bun typecheck`
- Push hook: workspace typecheck, 35 packages passed
- `bunx prettier --check src/routes/session/index.tsx src/context/session-tabs.tsx`
- Live PTY verification against the elected V2 server: enabled `tab_scroll`, scrolled one session several pages upward, switched to another tab and back, and confirmed the original transcript region and `Latest ↓` state were restored without affecting the other tab.

## Performance

Profiled warm tab switches in a real PTY against the elected V2 server using one warmup and repeated alternating switches. Timings ran from tab selection to the post-layout restored transcript.

| Scenario | Mounted rows | Median settle |
| --- | ---: | ---: |
| Bottom-pinned baseline | 40 | 75.7 ms |
| Previous full restoration | 444 | 286.6 ms |
| Bounded anchor restoration | 75 | 86.0 ms |
| Deep historical restoration | 114 | 101.9 ms |

Bounded restoration is about 70% faster in the measured scrolled-up case and stays close to the bottom-pinned path. The visible transcript was captured before and after deep restoration and matched exactly apart from the devtools focus marker.

Row reduction averaged about 1.1 ms, so caching reduced rows was rejected as the next optimization: transcript render/layout, not row derivation, dominated this workload. Temporary profiling instrumentation was removed before commit.
