### PR TITLE
chore: remove orphaned v2 exports

### DIFF
--- a/packages/core/src/instructions/index.ts
+++ b/packages/core/src/instructions/index.ts
@@ -195,18 +195,6 @@ export function hash(value: Schema.Json) {
   return Hash.make(createHash("sha256").update(canonical(value)).digest("hex"))
 }
 
-export function applyDelta(
-  values: Readonly<Record<string, Schema.Json>>,
-  delta: Readonly<Record<string, Option.Option<Schema.Json>>>,
-): Readonly<Record<string, Schema.Json>> {
-  const result: Record<string, Schema.Json> = { ...values }
-  for (const [key, value] of Object.entries(delta)) {
-    if (Option.isNone(value)) delete result[key]
-    else result[key] = value.value
-  }
-  return result
-}
-
 export function applyHashDelta(values: Values, delta: Delta): Values {
   const result: Record<string, Hash> = { ...values }
   for (const [key, value] of Object.entries(delta)) {

--- a/packages/core/test/instructions/index.test.ts
+++ b/packages/core/test/instructions/index.test.ts
@@ -125,9 +125,6 @@ describe("Instructions", () => {
       expect(
         Instructions.renderUpdate(instructions, { "api/value": "previous" }, { "api/value": Option.some(null) }),
       ).toBe("null")
-      expect(Instructions.applyDelta({ "api/value": "previous" }, { "api/value": Option.some(null) })).toEqual({
-        "api/value": null,
-      })
     }),
   )
 

--- a/packages/core/test/lib/instructions.ts
+++ b/packages/core/test/lib/instructions.ts
@@ -34,7 +34,11 @@ export const readUpdate = (instructions: Instructions.List, previous: State) =>
         hash === "removed" ? Option.none() : Option.some(admission.blobs[hash]),
       ]),
     ) as Readonly<Record<string, Option.Option<Schema.Json>>>
-    const values = Instructions.applyDelta(previous.values, delta)
+    const values: Record<string, Schema.Json> = { ...previous.values }
+    for (const [key, value] of Object.entries(delta)) {
+      if (Option.isNone(value)) delete values[key]
+      else values[key] = value.value
+    }
     return {
       values,
       text: Instructions.renderUpdate(instructions, previous.values, delta),

--- a/packages/schema/src/durable-event-manifest.ts
+++ b/packages/schema/src/durable-event-manifest.ts
@@ -4,9 +4,4 @@ import { Event } from "./event.js"
 import { Worktree } from "./worktree.js"
 import { SessionEvent } from "./session-event.js"
 
-export const SessionDurable = {
-  definitions: Event.durableMap(SessionEvent.DurableDefinitions),
-  schema: SessionEvent.Durable,
-} as const
-
 export const Durable = Event.durableMap([...SessionEvent.DurableDefinitions, Worktree.Event.Resolved])

--- a/packages/schema/src/mcp-event.ts
+++ b/packages/schema/src/mcp-event.ts
@@ -17,14 +17,6 @@ export const ResourcesChanged = Event.ephemeral({
   },
 })
 
-export const BrowserOpenFailed = Event.ephemeral({
-  type: "mcp.browser.open.failed",
-  schema: {
-    mcpName: Schema.String,
-    url: Schema.String,
-  },
-})
-
 // Emitted whenever a server's connection status settles (connected, failed, needs_auth, closed) so
 // observers can refresh status without polling.
 export const StatusChanged = Event.ephemeral({


### PR DESCRIPTION
## What

Remove three verified orphaned V2 exports from Schema and Core:

- `McpEvent.BrowserOpenFailed`
- `DurableEventManifest.SessionDurable`
- `Instructions.applyDelta`

## Impact

| Measure | Consequence |
| --- | --- |
| Code | 29 lines deleted and 5 added across 5 files |
| Surface | Removes 3 names with zero production callers |
| Runtime | No runtime behavior change |
| Wire compatibility | No event definition, manifest registration, or HTTP schema changes |
| Compatibility | External deep-import consumers of the three names stop compiling |
| Importance | Removes misleading alternatives to the canonical event and instruction paths |

## How

- Confirmed the MCP event is absent from MCP definitions and public event manifests.
- Kept session durability sourced from the canonical `SessionEvent.DurableDefinitions` and `SessionEvent.Durable` surfaces.
- Replaced the test helper's only `applyDelta` use with its local explicit value fold and retained null-versus-removal coverage.

## Scope

No Protocol or Server `HttpApi` changed, so client generation was not run.

## Testing

- `bun typecheck` in `packages/schema`
- `bun typecheck` in `packages/core`
- `bun run test test/event-manifest.test.ts test/event.test.ts` in `packages/schema`
- `bun run test test/instructions/index.test.ts` in `packages/core`
- Repository-wide typecheck push hook
