### PR TITLE
refactor(core): remove unused API members

### DIFF
--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -223,8 +223,6 @@ export const layer = Layer.effect(
   }),
 )
 
-export const locationLayer = layer
-
 export const node = makeLocationNode({ service: Service, layer, deps: [Bus.node] })
 
 export function validateAnswer(form: ReadonlyArray<Form.Field>, answer: Answer) {

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -89,7 +89,6 @@ export type BackgroundAllInput = {
 }
 
 export interface Interface {
-  readonly list: () => Effect.Effect<Info[]>
   readonly get: (id: string) => Effect.Effect<Info | undefined>
   readonly start: (input: StartInput) => Effect.Effect<Info>
   readonly wait: (input: WaitInput) => Effect.Effect<WaitResult>
@@ -185,12 +184,6 @@ export const make = Effect.gen(function* () {
       Effect.asVoid,
       Effect.forkIn(scope, { startImmediately: true }),
     )
-  })
-
-  const list: Interface["list"] = Effect.fn("Job.list")(function* () {
-    return Array.from((yield* SynchronizedRef.get(state.jobs)).values())
-      .map(snapshot)
-      .toSorted((a, b) => a.started_at - b.started_at)
   })
 
   const get: Interface["get"] = Effect.fn("Job.get")(function* (id) {
@@ -360,7 +353,7 @@ export const make = Effect.gen(function* () {
     return result.info
   })
 
-  return Service.of({ list, get, start, wait, block, background, backgroundAll, cancel })
+  return Service.of({ get, start, wait, block, background, backgroundAll, cancel })
 })
 
 const layer = Layer.effect(Service, make)

--- a/packages/core/src/util/encode.ts
+++ b/packages/core/src/util/encode.ts
@@ -10,15 +10,6 @@ export function base64Decode(value: string) {
   return new TextDecoder().decode(bytes)
 }
 
-export async function hash(content: string, algorithm = "SHA-256"): Promise<string> {
-  const encoder = new TextEncoder()
-  const data = encoder.encode(content)
-  const hashBuffer = await crypto.subtle.digest(algorithm, data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("")
-  return hashHex
-}
-
 export function checksum(content: string): string | undefined {
   if (!content) return undefined
   let hash = 0x811c9dc5


### PR DESCRIPTION
## What

Remove three high-confidence zero-caller Core API members:

- `Form.locationLayer`
- `hash` from `@opencode-ai/core/util/encode`
- `Job.Interface.list` and its implementation/service assembly

All live encode exports, Form's private `layer` and `Form.node`, and every other Job operation remain intact.

## How

Repository-wide searches covered production code, tests, scripts, generated files, module imports, namespace/property access, computed-property access, type-level references, and dynamic imports. No callers were found before or after the edit.

| Surface | Exact savings |
| --- | ---: |
| `packages/core/src/form.ts`: `Form.locationLayer` alias | 2 lines |
| `packages/core/src/util/encode.ts`: async `hash` export | 9 lines |
| `packages/core/src/job.ts`: `Interface.list` | 1 line |
| `packages/core/src/job.ts`: `Job.list` implementation | 6 lines |
| `packages/core/src/job.ts`: service assembly | 1 line replaced; no net line savings |
| **Total** | **18 net lines (19 deletions, 1 insertion)** |

There are no runtime or dependency savings; this only contracts unused source and type surfaces.

## Scope

Because `@opencode-ai/core` exposes wildcard-reachable module surfaces, this intentionally removes members that external consumers could technically import even though the repository has zero callers. No changeset is included for this accepted internal-surface contraction.

No behavior, protocol, server API, generated client, dependency, or runtime assembly changes are included.

## Testing

- `bun run test test/form.test.ts test/job.test.ts` from `packages/core` (17 passed)
- `bun typecheck` from `packages/core`
- `bun typecheck` from the repository root (35 workspace tasks passed)
- Push hook reran repository-wide `bun typecheck` (35 workspace tasks passed)
- No focused encode test exists
