### PR TITLE
chore(ui): remove stale motion pins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -974,8 +974,6 @@
         "marked-shiki": "catalog:",
         "morphdom": "2.7.8",
         "motion": "12.34.5",
-        "motion-dom": "12.34.3",
-        "motion-utils": "12.29.2",
         "remeda": "catalog:",
         "remend": "catalog:",
         "shiki": "catalog:",
@@ -4917,9 +4915,9 @@
 
     "motion": ["motion@12.34.5", "", { "dependencies": { "framer-motion": "^12.34.5", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-N06NLJ9IeBHeielRqIvYvjPfXuRdyTxa+9++BgpGa+hY2D7TcMkI6QzV3jaRuv0aZRXgMa7cPy9YcBUBisPzAQ=="],
 
-    "motion-dom": ["motion-dom@12.34.3", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ=="],
+    "motion-dom": ["motion-dom@12.43.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag=="],
 
-    "motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
@@ -8032,10 +8030,6 @@
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "mermaid/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
-    "motion/framer-motion/motion-dom": ["motion-dom@12.43.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag=="],
-
-    "motion/framer-motion/motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -97,8 +97,6 @@
     "marked-shiki": "catalog:",
     "morphdom": "2.7.8",
     "motion": "12.34.5",
-    "motion-dom": "12.34.3",
-    "motion-utils": "12.29.2",
     "remeda": "catalog:",
     "remend": "catalog:",
     "shiki": "catalog:",


### PR DESCRIPTION
## What

Remove stale direct `motion-dom` and `motion-utils` dependencies from `@opencode-ai/ui`. The package imports only `motion`, whose current dependency graph already supplies the required newer versions.

Runtime behavior is preserved: `packages/ui/src/components/motion-spring.tsx` continues to import `attachSpring`, `motionValue`, and `SpringOptions` from `motion`.

## How

- Remove the unused direct pins from `packages/ui/package.json`.
- Regenerate `bun.lock` with Bun 1.3.14.
- Keep `motion-dom@12.43.0` and `motion-utils@12.39.0` through `motion@12.34.5 -> framer-motion@12.43.0` while dropping the stale `12.34.3` and `12.29.2` package instances.
- Verify there are no source, config, or script imports of `motion-dom` or `motion-utils`.

## Impact

| Metric | Before | After | Savings |
| --- | ---: | ---: | ---: |
| Motion DOM/utils package instances in lock graph | 4 | 2 | 2 |
| Installed allocated size | 9,781,248 bytes | 5,083,136 bytes | 4,698,112 bytes (4.48046875 MiB) |
| Installed apparent size removed |  |  | 3,180,541 bytes across 518 files |
| `bun.lock` size | 1,199,449 bytes | 1,198,987 bytes | 462 bytes |

The installed-size comparison measures the exact `.bun` package directories in a baseline install from `origin/v2`; the retained size is the newer transitive pair and the removed size is the stale direct pair.

## Compatibility

The supported `@opencode-ai/ui` API and motion behavior are unchanged. Consumers that imported `motion-dom` or `motion-utils` directly only because `@opencode-ai/ui` declared them can no longer rely on that undeclared dependency access and must declare those packages themselves.

## Testing

- `bun install`
- `bun install --frozen-lockfile`
- `bunx prettier --write packages/ui/package.json`
- `bun typecheck` (`packages/ui`)
- `bun run test` (`packages/ui`, 27 passing)
- `bun run build` (`packages/ui`)
- `bun typecheck` (workspace pre-push command, 35 tasks passing)
- `git push -u origin remove-motion-pins` (pre-push workspace typecheck, 35 tasks passing)
