### PR TITLE
fix(tui): load local TUI plugins via SEA-safe runtime import

### DIFF
--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -15,6 +15,7 @@ import path from "path"
 import { stat } from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
 import type { Page } from "@opencode-ai/plugin/tui/context"
+import { importModule } from "@opencode-ai/util/runtime-import"
 import { resolveSlots, type Claim } from "./structure"
 import { createStore, produce, reconcile as reconcileStore, unwrap } from "solid-js/store"
 import { isDeepEqual } from "remeda"
@@ -535,7 +536,10 @@ async function resolvePlugin(
   const version = local ? freshSpecifier(entrypoint, (await stat(new URL(entrypoint))).mtimeMs) : entrypoint
   if (previous && previous.version === version && sameOptions(previous.options, options))
     return { status: "unchanged" as const, plugin: previous.plugin, version }
-  const mod: { readonly default?: unknown } = await import(version)
+  // importModule: the Node SEA embedder routes dynamic import() of file URLs
+  // through builtin-module lookup (ERR_UNKNOWN_BUILTIN_MODULE), so the vm-based
+  // runtime import is used instead; on Bun it is a plain import.
+  const mod = (await importModule(version)) as { readonly default?: unknown }
   if (!isPlugin(mod.default)) throw new Error(`Invalid V2 TUI plugin module: ${spec}`)
   return { status: "loaded" as const, plugin: mod.default, version }
 }


### PR DESCRIPTION
## Problem

The Node SEA build (opencode2-node) cannot load any local TUI plugin: every plugin under \`plugins/tui/\` fails to import with

\`\`\`
No such built-in module: file:///.../plugin.js?mtime=...
\`\`\`

(\`ERR_UNKNOWN_BUILTIN_MODULE\`) The Node SEA embedder routes dynamic \`import()\` of file URLs through builtin-module lookup, so \`await import(version)\` in the TUI plugin resolver always fails on the node binary; the bun build is unaffected.

## Fix

Use the shared \`importModule\` from \`@opencode-ai/util/runtime-import\` — on Node it is a vm-based import (\`USE_MAIN_CONTEXT_DEFAULT_LOADER\`) that bypasses the SEA restriction, on Bun it is a plain \`import()\`. The core plugin supervisor already uses it (\`packages/core/src/plugin/supervisor.ts\`).

## Verification

- Reproduced: built a minimal Node 26 SEA binary — plain \`import()\` of a file URL fails with \`ERR_UNKNOWN_BUILTIN_MODULE\` (with or without the \`?mtime=\` cache-busting query), the vm-based import succeeds.
- Plugin lifecycle smoke test (fake herdr socket + mock ctx, 16 checks: anchoring, working/blocked/idle, scope purge, release) passes.