### PR TITLE
refactor(util): load npm package parser lazily

### DIFF
--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import { describe, expect, test } from "bun:test"
-import { Effect, Option } from "effect"
+import { Effect } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Global } from "@opencode-ai/util/global"
 import { Npm } from "@opencode-ai/util/npm"
@@ -36,6 +36,48 @@ describe("Npm.sanitize", () => {
 })
 
 describe("Npm.add", () => {
+  test("resolves cached scoped package specs without reifying", async () => {
+    await using tmp = await tmpdir()
+    const spec = "@fixture/provider@1.0.0"
+    const directory = path.join(
+      tmp.path,
+      "cache",
+      "packages",
+      Npm.sanitize(spec),
+      "node_modules",
+      "@fixture",
+      "provider",
+    )
+    await fs.mkdir(directory, { recursive: true })
+    await writePackage(directory, { name: "@fixture/provider", exports: "./index.js" })
+    await Bun.write(path.join(directory, "index.js"), "export const fixture = true\n")
+
+    const entry = await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+
+    expect(entry.directory).toBe(directory)
+    expect(entry.entrypoint).toEndWith("/index.js")
+  })
+
+  test("falls back to the original spec when parsing fails", async () => {
+    await using tmp = await tmpdir()
+    const spec = "fixture provider"
+    const directory = path.join(tmp.path, "cache", "packages", Npm.sanitize(spec), "node_modules", spec)
+    await fs.mkdir(directory, { recursive: true })
+    await writePackage(directory, { name: spec, exports: "./index.js" })
+    await Bun.write(path.join(directory, "index.js"), "export const fixture = true\n")
+
+    const entry = await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+
+    expect(entry.directory).toBe(directory)
+    expect(entry.entrypoint).toEndWith("/index.js")
+  })
+
   test("reifies when package cache directory exists without the package installed", async () => {
     await using tmp = await tmpdir()
     await fs.mkdir(path.join(tmp.path, "fixture-provider"))

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -1,7 +1,6 @@
 export * as Npm from "./npm.js"
 
 import path from "path"
-import npa from "npm-package-arg"
 import { Effect, Schema, Context, Layer, Option, FileSystem } from "effect"
 import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
 import { FSUtil } from "./fs-util.js"
@@ -111,6 +110,7 @@ const layer = Layer.effect(
       )
 
     const add = Effect.fn("Npm.add")(function* (pkg: string, options?: { readonly subpaths?: readonly string[] }) {
+      const { default: npa } = yield* Effect.promise(() => import("npm-package-arg"))
       const dir = directory(pkg)
       const name = (() => {
         try {

--- a/packages/workerd-spike/vitest.config.ts
+++ b/packages/workerd-spike/vitest.config.ts
@@ -52,7 +52,7 @@ export default defineWorkersConfig({
       // lookup surface but back it with a static shim.
       { find: /^mime-types$/, replacement: new URL("./test/shims/mime-types.mjs", import.meta.url).pathname },
       // Plugin installs never happen in the workerd profile (plugin discovery
-      // is precompiled-only), so mock the package installation toolchain.
+      // is precompiled-only), so mock package installation when it is loaded.
       { find: /^@npmcli\/arborist(\/.*)?$/, replacement: mockProxy },
       { find: /^pacote(\/.*)?$/, replacement: mockProxy },
     ],


### PR DESCRIPTION
## What

Load `npm-package-arg` only when `Npm.add` runs instead of evaluating it whenever `@opencode-ai/util/npm` is imported. This keeps `Npm.node` construction and CLI startup paths that only need `Npm.install` or `Npm.which` from paying for package-spec parsing.

## Impact

Fresh-process benchmarks used Bun 1.3.14 on macOS arm64, with 10 warmups followed by 75 randomized, interleaved runs per revision and case. Medians are reported because separate sequential samples showed substantial scheduler outliers.

| Case | `origin/v2` median | This PR median | Change |
| --- | ---: | ---: | ---: |
| Import `packages/util/src/npm.ts` | 133.7 ms | 121.4 ms | -12.3 ms (-9.2%) |
| Import CLI runtime then Npm | 160.3 ms | 147.8 ms | -12.4 ms (-7.8%) |
| First `Npm.add` | Parser already loaded | Loads parser on demand | Latency moved to first use |
| Installed package / release binary size | Unchanged | Unchanged | No dependency removed |

The workerd compatibility probe also remained healthy (rounded output changed from 18.0 MiB to 17.9 MiB), but that probe bundle is not a shipped release artifact and this PR does not claim a package or production binary size reduction. `npm-package-arg` remains a runtime dependency and bundlers may retain dynamic imports.

## How

`packages/util/src/npm.ts` dynamically imports and destructures the parser at the top of the `Npm.add` effectful path. The existing parse `try`/`catch`, original-spec fallback, cache lookup, scoped package handling, reification, and entrypoint fallback are unchanged.

`packages/core/test/npm.test.ts` adds real-filesystem coverage for cached scoped specs and malformed-spec fallback alongside the existing package reification and subpath fallback test.

`packages/workerd-spike/vitest.config.ts` updates the package-installation mock comment now that the toolchain is loaded on demand.

## Scope

This does not remove `npm-package-arg`, change dependency or binary packaging, defer Arborist beyond its existing lazy import, or alter `Npm.install` / `Npm.which` behavior.

## Downsides

The first `Npm.add` call now pays the parser module-load latency, and a parser module-load failure is observed at first add rather than at process startup. Subsequent calls use the runtime module cache.

## Testing

- `bun run test npm.test.ts location-layer.test.ts plugin/provider-dynamic.test.ts` from `packages/core` (31 tests)
- `bun typecheck` from `packages/util`
- `bun typecheck` from `packages/core`
- `bun run build` from `packages/util`
- `bun run build` from `packages/core`
- Node ESM import/construction smoke against `packages/util/dist/npm.js`
- `bun run probe:workerd` from `packages/server`
- `bun run test` from `packages/workerd-spike` (6 real workerd tests)
- Push hook workspace typecheck (35 tasks)
- `bunx oxlint packages/util/src/npm.ts packages/core/test/npm.test.ts packages/workerd-spike/vitest.config.ts` (0 errors; pre-existing util warnings remain)
- `bunx prettier --write packages/util/src/npm.ts packages/core/test/npm.test.ts packages/workerd-spike/vitest.config.ts`
