### PR TITLE
perf(core): load MCP client lazily

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -19,8 +19,7 @@ import { KeyedMutex } from "../effect/keyed-mutex.js"
 import { Location } from "../location.js"
 import { waitForAbort } from "@opencode-ai/util/process"
 import { State } from "../state.js"
-import { MCPClient } from "./client.js"
-import { MCPOAuth } from "./oauth.js"
+import type { MCPClient } from "./client.js"
 
 export const ServerName = Schema.String.pipe(Schema.brand("MCP.ServerName"))
 export type ServerName = typeof ServerName.Type
@@ -245,7 +244,11 @@ export const layer = (options?: Options) =>
             draft.method.update({
               integrationID,
               method: { id: methodID, type: "oauth", label: name },
-              authorize: () => MCPOAuth.authorize({ name, config: remote, methodID }),
+              authorize: () =>
+                Effect.gen(function* () {
+                  const { MCPOAuth } = yield* Effect.promise(() => import("./oauth.js"))
+                  return yield* MCPOAuth.authorize({ name, config: remote, methodID })
+                }),
             })
           })
           .pipe(Scope.provide(scope))
@@ -264,6 +267,7 @@ export const layer = (options?: Options) =>
       // opens a browser, so an auth-gated connect ends in UnauthorizedError -> needs_auth rather than a redirect.
       const connectProvider = Effect.fnUntraced(function* (entry: ServerEntry) {
         if (entry.config.type !== "remote" || !entry.integrationID) return undefined
+        const { MCPOAuth } = yield* Effect.promise(() => import("./oauth.js"))
         const remote = entry.config
         const oauth = remote.oauth || undefined
         const base = {
@@ -505,6 +509,7 @@ export const layer = (options?: Options) =>
           const scope = yield* Scope.fork(root)
           entry.scope = scope
           const authProvider = yield* connectProvider(entry)
+          const { MCPClient } = yield* Effect.promise(() => import("./client.js"))
           // List tools as part of connect so a failure here marks the server failed rather than
           // leaving it connected with a silently empty tool list and no path to recover.
           const result = yield* MCPClient.connect(

--- a/packages/core/test/mcp-import-boundary.test.ts
+++ b/packages/core/test/mcp-import-boundary.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import path from "node:path"
+
+const root = path.resolve(import.meta.dir, "../../..")
+
+test("loads the MCP SDK only when connecting or authorizing", async () => {
+  const temporary = await mkdtemp(path.join(import.meta.dir, ".mcp-import-boundary-"))
+  const metafile = path.join(temporary, "meta.json")
+  try {
+    const result = Bun.spawn(
+      [
+        process.execPath,
+        "build",
+        "packages/core/src/mcp/index.ts",
+        "--target=node",
+        "--format=esm",
+        "--packages=bundle",
+        "--splitting",
+        `--metafile=${metafile}`,
+        `--outdir=${path.join(temporary, "out")}`,
+      ],
+      { cwd: root, stdout: "pipe", stderr: "pipe" },
+    )
+    const [exitCode, stdout, stderr] = await Promise.all([
+      result.exited,
+      new Response(result.stdout).text(),
+      new Response(result.stderr).text(),
+    ])
+    if (exitCode !== 0) throw new Error(stdout + stderr)
+
+    const metadata = await Bun.file(metafile).json()
+    const imports = metadata.inputs["packages/core/src/mcp/index.ts"].imports
+    const lazy = imports.filter(
+      (item: { original?: string }) => item.original === "./client.js" || item.original === "./oauth.js",
+    )
+    expect(new Set(lazy.map((item: { original: string }) => item.original))).toEqual(
+      new Set(["./client.js", "./oauth.js"]),
+    )
+    expect(lazy.every((item: { kind: string }) => item.kind === "dynamic-import")).toBe(true)
+  } finally {
+    await rm(temporary, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
**What**

Keep the MCP SDK out of startup evaluation when a location has no enabled MCP servers. Configured enabled servers still connect eagerly during location service construction; disabled servers and installations without MCP defer the SDK until connect or OAuth authorization is actually used.

**How**

- `packages/core/src/mcp/index.ts` keeps `MCPClient` as a type-only import.
- The MCP client module loads immediately before the existing connect call.
- OAuth support loads only for authenticated remote connects or interactive authorization.
- Native ESM module caching deduplicates concurrent first imports; existing per-server locks, scopes, status transitions, reconnects, and finalizers are unchanged.
- `packages/core/test/mcp-import-boundary.test.ts` bundles the production entry and asserts that both runtime edges remain dynamic.

**Impact**

| Bundle probe | Before entry | After entry | Entry delta | Total output delta |
| --- | ---: | ---: | ---: | ---: |
| MCP entry, split/minified | 460,446 B | 152,692 B | -307,754 B (-66.8%) | +972 B |
| workerd entry, split/minified | 4,739,168 B | 4,517,506 B | -221,662 B (-4.7%) | -70 B |
| workerd entry, flat/minified | 11,607,722 B | 11,610,589 B | +2,867 B | +2,867 B |

The flat workerd artifact remains one download, so its benefit is deferred evaluation rather than transfer size. In 20-process local measurements after importing `mcp/index.ts`, first client import averaged 77.31 ms; OAuth followed by client averaged 58.92 ms because the modules share SDK dependencies. That cost moves to the first enabled connect and is absent for no-MCP/disabled startup.

**Scope**

This does not make configured enabled servers connect on demand and does not change the MCP service API, config, protocol, server routes, connection policy, failure mapping, reconnect behavior, or shutdown behavior.

**Testing**

- `bun run test` in `packages/core`: 1,771 passed, 16 skipped
- `bun typecheck` in `packages/core`
- `bun run test test/workerd.test.ts` in `packages/server`
- `bun typecheck` in `packages/server`
- `bun run probe:workerd` in `packages/server`
- push hook: repository-wide `bun turbo typecheck --concurrency=3`, 35 tasks passed
- `bun run lint packages/core/src/mcp/index.ts packages/core/test/mcp-import-boundary.test.ts`: no errors; six pre-existing warnings in `mcp/index.ts`
