### PR TITLE
refactor(cli): load semver lazily for update checks

### DIFF
--- a/packages/cli/src/services/updater-action.ts
+++ b/packages/cli/src/services/updater-action.ts
@@ -1,0 +1,12 @@
+import semver from "semver"
+import type { Policy } from "./updater"
+
+export type Action = "none" | "upgrade"
+
+export function action(current: string, latest: string, policy: Policy): Action {
+  if (policy === false) return "none"
+  if (!semver.valid(current) || !semver.valid(latest) || semver.eq(latest, current)) return "none"
+  // Major upgrades are never installed automatically.
+  if (semver.major(latest) !== semver.major(current)) return "none"
+  return "upgrade"
+}

--- a/packages/cli/src/services/updater.test.ts
+++ b/packages/cli/src/services/updater.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { action, decodePolicy } from "./updater"
+import { action } from "./updater-action"
+import { decodePolicy } from "./updater"
 
 describe("updater", () => {
   test("reads autoupdate from JSONC", () => {

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -5,12 +5,10 @@ import { Context, Duration, Effect, FileSystem, Layer } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { parse, type ParseError } from "jsonc-parser"
 import path from "node:path"
-import semver from "semver"
 
 declare const OPENCODE_CLI_NAME: string | undefined
 
 export type Policy = boolean | "notify"
-export type Action = "none" | "upgrade"
 type Method = "npm" | "pnpm" | "bun" | "yarn"
 
 const packageName =
@@ -32,14 +30,6 @@ export function decodePolicy(text: string): Policy | undefined {
   if (errors.length || typeof input !== "object" || input === null || !("autoupdate" in input)) return
   const value = input.autoupdate
   if (typeof value === "boolean" || value === "notify") return value
-}
-
-export function action(current: string, latest: string, policy: Policy): Action {
-  if (policy === false) return "none"
-  if (!semver.valid(current) || !semver.valid(latest) || semver.eq(latest, current)) return "none"
-  // Major upgrades are never installed automatically.
-  if (semver.major(latest) !== semver.major(current)) return "none"
-  return "upgrade"
 }
 
 export const layer = Layer.effect(
@@ -150,6 +140,7 @@ export const layer = Layer.effect(
             current: OPENCODE_VERSION,
             latest: version,
           })
+          const { action } = yield* Effect.promise(() => import("./updater-action"))
           const next = action(OPENCODE_VERSION, version, policy)
           if (next === "none") return yield* Effect.logInfo("update check done", { action: "up-to-date" })
           const detected = yield* method()


### PR DESCRIPTION
## What

Defer loading `semver` until a CLI update check has fetched a candidate version and needs to compare it. Local installs, disabled checks, policy-disabled checks, and network failures no longer pay the import cost.

## Impact

| Measurement | Before | After | Impact |
| --- | ---: | ---: | ---: |
| Updater bundle placement | startup chunk | 58.4 KB lazy chunk | removed from eager module graph |
| Updater module initialization, median (40 paired/interleaved runs) | 156.8 ms | 149.7 ms | -7.1 ms (-4.5%) |
| First version comparison, median (40 paired/interleaved runs) | 0.12 ms | 6.28 ms | +6.16 ms once |

Process-level timings were noisy, so the bundle boundary is the deterministic result. The tradeoff is that the first successful update response moves roughly 6 ms of import latency into the background update check; subsequent checks reuse the module cache.

## How

- Move the existing synchronous comparison helper unchanged into `packages/cli/src/services/updater-action.ts`.
- Dynamically import that helper after `latest()` succeeds, immediately before comparison.
- Keep policy handling, log messages, installation-method detection, and upgrade behavior unchanged.

## Scope

This does not change update policy, version comparison semantics, notification behavior, polling frequency, or package-manager detection.

## Testing

- `bun run test src/services/updater.test.ts`
- Runtime harness with build-defined local/stable versions: local, disabled, rejected-fetch, and successful same-version paths
- `bun run typecheck`
- `bun run build --single --skip-install --skip-web-ui`
- `bunx prettier --check src/services/updater.ts src/services/updater-action.ts src/services/updater.test.ts`
- CLI suite excluding two baseline process-spawn failures: 184 passed
- Push hook workspace typecheck: 35 packages passed

`test/standalone.test.ts` and `test/acp/command.test.ts` fail identically on untouched `origin/v2` in this environment because the spawned CLI emits an external configuration JSON parse error before the tested protocol starts.
