### PR TITLE
fix(tui): scope unread updates to focused terminal

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { useRenderer } from "@opentui/solid"
 import { isDeepEqual } from "remeda"
 import { createSimpleContext } from "./helper"
 import { useClient } from "./client"
@@ -52,7 +53,10 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     const config = useConfig().data
     const location = useLocation()
     const paths = useTuiPaths()
+    const renderer = useRenderer()
     const enabled = () => config.tabs.enabled
+    // Focus reporting emits transitions, so an interactive launch owns unread state until its first blur.
+    const [focused, setFocused] = createSignal(true)
     // Keyed reconcile keeps tab object identity across reorders, so strip rows move instead of
     // mutating in place, which per-row animations and drag state depend on.
     const [store, updateStore] = useStorage().store<PersistedState>("tabs", {
@@ -68,6 +72,15 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     // User-closed tabs eligible for reopening; in-memory like history, deleted sessions pruned.
     let closedTabs: ClosedSessionTab[] = []
     const scrollPositions = new Map<string, number>()
+
+    const onFocus = () => setFocused(true)
+    const onBlur = () => setFocused(false)
+    renderer.on("focus", onFocus)
+    renderer.on("blur", onBlur)
+    onCleanup(() => {
+      renderer.off("focus", onFocus)
+      renderer.off("blur", onBlur)
+    })
 
     createEffect(() => {
       if (config.experimental?.tab_scroll === true) return
@@ -125,7 +138,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     }
 
     function markUnread(sessionID: string, unread: SessionTabUnread) {
-      if (!enabled()) return
+      if (!enabled() || !focused()) return
       const session = root(sessionID)
       if (current() === session || !state().tabs.some((tab) => tab.sessionID === session)) return
       if (state().unread[session] === unread) return
@@ -145,12 +158,21 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         sessionID,
         title: title(sessionID, state().tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
       })
-      if (tabs === state().tabs && !state().unread[sessionID]) return
+      if (tabs === state().tabs) return
       update((draft) => {
         draft.tabs = openSessionTab(draft.tabs, {
           sessionID,
           title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
         })
+      })
+    })
+
+    createEffect(() => {
+      if (!enabled() || !focused()) return
+      if (route.data.type !== "session" || route.data.sessionID === "dummy") return
+      const sessionID = root(route.data.sessionID)
+      if (!state().unread[sessionID]) return
+      update((draft) => {
         delete draft.unread[sessionID]
       })
     })

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -142,6 +142,9 @@ async function renderSessionTabs(
     vcsLocations,
     state,
     emit: (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } }),
+    focus: () => app.renderer.emit("focus"),
+    blur: () => app.renderer.emit("blur"),
+    flush: () => storage.flush(),
     async destroy() {
       app.renderer.destroy()
       await storage.flush()
@@ -149,6 +152,14 @@ async function renderSessionTabs(
     },
   }
 }
+
+const executionSucceeded = (sessionID: string): OpenCodeEvent => ({
+  id: `evt_done_${sessionID}`,
+  created: Date.now(),
+  type: "session.execution.succeeded",
+  durable: { aggregateID: sessionID, seq: 1, version: 1 },
+  data: { sessionID },
+})
 
 test("loads persisted tab metadata concurrently on connect", async () => {
   let release!: () => void
@@ -199,6 +210,46 @@ test("stores session tabs for the current working directory by default", async (
     expect(stored.cwd[directory].unread).toEqual({})
   } finally {
     await setup.destroy()
+  }
+})
+
+test("only the foreground TUI mutates unread state", async () => {
+  await using temporary = await tmpdir()
+  let foreground: Awaited<ReturnType<typeof renderSessionTabs>> | undefined
+  let background: Awaited<ReturnType<typeof renderSessionTabs>> | undefined
+
+  try {
+    foreground = await renderSessionTabs("first", { state: temporary.path })
+    background = await renderSessionTabs("second", { state: temporary.path })
+    foreground.focus()
+    background.blur()
+    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2)
+
+    const firstDone = executionSucceeded("first")
+    foreground.emit(firstDone)
+    background.emit(firstDone)
+    await Promise.all([foreground.flush(), background.flush()])
+    expect(foreground.tabs.status("first").unread).toBeUndefined()
+    expect(background.tabs.status("first").unread).toBeUndefined()
+
+    const secondDone = executionSucceeded("second")
+    foreground.emit(secondDone)
+    background.emit(secondDone)
+    await wait(
+      () =>
+        foreground?.tabs.status("second").unread === "activity" &&
+        background?.tabs.status("second").unread === "activity",
+    )
+
+    foreground.tabs.select("second")
+    await wait(
+      () =>
+        foreground?.tabs.status("second").unread === undefined &&
+        background?.tabs.status("second").unread === undefined,
+    )
+  } finally {
+    if (foreground) await foreground.destroy()
+    if (background) await background.destroy()
   }
 })
 


### PR DESCRIPTION
## What

Make the foreground TUI the sole owner of shared session-tab unread mutations. A blurred backup TUI can no longer mark a session unread or clear an unread marker merely because it has a different tab selected.

## Before / After

**Before**

1. TUI A is foregrounded on Session 1.
2. TUI B is blurred on Session 2.
3. Both TUIs receive the same execution-completed event.
4. TUI B evaluates the event against its own selected tab and writes shared unread state.
5. Either TUI can also clear that shared state based on its local selection, so the indicator does not reliably represent the foreground view.

**After**

1. TUI A owns unread mutations while focused.
2. TUI B still receives and folds server events, but cannot mark or clear unread state while blurred.
3. TUI A marks only completed sessions outside its selected tab.
4. Selecting an unread tab in TUI A clears it for the shared tab state.

## How

- `packages/tui/src/context/session-tabs.tsx` tracks OpenTUI focus and blur transitions and gates both completion marking and selected-tab clearing on foreground ownership.
- Route/tab synchronization remains independent from focus changes; a narrow effect handles foreground unread clearing.
- `packages/tui/test/context/session-tabs.test.tsx` runs two TUI providers against the same persisted state with divergent focus and selected sessions.

## Scope

- If every TUI is blurred when a session completes, no unread marker is recorded. This is intentional: only the foreground terminal owns unread state.
- A newly launched interactive TUI is considered foregrounded until OpenTUI reports its first blur transition.
- This does not change execution notifications, sounds, tab persistence, or server events.

## Testing

- `bun run test test/context/session-tabs.test.tsx` from `packages/tui`: 9 passed.
- `bun run test` from `packages/tui`: 697 passed, 5 skipped.
- `bun typecheck` from `packages/tui`: passed.
- Push hook workspace typecheck: 35 packages passed.
- `bunx prettier --check src/context/session-tabs.tsx test/context/session-tabs.test.tsx`: passed.

## Demo

No recording included: the regression is an incorrect shared marker produced by a blurred second TUI. The concurrent two-TUI test reproduces the process topology and verifies the persisted result directly.

## Flow

```mermaid
sequenceDiagram
    participant Server
    participant A as TUI A (focused)
    participant B as TUI B (blurred)
    participant State as Shared tab state

    Server->>A: execution completed
    Server->>B: execution completed
    B-->>State: no mutation
    alt completed session is selected in A
        A-->>State: no unread marker
    else completed session is backgrounded in A
        A->>State: mark unread
    end
    A->>State: clear when selected while focused
```
