### PR TITLE
fix(tui): refresh terminal size before resize

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -84,7 +84,7 @@ import { DialogVariant } from "./component/dialog-variant"
 import { createTuiAttention } from "./attention"
 import * as TuiAudio from "./audio"
 import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
-import { destroyRenderer } from "./util/renderer"
+import { destroyRenderer, installTerminalResizeRefresh } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
 
 registerOpencodeSpinner()
@@ -188,6 +188,10 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => installTerminalResizeRefresh()),
+        (uninstall) => Effect.sync(uninstall),
+      )
       const renderer = yield* Effect.acquireRelease(
         Effect.tryPromise({
           try: () =>

--- a/packages/tui/src/util/renderer.ts
+++ b/packages/tui/src/util/renderer.ts
@@ -1,5 +1,26 @@
 import type { CliRenderer } from "@opentui/core"
 
+type SignalTarget = {
+  prependListener(event: "SIGWINCH", listener: () => void): unknown
+  removeListener(event: "SIGWINCH", listener: () => void): unknown
+}
+
+type TerminalOutput = Pick<NodeJS.WriteStream, "isTTY"> & {
+  _refreshSize?: () => void
+}
+
+export function installTerminalResizeRefresh(
+  target: SignalTarget = process,
+  stdout: TerminalOutput = process.stdout,
+) {
+  if (!stdout.isTTY || !stdout._refreshSize) return () => {}
+  // Bun can leave columns/rows stale in some PTY hosts until the stream refreshes its cached window size.
+  const refresh = () => stdout._refreshSize?.()
+  refresh()
+  target.prependListener("SIGWINCH", refresh)
+  return () => target.removeListener("SIGWINCH", refresh)
+}
+
 export function destroyRenderer(renderer: Pick<CliRenderer, "isDestroyed" | "setTerminalTitle" | "destroy">) {
   renderer.setTerminalTitle("")
   if (renderer.isDestroyed) return

--- a/packages/tui/test/util/renderer.test.ts
+++ b/packages/tui/test/util/renderer.test.ts
@@ -1,5 +1,43 @@
 import { expect, test } from "bun:test"
-import { destroyRenderer } from "../../src/util/renderer"
+import { EventEmitter } from "node:events"
+import { destroyRenderer, installTerminalResizeRefresh } from "../../src/util/renderer"
+
+test("refreshes terminal dimensions before existing SIGWINCH listeners", () => {
+  const target = new EventEmitter()
+  const calls: string[] = []
+  target.on("SIGWINCH", () => calls.push("resize"))
+  const uninstall = installTerminalResizeRefresh(target, {
+    isTTY: true,
+    _refreshSize() {
+      calls.push("refresh")
+    },
+  })
+
+  expect(calls).toEqual(["refresh"])
+  calls.length = 0
+  target.emit("SIGWINCH")
+  expect(calls).toEqual(["refresh", "resize"])
+
+  uninstall()
+  calls.length = 0
+  target.emit("SIGWINCH")
+  expect(calls).toEqual(["resize"])
+})
+
+test("does not install a refresh hook for non-TTY output", () => {
+  const target = new EventEmitter()
+  let refreshes = 0
+  installTerminalResizeRefresh(target, {
+    isTTY: false,
+    _refreshSize() {
+      refreshes++
+    },
+  })
+
+  target.emit("SIGWINCH")
+  expect(refreshes).toBe(0)
+  expect(target.listenerCount("SIGWINCH")).toBe(0)
+})
 
 test("clears the terminal title before destroying the renderer", () => {
   const calls: string[] = []


### PR DESCRIPTION
### Issue for this PR

Closes #42225

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenTUI reads `process.stdout.columns` and `process.stdout.rows` when handling `SIGWINCH`. In affected PTY hosts, Bun can leave those cached values stale until the stream refreshes its window size.

This change refreshes the TTY dimensions before OpenTUI receives the resize signal. It performs one initial refresh, installs the listener ahead of the renderer listener, and removes it when the TUI scope closes.

### How did you verify your code works?

- `bun test` in `packages/tui`: 195 passed, 1 skipped
- `bun typecheck` in `packages/tui`
- Manual tmux conversation resize smoke test at 68 -> 119 -> 68 columns

### Screenshots / recordings

Not included. The failure is specific to live terminal resizing; the signal ordering is covered by a focused regression test and was also verified interactively in tmux.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
