### PR TITLE
fix(app): stabilize session navigation

### DIFF
--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -27,6 +27,30 @@ test("navigates to a subagent child session missing from the session list", asyn
   await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
 })
 
+test("keeps the parent visible while child lineage resolves", async ({ page }) => {
+  await setup(page)
+  const requested = Promise.withResolvers<void>()
+  const release = Promise.withResolvers<void>()
+  await page.route(
+    (url) => url.pathname === `/api/session/${childID}` && url.port === (process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"),
+    async (route) => {
+      requested.resolve()
+      await release.promise
+      await route.fallback()
+    },
+  )
+  await page.goto(sessionHref(parentID))
+  await expectSessionTitle(page, parentTitle)
+
+  await page.locator(`a[href="${sessionHref(childID)}"]`).click()
+  await requested.promise
+  await Promise.all([expect(page).toHaveURL(sessionHref(parentID)), expectSessionTitle(page, parentTitle)]).finally(
+    () => release.resolve(),
+  )
+
+  await expectSessionTitle(page, taskDescription)
+})
+
 test("shows the not found fallback when the viewed session is deleted", async ({ page }) => {
   const events: EventPayload[] = []
   await setup(page, () => events.splice(0, 1))

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -33,9 +33,8 @@ export function DirectoryDataProvider(
     return `/${slug()}/session/${sessionID}`
   }
   const navigateToSession = async (sessionID: string) => {
-    await serverSync()
-      .session.lineage.resolve(sessionID)
-      .catch(() => undefined)
+    const session = serverSync().session
+    await Promise.allSettled([session.lineage.resolve(sessionID), session.sync(sessionID)])
     navigate(href(sessionID))
   }
 

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -32,6 +32,12 @@ export function DirectoryDataProvider(
     if (props.server) return sessionHref(props.server, sessionID)
     return `/${slug()}/session/${sessionID}`
   }
+  const navigateToSession = async (sessionID: string) => {
+    await serverSync()
+      .session.lineage.resolve(sessionID)
+      .catch(() => undefined)
+    navigate(href(sessionID))
+  }
 
   createEffect(() => {
     // A draft lives at /new-session?draftId=… and has no directory segment to normalize.
@@ -61,7 +67,7 @@ export function DirectoryDataProvider(
           data={sync().data}
           directory={directory}
           sessionID={params.id}
-          onNavigateToSession={(sessionID: string) => navigate(href(sessionID))}
+          onNavigateToSession={navigateToSession}
           onSessionHref={href}
         >
           <LocalProvider>{props.children}</LocalProvider>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -33,7 +33,7 @@ export function DirectoryDataProvider(
     return `/${slug()}/session/${sessionID}`
   }
   const navigateToSession = async (sessionID: string) => {
-    const session = serverSync().session
+    const session = serverSync.session
     await Promise.allSettled([session.lineage.resolve(sessionID), session.sync(sessionID)])
     navigate(href(sessionID))
   }

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -2,7 +2,7 @@ import type { SessionInfo } from "@opencode-ai/client/promise"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { skipToken, useQuery } from "@tanstack/solid-query"
 import { DateTime } from "luxon"
-import { type Accessor, createEffect, createMemo, type JSX, startTransition } from "solid-js"
+import { type Accessor, createEffect, createMemo, type JSX, startTransition, untrack } from "solid-js"
 import { produce } from "solid-js/store"
 import { useCommand } from "@/context/command"
 import {
@@ -112,7 +112,7 @@ export function createHomeSessionsController(home: HomeController) {
         const key = `${ServerConnection.key(conn)}\0${record.session.id}`
         if (prefetched.has(key)) return
         prefetched.add(key)
-        void ctx.sync.session.sync(record.session.id).catch(() => {})
+        void untrack(() => ctx.sync.session.sync(record.session.id)).catch(() => {})
       })
   })
 

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -1,9 +1,8 @@
 import type { SessionInfo } from "@opencode-ai/client/promise"
-import { preloadMarkdown } from "@opencode-ai/session-ui/markdown-cache"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { skipToken, useQuery } from "@tanstack/solid-query"
 import { DateTime } from "luxon"
-import { type Accessor, createEffect, createMemo, createRoot, type JSX, startTransition } from "solid-js"
+import { type Accessor, createEffect, createMemo, type JSX, startTransition } from "solid-js"
 import { produce } from "solid-js/store"
 import { useCommand } from "@/context/command"
 import {
@@ -113,26 +112,7 @@ export function createHomeSessionsController(home: HomeController) {
         const key = `${ServerConnection.key(conn)}\0${record.session.id}`
         if (prefetched.has(key)) return
         prefetched.add(key)
-        createRoot((dispose) => {
-          try {
-            void ctx.sync.session
-              .sync(record.session.id)
-              .then(() =>
-                Promise.all(
-                  (ctx.sync.session.data.message[record.session.id] ?? []).flatMap((message) =>
-                    (ctx.sync.session.data.part[message.id] ?? []).flatMap((part) => {
-                      if (part.type !== "text" || !part.text) return []
-                      return preloadMarkdown(part.text, part.id)
-                    }),
-                  ),
-                ),
-              )
-              .catch(() => {})
-              .finally(dispose)
-          } catch {
-            dispose()
-          }
-        })
+        void ctx.sync.session.sync(record.session.id).catch(() => {})
       })
   })
 
@@ -199,6 +179,7 @@ export function createHomeSessionsController(home: HomeController) {
         const directory = project?.worktree ?? session.location.directory
         const ctx = home.server.focusedContext()
         if (!ctx) return
+        ctx.sync.session.remember(session)
         ctx.projects.open(directory)
         if (options?.background) {
           tabs.addSessionTab({ server: connKey, sessionId: session.id })

--- a/packages/app/test-browser/auto-scroll.test.ts
+++ b/packages/app/test-browser/auto-scroll.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { createAutoScroll } from "@opencode-ai/ui/hooks"
+import { createRoot } from "solid-js"
+
+test("restores bottom anchoring when Suspense reattaches the scroll viewport", async () => {
+  const main = document.createElement("main")
+  const surface = document.createElement("div")
+  const viewport = document.createElement("div")
+  const content = document.createElement("div")
+  surface.append(viewport)
+  viewport.append(content)
+  main.append(surface)
+  document.body.append(main)
+
+  let scrollTop = 200
+  Object.defineProperties(viewport, {
+    clientHeight: { value: 100 },
+    scrollHeight: { value: 300 },
+    scrollTop: {
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.min(value, 200)
+      },
+    },
+  })
+
+  const dispose = createRoot((dispose) => {
+    const scroll = createAutoScroll({ working: () => true })
+    scroll.scrollRef(viewport)
+    scroll.contentRef(content)
+    return dispose
+  })
+
+  surface.remove()
+  viewport.scrollTop = 0
+  main.append(surface)
+  await Promise.resolve()
+
+  expect(viewport.scrollTop).toBe(200)
+
+  dispose()
+  main.remove()
+})

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -162,7 +162,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
             spellcheck={state.mode === "normal"}
             // @ts-expect-error
             autocomplete="off"
-            class="relative z-10 block min-h-[60px] max-h-[180px] w-full overflow-y-auto whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none empty:before:content-['\\200B'] [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
+            class="relative z-10 block min-h-[60px] max-h-[180px] w-full overflow-y-auto whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none empty:before:content-['\200B'] [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
             classList={{ "font-mono!": state.mode === "shell", "opacity-50": props.disabled }}
             style={{
               "unicode-bidi": state.mode === "normal" ? "plaintext" : undefined,

--- a/packages/ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/ui/src/hooks/create-auto-scroll.tsx
@@ -186,6 +186,26 @@ export function createAutoScroll(options: AutoScrollOptions) {
     },
   )
 
+  createEffect(() => {
+    const el = store.scrollRef
+    if (!el) return
+    const root = el.closest("main")
+    if (!root) return
+    let connected = el.isConnected
+    const contains = (node: Node) => node === el || (node instanceof Element && node.contains(el))
+    const observer = new MutationObserver((records) => {
+      records.forEach((record) => {
+        if ([...record.removedNodes].some(contains)) connected = false
+        if (!record.addedNodes.length || ![...record.addedNodes].some(contains)) return
+        const reattached = !connected
+        connected = true
+        if (reattached) scrollToBottom(false)
+      })
+    })
+    observer.observe(root, { childList: true })
+    onCleanup(() => observer.disconnect())
+  })
+
   createEffect(
     on(options.working, (working: boolean) => {
       settling = false


### PR DESCRIPTION
## Summary

Session navigation now prepares the destination before committing the route. It also preserves bottom anchoring when Solid Suspense temporarily detaches a timeline and fixes the empty composer sentinel rendering as literal `\200B`.

This replaces the broad experimental work from #40427 with measured changes for current `v2`.

## Changes

- Resolve child lineage and load child messages concurrently before navigation.
- Keep the current session visible until the child destination is ready.
- Remember trusted Home session metadata before opening its route.
- Keep Home message prefetch, but remove eager Markdown parsing and sanitization from the foreground navigation window.
- Keep session-store reads outside Home effect tracking with `untrack`.
- Restore bottom anchoring when the root Suspense boundary reattaches the same scroll viewport.
- Emit one CSS escape for the empty composer zero-width sentinel instead of a literal `\200B` string.
- Add regression coverage for child continuity and Suspense scroll restoration.

## Production Benchmark

Baseline: `v2` at `ae14e78ba6`, including the consolidated desktop server data contexts.

Environment: Windows Chromium, production Vite build, serial execution, five runs per scenario.

| Scenario | Metric | v2 | PR | Change |
| --- | ---: | ---: | ---: | ---: |
| Home to session | First content | 209.5 ms | 147.0 ms | 30% faster |
| Home to session | Stable content | 277.7 ms | 183.9 ms | 34% faster |
| Child session | First content | 126.7 ms | 128.5 ms | within variance |
| Child session | Stable content | 156.8 ms | 142.8 ms | 9% faster |
| Child session | Blank samples | 4 | 0 | eliminated |

Unvisited session, draft, and close-to-Home controls moved by 0 to 8 ms in both directions, which is within the observed machine variance.

## Live Desktop Diagnosis

CDP reproduced the reported cross-workspace tab switch against the running desktop and local session data.

- Target initially painted at the bottom.
- Root Solid Suspense removed and reinserted the same timeline viewport.
- Native `scrollTop` reset to zero during detachment even though `overflow-anchor` was disabled.
- The scoped auto-scroll observer now restores the bottom synchronously on reattachment.
- A one-second post-fix trace contained no target top-scroll frame.
- Computed composer `::before` content is now the zero-width character instead of literal `\200B`.

## Validation

- Repository typecheck: 35/35 tasks passed.
- App unit tests: 692 passed, 13 skipped.
- App browser tests: 42 passed.
- UI tests: 27 passed.
- App, UI, Session UI, and E2E typechecks: passed.
- Child-navigation regression tests: 3 passed.
- Navigation benchmark: 25/25 PR scenarios passed; baseline child navigation failed all five zero-blank assertions.

Supersedes #40427.
