### PR TITLE
fix(tui): load local plugins via SEA-safe import

### DIFF
--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -18,6 +18,7 @@ import { readFile, stat } from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
 import type { Page } from "@opencode-ai/plugin/tui/context"
 import { Hash } from "@opencode-ai/util/hash"
+import { importModule } from "@opencode-ai/util/runtime-import"
 import { resolveSlots, type Claim } from "./structure"
 import { createStore, produce, reconcile as reconcileStore, unwrap } from "solid-js/store"
 import { isDeepEqual } from "remeda"
@@ -590,7 +591,7 @@ async function resolvePlugin(
     const version = generation === undefined ? entrypoint : freshSpecifier(entrypoint, generation)
     if (previous && previous.version === version && sameOptions(previous.options, options))
       return { status: "unchanged" as const, plugin: previous.plugin, version }
-    const mod: { readonly default?: unknown } = await import(version)
+    const mod = (await importModule(version)) as { readonly default?: unknown }
     if (generation !== undefined) {
       const observed = await sourceGeneration(entrypoint)
       // In-place saves can change the file between hashing and import. Retry


### PR DESCRIPTION
### Issue for this PR

https://github.com/anomalyco/opencode/issues/42481
Closes #42481

### Type of change

- [x] Bug fix

### What does this PR do?

the TUI plugin loader used a raw `import()`, which the node SEA binary can't service for file urls.  switched it to the existing `importModule` runtime import which is the same mechanism the server-side plugin loader already uses, so both builds resolve plugins through one SEA-safe path.

### How did you verify your code works?
ran a local build and manually tested it

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR