### PR TITLE
docs(providers): add EmpirioLabs AI to the provider directory

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -843,6 +843,33 @@ Selecting a router model is a drop-in replacement for any other model — OpenCo
 
 ---
 
+### EmpirioLabs AI
+
+1. Head over to the [EmpirioLabs dashboard](https://platform.empiriolabs.ai/dashboard/api-keys), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **EmpirioLabs AI**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your EmpirioLabs AI API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _Qwen3.8 Max_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### FrogBot
 
 1. Head over to the [FrogBot dashboard](https://app.frogbot.ai/signup), create an account, and generate an API key.


### PR DESCRIPTION
### Issue for this PR

N/A, small docs addition (no tracking issue). Replaces #36736, which was closed by automated PR cleanup.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an EmpirioLabs AI entry to the providers directory, following the same format as the other providers.

EmpirioLabs AI is OpenAI-compatible and already listed on models.dev, so OpenCode already resolves it through the models.dev catalog and loads it via `@ai-sdk/openai-compatible`. The directory page just didn't document it yet.

- Base URL: `https://api.empiriolabs.ai/v1`
- API key env: `EMPIRIOLABS_API_KEY`

### How did you verify your code works?

The provider resolves through models.dev: https://models.dev/providers/empiriolabs lists it with `api` = `https://api.empiriolabs.ai/v1`, `env` = `EMPIRIOLABS_API_KEY`, and `npm` = `@ai-sdk/openai-compatible`, which is the generic loader OpenCode already uses for models.dev providers, so `/connect` finds it and `/models` lists its models. This PR only adds the docs entry and matches the surrounding directory format.

### Screenshots / recordings

N/A, docs-only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
