### PR TITLE
fix(opencode): sum ACP prompt usage across the turn's requests

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -524,8 +524,8 @@ export function make(input: {
             ),
           "session",
         )
-        yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        const messages = yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
+        return yield* promptResponse(response.info, messages, params.messageId)
       }
 
       const known = snapshot.availableCommands.find((item) => item.name === command.name)
@@ -548,8 +548,8 @@ export function make(input: {
             ),
           "session",
         )
-        yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        const messages = yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
+        return yield* promptResponse(response.info, messages, params.messageId)
       }
 
       if (command.name === "compact") {
@@ -571,7 +571,7 @@ export function make(input: {
       }
 
       yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-      return yield* promptResponse(undefined, params.messageId)
+      return yield* promptResponse(undefined, undefined, params.messageId)
     }),
     cancel,
   }
@@ -638,17 +638,17 @@ function makeUsageService(sdk: OpencodeClient) {
         Effect.logError("failed to fetch messages for usage update", { error: error }).pipe(Effect.as(undefined)),
       ),
     )
-    if (!messages) return
+    if (!messages) return undefined
 
     const message = UsageService.latestAssistantMessage(messages)
-    if (!message?.providerID || !message.modelID) return
+    if (!message?.providerID || !message.modelID) return messages
 
     const size = yield* contextLimit({
       directory: params.directory,
       providerID: ProviderV2.ID.make(message.providerID),
       modelID: ModelV2.ID.make(message.modelID),
     })
-    if (!size) return
+    if (!size) return messages
 
     yield* Effect.promise(() =>
       params.connection
@@ -663,6 +663,7 @@ function makeUsageService(sdk: OpencodeClient) {
         })
         .catch(() => {}),
     )
+    return messages
   })
 
   return UsageService.Service.of({
@@ -823,19 +824,33 @@ function detectSlashCommand(parts: ReturnType<typeof promptContentToParts>) {
 
 const promptResponse = Effect.fn("ACP.promptResponse")(function* (
   info: AssistantInfo,
+  messages: readonly UsageService.SessionMessage[] | undefined,
   messageId: string | null | undefined,
 ) {
-  if (!info?.error) {
+  if (!info) {
     return {
       stopReason: "end_turn" as const,
-      ...(info ? { usage: UsageService.buildUsage(info) } : {}),
+      ...(messageId ? { userMessageId: messageId } : {}),
+      _meta: {},
+    }
+  }
+
+  // PromptResponse.usage is the turn's usage, and a turn emits one assistant
+  // message per tool-call step — so sum the turn's messages rather than report
+  // the final one. The final message is the fallback when the list is missing.
+  const usage = (messages ? UsageService.turnUsage(messages) : undefined) ?? UsageService.buildUsage(info)
+
+  if (!info.error) {
+    return {
+      stopReason: "end_turn" as const,
+      usage,
       ...(messageId ? { userMessageId: messageId } : {}),
       _meta: {},
     }
   }
 
   const base = {
-    usage: UsageService.buildUsage(info),
+    usage,
     ...(messageId ? { userMessageId: messageId } : {}),
     _meta: {},
   }
@@ -884,7 +899,7 @@ function sendUsageUpdate(
   sessionID: string,
   directory: string,
 ) {
-  if (!connection) return Effect.void
+  if (!connection) return Effect.succeed(undefined)
   return (usage ?? makeUsageService(sdk)).sendUpdate({
     connection,
     sessionID,

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -57,7 +57,7 @@ export interface Interface {
     readonly connection: UsageConnection
     readonly sessionID: string
     readonly directory: string
-  }) => Effect.Effect<void>
+  }) => Effect.Effect<readonly SessionMessage[] | undefined>
 }
 
 export class MessageLoader extends Context.Service<MessageLoader, MessageLoaderInterface>()(
@@ -100,6 +100,38 @@ export function buildUsage(message: AssistantTokenCost): Usage {
     ...(cachedReadTokens > 0 ? { cachedReadTokens } : {}),
     ...(cachedWriteTokens > 0 ? { cachedWriteTokens } : {}),
   }
+}
+
+/**
+ * Usage summed over the current turn: every assistant message after the last
+ * user message. Each tool-call step is its own assistant message, so the final
+ * message alone under-counts a multi-step turn. Subtask and compaction
+ * messages are parented to the same user message and count toward the turn.
+ */
+export function turnUsage(messages: readonly SessionMessage[]): Usage | undefined {
+  const start = messages.findLastIndex((message) => message.info.role === "user") + 1
+  const turn = messages
+    .slice(start)
+    .map((message) => message.info)
+    .filter((info): info is AssistantMessage => info.role === "assistant")
+  if (turn.length === 0) return undefined
+  return buildUsage(
+    turn.reduce(
+      (total, info) => ({
+        cost: total.cost + info.cost,
+        tokens: {
+          input: total.tokens.input + info.tokens.input,
+          output: total.tokens.output + info.tokens.output,
+          reasoning: total.tokens.reasoning + info.tokens.reasoning,
+          cache: {
+            read: total.tokens.cache.read + info.tokens.cache.read,
+            write: total.tokens.cache.write + info.tokens.cache.write,
+          },
+        },
+      }),
+      { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+    ),
+  )
 }
 
 export function latestAssistantMessage(messages: readonly SessionMessage[]): AssistantMessage | undefined {
@@ -192,18 +224,18 @@ const layer = Layer.effect(
             Effect.logError("failed to fetch messages for usage update", { error: error }).pipe(Effect.as(undefined)),
           ),
         )
-      if (!messages) return
+      if (!messages) return undefined
 
       const message = latestAssistantMessage(messages)
-      if (!message) return
-      if (!message.providerID || !message.modelID) return
+      if (!message) return messages
+      if (!message.providerID || !message.modelID) return messages
 
       const size = yield* contextLimit({
         directory: input.directory,
         providerID: ProviderV2.ID.make(message.providerID),
         modelID: ModelV2.ID.make(message.modelID),
       })
-      if (!size) return
+      if (!size) return messages
 
       yield* Effect.promise(() =>
         input.connection
@@ -218,6 +250,7 @@ const layer = Layer.effect(
           })
           .catch(() => {}),
       )
+      return messages
     })
 
     return Service.of({

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -316,6 +316,7 @@ describe("ACP service sessions", () => {
       sendUpdate: (input) =>
         Effect.sync(() => {
           usageUpdates.push(input.sessionID)
+          return undefined
         }),
     })
 
@@ -1327,7 +1328,7 @@ describe("ACP service sessions", () => {
         latestAssistantMessage: UsageService.latestAssistantMessage,
         totalSessionCost: UsageService.totalSessionCost,
         contextLimit: () => Effect.succeed(128000),
-        sendUpdate: () => Effect.void,
+        sendUpdate: () => Effect.succeed(undefined),
       }),
     })
     await Effect.runPromise(failing.newSession({ cwd: "/workspace", mcpServers: [] }))

--- a/packages/opencode/test/acp/usage.test.ts
+++ b/packages/opencode/test/acp/usage.test.ts
@@ -176,6 +176,41 @@ describe("acp usage", () => {
     expect(UsageService.totalSessionCost([assistant({ cost: 1.25 }), user(), assistant({ cost: 2.5 })])).toBe(3.75)
   })
 
+  describe("turn usage", () => {
+    const request = (input: number, output: number, read: number, write: number): UsageService.SessionMessage =>
+      assistant({ cost: 0, tokens: { input, output, reasoning: 0, cache: { read, write } } })
+
+    // Rows measured from a real 3-tool-call turn (4 model requests).
+    const turn = [request(3, 73, 0, 11156), request(1, 72, 11156, 143), request(1, 72, 11299, 140), request(1, 15, 11439, 140)]
+
+    test("sums every request of the turn, not just the final one", () => {
+      expect(UsageService.turnUsage([user(), ...turn])).toEqual({
+        inputTokens: 6,
+        outputTokens: 232,
+        cachedReadTokens: 33894,
+        cachedWriteTokens: 11579,
+        totalTokens: 45711,
+      })
+    })
+
+    test("bounds the sum to messages after the last user message", () => {
+      expect(UsageService.turnUsage([user(), request(500, 900, 0, 4000), user(), ...turn])).toEqual(
+        UsageService.turnUsage([user(), ...turn]),
+      )
+    })
+
+    test("matches buildUsage for a single-request turn", () => {
+      expect(UsageService.turnUsage([user(), request(3, 73, 0, 11156)])).toEqual(
+        UsageService.buildUsage({ cost: 0, tokens: { input: 3, output: 73, reasoning: 0, cache: { read: 0, write: 11156 } } }),
+      )
+    })
+
+    test("returns undefined when the turn has no assistant messages", () => {
+      expect(UsageService.turnUsage([])).toBeUndefined()
+      expect(UsageService.turnUsage([request(1, 1, 0, 0), user()])).toBeUndefined()
+    })
+  })
+
   it.effect("loads context limits from providers and caches by directory/provider/model", () => {
     const calls: string[] = []
     return Effect.gen(function* () {
@@ -252,14 +287,29 @@ describe("acp usage", () => {
     const updates: SessionNotification[] = []
     return Effect.gen(function* () {
       const usage = yield* UsageService.Service
-      yield* usage.sendUpdate({
+      const result = yield* usage.sendUpdate({
         connection: connection(updates),
         sessionID: "ses_1",
         directory: "/workspace",
       })
 
+      expect(result).toBeUndefined()
       expect(updates).toEqual([])
     }).pipe(Effect.provide(fakeLayer({ messages: Effect.fail(new Error("boom")) })))
+  })
+
+  it.effect("returns the fetched messages so callers can reuse them", () => {
+    const messages = [user(), assistant({ cost: 1 })]
+    return Effect.gen(function* () {
+      const usage = yield* UsageService.Service
+      const result = yield* usage.sendUpdate({
+        connection: connection([]),
+        sessionID: "ses_1",
+        directory: "/workspace",
+      })
+
+      expect(result).toEqual(messages)
+    }).pipe(Effect.provide(fakeLayer({ messages: Effect.succeed(messages) })))
   })
 
   it.effect("skips usage update when no assistant message exists", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #41660

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`PromptResponse.usage` was built from the turn's final assistant message. Each tool-call step is its own assistant message, so a turn with N tool calls reported 1 of N+1 model requests — the numbers in #41660.

`promptResponse` now sums every assistant message after the turn's last user message (new `UsageService.turnUsage`), falling back to the final message when the list isn't available. `sendUpdate` already fetches the message list right before `promptResponse` runs, so it now returns that list and the response reuses it — no extra round trip.

One semantic choice, flagged as a question in the issue: subtask and compaction messages are parented to the same user message, so their spend counts toward the turn. That matches the cost side, which already sums across messages.

### How did you verify your code works?

`bun test test/acp/` (133 pass) and `bun run typecheck` in packages/opencode. The new tests in test/acp/usage.test.ts drive the real measured rows from #41660 through `turnUsage`: the 4-request turn sums to input=6 output=232 cache_read=33894 cache_write=11579, where the old path reported the final row alone (1 / 15 / 11439 / 140). Also covered: the sum is bounded to the last user message, single-request turns are unchanged, and `sendUpdate` returns what it fetched.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
