### PR TITLE
fix(app): avoid zero message refresh limit

### DIFF
--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -267,6 +267,27 @@ describe("server session", () => {
     expect(store.data.message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
   })
 
+  test("keeps a valid page size when refreshing an empty current message page", async () => {
+    const requests: unknown[] = []
+    const messageApi = {
+      list: async (input: unknown) => {
+        requests.push(input)
+        return { data: [], cursor: { previous: null, next: null } }
+      },
+    } as unknown as MessageApi
+    const sessionApi = { get: async () => session("root") } as unknown as SessionApi
+    const store = createServerSession({} as OpencodeClient, sessionApi, messageApi)
+    store.remember(session("root"))
+
+    await store.sync("root")
+    await store.sync("root", { force: true })
+
+    expect(requests).toEqual([
+      { sessionID: "root", limit: 20, order: "desc" },
+      { sessionID: "root", limit: 20, order: "desc" },
+    ])
+  })
+
   test("extends a current page to include the user for split assistant turns", async () => {
     const user = { id: "msg_1_user", type: "user", text: "hello", time: { created: 1 } } as const
     const assistant = (id: string, created: number) => ({

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -842,7 +842,7 @@ export function createServerSession(
         resolve(sessionID, options),
         cached && !options?.force
           ? Promise.resolve()
-          : loadMessages(sessionID, options?.messageLimit ?? meta.limit[sessionID] ?? initialMessagePageSize),
+          : loadMessages(sessionID, options?.messageLimit || meta.limit[sessionID] || initialMessagePageSize),
       ])
     })
   }


### PR DESCRIPTION
### Issue for this PR

Closes #42267

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

An empty initial message page records a cached message count of zero. A later forced refresh reused that count as the request limit, causing the desktop client to send `limit=0`; the server rejects that value before the newly sent message can be loaded.

This change falls back to the initial message page size whenever the cached or requested limit is zero. Positive cached limits continue to preserve the existing window size.

### How did you verify your code works?

- Added a regression test that loads an empty page and then forces a refresh
- `bun test src/context/server-session.test.ts`: 75 passed
- `bun typecheck` in `packages/app`
- Push hook monorepo typecheck: 30/30 tasks passed

### Screenshots / recordings

Not included. The fix changes the message-fetch request limit; the request sequence is covered directly by the regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
