### PR TITLE
refactor(cli): replace updater semver dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -137,7 +137,6 @@
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
         "open": "10.1.2",
-        "semver": "catalog:",
         "solid-js": "catalog:",
         "uqr": "0.1.3",
         "ws": "8.21.0",
@@ -163,7 +162,6 @@
         "@parcel/watcher-win32-x64": "2.5.1",
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
-        "@types/semver": "catalog:",
         "@typescript/native-preview": "catalog:",
         "@yuuang/ffi-rs-darwin-arm64": "1.3.2",
         "@yuuang/ffi-rs-linux-arm64-gnu": "1.3.2",
@@ -6428,8 +6426,6 @@
     "@openauthjs/openauth/@standard-schema/spec": ["@standard-schema/spec@1.0.0-beta.3", "", {}, "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw=="],
 
     "@openauthjs/openauth/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
-
-    "@opencode-ai/cli/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@opencode-ai/console-app/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.7", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DrpkEoM3j9cBBWhufqBwnbbn+3nf1N9FP6xuVJ+e220jbactKuQgaZwjwP5CP1t+O94brm2JgVMD2atMGX3xIQ=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "immer": "11.1.4",
     "jsonc-parser": "3.3.1",
     "open": "10.1.2",
-    "semver": "catalog:",
     "solid-js": "catalog:",
     "uqr": "0.1.3",
     "ws": "8.21.0"
@@ -48,7 +47,6 @@
     "@opencode-ai/protocol": "workspace:*",
     "@tsconfig/bun": "catalog:",
     "@types/bun": "catalog:",
-    "@types/semver": "catalog:",
     "@typescript/native-preview": "catalog:",
     "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
     "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",

--- a/packages/cli/src/services/updater-action.ts
+++ b/packages/cli/src/services/updater-action.ts
@@ -1,0 +1,50 @@
+export type Policy = boolean | "notify"
+export type Action = "none" | "upgrade"
+
+const maximumComponent = "9007199254740991"
+const versionPattern =
+  /^v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+
+export function action(current: string, latest: string, policy: Policy): Action {
+  if (policy === false) return "none"
+  const currentVersion = parseReleaseVersion(current)
+  const latestVersion = parseReleaseVersion(latest)
+  if (!currentVersion || !latestVersion || sameRelease(currentVersion, latestVersion)) return "none"
+  // Major upgrades are never installed automatically.
+  if (currentVersion.major !== latestVersion.major) return "none"
+  return "upgrade"
+}
+
+function parseReleaseVersion(input: string) {
+  if (input.length > 256) return
+  const match = input.trim().match(versionPattern)
+  if (!match) return
+  if ([match[1], match[2], match[3]].some(invalidComponent)) return
+  if (
+    match[4]
+      ?.split(".")
+      .some((identifier) => identifier.length > 1 && identifier.startsWith("0") && /^[0-9]+$/.test(identifier))
+  )
+    return
+  return {
+    major: match[1],
+    core: `${match[1]}.${match[2]}.${match[3]}`,
+    prerelease: match[4]?.split(".") ?? [],
+  }
+}
+
+function sameRelease(current: NonNullable<ReturnType<typeof parseReleaseVersion>>, latest: typeof current) {
+  if (current.core !== latest.core || current.prerelease.length !== latest.prerelease.length) return false
+  return current.prerelease.every((identifier, index) => {
+    const other = latest.prerelease[index]
+    if (identifier === other) return true
+    // semver compares oversized numeric prerelease identifiers after numeric coercion.
+    return /^[0-9]+$/.test(identifier) && /^[0-9]+$/.test(other) && Number(identifier) === Number(other)
+  })
+}
+
+function invalidComponent(value: string) {
+  if (value.length > 1 && value.startsWith("0")) return true
+  if (value.length !== maximumComponent.length) return value.length > maximumComponent.length
+  return value > maximumComponent
+}

--- a/packages/cli/src/services/updater.test.ts
+++ b/packages/cli/src/services/updater.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { action, decodePolicy } from "./updater"
+import { action } from "./updater-action"
+import { decodePolicy } from "./updater"
 
 describe("updater", () => {
   test("reads autoupdate from JSONC", () => {
@@ -29,5 +30,49 @@ describe("updater", () => {
 
   test("upgrades when latest is lower (rollback)", () => {
     expect(action("1.2.4", "1.2.3", true)).toBe("upgrade")
+  })
+
+  test("accepts strict release version variants", () => {
+    expect(action("v1.2.3", " 1.2.4\n", true)).toBe("upgrade")
+    expect(action("1.2.3-alpha.1", "1.2.3-alpha.2", true)).toBe("upgrade")
+    expect(action("0.0.0-next-17403", "0.0.0-next-17403.2", true)).toBe("upgrade")
+    expect(action("1.2.3+old", "1.2.3+new", true)).toBe("none")
+    expect(action("v1.2.3+old", "1.2.3", true)).toBe("none")
+  })
+
+  test("preserves strict validity", () => {
+    const invalid = [
+      "=1.2.3",
+      "V1.2.3",
+      "1.2",
+      "1.2.3.4",
+      "01.2.3",
+      "1.02.3",
+      "1.2.03",
+      "1.2.3-01",
+      "1.2.3-",
+      "1.2.3+",
+      "1.2.3-alpha..1",
+      "1.2.3_alpha",
+      "9007199254740992.0.0",
+      "0.9007199254740992.0",
+      "0.0.9007199254740992",
+    ]
+    invalid.forEach((version) => expect(action("1.2.3", version, true), version).toBe("none"))
+  })
+
+  test("handles numeric limits without losing precision", () => {
+    expect(action("9007199254740991.0.0", "9007199254740991.0.1", true)).toBe("upgrade")
+    expect(action("9007199254740990.0.0", "9007199254740991.0.0", true)).toBe("none")
+  })
+
+  test("preserves equality for oversized numeric prerelease identifiers", () => {
+    expect(action("1.0.0-9007199254740992", "1.0.0-9007199254740993", true)).toBe("none")
+    expect(action("1.0.0-9007199254740991", "1.0.0-9007199254740992", true)).toBe("upgrade")
+  })
+
+  test("rejects versions longer than semver's limit before trimming", () => {
+    expect(action("1.2.3", `${" ".repeat(251)}1.2.3`, true)).toBe("none")
+    expect(action("1.2.3", `1.2.4+${"a".repeat(250)}`, true)).toBe("upgrade")
   })
 })

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -5,12 +5,10 @@ import { Context, Duration, Effect, FileSystem, Layer } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { parse, type ParseError } from "jsonc-parser"
 import path from "node:path"
-import semver from "semver"
+import { action, type Policy } from "./updater-action"
 
 declare const OPENCODE_CLI_NAME: string | undefined
 
-export type Policy = boolean | "notify"
-export type Action = "none" | "upgrade"
 type Method = "npm" | "pnpm" | "bun" | "yarn"
 
 const packageName =
@@ -32,14 +30,6 @@ export function decodePolicy(text: string): Policy | undefined {
   if (errors.length || typeof input !== "object" || input === null || !("autoupdate" in input)) return
   const value = input.autoupdate
   if (typeof value === "boolean" || value === "notify") return value
-}
-
-export function action(current: string, latest: string, policy: Policy): Action {
-  if (policy === false) return "none"
-  if (!semver.valid(current) || !semver.valid(latest) || semver.eq(latest, current)) return "none"
-  // Major upgrades are never installed automatically.
-  if (semver.major(latest) !== semver.major(current)) return "none"
-  return "upgrade"
 }
 
 export const layer = Layer.effect(
@@ -166,3 +156,4 @@ export const layer = Layer.effect(
 )
 
 export * as Updater from "./updater"
+export { action, type Action, type Policy } from "./updater-action"


### PR DESCRIPTION
## What

Replace the CLI updater’s general-purpose `semver` runtime dependency with a 50-line release-version action module tailored to the updater’s actual decisions: strict validity, equality, and major extraction.

The update behavior remains unchanged: invalid or equal versions do nothing, major changes do nothing, and every other same-major difference upgrades, including rollbacks and prerelease transitions.

## Impact

| Measurement | Before | After | Impact |
| --- | ---: | ---: | ---: |
| Bun macOS arm64 CLI binary | 150,530,402 B | 150,464,354 B | -66,048 B |
| Node CLI bundle | 26,134,396 B | 26,100,903 B | -33,493 B |
| Node CLI bundle, gzip | 10,502,124 B | 10,492,634 B | -9,490 B |
| CLI direct `semver` runtime edge | `semver@7.7.4` | none | removed |
| CLI direct `@types/semver` edge | `@types/semver@7.7.1` | none | removed |
| `--version` startup median, 20 runs | 513.3 ms | 516.9 ms | no measurable change within noise |

Artifact measurements use paired builds from untouched `origin/v2` and this branch with fixed `OPENCODE_VERSION=1.18.18` and `OPENCODE_CHANNEL=next`. `semver` remains in the workspace for unrelated packages and root release tooling; this removes only the CLI’s direct dependency and bundled updater usage.

## How

- Add `packages/cli/src/services/updater-action.ts` with the updater policy and a narrow strict release-version parser.
- Preserve `semver.valid` limits: 256 input characters, strict SemVer identifiers, and `Number.MAX_SAFE_INTEGER` bounds for major/minor/patch.
- Keep major values as decimal strings, avoiding precision loss during extraction and comparison.
- Normalize optional lowercase `v`, surrounding whitespace, and build metadata exactly as the existing updater action does.
- Preserve `semver.eq`’s existing oversized numeric prerelease behavior, including IEEE-754 collisions such as `9007199254740992` and `9007199254740993` comparing equal.
- Remove the CLI package’s direct `semver` and `@types/semver` declarations and update `bun.lock`.

Release producers were checked: stable builds emit plain `x.y.z`; preview builds emit `0.0.0-<channel>-<build>[.<attempt>]`. The update service accepts a broader opaque version token, so the parser intentionally preserves the full strict `semver@7.7.4` validity surface rather than narrowing to only currently produced strings.

## Scope

This does not change update policy, rollback behavior, release ordering, polling, installation-method detection, upgrade commands, the update API, or non-CLI `semver` dependencies.

This supersedes #42470 by removing the updater dependency instead of loading it lazily.

## Differential Evidence

A temporary deterministic oracle test compared the proposed action directly with exact `semver@7.7.4` for 328,869 assertions. It covered standard releases, `v` and whitespace handling, rejected `=`/uppercase prefixes, generated core/prerelease/build products, OpenCode `next` versions, dotted identifiers, build-insensitive equality, leading zeros, safe-integer boundaries, oversized numeric prereleases, malformed strings, rollback pairs, adjacent corpus pairs, and 100,000 seeded random strings up to 279 characters. The oracle test was removed after verification so `semver` is not retained as a CLI dependency.

## Testing

- `bun run test src/services/updater.test.ts` (11 passed)
- Temporary differential corpus against exact `semver@7.7.4` (328,869 assertions passed)
- `bun run typecheck`
- `OPENCODE_VERSION=1.18.18 OPENCODE_CHANNEL=next bun run build --skip-web-ui` (all 12 native targets)
- `OPENCODE_VERSION=1.18.18 OPENCODE_CHANNEL=next bun run build:node --bundle-only --skip-install` (`--version` and `--help` smoke checks passed)
- `bunx prettier --check src/services/updater-action.ts src/services/updater.ts src/services/updater.test.ts package.json`
- `.husky/pre-push` (35 workspace typechecks passed)
- Full CLI suite: 188 passed; the same three unrelated process/service tests fail on untouched `origin/v2` and this branch (`test/service.test.ts`, `test/standalone.test.ts`, `test/acp/command.test.ts`)