### PR TITLE
feat(tui): [v2] show cache hit rate in sidebar

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -16,6 +16,13 @@ export function SidebarContext(props: { context: Plugin.Context; sessionID: stri
   const state = createMemo(() =>
     contextUsage(msg(), props.context.data.location.model.list(session()?.location), session()?.revert?.messageID),
   )
+  const cacheRate = createMemo(() => {
+    const current = session()
+    if (!current) return undefined
+    const totalInput = current.tokens.input + current.tokens.cache.read
+    if (totalInput === 0) return undefined
+    return Math.round((current.tokens.cache.read / totalInput) * 100)
+  })
 
   return (
     <Show when={state() || cost() > 0}>
@@ -32,6 +39,9 @@ export function SidebarContext(props: { context: Plugin.Context; sessionID: stri
               </Show>
             </>
           )}
+        </Show>
+        <Show when={cacheRate() !== undefined}>
+          <text fg={theme.text.subdued}>{cacheRate()}% cache ratio</text>
         </Show>
         <Show when={cost() > 0}>
           <text fg={theme.text.subdued}>{money.format(cost())} spent</text>

--- a/packages/tui/test/feature-plugins/sidebar-context.test.tsx
+++ b/packages/tui/test/feature-plugins/sidebar-context.test.tsx
@@ -11,7 +11,10 @@ function context(options?: { cost?: number; tokens?: number }) {
     theme: { text: { default: color, subdued: color } },
     data: {
       session: {
-        get: () => ({ location: { directory: "/workspace" } }),
+        get: () => ({
+          location: { directory: "/workspace" },
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        }),
         cost: () => options?.cost ?? 0,
         message: {
           list: () =>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a cache hit rate to the sidebar so people can see how good OpenCode V2's caching really is.

### How did you verify your code works?

It simply works.

### Screenshots / recordings

<img width="1292" height="907" alt="image" src="https://github.com/user-attachments/assets/6f35bf9b-ac4e-4e87-a3ad-20e70fb3985b" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR