### PR TITLE
docs(zen): add Muse Spark 1.2

### DIFF
--- a/packages/web/src/content/docs/ar/zen.mdx
+++ b/packages/web/src/content/docs/ar/zen.mdx
@@ -94,6 +94,7 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -184,6 +185,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00   | $6.00   | $0.30           | -               |
 | Grok 4.5 (> 200K tokens)          | $4.00   | $12.00  | $0.60           | -               |
 | Grok Build 0.1                    | $1.00   | $2.00   | $0.20           | -               |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00   | $30.00  | $0.50           | $6.25           |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00  | $45.00  | $1.00           | $12.50          |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00   | $12.00  | $0.20           | $2.50           |

--- a/packages/web/src/content/docs/bs/zen.mdx
+++ b/packages/web/src/content/docs/bs/zen.mdx
@@ -99,6 +99,7 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/da/zen.mdx
+++ b/packages/web/src/content/docs/da/zen.mdx
@@ -99,6 +99,7 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/de/zen.mdx
+++ b/packages/web/src/content/docs/de/zen.mdx
@@ -90,6 +90,7 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/es/zen.mdx
+++ b/packages/web/src/content/docs/es/zen.mdx
@@ -99,6 +99,7 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | Grok 4.5 (≤ 200K tokens)          | $2.00   | $6.00   | $0.30            | -                  |
 | Grok 4.5 (> 200K tokens)          | $4.00   | $12.00  | $0.60            | -                  |
 | Grok Build 0.1                    | $1.00   | $2.00   | $0.20            | -                  |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00   | $30.00  | $0.50            | $6.25              |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00  | $45.00  | $1.00            | $12.50             |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00   | $12.00  | $0.20            | $2.50              |

--- a/packages/web/src/content/docs/fr/zen.mdx
+++ b/packages/web/src/content/docs/fr/zen.mdx
@@ -90,6 +90,7 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/it/zen.mdx
+++ b/packages/web/src/content/docs/it/zen.mdx
@@ -99,6 +99,7 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/ja/zen.mdx
+++ b/packages/web/src/content/docs/ja/zen.mdx
@@ -90,6 +90,7 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/ko/zen.mdx
+++ b/packages/web/src/content/docs/ko/zen.mdx
@@ -90,6 +90,7 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/nb/zen.mdx
+++ b/packages/web/src/content/docs/nb/zen.mdx
@@ -99,6 +99,7 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00   | $6.00   | $0.30         | -               |
 | Grok 4.5 (> 200K tokens)          | $4.00   | $12.00  | $0.60         | -               |
 | Grok Build 0.1                    | $1.00   | $2.00   | $0.20         | -               |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00   | $30.00  | $0.50         | $6.25           |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00  | $45.00  | $1.00         | $12.50          |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00   | $12.00  | $0.20         | $2.50           |

--- a/packages/web/src/content/docs/pl/zen.mdx
+++ b/packages/web/src/content/docs/pl/zen.mdx
@@ -99,6 +99,7 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | Grok 4.5 (≤ 200K tokens)          | $2.00   | $6.00   | $0.30          | -              |
 | Grok 4.5 (> 200K tokens)          | $4.00   | $12.00  | $0.60          | -              |
 | Grok Build 0.1                    | $1.00   | $2.00   | $0.20          | -              |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00   | $30.00  | $0.50          | $6.25          |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00  | $45.00  | $1.00          | $12.50         |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00   | $12.00  | $0.20          | $2.50          |

--- a/packages/web/src/content/docs/pt-br/zen.mdx
+++ b/packages/web/src/content/docs/pt-br/zen.mdx
@@ -90,6 +90,7 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00   | $6.00   | $0.30            | -                |
 | Grok 4.5 (> 200K tokens)          | $4.00   | $12.00  | $0.60            | -                |
 | Grok Build 0.1                    | $1.00   | $2.00   | $0.20            | -                |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00   | $30.00  | $0.50            | $6.25            |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00  | $45.00  | $1.00            | $12.50           |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00   | $12.00  | $0.20            | $2.50            |

--- a/packages/web/src/content/docs/ru/zen.mdx
+++ b/packages/web/src/content/docs/ru/zen.mdx
@@ -99,6 +99,7 @@ OpenCode Zen работает как любой другой провайдер 
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/th/zen.mdx
+++ b/packages/web/src/content/docs/th/zen.mdx
@@ -92,6 +92,7 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -182,6 +183,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/tr/zen.mdx
+++ b/packages/web/src/content/docs/tr/zen.mdx
@@ -90,6 +90,7 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -99,6 +99,7 @@ You can also access our models through the following API endpoints.
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -191,6 +192,7 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30       | -            |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60       | -            |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20       | -            |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50       | $6.25        |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00       | $12.50       |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20       | $2.50        |

--- a/packages/web/src/content/docs/zh-cn/zen.mdx
+++ b/packages/web/src/content/docs/zh-cn/zen.mdx
@@ -90,6 +90,7 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -180,6 +181,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30    | -        |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60    | -        |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20    | -        |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50    | $6.25    |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00    | $12.50   |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20    | $2.50    |

--- a/packages/web/src/content/docs/zh-tw/zen.mdx
+++ b/packages/web/src/content/docs/zh-tw/zen.mdx
@@ -94,6 +94,7 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | Grok 4.6                    | grok-4.6                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok 4.5                    | grok-4.5                    | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Grok Build 0.1              | grok-build-0.1              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Muse Spark 1.2              | muse-spark-1.2              | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Qwen3.7 Max                 | qwen3.7-max                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.7 Plus                | qwen3.7-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Qwen3.6 Plus                | qwen3.6-plus                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -185,6 +186,7 @@ https://opencode.ai/zen/v1/models
 | Grok 4.5 (≤ 200K tokens)          | $2.00  | $6.00   | $0.30    | -        |
 | Grok 4.5 (> 200K tokens)          | $4.00  | $12.00  | $0.60    | -        |
 | Grok Build 0.1                    | $1.00  | $2.00   | $0.20    | -        |
+| Muse Spark 1.2                     | $1.25  | $4.25   | $0.15       | -            |
 | GPT 5.6 Sol (≤ 272K tokens)       | $5.00  | $30.00  | $0.50    | $6.25    |
 | GPT 5.6 Sol (> 272K tokens)       | $10.00 | $45.00  | $1.00    | $12.50   |
 | GPT 5.6 Terra (≤ 272K tokens)     | $2.00  | $12.00  | $0.20    | $2.50    |


### PR DESCRIPTION
## Summary
- add Muse Spark 1.2 to Zen documentation

## Testing
- `bun run build` in `packages/web`