### PR TITLE
fix(core): attach session location to execution lifecycle events 

### DIFF
--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -26,6 +26,8 @@ export const createDirSyncContext = (
   serverSync: ReturnType<typeof createServerSyncContextInner>,
   serverSDK: ReturnType<typeof createServerSdkContext>,
 ) => {
+  // "global" is the location-less event bus key, not a project directory.
+  if (directory === "global") throw new Error("Invalid directory: global")
   const current = createMemo(() => serverSync.child(directory, { mcp: true }))
   const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
   const data = new Proxy({} as State, {

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -199,6 +199,13 @@ export function createServerNotificationState(input: { sdk: ServerSDK; sync: Ser
 
   const lookup = async (directory: string, sessionID?: string) => {
     if (!sessionID) return undefined
+    // Location-less bus events are keyed as "global"; that sentinel is not a
+    // filesystem path and must not bootstrap a directory store.
+    if (directory === "global") {
+      const session = input.sync.session.get(sessionID)
+      if (session) return session
+      return input.sync.session.resolve(sessionID).catch(() => undefined)
+    }
     const sync = input.sync.ensureDirSyncContext(directory)
     const session = sync.session.get(sessionID)
     if (session) return session

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -490,6 +490,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
   }
 
   async function bootstrapInstance(directory: string) {
+    if (directory === "global") return
     const key = directoryKey(directory)
     if (!key) return
     const pending = booting.get(key)

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -67,6 +67,12 @@ export const layer = Layer.effect(
     const releaseOnCommit = (sessionID: SessionSchema.ID) => ({
       commit: () => store.release(sessionID),
     })
+    // SessionExecution is process-global and not Location-scoped, so lifecycle
+    // publishes must carry the Session's location explicitly. Without it the web
+    // client maps the event to the "global" sentinel and bootstraps that string
+    // as a filesystem directory.
+    const lifecycleLocation = (sessionID: SessionSchema.ID) =>
+      store.get(sessionID).pipe(Effect.map((session) => session?.location))
     function drain(
       sessionID: SessionSchema.ID,
       force: boolean,
@@ -93,7 +99,13 @@ export const layer = Layer.effect(
       started: (sessionID) =>
         reportLifecycle(
           sessionID,
-          bus.publish(SessionEvent.Execution.Started, { sessionID }, claimOnCommit(sessionID)),
+          Effect.gen(function* () {
+            const location = yield* lifecycleLocation(sessionID)
+            yield* bus.publish(SessionEvent.Execution.Started, { sessionID }, {
+              ...claimOnCommit(sessionID),
+              ...(location ? { location } : {}),
+            })
+          }),
         ),
       drain: (sessionID, force) => drain(sessionID, force),
       // One terminal observation per busy period, covering every coalesced drain.
@@ -101,9 +113,14 @@ export const layer = Layer.effect(
         reportLifecycle(
           sessionID,
           Effect.gen(function* () {
+            const location = yield* lifecycleLocation(sessionID)
+            const withLocation = location ? { location } : {}
             const outcome = terminal(exit, reason)
             if (outcome.type === "succeeded") {
-              yield* bus.publish(SessionEvent.Execution.Succeeded, { sessionID }, releaseOnCommit(sessionID))
+              yield* bus.publish(SessionEvent.Execution.Succeeded, { sessionID }, {
+                ...releaseOnCommit(sessionID),
+                ...withLocation,
+              })
               return
             }
             if (outcome.type === "interrupted") {
@@ -112,7 +129,7 @@ export const layer = Layer.effect(
               yield* bus.publish(
                 SessionEvent.Execution.Interrupted,
                 { sessionID, reason: outcome.reason },
-                outcome.reason === "shutdown" ? undefined : releaseOnCommit(sessionID),
+                outcome.reason === "shutdown" ? withLocation : { ...releaseOnCommit(sessionID), ...withLocation },
               )
               return
             }
@@ -122,7 +139,7 @@ export const layer = Layer.effect(
                 sessionID,
                 error: outcome.error,
               },
-              releaseOnCommit(sessionID),
+              { ...releaseOnCommit(sessionID), ...withLocation },
             )
           }),
         ),

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -73,10 +73,11 @@ export const layer = (options?: Options) =>
         if (attempts > maxAttempts) {
           // Terminalize instead: the release hook clears the claim and resets the
           // counter atomically with the terminal event.
+          const session = yield* store.get(sessionID)
           yield* bus.publish(
             SessionEvent.Execution.Failed,
             { sessionID, error: RESUME_EXHAUSTED },
-            { commit: () => store.release(sessionID) },
+            { commit: () => store.release(sessionID), ...(session ? { location: session.location } : {}) },
           )
           return
         }

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -133,6 +133,34 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
+  it.effect("execution lifecycle events carry the Session location", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const sessionID = Session.ID.make("ses_lifecycle_location")
+      yield* seedSessions(database, [sessionID])
+
+      const started = yield* Deferred.make<SessionEvent.Execution.Started>()
+      const succeeded = yield* Deferred.make<SessionEvent.Execution.Succeeded>()
+      yield* bus.project(SessionEvent.Execution.Started, (event) => Deferred.succeed(started, event))
+      yield* bus.project(SessionEvent.Execution.Succeeded, (event) => Deferred.succeed(succeeded, event))
+
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, () => Effect.void)
+      const execution = Context.get(context, SessionExecution.Service)
+      yield* execution.resume(sessionID)
+      yield* execution.awaitIdle(sessionID)
+
+      const start = yield* Deferred.await(started)
+      const done = yield* Deferred.await(succeeded)
+      expect(start.location).toEqual({ directory: AbsolutePath.make("/project") })
+      expect(done.location).toEqual({ directory: AbsolutePath.make("/project") })
+      expect(start.data.sessionID).toBe(sessionID)
+      expect(done.data.sessionID).toBe(sessionID)
+    }),
+  )
+
   it.effect("starts every claimed execution without waiting for earlier drains to finish", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
@@ -224,6 +252,7 @@ describe("SessionExecution lifecycle", () => {
       yield* restart.resumeSuspendedSessions
       expect(drained).toEqual([])
       expect(failures.map((event) => event.data.error.type)).toEqual(["aborted"])
+      expect(failures[0].location).toEqual({ directory: AbsolutePath.make("/project") })
       // The terminal released the claim and reset the counter atomically.
       expect(yield* claims(database)).toEqual({ [sessionID]: false })
       expect(yield* attempts(database, sessionID)).toBe(0)


### PR DESCRIPTION
SessionExecution is global, so lifecycle publishes lacked location. The web client mapped those events to the "global" sentinel and bootstrapped it as a filesystem path, causing Path is not absolute: global 500s.

Also guard the app against treating the event-bus "global" key as a directory.

Fixes #42266
