### PR TITLE
fix(app): show session header for error-only sessions

### DIFF
--- a/packages/app/src/pages/session/timeline/controller.tsx
+++ b/packages/app/src/pages/session/timeline/controller.tsx
@@ -94,7 +94,9 @@ export function createTimelineController(input: {
       fallback: language.t("command.session.new"),
     })
   })
-  const showHeader = createMemo(() => !!(titleValue() || input.session.data.parentID()))
+  const showHeader = createMemo(
+    () => !!(titleValue() || input.session.data.parentID() || input.session.identity.sessionID()),
+  )
   const projection = createTimelineProjection({
     messages: input.session.history.messages,
     userMessages: input.userMessages,


### PR DESCRIPTION
Without this I couldn't find a way to delete a session that starts in an error