### PR TITLE
fix(opencode): handle snapshot exclude write failure gracefully

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -188,8 +188,11 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           ]
             .filter(Boolean)
             .join("\n")
-          yield* fs.ensureDir(path.join(state.gitdir, "info")).pipe(Effect.orDie)
-          yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
+          // Refreshing the exclude file is advisory, so a failure must not take the session down.
+          yield* Effect.gen(function* () {
+            yield* fs.ensureDir(path.join(state.gitdir, "info"))
+            yield* fs.writeFileString(target, text ? `${text}\n` : "")
+          }).pipe(Effect.catch((error) => Effect.logWarning("failed to write snapshot exclude", { target, error })))
         })
 
         // Reuse the hashes for the git storage between the original repo and snapshot

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -3,6 +3,8 @@ import { $ } from "bun"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import { Hash } from "@opencode-ai/core/util/hash"
 import fs from "fs/promises"
 import path from "path"
 import { Effect, Fiber, Layer } from "effect"
@@ -10,6 +12,7 @@ import { Snapshot } from "../../src/snapshot"
 import {
   disposeAllInstances,
   provideInstance,
+  requireInstance,
   testInstanceStoreLayer,
   TestInstance,
   tmpdirScoped,
@@ -645,6 +648,26 @@ it.instance(
     )
   }),
   { git: true },
+)
+
+it.instance(
+  "git info exclude write failure keeps tracking alive",
+  Effect.gen(function* () {
+    const tmp = yield* bootstrap()
+    const snapshot = yield* Snapshot.Service
+    const before = yield* snapshot.track()
+    expect(before).toBeTruthy()
+    // Make the snapshot exclude write fail: a directory can never be overwritten by a file.
+    const ctx = yield* requireInstance
+    const gitdir = path.join(Global.Path.data, "snapshot", ctx.project.id, Hash.fast(ctx.worktree))
+    yield* rm(path.join(gitdir, "info", "exclude"))
+    yield* mkdirp(path.join(gitdir, "info", "exclude"))
+    yield* write(`${tmp.path}/after.txt`, "after content")
+    const after = yield* snapshot.track()
+    expect(after).toBeTruthy()
+  }),
+  { git: true },
+  { timeout: 60000 },
 )
 
 it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #37493

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`sync()` in `packages/opencode/src/snapshot/index.ts` wrote the snapshot's `info/exclude` with `Effect.orDie`. That promotes a recoverable write failure into a defect, and because `sync()` runs inside `add()` -> `track()`/`patch()`, the defect escapes into the session and kills the turn the user is in the middle of.

Refreshing that exclude file is advisory, so it shouldn't be able to do that. Every other git step in this file already degrades instead of dying - `stage()`, `add()`, `patch()` and `cleanup()` all log a warning and carry on. `sync()` now does the same: the `ensureDir` + write are wrapped together, and a failure logs `failed to write snapshot exclude` and continues. Ignored files are still filtered separately by `ignore()` in `add()`, so a stale exclude file doesn't leak gitignored files into the snapshot.

Only the v1 path is touched - `packages/core/src/snapshot.ts` already handles this.

### How did you verify your code works?

Added `git info exclude write failure keeps tracking alive` to `test/snapshot/snapshot.test.ts`. It forces the write to fail by turning `<gitdir>/info/exclude` into a directory. On current dev that test dies with `AlreadyExists: FileSystem.writeFile (...)`; with the fix `track()` returns a hash. Full file is 54 pass / 3 skip / 0 fail.

To confirm it outside the test runner I ran the real CLI against a throwaway git repo with the same directory planted:

- before: `opencode debug snapshot track` exits 1 with `Error: Unexpected error`
- after: exits 0, prints the new hash, and the log has
  `level=WARN message="failed to write snapshot exclude" target="..." error="PlatformError: AlreadyExists: FileSystem.writeFile (...)"`

`bun run typecheck` in `packages/opencode` is clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
