### PR TITLE
docs: add SCX.ai to the providers list

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2093,6 +2093,35 @@ To use [Scaleway Generative APIs](https://www.scaleway.com/en/docs/generative-ap
 
 ---
 
+### SCX.ai
+
+[SCX.ai](https://scx.ai) is an Australian sovereign AI platform serving open models over an OpenAI-compatible API, hosted on renewable-powered infrastructure in Australia.
+
+1. Head over to the [SCX.ai platform](https://platform.scx.ai) to create an account and generate an API key.
+
+2. Run the `/connect` command and search for **SCX.ai**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your SCX.ai API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _MiniMax-M2.7_ or _GLM-5.2_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Snowflake Cortex
 
 [Snowflake Cortex](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api) gives you access to frontier models (Claude, OpenAI GPT-5, and more) via an OpenAI-compatible API. All inference runs within the Snowflake perimeter and is billed in Snowflake credits. For per-model rates, see the [Snowflake Service Consumption Table](https://www.snowflake.com/legal-files/CreditConsumptionTable.pdf).


### PR DESCRIPTION
### Issue for this PR

Closes # N/A — docs-only. Provider registration was anomalyco/models.dev#3085 (merged 2026-08-04).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an **SCX.ai** section to `docs/providers`, between Scaleway and Snowflake Cortex.

SCX.ai has been in models.dev since #3085 merged, so it already shows up in `/connect`
and `/models`. The providers page is maintained by hand though, so it was missing there.
This just fills that gap — same four steps as the Scaleway section (console link →
`/connect` → API key → `/models`).

English only. I left the 17 translated copies of `providers.mdx` alone because they
look like they're synced separately — tell me if you want them in here too.

### How did you verify your code works?

- Diff is `+29 −0` in one file, purely additive, no other sections touched.
- Confirmed SCX.ai actually resolves before documenting it: it's in `models.dev/api.json`,
  and in `~/.cache/opencode/models.json` on a local opencode 1.17.7 install.
- The three links in the section (scx.ai, platform.scx.ai, platform.scx.ai/docs) all return 200.
- The named models, MiniMax-M2.7 and GLM-5.2, both respond on the live API.
- Compiled the edited file locally with `@mdx-js/mdx` v3 — parses clean.

I did not run a full Astro site build; the addition is plain markdown with no JSX or
imports, structurally identical to the adjacent Scaleway section.

### Screenshots / recordings

N/A — text-only docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
