### PR TITLE
fix(skill): read SKILL.md content dynamically on tool execution

### DIFF
--- a/packages/core/src/tool/skill.ts
+++ b/packages/core/src/tool/skill.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { ToolFailure } from "@opencode-ai/llm"
 import { Effect, Layer, Schema } from "effect"
 import { makeLocationNode } from "../effect/app-node"
+import { ConfigMarkdown } from "../config/markdown"
 import { FSUtil } from "../fs-util"
 import { SkillV2 } from "../skill"
 import { PermissionV2 } from "../permission"
@@ -32,13 +33,13 @@ export const description = [
   "The skill name must match one of the available skills in the system context.",
 ].join("\n")
 
-export const toModelOutput = (skill: SkillV2.Info, files: ReadonlyArray<string>) => {
+export const toModelOutput = (skill: SkillV2.Info, files: ReadonlyArray<string>, content?: string) => {
   const directory = path.dirname(skill.location)
   return [
     `<skill_content name="${skill.name}">`,
     `# Skill: ${skill.name}`,
     "",
-    skill.content.trim(),
+    (content ?? skill.content).trim(),
     "",
     `Base directory for this skill: ${directory}`,
     "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
@@ -89,10 +90,14 @@ const layer = Layer.effectDiscard(
                         .toSorted()
                         .slice(0, FILE_LIMIT)
                     : []
+                const content = yield* fs.readFileStringSafe(skill.location).pipe(
+                  Effect.map((raw) => (raw ? ConfigMarkdown.parseOption(raw)?.content ?? skill.content : skill.content)),
+                  Effect.catch(() => Effect.succeed(skill.content)),
+                )
                 return {
                   name: skill.name,
                   directory,
-                  output: toModelOutput(skill, files),
+                  output: toModelOutput(skill, files, content),
                 }
               }).pipe(Effect.mapError((error) => unableToLoad(input.name, error)))
             }),

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -30,7 +30,7 @@ describe("SkillTool", () => {
           const reference = path.join(directory, "reference.md")
           yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))
           yield* Effect.promise(() =>
-            Promise.all([fs.writeFile(location, "unused"), fs.writeFile(reference, "reference")]),
+            Promise.all([fs.writeFile(location, "# Effect\n\nGuidance"), fs.writeFile(reference, "reference")]),
           )
 
           const info: SkillV2.Info = {
@@ -129,11 +129,11 @@ describe("SkillTool", () => {
             })
             yield* Effect.promise(() =>
               Promise.all([
-                fs.writeFile(flat.location, "public"),
+                fs.writeFile(flat.location, "Public"),
                 fs.writeFile(path.join(tmp.path, "secret.md"), "secret"),
               ]),
             )
-            current = [flat]
+            current = [flat, info]
             expect(
               yield* executeTool(registry, {
                 sessionID,
@@ -141,6 +141,18 @@ describe("SkillTool", () => {
                 call: { type: "tool-call", id: "call-flat-skill", name: "skill", input: { name: "public" } },
               }),
             ).toEqual({ type: "text", value: SkillTool.toModelOutput(flat, []) })
+
+            yield* Effect.promise(() => fs.writeFile(location, "# Effect\n\nUpdated Guidance"))
+            expect(
+              yield* executeTool(registry, {
+                sessionID,
+                ...toolIdentity,
+                call: { type: "tool-call", id: "call-skill-updated", name: "skill", input: { name: "effect" } },
+              }),
+            ).toEqual({
+              type: "text",
+              value: SkillTool.toModelOutput(info, [reference], "# Effect\n\nUpdated Guidance"),
+            })
           }).pipe(Effect.provide(skillToolLayer))
         }),
       ),

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { Effect, Schema } from "effect"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { ConfigMarkdown } from "@/config/markdown"
 import { Skill } from "../skill"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
@@ -42,13 +43,21 @@ export const SkillTool = Tool.define(
             limit: 10,
           })
 
+          const content = yield* Effect.tryPromise({
+            try: () => ConfigMarkdown.parse(info.location),
+            catch: () => undefined,
+          }).pipe(
+            Effect.map((md) => md?.content ?? info.content),
+            Effect.catch(() => Effect.succeed(info.content)),
+          )
+
           return {
             title: `Loaded skill: ${info.name}`,
             output: [
               `<skill_content name="${info.name}">`,
               `# Skill: ${info.name}`,
               "",
-              info.content.trim(),
+              content.trim(),
               "",
               `Base directory for this skill: ${base}`,
               "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -2,10 +2,9 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
-import type { Permission } from "../../src/permission"
 import type { Tool } from "@/tool/tool"
 import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "@/tool/registry"
@@ -88,8 +87,28 @@ Use this skill.
       expect(requests[0].always).toContain("tool-skill")
       expect(result.metadata.dir).toBe(skill)
       expect(result.output).toContain(`<skill_content name="tool-skill">`)
+      expect(result.output).toContain("Use this skill.")
       expect(result.output).toContain(`Base directory for this skill: ${skill}`)
       expect(result.output).toContain(`<file>${file}</file>`)
+
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(skill, "SKILL.md"),
+          `---
+name: tool-skill
+description: Skill for tool tests.
+---
+
+# Tool Skill
+
+Updated live guidance without restart.
+`,
+        ),
+      )
+
+      const updated = yield* tool.execute({ name: "tool-skill" }, ctx)
+      expect(updated.output).toContain("Updated live guidance without restart.")
+      expect(updated.output).not.toContain("Use this skill.")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #34443

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a `SKILL.md` file is edited during skill development or runtime, subsequent executions of the `skill` tool continue returning the stale in-memory cached content loaded at startup because `SkillTool.execute` previously relied purely on the initially loaded state.

This PR updates `packages/opencode/src/tool/skill.ts` and `packages/core/src/tool/skill.ts` to read and parse the markdown body dynamically from `location` on tool execution. If the file cannot be read or if the skill is built-in/embedded, it gracefully falls back to the existing cached content.

### How did you verify your code works?

- Added unit tests in `packages/opencode/test/tool/skill.test.ts` and `packages/core/test/tool-skill.test.ts` verifying that modifying a `SKILL.md` file on disk is immediately reflected in the output of the next `skill` tool execution without restarting the server.
- Ran all skill-related tests across `packages/core` and `packages/opencode`.
- Ran workspace-wide `bun turbo typecheck`.

### Screenshots / recordings

_N/A (backend tool execution change)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
