### PR TITLE
fix(session-ui): preserve mentions when the context menu opens

### DIFF
--- a/packages/app/e2e/regression/prompt-input-v2-context-mention.spec.ts
+++ b/packages/app/e2e/regression/prompt-input-v2-context-mention.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+const directory = "C:/OpenCode/PromptInputV2ContextMention"
+const projectID = "proj_prompt_input_v2_context_mention"
+const sessionID = "ses_prompt_input_v2_context_mention"
+
+// Reproduces: opening the "@ context" menu (plus button -> Context) rebuilds the
+// prompt via setText(promptText + "@"), which drops mention content and moves all
+// mention chips to the end, silently rewriting the draft.
+test("keeps existing mentions in place when the context menu opens", async ({ page }) => {
+  test.setTimeout(240_000)
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "prompt-input-v2-context-mention",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: [
+      {
+        id: sessionID,
+        slug: "prompt-input-v2-context-mention",
+        projectID,
+        directory,
+        title: "Prompt input V2 context mention",
+        version: "dev",
+        time: { created: 1700000000000, updated: 1700000000000 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+    findFiles: () => ["src/index.ts"],
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  const composer = page.locator('[data-component="prompt-input-v2"]')
+  const input = composer.locator('[data-component="prompt-input"]')
+  await expectAppVisible(composer)
+
+  // Build a draft with two mentions separated by text: "hi @src/index.ts and @src/index.ts"
+  await input.click()
+  await page.keyboard.type("hi ")
+  await page.keyboard.type("@src")
+  await page.locator('[data-suggestion-id="file:src/index.ts"]').click()
+  await page.waitForTimeout(100)
+  await page.keyboard.type(" and ")
+  await page.keyboard.type("@src")
+  await page.locator('[data-suggestion-id="file:src/index.ts"]').click()
+  await page.waitForTimeout(100)
+
+  const editorText = () =>
+    page.evaluate(() => document.querySelector('[data-component="prompt-input"]')?.textContent ?? "")
+
+  // Open the context menu via the plus button (this is the bug trigger).
+  await composer.getByRole("button", { name: "Add images and files" }).click()
+  await page.getByRole("menuitem", { name: "Context" }).click()
+  await page.waitForTimeout(100)
+
+  const after = await editorText()
+
+  // The two mentions keep their order and "and" stays between them; only a
+  // trailing "@" is appended at the caret. The old bug rewrote the draft so both
+  // mention chips collapsed to the end (e.g. "hi   and  @@src/index.ts@src/index.ts").
+  const firstMention = after.indexOf("@src/index.ts")
+  const secondMention = after.lastIndexOf("@src/index.ts")
+  const andPosition = after.indexOf("and")
+  expect(firstMention).not.toBe(-1)
+  expect(secondMention).toBeGreaterThan(firstMention)
+  expect(andPosition).toBeGreaterThan(firstMention)
+  expect(andPosition).toBeLessThan(secondMention)
+  expect(after.endsWith("@")).toBe(true)
+})

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -143,6 +143,10 @@ export function createPromptInputV2Controller(input: {
       draft.setText(command.value)
       return
     }
+    if (command.type === "draft.addText") {
+      draft.addText(command.value)
+      return
+    }
     if (command.type === "mention.add") {
       if (command.item.mention) draft.addMention(command.item.mention)
       return

--- a/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
@@ -161,4 +161,22 @@ describe("prompt input v2 interaction machine", () => {
     expect(result.state.popover).toEqual({ type: "context", query: "", activeID: "first" })
     expect(result.handled).toBeTrue()
   })
+
+  test("opens the context menu by appending @ without rebuilding the draft", () => {
+    const draft: PromptInputV2PersistedState = {
+      prompt: [
+        { type: "text", content: "hi ", start: 0, end: 3 },
+        { type: "file", content: "@src/index.ts", start: 3, end: 16, path: "src/index.ts" },
+        { type: "text", content: " and ", start: 16, end: 21 },
+        { type: "file", content: "@src/index.ts", start: 21, end: 34, path: "src/index.ts" },
+      ],
+      cursor: 34,
+      context: { items: [] },
+    }
+
+    const result = transitionPromptInputV2(createPromptInputV2InteractionState(), { type: "context.open" }, draft)
+
+    expect(result.commands).toContainEqual({ type: "draft.addText", value: "@" })
+    expect(result.commands.some((entry) => entry.type === "draft.setText")).toBe(false)
+  })
 })

--- a/packages/session-ui/src/v2/components/prompt-input/machine.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.ts
@@ -34,6 +34,7 @@ export type PromptInputV2InteractionEvent =
 
 export type PromptInputV2InteractionCommand =
   | { type: "draft.setText"; value: string }
+  | { type: "draft.addText"; value: string }
   | { type: "mention.add"; item: PromptInputV2Suggestion }
   | { type: "popover.filter"; popover: "command" | "context"; query: string }
   | { type: "suggestion.select"; id: string }
@@ -139,7 +140,7 @@ function openContext(
   persisted: PromptInputV2PersistedState,
 ): PromptInputV2Transition {
   return changed({ ...state, popover: { type: "context", query: "" }, focus: "editor" }, [
-    { type: "draft.setText", value: promptText(persisted) + "@" },
+    { type: "draft.addText", value: "@" },
     { type: "popover.filter", popover: "context", query: "" },
     { type: "focus.editor" },
   ])


### PR DESCRIPTION
### Issue for this PR

Closes #42546

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opening the `@` context menu (the `+` button → "Context") used to rebuild the draft via `setText(promptText + "@")`. `promptText` only joins `text` parts, so mention content was dropped, and `setText` moves every non-text part to the end — silently rewriting the draft (e.g. `hi @src/index.ts and @src/index.ts` became `hi   and  @@src/index.ts@src/index.ts`).

This changes `openContext` to emit a `draft.addText` command instead, which appends `@` at the caret via the existing `addText` store action and keeps the prompt structure intact.

### How did you verify your code works?

- Added a machine test asserting `context.open` emits `draft.addText` (not `draft.setText`).
- Added an e2e test that builds a draft with two mentions, opens the context menu, and asserts both mentions keep their order with `and` between them.
- `bun typecheck` in `packages/session-ui` passes.
- `bun test src/v2/components/prompt-input` in `packages/session-ui`: 17 pass.

### Screenshots / recordings

_This is not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
