### PR TITLE
fix(core): bypass poisoned markdown cache

### DIFF
--- a/packages/core/src/config/markdown.ts
+++ b/packages/core/src/config/markdown.ts
@@ -3,9 +3,9 @@ export * as ConfigMarkdown from "./markdown"
 import matter from "gray-matter"
 export function parse(content: string) {
   try {
-    return matter(content)
+    return matter(content, {})
   } catch {
-    return matter(sanitize(content))
+    return matter(sanitize(content), {})
   }
 }
 

--- a/packages/core/src/config/markdown.ts
+++ b/packages/core/src/config/markdown.ts
@@ -2,6 +2,7 @@ export * as ConfigMarkdown from "./markdown"
 
 import matter from "gray-matter"
 export function parse(content: string) {
+  // gray-matter mutates its shared defaults after a failed parse; fresh options keep retries isolated.
   try {
     return matter(content, {})
   } catch {

--- a/packages/core/test/config-markdown.test.ts
+++ b/packages/core/test/config-markdown.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { ConfigMarkdown } from "../src/config/markdown"
+
+describe("ConfigMarkdown.parse", () => {
+  test("reparses sanitized frontmatter after a failed strict parse", () => {
+    const content = `---
+name: repeated
+description: Trigger keywords: "e2e", "test"
+---
+body`
+
+    expect(ConfigMarkdown.parse(content).data).toEqual({
+      name: "repeated",
+      description: 'Trigger keywords: "e2e", "test"',
+    })
+    expect(ConfigMarkdown.parse(content).data).toEqual({
+      name: "repeated",
+      description: 'Trigger keywords: "e2e", "test"',
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #42350

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It bypasses `gray-matter`'s shared default-options cache in the markdown parser. A strict YAML error otherwise caches the original content before the sanitized retry, so parsing the same skill again returns empty frontmatter. A fresh options object isolates each parse while preserving the existing strict-then-sanitize behavior.

The call-site comment records why the otherwise no-op-looking options object must remain.

### How did you verify your code works?

- PR base: `3a31c4ea801915c0b050df4b3842997ea62b6e93`
- Current head: `a49a46c345ceffb47e4c2783d66c448a2da99c48`
- The original `origin/dev` baseline returned sanitized data once and `{}` on the second parse; the candidate returns the same sanitized data both times
- Focused tests: 7 passed
- Package and repository typechecks: passed, including 30/30 root tasks
- Standards and compliance checks: passed

The upstream `test`, `typecheck`, and `nix-eval` workflows require maintainer approval for this fork head.

### Screenshots / recordings

Not applicable; this is a parser fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
