### PR TITLE
docs(web): add opencode-usage-tracking to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [opencode usage tracking](https://github.com/Amanuel-Tesfaye-R/opencode-usage-tracking)    |dashboard for your OpenCode database to track usage- tokenusage.. |
 
 ---
 


### PR DESCRIPTION
Adds OpenCode Usage Tracking to the Projects section of the ecosystem page.

Dashboard for OpenCode that reads the local database and visualizes token usage, AI coding sessions, model breakdowns, tool calls, files edited, cost, todos, and more.

Closes #42560

### Type of change

- [x] Documentation

### What does this PR do?

Adds a single entry to the ecosystem.mdx Projects table linking to opencode-usage-tracking with a short description.

### How did you verify your code works?

Verified the markdown table format matches existing entries in the file.

### Checklist

- [x] I have not included unrelated changes in this PR