### PR TITLE
fix(tui): preserve background hint timing

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1519,20 +1519,28 @@ function turnTokenToolSummary(tool: SessionMessageAssistantTool) {
 function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
   const theme = useTheme()
   const shortcut = Keymap.useShortcut("session.background")
-  const running = createMemo(() => {
-    if (!shortcut()) return
-    const current = props.messages.findLast(
-      (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
-    )
-    const part = current?.content.find((part): part is SessionMessageAssistantTool => {
-      if (part.type !== "tool" || part.state.status !== "running") return false
-      const name = canonicalToolName(part.name)
-      return name === "shell" || name === "subagent"
-    })
-    if (!current || !part) return
-    return `${current.id}:${part.id}`
-  })
-  const visible = createDelayedPresence(running, BACKGROUND_TOOL_HINT_DELAY)
+  const running = createMemo(
+    () => {
+      if (!shortcut()) return
+      const current = props.messages.findLast(
+        (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
+      )
+      const part = current?.content.find((part): part is SessionMessageAssistantTool => {
+        if (part.type !== "tool" || part.state.status !== "running") return false
+        const name = canonicalToolName(part.name)
+        return name === "shell" || name === "subagent"
+      })
+      if (!current || !part) return
+      return { key: `${current.id}:${part.id}`, started: part.time.ran ?? part.time.created }
+    },
+    undefined,
+    {
+      equals: (previous, next) => previous?.key === next?.key && previous?.started === next?.started,
+    },
+  )
+  const visible = createDelayedPresence(running, (tool) =>
+    Math.max(0, BACKGROUND_TOOL_HINT_DELAY - (Date.now() - tool.started)),
+  )
   return (
     <Show when={visible() && shortcut()}>
       {(value) => (

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1519,27 +1519,23 @@ function turnTokenToolSummary(tool: SessionMessageAssistantTool) {
 function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
   const theme = useTheme()
   const shortcut = Keymap.useShortcut("session.background")
-  const running = createMemo(
-    () => {
-      if (!shortcut()) return
-      const current = props.messages.findLast(
-        (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
-      )
-      const part = current?.content.find((part): part is SessionMessageAssistantTool => {
-        if (part.type !== "tool" || part.state.status !== "running") return false
-        const name = canonicalToolName(part.name)
-        return name === "shell" || name === "subagent"
-      })
-      if (!current || !part) return
-      return { key: `${current.id}:${part.id}`, started: part.time.ran ?? part.time.created }
-    },
-    undefined,
-    {
-      equals: (previous, next) => previous?.key === next?.key && previous?.started === next?.started,
-    },
-  )
-  const visible = createDelayedPresence(running, (tool) =>
-    Math.max(0, BACKGROUND_TOOL_HINT_DELAY - (Date.now() - tool.started)),
+  const running = createMemo(() => {
+    if (!shortcut()) return
+    const current = props.messages.findLast(
+      (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
+    )
+    const part = current?.content.find((part): part is SessionMessageAssistantTool => {
+      if (part.type !== "tool" || part.state.status !== "running") return false
+      const name = canonicalToolName(part.name)
+      return name === "shell" || name === "subagent"
+    })
+    if (!current || !part) return
+    return { key: `${current.id}:${part.id}`, started: part.time.ran ?? part.time.created }
+  })
+  const visible = createDelayedPresence(
+    running,
+    (tool) => Math.max(0, BACKGROUND_TOOL_HINT_DELAY - (Date.now() - tool.started)),
+    (previous, next) => previous.key === next.key && previous.started === next.started,
   )
   return (
     <Show when={visible() && shortcut()}>

--- a/packages/tui/src/util/delayed-presence.ts
+++ b/packages/tui/src/util/delayed-presence.ts
@@ -1,14 +1,26 @@
-import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup, type Accessor } from "solid-js"
 
-export function createDelayedPresence<T>(source: Accessor<T | undefined>, delay: number | ((value: T) => number)) {
+export function createDelayedPresence<T>(
+  source: Accessor<T | undefined>,
+  delay: number | ((value: T) => number),
+  equals?: (previous: T, next: T) => boolean,
+) {
   const [visible, setVisible] = createSignal(false)
+  const value = equals
+    ? createMemo(source, undefined, {
+        equals: (previous, next) => {
+          if (previous === undefined || next === undefined) return previous === next
+          return equals(previous, next)
+        },
+      })
+    : source
 
   createEffect(() => {
-    const value = source()
+    const current = value()
     setVisible(false)
-    if (value === undefined) return
+    if (current === undefined) return
 
-    const remaining = typeof delay === "function" ? delay(value) : delay
+    const remaining = typeof delay === "function" ? delay(current) : delay
     if (remaining <= 0) {
       setVisible(true)
       return

--- a/packages/tui/src/util/delayed-presence.ts
+++ b/packages/tui/src/util/delayed-presence.ts
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, onCleanup, type Accessor } from "solid-js"
 
-export function createDelayedPresence<T>(source: Accessor<T | undefined>, delay: number) {
+export function createDelayedPresence<T>(source: Accessor<T | undefined>, delay: number | ((value: T) => number)) {
   const [visible, setVisible] = createSignal(false)
 
   createEffect(() => {
@@ -8,7 +8,13 @@ export function createDelayedPresence<T>(source: Accessor<T | undefined>, delay:
     setVisible(false)
     if (value === undefined) return
 
-    const timer = setTimeout(() => setVisible(true), delay)
+    const remaining = typeof delay === "function" ? delay(value) : delay
+    if (remaining <= 0) {
+      setVisible(true)
+      return
+    }
+
+    const timer = setTimeout(() => setVisible(true), remaining)
     onCleanup(() => clearTimeout(timer))
   })
 

--- a/packages/tui/test/util/delayed-presence.test.ts
+++ b/packages/tui/test/util/delayed-presence.test.ts
@@ -81,3 +81,34 @@ test("uses the remaining delay for the current value", async () => {
     jest.useRealTimers()
   }
 })
+
+test("does not restart the delay for an equivalent value", async () => {
+  jest.useFakeTimers()
+  const scope = createRoot((dispose) => {
+    const [value, setValue] = createSignal<{ id: string }>()
+    return {
+      dispose,
+      setValue,
+      visible: createDelayedPresence(value, 1_000, (previous, next) => previous.id === next.id),
+    }
+  })
+
+  try {
+    scope.setValue({ id: "first" })
+    await Promise.resolve()
+    jest.advanceTimersByTime(500)
+    scope.setValue({ id: "first" })
+    await Promise.resolve()
+    jest.advanceTimersByTime(499)
+    expect(scope.visible()).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(scope.visible()).toBe(true)
+
+    scope.setValue({ id: "second" })
+    await Promise.resolve()
+    expect(scope.visible()).toBe(false)
+  } finally {
+    scope.dispose()
+    jest.useRealTimers()
+  }
+})

--- a/packages/tui/test/util/delayed-presence.test.ts
+++ b/packages/tui/test/util/delayed-presence.test.ts
@@ -53,3 +53,31 @@ test("cancels the delay when the value disappears or the owner is disposed", asy
     jest.useRealTimers()
   }
 })
+
+test("uses the remaining delay for the current value", async () => {
+  jest.useFakeTimers()
+  const scope = createRoot((dispose) => {
+    const [value, setValue] = createSignal<{ age: number }>()
+    return {
+      dispose,
+      setValue,
+      visible: createDelayedPresence(value, (current) => Math.max(0, 1_000 - current.age)),
+    }
+  })
+
+  try {
+    scope.setValue({ age: 400 })
+    await Promise.resolve()
+    jest.advanceTimersByTime(599)
+    expect(scope.visible()).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(scope.visible()).toBe(true)
+
+    scope.setValue({ age: 1_000 })
+    await Promise.resolve()
+    expect(scope.visible()).toBe(true)
+  } finally {
+    scope.dispose()
+    jest.useRealTimers()
+  }
+})


### PR DESCRIPTION
## What

Keep the `ctrl+b` background-tool hint tied to how long the tool has been running, rather than how long the current tab view has been mounted.

## Before / After

**Before:** A shell or subagent showed the hint after one second, but switching away from its tab unmounted the hint state. Returning to the tab restarted the full delay and temporarily hid the hint even when the tool had already been running for much longer.

**After:** The hint waits only for the remainder of the tool's first second. Returning to a tab after that threshold shows it immediately.

## How

- `packages/tui/src/routes/session/index.tsx` derives the running tool's start time from `time.ran`, falling back to `time.created`, and computes the remaining delay from its age.
- `packages/tui/src/util/delayed-presence.ts` accepts either a fixed delay or a per-value delay while preserving cancellation when the source changes or disappears.
- Equivalent running-tool updates retain the original timer; a different tool starts a delay based on its own age.

## Scope

This only changes hint timing. The shortcut, eligible tool types, text, and background action are unchanged.

## Testing

- `cd packages/tui && bun run test` (699 passed, 5 skipped)
- `cd packages/tui && bun typecheck`
- Pre-push `bun turbo typecheck --concurrency=3` (34 packages passed)
- `bunx prettier --check src/routes/session/index.tsx src/util/delayed-presence.ts test/util/delayed-presence.test.ts`

## Demo

No visual artifact: the rendered hint is unchanged; this fixes its remount timing and is covered by deterministic delayed-presence regression tests.