### PR TITLE
fix(tui): debounce shared storage reloads

### DIFF
--- a/packages/tui/src/context/storage.tsx
+++ b/packages/tui/src/context/storage.tsx
@@ -110,10 +110,19 @@ function createStorage(root: string, channel: string) {
     },
   }
 
-  const watcher = watch(directory, () => entries.forEach((entry) => entry.reload()))
+  let reload: ReturnType<typeof setTimeout> | undefined
+  const watcher = watch(directory, () => {
+    clearTimeout(reload)
+    // Atomic writes notify for the temporary file before its final rename, and some
+    // platforms coalesce the rename event. Reload after the event burst has settled.
+    reload = setTimeout(() => entries.forEach((entry) => entry.reload()), 50)
+  })
   return {
     storage,
-    close: () => watcher.close(),
+    close: () => {
+      clearTimeout(reload)
+      watcher.close()
+    },
   }
 }
 

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -223,7 +223,7 @@ test("only the foreground TUI mutates unread state", async () => {
     background = await renderSessionTabs("second", { state: temporary.path })
     foreground.focus()
     background.blur()
-    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2)
+    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2, 10_000)
 
     const firstDone = executionSucceeded("first")
     foreground.emit(firstDone)
@@ -239,6 +239,7 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === "activity" &&
         background?.tabs.status("second").unread === "activity",
+      10_000,
     )
 
     foreground.tabs.select("second")
@@ -246,6 +247,7 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === undefined &&
         background?.tabs.status("second").unread === undefined,
+      10_000,
     )
   } finally {
     if (foreground) await foreground.destroy()

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -219,11 +219,11 @@ test("only the foreground TUI mutates unread state", async () => {
   let background: Awaited<ReturnType<typeof renderSessionTabs>> | undefined
 
   try {
-    foreground = await renderSessionTabs("first", { state: temporary.path })
+    foreground = await renderSessionTabs("first", { state: temporary.path, persisted: ["first", "second"] })
     background = await renderSessionTabs("second", { state: temporary.path })
     foreground.focus()
     background.blur()
-    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2, 10_000)
+    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2)
 
     const firstDone = executionSucceeded("first")
     foreground.emit(firstDone)
@@ -239,7 +239,6 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === "activity" &&
         background?.tabs.status("second").unread === "activity",
-      10_000,
     )
 
     foreground.tabs.select("second")
@@ -247,7 +246,6 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === undefined &&
         background?.tabs.status("second").unread === undefined,
-      10_000,
     )
   } finally {
     if (foreground) await foreground.destroy()

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -18,10 +18,10 @@ import { TestTuiContexts } from "../fixture/tui-environment"
 import { tmpdir } from "../fixture/fixture"
 import { createTuiResolvedConfig } from "../fixture/tui-runtime"
 
-async function wait(fn: () => boolean | Promise<boolean>, timeout = 2_000) {
+async function wait(fn: () => boolean | Promise<boolean>, timeout = 2_000, label = "condition") {
   const start = Date.now()
   while (!(await fn())) {
-    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    if (Date.now() - start > timeout) throw new Error(`timed out waiting for ${label}`)
     await Bun.sleep(10)
   }
 }
@@ -223,7 +223,7 @@ test("only the foreground TUI mutates unread state", async () => {
     background = await renderSessionTabs("second", { state: temporary.path })
     foreground.focus()
     background.blur()
-    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2)
+    await wait(() => foreground?.tabs.tabs().length === 2 && background?.tabs.tabs().length === 2, 2_000, "shared tabs")
 
     const firstDone = executionSucceeded("first")
     foreground.emit(firstDone)
@@ -240,6 +240,7 @@ test("only the foreground TUI mutates unread state", async () => {
         foreground?.tabs.status("second").unread === "activity" &&
         background?.tabs.status("second").unread === "activity",
       10_000,
+      "shared unread activity",
     )
 
     foreground.tabs.select("second")
@@ -248,6 +249,7 @@ test("only the foreground TUI mutates unread state", async () => {
         foreground?.tabs.status("second").unread === undefined &&
         background?.tabs.status("second").unread === undefined,
       10_000,
+      "shared unread clearing",
     )
   } finally {
     if (foreground) await foreground.destroy()

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -239,6 +239,7 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === "activity" &&
         background?.tabs.status("second").unread === "activity",
+      10_000,
     )
 
     foreground.tabs.select("second")
@@ -246,6 +247,7 @@ test("only the foreground TUI mutates unread state", async () => {
       () =>
         foreground?.tabs.status("second").unread === undefined &&
         background?.tabs.status("second").unread === undefined,
+      10_000,
     )
   } finally {
     if (foreground) await foreground.destroy()


### PR DESCRIPTION
## What

Make filesystem-backed TUI state converge reliably across concurrent TUI processes, and keep the foreground-only unread-state regression test focused on that behavior.

## Before / After

**Before:** an atomic write could notify the directory watcher while its temporary file was being created. The watcher immediately reloaded the old target file, and Linux could coalesce the final rename notification. A second TUI then kept stale tab or unread state indefinitely; increasing the test deadline did not help.

**After:** storage reloads are debounced until the short atomic-write event burst settles, so readers observe the committed JSON target. The unread test starts from persisted shared tabs, separating startup tab creation from unread propagation, and reports the exact failed phase.

## How

- `packages/tui/src/context/storage.tsx` debounces directory watcher reloads by 50ms and clears the pending reload during cleanup.
- `packages/tui/test/context/session-tabs.test.tsx` seeds both tabs before rendering concurrent TUIs, keeps longer deadlines only around cross-process propagation, and labels timeout phases.

## Scope

This does not address unrelated `dialog-open` render or CLI service-registration timeouts observed in separate CI attempts.

## Testing

- 200/200 targeted runs under 30-way process contention
- `bun run test` in `packages/tui` (697 passed, 5 skipped)
- `bun typecheck` in `packages/tui`
- repository pre-push typecheck (34 tasks passed)

## Flow

```mermaid
sequenceDiagram
  participant A as Foreground TUI
  participant FS as Atomic JSON storage
  participant B as Background TUI
  A->>FS: Write temporary file and rename target
  FS-->>B: Directory event burst
  B->>B: Debounce reload for 50ms
  B->>FS: Read committed target
  FS-->>B: Current shared state
```