### PR TITLE
fix(llm): support keyless compatible providers

### DIFF
--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -20,7 +20,7 @@ import type { LLMClientShape } from "@opencode-ai/llm/route"
 import { LLMNative } from "./native-request"
 
 export type RuntimeStatus =
-  | { readonly type: "supported"; readonly apiKey: string; readonly baseURL?: string }
+  | { readonly type: "supported"; readonly apiKey?: string; readonly baseURL?: string }
   | { readonly type: "unsupported"; readonly reason: string }
 export type StreamResult =
   | { readonly type: "supported"; readonly stream: Stream.Stream<LLMEvent, unknown> }
@@ -52,7 +52,9 @@ function statusWithFetch(
   fetch: typeof globalThis.fetch | undefined,
 ): RuntimeStatus {
   const providerID = input.model.providerID
-  if (providerID !== "openai" && providerID !== "anthropic" && !providerID.startsWith("opencode"))
+  const baseURL = typeof input.provider.options.baseURL === "string" ? input.provider.options.baseURL : undefined
+  const compatible = input.model.api.npm === "@ai-sdk/openai-compatible"
+  if (providerID !== "openai" && providerID !== "anthropic" && !providerID.startsWith("opencode") && !compatible)
     return { type: "unsupported", reason: "provider is not openai, opencode, or anthropic" }
   const npm = input.model.api.npm
   if (npm !== "@ai-sdk/openai" && npm !== "@ai-sdk/openai-compatible" && npm !== "@ai-sdk/anthropic")
@@ -62,12 +64,12 @@ function statusWithFetch(
   }
 
   const apiKey = typeof input.provider.options.apiKey === "string" ? input.provider.options.apiKey : input.provider.key
-  if (!apiKey) return { type: "unsupported", reason: "API key is not configured" }
+  if (!apiKey && !compatible) return { type: "unsupported", reason: "API key is not configured" }
 
   return {
     type: "supported",
     apiKey,
-    baseURL: typeof input.provider.options.baseURL === "string" ? input.provider.options.baseURL : undefined,
+    baseURL,
   }
 }
 

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -455,6 +455,20 @@ describe("session.llm-native.request", () => {
     ).toEqual({ type: "unsupported", reason: "API key is not configured" })
   })
 
+  test("enables native runtime without an API key for custom OpenAI-compatible providers", () => {
+    const model = {
+      ...baseModel,
+      providerID: ProviderV2.ID.make("local"),
+      api: { ...baseModel.api, npm: "@ai-sdk/openai-compatible", url: "http://192.168.1.34:8000/v1" },
+    }
+    const provider = { ...providerInfo, id: ProviderV2.ID.make("local"), options: {} }
+
+    expect(LLMNativeRuntime.status({ model, provider, auth: undefined })).toEqual({
+      type: "supported",
+      baseURL: "http://192.168.1.34:8000/v1",
+    })
+  })
+
   test("enables native runtime for Anthropic API-key models", () => {
     expect(
       LLMNativeRuntime.status({


### PR DESCRIPTION
## Summary

Support custom `@ai-sdk/openai-compatible` providers in OpenCode’s native LLM runtime without requiring an API key.

## Rationale

Self-hosted inference services such as SGLang, vLLM, Ollama, and LM Studio are commonly configured as custom providers and may intentionally accept unauthenticated requests over a private network.

The native runtime currently rejects custom providers by ID and separately requires a non-empty API key. This prevents a valid self-hosted OpenAI-compatible endpoint from using the native runtime.

## Behavior

- Accept custom `@ai-sdk/openai-compatible` provider IDs in the native runtime.
- Allow an absent `apiKey`.
- Send an authorization header only when a key is configured.
- Preserve existing behavior for authenticated providers.