### PR TITLE
feat(catalog): copy capture image from context menu

### DIFF
--- a/packages/lab/catalog/src/components/CaptureContextMenu.tsx
+++ b/packages/lab/catalog/src/components/CaptureContextMenu.tsx
@@ -36,6 +36,16 @@ export function CaptureContextMenu({ identifier, deepLink, issueLink, children }
     setPosition(undefined)
   }
 
+  const copyImage = () => {
+    const canvas = targetRef.current?.querySelector("canvas")
+    if (!canvas) return
+    const image = new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Failed to encode capture image"))), "image/png")
+    })
+    void navigator.clipboard.write([new ClipboardItem({ "image/png": image })])
+    setPosition(undefined)
+  }
+
   return (
     <span
       ref={targetRef}
@@ -58,13 +68,16 @@ export function CaptureContextMenu({ identifier, deepLink, issueLink, children }
               tabIndex={-1}
               style={{
                 left: Math.max(8, Math.min(position.x, window.innerWidth - 176)),
-                top: Math.max(8, Math.min(position.y, window.innerHeight - 84)),
+                top: Math.max(8, Math.min(position.y, window.innerHeight - 160)),
               }}
               onKeyDown={(event) => {
                 if (event.key === "Escape") setPosition(undefined)
               }}
               onPointerDown={(event) => event.stopPropagation()}
             >
+              <button type="button" role="menuitem" onClick={copyImage}>
+                Copy image
+              </button>
               <button type="button" role="menuitem" onClick={() => copy(identifier)}>
                 Copy ID
               </button>


### PR DESCRIPTION
## What

Adds a **Copy image** action to catalog capture context menus so reviewers can copy the rendered terminal canvas directly as a PNG. This ports the behavior from anomalyco/opencode-drive#59 into the V2 catalog package.

## How

- `packages/lab/catalog/src/components/CaptureContextMenu.tsx` encodes the rendered terminal canvas with `canvas.toBlob(..., "image/png")`.
- The action writes a PNG `ClipboardItem` through `navigator.clipboard.write`.
- The expanded four-row menu uses the existing viewport clamp with enough vertical space for the new action.
- Existing Copy ID, Copy deep link, and Report issue actions are unchanged.

## Scope

- Catalog viewer UI only.
- No capture, schema, protocol, generated catalog, or generated frame changes.
- No new test framework; this package has no component/browser test seam.

## Testing

- `bun run typecheck` from `packages/lab/catalog`
- `bun run test` from `packages/lab/catalog` (37 passed)
- `bun run build` from `packages/lab/catalog`
- `bun run lint -- packages/lab/catalog/src packages/lab/catalog/catalog packages/lab/catalog/scripts packages/lab/catalog/scenarios packages/lab/catalog/server.ts packages/lab/catalog/worker.ts` (0 errors; existing warnings only)
- Push hook: repository-wide Turbo typecheck (34 tasks passed)
- Browser Control, desktop 1440x900: native PNG clipboard write succeeded; copied PNG and source canvas were both 1180x680; bottom-right menu stayed in bounds; no horizontal overflow or console errors.
- Browser Control, mobile 390x844: native PNG clipboard write succeeded; copied PNG and source canvas were both 1180x680; right-edge menu stayed in bounds; no horizontal overflow or console errors.
- Browser Control also verified native Copy ID and Copy deep link writes, menu dismissal, and the Report issue target.