### PR TITLE
fix(tui): optimize Mermaid terminal rendering

### DIFF
--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -44,6 +44,7 @@ interface PreparedDiagram {
 }
 
 export interface MermaidMarkdownRendererOptions {
+  /** Use terminal-optimized diagram spacing. Defaults to true. */
   compact?: boolean
   /** Fold horizontal flowcharts that exceed this width. Defaults to 120 columns. */
   layoutMaxWidth?: number
@@ -118,10 +119,11 @@ function prepareDiagram(
   layoutMaxWidth: number,
 ): PreparedDiagram {
   const colors = options.colors ?? {}
+  const compact = options.compact ?? true
   switch (kind) {
     case "flowchart": {
       const grid = drawFlowchartDiagramGrid(parseMermaidFlowchartDiagram(source), {
-        compact: options.compact,
+        compact,
         layoutMaxWidth,
       })
       const size = grid.getTextSize({ trimTop: true, trimBottom: true })
@@ -161,7 +163,7 @@ function prepareDiagram(
       }
     }
     case "sequence": {
-      const grid = drawSequenceDiagramGrid(parseMermaidSequenceDiagram(source), { compact: options.compact })
+      const grid = drawSequenceDiagramGrid(parseMermaidSequenceDiagram(source), { compact })
       const size = grid.getTextSize()
       return {
         kind,

--- a/packages/merman/src/state/routing.test.ts
+++ b/packages/merman/src/state/routing.test.ts
@@ -243,6 +243,28 @@ describe("createStateTransitionRenderPlans", () => {
       ).toBe(false)
     }
   })
+
+  test("keeps routes to offset end markers continuous", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  [*] --> Pending
+  Pending --> Running
+  Running --> Idle
+  Running --> Interrupted
+  Interrupted --> [*]`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 12 })
+    const plan = createStateTransitionRenderPlans(diagram, layout.bounds, 30).find(
+      (plan) => plan.route.transition.to === "__end",
+    )!
+
+    expect(
+      plan.path.slice(1).every(([x, y], index) => {
+        const previous = plan.path[index]!
+        return Math.abs(x - previous[0]) + Math.abs(y - previous[1]) === 1
+      }),
+    ).toBe(true)
+  })
 })
 
 describe("createStateTransitionJunctionPlans", () => {

--- a/packages/merman/src/state/routing.ts
+++ b/packages/merman/src/state/routing.ts
@@ -216,6 +216,11 @@ function verticalCorridorCrossesUnrelatedState(
   })
 }
 
+function hasVerticalCorridor(from: BoxBounds, to: BoxBounds): boolean {
+  if (from.centerY < to.centerY) return from.top + from.height <= to.top - 1
+  return from.top - 1 >= to.top + to.height
+}
+
 function horizontalCorridorCrossesUnrelatedState(
   diagram: StateVisibleDiagram,
   transition: StateVisibleTransition,
@@ -388,6 +393,9 @@ export function createStateTransitionRoutePlans(
         }
         return [{ ...base, kind: "horizontal-forward", leftToRight: from.centerX <= to.centerX }]
       }
+      if (!hasVerticalCorridor(from, to)) {
+        return [{ ...base, kind: "side-parallel", railX: allocateSideRail(transition.label) }]
+      }
       if (from.centerX !== to.centerX) {
         return [{ ...base, kind: "vertical-elbow", hasReverse: false, offsetConnector: false }]
       }
@@ -395,6 +403,9 @@ export function createStateTransitionRoutePlans(
     }
 
     if (from.centerY !== to.centerY) {
+      if (!hasVerticalCorridor(from, to)) {
+        return [{ ...base, kind: "side-parallel", railX: allocateSideRail(transition.label) }]
+      }
       if (from.centerY > to.centerY && feedback)
         return [
           {

--- a/packages/merman/src/test/markdown.test.ts
+++ b/packages/merman/src/test/markdown.test.ts
@@ -78,6 +78,29 @@ flowchart LR
   expect(markdown.getChildren()[0]?.marginTop).toBe(1)
 })
 
+test("uses compact terminal spacing for Mermaid diagrams by default", async () => {
+  const testRenderer = await createTestRenderer({ width: 80, height: 40 })
+  renderer = testRenderer.renderer
+  const markdown = new MarkdownRenderable(renderer, {
+    id: "markdown-compact-mermaid",
+    content: `\`\`\`mermaid
+flowchart TD
+  repo[Organization profile repo] --> build[Build]
+  build --> worker[Isolated organization Worker]
+  worker --> sessions[SessionDOs]
+  sessions --> opencode[OpenCode + native plugins]
+  opencode --> modal[Modal workspaces]
+\`\`\``,
+    syntaxStyle,
+    renderNode: createMermaidMarkdownRenderer(renderer),
+  })
+
+  renderer.root.add(markdown)
+  await renderMarkdown(markdown, testRenderer.renderOnce)
+
+  expect(markdown.getChildren()[0]?.height).toBe(28)
+})
+
 test("recognizes normalized Mermaid fence info strings", async () => {
   const testRenderer = await createTestRenderer({ width: 80, height: 14 })
   renderer = testRenderer.renderer


### PR DESCRIPTION
## What

Optimize Mermaid diagrams for terminal Markdown. A six-node vertical flowchart now occupies 28 rows instead of 38 while retaining its node borders, connector stems, and arrowheads. State transitions to offset end markers also remain connected.

## Before / After

**Before:** The Markdown renderer forwarded an undefined `compact` option to Merman. Vertical flowcharts therefore used the lower-level library's spacious layout, adding three connector rows between every pair of nodes and making simple diagrams dominate the terminal viewport.

**After:** The Markdown renderer resolves `compact` to `true` by default for flowchart and sequence layouts. Callers can still request the spacious layout explicitly with `compact: false`.

**Before:** A state transition targeting an end marker on an overlapping vertical row could be classified as a vertical elbow even though no vertical corridor existed. Its route then jumped across the marker, rendering a detached line above it and arrow below it.

**After:** Vertically overlapping endpoints use the existing side route, preserving a continuous path into the end marker.

## How

- `packages/merman/src/markdown.ts` establishes compact spacing at the terminal Markdown boundary.
- `packages/merman/src/test/markdown.test.ts` reproduces the reported six-node flowchart and locks its rendered height to 28 rows.
- `packages/merman/src/state/routing.ts` avoids vertical elbows when endpoint bounds leave no vertical corridor.
- `packages/merman/src/state/routing.test.ts` verifies route continuity for the state graph used in the demo.

## Scope

The lower-level Merman rendering API keeps its existing spacing default. Timeline and GitGraph layout algorithms are unchanged.

## Testing

- `bun run test` in `packages/merman` (326 tests)
- `bun typecheck` in `packages/merman`
- Full workspace typecheck from the pre-push hook (34 tasks)
- `opencode-drive check mermaid-diagrams-drive.ts`
- Isolated OpenCode Drive run against this worktree, covering flowchart, sequence, state, timeline, and GitGraph Markdown fences

## Demo

Real TUI rendering from this worktree with a simulated model response. The walkthrough shows five Mermaid diagram types; the opening flowchart is the reported oversized case using the new compact default.

https://github.com/user-attachments/assets/4f212ecd-7203-48ad-a9ba-57e513dee0fe
