### PR TITLE
feat(tui): animate interrupt confirmation

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -5,7 +5,6 @@ import {
   MouseEvent,
   PasteEvent,
   decodePasteBytes,
-  type ColorInput,
   type KeyEvent,
 } from "@opentui/core"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match, For } from "solid-js"
@@ -13,6 +12,7 @@ import path from "path"
 import { useLocal } from "../../context/local"
 import { useTheme, useThemes } from "../../context/theme"
 import { tint } from "../../theme/color"
+import { createAnimatable, tween } from "../../ui/animation"
 import { EmptyBorder, SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { useClipboard } from "../../context/clipboard"
@@ -110,14 +110,37 @@ function fadeColor(color: RGBA, alpha: number) {
 
 export function PromptInterruptStatus(props: {
   armed: boolean
-  text: ColorInput
-  subdued: ColorInput
-  warning: ColorInput
+  animations?: boolean
+  text: RGBA
+  subdued: RGBA
+  warning: RGBA
+  flash?: RGBA
 }) {
+  const ignition = createAnimatable(
+    { level: 0 },
+    { enabled: () => props.animations ?? false, transition: tween({ duration: 0.22 }) },
+  )
+  createEffect(
+    on(
+      () => props.armed,
+      (armed) => {
+        if (!armed || !props.animations) return ignition.jump({ level: 0 })
+        ignition.jump({ level: 0.75 })
+        ignition.animate({ level: 0 })
+      },
+      { defer: true },
+    ),
+  )
+  const armedColor = createMemo(() => {
+    const level = ignition.value().level
+    if (level === 0 || !props.flash) return props.warning
+    return tint(props.warning, props.flash, level)
+  })
+
   return (
-    <text fg={props.armed ? props.warning : props.text} wrapMode="none" truncate flexShrink={1}>
+    <text fg={props.armed ? armedColor() : props.text} wrapMode="none" truncate flexShrink={1}>
       esc{" "}
-      <span style={{ fg: props.armed ? props.warning : props.subdued }}>
+      <span style={{ fg: props.armed ? armedColor() : props.subdued }}>
         {props.armed ? "again to interrupt" : "interrupt"}
       </span>
     </text>
@@ -1823,9 +1846,11 @@ export function Prompt(props: PromptProps) {
                       </box>
                       <PromptInterruptStatus
                         armed={store.interrupt > 0}
+                        animations={animationsEnabled()}
                         text={theme.text.default}
                         subdued={theme.text.subdued}
                         warning={theme.text.feedback.warning.default}
+                        flash={theme.decrease(theme.text.feedback.warning.default, 2)}
                       />
                     </box>
                   </Match>


### PR DESCRIPTION
## What

Flash the interrupt hint when the first Escape press arms confirmation. The copy changes immediately to `esc again to interrupt`, then settles to the theme's warning color after 220 ms.

## How

- Uses the existing TUI animation clock for an interruptible one-shot tint.
- Derives the flash from `text.feedback.warning.default` with `theme.decrease(..., 2)`, with no hard-coded hue.
- Skips directly to the settled warning color when animations are disabled.

## Scope

Interrupt behavior, keybindings, and theme tokens are unchanged.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/cli/tui/prompt-interrupt-status.test.tsx` in `packages/tui`
- `bunx prettier --check packages/tui/src/component/prompt/index.tsx packages/tui/test/cli/tui/prompt-interrupt-status.test.tsx`
- Push hook: full workspace `bun turbo typecheck --concurrency=3`
- Real PTY verification of replay, disabled animations, theme changes, and clean exit

## Demo

Production component rendered through a temporary local fixture.

https://github.com/user-attachments/assets/f30bc6ce-8242-4d27-9cf0-2910cbd27723
