### PR TITLE
fix(llm): send assistant text as input_text in OpenAI Responses requests (#42613)

### DIFF
--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -43,11 +43,6 @@ const OpenAIResponsesInputImage = Schema.Struct({
 const OpenAIResponsesInputContent = Schema.Union([OpenAIResponsesInputText, OpenAIResponsesInputImage])
 type OpenAIResponsesInputContent = Schema.Schema.Type<typeof OpenAIResponsesInputContent>
 
-const OpenAIResponsesOutputText = Schema.Struct({
-  type: Schema.tag("output_text"),
-  text: Schema.String,
-})
-
 const OpenAIResponsesReasoningSummaryText = Schema.Struct({
   type: Schema.tag("summary_text"),
   text: Schema.String,
@@ -78,7 +73,7 @@ const OpenAIResponsesFunctionCallOutput = Schema.Union([
 const OpenAIResponsesInputItem = Schema.Union([
   Schema.Struct({ role: Schema.tag("system"), content: Schema.String }),
   Schema.Struct({ role: Schema.tag("user"), content: Schema.Array(OpenAIResponsesInputContent) }),
-  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesOutputText) }),
+  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesInputText) }),
   OpenAIResponsesReasoningItem,
   OpenAIResponsesItemReference,
   Schema.Struct({
@@ -374,7 +369,7 @@ const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (requ
       const hostedToolReferences = new Set<string>()
       const flushText = () => {
         if (content.length === 0) return
-        input.push({ role: "assistant", content: content.map((part) => ({ type: "output_text", text: part.text })) })
+        input.push({ role: "assistant", content: content.map((part) => ({ type: "input_text", text: part.text })) })
         content.splice(0, content.length)
       }
       for (const part of message.content) {

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -153,7 +153,7 @@ describe("OpenAI Responses route", () => {
             { type: "input_text", text: "<system-update>\nTreat &lt;/system-update&gt; literally.\n</system-update>" },
           ],
         },
-        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "After." }] },
       ])
     }),
   )
@@ -529,11 +529,11 @@ describe("OpenAI Responses route", () => {
             encrypted_content: "encrypted-continuation-state",
             summary: [{ type: "summary_text", text: "I inspected the previous turn." }],
           },
-          { role: "assistant", content: [{ type: "output_text", text: "It shows a small test image." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "It shows a small test image." }] },
           { role: "user", content: [{ type: "input_text", text: "Check the weather in Paris before continuing." }] },
           { type: "function_call", call_id: "call_weather_1", name: "get_weather", arguments: '{"city":"Paris"}' },
           { type: "function_call_output", call_id: "call_weather_1", output: '{"temperature":22}' },
-          { role: "assistant", content: [{ type: "output_text", text: "Paris is 22 degrees." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "Paris is 22 degrees." }] },
           {
             role: "user",
             content: [{ type: "input_text", text: "Continue from this conversation in one short sentence." }],
@@ -947,7 +947,7 @@ describe("OpenAI Responses route", () => {
                     encrypted_content: "encrypted-state",
                     summary: [{ type: "summary_text", text: "Checked the previous diff." }],
                   },
-                  { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
+                  { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
                   { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
                 ],
               })
@@ -995,13 +995,13 @@ describe("OpenAI Responses route", () => {
       )
 
       expect(prepared.body.input).toEqual([
-        { role: "assistant", content: [{ type: "output_text", text: "Before." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "Before." }] },
         {
           type: "reasoning",
           encrypted_content: "encrypted-state",
           summary: [{ type: "summary_text", text: "Checked order." }],
         },
-        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "After." }] },
       ])
     }),
   )
@@ -1131,7 +1131,7 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body).toMatchObject({
         input: [
           { role: "user", content: [{ type: "input_text", text: "What changed?" }] },
-          { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
           { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
         ],
         store: false,


### PR DESCRIPTION
### Issue for this PR

Closes #42613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When conversation history contains an assistant text message, the OpenAI
Responses (`/responses`) request body used:

```json
{"role": "assistant", "content": [{"type": "output_text", "text": "..."}]}
```

`output_text` is not a valid easy-input content part: per the official OpenAI
schema (`openai-python` types), assistant easy-input messages accept only
`str | input_text | input_image | input_file`. Real `api.openai.com` tolerates
the non-conformant shape, but strict OpenAI-compatible servers validating with
the official SDK types (e.g. a self-hosted Qwen server exposing `/v1/responses`)
reject it with a 422/400 pydantic `ValidationError`, so switching a session to
such a model fails.

The fix lowers assistant text content as `input_text` in request bodies:

- `packages/llm/src/protocols/openai-responses.ts`:
  - Remove the now-unused `OpenAIResponsesOutputText` schema.
  - Lower assistant text content as `input_text` in request bodies
    (`lowerMessages`).
  - `OpenAIResponsesInputItem` assistant schema now uses `input_text` parts.
- `packages/llm/test/provider/openai-responses.test.ts`: update expected request
  bodies (`output_text` → `input_text` for assistant input messages).

The AI SDK path (`@ai-sdk/openai` `convertToOpenAIResponsesMessages`) emits the
same invalid shape and would need a separate fix upstream (`vercel/ai`) to fix
released builds.

### How did you verify your code works?

```sh
cd packages/llm
bun test test/provider/openai-responses.test.ts
```

54 pass, 0 fail.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR