### PR TITLE
fix(tui): refine tab marquee motion

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -34,7 +34,7 @@ import { TabPulse, unreadGlowIntensity } from "./tab-pulse"
 import { tint } from "../theme/color"
 import { SESSION_SIDEBAR_WIDTH } from "../ui/layout"
 import { projectName } from "../util/project"
-import { marqueeCycleWidth, marqueeOverflows, marqueeText } from "../util/marquee"
+import { marqueeCycleWidth, marqueeOverflows, marqueeText, marqueeTextParts } from "../util/marquee"
 import { useDialog } from "../ui/dialog"
 import { DialogSessionRename } from "./dialog-session-rename"
 
@@ -43,7 +43,7 @@ const FADE_WIDTH = 4
 // The add button renders as " + " at the end of the strip, so the tab layout leaves it room.
 const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
-const MARQUEE_INTERVAL = 100
+const MARQUEE_INTERVAL = 80
 const CONTEXT_MENU_WIDTH = 16
 const RIGHT_MOUSE_BUTTON = 2
 
@@ -398,7 +398,11 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   ? marqueeText(title(), titleWidth(), marquee.offset())
                   : Locale.takeWidth(title(), titleWidth()),
               )
-              const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
+              const visibleTitleParts = createMemo(() =>
+                scrolling()
+                  ? marqueeTextParts(title(), titleWidth(), marquee.offset())
+                  : Locale.graphemes(visibleTitle()).map((value) => ({ value, separator: false })),
+              )
               const titleFades = createMemo(() => marqueeOverflows(title(), titleWidth()) && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
                 const fixture = tabs.detail?.(tab.sessionID)
@@ -496,13 +500,13 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               }
               const separatorUpperColor = createMemo(() => tint(theme.background.default, previousGlowHue(), 0.1))
               const separatorLowerColor = createMemo(() => tint(theme.background.default, glowHue(), 0.12))
-              const titleColor = (index: number) => {
+              const titleColor = (index: number, separator: boolean) => {
                 const level = titleGlow.value().level
                 const color =
                   level === 0
                     ? foreground()
                     : glowTextColor(foreground(), glowColor(), 1 + numberWidth() + index, width(), level)
-                return titleFades()
+                const faded = titleFades()
                   ? fadeTitleColor(
                       color,
                       pulseBackground(),
@@ -511,6 +515,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       scrolling() ? marquee.leading() : 0,
                     )
                   : color
+                return separator ? tint(faded, pulseBackground(), 0.55) : faded
               }
               const release = () => {
                 setDragging(undefined)
@@ -647,9 +652,14 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                         selectable={false}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
                       >
-                        <Show when={titleGlow.value().level > 0 || titleFades()} fallback={visibleTitle()}>
+                        <Show
+                          when={scrolling() || titleGlow.value().level > 0 || titleFades()}
+                          fallback={visibleTitle()}
+                        >
                           <For each={visibleTitleParts()}>
-                            {(character, index) => <span style={{ fg: titleColor(index()) }}>{character}</span>}
+                            {(part, index) => (
+                              <span style={{ fg: titleColor(index(), part.separator) }}>{part.value}</span>
+                            )}
                           </For>
                         </Show>
                       </text>
@@ -988,7 +998,11 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
               ? marqueeText(title(), availableTitleWidth(), marquee.offset())
               : Locale.takeWidth(title(), availableTitleWidth()),
           )
-          const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
+          const visibleTitleParts = createMemo(() =>
+            scrolling()
+              ? marqueeTextParts(title(), availableTitleWidth(), marquee.offset())
+              : Locale.graphemes(visibleTitle()).map((value) => ({ value, separator: false })),
+          )
           const titleFades = createMemo(
             () => marqueeOverflows(title(), availableTitleWidth()) && availableTitleWidth() > FADE_WIDTH,
           )
@@ -1000,10 +1014,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           }
           // Title characters sitting over the glow tinge toward its color, following the same
           // spatial falloff as the glow itself; characters beyond the tail stay neutral.
-          const characterColor = (index: number) => {
+          const characterColor = (index: number, separator: boolean) => {
             const base = foreground()
             const color = glows() ? glowTextColor(base, glowColor(), 1 + numberWidth() + index, width()) : base
-            return titleFades()
+            const faded = titleFades()
               ? fadeTitleColor(
                   color,
                   background(),
@@ -1012,6 +1026,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   scrolling() ? marquee.leading() : 0,
                 )
               : color
+            return separator ? tint(faded, background(), 0.55) : faded
           }
           // The running sweep's level under the number cell, reported by the pulse renderable.
           const [sweepLevel, setSweepLevel] = createSignal(0)
@@ -1100,9 +1115,11 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   selectable={false}
                   attributes={bold()}
                 >
-                  <Show when={glows() || titleFades()} fallback={visibleTitle()}>
+                  <Show when={scrolling() || glows() || titleFades()} fallback={visibleTitle()}>
                     <For each={visibleTitleParts()}>
-                      {(character, index) => <span style={{ fg: characterColor(index()) }}>{character}</span>}
+                      {(part, index) => (
+                        <span style={{ fg: characterColor(index(), part.separator) }}>{part.value}</span>
+                      )}
                     </For>
                   </Show>
                 </text>

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1,6 +1,7 @@
 import { RGBA, ScrollBoxRenderable, TextAttributes, type MouseEvent } from "@opentui/core"
 import {
   For,
+  Index,
   Match,
   Show,
   Switch,
@@ -34,7 +35,7 @@ import { TabPulse, unreadGlowIntensity } from "./tab-pulse"
 import { tint } from "../theme/color"
 import { SESSION_SIDEBAR_WIDTH } from "../ui/layout"
 import { projectName } from "../util/project"
-import { marqueeCycleWidth, marqueeOverflows, marqueeText, marqueeTextParts } from "../util/marquee"
+import { marqueeCycleWidth, marqueeOverflows, marqueeTextParts } from "../util/marquee"
 import { useDialog } from "../ui/dialog"
 import { DialogSessionRename } from "./dialog-session-rename"
 
@@ -43,7 +44,7 @@ const FADE_WIDTH = 4
 // The add button renders as " + " at the end of the strip, so the tab layout leaves it room.
 const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
-const MARQUEE_INTERVAL = 80
+const MARQUEE_INTERVAL = 70
 const CONTEXT_MENU_WIDTH = 16
 const RIGHT_MOUSE_BUTTON = 2
 
@@ -393,15 +394,18 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const titleWidth = () => (hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth())
               const title = () => tab.title ?? "Untitled session"
               const scrolling = () => marquee.active() === tab.sessionID
-              const visibleTitle = createMemo(() =>
-                scrolling()
-                  ? marqueeText(title(), titleWidth(), marquee.offset())
-                  : Locale.takeWidth(title(), titleWidth()),
-              )
               const visibleTitleParts = createMemo(() =>
                 scrolling()
                   ? marqueeTextParts(title(), titleWidth(), marquee.offset())
-                  : Locale.graphemes(visibleTitle()).map((value) => ({ value, separator: false })),
+                  : Locale.graphemes(Locale.takeWidth(title(), titleWidth())).map((value) => ({
+                      value,
+                      separator: false,
+                    })),
+              )
+              const visibleTitle = createMemo(() =>
+                visibleTitleParts()
+                  .map((part) => part.value)
+                  .join(""),
               )
               const titleFades = createMemo(() => marqueeOverflows(title(), titleWidth()) && titleWidth() > FADE_WIDTH)
               const detail = createMemo(() => {
@@ -656,11 +660,11 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                           when={scrolling() || titleGlow.value().level > 0 || titleFades()}
                           fallback={visibleTitle()}
                         >
-                          <For each={visibleTitleParts()}>
+                          <Index each={visibleTitleParts()}>
                             {(part, index) => (
-                              <span style={{ fg: titleColor(index(), part.separator) }}>{part.value}</span>
+                              <span style={{ fg: titleColor(index, part().separator) }}>{part().value}</span>
                             )}
-                          </For>
+                          </Index>
                         </Show>
                       </text>
                       <text
@@ -993,15 +997,18 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 2)
           const availableTitleWidth = () => (hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth())
           const scrolling = () => marquee.active() === tab.sessionID
-          const visibleTitle = createMemo(() =>
-            scrolling()
-              ? marqueeText(title(), availableTitleWidth(), marquee.offset())
-              : Locale.takeWidth(title(), availableTitleWidth()),
-          )
           const visibleTitleParts = createMemo(() =>
             scrolling()
               ? marqueeTextParts(title(), availableTitleWidth(), marquee.offset())
-              : Locale.graphemes(visibleTitle()).map((value) => ({ value, separator: false })),
+              : Locale.graphemes(Locale.takeWidth(title(), availableTitleWidth())).map((value) => ({
+                  value,
+                  separator: false,
+                })),
+          )
+          const visibleTitle = createMemo(() =>
+            visibleTitleParts()
+              .map((part) => part.value)
+              .join(""),
           )
           const titleFades = createMemo(
             () => marqueeOverflows(title(), availableTitleWidth()) && availableTitleWidth() > FADE_WIDTH,
@@ -1116,11 +1123,11 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                   attributes={bold()}
                 >
                   <Show when={scrolling() || glows() || titleFades()} fallback={visibleTitle()}>
-                    <For each={visibleTitleParts()}>
+                    <Index each={visibleTitleParts()}>
                       {(part, index) => (
-                        <span style={{ fg: characterColor(index(), part.separator) }}>{part.value}</span>
+                        <span style={{ fg: characterColor(index, part().separator) }}>{part().value}</span>
                       )}
-                    </For>
+                    </Index>
                   </Show>
                 </text>
                 <text

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -44,7 +44,7 @@ const FADE_WIDTH = 4
 // The add button renders as " + " at the end of the strip, so the tab layout leaves it room.
 const ADD_TAB_WIDTH = 3
 const MARQUEE_DELAY = 600
-const MARQUEE_INTERVAL = 70
+const MARQUEE_INTERVAL = 80
 const CONTEXT_MENU_WIDTH = 16
 const RIGHT_MOUSE_BUTTON = 2
 

--- a/packages/tui/src/util/marquee.ts
+++ b/packages/tui/src/util/marquee.ts
@@ -3,6 +3,11 @@ import { stringWidth } from "./string-width"
 
 const GAP = " · "
 
+export type MarqueeTextPart = {
+  value: string
+  separator: boolean
+}
+
 export function marqueeCycleWidth(value: string) {
   return stringWidth(value + GAP)
 }
@@ -12,16 +17,35 @@ export function marqueeOverflows(value: string, width: number) {
 }
 
 export function marqueeText(value: string, width: number, offset: number) {
-  if (width <= 0) return ""
-  if (stringWidth(value) <= width || offset <= 0) return Locale.takeWidth(value, width)
+  return marqueeTextParts(value, width, offset)
+    .map((part) => part.value)
+    .join("")
+}
 
-  const loop = value + GAP
+export function marqueeTextParts(value: string, width: number, offset: number): MarqueeTextPart[] {
+  if (width <= 0) return []
+  if (stringWidth(value) <= width || offset <= 0)
+    return Locale.graphemes(Locale.takeWidth(value, width)).map((value) => ({ value, separator: false }))
+
+  const loop = [
+    ...Locale.graphemes(value).map((value) => ({ value, separator: false })),
+    ...Locale.graphemes(GAP).map((value) => ({ value, separator: value === "·" })),
+  ]
   const cursor = offset % marqueeCycleWidth(value)
-  const segments = Locale.graphemes(loop + loop)
-  const start = segments.reduce(
-    (state, segment, index) =>
-      state.width >= cursor ? state : { index: index + 1, width: state.width + stringWidth(segment) },
+  const parts = [...loop, ...loop]
+  const start = parts.reduce(
+    (state, part, index) =>
+      state.width >= cursor ? state : { index: index + 1, width: state.width + stringWidth(part.value) },
     { index: 0, width: 0 },
   ).index
-  return Locale.takeWidth(segments.slice(start).join(""), width)
+  const visible = Locale.graphemes(
+    Locale.takeWidth(
+      parts
+        .slice(start)
+        .map((part) => part.value)
+        .join(""),
+      width,
+    ),
+  ).length
+  return parts.slice(start, start + visible)
 }

--- a/packages/tui/src/util/marquee.ts
+++ b/packages/tui/src/util/marquee.ts
@@ -38,14 +38,14 @@ export function marqueeTextParts(value: string, width: number, offset: number): 
       state.width >= cursor ? state : { index: index + 1, width: state.width + stringWidth(part.value) },
     { index: 0, width: 0 },
   ).index
-  const visible = Locale.graphemes(
-    Locale.takeWidth(
-      parts
-        .slice(start)
-        .map((part) => part.value)
-        .join(""),
-      width,
-    ),
-  ).length
+  const visible = parts.slice(start).reduce(
+    (state, part) => {
+      if (state.done) return state
+      const next = stringWidth(part.value)
+      if (state.width + next > width) return { ...state, done: true }
+      return { count: state.count + 1, width: state.width + next, done: false }
+    },
+    { count: 0, width: 0, done: false },
+  ).count
   return parts.slice(start, start + visible)
 }

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -28,7 +28,7 @@ describe("session tab marquee", () => {
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
     scope.marquee.enter("first", "opencode", 6)
-    jest.advanceTimersByTime(1_600)
+    jest.advanceTimersByTime(1_400)
 
     expect(scope.marquee.active()).toBe("first")
     expect(scope.marquee.offset()).toBe(0)

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -28,7 +28,7 @@ describe("session tab marquee", () => {
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
     scope.marquee.enter("first", "opencode", 6)
-    jest.advanceTimersByTime(1_400)
+    jest.advanceTimersByTime(1_300)
 
     expect(scope.marquee.active()).toBe("first")
     expect(scope.marquee.offset()).toBe(0)

--- a/packages/tui/test/component/session-tabs-marquee.test.ts
+++ b/packages/tui/test/component/session-tabs-marquee.test.ts
@@ -28,7 +28,7 @@ describe("session tab marquee", () => {
     const scope = createRoot((dispose) => ({ marquee: createMarquee(() => false), dispose }))
 
     scope.marquee.enter("first", "opencode", 6)
-    jest.advanceTimersByTime(1_300)
+    jest.advanceTimersByTime(1_400)
 
     expect(scope.marquee.active()).toBe("first")
     expect(scope.marquee.offset()).toBe(0)

--- a/packages/tui/test/util/marquee.test.ts
+++ b/packages/tui/test/util/marquee.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { marqueeCycleWidth, marqueeOverflows, marqueeText } from "../../src/util/marquee"
+import { marqueeCycleWidth, marqueeOverflows, marqueeText, marqueeTextParts } from "../../src/util/marquee"
 import { stringWidth } from "../../src/util/string-width"
 
 describe("marquee text", () => {
@@ -23,6 +23,18 @@ describe("marquee text", () => {
     const title = "A long session title"
     expect(marqueeText(title, 8, marqueeCycleWidth(title) - 3)).toBe(" · A lon")
     expect(marqueeText(title, 8, marqueeCycleWidth(title))).toBe("A long s")
+  })
+
+  test("identifies only the generated separator dot", () => {
+    expect(marqueeTextParts("A · title", 6, 7)).toEqual([
+      { value: "l", separator: false },
+      { value: "e", separator: false },
+      { value: " ", separator: false },
+      { value: "·", separator: true },
+      { value: " ", separator: false },
+      { value: "A", separator: false },
+    ])
+    expect(marqueeTextParts("A · title", 6, 2)[0]).toEqual({ value: "·", separator: false })
   })
 
   test("clips wide graphemes to terminal cells", () => {


### PR DESCRIPTION
## What

Refines overflowing session tab marquees so the loop reads more naturally:

- dims the generated `·` separator against the tab background
- advances the marquee every 80ms instead of 100ms
- leaves dots that belong to the session title at normal contrast

## How

- `packages/tui/src/util/marquee.ts` exposes tagged marquee parts while preserving the existing text API
- `packages/tui/src/component/session-tabs.tsx` uses the separator tag in both vertical and horizontal tab layouts, applies the faster cadence, and retains OpenTUI spans by character position with Solid's `Index`
- each frame computes marquee parts once and clips the tagged graphemes without a second segmentation pass
- marquee tests cover separator provenance, wide graphemes, looping, and timing

## Scope

This only changes overflowing session titles while hovered. Static titles, tab details, and non-TUI clients are unchanged.

## Testing

- `bun run test test/util/marquee.test.ts test/component/session-tabs-marquee.test.ts` from `packages/tui` (10 passed)
- `bun typecheck` from `packages/tui`
- pre-push workspace typecheck (33 packages passed)
- live `bun run dev:live` pointer-hover verification in a real PTY

## Demo

Watch tab 3. The recording starts with its title stationary, then shows the hovered title scroll through the dimmed generated separator and continue into the next loop. This interaction preview was captured at the earlier 70ms tuning point; the final cadence is 80ms.

https://github.com/user-attachments/assets/db36382e-f699-4168-b0ef-0188f5b8f8c1
