### PR TITLE
fix(tui): preserve full-width tab hover

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1349,9 +1349,7 @@ function App(props: { pair?: DialogPairCredentials }) {
               width={1}
               height="100%"
               backgroundColor={
-                tabsResizeHovered() || tabsResizing()
-                  ? tabsTheme.background.action.primary.hovered
-                  : tabsTheme.background.default
+                tabsResizeHovered() || tabsResizing() ? tabsTheme.background.action.primary.hovered : undefined
               }
             />
           </box>


### PR DESCRIPTION
## What

Restore the full-width hover and selection background on vertical TUI tab rows after the resizable tab rail was introduced.

## Before / After

**Before:** The resize handle always painted its idle background over the rail's final column. Hovered and selected rows therefore ended with a one-cell dark notch at the right edge.

**After:** The resize handle remains a full-height, two-column mouse target, but its boundary is transparent while idle. Tab row backgrounds now reach the rail edge, while hovering or dragging the boundary still reveals the resize affordance.

## How

- `packages/tui/src/app.tsx`: stop painting the resize boundary's default background when it is neither hovered nor active.

## Scope

This only changes the idle paint of the vertical tab resize handle. Resize behavior, hit target size, and active boundary styling are unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/ui/layout.test.ts` from `packages/tui`
- Live `bun run dev:live` verification in a real PTY, including synthetic mouse movement over an unselected vertical tab row

## Demo

Hovered row background reaches the right edge of the vertical rail:

![Vertical tab row with full-width hover background](https://github.com/user-attachments/assets/f5998704-d1a5-4729-ac0c-dc152594889d)

Hovering the resize boundary reveals a one-cell, full-height divider:

![Vertical tab resize boundary hovered](https://github.com/user-attachments/assets/6f8b5b78-06ac-41d2-a4d7-0ff6554dd86a)
