### PR TITLE
fix(opencode): defer config reload until sessions are idle

### DIFF
--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -9,7 +9,7 @@ import { writeHeapSnapshot } from "node:v8"
 import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
-import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { awaitSessionsIdle, disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
 
 Heap.start()
 
@@ -26,6 +26,7 @@ GlobalBus.on("event", (event) => {
 })
 
 let server: Awaited<ReturnType<typeof Server.listen>> | undefined
+let reloading: Promise<void> | undefined
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {
@@ -61,13 +62,23 @@ export const rpc = {
     await upgrade().catch(() => {})
   },
   async reload() {
-    await AppRuntime.runPromise(
-      Effect.gen(function* () {
-        const cfg = yield* Config.Service
-        yield* cfg.invalidate()
-        yield* disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true })
-      }),
-    )
+    // SIGUSR2 arrives from desktop environments on theme changes, so a reload
+    // can land mid-run. Swapping config in disposes every instance, which
+    // cancels the session that is currently working — wait for it to finish
+    // instead. Signals that arrive while waiting join the pending reload.
+    if (!reloading) {
+      reloading = AppRuntime.runPromise(
+        Effect.gen(function* () {
+          yield* awaitSessionsIdle()
+          const cfg = yield* Config.Service
+          yield* cfg.invalidate()
+          yield* disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true })
+        }),
+      ).finally(() => {
+        reloading = undefined
+      })
+    }
+    await reloading
   },
   async shutdown() {
     await InstanceRuntime.disposeAllInstances()

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -19,6 +19,7 @@ export interface LoadInput {
 
 export interface Interface {
   readonly load: (input: LoadInput) => Effect.Effect<InstanceContext>
+  readonly list: () => Effect.Effect<InstanceContext[]>
   readonly reload: (input: LoadInput) => Effect.Effect<InstanceContext>
   readonly dispose: (ctx: InstanceContext) => Effect.Effect<void>
   readonly disposeDirectory: (directory: string) => Effect.Effect<void>
@@ -123,6 +124,13 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       ).pipe(Effect.withSpan("InstanceStore.load"))
     }
 
+    const list = Effect.fn("InstanceStore.list")(function* () {
+      const exits = yield* Effect.forEach([...cache.values()], (entry) =>
+        Deferred.await(entry.deferred).pipe(Effect.exit),
+      )
+      return exits.filter(Exit.isSuccess).map((exit) => exit.value)
+    })
+
     const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
       const directory = FSUtil.resolve(input.directory)
       return Effect.uninterruptibleMask((restore) =>
@@ -193,6 +201,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
 
     return Service.of({
       load,
+      list,
       reload,
       dispose,
       disposeDirectory,

--- a/packages/opencode/src/server/global-lifecycle.ts
+++ b/packages/opencode/src/server/global-lifecycle.ts
@@ -1,5 +1,7 @@
 import { GlobalBus } from "@/bus/global"
+import { InstanceRef } from "@/effect/instance-ref"
 import { InstanceStore } from "@/project/instance-store"
+import { SessionStatus } from "@/session/status"
 import { Effect } from "effect"
 import { Event } from "./event"
 
@@ -24,5 +26,25 @@ export const disposeAllInstancesAndEmitGlobalDisposed = Effect.fn("Server.dispos
     }).pipe(Effect.uninterruptible)
   },
 )
+
+// Disposing an instance cancels every session runner it owns, so a config
+// reload that lands while the model is streaming aborts the run. Callers that
+// reload on an external trigger (SIGUSR2, config writes) wait here first so the
+// reload is deferred rather than dropped.
+export const awaitSessionsIdle = Effect.fn("Server.awaitSessionsIdle")(function* () {
+  while (yield* sessionsBusy) {
+    yield* Effect.sleep(IDLE_POLL_INTERVAL)
+  }
+})
+
+const IDLE_POLL_INTERVAL = "250 millis"
+
+const sessionsBusy = Effect.gen(function* () {
+  const store = yield* InstanceStore.Service
+  const status = yield* SessionStatus.Service
+  const instances = yield* store.list()
+  const active = yield* Effect.forEach(instances, (ctx) => status.list().pipe(Effect.provideService(InstanceRef, ctx)))
+  return active.some((sessions) => sessions.size > 0)
+})
 
 export * as GlobalLifecycle from "./global-lifecycle"

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -50,6 +50,19 @@ describe("InstanceStore", () => {
     }),
   )
 
+  it.live("lists loaded instance contexts", () =>
+    Effect.gen(function* () {
+      const first = yield* tmpdirScoped({ git: true })
+      const second = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+
+      yield* store.load({ directory: first })
+      yield* store.load({ directory: second })
+
+      expect((yield* store.list()).map((ctx) => ctx.directory).toSorted()).toEqual([first, second].toSorted())
+    }),
+  )
+
   it.live("runs bootstrap with InstanceRef provided", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })

--- a/packages/opencode/test/server/global-lifecycle.test.ts
+++ b/packages/opencode/test/server/global-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { InstanceRef } from "../../src/effect/instance-ref"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { InstanceStore } from "../../src/project/instance-store"
+import { SessionID } from "../../src/session/schema"
+import { SessionStatus } from "../../src/session/status"
+import { awaitSessionsIdle } from "../../src/server/global-lifecycle"
+import { tmpdirScoped } from "../fixture/fixture"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
+
+const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+
+const it = testEffect(
+  LayerNode.compile(LayerNode.group([InstanceStore.node, SessionStatus.node, CrossSpawnSpawner.node]), [
+    [InstanceStore.bootstrapNode, noopBootstrap],
+  ]),
+)
+
+const sessionID = SessionID.make("ses_global_lifecycle")
+
+describe("awaitSessionsIdle", () => {
+  it.live("resolves when no instance has a busy session", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      yield* store.load({ directory: dir })
+
+      yield* awaitWithTimeout(awaitSessionsIdle(), "awaitSessionsIdle blocked while idle")
+    }),
+  )
+
+  it.live("waits for a busy session to go idle", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const ctx = yield* store.load({ directory: dir })
+      const status = yield* SessionStatus.Service
+
+      yield* status.set(sessionID, { type: "busy" }).pipe(Effect.provideService(InstanceRef, ctx))
+
+      const blocked = yield* awaitSessionsIdle().pipe(
+        Effect.as(false),
+        Effect.timeoutOrElse({ duration: "500 millis", orElse: () => Effect.succeed(true) }),
+      )
+      expect(blocked).toBe(true)
+
+      yield* status.set(sessionID, { type: "idle" }).pipe(Effect.provideService(InstanceRef, ctx))
+      yield* awaitWithTimeout(awaitSessionsIdle(), "awaitSessionsIdle did not resolve after the session went idle")
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #42621

### Type of change

- [x] Bug fix

### What does this PR do?

SIGUSR2 makes the TUI worker reload config, and that reload disposes every instance. Instance disposal cancels the session runners the instance owns, so a signal that lands mid-run kills whatever is in flight. Desktop environments send SIGUSR2 on theme changes (Omarchy runs `killall -SIGUSR2 opencode`), so switching themes while opencode is working aborts the request.

The reload now waits until no instance has a busy session before invalidating config and disposing, so the reload is deferred rather than dropped. Signals that arrive while waiting join the pending reload instead of stacking.

Themes still update immediately — that path never went through the worker. The TUI re-detects the terminal palette and re-scans theme files from its own SIGUSR2 handler.

`InstanceStore.list()` is new; the wait needs it to check `SessionStatus` per instance.

### How did you verify your code works?

Manually, before and after, using a shell command so no model call is involved:

1. `bun dev`, then `!sleep 45`, then `kill -SIGUSR2 <tui pid>` from another terminal.
2. On dev: the run aborts with "User aborted the command", and the log shows `disposing all instances` ~5ms after the signal.
3. On this branch: the run finishes normally, and `disposing all instances` appears once the session goes idle — so the config reload still happens, just later.

Tests:

- `test/server/global-lifecycle.test.ts` (new): `awaitSessionsIdle` returns while idle, and blocks until a busy session goes idle. Checked that it fails if the busy predicate is broken.
- `test/project/instance.test.ts`: coverage for `InstanceStore.list()`.
- `bun typecheck` clean in `packages/opencode`; `bun test test/server/httpapi-global.test.ts test/project/` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
