### PR TITLE
feat(server): safely evict idle directory instances

### DIFF
--- a/packages/core/src/instance-activity.ts
+++ b/packages/core/src/instance-activity.ts
@@ -1,0 +1,74 @@
+import { resolve } from "path"
+import { FSUtil } from "./fs-util"
+
+export interface Identity {
+  readonly directory: string
+}
+
+export interface Snapshot {
+  readonly identity: Identity
+  readonly generation: number
+  readonly runningPtys: number
+}
+
+interface State {
+  generation: number
+  runningPtys: number
+}
+
+const states = new Map<string, State>()
+let generation = 0
+
+/** Stable for the lifetime of an instance: absolute and lexical, without filesystem lookups. */
+export function identify(directory: string): Identity {
+  return { directory: resolve(FSUtil.windowsPath(directory)) }
+}
+
+const change = (identity: Identity, update?: (state: State) => void) => {
+  const state = states.get(identity.directory) ?? { generation: 0, runningPtys: 0 }
+  update?.(state)
+  generation++
+  state.generation = generation
+  states.set(identity.directory, state)
+}
+
+export function touch(identity: Identity) {
+  change(identity)
+}
+
+export function ptyStarted(identity: Identity) {
+  change(identity, (state) => state.runningPtys++)
+}
+
+export function ptyStopped(identity: Identity) {
+  const state = states.get(identity.directory)
+  if (!state || state.runningPtys === 0) return
+  change(identity, (current) => current.runningPtys--)
+}
+
+export function hasRunningPty(identity: Identity) {
+  return (states.get(identity.directory)?.runningPtys ?? 0) > 0
+}
+
+export function snapshot(identity: Identity): Snapshot {
+  const state = states.get(identity.directory)
+  return {
+    identity,
+    generation: state?.generation ?? 0,
+    runningPtys: state?.runningPtys ?? 0,
+  }
+}
+
+/** Must be called in the same synchronous call stack as the guarded state transition. */
+export function isCurrentAndIdle(value: Snapshot) {
+  const state = states.get(value.identity.directory)
+  return (state?.generation ?? 0) === value.generation && (state?.runningPtys ?? 0) === 0
+}
+
+export function forget(identity: Identity) {
+  const state = states.get(identity.directory)
+  if (!state || state.runningPtys > 0) return
+  states.delete(identity.directory)
+}
+
+export * as InstanceActivity from "./instance-activity"

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -10,6 +10,7 @@ import { Location } from "./location"
 import { PtyID } from "./pty/schema"
 import { Shell } from "./shell"
 import { lazy } from "./util/lazy"
+import { PtyActivity } from "./pty/activity"
 
 const BUFFER_LIMIT = 1024 * 1024 * 2
 // Exited sessions stay observable (status, exit code, retained output) until removed explicitly.
@@ -34,6 +35,7 @@ type Active = {
   cursor: number
   subscribers: Map<object, Subscriber>
   listeners: Disp[]
+  counted: boolean
 }
 
 export const Info = Pty.Info
@@ -94,6 +96,7 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const events = yield* EventV2.Service
     const location = yield* Location.Service
+    const activity = PtyActivity.identify(location.directory)
     const config = yield* Config.Service
     const context = yield* Effect.context()
     const runFork = Effect.runForkWith(context)
@@ -117,6 +120,10 @@ const layer = Layer.effect(
       for (const listener of session.listeners) listener.dispose()
       session.listeners.length = 0
       if (session.info.status === "running") {
+        if (session.counted) {
+          session.counted = false
+          PtyActivity.stopped(activity)
+        }
         try {
           session.process.kill()
         } catch {}
@@ -198,8 +205,10 @@ const layer = Layer.effect(
         cursor: 0,
         subscribers: new Map(),
         listeners: [],
+        counted: true,
       }
       sessions.set(id, session)
+      PtyActivity.started(activity)
       session.listeners.push(
         proc.onData((chunk) => {
           session.cursor += chunk.length
@@ -222,6 +231,10 @@ const layer = Layer.effect(
         }),
         proc.onExit(({ exitCode }) => {
           if (session.info.status === "exited") return
+          if (session.counted) {
+            session.counted = false
+            PtyActivity.stopped(activity)
+          }
           session.info.status = "exited"
           session.info.exitCode = exitCode
           notifyEnd(session, { exitCode })

--- a/packages/core/src/pty/activity.ts
+++ b/packages/core/src/pty/activity.ts
@@ -1,0 +1,20 @@
+import { InstanceActivity } from "../instance-activity"
+
+export function identify(directory: string) {
+  return InstanceActivity.identify(directory)
+}
+
+export function started(identity: InstanceActivity.Identity) {
+  InstanceActivity.ptyStarted(identity)
+}
+
+export function stopped(identity: InstanceActivity.Identity) {
+  InstanceActivity.ptyStopped(identity)
+}
+
+export function hasRunning(directory: string) {
+  const identity = identify(directory)
+  return InstanceActivity.hasRunningPty(identity)
+}
+
+export * as PtyActivity from "./activity"

--- a/packages/core/test/pty/activity.test.ts
+++ b/packages/core/test/pty/activity.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rename, rm, symlink } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
+import { InstanceActivity } from "../../src/instance-activity"
+import { PtyActivity } from "../../src/pty/activity"
+
+const canonical = "/tmp/opencode-pty-activity/b"
+const alias = "/tmp/opencode-pty-activity/a/../b"
+const canonicalIdentity = PtyActivity.identify(canonical)
+
+afterEach(() => {
+  PtyActivity.stopped(canonicalIdentity)
+  InstanceActivity.forget(canonicalIdentity)
+})
+
+describe("PtyActivity", () => {
+  test("canonicalizes lexical directory aliases", () => {
+    const aliasIdentity = PtyActivity.identify(alias)
+    const before = InstanceActivity.snapshot(canonicalIdentity).generation
+    PtyActivity.started(aliasIdentity)
+    expect(PtyActivity.hasRunning(canonical)).toBe(true)
+    const running = InstanceActivity.snapshot(canonicalIdentity).generation
+    expect(running).toBeGreaterThan(before)
+
+    PtyActivity.stopped(aliasIdentity)
+    expect(PtyActivity.hasRunning(alias)).toBe(false)
+    expect(InstanceActivity.snapshot(canonicalIdentity).generation).toBeGreaterThan(running)
+  })
+
+  test("keeps the owning identity across rename and symlink replacement", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-pty-retarget-"))
+    const owner = join(root, "owner")
+    const moved = join(root, "moved")
+    const replacement = join(root, "replacement")
+    await mkdir(owner)
+    await mkdir(replacement)
+    const identity = PtyActivity.identify(owner)
+
+    try {
+      PtyActivity.started(identity)
+      const running = InstanceActivity.snapshot(identity)
+      expect(running.runningPtys).toBe(1)
+
+      await rename(owner, moved)
+      await symlink(replacement, owner, "dir")
+
+      expect(PtyActivity.hasRunning(owner)).toBe(true)
+      PtyActivity.stopped(identity)
+      expect(PtyActivity.hasRunning(owner)).toBe(false)
+      expect(InstanceActivity.snapshot(identity).runningPtys).toBe(0)
+
+      PtyActivity.started(identity)
+      PtyActivity.stopped(identity)
+      const balanced = InstanceActivity.snapshot(identity)
+      expect(balanced.runningPtys).toBe(0)
+      expect(balanced.generation).toBeGreaterThan(running.generation)
+    } finally {
+      PtyActivity.stopped(identity)
+      InstanceActivity.forget(identity)
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/opencode/src/acp/directory.ts
+++ b/packages/opencode/src/acp/directory.ts
@@ -1,7 +1,5 @@
 import { Agent } from "@/agent/agent"
 import { Command } from "@/command"
-import { InstanceRef } from "@/effect/instance-ref"
-import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -114,28 +112,30 @@ export const loaderLayer = Layer.effect(
 
     return Loader.of({
       load: Effect.fn("ACPDirectoryLoader.load")(function* (directory) {
-        const ctx = yield* store.load({ directory })
-        return yield* Effect.gen(function* () {
-          const providers = yield* provider.list()
-          const [agents, defaultAgent, commands, defaultModel] = yield* Effect.all(
-            [agent.list(), agent.defaultInfo(), command.list(), provider.defaultModel().pipe(Effect.option)],
-            { concurrency: "unbounded" },
-          )
-          return build({
-            directory,
-            providers,
-            modes: agents
-              .filter((item) => item.mode !== "subagent" && item.hidden !== true)
-              .map((item) => ({
-                id: item.name,
-                name: item.name,
-                ...(item.description ? { description: item.description } : {}),
-              })),
-            defaultModeID: defaultAgent.name,
-            commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
-            ...(defaultModel._tag === "Some" ? { defaultModel: defaultModel.value } : {}),
-          })
-        }).pipe(Effect.provideService(InstanceRef, ctx))
+        return yield* store.provide(
+          { directory },
+          Effect.gen(function* () {
+            const providers = yield* provider.list()
+            const [agents, defaultAgent, commands, defaultModel] = yield* Effect.all(
+              [agent.list(), agent.defaultInfo(), command.list(), provider.defaultModel().pipe(Effect.option)],
+              { concurrency: "unbounded" },
+            )
+            return build({
+              directory,
+              providers,
+              modes: agents
+                .filter((item) => item.mode !== "subagent" && item.hidden !== true)
+                .map((item) => ({
+                  id: item.name,
+                  name: item.name,
+                  ...(item.description ? { description: item.description } : {}),
+                })),
+              defaultModeID: defaultAgent.name,
+              commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
+              ...(defaultModel._tag === "Some" ? { defaultModel: defaultModel.value } : {}),
+            })
+          }),
+        )
       }),
     })
   }),

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -1,7 +1,5 @@
 import type { AgentSideConnection, Usage } from "@agentclientprotocol/sdk"
 import type { AssistantMessage as OpenCodeAssistantMessage, Message } from "@opencode-ai/sdk/v2"
-import { InstanceRef } from "@/effect/instance-ref"
-import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { makeGlobalNode, Node } from "@opencode-ai/core/effect/app-node"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -130,10 +128,7 @@ export const contextLimitLoaderLayer = Layer.effect(
 
     return ContextLimitLoader.of({
       providers: Effect.fn("ACPUsageContextLimitLoader.providers")(function* (directory) {
-        const ctx = yield* store.load({ directory })
-        return yield* Effect.gen(function* () {
-          return yield* provider.list()
-        }).pipe(Effect.provideService(InstanceRef, ctx))
+        return yield* store.provide({ directory }, provider.list())
       }),
     })
   }),

--- a/packages/opencode/src/background/job.ts
+++ b/packages/opencode/src/background/job.ts
@@ -2,6 +2,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { BackgroundJob as CoreBackgroundJob } from "@opencode-ai/core/background-job"
 import { InstanceState } from "@/effect/instance-state"
 import { Effect, Layer } from "effect"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
 
 export {
   Service,
@@ -19,11 +20,30 @@ const layer = Layer.effect(
   CoreBackgroundJob.Service,
   Effect.gen(function* () {
     const state = yield* InstanceState.make(() => CoreBackgroundJob.make)
+    const tracked = (activity: InstanceActivity.Identity, run: Effect.Effect<string, unknown>) =>
+      Effect.sync(() => InstanceActivity.touch(activity)).pipe(
+        Effect.andThen(run),
+        Effect.ensuring(Effect.sync(() => InstanceActivity.touch(activity))),
+      )
     return CoreBackgroundJob.Service.of({
       list: () => InstanceState.useEffect(state, (jobs) => jobs.list()),
       get: (id) => InstanceState.useEffect(state, (jobs) => jobs.get(id)),
-      start: (input) => InstanceState.useEffect(state, (jobs) => jobs.start(input)),
-      extend: (input) => InstanceState.useEffect(state, (jobs) => jobs.extend(input)),
+      start: (input) =>
+        Effect.gen(function* () {
+          const activity = InstanceActivity.identify(yield* InstanceState.directory)
+          InstanceActivity.touch(activity)
+          return yield* InstanceState.useEffect(state, (jobs) =>
+            jobs.start({ ...input, run: tracked(activity, input.run) }),
+          )
+        }),
+      extend: (input) =>
+        Effect.gen(function* () {
+          const activity = InstanceActivity.identify(yield* InstanceState.directory)
+          InstanceActivity.touch(activity)
+          return yield* InstanceState.useEffect(state, (jobs) =>
+            jobs.extend({ ...input, run: tracked(activity, input.run) }),
+          )
+        }),
       wait: (input) => InstanceState.useEffect(state, (jobs) => jobs.wait(input)),
       waitForPromotion: (id) => InstanceState.useEffect(state, (jobs) => jobs.waitForPromotion(id)),
       promote: (id) => InstanceState.useEffect(state, (jobs) => jobs.promote(id)),

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -7,6 +7,18 @@ const positiveInteger = (name: string) =>
     Config.map((value) => (Number.isInteger(value) && value > 0 ? value : undefined)),
     Config.orElse(() => Config.succeed(undefined)),
   )
+const instanceIdleTimeout = Config.string("OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS").pipe(
+  Config.option,
+  Config.map((input) => {
+    if (Option.isNone(input)) return { value: undefined, warning: undefined }
+    const value = Number(input.value)
+    if (Number.isInteger(value) && value >= 60 * 60 * 1000) return { value, warning: undefined }
+    return {
+      value: undefined,
+      warning: "ignoring OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: expected an integer of at least 3600000 ms",
+    }
+  }),
+)
 const experimental = bool("OPENCODE_EXPERIMENTAL")
 const enabledByExperimental = (name: string) =>
   Config.all({ experimental, enabled: Config.boolean(name).pipe(Config.option) }).pipe(
@@ -51,6 +63,8 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   experimentalIconDiscovery: enabledByExperimental("OPENCODE_EXPERIMENTAL_ICON_DISCOVERY"),
   outputTokenMax: positiveInteger("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX"),
   bashDefaultTimeoutMs: positiveInteger("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
+  instanceIdleTimeoutMs: instanceIdleTimeout.pipe(Config.map((input) => input.value)),
+  instanceIdleTimeoutWarning: instanceIdleTimeout.pipe(Config.map((input) => input.warning)),
   experimentalNativeLlm: bool("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),
   experimentalWebSockets: bool("OPENCODE_EXPERIMENTAL_WEBSOCKETS"),
   client: Config.string("OPENCODE_CLIENT").pipe(Config.withDefault("cli")),

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -6,7 +6,8 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
+import { Clock, Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
 import * as Project from "./project"
@@ -17,12 +18,18 @@ export interface LoadInput {
   project?: Project.Info
 }
 
+export interface SweepIdleInput<E, R> {
+  readonly idleTimeoutMs: number
+  readonly canDispose: (ctx: InstanceContext) => Effect.Effect<boolean, E, R>
+}
+
 export interface Interface {
   readonly load: (input: LoadInput) => Effect.Effect<InstanceContext>
   readonly reload: (input: LoadInput) => Effect.Effect<InstanceContext>
   readonly dispose: (ctx: InstanceContext) => Effect.Effect<void>
   readonly disposeDirectory: (directory: string) => Effect.Effect<void>
   readonly disposeAll: () => Effect.Effect<void>
+  readonly sweepIdle: <E, R>(input: SweepIdleInput<E, R>) => Effect.Effect<number, E, R>
   readonly provide: <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
 }
 
@@ -30,8 +37,42 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/In
 
 export const use = serviceUse(Service)
 
-interface Entry {
+interface ActiveEntry {
+  readonly state: "active"
   readonly deferred: Deferred.Deferred<InstanceContext>
+  active: number
+  inactive: Deferred.Deferred<void> | undefined
+  lastUsed: number
+  readonly activity: InstanceActivity.Identity
+  activityGeneration: number
+}
+
+interface Lease {
+  readonly directory: string
+  readonly entry: ActiveEntry
+  active: boolean
+}
+
+const CurrentLeases = Context.Reference<readonly Lease[]>("~opencode/InstanceStore/CurrentLeases", {
+  defaultValue: () => [],
+})
+
+interface DisposingEntry {
+  readonly state: "disposing"
+  readonly done: Deferred.Deferred<void>
+  readonly activity: InstanceActivity.Identity
+}
+
+type Entry = ActiveEntry | DisposingEntry
+
+interface DirectoryKey {
+  readonly lexical: string
+  readonly directory: string
+}
+
+interface AliasEntry {
+  readonly directory: string
+  pending: number
 }
 
 const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Service> = Layer.effect(
@@ -41,6 +82,49 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     const bootstrap = yield* InstanceBootstrap.Service
     const scope = yield* Scope.Scope
     const cache = new Map<string, Entry>()
+    const aliases = new Map<string, AliasEntry>()
+
+    const directoryKey = (input: string): DirectoryKey => {
+      const lexical = InstanceActivity.identify(input).directory
+      const remembered = aliases.get(lexical)
+      if (remembered && (remembered.pending > 0 || cache.has(remembered.directory))) {
+        return { lexical, directory: remembered.directory }
+      }
+      if (remembered) aliases.delete(lexical)
+      const directory = cache.has(lexical) ? lexical : FSUtil.resolve(input)
+      return { lexical, directory }
+    }
+
+    const reserveDirectory = (input: string) => {
+      const key = directoryKey(input)
+      const remembered = aliases.get(key.lexical)
+      if (remembered?.directory === key.directory) remembered.pending++
+      else aliases.set(key.lexical, { directory: key.directory, pending: 1 })
+      return key
+    }
+
+    const releaseDirectory = (key: DirectoryKey) => {
+      const remembered = aliases.get(key.lexical)
+      if (remembered?.directory !== key.directory) return
+      remembered.pending--
+      if (remembered.pending === 0 && !cache.has(key.directory)) aliases.delete(key.lexical)
+    }
+
+    const clearAliases = (directory: string) => {
+      for (const [alias, target] of aliases) {
+        if (target.directory === directory && target.pending === 0) aliases.delete(alias)
+      }
+    }
+
+    const withReservedDirectory = <A, E, R>(
+      input: string,
+      use: (key: DirectoryKey) => Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E, R> =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => reserveDirectory(input)),
+        use,
+        (key) => Effect.sync(() => releaseDirectory(key)),
+      )
 
     const boot = (input: LoadInput & { directory: string }) =>
       Effect.gen(function* () {
@@ -66,15 +150,34 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       Effect.sync(() => {
         if (cache.get(directory) !== entry) return false
         cache.delete(directory)
+        clearAliases(directory)
         return true
       })
 
-    const completeLoad = (directory: string, input: LoadInput, entry: Entry) =>
+    const completeLoad = (directory: string, input: LoadInput, entry: ActiveEntry) =>
       Effect.gen(function* () {
         const exit = yield* Effect.exit(boot({ ...input, directory }))
         if (Exit.isFailure(exit)) yield* removeEntry(directory, entry)
         yield* Deferred.done(entry.deferred, exit).pipe(Effect.asVoid)
       })
+
+    const startLoad = (directory: string, input: LoadInput, now: number, active = 0) => {
+      const activity = InstanceActivity.identify(directory)
+      const entry: ActiveEntry = {
+        state: "active",
+        deferred: Deferred.makeUnsafe<InstanceContext>(),
+        active,
+        inactive: active > 0 ? Deferred.makeUnsafe<void>() : undefined,
+        lastUsed: now,
+        activity,
+        activityGeneration: InstanceActivity.snapshot(activity).generation,
+      }
+      cache.set(directory, entry)
+      return Effect.gen(function* () {
+        yield* Effect.logInfo("creating instance", { directory })
+        yield* completeLoad(directory, input, entry)
+      }).pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.as(entry))
+    }
 
     const emitDisposed = (input: { directory: string; project?: string }) =>
       Effect.sync(() =>
@@ -97,85 +200,216 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       yield* emitDisposed({ directory: ctx.directory, project: ctx.project.id })
     })
 
-    const disposeEntry = Effect.fnUntraced(function* (directory: string, entry: Entry, ctx: InstanceContext) {
-      if (cache.get(directory) !== entry) return false
-      yield* disposeContext(ctx)
-      if (cache.get(directory) !== entry) return false
-      cache.delete(directory)
-      return true
-    })
-
-    const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
-      return Effect.uninterruptibleMask((restore) =>
-        Effect.gen(function* () {
-          const existing = cache.get(directory)
-          if (existing) return yield* restore(Deferred.await(existing.deferred))
-
-          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
-          cache.set(directory, entry)
-          yield* Effect.gen(function* () {
-            yield* Effect.logInfo("creating instance", { directory: directory })
-            yield* completeLoad(directory, input, entry)
-          }).pipe(Effect.forkIn(scope, { startImmediately: true }))
-          return yield* restore(Deferred.await(entry.deferred))
-        }),
-      ).pipe(Effect.withSpan("InstanceStore.load"))
+    const touch = (entry: ActiveEntry, now: number) => {
+      entry.lastUsed = now
+      entry.activityGeneration = InstanceActivity.snapshot(entry.activity).generation
     }
 
-    const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
-      return Effect.uninterruptibleMask((restore) =>
-        Effect.gen(function* () {
-          const previous = cache.get(directory)
-          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
-          cache.set(directory, entry)
-          yield* Effect.gen(function* () {
-            yield* Effect.logInfo("reloading instance", { directory: directory })
-            if (previous) {
-              yield* Deferred.await(previous.deferred).pipe(Effect.ignore)
-              yield* Effect.promise(() => runDisposers(directory))
-              yield* emitDisposed({ directory, project: input.project?.id })
+    const releaseLease = (lease: Lease) =>
+      Effect.gen(function* () {
+        if (!lease.active) return
+        lease.active = false
+        lease.entry.active--
+        touch(lease.entry, yield* Clock.currentTimeMillis)
+        if (lease.entry.active !== 0) return
+        const inactive = lease.entry.inactive
+        lease.entry.inactive = undefined
+        if (inactive) yield* Deferred.succeed(inactive, undefined)
+      })
+
+    const releaseOwnedLeases = (directory: string, entry: ActiveEntry) =>
+      Effect.gen(function* () {
+        const leases = yield* CurrentLeases
+        yield* Effect.forEach(
+          leases,
+          (lease) =>
+            lease.directory === directory && lease.entry === entry && lease.active ? releaseLease(lease) : Effect.void,
+          { discard: true },
+        )
+      })
+
+    const claim = (directory: string, expected: ActiveEntry | undefined, validate: () => boolean = () => true) =>
+      Effect.sync(() => {
+        if (cache.get(directory) !== expected) return undefined
+        if (expected && expected.active > 0) return undefined
+        if (!validate()) return undefined
+        const tombstone: DisposingEntry = {
+          state: "disposing",
+          done: Deferred.makeUnsafe<void>(),
+          activity: expected?.activity ?? InstanceActivity.identify(directory),
+        }
+        cache.set(directory, tombstone)
+        return tombstone
+      })
+
+    const finishTombstone = (directory: string, tombstone: DisposingEntry) =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() => {
+          if (cache.get(directory) !== tombstone) return
+          cache.delete(directory)
+          clearAliases(directory)
+        })
+        yield* Deferred.succeed(tombstone.done, undefined).pipe(Effect.asVoid)
+      })
+
+    const disposeClaimed = (directory: string, tombstone: DisposingEntry, ctx: InstanceContext) =>
+      disposeContext(ctx).pipe(
+        Effect.ensuring(Effect.sync(() => InstanceActivity.forget(tombstone.activity))),
+        Effect.ensuring(finishTombstone(directory, tombstone)),
+        Effect.uninterruptible,
+      )
+
+    const claimAndDispose = (
+      directory: string,
+      expected: ActiveEntry | undefined,
+      ctx: InstanceContext,
+      validate?: () => boolean,
+    ) =>
+      Effect.gen(function* () {
+        const tombstone = yield* claim(directory, expected, validate)
+        if (!tombstone) return false
+        yield* disposeClaimed(directory, tombstone, ctx)
+        return true
+      }).pipe(Effect.uninterruptible)
+
+    const waitForInactive = (directory: string, entry: ActiveEntry): Effect.Effect<boolean> =>
+      Effect.suspend(() => {
+        if (cache.get(directory) !== entry) return Effect.succeed(false)
+        if (entry.active === 0) return Effect.succeed(true)
+        return Deferred.await(entry.inactive!).pipe(Effect.andThen(waitForInactive(directory, entry)))
+      })
+
+    const disposeWhenInactive = (directory: string, entry: ActiveEntry, ctx: InstanceContext): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (!(yield* waitForInactive(directory, entry))) return
+        if (yield* claimAndDispose(directory, entry, ctx)) return
+        if (cache.get(directory) !== entry) return
+        yield* disposeWhenInactive(directory, entry, ctx)
+      })
+
+    const loadFrozen = (key: DirectoryKey, input: LoadInput): Effect.Effect<InstanceContext> => {
+      const directory = key.directory
+      const loop = (): Effect.Effect<InstanceContext> =>
+        Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const existing = cache.get(directory)
+            if (existing?.state === "disposing") {
+              yield* restore(Deferred.await(existing.done))
+              return yield* restore(loop())
             }
-            yield* completeLoad(directory, input, entry)
-          }).pipe(Effect.forkIn(scope, { startImmediately: true }))
-          return yield* restore(Deferred.await(entry.deferred))
-        }),
-      ).pipe(Effect.withSpan("InstanceStore.reload"))
+            const now = yield* Clock.currentTimeMillis
+            if (existing) {
+              touch(existing, now)
+              return yield* restore(Deferred.await(existing.deferred))
+            }
+            const entry = yield* startLoad(directory, input, now)
+            return yield* restore(Deferred.await(entry.deferred))
+          }),
+        )
+      return loop().pipe(Effect.withSpan("InstanceStore.load"))
     }
+
+    const load = (input: LoadInput): Effect.Effect<InstanceContext> =>
+      withReservedDirectory(input.directory, (key) => loadFrozen(key, input))
+
+    const reload = (input: LoadInput): Effect.Effect<InstanceContext> =>
+      withReservedDirectory(input.directory, (key) => {
+        const directory = key.directory
+        const loop = (): Effect.Effect<InstanceContext> =>
+          Effect.uninterruptibleMask((restore) =>
+            Effect.gen(function* () {
+              const previous = cache.get(directory)
+              if (previous?.state === "disposing") {
+                yield* restore(Deferred.await(previous.done))
+                return yield* restore(loop())
+              }
+              if (!previous) return yield* restore(loadFrozen(key, { ...input, directory }))
+
+              const exit = yield* restore(Deferred.await(previous.deferred).pipe(Effect.exit))
+              if (Exit.isFailure(exit)) {
+                yield* removeEntry(directory, previous)
+                return yield* restore(loop())
+              }
+              yield* releaseOwnedLeases(directory, previous)
+              if (!(yield* restore(waitForInactive(directory, previous)))) return yield* restore(loop())
+              const tombstone = yield* claim(directory, previous)
+              if (!tombstone) return yield* restore(loop())
+
+              const entry = yield* Effect.gen(function* () {
+                yield* disposeContext(exit.value).pipe(
+                  Effect.ensuring(Effect.sync(() => InstanceActivity.forget(tombstone.activity))),
+                )
+                const now = yield* Clock.currentTimeMillis
+                return yield* startLoad(directory, input, now)
+              }).pipe(Effect.ensuring(finishTombstone(directory, tombstone)))
+              return yield* restore(Deferred.await(entry.deferred))
+            }),
+          )
+        return Effect.logInfo("reloading instance", { directory }).pipe(
+          Effect.flatMap(loop),
+          Effect.withSpan("InstanceStore.reload"),
+        )
+      })
 
     const dispose = Effect.fn("InstanceStore.dispose")(function* (ctx: InstanceContext) {
-      const entry = cache.get(ctx.directory)
-      if (!entry) return yield* disposeContext(ctx)
+      const directory = directoryKey(ctx.directory).directory
+      const entry = cache.get(directory)
+      if (entry?.state === "disposing") {
+        yield* Deferred.await(entry.done)
+        return undefined
+      }
+      if (!entry) {
+        yield* claimAndDispose(directory, undefined, ctx)
+        return undefined
+      }
 
       const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-      if (Exit.isFailure(exit)) return yield* removeEntry(ctx.directory, entry).pipe(Effect.asVoid)
-      if (exit.value !== ctx) return
-      yield* disposeEntry(ctx.directory, entry, ctx).pipe(Effect.asVoid)
+      if (Exit.isFailure(exit)) {
+        yield* removeEntry(directory, entry)
+        return undefined
+      }
+      if (exit.value !== ctx) return undefined
+      yield* releaseOwnedLeases(directory, entry)
+      yield* disposeWhenInactive(directory, entry, ctx)
+      return undefined
     })
 
     const disposeDirectory = Effect.fn("InstanceStore.disposeDirectory")(function* (input: string) {
-      const directory = FSUtil.resolve(input)
+      const directory = directoryKey(input).directory
       const entry = cache.get(directory)
-      if (!entry) return
+      if (!entry) return undefined
+      if (entry.state === "disposing") {
+        yield* Deferred.await(entry.done)
+        return undefined
+      }
       const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
-      if (Exit.isFailure(exit)) return yield* removeEntry(directory, entry).pipe(Effect.asVoid)
-      yield* disposeEntry(directory, entry, exit.value).pipe(Effect.asVoid)
+      if (Exit.isFailure(exit)) {
+        yield* removeEntry(directory, entry)
+        return undefined
+      }
+      yield* releaseOwnedLeases(directory, entry)
+      yield* disposeWhenInactive(directory, entry, exit.value)
+      return undefined
     })
 
     const disposeAllOnce = Effect.fnUntraced(function* () {
       yield* Effect.logInfo("disposing all instances")
       yield* Effect.forEach(
         [...cache.entries()],
-        (item) =>
+        ([directory, entry]) =>
           Effect.gen(function* () {
-            const exit = yield* Deferred.await(item[1].deferred).pipe(Effect.exit)
-            if (Exit.isFailure(exit)) {
-              yield* Effect.logWarning("instance dispose failed", { key: item[0], cause: exit.cause })
-              yield* removeEntry(item[0], item[1])
-              return
+            if (entry.state === "disposing") {
+              yield* Deferred.await(entry.done)
+              return undefined
             }
-            yield* disposeEntry(item[0], item[1], exit.value)
+            const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
+            if (Exit.isFailure(exit)) {
+              yield* Effect.logWarning("instance dispose failed", { key: directory, cause: exit.cause })
+              yield* removeEntry(directory, entry)
+              return undefined
+            }
+            yield* disposeWhenInactive(directory, entry, exit.value)
+            return undefined
           }),
         { discard: true },
       )
@@ -183,11 +417,79 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
 
     const cachedDisposeAll = yield* Effect.cachedWithTTL(disposeAllOnce(), Duration.zero)
     const disposeAll = Effect.fn("InstanceStore.disposeAll")(function* () {
+      const leases = yield* CurrentLeases
+      yield* Effect.forEach(leases, (lease) => (lease.active ? releaseLease(lease) : Effect.void), { discard: true })
       return yield* cachedDisposeAll
     })
 
+    const sweepIdle = Effect.fn("InstanceStore.sweepIdle")(function* <E, R>(input: SweepIdleInput<E, R>) {
+      const cutoff = (yield* Clock.currentTimeMillis) - input.idleTimeoutMs
+      const candidates = [...cache.entries()].filter(
+        (item): item is [string, ActiveEntry] =>
+          item[1].state === "active" && item[1].active === 0 && item[1].lastUsed <= cutoff,
+      )
+      const results = yield* Effect.forEach(candidates, ([directory, entry]) =>
+        Effect.gen(function* () {
+          const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
+          if (Exit.isFailure(exit)) {
+            yield* removeEntry(directory, entry)
+            return false
+          }
+          const activity = InstanceActivity.snapshot(entry.activity)
+          if (activity.generation !== entry.activityGeneration) {
+            touch(entry, yield* Clock.currentTimeMillis)
+            return false
+          }
+          const allowed = yield* input.canDispose(exit.value)
+          if (cache.get(directory) !== entry || entry.active !== 0 || entry.lastUsed > cutoff) return false
+          if (!allowed) {
+            touch(entry, yield* Clock.currentTimeMillis)
+            return false
+          }
+          return yield* claimAndDispose(directory, entry, exit.value, () => InstanceActivity.isCurrentAndIdle(activity))
+        }),
+      )
+      return results.filter(Boolean).length
+    })
+
     const provide = <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
-      load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx))))
+      withReservedDirectory(input.directory, (key) => {
+        const directory = key.directory
+        return Effect.uninterruptibleMask((restore) => {
+          const acquire = (): Effect.Effect<ActiveEntry> =>
+            Effect.gen(function* () {
+              const existing = cache.get(directory)
+              if (existing?.state === "disposing") {
+                yield* restore(Deferred.await(existing.done))
+                return yield* acquire()
+              }
+              const now = yield* Clock.currentTimeMillis
+              if (existing) {
+                if (existing.active === 0) existing.inactive = Deferred.makeUnsafe<void>()
+                existing.active++
+                touch(existing, now)
+                return existing
+              }
+              return yield* startLoad(directory, input, now, 1)
+            })
+
+          return Effect.gen(function* () {
+            const entry = yield* acquire()
+            const lease: Lease = { directory, entry, active: true }
+            const leases = yield* CurrentLeases
+            return yield* restore(
+              Deferred.await(entry.deferred).pipe(
+                Effect.flatMap((ctx) =>
+                  effect.pipe(
+                    Effect.provideService(InstanceRef, ctx),
+                    Effect.provideService(CurrentLeases, [...leases, lease]),
+                  ),
+                ),
+              ),
+            ).pipe(Effect.ensuring(releaseLease(lease)))
+          })
+        }).pipe(Effect.withSpan("InstanceStore.provide"))
+      })
 
     yield* Effect.addFinalizer(() => disposeAll().pipe(Effect.ignore))
 
@@ -197,6 +499,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       dispose,
       disposeDirectory,
       disposeAll,
+      sweepIdle,
       provide,
     })
   }),

--- a/packages/opencode/src/server/instance-eviction.ts
+++ b/packages/opencode/src/server/instance-eviction.ts
@@ -1,0 +1,59 @@
+import { BackgroundJob } from "@/background/job"
+import { InstanceRef } from "@/effect/instance-ref"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import type { InstanceContext } from "@/project/instance-context"
+import { InstanceStore } from "@/project/instance-store"
+import { SessionRunState } from "@/session/run-state"
+import { SessionStatus } from "@/session/status"
+import { PtyActivity } from "@opencode-ai/core/pty/activity"
+import { Effect, Layer, Schedule } from "effect"
+
+export const SWEEP_INTERVAL = "1 minute"
+
+export interface ActivityServices {
+  readonly runners: SessionRunState.Interface
+  readonly statuses: SessionStatus.Interface
+  readonly background: BackgroundJob.Interface
+}
+
+export const canDispose = Effect.fn("InstanceEviction.canDispose")(function* (
+  ctx: InstanceContext,
+  services: ActivityServices,
+) {
+  if (PtyActivity.hasRunning(ctx.directory)) return false
+  return yield* Effect.gen(function* () {
+    if (yield* services.runners.isActive()) return false
+    if (Array.from((yield* services.statuses.list()).values()).some((status) => status.type !== "idle")) return false
+    if ((yield* services.background.list()).some((job) => job.status === "running")) return false
+    return true
+  }).pipe(Effect.provideService(InstanceRef, ctx))
+})
+
+export const layer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const flags = yield* RuntimeFlags.Service
+    if (flags.instanceIdleTimeoutWarning) yield* Effect.logWarning(flags.instanceIdleTimeoutWarning)
+    const timeout = flags.instanceIdleTimeoutMs
+    if (timeout === undefined) return
+
+    const store = yield* InstanceStore.Service
+    const runners = yield* SessionRunState.Service
+    const statuses = yield* SessionStatus.Service
+    const background = yield* BackgroundJob.Service
+
+    yield* Effect.logInfo("instance idle eviction enabled", { timeout })
+    yield* store
+      .sweepIdle({
+        idleTimeoutMs: timeout,
+        canDispose: (ctx) => canDispose(ctx, { runners, statuses, background }),
+      })
+      .pipe(
+        Effect.tap((count) => (count > 0 ? Effect.logInfo("evicted idle instances", { count }) : Effect.void)),
+        Effect.catchCause((cause) => Effect.logWarning("instance idle sweep failed", { cause })),
+        Effect.repeat(Schedule.spaced(SWEEP_INTERVAL)),
+        Effect.forkScoped,
+      )
+  }),
+)
+
+export * as InstanceEviction from "./instance-eviction"

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -4,7 +4,7 @@ import * as InstanceState from "@/effect/instance-state"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { markInstanceForDisposal } from "../lifecycle"
+import { disposeInstance } from "../lifecycle"
 
 export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (handlers) =>
   Effect.gen(function* () {
@@ -17,7 +17,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
 
     const update = Effect.fn("ConfigHttpApi.update")(function* (ctx) {
       yield* configSvc.update(ctx.payload)
-      yield* markInstanceForDisposal(yield* InstanceState.context)
+      yield* disposeInstance(yield* InstanceState.context)
       return ctx.payload
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
@@ -10,7 +10,7 @@ import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { ApiVcsApplyError } from "../groups/instance"
-import { markInstanceForDisposal } from "../lifecycle"
+import { disposeInstance } from "../lifecycle"
 
 export const instanceHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance", (handlers) =>
   Effect.gen(function* () {
@@ -22,7 +22,7 @@ export const instanceHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance"
     const vcs = yield* Vcs.Service
 
     const dispose = Effect.fn("InstanceHttpApi.dispose")(function* () {
-      yield* markInstanceForDisposal(yield* InstanceState.context)
+      yield* disposeInstance(yield* InstanceState.context)
       return true
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
@@ -5,7 +5,7 @@ import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { ProjectNotFoundError } from "../errors"
-import { markInstanceForReload } from "../lifecycle"
+import { reloadInstance } from "../lifecycle"
 
 export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", (handlers) =>
   Effect.gen(function* () {
@@ -25,7 +25,7 @@ export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", 
       const next = yield* svc.initGit({ directory: ctx.directory, project: ctx.project })
       if (next.id === ctx.project.id && next.vcs === ctx.project.vcs && next.worktree === ctx.project.worktree)
         return next
-      yield* markInstanceForReload(ctx, {
+      yield* reloadInstance(ctx, {
         directory: ctx.directory,
         worktree: ctx.directory,
         project: next,

--- a/packages/opencode/src/server/routes/instance/httpapi/lifecycle.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/lifecycle.ts
@@ -2,53 +2,17 @@ import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
 import { InstanceStore } from "@/project/instance-store"
 import { Effect } from "effect"
-import { HttpEffect, HttpMiddleware, HttpServerRequest } from "effect/unstable/http"
 
-type MarkedInstance = {
-  ctx: InstanceContext
-  store: InstanceStore.Interface
-  bridge: EffectBridge.Shape
-}
-
-// Disposal is requested by an endpoint handler, but must run from the outer
-// server middleware after the response has been produced. The original Request
-// object is the stable handoff key between those two phases.
-const disposeAfterResponse = new WeakMap<object, MarkedInstance>()
-
-const mark = (ctx: InstanceContext) =>
+export const disposeInstance = (ctx: InstanceContext) =>
   Effect.gen(function* () {
-    return { ctx, store: yield* InstanceStore.Service, bridge: yield* EffectBridge.make() }
+    const store = yield* InstanceStore.Service
+    const bridge = yield* EffectBridge.make()
+    return yield* Effect.uninterruptible(bridge.run(store.dispose(ctx)))
   })
 
-export const markInstanceForDisposal = (ctx: InstanceContext) =>
+export const reloadInstance = (ctx: InstanceContext, next: InstanceStore.LoadInput) =>
   Effect.gen(function* () {
-    const marked = yield* mark(ctx)
-    return yield* HttpEffect.appendPreResponseHandler((request, response) =>
-      Effect.sync(() => {
-        // The response is sent before disposeMiddleware performs the teardown.
-        disposeAfterResponse.set(request.source, marked)
-        return response
-      }),
-    )
-  })
-
-export const markInstanceForReload = (ctx: InstanceContext, next: InstanceStore.LoadInput) =>
-  Effect.gen(function* () {
-    const marked = yield* mark(ctx)
-    return yield* HttpEffect.appendPreResponseHandler((_request, response) =>
-      Effect.as(Effect.uninterruptible(marked.bridge.run(marked.store.reload(next))), response),
-    )
-  })
-
-export const disposeMiddleware: HttpMiddleware.HttpMiddleware = (effect) =>
-  Effect.gen(function* () {
-    const response = yield* effect
-    const request = yield* HttpServerRequest.HttpServerRequest
-    const marked = disposeAfterResponse.get(request.source)
-    if (!marked) return response
-    disposeAfterResponse.delete(request.source)
-    yield* Effect.uninterruptible(marked.bridge.run(marked.store.dispose(marked.ctx))).pipe(
-      Effect.catchCause((cause) => Effect.logWarning("instance disposal failed", { cause })),
-    )
-    return response
+    const store = yield* InstanceStore.Service
+    const bridge = yield* EffectBridge.make()
+    yield* Effect.uninterruptible(bridge.run(store.reload({ ...next, directory: ctx.directory })))
   })

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -1,4 +1,4 @@
-import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { WorkspaceRef } from "@/effect/instance-ref"
 import { InstanceStore } from "@/project/instance-store"
 import { Effect, Layer } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
@@ -26,10 +26,9 @@ function provideInstanceContext<E>(
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
-    return yield* effect.pipe(
-      Effect.provideService(InstanceRef, ctx),
-      Effect.provideService(WorkspaceRef, route.workspaceID),
+    return yield* store.provide(
+      { directory: decode(route.directory) },
+      effect.pipe(Effect.provideService(WorkspaceRef, route.workspaceID)),
     )
   })
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -108,13 +108,13 @@ import { schemaErrorLayer as v2SchemaErrorLayer } from "@opencode-ai/server/midd
 import { workspaceHandlers } from "./handlers/workspace"
 import { instanceContextLayer } from "./middleware/instance-context"
 import { workspaceRoutingLayer } from "./middleware/workspace-routing"
-import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { compressionLayer } from "./middleware/compression"
 import { corsVaryFix } from "./middleware/cors-vary"
 import { errorLayer } from "./middleware/error"
 import { fenceLayer } from "./middleware/fence"
 import { schemaErrorLayer } from "./middleware/schema-error"
+import { InstanceEviction } from "@/server/instance-eviction"
 
 export const context = Context.makeUnsafe<unknown>(new Map())
 
@@ -279,6 +279,7 @@ export function createRoutes(
     ptyConnectApiRoutes,
     instanceRoutes,
     serverRoutes,
+    InstanceEviction.layer,
     docRoute,
     uiRoute,
   ).pipe(
@@ -318,7 +319,6 @@ export const webHandler = lazy(() =>
   HttpRouter.toWebHandler(routes, {
     disableLogger: true,
     memoMap,
-    middleware: disposeMiddleware,
   }),
 )
 

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -8,7 +8,6 @@ import { OpenApi } from "effect/unstable/httpapi"
 import { createServer } from "node:http"
 import { MDNS } from "./mdns"
 import { HttpApiApp } from "./routes/instance/httpapi/server"
-import { disposeMiddleware } from "./routes/instance/httpapi/lifecycle"
 import { WebSocketTracker } from "./routes/instance/httpapi/websocket-tracker"
 import { PublicApi } from "./routes/instance/httpapi/public"
 import type { CorsOptions } from "@opencode-ai/server/cors"
@@ -99,7 +98,6 @@ const listenEffect: (opts: ListenOptions) => Effect.Effect<EffectListener, unkno
 
 function listenerLayer(opts: ListenOptions, port: number) {
   return HttpRouter.serve(HttpApiApp.createRoutes(opts), {
-    middleware: disposeMiddleware,
     disableLogger: true,
     disableListenLog: true,
   }).pipe(

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -7,8 +7,10 @@ import { Effect, Latch, Layer, Scope, Context } from "effect"
 import { Session } from "./session"
 import { SessionID } from "./schema"
 import { SessionStatus } from "./status"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
 
 export interface Interface {
+  readonly isActive: () => Effect.Effect<boolean>
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly ensureRunning: (
@@ -74,6 +76,11 @@ const layer = Layer.effect(
       if (existing?.busy) yield* busyError(sessionID)
     })
 
+    const isActive = Effect.fn("SessionRunState.isActive")(function* () {
+      const data = yield* InstanceState.get(state)
+      return Array.from(data.runners.values()).some((item) => item.busy)
+    })
+
     const cancel = Effect.fn("SessionRunState.cancel")(function* (sessionID: SessionID) {
       yield* cancelBackgroundJobs(background, sessionID)
       const data = yield* InstanceState.get(state)
@@ -90,7 +97,12 @@ const layer = Layer.effect(
       onInterrupt: Effect.Effect<SessionV1.WithParts>,
       work: Effect.Effect<SessionV1.WithParts>,
     ) {
-      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(work)
+      const activity = InstanceActivity.identify(yield* InstanceState.directory)
+      const tracked = Effect.sync(() => InstanceActivity.touch(activity)).pipe(
+        Effect.andThen(work),
+        Effect.ensuring(Effect.sync(() => InstanceActivity.touch(activity))),
+      )
+      return yield* (yield* runner(sessionID, onInterrupt)).ensureRunning(tracked)
     })
 
     const startShell = Effect.fn("SessionRunState.startShell")(function* (
@@ -99,12 +111,17 @@ const layer = Layer.effect(
       work: Effect.Effect<SessionV1.WithParts>,
       ready?: Latch.Latch,
     ) {
+      const activity = InstanceActivity.identify(yield* InstanceState.directory)
+      const tracked = Effect.sync(() => InstanceActivity.touch(activity)).pipe(
+        Effect.andThen(work),
+        Effect.ensuring(Effect.sync(() => InstanceActivity.touch(activity))),
+      )
       return yield* (yield* runner(sessionID, onInterrupt))
-        .startShell(work, ready)
+        .startShell(tracked, ready)
         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ isActive, assertNotBusy, cancel, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -4,6 +4,7 @@ import { SessionID } from "./schema"
 import { Effect, Layer, Context } from "effect"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionStatusEvent } from "@opencode-ai/schema/session-status-event"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
 
 export const Info = SessionStatusEvent.Info
 export type Info = SessionStatusEvent.Info
@@ -37,6 +38,8 @@ const layer = Layer.effect(
     })
 
     const set = Effect.fn("SessionStatus.set")(function* (sessionID: SessionID, status: Info) {
+      const activity = InstanceActivity.identify(yield* InstanceState.directory)
+      InstanceActivity.touch(activity)
       const data = yield* InstanceState.get(state)
       yield* events.publish(Event.Status, { sessionID, status })
       if (status.type === "idle") {

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -312,6 +312,49 @@ describe("RuntimeFlags", () => {
     )
   }
 
+  for (const input of [
+    { name: "absent", config: {}, expected: undefined, warns: false },
+    {
+      name: "minimum",
+      config: { OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: "3600000" },
+      expected: 3_600_000,
+      warns: false,
+    },
+    {
+      name: "above minimum",
+      config: { OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: "7200000" },
+      expected: 7_200_000,
+      warns: false,
+    },
+    {
+      name: "below minimum",
+      config: { OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: "3599999" },
+      expected: undefined,
+      warns: true,
+    },
+    {
+      name: "invalid string",
+      config: { OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: "nope" },
+      expected: undefined,
+      warns: true,
+    },
+    {
+      name: "non-integer",
+      config: { OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: "3600000.5" },
+      expected: undefined,
+      warns: true,
+    },
+  ]) {
+    it.effect(`parses instanceIdleTimeoutMs from config: ${input.name}`, () =>
+      Effect.gen(function* () {
+        const flags = yield* readFlags.pipe(Effect.provide(fromConfig(input.config)))
+
+        expect(flags.instanceIdleTimeoutMs).toBe(input.expected)
+        expect(flags.instanceIdleTimeoutWarning !== undefined).toBe(input.warns)
+      }),
+    )
+  }
+
   it.effect("layer ignores the active ConfigProvider for omitted test overrides", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
@@ -344,6 +387,7 @@ describe("RuntimeFlags", () => {
       expect(flags.experimentalOxfmt).toBe(false)
       expect(flags.outputTokenMax).toBeUndefined()
       expect(flags.bashDefaultTimeoutMs).toBeUndefined()
+      expect(flags.instanceIdleTimeoutMs).toBeUndefined()
       expect(flags.client).toBe("cli")
     }),
   )

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
+import { PtyActivity } from "@opencode-ai/core/pty/activity"
 import { Deferred, Effect, Fiber, Layer } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { mkdir, rename, symlink, unlink } from "fs/promises"
+import { join } from "path"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { registerDisposer } from "../../src/effect/instance-registry"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
@@ -166,6 +171,521 @@ describe("InstanceStore", () => {
     }),
   )
 
+  it.live("serializes concurrent reloads", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const disposing = yield* Deferred.make<void>()
+      const releaseDispose = yield* Deferred.make<() => void>()
+      let disposed = 0
+      yield* registerDisposerScoped(() => {
+        disposed++
+        if (disposed !== 1) return Promise.resolve()
+        Deferred.doneUnsafe(disposing, Effect.void)
+        return new Promise<void>((resolve) => Deferred.doneUnsafe(releaseDispose, Effect.succeed(resolve)))
+      })
+
+      const first = yield* store.load({ directory: dir })
+      const reloadA = yield* store.reload({ directory: dir }).pipe(Effect.forkScoped)
+      yield* Deferred.await(disposing)
+      const reloadB = yield* store.reload({ directory: dir }).pipe(Effect.forkScoped)
+
+      const finishDispose = yield* Deferred.await(releaseDispose)
+      yield* Effect.sync(finishDispose)
+      const [second, third] = yield* Effect.all([Fiber.join(reloadA), Fiber.join(reloadB)])
+
+      expect(second).not.toBe(first)
+      expect(third).not.toBe(second)
+      expect(yield* store.load({ directory: dir })).toBe(third)
+      expect(disposed).toBe(2)
+    }),
+  )
+
+  it.effect("keeps an active lease and touches its last-used time on release", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const acquired = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const disposed: Array<string> = []
+      yield* registerDisposerScoped(async (directory) => {
+        disposed.push(directory)
+      })
+
+      yield* TestClock.setTime(0)
+      yield* store.load({ directory: dir })
+      yield* TestClock.setTime(100)
+      const lease = yield* store
+        .provide(
+          { directory: dir },
+          Deferred.succeed(acquired, undefined).pipe(Effect.andThen(Deferred.await(release))),
+        )
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(acquired)
+
+      yield* TestClock.setTime(200)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 0, canDispose: () => Effect.succeed(true) })).toBe(0)
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(lease)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+
+      yield* TestClock.setTime(251)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(1)
+      expect(disposed).toEqual([dir])
+    }),
+  )
+
+  it.live("waits for unrelated leases before reload", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const leased = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+
+      const first = yield* store.load({ directory: dir })
+      const lease = yield* store
+        .provide({ directory: dir }, Deferred.succeed(leased, undefined).pipe(Effect.andThen(Deferred.await(release))))
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(leased)
+      const reload = yield* store.reload({ directory: dir }).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+      expect(disposed).toBe(0)
+      expect(yield* store.load({ directory: dir })).toBe(first)
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(lease)
+      const second = yield* Fiber.join(reload)
+      expect(second).not.toBe(first)
+      expect(disposed).toBe(1)
+    }),
+  )
+
+  it.live("waits for unrelated leases before dispose", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const leased = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+
+      const first = yield* store.load({ directory: dir })
+      const lease = yield* store
+        .provide({ directory: dir }, Deferred.succeed(leased, undefined).pipe(Effect.andThen(Deferred.await(release))))
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(leased)
+      const dispose = yield* store.dispose(first).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+      expect(disposed).toBe(0)
+      expect(yield* store.load({ directory: dir })).toBe(first)
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(lease)
+      yield* Fiber.join(dispose)
+      expect(disposed).toBe(1)
+      expect(yield* store.load({ directory: dir })).not.toBe(first)
+    }),
+  )
+
+  it.effect("starts a new idle epoch after blocking activity completes", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      let active = true
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+
+      yield* TestClock.setTime(0)
+      yield* store.load({ directory: dir })
+      yield* TestClock.setTime(100)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(!active) })).toBe(0)
+
+      // The activity outlives the original idle timeout. Its first observed idle
+      // sweep starts a fresh epoch instead of immediately disposing the instance.
+      yield* TestClock.setTime(10_000)
+      active = false
+      InstanceActivity.touch(InstanceActivity.identify(dir))
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(!active) })).toBe(0)
+      yield* TestClock.setTime(10_049)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(!active) })).toBe(0)
+      yield* TestClock.setTime(10_050)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(!active) })).toBe(1)
+      expect(disposed).toBe(1)
+    }),
+  )
+
+  it.effect("retains activity entirely between sweeps for a full timeout", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+
+      yield* TestClock.setTime(0)
+      yield* store.load({ directory: dir })
+      yield* TestClock.setTime(100)
+      const activity = InstanceActivity.identify(dir)
+      InstanceActivity.touch(activity)
+      InstanceActivity.touch(activity)
+
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+      yield* TestClock.setTime(149)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+      yield* TestClock.setTime(150)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(1)
+    }),
+  )
+
+  it.effect("atomically rejects eviction when a PTY starts while policy checks are paused", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const checking = yield* Deferred.make<void>()
+      const resume = yield* Deferred.make<void>()
+
+      yield* TestClock.setTime(0)
+      const first = yield* store.load({ directory: dir })
+      const activity = PtyActivity.identify(first.directory)
+      yield* TestClock.setTime(100)
+      const sweep = yield* store
+        .sweepIdle({
+          idleTimeoutMs: 50,
+          canDispose: () =>
+            Deferred.succeed(checking, undefined).pipe(Effect.andThen(Deferred.await(resume)), Effect.as(true)),
+        })
+        .pipe(Effect.forkScoped)
+
+      yield* Deferred.await(checking)
+      PtyActivity.started(activity)
+      yield* Deferred.succeed(resume, undefined)
+      expect(yield* Fiber.join(sweep)).toBe(0)
+      expect(yield* store.load({ directory: dir })).toBe(first)
+      PtyActivity.stopped(activity)
+    }),
+  )
+
+  it.effect("keeps entry activity stable when its pathname is replaced", () =>
+    Effect.gen(function* () {
+      const root = yield* tmpdirScoped({ git: true })
+      const owner = join(root, "owner")
+      const moved = join(root, "moved")
+      const replacement = join(root, "replacement")
+      yield* Effect.promise(() => Promise.all([mkdir(owner), mkdir(replacement)]))
+      const store = yield* InstanceStore.Service
+
+      yield* TestClock.setTime(0)
+      const ctx = yield* store.load({ directory: owner })
+      const activity = PtyActivity.identify(ctx.directory)
+      PtyActivity.started(activity)
+
+      yield* Effect.promise(async () => {
+        await rename(owner, moved)
+        await symlink(replacement, owner, "dir")
+      })
+      yield* TestClock.setTime(100)
+      expect(PtyActivity.hasRunning(owner)).toBe(true)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+      expect(yield* store.load({ directory: owner })).toBe(ctx)
+
+      PtyActivity.stopped(activity)
+      expect(PtyActivity.hasRunning(owner)).toBe(false)
+      expect(InstanceActivity.snapshot(activity).runningPtys).toBe(0)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+      yield* TestClock.setTime(151)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(0)
+      yield* TestClock.setTime(202)
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 50, canDispose: () => Effect.succeed(true) })).toBe(1)
+    }),
+  )
+
+  it.effect("keeps a remembered symlink alias stable for the entry lifetime", () =>
+    Effect.gen(function* () {
+      const root = yield* tmpdirScoped({ git: true })
+      const target = join(root, "target")
+      const replacement = join(root, "replacement")
+      const alias = join(root, "alias")
+      yield* Effect.promise(async () => {
+        await Promise.all([mkdir(target), mkdir(replacement)])
+        await symlink(target, alias, "dir")
+      })
+      const store = yield* InstanceStore.Service
+
+      const ctx = yield* store.load({ directory: alias })
+      const activity = PtyActivity.identify(ctx.directory)
+      PtyActivity.started(activity)
+      yield* Effect.promise(async () => {
+        await unlink(alias)
+        await symlink(replacement, alias, "dir")
+      })
+
+      expect(yield* store.load({ directory: alias })).toBe(ctx)
+      expect(PtyActivity.hasRunning(ctx.directory)).toBe(true)
+      PtyActivity.stopped(activity)
+      expect(InstanceActivity.snapshot(activity).runningPtys).toBe(0)
+
+      yield* store.dispose(ctx)
+      const next = yield* store.load({ directory: alias })
+      expect(next).not.toBe(ctx)
+      expect(next.directory).toBe(replacement)
+    }),
+  )
+
+  it.live("keeps waiting alias loads on the frozen key across tombstone cleanup", () =>
+    Effect.gen(function* () {
+      const root = yield* tmpdirScoped({ git: true })
+      const canonical = join(root, "canonical")
+      const replacement = join(root, "replacement")
+      const alias = join(root, "alias")
+      yield* Effect.promise(async () => {
+        await Promise.all([mkdir(canonical), mkdir(replacement)])
+        await symlink(canonical, alias, "dir")
+      })
+      const store = yield* InstanceStore.Service
+      const disposing = yield* Deferred.make<void>()
+      const releaseDispose = yield* Deferred.make<() => void>()
+      let disposed = 0
+      yield* registerDisposerScoped(() => {
+        disposed++
+        if (disposed !== 1) return Promise.resolve()
+        Deferred.doneUnsafe(disposing, Effect.void)
+        return new Promise<void>((resolve) => Deferred.doneUnsafe(releaseDispose, Effect.succeed(resolve)))
+      })
+
+      const first = yield* store.load({ directory: alias })
+      const dispose = yield* store.dispose(first).pipe(Effect.forkScoped)
+      yield* Deferred.await(disposing)
+
+      const waitingA = yield* store.load({ directory: alias }).pipe(Effect.forkScoped)
+      const waitingB = yield* store.load({ directory: alias }).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+      yield* Effect.promise(async () => {
+        await unlink(alias)
+        await symlink(replacement, alias, "dir")
+      })
+
+      const finishDispose = yield* Deferred.await(releaseDispose)
+      yield* Effect.sync(finishDispose)
+      yield* Fiber.join(dispose)
+      const [secondA, secondB] = yield* Effect.all([Fiber.join(waitingA), Fiber.join(waitingB)])
+      const subsequent = yield* store.load({ directory: alias })
+
+      expect(secondA).not.toBe(first)
+      expect(secondB).toBe(secondA)
+      expect(subsequent).toBe(secondA)
+      expect(secondA.directory).toBe(canonical)
+
+      yield* store.dispose(secondA)
+      const afterCleanup = yield* store.load({ directory: alias })
+      expect(afterCleanup).not.toBe(secondA)
+      expect(afterCleanup.directory).toBe(replacement)
+      expect(disposed).toBe(2)
+    }),
+  )
+
+  it.live("releases an interrupted alias reservation", () =>
+    Effect.gen(function* () {
+      const root = yield* tmpdirScoped({ git: true })
+      const canonical = join(root, "canonical")
+      const replacement = join(root, "replacement")
+      const alias = join(root, "alias")
+      yield* Effect.promise(async () => {
+        await Promise.all([mkdir(canonical), mkdir(replacement)])
+        await symlink(canonical, alias, "dir")
+      })
+      const store = yield* InstanceStore.Service
+      const disposing = yield* Deferred.make<void>()
+      const releaseDispose = yield* Deferred.make<() => void>()
+      let disposed = 0
+      yield* registerDisposerScoped(() => {
+        disposed++
+        if (disposed !== 1) return Promise.resolve()
+        Deferred.doneUnsafe(disposing, Effect.void)
+        return new Promise<void>((resolve) => Deferred.doneUnsafe(releaseDispose, Effect.succeed(resolve)))
+      })
+
+      const first = yield* store.load({ directory: alias })
+      const dispose = yield* store.dispose(first).pipe(Effect.forkScoped)
+      yield* Deferred.await(disposing)
+      const waiting = yield* store.load({ directory: alias }).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+      yield* Effect.promise(async () => {
+        await unlink(alias)
+        await symlink(replacement, alias, "dir")
+      })
+      yield* Fiber.interrupt(waiting)
+
+      const finishDispose = yield* Deferred.await(releaseDispose)
+      yield* Effect.sync(finishDispose)
+      yield* Fiber.join(dispose)
+      const next = yield* store.load({ directory: alias })
+      expect(next.directory).toBe(replacement)
+      expect(disposed).toBe(1)
+    }),
+  )
+
+  it.effect("releases a lease when its effect is interrupted", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const acquired = yield* Deferred.make<void>()
+      const disposed: Array<string> = []
+      yield* registerDisposerScoped(async (directory) => {
+        disposed.push(directory)
+      })
+
+      const lease = yield* store
+        .provide({ directory: dir }, Deferred.succeed(acquired, undefined).pipe(Effect.andThen(Effect.never)))
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(acquired)
+      yield* Fiber.interrupt(lease)
+
+      expect(yield* store.sweepIdle({ idleTimeoutMs: 0, canDispose: () => Effect.succeed(true) })).toBe(1)
+      expect(disposed).toEqual([dir])
+    }),
+  )
+
+  it.effect("retains a candidate touched while its activity check is in flight", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const checking = yield* Deferred.make<void>()
+      const releaseCheck = yield* Deferred.make<void>()
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+
+      yield* TestClock.setTime(0)
+      const first = yield* store.load({ directory: dir })
+      yield* TestClock.setTime(100)
+      const sweep = yield* store
+        .sweepIdle({
+          idleTimeoutMs: 50,
+          canDispose: () =>
+            Deferred.succeed(checking, undefined).pipe(Effect.andThen(Deferred.await(releaseCheck)), Effect.as(true)),
+        })
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(checking)
+
+      expect(yield* store.load({ directory: dir })).toBe(first)
+      yield* Deferred.succeed(releaseCheck, undefined)
+      expect(yield* Fiber.join(sweep)).toBe(0)
+      expect(disposed).toBe(0)
+    }),
+  )
+
+  it.effect("retains a candidate leased while its activity check is in flight", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const checking = yield* Deferred.make<void>()
+      const releaseCheck = yield* Deferred.make<void>()
+      const leased = yield* Deferred.make<void>()
+      const releaseLease = yield* Deferred.make<void>()
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+
+      yield* TestClock.setTime(0)
+      yield* store.load({ directory: dir })
+      yield* TestClock.setTime(100)
+      const sweep = yield* store
+        .sweepIdle({
+          idleTimeoutMs: 50,
+          canDispose: () =>
+            Deferred.succeed(checking, undefined).pipe(Effect.andThen(Deferred.await(releaseCheck)), Effect.as(true)),
+        })
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(checking)
+      const lease = yield* store
+        .provide(
+          { directory: dir },
+          Deferred.succeed(leased, undefined).pipe(Effect.andThen(Deferred.await(releaseLease))),
+        )
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(leased)
+
+      yield* Deferred.succeed(releaseCheck, undefined)
+      expect(yield* Fiber.join(sweep)).toBe(0)
+      expect(disposed).toBe(0)
+      yield* Deferred.succeed(releaseLease, undefined)
+      yield* Fiber.join(lease)
+    }),
+  )
+
+  it.live("waits for disposal before loading a fresh context", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const disposing = yield* Deferred.make<void>()
+      const releaseDispose = yield* Deferred.make<() => void>()
+      let loaded = false
+      yield* registerDisposerScoped(() => {
+        Deferred.doneUnsafe(disposing, Effect.void)
+        return new Promise<void>((resolve) => Deferred.doneUnsafe(releaseDispose, Effect.succeed(resolve)))
+      })
+
+      const first = yield* store.load({ directory: dir })
+      const dispose = yield* store.dispose(first).pipe(Effect.forkScoped)
+      yield* Deferred.await(disposing)
+      const load = yield* store.load({ directory: dir }).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            loaded = true
+          }),
+        ),
+        Effect.forkScoped,
+      )
+      yield* Effect.yieldNow
+      expect(loaded).toBe(false)
+
+      const finishDispose = yield* Deferred.await(releaseDispose)
+      yield* Effect.sync(finishDispose)
+      yield* Fiber.join(dispose)
+      const second = yield* Fiber.join(load)
+      expect(second).not.toBe(first)
+      expect(yield* store.load({ directory: dir })).toBe(second)
+    }),
+  )
+
+  it.live("dedupes concurrent idle sweeps", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const disposing = yield* Deferred.make<void>()
+      const releaseDispose = yield* Deferred.make<() => void>()
+      let disposed = 0
+      yield* registerDisposerScoped(() => {
+        disposed++
+        Deferred.doneUnsafe(disposing, Effect.void)
+        return new Promise<void>((resolve) => Deferred.doneUnsafe(releaseDispose, Effect.succeed(resolve)))
+      })
+
+      yield* store.load({ directory: dir })
+      const first = yield* store
+        .sweepIdle({ idleTimeoutMs: 0, canDispose: () => Effect.succeed(true) })
+        .pipe(Effect.forkScoped)
+      yield* Deferred.await(disposing)
+      const second = yield* store
+        .sweepIdle({ idleTimeoutMs: 0, canDispose: () => Effect.succeed(true) })
+        .pipe(Effect.forkScoped)
+
+      const finishDispose = yield* Deferred.await(releaseDispose)
+      yield* Effect.sync(finishDispose)
+      expect(yield* Fiber.join(first)).toBe(1)
+      expect(yield* Fiber.join(second)).toBe(0)
+      expect(disposed).toBe(1)
+    }),
+  )
+
   it.live("stale dispose does not delete an in-flight reload", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped({ git: true })
@@ -223,6 +743,38 @@ describe("InstanceStore", () => {
       yield* Effect.sync(release)
       yield* Effect.all([Fiber.join(first), Fiber.join(second)])
       expect(disposed).toEqual([dir])
+    }),
+  )
+
+  it.live("releases every self-lease before sharing concurrent disposeAll", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const readyA = yield* Deferred.make<void>()
+      const readyB = yield* Deferred.make<void>()
+      const go = yield* Deferred.make<void>()
+      let disposed = 0
+      yield* registerDisposerScoped(async () => {
+        disposed++
+      })
+      yield* store.load({ directory: dir })
+
+      const caller = (ready: Deferred.Deferred<void>) =>
+        store.provide(
+          { directory: dir },
+          Deferred.succeed(ready, undefined).pipe(
+            Effect.andThen(Deferred.await(go)),
+            Effect.andThen(store.disposeAll()),
+          ),
+        )
+      const first = yield* caller(readyA).pipe(Effect.forkScoped)
+      const second = yield* caller(readyB).pipe(Effect.forkScoped)
+
+      yield* Deferred.await(readyA)
+      yield* Deferred.await(readyB)
+      yield* Deferred.succeed(go, undefined)
+      yield* Effect.all([Fiber.join(first), Fiber.join(second)])
+      expect(disposed).toBe(1)
     }),
   )
 

--- a/packages/opencode/test/server/httpapi-instance-context.test.ts
+++ b/packages/opencode/test/server/httpapi-instance-context.test.ts
@@ -13,7 +13,7 @@ import { Workspace } from "../../src/control-plane/workspace"
 import { InstanceRef, WorkspaceRef } from "../../src/effect/instance-ref"
 import { Project } from "../../src/project/project"
 import { Session } from "../../src/session/session"
-import { disposeMiddleware, markInstanceForDisposal } from "../../src/server/routes/instance/httpapi/lifecycle"
+import { disposeInstance } from "../../src/server/routes/instance/httpapi/lifecycle"
 import {
   InstanceContextMiddleware,
   instanceContextLayer,
@@ -118,7 +118,7 @@ const probeHandlers = HttpApiBuilder.group(ProbeApi, "probe", (handlers) =>
       Effect.fn("InstanceContextProbe.dispose")(function* () {
         const instance = yield* InstanceRef
         if (!instance) return false
-        yield* markInstanceForDisposal(instance)
+        yield* disposeInstance(instance)
         return true
       }),
     ),
@@ -138,9 +138,7 @@ const waitDisposedEvent = waitGlobalBusEvent({
 }).pipe(Effect.map((event) => ({ directory: event.directory, workspace: event.workspace })))
 
 const serveDisposeProbe = () =>
-  HttpRouter.serve(probeRoutes, { middleware: disposeMiddleware, disableListenLog: true, disableLogger: true }).pipe(
-    Layer.build,
-  )
+  HttpRouter.serve(probeRoutes, { disableListenLog: true, disableLogger: true }).pipe(Layer.build)
 
 describe("HttpApi instance context middleware", () => {
   it.live("provides instance context from the routed directory", () =>

--- a/packages/opencode/test/server/instance-eviction.test.ts
+++ b/packages/opencode/test/server/instance-eviction.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect } from "bun:test"
+import { BackgroundJob } from "@/background/job"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import type { InstanceContext } from "@/project/instance-context"
+import { InstanceStore } from "@/project/instance-store"
+import { InstanceEviction } from "@/server/instance-eviction"
+import { SessionRunState } from "@/session/run-state"
+import { SessionID } from "@/session/schema"
+import { SessionStatus } from "@/session/status"
+import { PtyActivity } from "@opencode-ai/core/pty/activity"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { Effect, Exit, Layer, Logger, Scope } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { it as base, testEffect } from "../lib/effect"
+
+const ctx: InstanceContext = {
+  directory: "/tmp/instance-eviction-test",
+  worktree: "/tmp/instance-eviction-test",
+  project: {
+    id: ProjectV2.ID.global,
+    worktree: "/tmp/instance-eviction-test",
+    time: { created: 0, updated: 0 },
+    sandboxes: [],
+  },
+}
+const ptyIdentity = PtyActivity.identify(ctx.directory)
+
+const activity = (input?: {
+  runner?: boolean
+  status?: SessionStatus.Info
+  job?: BackgroundJob.Status
+}): InstanceEviction.ActivityServices => ({
+  runners: {
+    isActive: () => Effect.succeed(input?.runner ?? false),
+    assertNotBusy: () => Effect.void,
+    cancel: () => Effect.void,
+    ensureRunning: (_sessionID, _onInterrupt, work) => work,
+    startShell: (_sessionID, _onInterrupt, work) => work,
+  },
+  statuses: {
+    get: () => Effect.succeed(input?.status ?? { type: "idle" }),
+    list: () =>
+      Effect.succeed(
+        input?.status
+          ? new Map([[SessionID.make("ses_test"), input.status]])
+          : new Map<SessionID, SessionStatus.Info>(),
+      ),
+    set: () => Effect.void,
+  },
+  background: {
+    list: () =>
+      Effect.succeed(
+        input?.job
+          ? [
+              {
+                id: "job_test",
+                type: "test",
+                status: input.job,
+                started_at: 0,
+              },
+            ]
+          : [],
+      ),
+    get: () => Effect.die("unused"),
+    start: () => Effect.die("unused"),
+    extend: () => Effect.die("unused"),
+    wait: () => Effect.die("unused"),
+    waitForPromotion: () => Effect.die("unused"),
+    promote: () => Effect.die("unused"),
+    cancel: () => Effect.die("unused"),
+  },
+})
+
+describe("InstanceEviction activity", () => {
+  base.effect("allows an inactive instance", () =>
+    Effect.gen(function* () {
+      expect(yield* InstanceEviction.canDispose(ctx, activity())).toBe(true)
+    }),
+  )
+
+  base.effect("blocks active runners", () =>
+    Effect.gen(function* () {
+      expect(yield* InstanceEviction.canDispose(ctx, activity({ runner: true }))).toBe(false)
+    }),
+  )
+
+  base.effect("blocks non-idle session status", () =>
+    Effect.gen(function* () {
+      expect(yield* InstanceEviction.canDispose(ctx, activity({ status: { type: "busy" } }))).toBe(false)
+    }),
+  )
+
+  base.effect("blocks running background jobs only", () =>
+    Effect.gen(function* () {
+      expect(yield* InstanceEviction.canDispose(ctx, activity({ job: "running" }))).toBe(false)
+      expect(yield* InstanceEviction.canDispose(ctx, activity({ job: "completed" }))).toBe(true)
+    }),
+  )
+
+  base.effect("blocks detached PTYs until every process exits", () =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        PtyActivity.started(ptyIdentity)
+        PtyActivity.started(ptyIdentity)
+      }),
+      () =>
+        Effect.gen(function* () {
+          expect(yield* InstanceEviction.canDispose(ctx, activity())).toBe(false)
+          PtyActivity.stopped(ptyIdentity)
+          expect(yield* InstanceEviction.canDispose(ctx, activity())).toBe(false)
+          PtyActivity.stopped(ptyIdentity)
+          expect(yield* InstanceEviction.canDispose(ctx, activity())).toBe(true)
+        }),
+      () =>
+        Effect.sync(() => {
+          PtyActivity.stopped(ptyIdentity)
+          PtyActivity.stopped(ptyIdentity)
+        }),
+    ),
+  )
+})
+
+describe("InstanceEviction schedule", () => {
+  let sweeps = 0
+  const store: InstanceStore.Interface = {
+    load: () => Effect.die("unused"),
+    reload: () => Effect.die("unused"),
+    dispose: () => Effect.die("unused"),
+    disposeDirectory: () => Effect.die("unused"),
+    disposeAll: () => Effect.die("unused"),
+    sweepIdle: () =>
+      Effect.sync(() => {
+        sweeps++
+        return 0
+      }),
+    provide: (_input, effect) => effect,
+  }
+  const services = activity()
+  const it = testEffect(
+    Layer.mergeAll(
+      RuntimeFlags.layer({ instanceIdleTimeoutMs: 3_600_000 }),
+      Layer.succeed(InstanceStore.Service, store),
+      Layer.succeed(SessionRunState.Service, services.runners),
+      Layer.succeed(SessionStatus.Service, services.statuses),
+      Layer.succeed(BackgroundJob.Service, services.background),
+    ),
+  )
+
+  const disabled = testEffect(
+    Layer.mergeAll(
+      RuntimeFlags.layer({ instanceIdleTimeoutMs: undefined }),
+      Layer.succeed(InstanceStore.Service, store),
+      Layer.succeed(SessionRunState.Service, services.runners),
+      Layer.succeed(SessionStatus.Service, services.statuses),
+      Layer.succeed(BackgroundJob.Service, services.background),
+    ),
+  )
+
+  const warning = "ignoring OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS: expected an integer of at least 3600000 ms"
+  const invalid = testEffect(
+    Layer.mergeAll(
+      RuntimeFlags.layer({ instanceIdleTimeoutMs: undefined, instanceIdleTimeoutWarning: warning }),
+      Layer.succeed(InstanceStore.Service, store),
+      Layer.succeed(SessionRunState.Service, services.runners),
+      Layer.succeed(SessionStatus.Service, services.statuses),
+      Layer.succeed(BackgroundJob.Service, services.background),
+    ),
+  )
+
+  invalid.effect("warns when an invalid timeout disables eviction", () => {
+    const messages: Array<unknown> = []
+    const logger = Logger.make((options) => messages.push(options.message))
+    return Layer.build(InstanceEviction.layer).pipe(
+      Effect.provide(Logger.layer([logger])),
+      Effect.tap(() => Effect.sync(() => expect(JSON.stringify(messages)).toContain(warning))),
+    )
+  })
+
+  disabled.effect("does not sweep when the timeout is unset", () =>
+    Effect.gen(function* () {
+      sweeps = 0
+      yield* Layer.build(InstanceEviction.layer)
+      yield* TestClock.adjust("5 minutes")
+      yield* Effect.yieldNow
+      expect(sweeps).toBe(0)
+    }),
+  )
+
+  it.effect("stops sweeping when its scope closes", () =>
+    Effect.gen(function* () {
+      sweeps = 0
+      const scope = yield* Scope.make()
+      yield* Layer.buildWithScope(InstanceEviction.layer, scope)
+      yield* Effect.yieldNow
+      expect(sweeps).toBe(1)
+
+      yield* TestClock.adjust(InstanceEviction.SWEEP_INTERVAL)
+      yield* Effect.yieldNow
+      expect(sweeps).toBe(2)
+
+      yield* Scope.close(scope, Exit.void)
+      yield* TestClock.adjust("5 minutes")
+      yield* Effect.yieldNow
+      expect(sweeps).toBe(2)
+    }),
+  )
+})

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -11,7 +11,7 @@ import { InstanceStore } from "../../src/project/instance-store"
 import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
 import { Snapshot } from "../../src/snapshot"
 import { resetDatabase } from "../fixture/db"
-import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { disposeAllInstances, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { httpApiLayer, requestInDirectory } from "./httpapi-layer"
 
@@ -53,13 +53,13 @@ const disposedEvents = (seen: GlobalEvent[], dir: string) =>
   seen.filter((evt) => evt.directory === dir && evt.payload.type === "server.instance.disposed").length
 
 describe("project.initGit endpoint", () => {
-  it.instance("initializes git and reloads immediately", () =>
+  it.effect("initializes git and reloads immediately", () =>
     Effect.gen(function* () {
-      const tmp = yield* TestInstance
+      const directory = yield* tmpdirScoped()
       const fs = yield* FSUtil.Service
       const events = yield* collectGlobalEvents()
 
-      const init = yield* request(tmp.directory, "/project/git/init", {
+      const init = yield* request(directory, "/project/git/init", {
         method: "POST",
       })
       const body = yield* json(init)
@@ -67,21 +67,21 @@ describe("project.initGit endpoint", () => {
       expect(body).toMatchObject({
         id: "global",
         vcs: "git",
-        worktree: tmp.directory,
+        worktree: directory,
       })
       // Reload behavior: bus emits exactly one server.instance.disposed for the directory.
-      expect(disposedEvents(events.seen, tmp.directory)).toBe(1)
-      expect(yield* fs.exists(path.join(tmp.directory, ".git", "opencode"))).toBe(false)
+      expect(disposedEvents(events.seen, directory)).toBe(1)
+      expect(yield* fs.exists(path.join(directory, ".git", "opencode"))).toBe(false)
 
-      const current = yield* request(tmp.directory, "/project/current")
+      const current = yield* request(directory, "/project/current")
       expect(current.status).toBe(200)
       expect(yield* json(current)).toMatchObject({
         id: "global",
         vcs: "git",
-        worktree: tmp.directory,
+        worktree: directory,
       })
 
-      const ctx = yield* InstanceStore.use.reload({ directory: tmp.directory })
+      const ctx = yield* InstanceStore.use.reload({ directory })
       const tracked = yield* Snapshot.Service.use((snapshot) => snapshot.track()).pipe(
         Effect.provideService(InstanceRef, ctx),
       )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -57,6 +57,8 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { InstanceActivity } from "@opencode-ai/core/instance-activity"
+import { InstanceState } from "@/effect/instance-state"
 
 const summary = Layer.succeed(
   SessionSummary.Service,
@@ -1468,30 +1470,71 @@ it.instance("prompt submitted during an active run is included in the next LLM i
   }),
 )
 
-it.instance("assertNotBusy fails with BusyError when loop running", () =>
+it.instance(
+  "assertNotBusy fails with BusyError when loop running",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const run = yield* SessionRunState.Service
+      const sessions = yield* Session.Service
+      const directory = yield* InstanceState.directory
+      const activity = InstanceActivity.identify(directory)
+      const before = InstanceActivity.snapshot(activity).generation
+      yield* llm.hang
+
+      const chat = yield* sessions.create({})
+      yield* user(chat.id, "hi")
+
+      const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+      yield* llm.wait(1)
+      yield* waitForBusy(chat.id)
+
+      expect(yield* run.isActive()).toBe(true)
+      const active = InstanceActivity.snapshot(activity).generation
+      expect(active).toBeGreaterThan(before)
+      const exit = yield* run.assertNotBusy(chat.id).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.squash(exit.cause)).toBeInstanceOf(Session.BusyError)
+        expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "SessionBusyError", sessionID: chat.id })
+      }
+
+      yield* prompt.cancel(chat.id)
+      yield* Fiber.await(fiber)
+      expect(yield* run.isActive()).toBe(false)
+      expect(InstanceActivity.snapshot(activity).generation).toBeGreaterThan(active)
+    }),
+  20_000,
+)
+
+noLLMServer.instance("records status and background activity epochs", () =>
   Effect.gen(function* () {
-    const { llm } = yield* useServerConfig(providerCfg)
-    const prompt = yield* SessionPrompt.Service
-    const run = yield* SessionRunState.Service
     const sessions = yield* Session.Service
-    yield* llm.hang
-
+    const statuses = yield* SessionStatus.Service
+    const background = yield* BackgroundJob.Service
+    const directory = yield* InstanceState.directory
     const chat = yield* sessions.create({})
-    yield* user(chat.id, "hi")
 
-    const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
-    yield* llm.wait(1)
-    yield* waitForBusy(chat.id)
+    const activity = InstanceActivity.identify(directory)
+    const beforeStatus = InstanceActivity.snapshot(activity).generation
+    yield* statuses.set(chat.id, { type: "busy" })
+    yield* statuses.set(chat.id, { type: "idle" })
+    const afterStatus = InstanceActivity.snapshot(activity).generation
+    expect(afterStatus).toBeGreaterThan(beforeStatus)
 
-    const exit = yield* run.assertNotBusy(chat.id).pipe(Effect.exit)
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      expect(Cause.squash(exit.cause)).toBeInstanceOf(Session.BusyError)
-      expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "SessionBusyError", sessionID: chat.id })
-    }
-
-    yield* prompt.cancel(chat.id)
-    yield* Fiber.await(fiber)
+    const started = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    const job = yield* background.start({
+      type: "test",
+      run: Deferred.succeed(started, undefined).pipe(Effect.andThen(Deferred.await(release)), Effect.as("done")),
+    })
+    yield* Deferred.await(started)
+    const afterStart = InstanceActivity.snapshot(activity).generation
+    expect(afterStart).toBeGreaterThan(afterStatus)
+    yield* Deferred.succeed(release, undefined)
+    yield* background.wait({ id: job.id })
+    expect(InstanceActivity.snapshot(activity).generation).toBeGreaterThan(afterStart)
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #33720

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode serve` keeps one runtime per directory forever, retaining its plugins, watchers, LSPs, MCPs, and database handles. This adds opt-in idle disposal through `OPENCODE_EXPERIMENTAL_INSTANCE_IDLE_TIMEOUT_MS` (minimum one hour; unset means disabled).

Activity leases and final busy-state checks prevent disposal during requests, session runs, background jobs, or PTYs. A disposing tombstone makes concurrent loads wait for cleanup instead of receiving a runtime that is being destroyed. Symlink aliases remain reserved while a waiter retries, preventing duplicate runtimes after retargeting.

This is deliberately timeout-based rather than entry-count LRU: an old directory may still contain active background work.

### How did you verify your code works?

Added deterministic tests for request leases, concurrent disposal/load, session/background/PTY activity, symlink retargeting, interrupted waiters, and disabled/invalid timeout settings. Ran the focused Core/OpenCode tests, both typechecks, lint/format checks, and a native Linux x64 build plus binary smoke test.

### Screenshots / recordings

N/A — server/runtime change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
