### PR TITLE
fix(server): preserve directory events across reloads

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -2,9 +2,10 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { GlobalBus } from "@/bus/global"
 import { EventV2 } from "@opencode-ai/core/event"
+import { NodeHttpServerRequest } from "@effect/platform-node"
 import { Effect, Queue } from "effect"
 import * as Stream from "effect/Stream"
-import { HttpServerResponse } from "effect/unstable/http"
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import * as Sse from "effect/unstable/encoding/Sse"
 import { EventApi } from "../groups/event"
@@ -26,49 +27,82 @@ function eventResponse(events: EventV2.Interface) {
   return Effect.gen(function* () {
     const instance = yield* InstanceState.context
     const workspaceID = yield* InstanceState.workspaceID
-    // Listener registration is eager, so events published after this point cannot
-    // be lost while the HTTP body fiber is starting or emitting server.connected.
-    const queue = yield* Queue.unbounded<EventV2.Payload>()
-    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
-    yield* Effect.addFinalizer(() => unsubscribe)
-    const stream = Stream.fromQueue(queue).pipe(
-      Stream.filter(
-        (event) =>
-          event.location?.directory === instance.directory &&
-          (event.location.workspaceID === undefined || event.location.workspaceID === workspaceID),
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const output = Stream.scoped(
+      Stream.unwrap(
+        Effect.gen(function* () {
+          // Acquire both subscriptions in the response body's scope before its
+          // first server.connected element. Disconnecting the body releases them.
+          const queue = yield* Queue.unbounded<EventV2.Payload>()
+          const disposedQueue = yield* Queue.unbounded<{ id: string; type: string; properties: unknown }>()
+          const disconnectedQueue = yield* Queue.unbounded<void>()
+          const listener = (event: {
+            directory?: string
+            payload: { id?: string; type?: string; properties?: unknown }
+          }) => {
+            if (event.directory !== instance.directory || event.payload.type !== "server.instance.disposed") return
+            Queue.offerUnsafe(disposedQueue, {
+              id: event.payload.id ?? eventID(),
+              type: "server.instance.disposed",
+              properties: event.payload.properties ?? {},
+            })
+          }
+          yield* Effect.acquireRelease(
+            Effect.gen(function* () {
+              const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
+              GlobalBus.on("event", listener)
+              // The listening server is Node-backed, while the in-process web
+              // handler has a Web Request source and relies on stream release.
+              const socket: ReturnType<typeof NodeHttpServerRequest.toIncomingMessage>["socket"] | undefined =
+                NodeHttpServerRequest.toIncomingMessage(request)?.socket
+              let closed = false
+              const onClose = () => {
+                if (closed) return
+                closed = true
+                GlobalBus.off("event", listener)
+                Queue.offerUnsafe(disconnectedQueue, undefined)
+              }
+              socket?.once("close", onClose)
+              if (socket?.destroyed) onClose()
+              return { unsubscribe, socket, onClose }
+            }),
+            ({ unsubscribe, socket, onClose }) =>
+              Effect.gen(function* () {
+                socket?.off("close", onClose)
+                GlobalBus.off("event", listener)
+                yield* unsubscribe
+              }),
+          )
+
+          const stream = Stream.fromQueue(queue).pipe(
+            Stream.filter(
+              (event) =>
+                event.location?.directory === instance.directory &&
+                (event.location.workspaceID === undefined || event.location.workspaceID === workspaceID),
+            ),
+            Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
+          )
+          const heartbeat = Stream.tick("10 seconds").pipe(
+            Stream.drop(1),
+            Stream.map(() => ({ id: eventID(), type: "server.heartbeat", properties: {} })),
+          )
+          const outputEvents = Stream.make({ id: eventID(), type: "server.connected", properties: {} }).pipe(
+            Stream.concat(
+              stream.pipe(
+                Stream.merge(Stream.fromQueue(disposedQueue), { haltStrategy: "left" }),
+                Stream.merge(heartbeat, { haltStrategy: "left" }),
+              ),
+            ),
+          )
+          const disconnected = Stream.fromQueue(disconnectedQueue).pipe(Stream.take(1), Stream.drain)
+          return outputEvents.pipe(Stream.merge(disconnected, { haltStrategy: "right" }))
+        }),
       ),
-      Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
-    )
-    const disposed = Stream.callback<{ id: string; type: string; properties: unknown }>((queue) => {
-      const listener = (event: {
-        directory?: string
-        payload: { id?: string; type?: string; properties?: unknown }
-      }) => {
-        if (event.directory !== instance.directory || event.payload.type !== "server.instance.disposed") return
-        Queue.offerUnsafe(queue, {
-          id: event.payload.id ?? eventID(),
-          type: "server.instance.disposed",
-          properties: event.payload.properties ?? {},
-        })
-      }
-      return Effect.acquireRelease(
-        Effect.sync(() => GlobalBus.on("event", listener)),
-        () => Effect.sync(() => GlobalBus.off("event", listener)),
-      )
-    })
-    const output = stream.pipe(
-      Stream.merge(disposed, { haltStrategy: "left" }),
-      Stream.takeUntil((event) => event.type === "server.instance.disposed"),
-    )
-    const heartbeat = Stream.tick("10 seconds").pipe(
-      Stream.drop(1),
-      Stream.map(() => ({ id: eventID(), type: "server.heartbeat", properties: {} })),
     )
 
     yield* Effect.logInfo("event connected")
     return HttpServerResponse.stream(
-      Stream.make({ id: eventID(), type: "server.connected", properties: {} }).pipe(
-        Stream.concat(output.pipe(Stream.merge(heartbeat, { haltStrategy: "left" }))),
+      output.pipe(
         Stream.map(eventData),
         Stream.pipeThroughChannel(Sse.encode()),
         Stream.encodeText,

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect } from "bun:test"
-import { Effect, Layer, Queue, Schema, Stream } from "effect"
+import { Effect, Queue, Schema, Stream } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import * as NodeHttp from "node:http"
+import { GlobalBus } from "../../src/bus/global"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
+import { InstanceStore } from "../../src/project/instance-store"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { pollWithTimeout, testEffect } from "../lib/effect"
 import { httpApiLayer, requestInDirectory } from "./httpapi-layer"
 
 const EventData = Schema.Struct({
@@ -23,6 +27,14 @@ const readEvent = (reader: Queue.Dequeue<Uint8Array>) =>
     return Schema.decodeUnknownSync(EventData)(JSON.parse(new TextDecoder().decode(value).replace(/^data: /, "")))
   })
 
+const readEventType = (reader: Queue.Dequeue<Uint8Array>, type: string) =>
+  Effect.gen(function* () {
+    while (true) {
+      const event = yield* readEvent(reader)
+      if (event.type === type) return event
+    }
+  })
+
 const openEventStream = (directory: string) =>
   Effect.gen(function* () {
     const response = yield* requestInDirectory(EventPaths.event, directory)
@@ -33,6 +45,72 @@ const openEventStream = (directory: string) =>
     )
     return { response, reader }
   })
+
+const openTcpEventStream = (url: string, directory: string) =>
+  Effect.acquireRelease(
+    Effect.promise(
+      () =>
+        new Promise<{
+          response: { status: number }
+          next: () => Promise<typeof EventData.Type>
+          close: () => Promise<void>
+        }>((resolve, reject) => {
+          const request = NodeHttp.get(url, {
+            headers: { "x-opencode-directory": directory },
+          })
+          request.once("error", reject)
+          request.once("response", (response) => {
+            let buffer = ""
+            let closed = false
+            const values: Array<typeof EventData.Type> = []
+            const waiters: Array<{
+              resolve: (event: typeof EventData.Type) => void
+              reject: (error: Error) => void
+            }> = []
+            const flush = () => {
+              while (true) {
+                const boundary = buffer.indexOf("\n\n")
+                if (boundary < 0) return
+                const raw = buffer.slice(0, boundary)
+                buffer = buffer.slice(boundary + 2)
+                const data = raw
+                  .split("\n")
+                  .find((line) => line.startsWith("data: "))
+                  ?.slice(6)
+                if (!data) continue
+                const event = Schema.decodeUnknownSync(EventData)(JSON.parse(data))
+                const waiter = waiters.shift()
+                if (waiter) waiter.resolve(event)
+                else values.push(event)
+              }
+            }
+            response.setEncoding("utf8")
+            response.on("data", (chunk: string) => {
+              buffer += chunk.replaceAll("\r\n", "\n")
+              flush()
+            })
+            response.once("error", (error) => {
+              while (waiters.length > 0) waiters.shift()!.reject(error)
+            })
+            const next = () => {
+              const value = values.shift()
+              if (value) return Promise.resolve(value)
+              return new Promise<typeof EventData.Type>((resolve, reject) => waiters.push({ resolve, reject }))
+            }
+            const close = async () => {
+              if (closed) return
+              closed = true
+              const done = new Promise<void>((resolve) => response.once("close", resolve))
+              response.destroy()
+              request.destroy()
+              await done
+            }
+            resolve({ response: { status: response.statusCode ?? 0 }, next, close })
+          })
+        }),
+    ),
+    (client) => Effect.promise(client.close),
+  )
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -57,6 +135,7 @@ describe("event HttpApi", () => {
         expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
       }),
     { git: true, config: { formatter: false, lsp: false } },
+    20_000,
   )
 
   it.instance(
@@ -75,6 +154,7 @@ describe("event HttpApi", () => {
         expect(status).toBe("open")
       }),
     { git: true, config: { formatter: false, lsp: false } },
+    20_000,
   )
 
   it.instance(
@@ -90,5 +170,67 @@ describe("event HttpApi", () => {
         expect(yield* readEvent(reader)).toMatchObject({ type: "session.created" })
       }),
     { git: true, config: { formatter: false, lsp: false } },
+    20_000,
+  )
+
+  it.instance(
+    "survives instance disposal and receives replacement events",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const store = yield* InstanceStore.Service
+        const { reader } = yield* openEventStream(directory)
+        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+
+        yield* store.reload({ directory })
+        expect(yield* readEventType(reader, "server.instance.disposed")).toMatchObject({
+          type: "server.instance.disposed",
+          properties: { directory },
+        })
+
+        const created = yield* requestInDirectory("/session", directory, { method: "POST" })
+        expect(created.status).toBe(200)
+        expect(yield* readEventType(reader, "session.created")).toMatchObject({ type: "session.created" })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+    20_000,
+  )
+
+  it.instance(
+    "releases subscriptions when a TCP client disconnects",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const store = yield* InstanceStore.Service
+        const server = yield* HttpServer.HttpServer
+        const baseline = GlobalBus.listenerCount("event")
+        const client = yield* openTcpEventStream(
+          new URL(EventPaths.event, HttpServer.formatAddress(server.address)).toString(),
+          directory,
+        )
+
+        expect(client.response.status).toBe(200)
+        expect(yield* Effect.promise(client.next)).toMatchObject({ type: "server.connected" })
+        expect(GlobalBus.listenerCount("event")).toBe(baseline + 1)
+
+        yield* store.reload({ directory })
+        expect(yield* Effect.promise(client.next)).toMatchObject({
+          type: "server.instance.disposed",
+          properties: { directory },
+        })
+        const created = yield* requestInDirectory("/session", directory, { method: "POST" })
+        expect(created.status).toBe(200)
+        let event = yield* Effect.promise(client.next)
+        while (event.type !== "session.created") event = yield* Effect.promise(client.next)
+
+        yield* Effect.promise(client.close)
+        yield* pollWithTimeout(
+          Effect.sync(() => (GlobalBus.listenerCount("event") === baseline ? true : undefined)),
+          "GlobalBus listener was retained after TCP disconnect",
+        )
+        expect(GlobalBus.listenerCount("event")).toBe(baseline)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+    20_000,
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #36495

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A directory-scoped `/event` stream currently ends when its instance is disposed, even though the subscription is keyed by the stable directory and the replacement instance emits to the same process-wide bus. This keeps the stream open across disposal/recreation while still forwarding `server.instance.disposed` as an informational event.

The bus subscriptions now live for the actual response-body lifetime and are removed when the client socket closes, avoiding a listener leak.

### How did you verify your code works?

Added regression tests showing that one connection receives the disposal event and later events from the replacement instance, and that a real Node/Bun socket disconnect returns the global listener count to baseline. The focused tests pass (5 tests), as does the OpenCode typecheck.

### Screenshots / recordings

N/A — server SSE behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
