### PR TITLE
fix(opencode): compare messages by time.created, not id, in latest()/runLoop

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -588,23 +588,32 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: Ses
 
 // filterCompacted reorders messages for model consumption
 // ([compaction-user, summary, ...retained tail..., continue-user]), so array
-// position is not chronological. Derive each binding by max id (MessageID
-// is monotonic via MessageID.ascending) so a pre-compaction overflowing tail
-// assistant doesn't get mistaken for the most recent turn. tasks are
-// compaction/subtask parts attached to user messages newer than the latest
-// finished assistant — i.e. unprocessed work.
+// position is not chronological. Derive each binding by creation time
+// (info.time.created) with id as a tiebreaker, matching the
+// (desc time_created, desc id) ordering used by the pagination queries.
+// NOTE: MessageIDs from Identifier.ascending() are NOT monotonic — the
+// 48-bit timestamp field wraps (Date.now()*0x1000 overflows 6 bytes), so a
+// freshly-generated "msg_000..." can sort before older IDs. Comparing by id
+// alone would pick a stale message as "latest". tasks are compaction/subtask
+// parts attached to user messages newer than the latest finished assistant —
+// i.e. unprocessed work.
+export function isAfter(a: Pick<Info, "time" | "id">, b: Pick<Info, "time" | "id">): boolean {
+  if (a.time.created !== b.time.created) return a.time.created > b.time.created
+  return a.id > b.id
+}
+
 export function latest(msgs: WithParts[]) {
   let user: User | undefined
   let assistant: Assistant | undefined
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
-    if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
-    if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
+    if (info.role === "user" && (!user || isAfter(info, user))) user = info
+    if (info.role === "assistant" && (!assistant || isAfter(info, assistant))) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || isAfter(info, finished))) finished = info
   }
   const tasks = msgs.flatMap((m) =>
-    finished && m.info.id <= finished.id
+    finished && !isAfter(m.info, finished)
       ? []
       : m.parts.filter((p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask"),
   )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
 import { SessionID, MessageID, PartID } from "./schema"
-import { MessageV2 } from "./message-v2"
+import { MessageV2, isAfter } from "./message-v2"
 import { SessionRevert } from "./revert"
 import { Session } from "./session"
 import { Agent } from "../agent/agent"
@@ -1165,7 +1165,7 @@ export const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            !isAfter(lastUser, lastAssistant)
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
@@ -1306,7 +1306,7 @@ export const layer = Layer.effect(
 
             if (step > 1 && lastFinished) {
               for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
+                if (m.info.role !== "user" || !isAfter(m.info, lastFinished)) continue
                 for (const p of m.parts) {
                   if (p.type !== "text" || p.ignored || p.synthetic) continue
                   if (!p.text.trim()) continue

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1658,4 +1658,37 @@ describe("session.message-v2.latest", () => {
     expect(state.tasks).toHaveLength(1)
     expect(state.tasks[0]).toMatchObject({ type: "compaction", auto: true })
   })
+
+  // Regression for ID wraparound (#42639). Identifier.ascending() IDs are not
+  // monotonic once Date.now()*0x1000 overflows the 48-bit timestamp field, so
+  // a fresh "msg_000..." can sort before older "msg_0a8a..." by string. Before
+  // the fix, latest() compared ids as strings and picked the stale user,
+  // causing runLoop to exit before processing the new input.
+  test("latest picks the newest by time.created even when ids wrap around", () => {
+    const OLD_USER = MessageID.make("msg_0a8a0a8a0a8a0a8a")
+    const OLD_ASSISTANT = MessageID.make("msg_0a8b0a8b0a8b0a8b")
+    const NEW_USER = MessageID.make("msg_0000000000000000")
+
+    const oldUser: SessionV1.WithParts = {
+      info: { ...userInfo(OLD_USER), time: { created: 1000 } } as SessionV1.User,
+      parts: [{ ...basePart(OLD_USER, "p1"), type: "text", text: "old" }] as SessionV1.Part[],
+    }
+    const oldAssistant: SessionV1.WithParts = {
+      info: {
+        ...assistantInfo(OLD_ASSISTANT, OLD_USER),
+        finish: "stop",
+        time: { created: 1001 },
+      } as SessionV1.Assistant,
+      parts: [],
+    }
+    const newUser: SessionV1.WithParts = {
+      info: { ...userInfo(NEW_USER), time: { created: 2000 } } as SessionV1.User,
+      parts: [{ ...basePart(NEW_USER, "p1"), type: "text", text: "new" }] as SessionV1.Part[],
+    }
+
+    const state = MessageV2.latest([oldUser, oldAssistant, newUser])
+
+    expect(state.user?.id).toBe(NEW_USER)
+    expect(state.finished?.id).toBe(OLD_ASSISTANT)
+  })
 })


### PR DESCRIPTION
Fixes #42639

latest() and runLoop compared messages by id string, but IDs from
Identifier.ascending() wrap around (Date.now()*0x1000 overflows the 6-byte
timestamp field), so a fresh "msg_000..." sorts before older IDs. This made
latest() pick a stale message and the run loop exit before processing new
user input.

Compare by info.time.created with id as tiebreaker, matching the existing
(desc time_created, desc id) pagination ordering.

## Verification
- bun test packages/opencode/test/session/message-v2.test.ts