### PR TITLE
fix(tui): open footer status dialogs on click

### DIFF
--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -20,7 +20,12 @@ function Mcp(props: { context: Plugin.Context }) {
 
   return (
     <Show when={list().length}>
-      <box gap={1} flexDirection="row" flexShrink={0}>
+      <box
+        gap={1}
+        flexDirection="row"
+        flexShrink={0}
+        onMouseUp={() => props.context.keymap.dispatch("mcp.list")}
+      >
         <text fg={props.context.theme.text.default}>
           <Switch>
             <Match when={failed()}>
@@ -56,7 +61,12 @@ function Plugins(props: { context: Plugin.Context }) {
 
   return (
     <Show when={failed()}>
-      <box gap={1} flexDirection="row" flexShrink={0}>
+      <box
+        gap={1}
+        flexDirection="row"
+        flexShrink={0}
+        onMouseUp={() => props.context.keymap.dispatch("plugins.list")}
+      >
         <text fg={props.context.theme.text.default}>
           <span style={{ fg: props.context.theme.text.feedback.error.default }}>⊙ </span>
           {failed()} plugin{failed() === 1 ? "" : "s"} failed


### PR DESCRIPTION
## What

Make the MCP and plugin status groups in the TUI home footer clickable.

**Before:** Clicking either footer status did nothing. Users had to type `/mcps` or `/plugins` to open the corresponding dialog.

**After:** Clicking anywhere in the MCP status group opens MCP servers, and clicking anywhere in the plugin failure status group opens Plugins. Slash commands continue to behave the same way.

## How

`packages/tui/src/feature-plugins/home/footer.tsx` dispatches the existing `mcp.list` and `plugins.list` keymap commands from each status group's `onMouseUp` handler. This reuses the same dialog paths as keyboard and slash-command invocation.

## Scope

This only changes the two status groups rendered in the TUI home footer. It does not change dialog behavior, status calculation, or footer visibility rules.

## Testing

- `bun run lint packages/tui/src/feature-plugins/home/footer.tsx`
- `bun typecheck` from `packages/tui`
- Push hook: full workspace `bun turbo typecheck --concurrency=3`
- Live PTY check with `bun run dev:live`: clicked the MCP status and confirmed MCP servers opened, then clicked the plugin failure status and confirmed Plugins opened
- `bun run test test/feature-plugins/home-footer.test.ts` currently fails before test execution on the existing `HomeFooter` circular-initialization error in `src/plugin/builtins.ts`

## Demo

The recording shows real mouse clicks against the live V2 TUI footer.

https://github.com/user-attachments/assets/fb0b9c08-c2b2-4d74-89d3-de614a90eab9
