### PR TITLE
fix(tui): preserve transparent tab backgrounds

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1015,7 +1015,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
             theme.background.default.r,
             theme.background.default.g,
             theme.background.default.b,
-            mode() === "light" ? 0.14 : 0.28,
+            theme.background.default.a * (mode() === "light" ? 0.14 : 0.28),
           ),
         )
       }}


### PR DESCRIPTION
## What

Preserve transparent terminal backgrounds beneath the horizontal session tab strip without changing the shadow on opaque themes.

## Before / After

**Before:** the tab shadow replaced a transparent theme background with a fixed 14%/28% alpha, producing an opaque full-width stripe beneath the tabs.

**After:** the shadow opacity is multiplied by the theme background alpha. Opaque themes retain the existing shadow, while fully transparent themes leave the row transparent.

## How

`packages/tui/src/component/session-tabs.tsx` now composes the horizontal tab shadow alpha with `theme.background.default.a` instead of discarding the theme alpha.

## Scope

This does not attempt to detect terminal-emulator window opacity. Terminal protocols expose the configured background color, but not portable compositor opacity. The fix follows the transparency explicitly represented by the OpenCode theme.

## Testing

- `bun run test test/component/session-tabs-marquee.test.ts test/component/tab-pulse.test.tsx`
- `bun typecheck` in `packages/tui`
- Full repository typecheck from the pre-push hook
- Real scrolled session captured before and after with OpenCode Drive

## Demo

All frames come from a real OpenCode Drive session. Drive submits a prompt, streams a 70-row assistant response, then sends Page Up twice so `Transcript row 33` scrolls directly beneath the fixed tab strip.

### Transparent theme

The Drive-captured cell alpha is composited over the same purple terminal backdrop. Before the fix, the shadow forces the row containing `Transcript row 33` opaque; after the fix, the backdrop remains visible behind that row.

| Before | After |
| --- | --- |
| ![Before: scrolled transcript row becomes an opaque stripe](https://github.com/user-attachments/assets/33bdc6ca-f76f-4a60-8157-6784e320b8f9) | ![After: scrolled transcript row keeps the transparent backdrop](https://github.com/user-attachments/assets/82ec481f-cf8a-465f-9534-ff4675f568d1) |

### Normal opaque theme

The same scrolled session under the normal theme retains the intended dimmed row beneath the tabs.

![Opaque theme: shadow retained over the scrolled transcript](https://github.com/user-attachments/assets/8d3cd4f2-e7eb-4091-b616-8162ab4d3212)
