### PR TITLE
fix(tui): remove shadow scrim under horizontal tab strip

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -1001,24 +1001,6 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
       }}
       onMouseDrag={drag}
       onMouseDragEnd={release}
-      renderAfter={function (buffer) {
-        const x = Math.max(0, this.screenX)
-        const y = this.screenY + this.height
-        const width = Math.min(this.width, buffer.width - x)
-        if (y < 0 || y >= buffer.height || width <= 0) return
-        buffer.fillRect(
-          x,
-          y,
-          width,
-          1,
-          RGBA.fromValues(
-            theme.background.default.r,
-            theme.background.default.g,
-            theme.background.default.b,
-            mode() === "light" ? 0.14 : 0.28,
-          ),
-        )
-      }}
     >
       <Show when={layout().before > 0}>
         <text width={sessionTabOverflowWidth(layout().before)} fg={theme.text.subdued} selectable={false}>


### PR DESCRIPTION
## Summary

The horizontal session tab strip painted a translucent scrim (via `renderAfter` + `fillRect` with alpha 0.14 light / 0.28 dark) over the row directly beneath it. Because the fill is translucent, it alpha-blends over already-rendered content, washing out both the background and any text on the first content line — making the top line under the tabs look faded.

This removes the scrim so the first line below the tabs renders at full color.

## Changes

- Remove the `renderAfter` shadow scrim from `HorizontalSessionTabs` in `packages/tui/src/component/session-tabs.tsx`

## Testing

- `bun typecheck` passes in `packages/tui`