### PR TITLE
fix(core): keep plan mode reminders in sync with session agent

### DIFF
--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -1,7 +1,7 @@
 export * as PlanPlugin from "./plan.js"
 
 import { ToolFailure } from "@opencode-ai/ai"
-import { define } from "@opencode-ai/plugin/effect/plugin"
+import { define, type Context } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Agent } from "../agent.js"
 import { SessionEvent } from "../session/event.js"
@@ -40,35 +40,47 @@ export const Plugin = define({
 
     yield* ctx.event.subscribe().pipe(
       Stream.filter(
-        (event): event is SessionEvent.Created | SessionEvent.AgentSelected =>
-          event.type === "session.created" || event.type === "session.agent.selected",
+        (event): event is SessionEvent.Created | SessionEvent.AgentSelected | SessionEvent.Compaction.Ended =>
+          event.type === "session.created" ||
+          event.type === "session.agent.selected" ||
+          event.type === "session.compaction.ended",
       ),
-      Stream.runForEach((event) => {
-        const text = reminder(event)
-        if (!text) return Effect.void
-        return ctx.session
-          .synthetic({
+      Stream.runForEach((event) =>
+        Effect.gen(function* () {
+          const text = yield* reminder(ctx.session, event)
+          if (!text) return
+          yield* ctx.session.synthetic({
             sessionID: event.data.sessionID,
             text,
             resume: false,
           })
-          .pipe(
-            Effect.catchCause((cause) =>
-              Effect.logWarning("failed to inject Plan mode reminder", { sessionID: event.data.sessionID, cause }),
-            ),
-          )
-      }),
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to inject Plan mode reminder", { sessionID: event.data.sessionID, cause }),
+          ),
+        ),
+      ),
       Effect.forkScoped({ startImmediately: true }),
     )
   }),
 })
 
-function reminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
+const reminder = Effect.fnUntraced(function* (
+  session: Context["session"],
+  event: SessionEvent.Created | SessionEvent.AgentSelected | SessionEvent.Compaction.Ended,
+) {
   if (event.type === "session.created") {
     if (event.data.agent !== plan) return
+    return enter
+  }
+  if (event.type === "session.compaction.ended") {
+    // Compaction cuts the transcript at the checkpoint, dropping any earlier enter
+    // reminder, so re-assert Plan mode when the session is still on the plan agent.
+    const info = yield* session.get({ sessionID: event.data.sessionID })
+    if (info.agent !== plan) return
     return enter
   }
   if (event.data.agent === event.data.previous) return
   if (event.data.agent === plan) return enter
   if (event.data.previous === plan) return leave
-}
+})

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -41,9 +41,9 @@ export const Plugin = define({
     // Compaction and committed reverts can strip reminders while the session's agent stays
     // put. Reconcile per request, appending near the tail so the cached prefix stays warm.
     yield* ctx.session.hook("context", (event) => {
-      const believed = lastReminder(event.messages)
-      const missing = event.agent === plan && believed !== enter
-      const stale = event.agent !== plan && believed === enter
+      const reminder = lastReminder(event.messages)
+      const missing = event.agent === plan && reminder !== enter
+      const stale = event.agent !== plan && reminder === enter
       const text = missing ? enter : stale ? leave : undefined
       if (!text) return Effect.void
       // Before the user's prompt, matching where agent-switch reminders land.
@@ -64,7 +64,7 @@ export const Plugin = define({
           event.type === "session.created" || event.type === "session.agent.selected",
       ),
       Stream.runForEach((event) => {
-        const text = reminder(event)
+        const text = switchReminder(event)
         if (!text) return Effect.void
         return ctx.session
           .synthetic({
@@ -83,7 +83,7 @@ export const Plugin = define({
   }),
 })
 
-function reminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
+function switchReminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
   if (event.type === "session.created") {
     if (event.data.agent !== plan) return
     return enter

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -1,7 +1,7 @@
 export * as PlanPlugin from "./plan.js"
 
-import { ToolFailure } from "@opencode-ai/ai"
-import { define, type Context } from "@opencode-ai/plugin/effect/plugin"
+import { Message, ToolFailure } from "@opencode-ai/ai"
+import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Agent } from "../agent.js"
 import { SessionEvent } from "../session/event.js"
@@ -38,49 +38,65 @@ export const Plugin = define({
       })
     })
 
+    // Compaction and committed reverts can strip reminders while the session's agent stays
+    // put. Reconcile per request, appending near the tail so the cached prefix stays warm.
+    yield* ctx.session.hook("context", (event) => {
+      const believed = lastReminder(event.messages)
+      const missing = event.agent === plan && believed !== enter
+      const stale = event.agent !== plan && believed === enter
+      const text = missing ? enter : stale ? leave : undefined
+      if (!text) return Effect.void
+      // Before the user's prompt, matching where agent-switch reminders land.
+      const at = event.messages.at(-1)?.role === "user" ? event.messages.length - 1 : event.messages.length
+      event.messages.splice(at, 0, Message.user(text))
+      return ctx.session
+        .synthetic({ sessionID: event.sessionID, text, resume: false })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to persist Plan mode reminder", { sessionID: event.sessionID, cause }),
+          ),
+        )
+    })
+
     yield* ctx.event.subscribe().pipe(
       Stream.filter(
-        (event): event is SessionEvent.Created | SessionEvent.AgentSelected | SessionEvent.Compaction.Ended =>
-          event.type === "session.created" ||
-          event.type === "session.agent.selected" ||
-          event.type === "session.compaction.ended",
+        (event): event is SessionEvent.Created | SessionEvent.AgentSelected =>
+          event.type === "session.created" || event.type === "session.agent.selected",
       ),
-      Stream.runForEach((event) =>
-        Effect.gen(function* () {
-          const text = yield* reminder(ctx.session, event)
-          if (!text) return
-          yield* ctx.session.synthetic({
+      Stream.runForEach((event) => {
+        const text = reminder(event)
+        if (!text) return Effect.void
+        return ctx.session
+          .synthetic({
             sessionID: event.data.sessionID,
             text,
             resume: false,
           })
-        }).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning("failed to inject Plan mode reminder", { sessionID: event.data.sessionID, cause }),
-          ),
-        ),
-      ),
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("failed to inject Plan mode reminder", { sessionID: event.data.sessionID, cause }),
+            ),
+          )
+      }),
       Effect.forkScoped({ startImmediately: true }),
     )
   }),
 })
 
-const reminder = Effect.fnUntraced(function* (
-  session: Context["session"],
-  event: SessionEvent.Created | SessionEvent.AgentSelected | SessionEvent.Compaction.Ended,
-) {
+function reminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
   if (event.type === "session.created") {
     if (event.data.agent !== plan) return
-    return enter
-  }
-  if (event.type === "session.compaction.ended") {
-    // Compaction cuts the transcript at the checkpoint, dropping any earlier enter
-    // reminder, so re-assert Plan mode when the session is still on the plan agent.
-    const info = yield* session.get({ sessionID: event.data.sessionID })
-    if (info.agent !== plan) return
     return enter
   }
   if (event.data.agent === event.data.previous) return
   if (event.data.agent === plan) return enter
   if (event.data.previous === plan) return leave
-})
+}
+
+function lastReminder(messages: ReadonlyArray<Message>) {
+  return messages.reduce<string | undefined>((found, message) => {
+    const part = message.role === "user" && message.content.length === 1 ? message.content[0] : undefined
+    if (part?.type !== "text") return found
+    return part.text === enter || part.text === leave ? part.text : found
+  }, undefined)
+}

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect } from "bun:test"
+import { DateTime, Effect, Stream } from "effect"
+import { Agent } from "@opencode-ai/core/agent"
+import { Event } from "@opencode-ai/schema/event"
+import { Money } from "@opencode-ai/schema/money"
+import { PlanPlugin } from "@opencode-ai/core/plugin/plan"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Project } from "@opencode-ai/core/project"
+import { Session } from "@opencode-ai/core/session"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionInbox } from "@opencode-ai/core/session/inbox"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { it } from "../lib/effect"
+import { host } from "./host"
+
+const sessionID = Session.ID.make("ses_plan_test")
+const plan = Agent.ID.make("plan")
+const build = Agent.ID.make("build")
+
+const envelope = () => ({
+  id: Event.ID.create(),
+  created: DateTime.makeUnsafe(0),
+  durable: { aggregateID: sessionID, seq: Event.Seq.make(0), version: Event.Version.make(1) },
+})
+
+const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentSelected => ({
+  ...envelope(),
+  type: "session.agent.selected",
+  data: { sessionID, agent, previous },
+})
+
+const compactionEnded = (): SessionEvent.Compaction.Ended => ({
+  ...envelope(),
+  type: "session.compaction.ended",
+  data: { sessionID, reason: "manual", text: "summary", recent: "" },
+})
+
+const sessionInfo = (agent?: Agent.ID): Session.Info => ({
+  id: sessionID,
+  projectID: Project.ID.make("test"),
+  agent,
+  cost: Money.USD.zero,
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  time: { created: DateTime.makeUnsafe(0), updated: DateTime.makeUnsafe(0) },
+  location: { directory: AbsolutePath.make("/") },
+})
+
+/** Runs the plan plugin against stubbed domains and captures injected reminders. */
+const run = Effect.fnUntraced(function* (
+  events: ReadonlyArray<SessionEvent.AgentSelected | SessionEvent.Compaction.Ended>,
+  agent?: Agent.ID,
+) {
+  const captured = new Array<string>()
+  yield* PlanPlugin.Plugin.effect(
+    host({
+      agent: {
+        get: () => Effect.die("unused agent.get"),
+        list: () => Effect.die("unused agent.list"),
+        reload: () => Effect.die("unused agent.reload"),
+        transform: () => Effect.succeed({ dispose: Effect.void }),
+      },
+      tool: {
+        transform: () => Effect.die("unused tool.transform"),
+        hook: () => Effect.succeed({ dispose: Effect.void }),
+      },
+      event: {
+        subscribe: () => Stream.fromIterable(events),
+      },
+      session: {
+        get: () => Effect.succeed(sessionInfo(agent)),
+        synthetic: (input) => {
+          captured.push(input.text)
+          return Effect.succeed(
+            SessionInbox.Synthetic.make({
+              id: SessionMessage.ID.make("msg_plan_test"),
+              sessionID,
+              timeCreated: DateTime.makeUnsafe(0),
+              type: "synthetic",
+              payload: { text: input.text },
+              delivery: "steer",
+            }),
+          )
+        },
+      },
+    }),
+  )
+  return captured
+})
+
+const settle = (captured: ReadonlyArray<string>, expected: number, remaining = 1000): Effect.Effect<void, Error> =>
+  Effect.gen(function* () {
+    if (captured.length >= expected) return
+    if (remaining === 0) {
+      return yield* Effect.fail(new Error(`Timed out waiting for ${expected} reminders, saw ${captured.length}`))
+    }
+    yield* Effect.promise(() => Bun.sleep(1))
+    yield* settle(captured, expected, remaining - 1)
+  })
+
+describe("plan plugin reminders", () => {
+  it.effect("injects enter and leave reminders on agent switches", () =>
+    Effect.gen(function* () {
+      const captured = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
+      yield* settle(captured, 2)
+      expect(captured[0]).toContain("You are in Plan mode")
+      expect(captured[1]).toContain("NO LONGER in Plan mode")
+    }),
+  )
+
+  it.effect("re-injects the enter reminder after compaction while on the plan agent", () =>
+    Effect.gen(function* () {
+      const captured = yield* run([compactionEnded()], plan)
+      yield* settle(captured, 1)
+      expect(captured).toHaveLength(1)
+      expect(captured[0]).toContain("You are in Plan mode")
+    }),
+  )
+
+  it.effect("ignores compaction when the session is not on the plan agent", () =>
+    Effect.gen(function* () {
+      // The trailing switch to plan proves the earlier compaction event was processed.
+      const captured = yield* run([compactionEnded(), agentSelected(plan, build)], build)
+      yield* settle(captured, 1)
+      expect(captured).toHaveLength(1)
+      expect(captured[0]).toContain("You are in Plan mode")
+    }),
+  )
+})

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -20,7 +20,7 @@ const build = Agent.ID.make("build")
 
 const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentSelected => ({
   id: Event.ID.create(),
-  created: DateTime.makeUnsafe(0),
+  created: 0,
   durable: { aggregateID: sessionID, seq: Event.Seq.make(0), version: Event.Version.make(1) },
   type: "session.agent.selected",
   data: { sessionID, agent, previous },

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect } from "bun:test"
+import { Message } from "@opencode-ai/ai"
 import { DateTime, Effect, Stream } from "effect"
+import type { SessionContext } from "@opencode-ai/plugin/effect/session"
 import { Agent } from "@opencode-ai/core/agent"
 import { Event } from "@opencode-ai/schema/event"
-import { Money } from "@opencode-ai/schema/money"
+import { Model } from "@opencode-ai/core/model"
 import { PlanPlugin } from "@opencode-ai/core/plugin/plan"
-import { AbsolutePath } from "@opencode-ai/core/schema"
-import { Project } from "@opencode-ai/core/project"
+import { Provider } from "@opencode-ai/core/provider"
 import { Session } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionInbox } from "@opencode-ai/core/session/inbox"
@@ -17,40 +18,18 @@ const sessionID = Session.ID.make("ses_plan_test")
 const plan = Agent.ID.make("plan")
 const build = Agent.ID.make("build")
 
-const envelope = () => ({
+const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentSelected => ({
   id: Event.ID.create(),
   created: DateTime.makeUnsafe(0),
   durable: { aggregateID: sessionID, seq: Event.Seq.make(0), version: Event.Version.make(1) },
-})
-
-const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentSelected => ({
-  ...envelope(),
   type: "session.agent.selected",
   data: { sessionID, agent, previous },
 })
 
-const compactionEnded = (): SessionEvent.Compaction.Ended => ({
-  ...envelope(),
-  type: "session.compaction.ended",
-  data: { sessionID, reason: "manual", text: "summary", recent: "" },
-})
-
-const sessionInfo = (agent?: Agent.ID): Session.Info => ({
-  id: sessionID,
-  projectID: Project.ID.make("test"),
-  agent,
-  cost: Money.USD.zero,
-  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-  time: { created: DateTime.makeUnsafe(0), updated: DateTime.makeUnsafe(0) },
-  location: { directory: AbsolutePath.make("/") },
-})
-
-/** Runs the plan plugin against stubbed domains and captures injected reminders. */
-const run = Effect.fnUntraced(function* (
-  events: ReadonlyArray<SessionEvent.AgentSelected | SessionEvent.Compaction.Ended>,
-  agent?: Agent.ID,
-) {
-  const captured = new Array<string>()
+/** Runs the plan plugin against stubbed domains, capturing persisted reminders and the context hook. */
+const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.AgentSelected> = []) {
+  const persisted = new Array<string>()
+  let contextHook: ((input: SessionContext) => Effect.Effect<void>) | undefined
   yield* PlanPlugin.Plugin.effect(
     host({
       agent: {
@@ -67,9 +46,12 @@ const run = Effect.fnUntraced(function* (
         subscribe: () => Stream.fromIterable(events),
       },
       session: {
-        get: () => Effect.succeed(sessionInfo(agent)),
+        hook: (name, callback) => {
+          if (name === "context") contextHook = callback as (input: SessionContext) => Effect.Effect<void>
+          return Effect.succeed({ dispose: Effect.void })
+        },
         synthetic: (input) => {
-          captured.push(input.text)
+          persisted.push(input.text)
           return Effect.succeed(
             SessionInbox.Synthetic.make({
               id: SessionMessage.ID.make("msg_plan_test"),
@@ -84,45 +66,115 @@ const run = Effect.fnUntraced(function* (
       },
     }),
   )
-  return captured
+  if (!contextHook) return yield* Effect.die("plan plugin did not register a context hook")
+  return { persisted, contextHook }
 })
 
-const settle = (captured: ReadonlyArray<string>, expected: number, remaining = 1000): Effect.Effect<void, Error> =>
+const request = (agent: Agent.ID, messages: Array<Message>): SessionContext => ({
+  sessionID,
+  agent,
+  model: { id: Model.ID.make("test-model"), providerID: Provider.ID.make("test") },
+  system: [],
+  messages,
+  tools: {},
+})
+
+const settle = (persisted: ReadonlyArray<string>, expected: number, remaining = 1000): Effect.Effect<void, Error> =>
   Effect.gen(function* () {
-    if (captured.length >= expected) return
+    if (persisted.length >= expected) return
     if (remaining === 0) {
-      return yield* Effect.fail(new Error(`Timed out waiting for ${expected} reminders, saw ${captured.length}`))
+      return yield* Effect.fail(new Error(`Timed out waiting for ${expected} reminders, saw ${persisted.length}`))
     }
     yield* Effect.promise(() => Bun.sleep(1))
-    yield* settle(captured, expected, remaining - 1)
+    yield* settle(persisted, expected, remaining - 1)
   })
+
+/** The exact reminder texts, derived from plugin behavior rather than duplicated here. */
+const reminders = Effect.gen(function* () {
+  const planRun = yield* run()
+  yield* planRun.contextHook(request(plan, []))
+  const buildRun = yield* run()
+  yield* buildRun.contextHook(request(build, [Message.user(planRun.persisted[0]!)]))
+  return { enter: planRun.persisted[0]!, leave: buildRun.persisted[0]! }
+})
 
 describe("plan plugin reminders", () => {
   it.effect("injects enter and leave reminders on agent switches", () =>
     Effect.gen(function* () {
-      const captured = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
-      yield* settle(captured, 2)
-      expect(captured[0]).toContain("You are in Plan mode")
-      expect(captured[1]).toContain("NO LONGER in Plan mode")
+      const { persisted } = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
+      yield* settle(persisted, 2)
+      expect(persisted[0]).toContain("You are in Plan mode")
+      expect(persisted[1]).toContain("NO LONGER in Plan mode")
     }),
   )
 
-  it.effect("re-injects the enter reminder after compaction while on the plan agent", () =>
+  it.effect("reconciles a missing enter reminder into the request and persists it", () =>
     Effect.gen(function* () {
-      const captured = yield* run([compactionEnded()], plan)
-      yield* settle(captured, 1)
-      expect(captured).toHaveLength(1)
-      expect(captured[0]).toContain("You are in Plan mode")
+      const { persisted, contextHook } = yield* run()
+      const messages = [Message.user("what agent are you?")]
+      yield* contextHook(request(plan, messages))
+      expect(messages).toHaveLength(2)
+      // Inserted before the user's prompt, matching where agent-switch reminders land.
+      const first = messages[0]?.content[0]
+      expect(first?.type === "text" && first.text).toContain("You are in Plan mode")
+      expect(persisted).toHaveLength(1)
     }),
   )
 
-  it.effect("ignores compaction when the session is not on the plan agent", () =>
+  it.effect("does nothing when the transcript already has a live enter reminder", () =>
     Effect.gen(function* () {
-      // The trailing switch to plan proves the earlier compaction event was processed.
-      const captured = yield* run([compactionEnded(), agentSelected(plan, build)], build)
-      yield* settle(captured, 1)
-      expect(captured).toHaveLength(1)
-      expect(captured[0]).toContain("You are in Plan mode")
+      const { enter } = yield* reminders
+      const { persisted, contextHook } = yield* run()
+      const messages = [Message.user(enter), Message.user("hello")]
+      yield* contextHook(request(plan, messages))
+      expect(messages).toHaveLength(2)
+      expect(persisted).toHaveLength(0)
+    }),
+  )
+
+  it.effect("reconciles a stale enter reminder with a leave reminder", () =>
+    Effect.gen(function* () {
+      const { enter } = yield* reminders
+      const { persisted, contextHook } = yield* run()
+      const messages = [Message.user(enter), Message.user("ok implement it")]
+      yield* contextHook(request(build, messages))
+      expect(messages).toHaveLength(3)
+      const middle = messages[1]?.content[0]
+      expect(middle?.type === "text" && middle.text).toContain("NO LONGER in Plan mode")
+      expect(persisted).toHaveLength(1)
+    }),
+  )
+
+  it.effect("does nothing for non-plan sessions without plan history", () =>
+    Effect.gen(function* () {
+      const { persisted, contextHook } = yield* run()
+      const messages = [Message.user("hello")]
+      yield* contextHook(request(build, messages))
+      expect(messages).toHaveLength(1)
+      expect(persisted).toHaveLength(0)
+    }),
+  )
+
+  it.effect("does nothing when a leave reminder already follows the enter reminder", () =>
+    Effect.gen(function* () {
+      const { enter, leave } = yield* reminders
+      const { persisted, contextHook } = yield* run()
+      const messages = [Message.user(enter), Message.user(leave), Message.user("continue")]
+      yield* contextHook(request(build, messages))
+      expect(messages).toHaveLength(3)
+      expect(persisted).toHaveLength(0)
+    }),
+  )
+
+  it.effect("treats reminder text quoted inside a larger message as not live", () =>
+    Effect.gen(function* () {
+      const { enter } = yield* reminders
+      const { persisted, contextHook } = yield* run()
+      // Mirrors a compaction checkpoint quoting the reminder inside <recent-context>.
+      const messages = [Message.user(`<conversation-checkpoint>\n${enter}\n</conversation-checkpoint>`)]
+      yield* contextHook(request(plan, messages))
+      expect(messages).toHaveLength(2)
+      expect(persisted).toHaveLength(1)
     }),
   )
 })


### PR DESCRIPTION
## Problem

The plan plugin communicates Plan mode to the model via `<system-reminder>` synthetic messages injected on `session.created` / `session.agent.selected`. Those messages live in the transcript, but the mode itself lives in durable session state (`SessionTable.agent`) — and several operations edit the transcript without touching the agent:

- **Compaction** cuts model-visible history at the checkpoint (`SessionHistory.messageRows` loads `seq >= compaction.seq`), dropping the enter reminder while the session stays on `plan`.
- **Committed reverts** delete all message rows past the boundary while `SessionTable.agent` stays put and no `session.agent.selected` re-fires. Undoing past the switch *into* plan leaves the model unaware it's in Plan mode (including the undo-to-empty-session case); undoing past the switch *out of* plan leaves a stale enter reminder so the model wrongly refuses to edit.
- Synthetics admitted while a revert is staged never wake execution and are deleted by the commit before delivery.

In all cases the tool hook still hard-blocks edits, but the model has a wrong or missing idea of what mode it is in.

## Fix

Reconcile the transcript against the durable agent on every model request via `ctx.session.hook("context")`:

- Find the most recent live enter/leave reminder in the visible messages (whole-message equality, so reminder text quoted inside a compaction checkpoint doesn't count).
- If the session is on `plan` with no live enter reminder, or off `plan` with a stale one, insert the correct reminder into the current request — before the trailing user message, matching where agent-switch reminders land — and persist a durable copy via `ctx.session.synthetic` so subsequent requests find it and the reconciler goes back to a no-op.

The steady state is unchanged: durable enter/leave synthetics on agent switches do the work, and the reconciler does nothing while transcript and agent agree. Reminders only ever land near the request tail and earlier messages are never rewritten, so the prompt cache prefix stays warm; healing costs one small uncached insertion, once.

This matches how Claude Code and Grok handle mode reminders (persisted, append-only, re-derived from mode state at prompt time); their periodic full/sparse re-assertion cadence is intentionally not adopted.

## Tests

`test/plugin/plan.test.ts` runs the real plugin effect against a stubbed plugin context:

- enter/leave injection on agent switches (pre-existing behavior)
- missing enter reminder reconciled into the request (undo-to-empty scenario) and persisted
- steady-state no-op with a live enter reminder
- stale enter reconciled with a leave reminder
- no injection for non-plan sessions without plan history
- no injection when a leave reminder already follows the enter
- reminder text quoted inside a checkpoint-like message treated as not live

Reminder texts in tests are derived by invoking the plugin rather than duplicating the strings.