### PR TITLE
fix(prompt-input): don't steal caret/focus while the editor is focused

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -546,6 +546,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const cursor = currentCursor()
     savedCursor = cursor
     if (cursor !== null && cursor !== prompt.cursor()) prompt.set(prompt.current(), cursor)
+    // Re-sync the DOM with the store. While focused we skip the rebuild in the
+    // prompt.current() effect to avoid stealing the caret during agent streaming
+    // (#41332); this catches up any programmatic draft change made while focused.
+    reconcile(prompt.current().filter((part) => part.type !== "image"))
     closePopover()
     setComposing(false)
   }
@@ -866,6 +870,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       () => prompt.current(),
       (parts) => {
         if (composing()) return
+        // Don't rebuild the editor DOM while the user is actively editing inside it.
+        // A programmatic change to the draft (e.g. a draft restore while the agent
+        // is streaming) used to clear and rebuild the contenteditable, which
+        // collapsed the caret to position 0 and yanked focus away from whatever the
+        // user was doing — see #41332. The store stays authoritative and is re-synced
+        // to the DOM on blur (handleBlur below).
+        if (document.activeElement === editorRef) return
         reconcile(parts.filter((part) => part.type !== "image"))
       },
     ),

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -70,6 +70,13 @@ export function PromptInputV2(props: PromptInputV2Props) {
       localInput = false
       return
     }
+    // Don't rebuild the editor DOM while the user is actively editing inside it.
+    // A programmatic change to the draft (e.g. a draft restore while the agent is
+    // streaming) used to clear and rebuild the contenteditable, which collapsed the
+    // caret and yanked focus away from the user — see #41332. The store stays
+    // authoritative; the editor is re-synced from parts() on the next editable
+    // change (localInput) and on blur.
+    if (document.activeElement === editor) return
     renderPromptInputV2Editor(editor, parts)
   })
 


### PR DESCRIPTION
## Summary

Fixes the desktop focus-steal / caret-reset bug reported in #41332.

When the draft prompt is reassigned programmatically (e.g. a draft restore
triggered while the agent is streaming), the `prompt.current()` reactive effect
rebuilt the contenteditable DOM. Because `renderEditor()` clears and rebuilds the
node tree, the caret collapsed to **position 0** and focus was yanked away from
whatever the user was doing. On X11 the WM then raises the window ("pops to
front"), matching the reported symptom.

User typing was already safe (`mirror.input` short-circuits reconcile / `localInput`
in v2), but programmatic draft changes during streaming were not.

## Changes

- `packages/app/src/components/prompt-input.tsx`
  - Guard the `prompt.current()` effect so it skips the DOM rebuild while the
    editor is focused; re-sync the DOM from the store on blur (`handleBlur`).
  - The store stays authoritative — only the visual rebuild is deferred.
- `packages/session-ui/src/v2/components/prompt-input/index.tsx`
  - Same guard on the `parts()` effect (the v2 composer had the same
    rebuild-on-change path).

## Test plan

- [x] Typecheck passes (`tsgo`/`tsc --noEmit` in both packages)
- [ ] Manual: start a long-running agent task, keep typing in the prompt input
      (and in a terminal pane) — caret should stay put and the window should not
      steal focus / pop to front while the agent streams.

Note: I could not fully reproduce in CI; this targets the documented mechanism
in #41332. Happy to adjust if maintainers can point at a more precise trigger.

Closes #41332