### PR TITLE
refactor(protocol): move worktree routes out of experimental namespace

### DIFF
--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -278,7 +278,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     }
     if (path === "/api/project/current")
       return json(route, { id: (config.project as { id?: string }).id, directory: config.directory })
-    const worktree = path.match(/^\/api\/experimental\/project\/([^/]+)\/worktree$/)?.[1]
+    const worktree = path.match(/^\/api\/worktree\/([^/]+)$/)?.[1]
     if (worktree && route.request().method() === "GET")
       return json(route, [
         { directory: config.directory },
@@ -294,7 +294,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     }
     if (worktree && route.request().method() === "DELETE")
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
-    if (/^\/api\/experimental\/project\/[^/]+\/worktree\/refresh$/.test(path))
+    if (/^\/api\/worktree\/[^/]+\/refresh$/.test(path))
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
     if (path === "/api/permission/request")
       return json(route, {

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -1671,7 +1671,7 @@ export function make(options: ClientOptions) {
         request<WorktreeListOutput>(
           {
             method: "GET",
-            path: `/api/experimental/project/${encodeURIComponent(input.projectID)}/worktree`,
+            path: `/api/worktree/${encodeURIComponent(input.projectID)}`,
             successStatus: 200,
             declaredStatuses: [401, 400],
             empty: false,
@@ -1682,7 +1682,7 @@ export function make(options: ClientOptions) {
         request<WorktreeCreateOutput>(
           {
             method: "POST",
-            path: `/api/experimental/project/${encodeURIComponent(input.projectID)}/worktree`,
+            path: `/api/worktree/${encodeURIComponent(input.projectID)}`,
             body: {
               strategy: input["strategy"],
               from: input["from"],
@@ -1699,7 +1699,7 @@ export function make(options: ClientOptions) {
         request<WorktreeRemoveOutput>(
           {
             method: "DELETE",
-            path: `/api/experimental/project/${encodeURIComponent(input.projectID)}/worktree`,
+            path: `/api/worktree/${encodeURIComponent(input.projectID)}`,
             body: { directory: input["directory"], force: input["force"] },
             successStatus: 204,
             declaredStatuses: [400, 401],
@@ -1711,7 +1711,7 @@ export function make(options: ClientOptions) {
         request<WorktreeRefreshOutput>(
           {
             method: "POST",
-            path: `/api/experimental/project/${encodeURIComponent(input.projectID)}/worktree/refresh`,
+            path: `/api/worktree/${encodeURIComponent(input.projectID)}/refresh`,
             successStatus: 204,
             declaredStatuses: [400, 401],
             empty: true,

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -283,10 +283,10 @@ test("worktree methods use the global project contract", async () => {
   await client.worktree.refresh({ projectID: "proj_test" })
 
   expect(requests.map((request) => [request.method, request.url])).toEqual([
-    ["GET", "http://localhost:3000/api/experimental/project/proj_test/worktree"],
-    ["POST", "http://localhost:3000/api/experimental/project/proj_test/worktree"],
-    ["DELETE", "http://localhost:3000/api/experimental/project/proj_test/worktree"],
-    ["POST", "http://localhost:3000/api/experimental/project/proj_test/worktree/refresh"],
+    ["GET", "http://localhost:3000/api/worktree/proj_test"],
+    ["POST", "http://localhost:3000/api/worktree/proj_test"],
+    ["DELETE", "http://localhost:3000/api/worktree/proj_test"],
+    ["POST", "http://localhost:3000/api/worktree/proj_test/refresh"],
   ])
   expect(await requests[1]?.json()).toEqual({
     strategy: "git",

--- a/packages/protocol/src/groups/worktree.ts
+++ b/packages/protocol/src/groups/worktree.ts
@@ -3,7 +3,7 @@ import { Worktree } from "@opencode-ai/schema/worktree"
 import { Schema, Struct } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 
-const root = "/api/experimental/project/:projectID/worktree"
+const root = "/api/worktree/:projectID"
 
 export class WorktreeError extends Schema.ErrorClass<WorktreeError>("WorktreeError")(
   {

--- a/packages/server/test/worktree.test.ts
+++ b/packages/server/test/worktree.test.ts
@@ -36,7 +36,7 @@ it.live("lists, creates, and removes worktrees by project ID", () =>
         const resolved = yield* Effect.promise(() => fetch(location, { headers }).then((response) => response.json()))
         if (!isRecord(resolved) || !isRecord(resolved.project) || typeof resolved.project.id !== "string")
           throw new Error("Expected resolved project")
-        const url = new URL(`/api/experimental/project/${resolved.project.id}/worktree`, base)
+        const url = new URL(`/api/worktree/${resolved.project.id}`, base)
 
         const initial = yield* Effect.promise(() => fetch(url, { headers }).then((response) => response.json()))
         expect(initial).toEqual([{ directory: project }])

--- a/packages/tui/test/fixture/tui-client.ts
+++ b/packages/tui/test/fixture/tui-client.ts
@@ -107,12 +107,12 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
       })
     if (url.pathname === "/api/project/current") return json({ id: "proj_test", directory: worktree })
     if (url.pathname === "/api/project") return json([])
-    if (url.pathname === "/api/experimental/project/proj_test/worktree") {
+    if (url.pathname === "/api/worktree/proj_test") {
       if (request.method === "GET") return json([{ directory: worktree }])
       if (request.method === "POST") return json({ directory: `${worktree}/created` })
       return new Response(null, { status: 204 })
     }
-    if (url.pathname === "/api/experimental/project/proj_test/worktree/refresh")
+    if (url.pathname === "/api/worktree/proj_test/refresh")
       return new Response(null, { status: 204 })
     if (url.pathname === "/api/shell")
       return json({


### PR DESCRIPTION
## Summary

Promotes the worktree APIs out of the experimental URL namespace and flattens them to a top-level resource:

| Endpoint | Method | Old URL | New URL |
|---|---|---|---|
| `worktree.list` | GET | `/api/experimental/project/:projectID/worktree` | `/api/worktree/:projectID` |
| `worktree.create` | POST | `/api/experimental/project/:projectID/worktree` | `/api/worktree/:projectID` |
| `worktree.remove` | DELETE | `/api/experimental/project/:projectID/worktree` | `/api/worktree/:projectID` |
| `worktree.refresh` | POST | `/api/experimental/project/:projectID/worktree/refresh` | `/api/worktree/:projectID/refresh` |

The OpenApi identifiers (`v2.worktree.*`) were already non-experimental, so only the URL paths change.

## Changes

- `packages/protocol/src/groups/worktree.ts`: update route root
- `packages/client/src/promise/generated/client.ts`: regenerated via `bun run generate`
- Updated hardcoded paths in client, server, and tui test fixtures

## Testing

- `bun typecheck` passes in `protocol`, `client`, `server`
- `packages/server/test/worktree.test.ts`: 1 pass (end-to-end route exercise)
- `packages/client/test/promise.test.ts`: 21 pass, 1 pre-existing failure (`question` group assertion, fails on clean `origin/v2` as well)
- `packages/tui/test/cli/tui/data.test.tsx`: 41 pass