### PR TITLE
fix(mcp): fail loudly on MCP server config missing type

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -111,7 +111,7 @@ export const Info = Schema.Struct({
     description: "Custom provider configurations and model overrides",
   }),
   mcp: Schema.optional(
-    Schema.Record(Schema.String, Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })])),
+    Schema.Record(Schema.String, Schema.Union([ConfigMCPV1.Info, ConfigMCPV1.BareEnabled])),
   ).annotate({ description: "MCP (Model Context Protocol) server configurations" }),
   formatter: Schema.optional(ConfigFormatterV1.Info).annotate({
     description:

--- a/packages/core/src/v1/config/mcp.ts
+++ b/packages/core/src/v1/config/mcp.ts
@@ -59,5 +59,19 @@ export const Remote = Schema.Struct({
 }).annotate({ identifier: "McpRemoteConfig" })
 export type Remote = Schema.Schema.Type<typeof Remote>
 
-export const Info = Schema.Union([Local, Remote]).annotate({ discriminator: "type" })
+export const Info = Schema.Union([Local, Remote]).annotate({
+  discriminator: "type",
+  expected: 'an MCP server entry with a "type" of "local" or "remote"',
+})
 export type Info = Schema.Schema.Type<typeof Info>
+
+// A bare `{ "enabled": boolean }` entry that overrides the `enabled` flag of a server defined in a broader-scope config file
+export const BareEnabled = Schema.declare(
+  (u): u is { enabled: boolean } =>
+    typeof u === "object" && u !== null && Object.keys(u).length === 1 && "enabled" in u && typeof u.enabled === "boolean",
+  {
+    expected: 'an MCP server entry that is exactly { "enabled": boolean }',
+    description: 'A bare { "enabled": boolean } entry that overrides the enabled flag of an MCP server defined in a broader-scope config file',
+  },
+)
+export type BareEnabled = Schema.Schema.Type<typeof BareEnabled>

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1400,6 +1400,78 @@ it.instance("project config can override MCP server enabled status", () =>
   }),
 )
 
+// MCP config validation
+
+it.instance("rejects MCP server entry missing the type field", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      mcp: {
+        broken: {
+          command: ["npx", "-y", "some-mcp"],
+        },
+      },
+    })
+    const exit = yield* Config.use.get().pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)
+
+it.instance("rejects MCP server entry missing type but with enabled", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      mcp: {
+        datalens: {
+          command: ["npx", "-y", "@datalens-tech/mcp@latest"],
+          enabled: true,
+        },
+      },
+    })
+    const exit = yield* Config.use.get().pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+    const error = Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined
+    expect(NamedError.hasName(error, "ConfigInvalidError")).toBe(true)
+    const message = (error as { data?: { issues?: Array<{ message?: string }> } })
+      .data?.issues?.map((i) => i.message)
+      .join("\n")
+    expect(message ?? "").toContain('{ "enabled": boolean }')
+  }),
+)
+
+it.instance("rejects malformed MCP server entry with type but invalid fields", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      mcp: {
+        datalens: {
+          type: "local",
+          command: "npx",
+          args: ["-y", "@datalens-tech/mcp@latest"],
+          enabled: true,
+        },
+      },
+    })
+    const exit = yield* Config.use.get().pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)
+
+it.instance("accepts a bare enabled entry to disable an MCP server defined elsewhere", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      mcp: { "some-server": { enabled: false } },
+    })
+    const config = yield* Config.use.get()
+    expect(config.mcp?.["some-server"]).toEqual({ enabled: false })
+  }),
+)
+
 it.instance("MCP config deep merges preserving base config properties", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #41229

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Many MCP config JSON objects written for Claude Code setup don't carry fields like `type` and `enabled` which Opencode uses. Previously, if you tried to configure an MCP server without a `type` field, Opencode would start, but you were not be able to load or use the MCP, and you wouldn't know why without going in and looking at the logs. This diverges from other validation behavior, for example for the `enabled` field, which fails loudly when malformed. 

Additionally, if you tried to configure a server without both `type` and `enabled`, you would get a CLI error indicating that the `enabled` field is missing, when really, you could configure an MCP server without `enabled` just fine. However, we want to be able to define standalone MCP entries that ONLY have the "enabled" field, which serve to override the global config where the startup commands etc are actually defined. The old Info object also matched an entry containing `enabled` against a loose `Schema.Struct({ enabled: Boolean })`, so entries like `{ "command": [...], "enabled": true }` were silently treated as directory-level overrides (whereas if other fields like "command" are being defined, this is an outer-level server definition that should be flagged as malformed). 

#### Changes
- Add a `BareEnabled` schema declaration that strictly matches exactly `{ "enabled": boolean }` (so only actual override entries are treated as such)
- Annotate the `expected` value of `type` so the error is more informative in telling the user what the value of the field should be

### How did you verify your code works?
- *Unit tests*: Added unit tests covering: entry missing `type`, entry missing `type` but with `enabled`, malformed entry with `type`, and a valid bare `{ "enabled": boolean }` override.
- *Local tests*: Tested CLI locally, changing and removing MCP config's "type" and "enabled" fields. If "type" is not specified on a non-override entry, opencode will now fail to start and emit an error rather than failing silently and failing to load MCP server(s). 

### Screenshots / recordings
<img width="566" height="119" alt="Screenshot 2026-08-14 at 7 19 47 PM" src="https://github.com/user-attachments/assets/22283854-f154-4196-a45d-7609fc29bd32" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
