### PR TITLE
fix(desktop): show window on did-finish-load fallback for wayland

### DIFF
--- a/packages/desktop/src/main/windows/index.ts
+++ b/packages/desktop/src/main/windows/index.ts
@@ -94,7 +94,14 @@ export function createMainWindow(id: string = randomUUID()) {
   wireFullscreen(win)
   loadWindow(win, "index.html")
   wireZoom(win)
-  win.once("ready-to-show", () => win.show())
+  let revealed = false
+  const reveal = () => {
+    if (revealed || win.isDestroyed()) return
+    revealed = true
+    win.show()
+  }
+  win.once("ready-to-show", reveal)
+  if (process.platform === "linux") win.webContents.once("did-finish-load", reveal)
   return win
 }
 


### PR DESCRIPTION
### Issue for this PR

https://github.com/anomalyco/opencode/issues/42679
Closes #42679

### Type of change

- [x] Bug fix

### What does this PR do?
Adds a Linux-only fallback that reveals the window on `did-finish-load`. A `revealed` flag keeps `show()` single-fire when both events occur; macOS/Windows keep the `ready-to-show` behavior.

### How did you verify your code works?
ran a local build on wayland machine and verified that the window opens

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
