### PR TITLE
fix(core): keep queued work parked after interrupt

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -789,7 +789,10 @@ const layer = Layer.effect(
             return false
           }),
         )
-        if (recovered) return
+        if (recovered) {
+          yield* execution.wake(input.sessionID, { scope: "active" })
+          return
+        }
         yield* execution.wake(input.sessionID)
       }),
       compact: Effect.fn("Session.compact")(function* (input) {
@@ -875,9 +878,7 @@ const layer = Layer.effect(
       interrupt: Effect.fn("Session.interrupt")((sessionID, options) =>
         Effect.uninterruptible(
           Effect.gen(function* () {
-            yield* execution.interrupt(sessionID)
-            if (options?.continue && (yield* SessionInbox.has(db, sessionID, "steer")))
-              yield* execution.wake(sessionID, { scope: "steer" })
+            yield* execution.interrupt(sessionID, options)
           }),
         ),
       ),

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -790,7 +790,7 @@ const layer = Layer.effect(
           }),
         )
         if (recovered) {
-          yield* execution.wake(input.sessionID, { scope: "active" })
+          yield* execution.wakeActive(input.sessionID)
           return
         }
         yield* execution.wake(input.sessionID)

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -876,11 +876,7 @@ const layer = Layer.effect(
         ),
       ),
       interrupt: Effect.fn("Session.interrupt")((sessionID, options) =>
-        Effect.uninterruptible(
-          Effect.gen(function* () {
-            yield* execution.interrupt(sessionID, options)
-          }),
-        ),
+        Effect.uninterruptible(execution.interrupt(sessionID, options)),
       ),
       revert: {
         stage: Effect.fn("Session.revert.stage")(function* (input) {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -876,7 +876,8 @@ const layer = Layer.effect(
         Effect.uninterruptible(
           Effect.gen(function* () {
             yield* execution.interrupt(sessionID)
-            if (options?.continue && (yield* SessionInbox.has(db, sessionID, "any"))) yield* execution.wake(sessionID)
+            if (options?.continue && (yield* SessionInbox.has(db, sessionID, "steer")))
+              yield* execution.wake(sessionID, { scope: "steer" })
           }),
         ),
       ),

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -1,7 +1,8 @@
 export * as SessionExecution from "./execution.js"
 
-import { Cause, Context, Effect, Exit, Layer, Stream } from "effect"
+import { Cause, Context, Effect, Exit, Layer } from "effect"
 import { Bus } from "../bus.js"
+import { Database } from "../database/database.js"
 import { LocationServiceMap } from "../location-service-map.js"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { SessionEvent } from "./event.js"
@@ -11,6 +12,7 @@ import { SessionSchema } from "./schema.js"
 import { SessionStore } from "./store.js"
 import { toSessionError } from "./to-session-error.js"
 import { UserInterruptedError } from "./error.js"
+import { SessionInbox } from "./inbox.js"
 
 export interface Interface {
   /** Snapshots active execution owned by this process. */
@@ -20,10 +22,10 @@ export interface Interface {
   /** Registers newly recorded work. Repeated wakeups coalesce, with a full drain taking precedence. */
   readonly wake: (
     sessionID: SessionSchema.ID,
-    options?: { readonly scope?: SessionRunner.DrainScope },
+    options?: { readonly scope?: SessionRunner.DrainScope | "active" },
   ) => Effect.Effect<void>
   /** Interrupt active work owned by this process. Idle interruption is a no-op. */
-  readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  readonly interrupt: (sessionID: SessionSchema.ID, options?: { readonly continue?: boolean }) => Effect.Effect<void>
   /** Resolves once this process owns no active execution for the Session. Returns immediately when idle and never starts work. */
   readonly awaitIdle: (sessionID: SessionSchema.ID) => Effect.Effect<void>
 }
@@ -48,8 +50,11 @@ export const layer = Layer.effect(
     const store = yield* SessionStore.Service
     const locations = yield* LocationServiceMap.Service
     const bus = yield* Bus.Service
+    const db = (yield* Database.Service).db
     const wakeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
     const activeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
+    const continuingInterrupts = new Map<SessionSchema.ID, Set<symbol>>()
+    const deferredWakes = new Set<SessionSchema.ID>()
     const reportLifecycle = <A>(sessionID: SessionSchema.ID, effect: Effect.Effect<A>) =>
       effect.pipe(
         Effect.tapCause((cause) =>
@@ -145,22 +150,65 @@ export const layer = Layer.effect(
           }),
         ),
     })
-    const wake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
+    const scheduleWake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
       Effect.sync(() => {
         if (scope === "all" || !wakeScopes.has(sessionID)) wakeScopes.set(sessionID, scope)
       }).pipe(Effect.andThen(coordinator.wake(sessionID)))
 
-    yield* bus.subscribe(SessionEvent.Moved).pipe(
-      Stream.runForEach((event) => wake(event.data.sessionID, activeScopes.get(event.data.sessionID) ?? "all")),
-      Effect.forkScoped,
-    )
+    const wake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
+      Effect.suspend(() => {
+        if (!continuingInterrupts.has(sessionID)) return scheduleWake(sessionID, scope)
+        deferredWakes.add(sessionID)
+        return Effect.void
+      })
+
+    const interrupt = (sessionID: SessionSchema.ID, options?: { readonly continue?: boolean }) => {
+      if (!options?.continue) return coordinator.interrupt(sessionID, "user")
+      const token = Symbol()
+      const release = Effect.sync(() => {
+        const active = continuingInterrupts.get(sessionID)
+        active?.delete(token)
+        if (active?.size !== 0) return
+        continuingInterrupts.delete(sessionID)
+        deferredWakes.delete(sessionID)
+      })
+      return Effect.uninterruptible(
+        Effect.sync(() => {
+          const active = continuingInterrupts.get(sessionID)
+          if (active) {
+            active.add(token)
+            return
+          }
+          continuingInterrupts.set(sessionID, new Set([token]))
+          deferredWakes.delete(sessionID)
+          wakeScopes.delete(sessionID)
+        }).pipe(
+          Effect.andThen(coordinator.interrupt(sessionID, "user")),
+          Effect.andThen(SessionInbox.has(db, sessionID, "steer")),
+          Effect.flatMap((hasSteer) =>
+            Effect.sync(() => {
+              const deferred = deferredWakes.delete(sessionID)
+              return hasSteer || deferred
+            }).pipe(
+              Effect.flatMap((resume) =>
+                resume ? scheduleWake(sessionID, "steer").pipe(Effect.andThen(release)) : release,
+              ),
+            ),
+          ),
+          Effect.ensuring(release),
+        ),
+      )
+    }
 
     return Service.of({
       active: coordinator.active,
-      interrupt: (sessionID) =>
-        Effect.sync(() => wakeScopes.delete(sessionID)).pipe(Effect.andThen(coordinator.interrupt(sessionID, "user"))),
+      interrupt,
       resume: coordinator.run,
-      wake: (sessionID, options) => wake(sessionID, options?.scope ?? "all"),
+      wake: (sessionID, options) => {
+        if (options?.scope !== "active") return wake(sessionID, options?.scope ?? "all")
+        const scope = activeScopes.get(sessionID)
+        return scope ? wake(sessionID, scope) : Effect.void
+      },
       awaitIdle: coordinator.awaitIdle,
     })
   }),
@@ -169,7 +217,7 @@ export const layer = Layer.effect(
 export const node = makeGlobalNode({
   service: Service,
   layer,
-  deps: [SessionStore.node, LocationServiceMap.node, Bus.node],
+  deps: [SessionStore.node, LocationServiceMap.node, Bus.node, Database.node],
 })
 
 /** Low-level compatibility layer for callers that only need durable Session recording. */

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -17,8 +17,11 @@ export interface Interface {
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   /** Starts execution while idle or joins the active execution. */
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, SessionRunner.RunError>
-  /** Registers newly recorded work. Repeated wakeups may coalesce. */
-  readonly wake: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  /** Registers newly recorded work. Repeated wakeups coalesce, with a full drain taking precedence. */
+  readonly wake: (
+    sessionID: SessionSchema.ID,
+    options?: { readonly scope?: SessionRunner.DrainScope },
+  ) => Effect.Effect<void>
   /** Interrupt active work owned by this process. Idle interruption is a no-op. */
   readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
   /** Resolves once this process owns no active execution for the Session. Returns immediately when idle and never starts work. */
@@ -45,6 +48,8 @@ export const layer = Layer.effect(
     const store = yield* SessionStore.Service
     const locations = yield* LocationServiceMap.Service
     const bus = yield* Bus.Service
+    const wakeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
+    const activeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
     const reportLifecycle = <A>(sessionID: SessionSchema.ID, effect: Effect.Effect<A>) =>
       effect.pipe(
         Effect.tapCause((cause) =>
@@ -71,12 +76,13 @@ export const layer = Layer.effect(
       sessionID: SessionSchema.ID,
       force: boolean,
       continuation?: SessionRunner.Continuation,
+      scope: SessionRunner.DrainScope = "all",
     ): Effect.Effect<void, SessionRunner.RunError> {
       return Effect.gen(function* () {
         const session = yield* store.get(sessionID)
         if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
         const result = yield* SessionRunner.Service.use((runner) =>
-          runner.drain({ sessionID, force, continuation }),
+          runner.drain({ sessionID, force, continuation, scope }),
         ).pipe(
           Effect.provide(locations.get(session.location)),
           Effect.tapCause((cause) =>
@@ -86,7 +92,7 @@ export const layer = Layer.effect(
           ),
         )
         if (result.type === "complete") return
-        return yield* drain(sessionID, false, result.continuation)
+        return yield* drain(sessionID, false, result.continuation, scope)
       })
     }
     const coordinator = yield* SessionRunCoordinator.make<SessionSchema.ID, SessionRunner.RunError, InterruptReason>({
@@ -95,7 +101,19 @@ export const layer = Layer.effect(
           sessionID,
           bus.publish(SessionEvent.Execution.Started, { sessionID }, claimOnCommit(sessionID)),
         ),
-      drain: (sessionID, force) => drain(sessionID, force),
+      drain: (sessionID, force) =>
+        Effect.sync(() => {
+          const scope = force ? "all" : (wakeScopes.get(sessionID) ?? "all")
+          wakeScopes.delete(sessionID)
+          return scope
+        }).pipe(
+          Effect.flatMap((scope) =>
+            Effect.sync(() => activeScopes.set(sessionID, scope)).pipe(
+              Effect.andThen(drain(sessionID, force, undefined, scope)),
+              Effect.ensuring(Effect.sync(() => activeScopes.delete(sessionID))),
+            ),
+          ),
+        ),
       // One terminal observation per busy period, covering every coalesced drain.
       settled: (sessionID, exit, reason) =>
         reportLifecycle(
@@ -127,16 +145,22 @@ export const layer = Layer.effect(
           }),
         ),
     })
+    const wake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
+      Effect.sync(() => {
+        if (scope === "all" || !wakeScopes.has(sessionID)) wakeScopes.set(sessionID, scope)
+      }).pipe(Effect.andThen(coordinator.wake(sessionID)))
+
     yield* bus.subscribe(SessionEvent.Moved).pipe(
-      Stream.runForEach((event) => coordinator.wake(event.data.sessionID)),
+      Stream.runForEach((event) => wake(event.data.sessionID, activeScopes.get(event.data.sessionID) ?? "all")),
       Effect.forkScoped,
     )
 
     return Service.of({
       active: coordinator.active,
-      interrupt: (sessionID) => coordinator.interrupt(sessionID, "user"),
+      interrupt: (sessionID) =>
+        Effect.sync(() => wakeScopes.delete(sessionID)).pipe(Effect.andThen(coordinator.interrupt(sessionID, "user"))),
       resume: coordinator.run,
-      wake: coordinator.wake,
+      wake: (sessionID, options) => wake(sessionID, options?.scope ?? "all"),
       awaitIdle: coordinator.awaitIdle,
     })
   }),

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -19,11 +19,10 @@ export interface Interface {
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   /** Starts execution while idle or joins the active execution. */
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, SessionRunner.RunError>
-  /** Registers newly recorded work. Repeated wakeups coalesce, with a full drain taking precedence. */
-  readonly wake: (
-    sessionID: SessionSchema.ID,
-    options?: { readonly scope?: SessionRunner.DrainScope | "active" },
-  ) => Effect.Effect<void>
+  /** Registers newly recorded work. Repeated wakeups may coalesce. */
+  readonly wake: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  /** Wakes only an active execution, preserving its current input eligibility. */
+  readonly wakeActive: (sessionID: SessionSchema.ID) => Effect.Effect<void>
   /** Interrupt active work owned by this process. Idle interruption is a no-op. */
   readonly interrupt: (sessionID: SessionSchema.ID, options?: { readonly continue?: boolean }) => Effect.Effect<void>
   /** Resolves once this process owns no active execution for the Session. Returns immediately when idle and never starts work. */
@@ -51,10 +50,6 @@ export const layer = Layer.effect(
     const locations = yield* LocationServiceMap.Service
     const bus = yield* Bus.Service
     const db = (yield* Database.Service).db
-    const wakeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
-    const activeScopes = new Map<SessionSchema.ID, SessionRunner.DrainScope>()
-    const continuingInterrupts = new Map<SessionSchema.ID, Set<symbol>>()
-    const deferredWakes = new Set<SessionSchema.ID>()
     const reportLifecycle = <A>(sessionID: SessionSchema.ID, effect: Effect.Effect<A>) =>
       effect.pipe(
         Effect.tapCause((cause) =>
@@ -81,13 +76,13 @@ export const layer = Layer.effect(
       sessionID: SessionSchema.ID,
       force: boolean,
       continuation?: SessionRunner.Continuation,
-      scope: SessionRunner.DrainScope = "all",
+      promotable: SessionInbox.Promotable = "input",
     ): Effect.Effect<void, SessionRunner.RunError> {
       return Effect.gen(function* () {
         const session = yield* store.get(sessionID)
         if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
         const result = yield* SessionRunner.Service.use((runner) =>
-          runner.drain({ sessionID, force, continuation, scope }),
+          runner.drain({ sessionID, force, continuation, promotable }),
         ).pipe(
           Effect.provide(locations.get(session.location)),
           Effect.tapCause((cause) =>
@@ -97,7 +92,7 @@ export const layer = Layer.effect(
           ),
         )
         if (result.type === "complete") return
-        return yield* drain(sessionID, false, result.continuation, scope)
+        return yield* drain(sessionID, false, result.continuation, promotable)
       })
     }
     const coordinator = yield* SessionRunCoordinator.make<SessionSchema.ID, SessionRunner.RunError, InterruptReason>({
@@ -106,19 +101,7 @@ export const layer = Layer.effect(
           sessionID,
           bus.publish(SessionEvent.Execution.Started, { sessionID }, claimOnCommit(sessionID)),
         ),
-      drain: (sessionID, force) =>
-        Effect.sync(() => {
-          const scope = force ? "all" : (wakeScopes.get(sessionID) ?? "all")
-          wakeScopes.delete(sessionID)
-          return scope
-        }).pipe(
-          Effect.flatMap((scope) =>
-            Effect.sync(() => activeScopes.set(sessionID, scope)).pipe(
-              Effect.andThen(drain(sessionID, force, undefined, scope)),
-              Effect.ensuring(Effect.sync(() => activeScopes.delete(sessionID))),
-            ),
-          ),
-        ),
+      drain: (sessionID, force, promotable) => drain(sessionID, force, undefined, promotable),
       // One terminal observation per busy period, covering every coalesced drain.
       settled: (sessionID, exit, reason) =>
         reportLifecycle(
@@ -150,65 +133,20 @@ export const layer = Layer.effect(
           }),
         ),
     })
-    const scheduleWake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
-      Effect.sync(() => {
-        if (scope === "all" || !wakeScopes.has(sessionID)) wakeScopes.set(sessionID, scope)
-      }).pipe(Effect.andThen(coordinator.wake(sessionID)))
-
-    const wake = (sessionID: SessionSchema.ID, scope: SessionRunner.DrainScope) =>
-      Effect.suspend(() => {
-        if (!continuingInterrupts.has(sessionID)) return scheduleWake(sessionID, scope)
-        deferredWakes.add(sessionID)
-        return Effect.void
-      })
-
-    const interrupt = (sessionID: SessionSchema.ID, options?: { readonly continue?: boolean }) => {
-      if (!options?.continue) return coordinator.interrupt(sessionID, "user")
-      const token = Symbol()
-      const release = Effect.sync(() => {
-        const active = continuingInterrupts.get(sessionID)
-        active?.delete(token)
-        if (active?.size !== 0) return
-        continuingInterrupts.delete(sessionID)
-        deferredWakes.delete(sessionID)
-      })
-      return Effect.uninterruptible(
-        Effect.sync(() => {
-          const active = continuingInterrupts.get(sessionID)
-          if (active) {
-            active.add(token)
-            return
-          }
-          continuingInterrupts.set(sessionID, new Set([token]))
-          deferredWakes.delete(sessionID)
-          wakeScopes.delete(sessionID)
-        }).pipe(
-          Effect.andThen(coordinator.interrupt(sessionID, "user")),
-          Effect.andThen(SessionInbox.has(db, sessionID, "steer")),
-          Effect.flatMap((hasSteer) =>
-            Effect.sync(() => {
-              const deferred = deferredWakes.delete(sessionID)
-              return hasSteer || deferred
-            }).pipe(
-              Effect.flatMap((resume) =>
-                resume ? scheduleWake(sessionID, "steer").pipe(Effect.andThen(release)) : release,
-              ),
-            ),
-          ),
-          Effect.ensuring(release),
-        ),
-      )
-    }
 
     return Service.of({
       active: coordinator.active,
-      interrupt,
+      interrupt: (sessionID, options) =>
+        coordinator.interrupt(
+          sessionID,
+          "user",
+          options?.continue
+            ? { continue: { request: "steer", when: SessionInbox.has(db, sessionID, "steer") } }
+            : undefined,
+        ),
       resume: coordinator.run,
-      wake: (sessionID, options) => {
-        if (options?.scope !== "active") return wake(sessionID, options?.scope ?? "all")
-        const scope = activeScopes.get(sessionID)
-        return scope ? wake(sessionID, scope) : Effect.void
-      },
+      wake: coordinator.wake,
+      wakeActive: coordinator.wakeActive,
       awaitIdle: coordinator.awaitIdle,
     })
   }),
@@ -227,6 +165,7 @@ export const noopLayer = Layer.succeed(
     active: Effect.succeed(new Set()),
     resume: () => Effect.void,
     wake: () => Effect.void,
+    wakeActive: () => Effect.void,
     interrupt: () => Effect.void,
     awaitIdle: () => Effect.void,
   }),

--- a/packages/core/src/session/inbox.ts
+++ b/packages/core/src/session/inbox.ts
@@ -349,6 +349,14 @@ export const nextSteer = Effect.fn("SessionInbox.nextSteer")(function* (
   return row ? fromRow(row) : undefined
 })
 
+export const nextPromotable = Effect.fn("SessionInbox.nextPromotable")(function* (
+  db: DatabaseService,
+  sessionID: SessionSchema.ID,
+  promotable: Promotable,
+) {
+  return (yield* nextSteer(db, sessionID)) ?? (promotable === "input" ? yield* nextQueued(db, sessionID) : undefined)
+})
+
 /**
  * Which pending rows count: "any" counts every row, while "input" means any
  * item in either delivery mode.

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -1,6 +1,7 @@
 export * as SessionRunCoordinator from "./run-coordinator.js"
 
 import { Deferred, Effect, Exit, Fiber, FiberSet, Scope } from "effect"
+import type { Promotable } from "./inbox.js"
 
 /** Serializes execution for each key while allowing different keys to run concurrently. */
 export interface Coordinator<Key, E, Reason = never> {
@@ -9,26 +10,41 @@ export interface Coordinator<Key, E, Reason = never> {
   /** Starts an execution while idle, or joins the active execution and returns its exit. */
   readonly run: (key: Key) => Effect.Effect<void, E>
   /** Rings the doorbell: an idle key starts an execution; an active one drains again before settling. */
-  readonly wake: (key: Key) => Effect.Effect<void>
+  readonly wake: (key: Key, request?: Request) => Effect.Effect<void>
+  /** Rings the current execution's doorbell with its existing request. Idle keys remain idle. */
+  readonly wakeActive: (key: Key) => Effect.Effect<void>
   /** Stops the active execution, clears its doorbell, and waits for cleanup. No-op when idle. */
-  readonly interrupt: (key: Key, reason?: Reason) => Effect.Effect<void>
+  readonly interrupt: (
+    key: Key,
+    reason?: Reason,
+    options?: { readonly continue?: { readonly request: Request; readonly when: Effect.Effect<boolean> } },
+  ) => Effect.Effect<void>
   /** Resolves once no execution is active for the key. Returns immediately when already idle and never starts work. */
   readonly awaitIdle: (key: Key) => Effect.Effect<void>
 }
 
+export type Request = Promotable
+
 /**
  * One execution is a busy period for one key: one fiber that drains from the first wake
  * until the key would stay idle. `pendingWake` is the doorbell: work recorded during the
- * execution rings it, and the execution loop drains again instead of ending. The doorbell
- * closes the gap between a drain's last eligibility check and the idle transition, since
- * those cannot be one atomic step. `done` resolves joiners with this execution's exit.
+ * execution rings it with its eligibility request, and the execution loop drains again
+ * instead of ending. The doorbell closes the gap between a drain's last eligibility check
+ * and the idle transition, since those cannot be one atomic step. `done` resolves joiners
+ * with this execution's exit.
  */
 type Execution<E, Reason> = {
   readonly done: Deferred.Deferred<void, E>
   owner?: Fiber.Fiber<void>
-  pendingWake: boolean
+  request: Request
+  pendingWake?: Request
   stopping: boolean
   interruptionReason?: Reason
+  continuation?: {
+    readonly request: Request
+    readonly when: Effect.Effect<boolean>
+    signaled: boolean
+  }
 }
 
 /**
@@ -43,7 +59,7 @@ type Execution<E, Reason> = {
  * ```
  */
 export const make = <Key, E, Reason = never>(options: {
-  readonly drain: (key: Key, force: boolean) => Effect.Effect<void, E>
+  readonly drain: (key: Key, force: boolean, request: Request) => Effect.Effect<void, E>
   /** Runs once when a process-local busy period begins, before its first drain. */
   readonly started?: (key: Key) => Effect.Effect<void>
   /**
@@ -55,23 +71,26 @@ export const make = <Key, E, Reason = never>(options: {
   Effect.gen(function* () {
     const executions = new Map<Key, Execution<E, Reason>>()
     const fork = yield* FiberSet.makeRuntime<never, void, never>()
+    const merge = (left: Request, right: Request): Request =>
+      left === "input" || right === "input" ? "input" : "steer"
 
     const loop = (key: Key, execution: Execution<E, Reason>, force: boolean): Effect.Effect<void, E> =>
-      Effect.suspend(() => options.drain(key, force)).pipe(
+      Effect.suspend(() => options.drain(key, force, execution.request)).pipe(
         Effect.flatMap(() =>
           Effect.suspend(() => {
-            if (execution.stopping || !execution.pendingWake) return Effect.void
-            execution.pendingWake = false
+            if (execution.stopping || execution.pendingWake === undefined) return Effect.void
+            execution.request = execution.pendingWake
+            execution.pendingWake = undefined
             // Trampoline so drains that complete synchronously cannot grow the stack.
             return Effect.yieldNow.pipe(Effect.andThen(loop(key, execution, false)))
           }),
         ),
       )
 
-    const start = (key: Key, force: boolean) => {
+    const start = (key: Key, force: boolean, request: Request) => {
       const execution: Execution<E, Reason> = {
         done: Deferred.makeUnsafe<void, E>(),
-        pendingWake: false,
+        request,
         stopping: false,
       }
       executions.set(key, execution)
@@ -87,7 +106,7 @@ export const make = <Key, E, Reason = never>(options: {
               execution.owner = undefined
             }).pipe(Effect.andThen(options.settled?.(key, exit, execution.interruptionReason) ?? Effect.void)),
           ),
-          Effect.onExit((exit) => Effect.sync(() => settle(key, execution, exit))),
+          Effect.onExit((exit) => finish(key, execution, exit)),
           Effect.exit,
           Effect.asVoid,
         ),
@@ -97,10 +116,20 @@ export const make = <Key, E, Reason = never>(options: {
 
     // A doorbell that survives the execution loop (rung after the loop decided to end, or
     // during failure or interruption cleanup) starts a fresh execution for the remaining work.
-    const settle = (key: Key, execution: Execution<E, Reason>, exit: Exit.Exit<void, E>) => {
-      if (execution.pendingWake) start(key, false)
+    const settle = (key: Key, execution: Execution<E, Reason>, exit: Exit.Exit<void, E>, continuation: boolean) => {
+      if (continuation && execution.continuation) start(key, false, execution.continuation.request)
+      else if (execution.pendingWake) start(key, false, execution.pendingWake)
       else executions.delete(key)
       Deferred.doneUnsafe(execution.done, exit)
+    }
+
+    const finish = (key: Key, execution: Execution<E, Reason>, exit: Exit.Exit<void, E>) => {
+      if (!execution.continuation) return Effect.sync(() => settle(key, execution, exit, false))
+      return execution.continuation.when.pipe(
+        Effect.flatMap((ready) =>
+          Effect.sync(() => settle(key, execution, exit, ready || execution.continuation?.signaled === true)),
+        ),
+      )
     }
 
     const run = (key: Key): Effect.Effect<void, E> =>
@@ -111,26 +140,57 @@ export const make = <Key, E, Reason = never>(options: {
           if (execution.stopping) return Deferred.await(execution.done).pipe(Effect.andThen(run(key)))
           return Deferred.await(execution.done)
         }
-        return Deferred.await(start(key, true).done)
+        return Deferred.await(start(key, true, "input").done)
       })
 
-    const wake = (key: Key) =>
+    const wake = (key: Key, request: Request = "input") =>
       Effect.sync(() => {
         const execution = executions.get(key)
         if (execution !== undefined) {
-          execution.pendingWake = true
+          if (execution.stopping) {
+            if (execution.continuation) execution.continuation.signaled = true
+            else execution.continuation = { request, when: Effect.succeed(true), signaled: true }
+            return
+          }
+          execution.pendingWake = execution.pendingWake ? merge(execution.pendingWake, request) : request
           return
         }
-        start(key, false)
+        start(key, false, request)
       })
 
-    const interrupt = (key: Key, reason?: Reason): Effect.Effect<void> =>
+    const wakeActive = (key: Key) =>
       Effect.suspend(() => {
         const execution = executions.get(key)
-        if (execution?.owner === undefined || execution.stopping) return Effect.void
+        return execution ? wake(key, execution.request) : Effect.void
+      })
+
+    const interrupt = (
+      key: Key,
+      reason?: Reason,
+      options?: { readonly continue?: { readonly request: Request; readonly when: Effect.Effect<boolean> } },
+    ): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        const execution = executions.get(key)
+        if (execution === undefined) return Effect.void
+        if (execution.stopping) {
+          if (options?.continue)
+            execution.continuation = {
+              ...options.continue,
+              signaled: execution.continuation?.signaled ?? false,
+            }
+          return Deferred.await(execution.done).pipe(Effect.exit, Effect.asVoid)
+        }
+        if (execution.owner === undefined) {
+          if (!options?.continue) return Effect.void
+          execution.stopping = true
+          execution.pendingWake = undefined
+          execution.continuation = { ...options.continue, signaled: false }
+          return Deferred.await(execution.done).pipe(Effect.exit, Effect.asVoid)
+        }
         execution.stopping = true
-        execution.pendingWake = false
+        execution.pendingWake = undefined
         execution.interruptionReason = reason
+        if (options?.continue) execution.continuation = { ...options.continue, signaled: false }
         return Fiber.interrupt(execution.owner)
       })
 
@@ -143,5 +203,5 @@ export const make = <Key, E, Reason = never>(options: {
         return Deferred.await(execution.done).pipe(Effect.exit, Effect.andThen(awaitIdle(key)))
       })
 
-    return { active: Effect.sync(() => new Set(executions.keys())), run, wake, interrupt, awaitIdle }
+    return { active: Effect.sync(() => new Set(executions.keys())), run, wake, wakeActive, interrupt, awaitIdle }
   })

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -71,8 +71,6 @@ export const make = <Key, E, Reason = never>(options: {
   Effect.gen(function* () {
     const executions = new Map<Key, Execution<E, Reason>>()
     const fork = yield* FiberSet.makeRuntime<never, void, never>()
-    const merge = (left: Request, right: Request): Request =>
-      left === "input" || right === "input" ? "input" : "steer"
 
     const loop = (key: Key, execution: Execution<E, Reason>, force: boolean): Effect.Effect<void, E> =>
       Effect.suspend(() => options.drain(key, force, execution.request)).pipe(
@@ -116,8 +114,8 @@ export const make = <Key, E, Reason = never>(options: {
 
     // A doorbell that survives the execution loop (rung after the loop decided to end, or
     // during failure or interruption cleanup) starts a fresh execution for the remaining work.
-    const settle = (key: Key, execution: Execution<E, Reason>, exit: Exit.Exit<void, E>, continuation: boolean) => {
-      if (continuation && execution.continuation) start(key, false, execution.continuation.request)
+    const settle = (key: Key, execution: Execution<E, Reason>, exit: Exit.Exit<void, E>, resume: boolean) => {
+      if (resume && execution.continuation) start(key, false, execution.continuation.request)
       else if (execution.pendingWake) start(key, false, execution.pendingWake)
       else executions.delete(key)
       Deferred.doneUnsafe(execution.done, exit)
@@ -152,7 +150,8 @@ export const make = <Key, E, Reason = never>(options: {
             else execution.continuation = { request, when: Effect.succeed(true), signaled: true }
             return
           }
-          execution.pendingWake = execution.pendingWake ? merge(execution.pendingWake, request) : request
+          // Coalesced wakes keep the widest request: "input" subsumes "steer".
+          execution.pendingWake = execution.pendingWake === "input" ? "input" : request
           return
         }
         start(key, false, request)

--- a/packages/core/src/session/runner/index.ts
+++ b/packages/core/src/session/runner/index.ts
@@ -18,6 +18,9 @@ export type RunError =
 
 export type Continuation = { readonly step: number }
 
+/** "steer" settles the active intent without promoting queued next-turn work. */
+export type DrainScope = "all" | "steer"
+
 export type DrainResult =
   | { readonly type: "complete" }
   | { readonly type: "moved"; readonly continuation?: Continuation }
@@ -29,6 +32,7 @@ export interface Interface {
     readonly sessionID: SessionSchema.ID
     readonly force: boolean
     readonly continuation?: Continuation
+    readonly scope?: DrainScope
   }) => Effect.Effect<DrainResult, RunError>
 }
 

--- a/packages/core/src/session/runner/index.ts
+++ b/packages/core/src/session/runner/index.ts
@@ -3,6 +3,7 @@ export * as SessionRunner from "./index.js"
 import type { AIError } from "@opencode-ai/ai"
 import { Context, Effect } from "effect"
 import { SessionSchema } from "../schema.js"
+import type { Promotable } from "../inbox.js"
 import type { AgentNotFoundError, MessageDecodeError, StepFailedError, UserInterruptedError } from "../error.js"
 import { SessionRunnerModel } from "./model.js"
 import type { Instructions } from "../../instructions/index.js"
@@ -18,9 +19,6 @@ export type RunError =
 
 export type Continuation = { readonly step: number }
 
-/** "steer" settles the active intent without promoting queued next-turn work. */
-export type DrainScope = "all" | "steer"
-
 export type DrainResult =
   | { readonly type: "complete" }
   | { readonly type: "moved"; readonly continuation?: Continuation }
@@ -32,7 +30,8 @@ export interface Interface {
     readonly sessionID: SessionSchema.ID
     readonly force: boolean
     readonly continuation?: Continuation
-    readonly scope?: DrainScope
+    /** "steer" settles the active intent without promoting queued next-turn work. */
+    readonly promotable?: Promotable
   }) => Effect.Effect<DrainResult, RunError>
 }
 

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -24,7 +24,7 @@ import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
 import { SessionStore } from "../store.js"
 import { SessionTitle } from "../title.js"
-import { Service, type Continuation, type DrainScope } from "./index.js"
+import { Service, type Continuation } from "./index.js"
 import { createLLMEventPublisher, type StepRecord } from "./publish-llm-event.js"
 import { Snapshot } from "../../snapshot.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -128,16 +128,12 @@ const layer = Layer.effect(
       readonly sessionID: SessionSchema.ID
       readonly force: boolean
       readonly continuation?: Continuation
-      readonly scope?: DrainScope
+      readonly promotable?: SessionInbox.Promotable
     }) {
       let force = input.force
       let continuation = input.continuation
-      const promotable = input.scope === "steer" ? "steer" : "input"
-      if (
-        !force &&
-        !continuation &&
-        !(yield* SessionInbox.has(db, input.sessionID, input.scope === "steer" ? "steer" : "any"))
-      )
+      const promotable = input.promotable ?? "input"
+      if (!force && !continuation && !(yield* SessionInbox.has(db, input.sessionID, promotable)))
         return { type: "complete" as const }
       yield* settleStaleToolCalls(input.sessionID)
       while (true) {
@@ -150,7 +146,7 @@ const layer = Layer.effect(
           return { type: "complete" as const }
         const result = yield* runSteps(input.sessionID, continuation, promotable)
         if (result.type === "moved") return result
-        if (input.scope === "steer") return { type: "complete" as const }
+        if (promotable === "steer") return { type: "complete" as const }
         force = false
         continuation = undefined
       }
@@ -530,9 +526,7 @@ const layer = Layer.effect(
           const pending = yield* SessionInbox.serialized(
             sessionID,
             Effect.gen(function* () {
-              const selected =
-                (yield* SessionInbox.nextSteer(db, sessionID)) ??
-                (promotable === "input" ? yield* SessionInbox.nextQueued(db, sessionID) : undefined)
+              const selected = yield* SessionInbox.nextPromotable(db, sessionID, promotable)
               if (selected?.type !== "compaction") return
               yield* bus.publishAll([
                 [SessionEvent.InboxDelivered, { sessionID, inboxID: selected.id }],
@@ -574,9 +568,7 @@ const layer = Layer.effect(
       return yield* SessionInbox.serialized(
         sessionID,
         Effect.gen(function* () {
-          const pending =
-            (yield* SessionInbox.nextSteer(db, sessionID)) ??
-            (promotable === "input" ? yield* SessionInbox.nextQueued(db, sessionID) : undefined)
+          const pending = yield* SessionInbox.nextPromotable(db, sessionID, promotable)
           if (pending?.type !== "move") return false
           yield* modelTransport.close(sessionID)
           yield* bus.publishAll([

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -24,7 +24,7 @@ import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
 import { SessionStore } from "../store.js"
 import { SessionTitle } from "../title.js"
-import { Service, type Continuation } from "./index.js"
+import { Service, type Continuation, type DrainScope } from "./index.js"
 import { createLLMEventPublisher, type StepRecord } from "./publish-llm-event.js"
 import { Snapshot } from "../../snapshot.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -128,22 +128,29 @@ const layer = Layer.effect(
       readonly sessionID: SessionSchema.ID
       readonly force: boolean
       readonly continuation?: Continuation
+      readonly scope?: DrainScope
     }) {
       let force = input.force
       let continuation = input.continuation
-      if (!force && !continuation && !(yield* SessionInbox.has(db, input.sessionID, "any")))
+      const promotable = input.scope === "steer" ? "steer" : "input"
+      if (
+        !force &&
+        !continuation &&
+        !(yield* SessionInbox.has(db, input.sessionID, input.scope === "steer" ? "steer" : "any"))
+      )
         return { type: "complete" as const }
       yield* settleStaleToolCalls(input.sessionID)
       while (true) {
-        if (yield* runPendingCompaction(input.sessionID)) {
+        if (yield* runPendingCompaction(input.sessionID, promotable)) {
           force = false
           continue
         }
-        if (yield* runPendingMove(input.sessionID, "input")) return { type: "moved" as const }
-        if (!force && !continuation && !(yield* SessionInbox.has(db, input.sessionID, "input")))
+        if (yield* runPendingMove(input.sessionID, promotable)) return { type: "moved" as const }
+        if (!force && !continuation && !(yield* SessionInbox.has(db, input.sessionID, promotable)))
           return { type: "complete" as const }
-        const result = yield* runSteps(input.sessionID, continuation)
+        const result = yield* runSteps(input.sessionID, continuation, promotable)
         if (result.type === "moved") return result
+        if (input.scope === "steer") return { type: "complete" as const }
         force = false
         continuation = undefined
       }
@@ -156,13 +163,14 @@ const layer = Layer.effect(
     const runSteps = Effect.fn("SessionRunner.runSteps")(function* (
       sessionID: SessionSchema.ID,
       continuation?: Continuation,
+      initialPromotable: SessionInbox.Promotable = continuation ? "steer" : "input",
     ) {
       // Fresh work may promote queued input; later steps absorb steers only.
-      let promotable: SessionInbox.Promotable = continuation ? "steer" : "input"
+      let promotable = initialPromotable
       let step = continuation?.step ?? 1
       let next = continuation
       while (true) {
-        if (yield* runPendingCompaction(sessionID)) continue
+        if (yield* runPendingCompaction(sessionID, "steer")) continue
         if (yield* runPendingMove(sessionID, "steer")) return { type: "moved" as const, continuation: next }
         const result = yield* runStep(sessionID, promotable, step)
         next = result.needsContinuation ? { step: result.step + 1 } : undefined
@@ -515,6 +523,7 @@ const layer = Layer.effect(
     /** Executes a previously admitted manual compaction request, if one is pending. */
     const runPendingCompaction = Effect.fn("SessionRunner.runPendingCompaction")(function* (
       sessionID: SessionSchema.ID,
+      promotable: SessionInbox.Promotable,
     ) {
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
@@ -522,7 +531,8 @@ const layer = Layer.effect(
             sessionID,
             Effect.gen(function* () {
               const selected =
-                (yield* SessionInbox.nextSteer(db, sessionID)) ?? (yield* SessionInbox.nextQueued(db, sessionID))
+                (yield* SessionInbox.nextSteer(db, sessionID)) ??
+                (promotable === "input" ? yield* SessionInbox.nextQueued(db, sessionID) : undefined)
               if (selected?.type !== "compaction") return
               yield* bus.publishAll([
                 [SessionEvent.InboxDelivered, { sessionID, inboxID: selected.id }],

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -158,11 +158,11 @@ const layer = Layer.effect(
      */
     const runSteps = Effect.fn("SessionRunner.runSteps")(function* (
       sessionID: SessionSchema.ID,
-      continuation?: Continuation,
-      initialPromotable: SessionInbox.Promotable = continuation ? "steer" : "input",
+      continuation: Continuation | undefined,
+      drainPromotable: SessionInbox.Promotable,
     ) {
-      // Fresh work may promote queued input; later steps absorb steers only.
-      let promotable = initialPromotable
+      // Fresh work may promote queued input; resumed turns and later steps absorb steers only.
+      let promotable: SessionInbox.Promotable = continuation ? "steer" : drainPromotable
       let step = continuation?.step ?? 1
       let next = continuation
       while (true) {

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -14,8 +14,9 @@ import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { UserInterruptedError } from "@opencode-ai/core/session/error"
 import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionRunner } from "@opencode-ai/core/session/runner/index"
-import { SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionInboxTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { Context, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Scope } from "effect"
 import { eq } from "drizzle-orm"
@@ -161,6 +162,106 @@ describe("SessionExecution lifecycle", () => {
       yield* execution.awaitIdle(sessionID)
 
       expect(scopes).toEqual(["steer", "all"])
+    }),
+  )
+
+  it.effect("an active-scope wake preserves a steer-scoped execution", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_wake_scope_preserved")
+      yield* seedSessions(database, [sessionID])
+
+      const firstRunning = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const scopes: Array<SessionRunner.DrainScope | undefined> = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, (input) =>
+        Effect.gen(function* () {
+          scopes.push(input.scope)
+          if (scopes.length !== 1) return
+          yield* Deferred.succeed(firstRunning, undefined)
+          yield* Deferred.await(release)
+        }),
+      )
+      const execution = Context.get(context, SessionExecution.Service)
+
+      yield* execution.wake(sessionID, { scope: "steer" })
+      yield* Deferred.await(firstRunning)
+      yield* execution.wake(sessionID, { scope: "active" })
+      yield* Deferred.succeed(release, undefined)
+      yield* execution.awaitIdle(sessionID)
+
+      expect(scopes).toEqual(["steer", "steer"])
+    }),
+  )
+
+  it.effect("an active-scope wake does not start an idle execution", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_wake_scope_idle")
+      yield* seedSessions(database, [sessionID])
+
+      const scopes: Array<SessionRunner.DrainScope | undefined> = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, (input) => Effect.sync(() => scopes.push(input.scope)))
+      const execution = Context.get(context, SessionExecution.Service)
+
+      yield* execution.wake(sessionID, { scope: "active" })
+      yield* execution.awaitIdle(sessionID)
+
+      expect(scopes).toEqual([])
+    }),
+  )
+
+  it.effect("overlapping interrupt-generation wakes cannot promote queued work", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_interrupt_scope_race")
+      yield* seedSessions(database, [sessionID])
+      yield* database.db
+        .insert(SessionInboxTable)
+        .values({
+          id: SessionMessage.ID.make("msg_interrupt_queue"),
+          session_id: sessionID,
+          type: "synthetic",
+          payload: { text: "Queue for later" },
+          delivery: "queue",
+          enqueued_seq: 1,
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      const firstRunning = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const scopes: Array<SessionRunner.DrainScope | undefined> = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, (input) =>
+        Effect.gen(function* () {
+          scopes.push(input.scope)
+          if (scopes.length !== 1) return
+          yield* Deferred.succeed(firstRunning, undefined)
+          yield* Effect.uninterruptible(Deferred.await(release))
+        }),
+      )
+      const execution = Context.get(context, SessionExecution.Service)
+
+      yield* execution.resume(sessionID).pipe(Effect.forkIn(scope))
+      yield* Deferred.await(firstRunning)
+      const interrupted = yield* Effect.all([
+        execution.interrupt(sessionID, { continue: true }).pipe(Effect.forkIn(scope)),
+        execution.interrupt(sessionID, { continue: true }).pipe(Effect.forkIn(scope)),
+      ])
+      yield* Effect.yieldNow
+      yield* execution.wake(sessionID)
+      yield* Deferred.succeed(release, undefined)
+      yield* Effect.forEach(interrupted, Fiber.join, { discard: true })
+      yield* execution.awaitIdle(sessionID)
+
+      expect(scopes[0]).toBe("all")
+      expect(scopes.slice(1)).toEqual(["steer"])
     }),
   )
 

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -14,9 +14,8 @@ import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { UserInterruptedError } from "@opencode-ai/core/session/error"
 import { SessionEvent } from "@opencode-ai/core/session/event"
-import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionRunner } from "@opencode-ai/core/session/runner/index"
-import { SessionInboxTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { Context, Deferred, Effect, Exit, Fiber, Layer, LayerMap, Scope } from "effect"
 import { eq } from "drizzle-orm"
@@ -131,137 +130,6 @@ describe("SessionExecution lifecycle", () => {
       yield* execution.interrupt(sessionID)
       yield* execution.awaitIdle(sessionID)
       expect((yield* claims(database))[sessionID]).toBe(false)
-    }),
-  )
-
-  it.effect("a full wake upgrades a steer-scoped execution", () =>
-    Effect.gen(function* () {
-      const database = yield* Database.Service
-      const sessionID = Session.ID.make("ses_wake_scope_upgrade")
-      yield* seedSessions(database, [sessionID])
-
-      const firstRunning = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
-      const scopes: Array<SessionRunner.DrainScope | undefined> = []
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* buildExecution(scope, (input) =>
-        Effect.gen(function* () {
-          scopes.push(input.scope)
-          if (scopes.length !== 1) return
-          yield* Deferred.succeed(firstRunning, undefined)
-          yield* Deferred.await(release)
-        }),
-      )
-      const execution = Context.get(context, SessionExecution.Service)
-
-      yield* execution.wake(sessionID, { scope: "steer" })
-      yield* Deferred.await(firstRunning)
-      yield* execution.wake(sessionID)
-      yield* Deferred.succeed(release, undefined)
-      yield* execution.awaitIdle(sessionID)
-
-      expect(scopes).toEqual(["steer", "all"])
-    }),
-  )
-
-  it.effect("an active-scope wake preserves a steer-scoped execution", () =>
-    Effect.gen(function* () {
-      const database = yield* Database.Service
-      const sessionID = Session.ID.make("ses_wake_scope_preserved")
-      yield* seedSessions(database, [sessionID])
-
-      const firstRunning = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
-      const scopes: Array<SessionRunner.DrainScope | undefined> = []
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* buildExecution(scope, (input) =>
-        Effect.gen(function* () {
-          scopes.push(input.scope)
-          if (scopes.length !== 1) return
-          yield* Deferred.succeed(firstRunning, undefined)
-          yield* Deferred.await(release)
-        }),
-      )
-      const execution = Context.get(context, SessionExecution.Service)
-
-      yield* execution.wake(sessionID, { scope: "steer" })
-      yield* Deferred.await(firstRunning)
-      yield* execution.wake(sessionID, { scope: "active" })
-      yield* Deferred.succeed(release, undefined)
-      yield* execution.awaitIdle(sessionID)
-
-      expect(scopes).toEqual(["steer", "steer"])
-    }),
-  )
-
-  it.effect("an active-scope wake does not start an idle execution", () =>
-    Effect.gen(function* () {
-      const database = yield* Database.Service
-      const sessionID = Session.ID.make("ses_wake_scope_idle")
-      yield* seedSessions(database, [sessionID])
-
-      const scopes: Array<SessionRunner.DrainScope | undefined> = []
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* buildExecution(scope, (input) => Effect.sync(() => scopes.push(input.scope)))
-      const execution = Context.get(context, SessionExecution.Service)
-
-      yield* execution.wake(sessionID, { scope: "active" })
-      yield* execution.awaitIdle(sessionID)
-
-      expect(scopes).toEqual([])
-    }),
-  )
-
-  it.effect("overlapping interrupt-generation wakes cannot promote queued work", () =>
-    Effect.gen(function* () {
-      const database = yield* Database.Service
-      const sessionID = Session.ID.make("ses_interrupt_scope_race")
-      yield* seedSessions(database, [sessionID])
-      yield* database.db
-        .insert(SessionInboxTable)
-        .values({
-          id: SessionMessage.ID.make("msg_interrupt_queue"),
-          session_id: sessionID,
-          type: "synthetic",
-          payload: { text: "Queue for later" },
-          delivery: "queue",
-          enqueued_seq: 1,
-        })
-        .run()
-        .pipe(Effect.orDie)
-
-      const firstRunning = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
-      const scopes: Array<SessionRunner.DrainScope | undefined> = []
-      const scope = yield* Scope.make()
-      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
-      const context = yield* buildExecution(scope, (input) =>
-        Effect.gen(function* () {
-          scopes.push(input.scope)
-          if (scopes.length !== 1) return
-          yield* Deferred.succeed(firstRunning, undefined)
-          yield* Effect.uninterruptible(Deferred.await(release))
-        }),
-      )
-      const execution = Context.get(context, SessionExecution.Service)
-
-      yield* execution.resume(sessionID).pipe(Effect.forkIn(scope))
-      yield* Deferred.await(firstRunning)
-      const interrupted = yield* Effect.all([
-        execution.interrupt(sessionID, { continue: true }).pipe(Effect.forkIn(scope)),
-        execution.interrupt(sessionID, { continue: true }).pipe(Effect.forkIn(scope)),
-      ])
-      yield* Effect.yieldNow
-      yield* execution.wake(sessionID)
-      yield* Deferred.succeed(release, undefined)
-      yield* Effect.forEach(interrupted, Fiber.join, { discard: true })
-      yield* execution.awaitIdle(sessionID)
-
-      expect(scopes[0]).toBe("all")
-      expect(scopes.slice(1)).toEqual(["steer"])
     }),
   )
 

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -133,6 +133,37 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
+  it.effect("a full wake upgrades a steer-scoped execution", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionID = Session.ID.make("ses_wake_scope_upgrade")
+      yield* seedSessions(database, [sessionID])
+
+      const firstRunning = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const scopes: Array<SessionRunner.DrainScope | undefined> = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, (input) =>
+        Effect.gen(function* () {
+          scopes.push(input.scope)
+          if (scopes.length !== 1) return
+          yield* Deferred.succeed(firstRunning, undefined)
+          yield* Deferred.await(release)
+        }),
+      )
+      const execution = Context.get(context, SessionExecution.Service)
+
+      yield* execution.wake(sessionID, { scope: "steer" })
+      yield* Deferred.await(firstRunning)
+      yield* execution.wake(sessionID)
+      yield* Deferred.succeed(release, undefined)
+      yield* execution.awaitIdle(sessionID)
+
+      expect(scopes).toEqual(["steer", "all"])
+    }),
+  )
+
   it.effect("starts every claimed execution without waiting for earlier drains to finish", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -51,6 +51,7 @@ const execution = Layer.succeed(
       Effect.sync(() => {
         wakeCalls.push(sessionID)
       }),
+    wakeActive: () => Effect.void,
     awaitIdle: () => Effect.void,
   }),
 )
@@ -191,20 +192,6 @@ describe("Session.prompt", () => {
 
       expect(interruptCalls).toEqual([sessionID])
       expect(interruptContinuations).toEqual([true])
-      expect(wakeCalls).toEqual([])
-    }),
-  )
-
-  it.effect("does not continue after interruption without pending work", () =>
-    Effect.gen(function* () {
-      yield* setup
-      const session = yield* Session.Service
-      interruptCalls.length = 0
-      wakeCalls.length = 0
-
-      yield* session.interrupt(sessionID, { continue: true })
-
-      expect(interruptCalls).toEqual([sessionID])
       expect(wakeCalls).toEqual([])
     }),
   )

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -32,6 +32,7 @@ import { testEffect } from "./lib/effect"
 const executionCalls: Session.ID[] = []
 const interruptCalls: Session.ID[] = []
 const wakeCalls: Session.ID[] = []
+const wakeScopes: Array<string | undefined> = []
 const activeSessions = new Set<Session.ID>()
 const execution = Layer.succeed(
   SessionExecution.Service,
@@ -45,9 +46,10 @@ const execution = Layer.succeed(
       Effect.sync(() => {
         interruptCalls.push(sessionID)
       }),
-    wake: (sessionID) =>
+    wake: (sessionID, options) =>
       Effect.sync(() => {
         wakeCalls.push(sessionID)
+        wakeScopes.push(options?.scope)
       }),
     awaitIdle: () => Effect.void,
   }),
@@ -177,18 +179,40 @@ describe("Session.prompt", () => {
     }),
   )
 
-  it.effect("continues after interruption when pending work remains", () =>
+  it.effect("continues steering input after interruption", () =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* Session.Service
       yield* session.synthetic({ sessionID, text: "Continue after interrupt", resume: false })
       interruptCalls.length = 0
       wakeCalls.length = 0
+      wakeScopes.length = 0
 
       yield* session.interrupt(sessionID, { continue: true })
 
       expect(interruptCalls).toEqual([sessionID])
       expect(wakeCalls).toEqual([sessionID])
+      expect(wakeScopes).toEqual(["steer"])
+    }),
+  )
+
+  it.effect("leaves queued input parked after interruption", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* Session.Service
+      yield* session.synthetic({
+        sessionID,
+        text: "Wait until explicitly resumed",
+        delivery: "queue",
+        resume: false,
+      })
+      interruptCalls.length = 0
+      wakeCalls.length = 0
+
+      yield* session.interrupt(sessionID, { continue: true })
+
+      expect(interruptCalls).toEqual([sessionID])
+      expect(wakeCalls).toEqual([])
     }),
   )
 

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -31,8 +31,8 @@ import { testEffect } from "./lib/effect"
 
 const executionCalls: Session.ID[] = []
 const interruptCalls: Session.ID[] = []
+const interruptContinuations: Array<boolean | undefined> = []
 const wakeCalls: Session.ID[] = []
-const wakeScopes: Array<string | undefined> = []
 const activeSessions = new Set<Session.ID>()
 const execution = Layer.succeed(
   SessionExecution.Service,
@@ -42,14 +42,14 @@ const execution = Layer.succeed(
       Effect.sync(() => {
         executionCalls.push(sessionID)
       }),
-    interrupt: (sessionID) =>
+    interrupt: (sessionID, options) =>
       Effect.sync(() => {
         interruptCalls.push(sessionID)
+        interruptContinuations.push(options?.continue)
       }),
-    wake: (sessionID, options) =>
+    wake: (sessionID) =>
       Effect.sync(() => {
         wakeCalls.push(sessionID)
-        wakeScopes.push(options?.scope)
       }),
     awaitIdle: () => Effect.void,
   }),
@@ -179,39 +179,18 @@ describe("Session.prompt", () => {
     }),
   )
 
-  it.effect("continues steering input after interruption", () =>
+  it.effect("forwards interrupt continuation policy", () =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* Session.Service
-      yield* session.synthetic({ sessionID, text: "Continue after interrupt", resume: false })
       interruptCalls.length = 0
-      wakeCalls.length = 0
-      wakeScopes.length = 0
-
-      yield* session.interrupt(sessionID, { continue: true })
-
-      expect(interruptCalls).toEqual([sessionID])
-      expect(wakeCalls).toEqual([sessionID])
-      expect(wakeScopes).toEqual(["steer"])
-    }),
-  )
-
-  it.effect("leaves queued input parked after interruption", () =>
-    Effect.gen(function* () {
-      yield* setup
-      const session = yield* Session.Service
-      yield* session.synthetic({
-        sessionID,
-        text: "Wait until explicitly resumed",
-        delivery: "queue",
-        resume: false,
-      })
-      interruptCalls.length = 0
+      interruptContinuations.length = 0
       wakeCalls.length = 0
 
       yield* session.interrupt(sessionID, { continue: true })
 
       expect(interruptCalls).toEqual([sessionID])
+      expect(interruptContinuations).toEqual([true])
       expect(wakeCalls).toEqual([])
     }),
   )

--- a/packages/core/test/session-run-coordinator.test.ts
+++ b/packages/core/test/session-run-coordinator.test.ts
@@ -269,6 +269,35 @@ describe("SessionRunCoordinator", () => {
     ),
   )
 
+  it.effect("replaces a settlement-window wake with a steer continuation", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settling = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) => Effect.sync(() => requests.push(request)),
+          settled: () => Deferred.succeed(settling, undefined).pipe(Effect.andThen(Deferred.await(release))),
+        })
+
+        yield* coordinator.wake("session", "input")
+        yield* Deferred.await(settling)
+        yield* coordinator.wake("session", "input")
+        const interrupted = yield* coordinator
+          .interrupt("session", undefined, {
+            continue: { request: "steer", when: Effect.succeed(true) },
+          })
+          .pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(interrupted)
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["input", "steer"])
+      }),
+    ),
+  )
+
   it.effect("interrupts active execution and clears its pending wake", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -338,6 +367,193 @@ describe("SessionRunCoordinator", () => {
 
         expect(runs).toBe(2)
         expect(starts).toBe(2)
+      }),
+    ),
+  )
+
+  it.effect("coalesces drain requests with input taking precedence", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.gen(function* () {
+              requests.push(request)
+              if (requests.length !== 1) return
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Deferred.await(release)
+            }),
+        })
+
+        yield* coordinator.wake("session", "steer")
+        yield* Deferred.await(firstStarted)
+        yield* coordinator.wake("session", "steer")
+        yield* coordinator.wake("session", "input")
+        yield* Deferred.succeed(release, undefined)
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["steer", "input"])
+      }),
+    ),
+  )
+
+  it.effect("does not carry a completed input request into a steer drain", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.gen(function* () {
+              requests.push(request)
+              if (requests.length !== 1) return
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Deferred.await(release)
+            }),
+        })
+
+        yield* coordinator.wake("session", "input")
+        yield* Deferred.await(firstStarted)
+        yield* coordinator.wake("session", "steer")
+        yield* Deferred.succeed(release, undefined)
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["input", "steer"])
+      }),
+    ),
+  )
+
+  it.effect("an active wake inherits scope without starting idle work", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.gen(function* () {
+              requests.push(request)
+              if (requests.length !== 1) return
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Deferred.await(release)
+            }),
+        })
+
+        yield* coordinator.wakeActive("session")
+        yield* coordinator.wake("session", "steer")
+        yield* Deferred.await(firstStarted)
+        yield* coordinator.wakeActive("session")
+        yield* Deferred.succeed(release, undefined)
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["steer", "steer"])
+      }),
+    ),
+  )
+
+  it.effect("coalesces overlapping interrupt continuations into one steer successor", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const cleanupStarted = yield* Deferred.make<void>()
+        const cleanupGate = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.gen(function* () {
+              requests.push(request)
+              if (requests.length !== 1) return
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Effect.never.pipe(
+                Effect.onInterrupt(() =>
+                  Deferred.succeed(cleanupStarted, undefined).pipe(Effect.andThen(Deferred.await(cleanupGate))),
+                ),
+              )
+            }),
+        })
+        const continuation = { continue: { request: "steer" as const, when: Effect.succeed(false) } }
+
+        yield* coordinator.wake("session")
+        yield* Deferred.await(firstStarted)
+        const first = yield* coordinator.interrupt("session", undefined, continuation).pipe(Effect.forkChild)
+        yield* Deferred.await(cleanupStarted)
+        const second = yield* coordinator.interrupt("session", undefined, continuation).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* coordinator.wake("session", "input")
+        yield* Deferred.succeed(cleanupGate, undefined)
+        yield* Effect.all([Fiber.join(first), Fiber.join(second)])
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["input", "steer"])
+      }),
+    ),
+  )
+
+  it.effect("a continuing interrupt replaces a cleanup-era input wake", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const cleanupStarted = yield* Deferred.make<void>()
+        const cleanupGate = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.gen(function* () {
+              requests.push(request)
+              if (requests.length !== 1) return
+              yield* Deferred.succeed(firstStarted, undefined)
+              yield* Effect.never.pipe(
+                Effect.onInterrupt(() =>
+                  Deferred.succeed(cleanupStarted, undefined).pipe(Effect.andThen(Deferred.await(cleanupGate))),
+                ),
+              )
+            }),
+        })
+
+        yield* coordinator.wake("session", "input")
+        yield* Deferred.await(firstStarted)
+        const plain = yield* coordinator.interrupt("session").pipe(Effect.forkChild)
+        yield* Deferred.await(cleanupStarted)
+        yield* coordinator.wake("session", "input")
+        const continuing = yield* coordinator
+          .interrupt("session", undefined, {
+            continue: { request: "steer", when: Effect.succeed(false) },
+          })
+          .pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* Deferred.succeed(cleanupGate, undefined)
+        yield* Effect.all([Fiber.join(plain), Fiber.join(continuing)])
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["input", "steer"])
+      }),
+    ),
+  )
+
+  it.effect("does not start a conditional continuation without eligible work", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const requests: SessionRunCoordinator.Request[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key, _force, request) =>
+            Effect.sync(() => requests.push(request)).pipe(
+              Effect.andThen(Deferred.succeed(started, undefined)),
+              Effect.andThen(Effect.never),
+            ),
+        })
+
+        yield* coordinator.wake("session")
+        yield* Deferred.await(started)
+        yield* coordinator.interrupt("session", undefined, {
+          continue: { request: "steer", when: Effect.succeed(false) },
+        })
+        yield* coordinator.awaitIdle("session")
+
+        expect(requests).toEqual(["input"])
       }),
     ),
   )

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -126,6 +126,7 @@ const execution = (llmClient: Layer.Layer<typeof LLMClient.Service>) =>
         active: coordinator.active,
         resume: coordinator.run,
         wake: coordinator.wake,
+        wakeActive: coordinator.wakeActive,
         interrupt: (sessionID) => coordinator.interrupt(sessionID),
         awaitIdle: coordinator.awaitIdle,
       })

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -126,7 +126,7 @@ const execution = (llmClient: Layer.Layer<typeof LLMClient.Service>) =>
         active: coordinator.active,
         resume: coordinator.run,
         wake: coordinator.wake,
-        interrupt: coordinator.interrupt,
+        interrupt: (sessionID) => coordinator.interrupt(sessionID),
         awaitIdle: coordinator.awaitIdle,
       })
     }),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -413,7 +413,7 @@ const execution = Layer.effect(
       active: coordinator.active,
       resume: coordinator.run,
       wake: coordinator.wake,
-      interrupt: coordinator.interrupt,
+      interrupt: (sessionID) => coordinator.interrupt(sessionID),
       awaitIdle: coordinator.awaitIdle,
     })
   }),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -3088,6 +3088,24 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("stops a steer-scoped drain before queued input", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      const { db } = yield* Database.Service
+      yield* session.prompt({ sessionID, text: "Queue for later", delivery: "queue", resume: false })
+      yield* session.prompt({ sessionID, text: "Steer now", resume: false })
+      yield* TestLLM.push(TestLLM.stop())
+
+      const runner = yield* SessionRunner.Service
+      yield* runner.drain({ sessionID, force: false, scope: "steer" })
+
+      expect(requests).toHaveLength(1)
+      expect(userTexts(requests[0])).toEqual(["Steer now"])
+      expect(yield* SessionInbox.has(db, sessionID, "steer")).toBe(false)
+      expect(yield* SessionInbox.has(db, sessionID, "queue")).toBe(true)
+    }),
+  )
+
   it.effect("promotes queued input after steering continuation ends", () =>
     Effect.gen(function* () {
       const session = yield* setup

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -413,6 +413,7 @@ const execution = Layer.effect(
       active: coordinator.active,
       resume: coordinator.run,
       wake: coordinator.wake,
+      wakeActive: coordinator.wakeActive,
       interrupt: (sessionID) => coordinator.interrupt(sessionID),
       awaitIdle: coordinator.awaitIdle,
     })
@@ -3097,7 +3098,7 @@ describe("SessionRunnerLLM", () => {
       yield* TestLLM.push(TestLLM.stop())
 
       const runner = yield* SessionRunner.Service
-      yield* runner.drain({ sessionID, force: false, scope: "steer" })
+      yield* runner.drain({ sessionID, force: false, promotable: "steer" })
 
       expect(requests).toHaveLength(1)
       expect(userTexts(requests[0])).toEqual(["Steer now"])

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1384,6 +1384,44 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("keeps queued input parked across a mid-turn move", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      const bus = yield* Bus.Service
+      const { db } = yield* Database.Service
+      yield* admit(session, "Echo before moving")
+      yield* TestLLM.push(
+        TestLLM.tool("call-move", "echo", { text: "moving" }),
+        TestLLM.text("Done", "text-after-move"),
+        TestLLM.text("Handled queue", "text-after-queue"),
+      )
+      const tools = yield* blockTools()
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* tools.started
+      yield* session.prompt({ sessionID, text: "Queued for later", delivery: "queue", resume: false })
+      yield* SessionInbox.admit(db, bus, {
+        id: SessionMessage.ID.create(),
+        sessionID,
+        item: {
+          type: "move",
+          payload: {
+            location: Location.Ref.make({ directory: AbsolutePath.make("/project") }),
+            projectID: Project.ID.global,
+          },
+          delivery: "steer",
+        },
+      })
+
+      yield* tools.release
+      yield* Fiber.join(run)
+
+      // The resumed turn absorbs steers only; queued input waits for the turn to end.
+      expect(requests).toHaveLength(3)
+      expect(userTexts(requests[1])).not.toContain("Queued for later")
+      expect(userTexts(requests[2])).toContain("Queued for later")
+    }),
+  )
+
   it.effect("seeds a fork with the parent's newest instruction values", () =>
     Effect.gen(function* () {
       const session = yield* setup

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -115,6 +115,7 @@ const executionNode = makeGlobalNode({
         active: Effect.succeed(new Set()),
         resume: complete,
         wake: () => Effect.void,
+        wakeActive: () => Effect.void,
         interrupt: () => Effect.void,
         awaitIdle: (id) => complete(id).pipe(Effect.exit, Effect.asVoid),
       })

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -86,6 +86,7 @@ const executionNode = makeGlobalNode({
         active: Effect.succeed(new Set()),
         resume: complete,
         wake: () => Effect.void,
+        wakeActive: () => Effect.void,
         interrupt: () => Effect.void,
         awaitIdle: (sessionID) => complete(sessionID).pipe(Effect.exit, Effect.asVoid),
       })

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -660,7 +660,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
             identifier: "v2.session.interrupt",
             summary: "Interrupt session execution",
             description:
-              "Interrupt active execution owned by this OpenCode process. Idle interruption is a no-op. When continue=true, execution resumes if durable inbox work remains after interruption.",
+              "Interrupt active execution owned by this OpenCode process. Idle interruption is a no-op. When continue=true, execution resumes pending steering input while queued work remains parked.",
           }),
         ),
     )


### PR DESCRIPTION
## What

Make `session.interrupt?continue=true` resume only steering input from the interrupted intent. Explicitly queued next-turn work remains parked until a later full wake or resume.

## Before / After

**Before:** `continue=true` checked for any durable inbox row and started a normal Session drain. That drain eventually promoted queued user prompts, compactions, and moves, so interrupting an active response could unexpectedly execute work the user had explicitly queued for later.

**After:** continuation starts a steer-scoped drain. It consumes steering input and steering controls, then stops at the queue boundary. Wakes arriving during cancellation are folded into the same steer-only successor, including overlapping interrupts; they cannot upgrade the cancellation successor into a full queue drain.

## How

- `packages/core/src/session/execution.ts` owns scoped interrupt continuation and tokenizes overlapping interrupt generations. Full wakes still win during ordinary execution, while wakes during cancellation are deferred into one steer-only successor.
- `packages/core/src/session/runner/llm.ts` adds a steer-only drain boundary and keeps queued user and control rows untouched.
- Immediate missing-location recovery now requests the currently active scope synchronously. It neither infers scope from an asynchronous `Moved` event nor starts an idle full drain.
- `packages/protocol/src/groups/session.ts` documents the corrected `continue=true` contract.
- Regression coverage includes queued input, full-wake escalation outside interruption, admissions during cancellation, overlapping interrupts, active relocation, and idle relocation.

## Scope

- Normal successful turn completion still promotes queued work in FIFO order.
- Plain interruption without `continue=true` is unchanged.
- The HTTP query shape remains backward compatible; only the continuation behavior is narrowed.

## Testing

- `bun run test` in `packages/core`: 1,799 passed, 16 skipped, 0 failed.
- `bun typecheck` in `packages/core`, `packages/protocol`, `packages/client`, and `packages/server`.
- Pre-push `bun turbo typecheck --concurrency=3`: 33 tasks passed.
- `bun run generate` in `packages/client` produced no generated diff.
- Targeted client interrupt contract test passed.
- Full client suite: 56 passed; one existing contract-list test fails because it expects the unchanged generated client to expose `question`.

## Flow

```mermaid
flowchart TD
  A[Interrupt with continue=true] --> B[Mark interrupt generation]
  B --> C[Stop active execution]
  C --> D{Steer or deferred wake?}
  D -- No --> E[Stay idle]
  D -- Yes --> F[Start steer-scoped drain]
  F --> G[Promote steering input and controls]
  G --> H[Stop at queue boundary]
  H --> I[Queued work remains pending]
```
