### PR TITLE
fix(opencode): compare ID timestamps numerically in isAfter() to handle 48-bit overflow

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -597,10 +597,19 @@ export function latest(msgs: WithParts[]) {
   return { user, assistant, finished, tasks }
 }
 
+// Compare the encoded timestamp bytes numerically instead of lexicographically.
+// The6-byte timestamp field overflows 2^48 since ~2023, so string comparison
+// of the hex-encoded bytes gives wrong results after wraparound.
+function compareIdTimestamps(a: string, b: string): number {
+  const aHex = a.slice(a.indexOf("_") + 1, a.indexOf("_") + 13)
+  const bHex = b.slice(b.indexOf("_") + 1, b.indexOf("_") + 13)
+  return Number(BigInt("0x" + aHex) - BigInt("0x" + bHex))
+}
+
 function isAfter(info: Info, other?: Info) {
   if (!other) return true
   if (info.time.created !== other.time.created) return info.time.created > other.time.created
-  return info.id > other.id
+  return compareIdTimestamps(info.id, other.id) > 0
 }
 
 export function fromError(


### PR DESCRIPTION
### Issue for this PR

Closes #42639

### Type of change

- [x] Bug fix

### What does this PR do?

MessageV2.latest() uses isAfter() to find the most recent user/assistant message. The tiebreaker compared IDs as strings, but the 6-byte timestamp field in ascending IDs overflows 2^48 since ~2023, making string comparison give wrong results after wraparound. Now extracts the timestamp hex from each ID and compares numerically via BigInt.

### How did you verify your code works?

Code review -- the overflow math is straightforward. The primary comparison (time.created) is unchanged; only the equal-timestamp tiebreaker is fixed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR