### PR TITLE
fix(tui): re-query terminal palette on focus for system theme refresh

### DIFF
--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -225,6 +225,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
     renderer.on(CliRenderEvents.THEME_MODE, handle)
 
+    // Re-query terminal palette on focus so the system theme stays current
+    // when the host terminal changes its color scheme (e.g. inside herdr).
+    const handleFocus = () => {
+      if (store.lock) return
+      if (store.active === "system") refreshSystemTheme()
+    }
+    renderer.on("focus", handleFocus)
+
     const handleThemeNotification = (sequence: string) => {
       if (sequence !== "\x1b[?997;1n" && sequence !== "\x1b[?997;2n") return false
       queueMicrotask(() => refreshSystemTheme())
@@ -247,6 +255,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     onCleanup(() => {
       renderer.off(CliRenderEvents.THEME_MODE, handle)
+      renderer.off("focus", handleFocus)
       renderer.removeInputHandler(handleThemeNotification)
       unsubscribeRefresh?.()
       for (const timeout of themeRefreshTimeouts) clearTimeout(timeout)


### PR DESCRIPTION
### Issue for this PR

Closes #42635

### Type of change

- [x] Bug fix

### What does this PR do?

The system theme only refreshed on ?997 escape sequences or SIGUSR2, which never arrive inside terminal multiplexers like herdr. Added a focus event listener that re-queries the terminal palette when the system theme is active, so the theme stays current when the host terminal changes color scheme.

### How did you verify your code works?

Code review -- the renderer already emits focus events (used in attention.ts), and refreshSystemTheme() handles concurrent calls safely.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR