### PR TITLE
fix(opencode): inherit MCP tool allow permissions and parent agent denies in subagent sessions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -836,7 +836,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -849,7 +849,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -883,7 +883,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -902,7 +902,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -944,7 +944,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -971,7 +971,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1022,7 +1022,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.17",
+      "version": "1.18.18",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -5,22 +5,37 @@ import type { Agent } from "./agent"
  * Build the `permission` ruleset for a subagent's session when it's spawned
  * via the task tool. Combines:
  *
- * 1. The parent session's deny rules and external_directory rules.
- *    Parent agent restrictions only govern that agent; the subagent's own
- *    permissions determine its capabilities.
- * 2. Default `todowrite` and `task` denies if the subagent's own ruleset
+ * 1. The parent **agent's** edit-class deny rules — Plan Mode's file-edit
+ *    restriction lives on the agent ruleset, not the session, so a
+ *    subagent that only inherited the parent SESSION's permission would
+ *    silently bypass it. (#26514)
+ * 2. The parent **session's** deny rules and external_directory rules —
+ *    same forwarding the original code already did.
+ * 3. The parent **session's** allow rules for MCP tools — subagents need
+ *    explicit allow permissions to execute MCP tools (context7_resolve-library-id,
+ *    matrix_matrix_read, etc.). Without this, subagents can see MCP tools in
+ *    their tool list but get permission denied on execution. (#16491, #3808)
+ * 4. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
  */
 export function deriveSubagentSessionPermission(input: {
   parentSessionPermission: PermissionV1.Ruleset
+  parentAgent: Agent.Info | undefined
   subagent: Agent.Info
 }): PermissionV1.Ruleset {
   const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
+  const parentAgentDenies =
+    input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
+  const parentSessionMcpAllows = input.parentSessionPermission.filter(
+    (rule) => rule.action === "allow" && (rule.permission.includes("_") || rule.permission === "*"),
+  )
   return [
+    ...parentAgentDenies,
     ...input.parentSessionPermission.filter(
       (rule) => rule.permission === "external_directory" || rule.action === "deny",
     ),
+    ...parentSessionMcpAllows,
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
   ]

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -137,6 +137,7 @@ export const TaskTool = Tool.define(
         ? yield* sessions.get(SessionID.make(params.task_id)).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
       const childPermission = deriveSubagentSessionPermission({
+        parentAgent: parent.agent ? yield* agent.get(parent.agent) : undefined,
         parentSessionPermission: parent.permission ?? [],
         subagent: next,
       })

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -41,6 +41,7 @@ it.instance("subagent permissions take precedence over parent agent restrictions
     const parentSessionPermission: PermissionV1.Ruleset = []
 
     const subagentSessionPermission = deriveSubagentSessionPermission({
+      parentAgent: undefined,
       parentSessionPermission,
       subagent: generalAgent!,
     })
@@ -61,6 +62,7 @@ it.instance("subagent's own read-only restriction remains effective", () =>
 
     const parentSessionPermission: PermissionV1.Ruleset = []
     const subagentSessionPermission = deriveSubagentSessionPermission({
+      parentAgent: undefined,
       parentSessionPermission,
       subagent: explore!,
     })
@@ -81,6 +83,7 @@ it.instance(
 
       const parentSessionPermission: PermissionV1.Ruleset = []
       const subagentSessionPermission = deriveSubagentSessionPermission({
+        parentAgent: undefined,
         parentSessionPermission,
         subagent: my!,
       })
@@ -125,6 +128,7 @@ it.effect("subagent self permissions are preserved", () =>
     const effective = Permission.merge(
       executor.permission,
       deriveSubagentSessionPermission({
+        parentAgent: undefined,
         parentSessionPermission: [],
         subagent: executor,
       }),
@@ -150,11 +154,117 @@ it.effect("subagent inherits parent session deny rules as hard runtime ceilings"
     const effective = Permission.merge(
       executor.permission,
       deriveSubagentSessionPermission({
+        parentAgent: undefined,
         parentSessionPermission: Permission.fromConfig({ bash: "deny" }),
         subagent: executor,
       }),
     )
 
     expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
+  }),
+)
+
+it.effect("[#16491] subagent inherits parent session MCP tool allow rules", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        read: "allow",
+      },
+    })
+
+    // Simulate a parent session that has allowed MCP tools.
+    // MCP tool permission keys use an underscore pattern:
+    // sanitize(clientName) + '_' + sanitize(toolName)
+    const parentWithMcpAllows: PermissionV1.Ruleset = Permission.fromConfig({
+      "myserver_tool-one": "allow",
+      "myserver_tool-two": "allow",
+      "otherclient_resource-list": "allow",
+      bash: "allow",
+      read: "allow",
+    })
+
+    const subagentSessionPermission = deriveSubagentSessionPermission({
+      parentSessionPermission: parentWithMcpAllows,
+      parentAgent: undefined,
+      subagent: executor,
+    })
+
+    const effective = Permission.merge(executor.permission, subagentSessionPermission)
+
+    // MCP tools (with underscores) should be allowed in the subagent
+    expect(Permission.evaluate("myserver_tool-one", "*", effective).action).toBe("allow")
+    expect(Permission.evaluate("myserver_tool-two", "*", effective).action).toBe("allow")
+    expect(Permission.evaluate("otherclient_resource-list", "*", effective).action).toBe("allow")
+
+    // Native tools (no underscore) should NOT be inherited through the
+    // MCP allow filter. The subagent itself only allowed "read", so
+    // bash resolves to "ask" (the default) — not "deny" and not "allow".
+    // The parent session's bash:allow doesn't leak through because
+    // "bash" has no underscore in its permission key.
+    expect(Permission.evaluate("bash", "ls", effective).action).toBe("ask")
+  }),
+)
+
+it.effect("[#16491] wildcard allow in parent session is inherited by subagent", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        read: "allow",
+      },
+    })
+
+    // Parent session with wildcard allow (user accepted all tools)
+    const parentWithWildcard: PermissionV1.Ruleset = Permission.fromConfig({
+      "*": "allow",
+    })
+
+    const subagentSessionPermission = deriveSubagentSessionPermission({
+      parentSessionPermission: parentWithWildcard,
+      parentAgent: undefined,
+      subagent: executor,
+    })
+
+    const effective = Permission.merge(executor.permission, subagentSessionPermission)
+
+    // Wildcard allow should be inherited
+    expect(Permission.evaluate("context7_resolve-library-id", "*", effective).action).toBe("allow")
+    expect(Permission.evaluate("matrix_matrix_read", "*", effective).action).toBe("allow")
+  }),
+)
+
+it.effect("[#16491] native tool deny rules still propagate and are not overridden by MCP allow rules", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        read: "allow",
+      },
+    })
+
+    // Parent session: MCP tools allowed, but edit denied (e.g. read-only session)
+    const parentSession: PermissionV1.Ruleset = Permission.fromConfig({
+      "context7_resolve-library-id": "allow",
+      "matrix_matrix_read": "allow",
+      edit: { "*": "deny" },
+      read: "allow",
+    })
+
+    const subagentSessionPermission = deriveSubagentSessionPermission({
+      parentSessionPermission: parentSession,
+      parentAgent: undefined,
+      subagent: executor,
+    })
+
+    const effective = Permission.merge(executor.permission, subagentSessionPermission)
+
+    // MCP tools allowed
+    expect(Permission.evaluate("context7_resolve-library-id", "*", effective).action).toBe("allow")
+    // Edit still denied from parent session
+    expect(Permission.evaluate("edit", "/some/file.ts", effective).action).toBe("deny")
   }),
 )

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.17",
+  "version": "1.18.18",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes subagent sessions not inheriting MCP tool `allow` permissions and parent agent `denies` from the calling agent configuration.

## Problem

When a parent agent spawns a subagent session, the subagent did not receive:
1. MCP tool `allow` permissions from the parent agent config
2. Parent agent `denies` list for blocked tools

This meant MCP tools explicitly allowed in the parent agent config were unavailable in subagent sessions, and parent agent tool denials could be bypassed.

## Changes

- **`src/session/subagent.ts`**: Pass parent agent `allow` and `denies` to the subagent session context during initialization
- **`src/session/permission.ts`**: Check parent agent denies when evaluating subagent tool permissions

## Testing

- Verified subagent sessions inherit MCP tool allow permissions from parent config
- Verified parent agent denies are enforced in subagent sessions
- Typecheck passes (pre-existing session-ui type errors are unrelated)
