### PR TITLE
docs(core): document project-level external skill auto-discovery

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -47,7 +47,8 @@ already-loaded config until then.
 | Global commands               | `~/.config/opencode/command(s)/<name>.md`                                                                                 |
 | Project skills                | `.opencode/skill(s)/<name>/SKILL.md`                                                                                      |
 | Global skills                 | `~/.config/opencode/skill(s)/<name>/SKILL.md`                                                                             |
-| External skills (auto-loaded) | `~/.claude/skills/<name>/SKILL.md`, `~/.agents/skills/<name>/SKILL.md`                                                    |
+| External skills — global (auto-loaded)  | `~/.claude/skills/<name>/SKILL.md`, `~/.agents/skills/<name>/SKILL.md`                                                    |
+| External skills — project (auto-loaded) | `.claude/skills/<name>/SKILL.md`, `.agents/skills/<name>/SKILL.md` (discovered by walking up from the cwd to the worktree root) |
 
 Configs from each scope are deep-merged. Project overrides global. Unknown
 top-level keys in `opencode.json` are rejected with `ConfigInvalidError`.


### PR DESCRIPTION
### Issue for this PR

Closes #41850

### Type of change

- [x] Documentation

### What does this PR do?

Fixes the `customize-opencode` built-in skill's "Where files live" table, which listed external skills (`~/.claude/skills`, `~/.agents/skills`) as home-directory-only. The skill loader (`discoverSkills`) also auto-discovers **project-level** `.claude/skills/**/SKILL.md` and `.agents/skills/**/SKILL.md` by walking up from the cwd to the worktree root, but the docs steered users toward `.opencode/skills/` plus a manual `skills.paths` entry instead.

The table now splits external skills into global and project scopes, with a note that project external skills are discovered by walking up to the worktree root.

### How did you verify your code works?

- Wording matches the loader behavior documented and verified in #41850 (global + project scope scanning)
- Docs-only change; no code or test impact

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
