### PR TITLE
fix(tui): refresh moved tab metadata

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -248,6 +248,12 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     onCleanup(event.on("session.execution.interrupted", (evt) => markUnread(evt.data.sessionID, "activity")))
     onCleanup(event.on("session.execution.failed", (evt) => markUnread(evt.data.sessionID, "error")))
     onCleanup(
+      event.on("session.moved", (evt) => {
+        if (!enabled() || !state().tabs.some((tab) => tab.sessionID === root(evt.data.sessionID))) return
+        void Promise.allSettled([data.location.syncInfo(evt.data.location), data.location.vcs.sync(evt.data.location)])
+      }),
+    )
+    onCleanup(
       event.on("session.inbox.enqueued", (evt) => {
         if (!enabled() || evt.data.item.type !== "user") return
         const sessionID = root(evt.data.sessionID)

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -197,6 +197,32 @@ test("loads VCS metadata for each persisted tab location", async () => {
   }
 })
 
+test("loads location metadata when an open session moves", async () => {
+  const destination = `${directory}/moved-worktree`
+  const setup = await renderSessionTabs("first")
+
+  try {
+    await wait(() => setup.locations.includes(directory) && setup.vcsLocations.includes(directory))
+    setup.emit({
+      id: "evt_moved",
+      created: 1,
+      type: "session.moved",
+      durable: { aggregateID: "first", seq: 1, version: 1 },
+      data: {
+        sessionID: "first",
+        location: { directory: destination },
+        projectID: "project",
+      },
+    })
+
+    await wait(() => setup.data.session.get("first")?.location.directory === destination)
+    await wait(() => setup.locations.includes(destination))
+    await wait(() => setup.vcsLocations.includes(destination))
+  } finally {
+    await setup.destroy()
+  }
+})
+
 test("stores session tabs for the current working directory by default", async () => {
   const setup = await renderSessionTabs("first")
 


### PR DESCRIPTION
## What

Keep inactive vertical-tab worktree labels current when an open session moves to another location.

## Before / After

**Before:** The tab metadata prefetch was keyed only by open session IDs. A `session.moved` event changed the session location without changing that key, so the destination location and VCS caches stayed cold. The vertical tab showed only its previous/fallback project detail until the user activated it.

**After:** An open tab reacts to `session.moved` by loading location and VCS metadata for the destination immediately. Its worktree/branch detail updates without activation.

## How

- `packages/tui/src/context/session-tabs.tsx` listens for moved open sessions and syncs the destination location and VCS caches.
- `packages/tui/test/context/session-tabs.test.tsx` covers moving an already-prefetched tab and verifies both destination metadata requests occur.

## Scope

This only changes metadata hydration for already-open tabs. Session movement, tab persistence, and label formatting are unchanged.

## Testing

- `bun run test test/context/session-tabs.test.tsx` from `packages/tui` (10 passing)
- `bun typecheck` from `packages/tui`
- Push hook: `bun turbo typecheck --concurrency=3` (33 packages passing)
- `bunx prettier --check src/context/session-tabs.tsx test/context/session-tabs.test.tsx`

## Flow

```mermaid
sequenceDiagram
  participant Event as Session event stream
  participant Tabs as SessionTabsProvider
  participant Data as TUI data cache
  participant Rail as Vertical tab rail

  Event->>Tabs: session.moved(destination)
  Tabs->>Data: sync destination location + VCS
  Data-->>Rail: reactive metadata update
  Rail-->>Rail: render worktree/branch detail
```
