### PR TITLE
docs: align v2 specification index

### DIFF
--- a/specs/v2/README.md
+++ b/specs/v2/README.md
@@ -25,13 +25,13 @@ Generated clients follow the assembled public `HttpApi`. GitHub issues own activ
 | [Session](./session.md) | Explain prompt admission, execution, instructions, compaction, and recovery boundaries. |
 | [Tools](./tools.md)     | Explain tool construction, registration, execution, and outcome laws.                   |
 
-## Decisions And Proposals
+## Decision Records
 
 | Document                                                          | Status                     | Job                                                                         |
 | ----------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------- |
 | [Event stream](./event-stream-architecture.md)                    | Accepted and implemented   | Record why public events use one encoded feed with independent queues.      |
 | [Managed restart continuation](./session-restart-continuation.md) | Superseded decision record | Preserve the graceful-only design replaced by write-ahead execution claims. |
-| [Provider policy](./provider-policy.md)                           | Proposed and unimplemented | Explore provider authorization independently from provider configuration.   |
+| [Provider policy](./provider-policy.md)                           | Accepted and implemented   | Record provider authorization independently from provider configuration.    |
 
 ## Historical Context
 


### PR DESCRIPTION
### Issue for this PR

Not required for documentation cleanup.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Aligns the V2 specification index with the documents it indexes. Provider Policy is implemented, and the section now describes its entries as decision records rather than active proposals.

### How did you verify your code works?

- Confirmed every linked specification exists.
- Checked indexed statuses against each document.
- Ran Prettier and `git diff --check`.

### Screenshots / recordings

Not applicable; documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
