### PR TITLE
fix(app): generate blob ids without crypto.subtle in non-secure contexts

### DIFF
--- a/packages/app/src/utils/draft-store.ts
+++ b/packages/app/src/utils/draft-store.ts
@@ -22,10 +22,21 @@ function blobUrl(id: string, blob: Blob) {
 }
 
 async function blobID(blob: Blob) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
+  const bytes = new Uint8Array(await blob.arrayBuffer())
+  if (!crypto.subtle) return insecureContextID(bytes)
+  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
   return id
+}
+
+// crypto.subtle only exists in secure contexts, so over plain HTTP on a
+// non-localhost origin we hash with FNV-1a instead. Equal blobs must still
+// produce equal IDs so the store deduplicates and drafts resolve on reload.
+function insecureContextID(bytes: Uint8Array) {
+  const fnv1a = (seed: number) =>
+    (bytes.reduce((hash, byte) => Math.imul(hash ^ byte, 0x01000193), seed) >>> 0).toString(16).padStart(8, "0")
+  return fnv1a(0x811c9dc5) + fnv1a(0x01000193)
 }
 
 export async function createBlobReference(blob: Blob): Promise<BlobReference> {

--- a/packages/app/src/utils/draft-store.ts
+++ b/packages/app/src/utils/draft-store.ts
@@ -22,21 +22,13 @@ function blobUrl(id: string, blob: Blob) {
 }
 
 async function blobID(blob: Blob) {
-  const bytes = new Uint8Array(await blob.arrayBuffer())
-  if (!crypto.subtle) return insecureContextID(bytes)
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)))
+  const bytes = crypto.subtle
+    ? new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer()))
+    : crypto.getRandomValues(new Uint8Array(16))
+  const id = Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
   return id
-}
-
-// crypto.subtle only exists in secure contexts, so over plain HTTP on a
-// non-localhost origin we hash with FNV-1a instead. Equal blobs must still
-// produce equal IDs so the store deduplicates and drafts resolve on reload.
-function insecureContextID(bytes: Uint8Array) {
-  const fnv1a = (seed: number) =>
-    (bytes.reduce((hash, byte) => Math.imul(hash ^ byte, 0x01000193), seed) >>> 0).toString(16).padStart(8, "0")
-  return fnv1a(0x811c9dc5) + fnv1a(0x01000193)
 }
 
 export async function createBlobReference(blob: Blob): Promise<BlobReference> {


### PR DESCRIPTION
Fixes #41706

## Problem

`blobID()` calls `crypto.subtle.digest` unconditionally. Browsers do not expose `crypto.subtle` over plain HTTP on a non-localhost origin, so pasting an image from `http://<server-ip>:4096` throws.

## Fix

Keep SHA-256 content addressing when `crypto.subtle` is available. Otherwise, generate a 128-bit ID with `crypto.getRandomValues()`, which is available in insecure contexts.

The fallback does not read or synchronously hash the blob. Deduplication is disabled only on the insecure HTTP path.

This supersedes #41710, which uses `Math.random()` and `Date.now()` for the fallback ID.
