### PR TITLE
docs: add OpenCodeMirror to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [OpenCodeMirror](https://github.com/iceberghbs/OpenCodeMirror)                                     | Mirror OpenCode sessions to chat platforms; control your agent from your phone                     |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation-only change (adds an entry to the ecosystem list)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenCodeMirror to the ecosystem plugins list. OpenCodeMirror is a native
OpenCode plugin that mirrors sessions to Telegram and lets you control the
agent from your phone.

### How did you verify your code works?

The change is a single table row in the ecosystem markdown docs. I verified the
row matches the existing name/description column format and that the link points
to the correct repository.

### Screenshots / recordings

N/A (documentation-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
