### PR TITLE
fix(desktop): verify updates before install

### DIFF
--- a/packages/desktop/src/main/updater-controller.test.ts
+++ b/packages/desktop/src/main/updater-controller.test.ts
@@ -87,15 +87,15 @@ describe("updater controller", () => {
     expect(app.calls).toEqual(["check", "download"])
   })
 
-  test("clicking install twice stops the servers once and installs once", async () => {
+  test("clicking install twice checks once and installs the staged version once", async () => {
     const app = setup()
     await app.controller.start()
 
     void app.controller.install()
     void app.controller.install()
 
-    await Promise.resolve()
-    expect(app.calls).toEqual(["check", "download", "prepare", "install:2.0.0"])
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(app.calls).toEqual(["check", "download", "check", "prepare", "install:2.0.0"])
     expect(app.controller.getState()).toEqual({ status: "installing", version: "2.0.0" })
   })
 
@@ -105,8 +105,41 @@ describe("updater controller", () => {
     void app.controller.install()
 
     await app.controller.check()
+    await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(app.calls).toEqual(["check", "download", "prepare", "install:2.0.0"])
+    expect(app.calls).toEqual(["check", "download", "check", "prepare", "install:2.0.0"])
+  })
+
+  test("clicking install downloads and installs a newer release", async () => {
+    let latest = "2.0.0"
+    const app = setup({ latest: () => latest })
+    await app.controller.start()
+
+    latest = "3.0.0"
+    void app.controller.install()
+
+    expect(app.controller.getState()).toEqual({ status: "installing", version: "2.0.0" })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(app.calls).toEqual(["check", "download", "check", "download", "prepare", "install:3.0.0"])
+    expect(app.controller.getState()).toEqual({ status: "installing", version: "3.0.0" })
+  })
+
+  test("clicking install uses the staged release when the final check fails", async () => {
+    let offline = false
+    const app = setup({
+      latest: () => {
+        if (offline) throw new Error("offline")
+        return "2.0.0"
+      },
+    })
+    await app.controller.start()
+
+    offline = true
+    void app.controller.install()
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(app.calls).toEqual(["check", "download", "check", "prepare", "install:2.0.0"])
+    expect(app.controller.getState()).toEqual({ status: "installing", version: "2.0.0" })
   })
 
   test("later checks stay silent while ready and pick up newer versions", async () => {
@@ -188,7 +221,7 @@ describe("updater controller", () => {
     expect(app.controller.getState()).toEqual({ status: "ready", version: "2.0.0" })
 
     void app.controller.install()
-    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
     expect(attempts).toBe(2)
     expect(app.controller.getState()).toEqual({ status: "installing", version: "2.0.0" })
   })

--- a/packages/desktop/src/main/updater-controller.ts
+++ b/packages/desktop/src/main/updater-controller.ts
@@ -95,10 +95,12 @@ export function createUpdaterController(input: {
     const platform = input.platform
     if (!platform || state.status !== "ready") return Promise.reject(new Error("Update is not ready to install"))
 
-    transition({ status: "installing", version: state.version })
+    const staged = state.version
+    transition({ status: "installing", version: staged })
     installing = (async () => {
-      // A click during a silent refresh waits for the newer download, then installs it.
-      if (pending) await pending
+      // Installation is the commit point: refresh once more so one restart lands
+      // on the newest release, or keep the known-good staged update if checking fails.
+      await (pending ?? refreshStaged(platform, staged))
       await input.lifecycle.prepareToRestart()
       await platform.installAndRestart()
     })().catch((error) => {


### PR DESCRIPTION
## Why

The background refresh reduces stale updates, but its 10-minute interval cannot guarantee that the staged release is current when the user clicks the blue update button. Installing that stale release can show another update prompt immediately after restart.

The click is the final commit point. It must verify the release before installation so one user action lands on the newest available version.

## Change

- Enter the existing `installing` state immediately, so the normal spinner appears.
- Start a silent final check, or join one already in progress.
- If a newer release exists, download and persist it before restart.
- If the check fails or finds no newer release, install the known-good staged release.
- Keep duplicate clicks coalesced into the same installation.

## Verification

- Added user-flow coverage for a current staged release, a newly available release, and a failed final check.
- All 51 desktop main-process tests pass.
- `bun typecheck` passes in `packages/desktop`.