### PR TITLE
fix(llm): send assistant text as input_text in OpenAI Responses requests (#42613)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1069,6 +1069,7 @@
     "@ai-sdk/xai@3.0.102": "patches/@ai-sdk%2Fxai@3.0.102.patch",
     "@modelcontextprotocol/sdk@1.29.0": "patches/@modelcontextprotocol%2Fsdk@1.29.0.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",
+    "@ai-sdk/openai@3.0.84": "patches/@ai-sdk%2Fopenai@3.0.84.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
     "effect@4.0.0-beta.83": "patches/effect@4.0.0-beta.83.patch",
     "@ai-sdk/mistral@3.0.51": "patches/@ai-sdk%2Fmistral@3.0.51.patch",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "effect@4.0.0-beta.83": "patches/effect@4.0.0-beta.83.patch",
     "@tanstack/virtual-core@3.17.3": "patches/@tanstack%2Fvirtual-core@3.17.3.patch",
     "@ai-sdk/openai-compatible@2.0.41": "patches/@ai-sdk%2Fopenai-compatible@2.0.41.patch",
-    "@ai-sdk/groq@3.0.31": "patches/@ai-sdk%2Fgroq@3.0.31.patch"
+    "@ai-sdk/groq@3.0.31": "patches/@ai-sdk%2Fgroq@3.0.31.patch",
+    "@ai-sdk/openai@3.0.84": "patches/@ai-sdk%2Fopenai@3.0.84.patch"
   }
 }

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -43,11 +43,6 @@ const OpenAIResponsesInputImage = Schema.Struct({
 const OpenAIResponsesInputContent = Schema.Union([OpenAIResponsesInputText, OpenAIResponsesInputImage])
 type OpenAIResponsesInputContent = Schema.Schema.Type<typeof OpenAIResponsesInputContent>
 
-const OpenAIResponsesOutputText = Schema.Struct({
-  type: Schema.tag("output_text"),
-  text: Schema.String,
-})
-
 const OpenAIResponsesReasoningSummaryText = Schema.Struct({
   type: Schema.tag("summary_text"),
   text: Schema.String,
@@ -78,7 +73,7 @@ const OpenAIResponsesFunctionCallOutput = Schema.Union([
 const OpenAIResponsesInputItem = Schema.Union([
   Schema.Struct({ role: Schema.tag("system"), content: Schema.String }),
   Schema.Struct({ role: Schema.tag("user"), content: Schema.Array(OpenAIResponsesInputContent) }),
-  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesOutputText) }),
+  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesInputText) }),
   OpenAIResponsesReasoningItem,
   OpenAIResponsesItemReference,
   Schema.Struct({
@@ -374,7 +369,7 @@ const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (requ
       const hostedToolReferences = new Set<string>()
       const flushText = () => {
         if (content.length === 0) return
-        input.push({ role: "assistant", content: content.map((part) => ({ type: "output_text", text: part.text })) })
+        input.push({ role: "assistant", content: content.map((part) => ({ type: "input_text", text: part.text })) })
         content.splice(0, content.length)
       }
       for (const part of message.content) {

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -40,6 +40,11 @@ const OpenAIResponsesInputImage = Schema.Struct({
   type: Schema.tag("input_image"),
   image_url: Schema.String,
 })
+const OpenAIResponsesOutputText = Schema.Struct({
+  type: Schema.tag("output_text"),
+  text: Schema.String,
+})
+const OpenAIResponsesAssistantContent = Schema.Union([OpenAIResponsesInputText, OpenAIResponsesOutputText])
 const OpenAIResponsesInputContent = Schema.Union([OpenAIResponsesInputText, OpenAIResponsesInputImage])
 type OpenAIResponsesInputContent = Schema.Schema.Type<typeof OpenAIResponsesInputContent>
 
@@ -73,7 +78,7 @@ const OpenAIResponsesFunctionCallOutput = Schema.Union([
 const OpenAIResponsesInputItem = Schema.Union([
   Schema.Struct({ role: Schema.tag("system"), content: Schema.String }),
   Schema.Struct({ role: Schema.tag("user"), content: Schema.Array(OpenAIResponsesInputContent) }),
-  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesInputText) }),
+  Schema.Struct({ role: Schema.tag("assistant"), content: Schema.Array(OpenAIResponsesAssistantContent) }),
   OpenAIResponsesReasoningItem,
   OpenAIResponsesItemReference,
   Schema.Struct({
@@ -369,7 +374,8 @@ const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (requ
       const hostedToolReferences = new Set<string>()
       const flushText = () => {
         if (content.length === 0) return
-        input.push({ role: "assistant", content: content.map((part) => ({ type: "input_text", text: part.text })) })
+        const textContentType = OpenAIOptions.assistantTextContentType(request)
+        input.push({ role: "assistant", content: content.map((part) => ({ type: textContentType, text: part.text })) })
         content.splice(0, content.length)
       }
       for (const part of message.content) {

--- a/packages/llm/src/protocols/utils/openai-options.ts
+++ b/packages/llm/src/protocols/utils/openai-options.ts
@@ -50,6 +50,19 @@ export const store = (request: LLMRequest): boolean | undefined => {
   return typeof value === "boolean" ? value : undefined
 }
 
+const ASSISTANT_TEXT_CONTENT_TYPES = new Set<string>(["input_text", "output_text"])
+export type OpenAIResponsesAssistantTextContentType = "input_text" | "output_text"
+
+// Assistant history content type sent back to the provider. Defaults to
+// `output_text` (the OpenAI-native shape); vLLM-compatible Responses
+// servers require `input_text` instead, opt in per model.
+export const assistantTextContentType = (request: LLMRequest): OpenAIResponsesAssistantTextContentType => {
+  const value = options(request)?.assistantTextContentType
+  return typeof value === "string" && ASSISTANT_TEXT_CONTENT_TYPES.has(value)
+    ? (value as OpenAIResponsesAssistantTextContentType)
+    : "output_text"
+}
+
 export const reasoningEffort = (request: LLMRequest): ReasoningEffort | undefined => {
   const value = options(request)?.reasoningEffort
   return isAnyReasoningEffort(value) ? value : undefined

--- a/packages/llm/src/providers/openai-options.ts
+++ b/packages/llm/src/providers/openai-options.ts
@@ -1,8 +1,16 @@
 import type { ProviderOptions, ReasoningEffort, TextVerbosity } from "../schema"
 import { mergeProviderOptions } from "../schema"
-import type { OpenAIResponseIncludable, OpenAIServiceTier } from "../protocols/utils/openai-options"
+import type {
+  OpenAIResponseIncludable,
+  OpenAIResponsesAssistantTextContentType,
+  OpenAIServiceTier,
+} from "../protocols/utils/openai-options"
 
-export type { OpenAIResponseIncludable, OpenAIServiceTier } from "../protocols/utils/openai-options"
+export type {
+  OpenAIResponseIncludable,
+  OpenAIResponsesAssistantTextContentType,
+  OpenAIServiceTier,
+} from "../protocols/utils/openai-options"
 
 export interface OpenAIOptionsInput {
   readonly [key: string]: unknown
@@ -16,6 +24,7 @@ export interface OpenAIOptionsInput {
   readonly include?: ReadonlyArray<OpenAIResponseIncludable>
   readonly textVerbosity?: TextVerbosity
   readonly serviceTier?: OpenAIServiceTier
+  readonly assistantTextContentType?: OpenAIResponsesAssistantTextContentType
 }
 
 export type OpenAIProviderOptionsInput = ProviderOptions & {
@@ -35,6 +44,7 @@ const openAIProviderOptions = (options: OpenAIOptionsInput | undefined): Provide
       include: options?.include,
       textVerbosity: options?.textVerbosity,
       serviceTier: options?.serviceTier,
+      assistantTextContentType: options?.assistantTextContentType,
     }),
   )
   if (Object.keys(openai).length === 0) return undefined

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -153,7 +153,7 @@ describe("OpenAI Responses route", () => {
             { type: "input_text", text: "<system-update>\nTreat &lt;/system-update&gt; literally.\n</system-update>" },
           ],
         },
-        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "After." }] },
       ])
     }),
   )
@@ -529,11 +529,11 @@ describe("OpenAI Responses route", () => {
             encrypted_content: "encrypted-continuation-state",
             summary: [{ type: "summary_text", text: "I inspected the previous turn." }],
           },
-          { role: "assistant", content: [{ type: "output_text", text: "It shows a small test image." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "It shows a small test image." }] },
           { role: "user", content: [{ type: "input_text", text: "Check the weather in Paris before continuing." }] },
           { type: "function_call", call_id: "call_weather_1", name: "get_weather", arguments: '{"city":"Paris"}' },
           { type: "function_call_output", call_id: "call_weather_1", output: '{"temperature":22}' },
-          { role: "assistant", content: [{ type: "output_text", text: "Paris is 22 degrees." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "Paris is 22 degrees." }] },
           {
             role: "user",
             content: [{ type: "input_text", text: "Continue from this conversation in one short sentence." }],
@@ -947,7 +947,7 @@ describe("OpenAI Responses route", () => {
                     encrypted_content: "encrypted-state",
                     summary: [{ type: "summary_text", text: "Checked the previous diff." }],
                   },
-                  { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
+                  { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
                   { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
                 ],
               })
@@ -995,13 +995,13 @@ describe("OpenAI Responses route", () => {
       )
 
       expect(prepared.body.input).toEqual([
-        { role: "assistant", content: [{ type: "output_text", text: "Before." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "Before." }] },
         {
           type: "reasoning",
           encrypted_content: "encrypted-state",
           summary: [{ type: "summary_text", text: "Checked order." }],
         },
-        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+        { role: "assistant", content: [{ type: "input_text", text: "After." }] },
       ])
     }),
   )
@@ -1131,7 +1131,7 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body).toMatchObject({
         input: [
           { role: "user", content: [{ type: "input_text", text: "What changed?" }] },
-          { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
+          { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
           { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
         ],
         store: false,

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -153,6 +153,39 @@ describe("OpenAI Responses route", () => {
             { type: "input_text", text: "<system-update>\nTreat &lt;/system-update&gt; literally.\n</system-update>" },
           ],
         },
+        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+      ])
+    }),
+  )
+
+  it.effect("sends assistant text as output_text by default", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.request({
+          model,
+          messages: [Message.user("Before."), Message.assistant("After.")],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        { role: "user", content: [{ type: "input_text", text: "Before." }] },
+        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
+      ])
+    }),
+  )
+
+  it.effect("sends assistant text as input_text when opted in per model", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.request({
+          model,
+          messages: [Message.user("Before."), Message.assistant("After.")],
+          providerOptions: { openai: { assistantTextContentType: "input_text" } },
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        { role: "user", content: [{ type: "input_text", text: "Before." }] },
         { role: "assistant", content: [{ type: "input_text", text: "After." }] },
       ])
     }),
@@ -529,11 +562,11 @@ describe("OpenAI Responses route", () => {
             encrypted_content: "encrypted-continuation-state",
             summary: [{ type: "summary_text", text: "I inspected the previous turn." }],
           },
-          { role: "assistant", content: [{ type: "input_text", text: "It shows a small test image." }] },
+          { role: "assistant", content: [{ type: "output_text", text: "It shows a small test image." }] },
           { role: "user", content: [{ type: "input_text", text: "Check the weather in Paris before continuing." }] },
           { type: "function_call", call_id: "call_weather_1", name: "get_weather", arguments: '{"city":"Paris"}' },
           { type: "function_call_output", call_id: "call_weather_1", output: '{"temperature":22}' },
-          { role: "assistant", content: [{ type: "input_text", text: "Paris is 22 degrees." }] },
+          { role: "assistant", content: [{ type: "output_text", text: "Paris is 22 degrees." }] },
           {
             role: "user",
             content: [{ type: "input_text", text: "Continue from this conversation in one short sentence." }],
@@ -947,7 +980,7 @@ describe("OpenAI Responses route", () => {
                     encrypted_content: "encrypted-state",
                     summary: [{ type: "summary_text", text: "Checked the previous diff." }],
                   },
-                  { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
+                  { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
                   { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
                 ],
               })
@@ -995,13 +1028,13 @@ describe("OpenAI Responses route", () => {
       )
 
       expect(prepared.body.input).toEqual([
-        { role: "assistant", content: [{ type: "input_text", text: "Before." }] },
+        { role: "assistant", content: [{ type: "output_text", text: "Before." }] },
         {
           type: "reasoning",
           encrypted_content: "encrypted-state",
           summary: [{ type: "summary_text", text: "Checked order." }],
         },
-        { role: "assistant", content: [{ type: "input_text", text: "After." }] },
+        { role: "assistant", content: [{ type: "output_text", text: "After." }] },
       ])
     }),
   )
@@ -1131,7 +1164,7 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body).toMatchObject({
         input: [
           { role: "user", content: [{ type: "input_text", text: "What changed?" }] },
-          { role: "assistant", content: [{ type: "input_text", text: "The parser changed." }] },
+          { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
           { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
         ],
         store: false,

--- a/patches/@ai-sdk%2Fopenai@3.0.84.patch
+++ b/patches/@ai-sdk%2Fopenai@3.0.84.patch
@@ -1,0 +1,193 @@
+diff --git a/dist/index.js b/dist/index.js
+index d3ff1b8..965209a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -2977,6 +2977,7 @@ async function convertToOpenAIResponsesInput({
+   fileIdPrefixes,
+   passThroughUnsupportedFiles = false,
+   store,
++  assistantTextContentType = "output_text",
+   hasConversation = false,
+   hasPreviousResponseId = false,
+   hasLocalShellTool = false,
+@@ -3126,7 +3127,7 @@ async function convertToOpenAIResponsesInput({
+               }
+               input.push({
+                 role: "assistant",
+-                content: [{ type: "output_text", text: part.text }],
++                content: [{ type: assistantTextContentType, text: part.text }],
+                 id,
+                 ...phase != null && { phase }
+               });
+@@ -4669,6 +4670,13 @@ var openaiLanguageModelResponsesOptionsSchema = (0, import_provider_utils28.lazy
+        * @see https://platform.openai.com/docs/api-reference/conversations/create
+        */
+       conversation: import_v423.z.string().nullish(),
++      /**
++       * The content type to use for assistant text parts when sending historical
++       * assistant messages via the Responses API. Defaults to `output_text`.
++       * OpenAI-compatible servers that reject `output_text` (e.g. some vLLM
++       * deployments) can set this to `input_text`.
++       */
++      assistantTextContentType: import_v423.z.string().nullish(),
+       /**
+        * The set of extra fields to include in the response (advanced, usually not needed).
+        * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
+@@ -5294,6 +5302,7 @@ var OpenAIResponsesLanguageModel = class {
+       fileIdPrefixes: this.config.fileIdPrefixes,
+       passThroughUnsupportedFiles: (_d = openaiOptions == null ? void 0 : openaiOptions.passThroughUnsupportedFiles) != null ? _d : false,
+       store: (_e = openaiOptions == null ? void 0 : openaiOptions.store) != null ? _e : true,
++      assistantTextContentType: (_e = openaiOptions == null ? void 0 : openaiOptions.assistantTextContentType) != null ? _e : "output_text",
+       hasConversation: (openaiOptions == null ? void 0 : openaiOptions.conversation) != null,
+       hasPreviousResponseId: (openaiOptions == null ? void 0 : openaiOptions.previousResponseId) != null,
+       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 2644043..6079288 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -3072,6 +3072,7 @@ async function convertToOpenAIResponsesInput({
+   fileIdPrefixes,
+   passThroughUnsupportedFiles = false,
+   store,
++  assistantTextContentType = "output_text",
+   hasConversation = false,
+   hasPreviousResponseId = false,
+   hasLocalShellTool = false,
+@@ -3221,7 +3222,7 @@ async function convertToOpenAIResponsesInput({
+               }
+               input.push({
+                 role: "assistant",
+-                content: [{ type: "output_text", text: part.text }],
++                content: [{ type: assistantTextContentType, text: part.text }],
+                 id,
+                 ...phase != null && { phase }
+               });
+@@ -4770,6 +4771,13 @@ var openaiLanguageModelResponsesOptionsSchema = lazySchema21(
+        * @see https://platform.openai.com/docs/api-reference/conversations/create
+        */
+       conversation: z23.string().nullish(),
++      /**
++       * The content type to use for assistant text parts when sending historical
++       * assistant messages via the Responses API. Defaults to `output_text`.
++       * OpenAI-compatible servers that reject `output_text` (e.g. some vLLM
++       * deployments) can set this to `input_text`.
++       */
++      assistantTextContentType: z23.string().nullish(),
+       /**
+        * The set of extra fields to include in the response (advanced, usually not needed).
+        * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
+@@ -5397,6 +5405,7 @@ var OpenAIResponsesLanguageModel = class {
+       fileIdPrefixes: this.config.fileIdPrefixes,
+       passThroughUnsupportedFiles: (_d = openaiOptions == null ? void 0 : openaiOptions.passThroughUnsupportedFiles) != null ? _d : false,
+       store: (_e = openaiOptions == null ? void 0 : openaiOptions.store) != null ? _e : true,
++      assistantTextContentType: (_e = openaiOptions == null ? void 0 : openaiOptions.assistantTextContentType) != null ? _e : "output_text",
+       hasConversation: (openaiOptions == null ? void 0 : openaiOptions.conversation) != null,
+       hasPreviousResponseId: (openaiOptions == null ? void 0 : openaiOptions.previousResponseId) != null,
+       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
+diff --git a/dist/internal/index.js b/dist/internal/index.js
+index aedcfc7..39efefa 100644
+--- a/dist/internal/index.js
++++ b/dist/internal/index.js
+@@ -2925,6 +2925,7 @@ async function convertToOpenAIResponsesInput({
+   fileIdPrefixes,
+   passThroughUnsupportedFiles = false,
+   store,
++  assistantTextContentType = "output_text",
+   hasConversation = false,
+   hasPreviousResponseId = false,
+   hasLocalShellTool = false,
+@@ -3074,7 +3075,7 @@ async function convertToOpenAIResponsesInput({
+               }
+               input.push({
+                 role: "assistant",
+-                content: [{ type: "output_text", text: part.text }],
++                content: [{ type: assistantTextContentType, text: part.text }],
+                 id,
+                 ...phase != null && { phase }
+               });
+@@ -4617,6 +4618,13 @@ var openaiLanguageModelResponsesOptionsSchema = (0, import_provider_utils26.lazy
+        * @see https://platform.openai.com/docs/api-reference/conversations/create
+        */
+       conversation: import_v419.z.string().nullish(),
++      /**
++       * The content type to use for assistant text parts when sending historical
++       * assistant messages via the Responses API. Defaults to `output_text`.
++       * OpenAI-compatible servers that reject `output_text` (e.g. some vLLM
++       * deployments) can set this to `input_text`.
++       */
++      assistantTextContentType: import_v419.z.string().nullish(),
+       /**
+        * The set of extra fields to include in the response (advanced, usually not needed).
+        * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
+@@ -5563,6 +5571,7 @@ var OpenAIResponsesLanguageModel = class {
+       fileIdPrefixes: this.config.fileIdPrefixes,
+       passThroughUnsupportedFiles: (_d = openaiOptions == null ? void 0 : openaiOptions.passThroughUnsupportedFiles) != null ? _d : false,
+       store: (_e = openaiOptions == null ? void 0 : openaiOptions.store) != null ? _e : true,
++      assistantTextContentType: (_e = openaiOptions == null ? void 0 : openaiOptions.assistantTextContentType) != null ? _e : "output_text",
+       hasConversation: (openaiOptions == null ? void 0 : openaiOptions.conversation) != null,
+       hasPreviousResponseId: (openaiOptions == null ? void 0 : openaiOptions.previousResponseId) != null,
+       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
+diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
+index 40d83eb..4858f32 100644
+--- a/dist/internal/index.mjs
++++ b/dist/internal/index.mjs
+@@ -2968,6 +2968,7 @@ async function convertToOpenAIResponsesInput({
+   fileIdPrefixes,
+   passThroughUnsupportedFiles = false,
+   store,
++  assistantTextContentType = "output_text",
+   hasConversation = false,
+   hasPreviousResponseId = false,
+   hasLocalShellTool = false,
+@@ -3117,7 +3118,7 @@ async function convertToOpenAIResponsesInput({
+               }
+               input.push({
+                 role: "assistant",
+-                content: [{ type: "output_text", text: part.text }],
++                content: [{ type: assistantTextContentType, text: part.text }],
+                 id,
+                 ...phase != null && { phase }
+               });
+@@ -4666,6 +4667,13 @@ var openaiLanguageModelResponsesOptionsSchema = lazySchema17(
+        * @see https://platform.openai.com/docs/api-reference/conversations/create
+        */
+       conversation: z19.string().nullish(),
++      /**
++       * The content type to use for assistant text parts when sending historical
++       * assistant messages via the Responses API. Defaults to `output_text`.
++       * OpenAI-compatible servers that reject `output_text` (e.g. some vLLM
++       * deployments) can set this to `input_text`.
++       */
++      assistantTextContentType: z19.string().nullish(),
+       /**
+        * The set of extra fields to include in the response (advanced, usually not needed).
+        * Example values: 'reasoning.encrypted_content', 'file_search_call.results', 'web_search_call.results', 'message.output_text.logprobs'.
+@@ -5642,6 +5650,7 @@ var OpenAIResponsesLanguageModel = class {
+       fileIdPrefixes: this.config.fileIdPrefixes,
+       passThroughUnsupportedFiles: (_d = openaiOptions == null ? void 0 : openaiOptions.passThroughUnsupportedFiles) != null ? _d : false,
+       store: (_e = openaiOptions == null ? void 0 : openaiOptions.store) != null ? _e : true,
++      assistantTextContentType: (_e = openaiOptions == null ? void 0 : openaiOptions.assistantTextContentType) != null ? _e : "output_text",
+       hasConversation: (openaiOptions == null ? void 0 : openaiOptions.conversation) != null,
+       hasPreviousResponseId: (openaiOptions == null ? void 0 : openaiOptions.previousResponseId) != null,
+       hasLocalShellTool: hasOpenAITool("openai.local_shell"),
+diff --git a/src/responses/convert-to-openai-responses-input.ts b/src/responses/convert-to-openai-responses-input.ts
+index 9d393ee..fa2e859 100644
+--- a/src/responses/convert-to-openai-responses-input.ts
++++ b/src/responses/convert-to-openai-responses-input.ts
+@@ -66,6 +66,7 @@ export async function convertToOpenAIResponsesInput({
+   fileIdPrefixes,
+   passThroughUnsupportedFiles = false,
+   store,
++  assistantTextContentType = "output_text",
+   hasConversation = false,
+   hasPreviousResponseId = false,
+   hasLocalShellTool = false,
+@@ -271,7 +272,7 @@ export async function convertToOpenAIResponsesInput({
+ 
+               input.push({
+                 role: 'assistant',
+-                content: [{ type: 'output_text', text: part.text }],
++                content: [{ type: assistantTextContentType, text: part.text }],
+                 id,
+                 ...(phase != null && { phase }),
+               });


### PR DESCRIPTION
### Issue for this PR

Closes #42613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When conversation history contains an assistant text message, the OpenAI
Responses (`/responses`) request body used:

```json
{"role": "assistant", "content": [{"type": "output_text", "text": "..."}]}
```

`output_text` is not a valid easy-input content part: per the official OpenAI
schema (`openai-python` types), assistant easy-input messages accept only
`str | input_text | input_image | input_file`. Real `api.openai.com` tolerates
the non-conformant shape, but strict OpenAI-compatible servers validating with
the official SDK types (e.g. a self-hosted Qwen server exposing `/v1/responses`)
reject it with a 422/400 pydantic `ValidationError`, so switching a session to
such a model fails.

The fix lowers assistant text content as `input_text` in request bodies:

- `packages/llm/src/protocols/openai-responses.ts`:
  - Remove the now-unused `OpenAIResponsesOutputText` schema.
  - Lower assistant text content as `input_text` in request bodies
    (`lowerMessages`).
  - `OpenAIResponsesInputItem` assistant schema now uses `input_text` parts.
- `packages/llm/test/provider/openai-responses.test.ts`: update expected request
  bodies (`output_text` → `input_text` for assistant input messages).

The AI SDK path (`@ai-sdk/openai` `convertToOpenAIResponsesMessages`) emits the
same invalid shape and would need a separate fix upstream (`vercel/ai`) to fix
released builds.

### How did you verify your code works?

```sh
cd packages/llm
bun test test/provider/openai-responses.test.ts
```

54 pass, 0 fail.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR