### PR TITLE
fix(core): replay thinking safely and drop unsettled tool calls from errored messages

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -142,6 +142,11 @@ const toolResult = (tool: SessionMessage.AssistantTool, providerMetadata: Provid
   }
 }
 
+const replayableReasoningState = (state: Record<string, unknown> | undefined) =>
+  state !== undefined &&
+  ((typeof state.signature === "string" && state.signature.length > 0) ||
+    (typeof state.redactedData === "string" && state.redactedData.length > 0))
+
 const assistant = (message: SessionMessage.Assistant, model: Model.Ref, providerMetadataKey: string) => {
   const sameProvider = String(message.model.providerID) === String(model.providerID)
   const sameModel = sameProvider && String(message.model.id) === String(model.id)
@@ -156,7 +161,10 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
         },
       ]
     if (item.type === "reasoning")
-      return reuseProviderMetadata
+      // Errored messages replay reasoning only when the provider state is
+      // replay-safe (signed thinking or redacted data); an interrupted
+      // thinking block without a signature must not be replayed as one.
+      return sameModel && (message.error === undefined || replayableReasoningState(item.state))
         ? [
             {
               type: "reasoning",
@@ -167,6 +175,11 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
         : item.text.length > 0
           ? [{ type: "text", text: item.text }]
           : []
+    // Never replay an unsettled tool call from an errored message: it was
+    // never executed, its replay would demand the preceding thinking block,
+    // and the missing tool_result would fail provider validation.
+    const unsettled = item.state.status === "streaming" || item.state.status === "running"
+    if (message.error !== undefined && unsettled) return []
     const reuseToolProviderMetadata =
       reuseProviderMetadata ||
       (sameModel && item.executed === true && (item.state.status === "completed" || item.state.status === "error"))

--- a/packages/core/test/to-llm-message.test.ts
+++ b/packages/core/test/to-llm-message.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test"
+import { Agent } from "@opencode-ai/core/agent"
+import { Model } from "@opencode-ai/core/model"
+import { Provider } from "@opencode-ai/core/provider"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { toLLMMessages } from "@opencode-ai/core/session/runner/to-llm-message"
+import { Schema } from "effect"
+
+const model = { id: Model.ID.make("test-model"), providerID: Provider.ID.make("test-provider") }
+
+const reasoning = (text: string, state: Record<string, unknown> | undefined) => ({
+  type: "reasoning",
+  text,
+  ...(state === undefined ? {} : { state }),
+  time: { created: 0, completed: 0 },
+})
+
+const streamingTool = {
+  type: "tool",
+  id: "tool_1",
+  name: "read",
+  executed: false,
+  state: { status: "streaming", input: '{"path":"a.ts"}' },
+  time: { created: 0 },
+}
+
+const runningTool = {
+  type: "tool",
+  id: "tool_2",
+  name: "write",
+  executed: false,
+  state: { status: "running", input: {}, metadata: {} },
+  time: { created: 0 },
+}
+
+const completedTool = {
+  type: "tool",
+  id: "tool_3",
+  name: "read",
+  executed: true,
+  state: { status: "completed", input: {}, content: [{ type: "text", text: "ok" }] },
+  time: { created: 0, completed: 0 },
+}
+
+const assistant = (content: unknown[], error: unknown = undefined) =>
+  Schema.decodeUnknownSync(SessionMessage.Assistant)({
+    id: SessionMessage.ID.make("msg_assistant"),
+    type: "assistant",
+    agent: Agent.defaultID,
+    model,
+    content,
+    ...(error === undefined ? {} : { error }),
+    time: { created: 0, completed: 0 },
+  })
+
+const contents = (message: { content: readonly unknown[] }) => message.content
+
+describe("toLLMMessages errored assistant messages", () => {
+  test("replays signed thinking with an unsettled tool call dropped", () => {
+    const messages = toLLMMessages(
+      [assistant([reasoning("thinking text", { signature: "sig-1" }), streamingTool], { type: "aborted", message: "Step interrupted" })],
+      model,
+    )
+
+    expect(messages.map(contents)).toEqual([
+      [{ type: "reasoning", text: "thinking text", providerMetadata: { "test-provider": { signature: "sig-1" } } }],
+    ])
+  })
+
+  test("replays redacted thinking without a downgrade", () => {
+    const messages = toLLMMessages(
+      [assistant([reasoning("", { redactedData: "redacted-payload" }), streamingTool], { type: "aborted", message: "Step interrupted" })],
+      model,
+    )
+
+    expect(messages.map(contents)).toEqual([
+      [{ type: "reasoning", text: "", providerMetadata: { "test-provider": { redactedData: "redacted-payload" } } }],
+    ])
+  })
+
+  test("downgrades unsigned thinking to text and drops the unsettled tool call", () => {
+    const messages = toLLMMessages(
+      [assistant([reasoning("partial thinking", undefined), streamingTool], { type: "aborted", message: "Step interrupted" })],
+      model,
+    )
+
+    expect(messages.map(contents)).toEqual([[{ type: "text", text: "partial thinking" }]])
+  })
+
+  test("keeps an executed completed tool call and its result", () => {
+    const messages = toLLMMessages(
+      [assistant([reasoning("thinking text", { signature: "sig-1" }), completedTool], { type: "aborted", message: "Step interrupted" })],
+      model,
+    )
+
+    expect(messages.map(contents)).toEqual([
+      [
+        { type: "reasoning", text: "thinking text", providerMetadata: { "test-provider": { signature: "sig-1" } } },
+        { type: "tool-call", id: "tool_3", name: "read", input: {}, providerExecuted: true },
+        {
+          type: "tool-result",
+          id: "tool_3",
+          name: "read",
+          result: { type: "text", value: "ok" },
+          providerExecuted: true,
+        },
+      ],
+    ])
+  })
+
+  test("drops an executed but unsettled tool call", () => {
+    const messages = toLLMMessages(
+      [assistant([reasoning("partial thinking", undefined), runningTool], { type: "aborted", message: "Step interrupted" })],
+      model,
+    )
+
+    expect(messages.map(contents)).toEqual([[{ type: "text", text: "partial thinking" }]])
+  })
+
+  test("downgrades thinking and drops the tool call after a model switch", () => {
+    const switched = { id: Model.ID.make("other-model"), providerID: Provider.ID.make("test-provider") }
+    const messages = toLLMMessages(
+      [assistant([reasoning("thinking text", { signature: "sig-1" }), streamingTool], { type: "aborted", message: "Step interrupted" })],
+      switched,
+    )
+
+    expect(messages.map(contents)).toEqual([[{ type: "text", text: "thinking text" }]])
+  })
+
+  test("replays signed thinking and an unsettled tool call from a completed message", () => {
+    const messages = toLLMMessages([assistant([reasoning("thinking text", { signature: "sig-1" }), streamingTool])], model)
+
+    expect(messages.map(contents)).toEqual([
+      [
+        { type: "reasoning", text: "thinking text", providerMetadata: { "test-provider": { signature: "sig-1" } } },
+        { type: "tool-call", id: "tool_1", name: "read", input: { path: "a.ts" }, providerExecuted: false },
+      ],
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #38620

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Multi-turn thinking + tool-use conversations with Anthropic break after an interrupt or failure mid-step: the follow-up request replays the errored message's `tool_use` parts stripped of their reasoning blocks, and the provider rejects the request with 400 (thinking enabled requires every `tool_use` to be preceded by its `thinking`/`redacted_thinking` block).

In `packages/core/src/session/runner/to-llm-message.ts`, `reuseProviderMetadata` required `message.error === undefined`, so reasoning state was dropped (downgraded to text) for errored messages while their tool parts were still replayed. Two changes, keeping the errored-message guard's intent while preserving the replay invariant:

1. **Replay reasoning only when replay-safe.** Reasoning from an errored message is replayed with provider metadata only when the provider state carries a `signature` or `redactedData` (a thinking block Anthropic emitted in full) and the model is unchanged. An interrupted thinking block without a signature is still downgraded to text, never replayed as a thinking block.
2. **Drop unsettled tool calls from errored messages.** Tool calls in `streaming`/`running` state were never executed, so dropping them loses no durable work; replaying them would both demand the preceding thinking block and be left without a matching `tool_result`. Executed tools (completed/error state, including provider-executed hosted tools) keep their call + result.

### How did you verify your code works?

- Added 7 tests in `packages/core/test/to-llm-message.test.ts` covering signed/redacted/unsigned thinking, unsettled and executed tool calls, provider-hosted results, model switches, and a regression guard for completed messages.
- Full `packages/core` suite: 1806 pass, 0 fail.
- `bun typecheck` clean.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR