### PR TITLE
fix(provider): don't crash Provider.list when Cloudflare token missing

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -800,10 +800,18 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         env["CLOUDFLARE_API_TOKEN"] || env["CF_AIG_TOKEN"] || (auth?.type === "api" ? auth.key : undefined)
 
       if (!apiToken) {
-        throw new Error(
-          "CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway. " +
-            "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
-        )
+        // Don't crash Provider.list when the env/auth has Cloudflare IDs but no
+        // token — the provider is simply unavailable until credentials exist.
+        // Defer the error to getModel so listing other providers still works.
+        return {
+          autoload: false,
+          async getModel() {
+            throw new Error(
+              "CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway. " +
+                "Set it via environment variable or run `opencode auth cloudflare-ai-gateway`.",
+            )
+          },
+        }
       }
 
       const { createAiGateway } = yield* Effect.promise(() => import("ai-gateway-provider"))


### PR DESCRIPTION
### Issue for this PR

Closes #42739

### Type of change

- [x] Bug fix

### What does this PR do?

`Provider.list` crashes with an unhandled error when Cloudflare AI Gateway env vars (`CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_GATEWAY_ID`) are present but no API token is set:

```
Error: CLOUDFLARE_API_TOKEN (or CF_AIG_TOKEN) is required for Cloudflare AI Gateway...
    at Provider.list ...
```

The `cloudflare-ai-gateway` loader throws directly when the token is missing, which propagates out of `Provider.list` and takes down the whole server/TUI on startup. Every other missing-credential path in this file (e.g. missing account/gateway IDs) already returns `{ autoload: false, getModel() { throw ... } }`, deferring the error until the provider is actually used.

This change makes the missing-token path consistent: the provider is listed as unavailable (`autoload: false`) and the clear error only surfaces when a model is actually requested through it.

Changes:
- `packages/opencode/src/provider/provider.ts`: return `{ autoload: false, getModel() { throw ... } }` instead of throwing during provider loading when the Cloudflare token is missing.

### How did you verify your code works?

- Ran `bun test test/provider/provider.test.ts`: 100 pass, 0 fail (includes the existing cloudflare-ai-gateway tests, which still pass).
- The new behavior mirrors the already-tested missing-ID path in the same loader.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR