### PR TITLE
docs: add caspian-opencode-plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [caspian-opencode-plugin](https://github.com/TryCaspian/caspian-sdk/tree/main/packages/opencode)   | Email, Telegram, and Discord inbox for your opencode. Continue coding session on any channel.      |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #42752

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `caspian-opencode-plugin` to the ecosystem plugins table. It gives an OpenCode agent an email / Telegram / Discord inbox.

| [caspian-opencode-plugin](https://github.com/TryCaspian/caspian-sdk/tree/main/packages/opencode) | Email, Telegram, and Discord inbox for your agent |

### How did you verify your code works?

Checked the table renders and the repo link opens `packages/opencode`.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR