### PR TITLE
fix(compaction): skip summary messages in token display; add stylua formatter

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/sidebar/context.tsx
@@ -15,7 +15,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
   const cost = createMemo(() => msg().reduce((sum, item) => sum + (item.role === "assistant" ? item.cost : 0), 0))
 
   const state = createMemo(() => {
-    const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg().findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0 && !item.summary)
     if (!last) {
       return {
         tokens: 0,

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -411,3 +411,13 @@ export const dfmt: Info = {
     return [match, "-i", "$FILE"]
   },
 }
+
+export const stylua: Info = {
+  name: "stylua",
+  extensions: [".lua"],
+  async enabled() {
+    const match = which("stylua")
+    if (!match) return false
+    return [match, "$FILE"]
+  },
+}


### PR DESCRIPTION
## Compaction Token Display Fix

### Problem
After compaction, the sidebar context view showed 100% token usage instead of the actual post-compaction usage. The UI was reading tokens.input from the compaction summary message, which carries the full pre-compaction history token count.

### Fix
Skip messages with summary: true when finding the last assistant message for token counting, matching Cloud Code behavior.

## Stylua Formatter

Add stylua formatter support for .lua files, following the same pattern as existing formatters like dfmt.