### PR TITLE
refactor: improve concurrent session throughput

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -226,7 +226,7 @@ type OpenAIChatRequestMessage = LLMRequest["messages"][number]
 interface PendingToolDelta {
   readonly id?: string
   readonly name?: string
-  readonly input: string
+  readonly chunks: string[]
 }
 
 export interface ParserState {
@@ -754,13 +754,15 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       const pending = pendingTools[index]
       const id = current?.id ?? pending?.id ?? (tool.id || undefined)
       const name = current?.name ?? pending?.name ?? (tool.function?.name || undefined)
-      const text = `${pending?.input ?? ""}${tool.function?.arguments ?? ""}`
+      const delta = tool.function?.arguments ?? ""
       latestToolIndex = index
       nextToolIndex = Math.max(nextToolIndex, index + 1)
       if (!current && (!id || !name)) {
+        const chunks = pending?.chunks ?? []
+        if (delta.length > 0) chunks.push(delta)
         pendingTools = {
           ...pendingTools,
-          [index]: { id: id || undefined, name: name || undefined, input: text },
+          [index]: { id: id || undefined, name: name || undefined, chunks },
         }
         continue
       }
@@ -772,7 +774,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         ADAPTER,
         tools,
         index,
-        { id: id || undefined, name: name || undefined, text },
+        { id: id || undefined, name: name || undefined, text: `${pending?.chunks.join("") ?? ""}${delta}` },
         "OpenAI Chat tool call delta is missing id or name",
       )
       if (ToolStream.isError(result)) return yield* result

--- a/packages/ai/src/protocols/utils/tool-stream.ts
+++ b/packages/ai/src/protocols/utils/tool-stream.ts
@@ -1,15 +1,18 @@
 import { Effect } from "effect"
 import { AIError, LLMEvent, type ProviderMetadata, type ToolCall, type ToolInputError } from "../../schema/index.js"
-import { eventError, parseToolInput, type ToolAccumulator } from "../shared.js"
+import { eventError, parseToolInput } from "../shared.js"
 
 type StreamKey = string | number
 
 /**
  * One pending streamed tool call. Providers emit the tool identity and JSON
- * argument text across separate chunks; `input` is the raw JSON string collected
- * so far, not the parsed object.
+ * argument text across separate chunks. Keep chunks separate until the terminal
+ * boundary so appending small provider fragments stays linear.
  */
-export interface PendingTool extends ToolAccumulator {
+export interface PendingTool {
+  readonly id: string
+  readonly name: string
+  readonly chunks: string[]
   readonly providerExecuted?: boolean
   readonly providerMetadata?: ProviderMetadata
 }
@@ -65,7 +68,7 @@ const inputDelta = (tool: PendingTool, text: string) =>
   })
 
 const toolCall = (route: string, tool: PendingTool, inputOverride?: string) => {
-  const raw = inputOverride ?? tool.input
+  const raw = inputOverride ?? tool.chunks.join("")
   return parseToolInput(route, tool.name, raw).pipe(
     Effect.map((input): ToolCall | ToolInputError =>
       LLMEvent.toolCall({
@@ -123,8 +126,8 @@ export const isError = <K extends StreamKey>(result: AppendOutcome<K> | AIError)
 export const start = <K extends StreamKey>(
   tools: State<K>,
   key: K,
-  tool: Omit<PendingTool, "input"> & { readonly input?: string },
-) => withTool(tools, key, { ...tool, input: tool.input ?? "" })
+  tool: Omit<PendingTool, "chunks"> & { readonly input?: string },
+) => withTool(tools, key, { ...tool, chunks: tool.input === undefined ? [] : [tool.input] })
 
 /**
  * Append a streamed argument delta, starting the tool if this provider encodes
@@ -144,10 +147,12 @@ export const appendOrStart = <K extends StreamKey>(
   const name = current?.name ?? delta.name
   if (!id || !name) return eventError(route, missingToolMessage)
 
-  const tool = {
+  const chunks = current?.chunks ?? []
+  if (delta.text.length > 0) chunks.push(delta.text)
+  const tool: PendingTool = {
     id,
     name,
-    input: `${current?.input ?? ""}${delta.text}`,
+    chunks,
     providerExecuted: current?.providerExecuted,
     providerMetadata: current?.providerMetadata,
   }
@@ -171,7 +176,8 @@ export const appendExisting = <K extends StreamKey>(
   const current = tools[key]
   if (!current) return eventError(route, missingToolMessage)
   if (text.length === 0) return { tools, tool: current, events: [] }
-  return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
+  current.chunks.push(text)
+  return appendTool(tools, key, current, text)
 }
 
 /**

--- a/packages/ai/test/tool-stream.test.ts
+++ b/packages/ai/test/tool-stream.test.ts
@@ -19,6 +19,7 @@ describe("ToolStream", () => {
       if (ToolStream.isError(first)) return yield* first
       const second = ToolStream.appendOrStart(ADAPTER, first.tools, 0, { text: ':"weather"}' }, "missing tool")
       if (ToolStream.isError(second)) return yield* second
+      expect(second.tools[0]?.chunks).toEqual(['{"query"', ':"weather"}'])
       const finished = yield* ToolStream.finish(ADAPTER, second.tools, 0)
 
       expect(first.events).toEqual([

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -194,6 +194,8 @@ export function configured(options?: Options) {
           typed: new Map<string, PubSub.PubSub<Event.Payload>>(),
         }
         const routed = new Set<RoutedSubscription>()
+        const routedByType = new Map<string, Set<RoutedSubscription>>()
+        const routedWildcard = new Set<RoutedSubscription>()
         const projectors = new Map<string, Subscriber[]>()
         const listeners = new Array<Subscriber>()
         const durableLocks = KeyedMutex.makeUnsafe<string>()
@@ -218,13 +220,26 @@ export function configured(options?: Options) {
                 const subscription = yield* PubSub.subscribe(pubsub)
                 const route = { types, location, pubsub }
                 routed.add(route)
+                if (types === undefined) routedWildcard.add(route)
+                else
+                  for (const type of types) {
+                    const selected = routedByType.get(type) ?? new Set()
+                    selected.add(route)
+                    routedByType.set(type, selected)
+                  }
                 return { route, subscription }
               }),
               ({ route }) =>
-                Effect.sync(() => routed.delete(route)).pipe(
-                  Effect.andThen(PubSub.shutdown(route.pubsub)),
-                  Effect.asVoid,
-                ),
+                Effect.sync(() => {
+                  routed.delete(route)
+                  if (route.types === undefined) routedWildcard.delete(route)
+                  else
+                    for (const type of route.types) {
+                      const selected = routedByType.get(type)
+                      selected?.delete(route)
+                      if (selected?.size === 0) routedByType.delete(type)
+                    }
+                }).pipe(Effect.andThen(PubSub.shutdown(route.pubsub)), Effect.asVoid),
             ).pipe(Effect.map(({ subscription }) => Stream.fromSubscription(subscription))),
           )
 
@@ -465,8 +480,8 @@ export function configured(options?: Options) {
             )
             const typed = pubsub.typed.get(event.type)
             if (typed) yield* PubSub.publish(typed, event)
-            yield* Effect.forEach(routed, (route) => {
-              if (route.types !== undefined && !route.types.has(event.type)) return Effect.void
+            const routes = [...(routedByType.get(event.type) ?? []), ...routedWildcard]
+            yield* Effect.forEach(routes, (route) => {
               if (
                 route.location !== undefined &&
                 event.location !== undefined &&

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -172,6 +172,11 @@ interface Options {
   readonly persist?: boolean
 }
 
+type RoutedSubscription = {
+  readonly types: ReadonlySet<string>
+  readonly pubsub: PubSub.PubSub<Event.Payload>
+}
+
 export function configured(options?: Options) {
   return makeGlobalNode({
     service: Service,
@@ -187,6 +192,7 @@ export function configured(options?: Options) {
           durable: new Map<string, Set<PubSub.PubSub<void>>>(),
           typed: new Map<string, PubSub.PubSub<Event.Payload>>(),
         }
+        const routed = new Set<RoutedSubscription>()
         const projectors = new Map<string, Subscriber[]>()
         const listeners = new Array<Subscriber>()
         const durableLocks = KeyedMutex.makeUnsafe<string>()
@@ -203,6 +209,24 @@ export function configured(options?: Options) {
             return created
           })
 
+        const streamRouted = (definitions: readonly Event.Definition[]) =>
+          Stream.unwrap(
+            Effect.acquireRelease(
+              Effect.gen(function* () {
+                const pubsub = yield* PubSub.unbounded<Event.Payload>()
+                const subscription = yield* PubSub.subscribe(pubsub)
+                const route = { types: new Set(definitions.map((definition) => definition.type)), pubsub }
+                routed.add(route)
+                return { route, subscription }
+              }),
+              ({ route }) =>
+                Effect.sync(() => routed.delete(route)).pipe(
+                  Effect.andThen(PubSub.shutdown(route.pubsub)),
+                  Effect.asVoid,
+                ),
+            ).pipe(Effect.map(({ subscription }) => Stream.fromSubscription(subscription))),
+          )
+
         yield* Effect.addFinalizer(() =>
           Effect.gen(function* () {
             yield* PubSub.shutdown(pubsub.live)
@@ -212,6 +236,7 @@ export function configured(options?: Options) {
               { discard: true },
             )
             yield* Effect.forEach(pubsub.typed.values(), PubSub.shutdown, { discard: true })
+            yield* Effect.forEach(routed, (route) => PubSub.shutdown(route.pubsub), { discard: true })
           }),
         )
 
@@ -439,6 +464,9 @@ export function configured(options?: Options) {
             )
             const typed = pubsub.typed.get(event.type)
             if (typed) yield* PubSub.publish(typed, event)
+            yield* Effect.forEach(routed, (route) =>
+              route.types.has(event.type) ? PubSub.publish(route.pubsub, event) : Effect.void,
+            )
             yield* PubSub.publish(pubsub.live, event)
           })
         }
@@ -694,8 +722,7 @@ export function configured(options?: Options) {
           if (isDefinition(input)) {
             return local(Stream.unwrap(getOrCreate(input).pipe(Effect.map((pubsub) => Stream.fromPubSub(pubsub)))))
           }
-          const types = new Set(input.map((definition) => definition.type))
-          return streamLive().pipe(Stream.filter((event) => types.has(event.type)))
+          return local(streamRouted(input))
         }
 
         const streamLive = (): Stream.Stream<Event.Payload> => local(Stream.fromPubSub(pubsub.live))

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -173,7 +173,8 @@ interface Options {
 }
 
 type RoutedSubscription = {
-  readonly types: ReadonlySet<string>
+  readonly types?: ReadonlySet<string>
+  readonly location?: Location.Ref
   readonly pubsub: PubSub.PubSub<Event.Payload>
 }
 
@@ -209,13 +210,13 @@ export function configured(options?: Options) {
             return created
           })
 
-        const streamRouted = (definitions: readonly Event.Definition[]) =>
+        const streamRouted = (types?: ReadonlySet<string>, location?: Location.Ref) =>
           Stream.unwrap(
             Effect.acquireRelease(
               Effect.gen(function* () {
                 const pubsub = yield* PubSub.unbounded<Event.Payload>()
                 const subscription = yield* PubSub.subscribe(pubsub)
-                const route = { types: new Set(definitions.map((definition) => definition.type)), pubsub }
+                const route = { types, location, pubsub }
                 routed.add(route)
                 return { route, subscription }
               }),
@@ -464,9 +465,17 @@ export function configured(options?: Options) {
             )
             const typed = pubsub.typed.get(event.type)
             if (typed) yield* PubSub.publish(typed, event)
-            yield* Effect.forEach(routed, (route) =>
-              route.types.has(event.type) ? PubSub.publish(route.pubsub, event) : Effect.void,
-            )
+            yield* Effect.forEach(routed, (route) => {
+              if (route.types !== undefined && !route.types.has(event.type)) return Effect.void
+              if (
+                route.location !== undefined &&
+                event.location !== undefined &&
+                (route.location.directory !== event.location.directory ||
+                  route.location.workspaceID !== event.location.workspaceID)
+              )
+                return Effect.void
+              return PubSub.publish(route.pubsub, event)
+            })
             yield* PubSub.publish(pubsub.live, event)
           })
         }
@@ -692,25 +701,10 @@ export function configured(options?: Options) {
             .pipe(Effect.orDie)
         }
 
-        const local = <A extends Event.Payload>(stream: Stream.Stream<A>) =>
-          Stream.unwrap(
-            Effect.serviceOption(Location.Service).pipe(
-              Effect.map((location) =>
-                Option.match(location, {
-                  onNone: () => stream,
-                  onSome: (location) =>
-                    stream.pipe(
-                      Stream.filter(
-                        (event) =>
-                          !event.location ||
-                          (event.location.directory === location.directory &&
-                            event.location.workspaceID === location.workspaceID),
-                      ),
-                    ),
-                }),
-              ),
-            ),
-          )
+        const locationRef = (location: Location.Ref): Location.Ref => ({
+          directory: location.directory,
+          workspaceID: location.workspaceID,
+        })
 
         function subscribe(): Stream.Stream<Event.Payload>
         function subscribe<D extends Event.Definition>(definition: D): Stream.Stream<Event.Payload<D>>
@@ -720,12 +714,40 @@ export function configured(options?: Options) {
         function subscribe(input?: Event.Definition | readonly Event.Definition[]): Stream.Stream<Event.Payload> {
           if (input === undefined) return streamLive()
           if (isDefinition(input)) {
-            return local(Stream.unwrap(getOrCreate(input).pipe(Effect.map((pubsub) => Stream.fromPubSub(pubsub)))))
+            return Stream.unwrap(
+              Effect.serviceOption(Location.Service).pipe(
+                Effect.flatMap((location) =>
+                  Option.match(location, {
+                    onNone: () => getOrCreate(input).pipe(Effect.map((pubsub) => Stream.fromPubSub(pubsub))),
+                    onSome: (location) => Effect.succeed(streamRouted(new Set([input.type]), locationRef(location))),
+                  }),
+                ),
+              ),
+            )
           }
-          return local(streamRouted(input))
+          return Stream.unwrap(
+            Effect.serviceOption(Location.Service).pipe(
+              Effect.map((location) =>
+                streamRouted(
+                  new Set(input.map((definition) => definition.type)),
+                  Option.match(location, { onNone: () => undefined, onSome: locationRef }),
+                ),
+              ),
+            ),
+          )
         }
 
-        const streamLive = (): Stream.Stream<Event.Payload> => local(Stream.fromPubSub(pubsub.live))
+        const streamLive = (): Stream.Stream<Event.Payload> =>
+          Stream.unwrap(
+            Effect.serviceOption(Location.Service).pipe(
+              Effect.map((location) =>
+                Option.match(location, {
+                  onNone: () => Stream.fromPubSub(pubsub.live),
+                  onSome: (location) => streamRouted(undefined, locationRef(location)),
+                }),
+              ),
+            ),
+          )
 
         const readAfter = (
           aggregateID: string,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,4 +1,5 @@
 export * as Config from "./config.js"
+export { Event } from "@opencode-ai/schema/config"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,4 @@
 export * as Config from "./config.js"
-export { Event } from "@opencode-ai/schema/config"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -17,6 +17,7 @@ import type { LocationMutation } from "../../location-mutation.js"
 import type { ReadTool } from "../../tool/plugin/read.js"
 import type { EditTool } from "../../tool/plugin/edit.js"
 import { AbsolutePath } from "../../schema.js"
+import { Bus } from "../../bus.js"
 
 const legacySources = [
   { pattern: "{agent,agents}/**/*.md", primary: false },
@@ -50,6 +51,7 @@ export const Plugin = define({
   id: "opencode.config.agent",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
     const load = Effect.fn("ConfigAgentPlugin.load")(function* () {
@@ -82,7 +84,7 @@ export const Plugin = define({
       .pipe(
         Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isAgentSource(entries, update.path))),
       )
-    const configUpdates = ctx.event.subscribe().pipe(Stream.filter((event) => event.type === "config.updated"))
+    const configUpdates = bus.subscribe(Config.Event.Updated)
     yield* Stream.merge(sourceChanges, configUpdates).pipe(
       Stream.debounce("100 millis"),
       Stream.runForEach(() => reload),

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -17,7 +17,6 @@ import type { LocationMutation } from "../../location-mutation.js"
 import type { ReadTool } from "../../tool/plugin/read.js"
 import type { EditTool } from "../../tool/plugin/edit.js"
 import { AbsolutePath } from "../../schema.js"
-import { Bus } from "../../bus.js"
 
 const legacySources = [
   { pattern: "{agent,agents}/**/*.md", primary: false },
@@ -51,7 +50,6 @@ export const Plugin = define({
   id: "opencode.config.agent",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
     const load = Effect.fn("ConfigAgentPlugin.load")(function* () {
@@ -84,7 +82,7 @@ export const Plugin = define({
       .pipe(
         Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isAgentSource(entries, update.path))),
       )
-    const configUpdates = bus.subscribe(Config.Event.Updated)
+    const configUpdates = ctx.event.subscribe("config.updated")
     yield* Stream.merge(sourceChanges, configUpdates).pipe(
       Stream.debounce("100 millis"),
       Stream.runForEach(() => reload),

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -9,6 +9,7 @@ import { Command } from "../../command.js"
 import { Config } from "../../config.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { ConfigMarkdown } from "../markdown.js"
+import { Bus } from "../../bus.js"
 
 const decodeCommand = Schema.decodeUnknownOption(ConfigCommand.Info)
 
@@ -16,6 +17,7 @@ export const Plugin = define({
   id: "opencode.config.command",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
       return yield* Effect.forEach(yield* config.entries(), (entry) => {
@@ -43,7 +45,7 @@ export const Plugin = define({
           Effect.map(config.entries(), (entries) => isCommandSource(entries, update.path)),
         ),
       )
-    const configUpdates = ctx.event.subscribe().pipe(Stream.filter((event) => event.type === "config.updated"))
+    const configUpdates = bus.subscribe(Config.Event.Updated)
     yield* Stream.merge(sourceChanges, configUpdates).pipe(
       Stream.debounce("100 millis"),
       Stream.runForEach(() => reload),

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -9,7 +9,6 @@ import { Command } from "../../command.js"
 import { Config } from "../../config.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { ConfigMarkdown } from "../markdown.js"
-import { Bus } from "../../bus.js"
 
 const decodeCommand = Schema.decodeUnknownOption(ConfigCommand.Info)
 
@@ -17,7 +16,6 @@ export const Plugin = define({
   id: "opencode.config.command",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
       return yield* Effect.forEach(yield* config.entries(), (entry) => {
@@ -45,7 +43,7 @@ export const Plugin = define({
           Effect.map(config.entries(), (entries) => isCommandSource(entries, update.path)),
         ),
       )
-    const configUpdates = bus.subscribe(Config.Event.Updated)
+    const configUpdates = ctx.event.subscribe("config.updated")
     yield* Stream.merge(sourceChanges, configUpdates).pipe(
       Stream.debounce("100 millis"),
       Stream.runForEach(() => reload),

--- a/packages/core/src/config/plugin/policy.ts
+++ b/packages/core/src/config/plugin/policy.ts
@@ -5,11 +5,13 @@ import { Document } from "@opencode-ai/schema/config"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
 import { Wildcard } from "../../util/wildcard.js"
+import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.policy",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.catalog.transform((catalog) => {
       // User-global policy takes priority over policy authored by a repository.
@@ -22,8 +24,7 @@ export const Plugin = define({
         if (policy?.effect === "deny") catalog.provider.remove(record.provider.id)
       }
     })
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "config.updated"),
+    yield* bus.subscribe(Config.Event.Updated).pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/policy.ts
+++ b/packages/core/src/config/plugin/policy.ts
@@ -5,13 +5,11 @@ import { Document } from "@opencode-ai/schema/config"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
 import { Wildcard } from "../../util/wildcard.js"
-import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.policy",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.catalog.transform((catalog) => {
       // User-global policy takes priority over policy authored by a repository.
@@ -24,7 +22,7 @@ export const Plugin = define({
         if (policy?.effect === "deny") catalog.provider.remove(record.provider.id)
       }
     })
-    yield* bus.subscribe(Config.Event.Updated).pipe(
+    yield* ctx.event.subscribe("config.updated").pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/provider.ts
+++ b/packages/core/src/config/plugin/provider.ts
@@ -6,13 +6,11 @@ import { Money } from "@opencode-ai/schema/money"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
 import { Provider } from "../../provider.js"
-import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.provider",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.integration.transform((integrations) => {
       for (const [id, provider] of configuredProviders(loaded.entries)) {
@@ -98,7 +96,7 @@ export const Plugin = define({
         }
       }
     })
-    yield* bus.subscribe(Config.Event.Updated).pipe(
+    yield* ctx.event.subscribe("config.updated").pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/provider.ts
+++ b/packages/core/src/config/plugin/provider.ts
@@ -6,11 +6,13 @@ import { Money } from "@opencode-ai/schema/money"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
 import { Provider } from "../../provider.js"
+import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.provider",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.integration.transform((integrations) => {
       for (const [id, provider] of configuredProviders(loaded.entries)) {
@@ -96,8 +98,7 @@ export const Plugin = define({
         }
       }
     })
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "config.updated"),
+    yield* bus.subscribe(Config.Event.Updated).pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/reference.ts
+++ b/packages/core/src/config/plugin/reference.ts
@@ -10,11 +10,13 @@ import { Reference } from "../../reference.js"
 import { AbsolutePath } from "../../schema.js"
 import { Global } from "@opencode-ai/util/global"
 import { Location } from "../../location.js"
+import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.reference",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const location = yield* Location.Service
     const global = yield* Global.Service
     const loaded = { entries: yield* config.entries() }
@@ -49,8 +51,7 @@ export const Plugin = define({
       }
       for (const [name, source] of entries) draft.add(name, source)
     })
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "config.updated"),
+    yield* bus.subscribe(Config.Event.Updated).pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/reference.ts
+++ b/packages/core/src/config/plugin/reference.ts
@@ -10,13 +10,11 @@ import { Reference } from "../../reference.js"
 import { AbsolutePath } from "../../schema.js"
 import { Global } from "@opencode-ai/util/global"
 import { Location } from "../../location.js"
-import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.reference",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const location = yield* Location.Service
     const global = yield* Global.Service
     const loaded = { entries: yield* config.entries() }
@@ -51,7 +49,7 @@ export const Plugin = define({
       }
       for (const [name, source] of entries) draft.add(name, source)
     })
-    yield* bus.subscribe(Config.Event.Updated).pipe(
+    yield* ctx.event.subscribe("config.updated").pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/skill.ts
+++ b/packages/core/src/config/plugin/skill.ts
@@ -13,6 +13,7 @@ import { AbsolutePath } from "../../schema.js"
 import { Skill } from "../../skill.js"
 import { SkillDiscovery } from "../../skill/discovery.js"
 import { SkillFile } from "./skill-file.js"
+import { Bus } from "../../bus.js"
 
 type Source = Skill.DirectorySource | Skill.UrlSource
 
@@ -20,6 +21,7 @@ export const Plugin = define({
   id: "opencode.config.skill",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const discovery = yield* SkillDiscovery.Service
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
@@ -180,8 +182,7 @@ export const Plugin = define({
     yield* ctx.skill.transform((draft) => {
       for (const skill of loaded.skills) draft.add(skill)
     })
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "config.updated"),
+    yield* bus.subscribe(Config.Event.Updated).pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/skill.ts
+++ b/packages/core/src/config/plugin/skill.ts
@@ -13,7 +13,6 @@ import { AbsolutePath } from "../../schema.js"
 import { Skill } from "../../skill.js"
 import { SkillDiscovery } from "../../skill/discovery.js"
 import { SkillFile } from "./skill-file.js"
-import { Bus } from "../../bus.js"
 
 type Source = Skill.DirectorySource | Skill.UrlSource
 
@@ -21,7 +20,6 @@ export const Plugin = define({
   id: "opencode.config.skill",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const discovery = yield* SkillDiscovery.Service
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
@@ -182,7 +180,7 @@ export const Plugin = define({
     yield* ctx.skill.transform((draft) => {
       for (const skill of loaded.skills) draft.add(skill)
     })
-    yield* bus.subscribe(Config.Event.Updated).pipe(
+    yield* ctx.event.subscribe("config.updated").pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/websearch.ts
+++ b/packages/core/src/config/plugin/websearch.ts
@@ -3,19 +3,20 @@ export * as ConfigWebSearchPlugin from "./websearch.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
+import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.websearch",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
+    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.websearch.transform((websearch) => {
       const selection = Config.latest(loaded.entries, "websearch")
       if (selection === false) websearch.default.set(false)
       if (selection) websearch.default.set(selection.provider)
     })
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter((event) => event.type === "config.updated"),
+    yield* bus.subscribe(Config.Event.Updated).pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/config/plugin/websearch.ts
+++ b/packages/core/src/config/plugin/websearch.ts
@@ -3,20 +3,18 @@ export * as ConfigWebSearchPlugin from "./websearch.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
-import { Bus } from "../../bus.js"
 
 export const Plugin = define({
   id: "opencode.config.websearch",
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
-    const bus = yield* Bus.Service
     const loaded = { entries: yield* config.entries() }
     yield* ctx.websearch.transform((websearch) => {
       const selection = Config.latest(loaded.entries, "websearch")
       if (selection === false) websearch.default.set(false)
       if (selection) websearch.default.set(selection.provider)
     })
-    yield* bus.subscribe(Config.Event.Updated).pipe(
+    yield* ctx.event.subscribe("config.updated").pipe(
       Stream.runForEach(() =>
         config.entries().pipe(
           Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -33,6 +33,7 @@ type InventoryKey = {
   readonly home: boolean
 }
 type Inventory = {
+  readonly scope: Scope.Scope
   index: ReturnType<typeof emptyIndex>
   initialized: boolean
   settledAt: number
@@ -51,11 +52,16 @@ const inventoriesLayer = Layer.effect(
   Inventories,
   RcMap.make({
     lookup: () =>
-      Effect.succeed<Inventory>({
-        index: emptyIndex(),
-        initialized: false,
-        settledAt: Number.NEGATIVE_INFINITY,
-        refreshing: false,
+      Effect.gen(function* () {
+        const scope = yield* Scope.Scope
+        const inventory: Inventory = {
+          scope,
+          index: emptyIndex(),
+          initialized: false,
+          settledAt: Number.NEGATIVE_INFINITY,
+          refreshing: false,
+        }
+        return inventory
       }),
   }),
 )
@@ -89,7 +95,6 @@ export const ripgrepLayer = Layer.effect(
     const location = yield* Location.Service
     const ripgrep = yield* Ripgrep.Service
     const inventories = yield* Inventories
-    const scope = yield* Scope.Scope
     const clock = yield* Clock.Clock
     const home = Protected.isHome(location.directory)
     const limit = location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000
@@ -124,9 +129,13 @@ export const ripgrepLayer = Layer.effect(
       inventory.initialized = true
     }).pipe(
       Effect.orDie,
-      Effect.ensuring(
+      Effect.tap(() =>
         Effect.sync(() => {
           inventory.settledAt = clock.currentTimeMillisUnsafe()
+        }),
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
           inventory.refreshing = false
         }),
       ),
@@ -135,7 +144,7 @@ export const ripgrepLayer = Layer.effect(
       if (inventory.refreshing || clock.currentTimeMillisUnsafe() < inventory.settledAt + REFRESH_INTERVAL) return
       inventory.refreshing = true
       return scan
-    }).pipe(Effect.flatMap((effect) => (effect ? effect.pipe(Effect.forkIn(scope)) : Effect.void)))
+    }).pipe(Effect.flatMap((effect) => (effect ? effect.pipe(Effect.forkIn(inventory.scope)) : Effect.void)))
     yield* refresh
     return Service.of({
       find: (input) =>

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -1,8 +1,8 @@
 export * as FileSystemSearch from "./search.js"
 
-import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { makeGlobalNode, makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Clock, Context, Duration, Effect, Layer, Schema, Scope } from "effect"
+import { Clock, Context, Duration, Effect, Layer, RcMap, Schema, Scope } from "effect"
 import { Fff } from "#fff"
 import fuzzysort from "fuzzysort"
 import { FileSystem } from "../filesystem.js"
@@ -10,6 +10,7 @@ import { Location } from "../location.js"
 import { Ripgrep } from "../ripgrep.js"
 import { RelativePath } from "../schema.js"
 import { Protected } from "./protected.js"
+import { FSUtil } from "@opencode-ai/util/fs-util"
 
 export interface Interface {
   readonly find: (input: FileSystem.FindInput) => Effect.Effect<FileSystem.Entry[]>
@@ -24,10 +25,42 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Fi
 
 const REFRESH_INTERVAL = Duration.toMillis("10 seconds")
 type Prepared = ReturnType<typeof fuzzysort.prepare>
+type InventoryKey = {
+  readonly projectID: string
+  readonly workspaceID: string | null
+  readonly directory: string
+  readonly limit: number
+  readonly home: boolean
+}
+type Inventory = {
+  index: ReturnType<typeof emptyIndex>
+  initialized: boolean
+  settledAt: number
+  refreshing: boolean
+}
+
+class Inventories extends Context.Service<Inventories, RcMap.RcMap<InventoryKey, Inventory>>()(
+  "@opencode/FileSystem/Search/Inventories",
+) {}
 
 function emptyIndex() {
   return { files: new Map<string, Prepared>(), directories: new Map<string, Prepared>() }
 }
+
+const inventoriesLayer = Layer.effect(
+  Inventories,
+  RcMap.make({
+    lookup: () =>
+      Effect.succeed<Inventory>({
+        index: emptyIndex(),
+        initialized: false,
+        settledAt: Number.NEGATIVE_INFINITY,
+        refreshing: false,
+      }),
+  }),
+)
+
+const inventoriesNode = makeGlobalNode({ service: Inventories, layer: inventoriesLayer, deps: [] })
 
 function search(index: ReturnType<typeof emptyIndex>, input: FileSystem.FindInput) {
   const items =
@@ -55,21 +88,26 @@ export const ripgrepLayer = Layer.effect(
   Effect.gen(function* () {
     const location = yield* Location.Service
     const ripgrep = yield* Ripgrep.Service
+    const inventories = yield* Inventories
     const scope = yield* Scope.Scope
     const clock = yield* Clock.Clock
     const home = Protected.isHome(location.directory)
-    let index = emptyIndex()
-    let initialized = false
-    let settledAt = Number.NEGATIVE_INFINITY
-    let refreshing = false
+    const limit = location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000
+    const inventory = yield* RcMap.get(inventories, {
+      projectID: location.project.id,
+      workspaceID: location.workspaceID ?? null,
+      directory: location.workspaceID === undefined ? FSUtil.resolve(location.directory) : location.directory,
+      limit,
+      home,
+    })
     const scan = Effect.gen(function* () {
       const next = emptyIndex()
-      const previous = index
-      if (!initialized) index = next
+      const previous = inventory.index
+      if (!inventory.initialized) inventory.index = next
       yield* ripgrep.find({
         cwd: location.directory,
         pattern: "*",
-        limit: location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000,
+        limit,
         exclude: home ? [...Protected.names()].map((name) => `${name}/**`) : undefined,
         onEntry: (entry) =>
           Effect.sync(() => {
@@ -82,20 +120,20 @@ export const ripgrepLayer = Layer.effect(
             })
           }),
       })
-      index = next
-      initialized = true
+      inventory.index = next
+      inventory.initialized = true
     }).pipe(
       Effect.orDie,
       Effect.ensuring(
         Effect.sync(() => {
-          settledAt = clock.currentTimeMillisUnsafe()
-          refreshing = false
+          inventory.settledAt = clock.currentTimeMillisUnsafe()
+          inventory.refreshing = false
         }),
       ),
     )
     const refresh = Effect.sync(() => {
-      if (refreshing || clock.currentTimeMillisUnsafe() < settledAt + REFRESH_INTERVAL) return
-      refreshing = true
+      if (inventory.refreshing || clock.currentTimeMillisUnsafe() < inventory.settledAt + REFRESH_INTERVAL) return
+      inventory.refreshing = true
       return scan
     }).pipe(Effect.flatMap((effect) => (effect ? effect.pipe(Effect.forkIn(scope)) : Effect.void)))
     yield* refresh
@@ -103,7 +141,7 @@ export const ripgrepLayer = Layer.effect(
       find: (input) =>
         Effect.gen(function* () {
           yield* refresh
-          return search(index, input)
+          return search(inventory.index, input)
         }),
     })
   }),
@@ -189,7 +227,11 @@ export const layer = (options?: Options) =>
   )
 
 export function configured(options?: Options) {
-  return makeLocationNode({ service: Service, layer: layer(options), deps: [Location.node, Ripgrep.node] })
+  return makeLocationNode({
+    service: Service,
+    layer: layer(options),
+    deps: [Location.node, Ripgrep.node, inventoriesNode],
+  })
 }
 
 export const node = configured()

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -180,7 +180,8 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
         }),
     },
     event: {
-      subscribe: () => bus.subscribe(EventManifest.ServerDefinitions),
+      subscribe: () =>
+        bus.subscribe(EventManifest.ServerDefinitions).pipe(Stream.provideService(Location.Service, location)),
     },
     integration: {
       list: () => response(integration.list()),

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -180,7 +180,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
         }),
     },
     event: {
-      subscribe: () => bus.subscribe().pipe(Stream.filter(EventManifest.isServer)),
+      subscribe: () => bus.subscribe(EventManifest.ServerDefinitions),
     },
     integration: {
       list: () => response(integration.list()),

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -64,14 +64,17 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
     if (selection === undefined)
       return bus.subscribe(EventManifest.ServerDefinitions).pipe(Stream.provideService(Location.Service, location))
     const types = typeof selection === "string" ? [selection] : selection
-    const first = EventManifest.Server.get(types[0])
-    if (first === undefined) return Stream.die(new Error(`Unknown plugin event type: ${types[0]}`))
     const definitions = types
-      .slice(1)
       .map((type) => EventManifest.Server.get(type))
       .filter((definition) => definition !== undefined)
+    if (definitions.length !== types.length) {
+      const unknown = types.find((type) => !EventManifest.Server.has(type))
+      return Stream.die(new Error(`Unknown plugin event type: ${unknown ?? "unknown"}`))
+    }
+    const first = definitions[0]
+    if (first === undefined) return Stream.die(new Error("Plugin event selection cannot be empty"))
     return bus
-      .subscribe([first, ...definitions])
+      .subscribe([first, ...definitions.slice(1)])
       .pipe(Stream.filter(EventManifest.isServer), Stream.provideService(Location.Service, location))
   }
 

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -1,6 +1,7 @@
 export * as PluginHost from "./host.js"
 
 import { Plugin } from "@opencode-ai/plugin/effect"
+import type { EventSelection } from "@opencode-ai/plugin/effect/event"
 import type { IntegrationMethodRegistration } from "@opencode-ai/plugin/effect/integration"
 import type { CredentialOAuth } from "@opencode-ai/sdk/v2/types"
 import { EventManifest } from "@opencode-ai/schema/event-manifest"
@@ -59,6 +60,20 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
     ref.directory === location.directory && ref.workspaceID === location.workspaceID
   const response = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
     effect.pipe(Effect.map((data) => ({ location: locationInfo(), data })))
+  const subscribeEvents = (selection?: EventSelection) => {
+    if (selection === undefined)
+      return bus.subscribe(EventManifest.ServerDefinitions).pipe(Stream.provideService(Location.Service, location))
+    const types = typeof selection === "string" ? [selection] : selection
+    const first = EventManifest.Server.get(types[0])
+    if (first === undefined) return Stream.die(new Error(`Unknown plugin event type: ${types[0]}`))
+    const definitions = types
+      .slice(1)
+      .map((type) => EventManifest.Server.get(type))
+      .filter((definition) => definition !== undefined)
+    return bus
+      .subscribe([first, ...definitions])
+      .pipe(Stream.filter(EventManifest.isServer), Stream.provideService(Location.Service, location))
+  }
 
   return {
     app,
@@ -180,8 +195,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: import("../p
         }),
     },
     event: {
-      subscribe: () =>
-        bus.subscribe(EventManifest.ServerDefinitions).pipe(Stream.provideService(Location.Service, location)),
+      subscribe: subscribeEvents,
     },
     integration: {
       list: () => response(integration.list()),

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -4,6 +4,7 @@ import { ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Agent } from "../agent.js"
+import { Bus } from "../bus.js"
 import { SessionEvent } from "../session/event.js"
 
 const plan = Agent.ID.make("plan")
@@ -21,6 +22,7 @@ You are NO LONGER in Plan mode. The previous Plan restrictions no longer apply. 
 export const Plugin = define({
   id: "opencode.plan",
   effect: Effect.fn(function* (ctx) {
+    const bus = yield* Bus.Service
     yield* ctx.agent.transform((draft) => {
       draft.update(plan, (item) => {
         item.name = Agent.Name.make("Plan")
@@ -38,11 +40,7 @@ export const Plugin = define({
       })
     })
 
-    yield* ctx.event.subscribe().pipe(
-      Stream.filter(
-        (event): event is SessionEvent.Created | SessionEvent.AgentSelected =>
-          event.type === "session.created" || event.type === "session.agent.selected",
-      ),
+    yield* bus.subscribe([SessionEvent.Created, SessionEvent.AgentSelected]).pipe(
       Stream.runForEach((event) => {
         const text = reminder(event)
         if (!text) return Effect.void

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -4,7 +4,6 @@ import { ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Agent } from "../agent.js"
-import { Bus } from "../bus.js"
 import { SessionEvent } from "../session/event.js"
 
 const plan = Agent.ID.make("plan")
@@ -22,7 +21,6 @@ You are NO LONGER in Plan mode. The previous Plan restrictions no longer apply. 
 export const Plugin = define({
   id: "opencode.plan",
   effect: Effect.fn(function* (ctx) {
-    const bus = yield* Bus.Service
     yield* ctx.agent.transform((draft) => {
       draft.update(plan, (item) => {
         item.name = Agent.Name.make("Plan")
@@ -40,7 +38,11 @@ export const Plugin = define({
       })
     })
 
-    yield* bus.subscribe([SessionEvent.Created, SessionEvent.AgentSelected]).pipe(
+    yield* ctx.event.subscribe(["session.created", "session.agent.selected"]).pipe(
+      Stream.filter(
+        (event): event is SessionEvent.Created | SessionEvent.AgentSelected =>
+          event.type === "session.created" || event.type === "session.agent.selected",
+      ),
       Stream.runForEach((event) => {
         const text = reminder(event)
         if (!text) return Effect.void

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -1,6 +1,6 @@
 export * as Worktree from "./worktree.js"
 
-import { Context, Deferred, Effect, Layer, Schema } from "effect"
+import { Context, Deferred, Effect, FiberSet, Layer, Schema } from "effect"
 import { and, asc, desc, eq, isNotNull, isNull, ne, or } from "drizzle-orm"
 import path from "path"
 import { AbsolutePath } from "./schema.js"
@@ -148,6 +148,7 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
     const db = (yield* Database.Service).db
     const bus = yield* Bus.Service
+    const forkRefresh = yield* FiberSet.makeRuntime<never, void, never>()
 
     const changed = Effect.fnUntraced(function* (projectID: ProjectSchema.ID, update: boolean) {
       if (update) yield* bus.publish(Event.Updated, { projectID })
@@ -338,14 +339,19 @@ const layer = Layer.effect(
         if (existing) return Deferred.await(existing)
         const deferred = Deferred.makeUnsafe<RefreshResult, Error>()
         bootRefreshes.set(input.projectID, deferred)
-        return refresh(input).pipe(
-          Effect.onExit((exit) =>
-            Effect.sync(() => {
-              if (bootRefreshes.get(input.projectID) === deferred) bootRefreshes.delete(input.projectID)
-              Deferred.doneUnsafe(deferred, exit)
-            }),
+        forkRefresh(
+          refresh(input).pipe(
+            Effect.exit,
+            Effect.tap((exit) =>
+              Effect.sync(() => {
+                if (bootRefreshes.get(input.projectID) === deferred) bootRefreshes.delete(input.projectID)
+                Deferred.doneUnsafe(deferred, exit)
+              }),
+            ),
+            Effect.asVoid,
           ),
         )
+        return Deferred.await(deferred)
       })
 
     return Service.of({

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -1,6 +1,6 @@
 export * as Worktree from "./worktree.js"
 
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Deferred, Effect, Layer, Schema } from "effect"
 import { and, asc, desc, eq, isNotNull, isNull, ne, or } from "drizzle-orm"
 import path from "path"
 import { AbsolutePath } from "./schema.js"
@@ -119,6 +119,7 @@ export interface Interface {
   readonly create: (input: CreateInput) => Effect.Effect<Info, Error>
   readonly remove: (input: RemoveInput) => Effect.Effect<void, Error>
   readonly refresh: (input: RefreshInput) => Effect.Effect<RefreshResult, Error>
+  readonly refreshAfterBoot: (input: RefreshInput) => Effect.Effect<RefreshResult, Error>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Worktree") {}
@@ -128,7 +129,7 @@ export const refreshAfterBoot = Effect.gen(function* () {
   const worktrees = yield* Service
   yield* Effect.gen(function* () {
     yield* Effect.logInfo("worktree refresh started", { projectID: location.project.id })
-    const result = yield* worktrees.refresh({ projectID: location.project.id })
+    const result = yield* worktrees.refreshAfterBoot({ projectID: location.project.id })
     yield* Effect.logInfo("worktree refresh done", {
       projectID: location.project.id,
       updated: result.updated,
@@ -330,12 +331,30 @@ const layer = Layer.effect(
       return changes
     })
 
+    const bootRefreshes = new Map<ProjectSchema.ID, Deferred.Deferred<RefreshResult, Error>>()
+    const refreshAfterBoot = (input: RefreshInput) =>
+      Effect.suspend(() => {
+        const existing = bootRefreshes.get(input.projectID)
+        if (existing) return Deferred.await(existing)
+        const deferred = Deferred.makeUnsafe<RefreshResult, Error>()
+        bootRefreshes.set(input.projectID, deferred)
+        return refresh(input).pipe(
+          Effect.onExit((exit) =>
+            Effect.sync(() => {
+              if (bootRefreshes.get(input.projectID) === deferred) bootRefreshes.delete(input.projectID)
+              Deferred.doneUnsafe(deferred, exit)
+            }),
+          ),
+        )
+      })
+
     return Service.of({
       register,
       list: ops.list,
       create,
       remove,
       refresh,
+      refreshAfterBoot,
     })
   }),
 )

--- a/packages/core/test/bus.test.ts
+++ b/packages/core/test/bus.test.ts
@@ -121,12 +121,25 @@ describe("Bus", () => {
       yield* Effect.yieldNow
 
       yield* bus.publish(Message, { text: "hello" })
+      yield* bus.publish(GlobalMessage, { text: "ignored" })
       yield* bus.publish(CountMessage, { count: 2 })
 
       const received = Array.from(yield* Fiber.join(fiber)).map((event) =>
         event.type === "test.message" ? event.data.text : event.data.count,
       )
       expect(received).toEqual(["hello", 2])
+    }),
+  )
+
+  it.effect("delivers duplicate selected definitions once", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const fiber = yield* bus.subscribe([Message, Message]).pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      const event = yield* bus.publish(Message, { text: "hello" })
+
+      expect(Array.from(yield* Fiber.join(fiber))).toEqual([event])
     }),
   )
 

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -3,7 +3,7 @@ import fuzzysort from "fuzzysort"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
-import { Deferred, Effect, Layer } from "effect"
+import { Deferred, Effect, Exit, Layer, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -28,6 +28,7 @@ describe("FileSystemSearch", () => {
     await fs.symlink(root.path, alias, process.platform === "win32" ? "junction" : "dir")
     let scans = 0
     const scanned = Effect.runSync(Deferred.make<void>())
+    const release = Effect.runSync(Deferred.make<void>())
     const ripgrep = Layer.succeed(
       Ripgrep.Service,
       Ripgrep.Service.of({
@@ -35,8 +36,9 @@ describe("FileSystemSearch", () => {
           Effect.gen(function* () {
             scans++
             const entry = FileSystem.Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" })
-            if (input.onEntry) yield* input.onEntry(entry)
             yield* Deferred.succeed(scanned, undefined)
+            yield* Deferred.await(release)
+            if (input.onEntry) yield* input.onEntry(entry)
             return [entry]
           }),
         glob: () => Effect.succeed([]),
@@ -52,13 +54,23 @@ describe("FileSystemSearch", () => {
       await Effect.runPromise(
         Effect.gen(function* () {
           const locations = yield* LocationServiceMap.Service
-          const first = yield* locations.contextEffect(Location.Ref.make({ directory: AbsolutePath.make(root.path) }))
-          const second = yield* locations.contextEffect(Location.Ref.make({ directory: AbsolutePath.make(alias) }))
+          const firstScope = yield* Scope.make()
+          const secondScope = yield* Scope.make()
+          yield* Effect.addFinalizer(() => Scope.close(secondScope, Exit.void))
+          yield* locations
+            .contextEffect(Location.Ref.make({ directory: AbsolutePath.make(root.path) }))
+            .pipe(Scope.provide(firstScope))
           yield* Deferred.await(scanned)
-          const find = FileSystemSearch.Service.use((search) => search.find({ query: "index", type: "file" }))
+          const second = yield* locations
+            .contextEffect(Location.Ref.make({ directory: AbsolutePath.make(alias) }))
+            .pipe(Scope.provide(secondScope))
+          yield* Scope.close(firstScope, Exit.void)
+          yield* Deferred.succeed(release, undefined)
+          const find = FileSystemSearch.Service.use((search) => search.find({ query: "index", type: "file" })).pipe(
+            Effect.provideContext(second),
+          )
 
-          expect(yield* find.pipe(Effect.provideContext(first))).toHaveLength(1)
-          expect(yield* find.pipe(Effect.provideContext(second))).toHaveLength(1)
+          expect(yield* find.pipe(Effect.repeat({ until: (entries) => entries.length > 0 }))).toHaveLength(1)
           expect(scans).toBe(1)
         }).pipe(Effect.provide(layer), Effect.scoped),
       )

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, spyOn, test } from "bun:test"
 import fuzzysort from "fuzzysort"
+import fs from "fs/promises"
 import os from "os"
 import path from "path"
 import { Deferred, Effect, Layer } from "effect"
 import { TestClock } from "effect/testing"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { Protected } from "@opencode-ai/core/filesystem/protected"
 import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
@@ -12,8 +14,60 @@ import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { location } from "../fixture/location"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { Database } from "@opencode-ai/core/database/database"
+import { Bus } from "@opencode-ai/core/bus"
+import { Global } from "@opencode-ai/util/global"
+import { tempGlobalLayer } from "../fixture/global"
+import { tmpdir } from "../fixture/tmpdir"
 
 describe("FileSystemSearch", () => {
+  test("shares a ripgrep inventory for one physical scan root", async () => {
+    const root = await tmpdir()
+    const alias = root.path + "-alias"
+    await fs.symlink(root.path, alias, process.platform === "win32" ? "junction" : "dir")
+    let scans = 0
+    const scanned = Effect.runSync(Deferred.make<void>())
+    const ripgrep = Layer.succeed(
+      Ripgrep.Service,
+      Ripgrep.Service.of({
+        find: (input) =>
+          Effect.gen(function* () {
+            scans++
+            const entry = FileSystem.Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" })
+            if (input.onEntry) yield* input.onEntry(entry)
+            yield* Deferred.succeed(scanned, undefined)
+            return [entry]
+          }),
+        glob: () => Effect.succeed([]),
+        grep: () => Effect.succeed([]),
+      }),
+    )
+    const layer = AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, LocationServiceMap.node]), [
+      [Global.node, tempGlobalLayer],
+      [Ripgrep.node, ripgrep],
+    ])
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const first = yield* locations.contextEffect(Location.Ref.make({ directory: AbsolutePath.make(root.path) }))
+          const second = yield* locations.contextEffect(Location.Ref.make({ directory: AbsolutePath.make(alias) }))
+          yield* Deferred.await(scanned)
+          const find = FileSystemSearch.Service.use((search) => search.find({ query: "index", type: "file" }))
+
+          expect(yield* find.pipe(Effect.provideContext(first))).toHaveLength(1)
+          expect(yield* find.pipe(Effect.provideContext(second))).toHaveLength(1)
+          expect(scans).toBe(1)
+        }).pipe(Effect.provide(layer), Effect.scoped),
+      )
+    } finally {
+      await fs.rm(alias, { recursive: true, force: true })
+      await root[Symbol.asyncDispose]()
+    }
+  })
+
   test("bounds a home scan even when home is detected as a repository", async () => {
     let observed: Ripgrep.FindInput | undefined
     const home = AbsolutePath.make(os.homedir())

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -463,7 +463,7 @@ describe("LocationServiceMap", () => {
             const secondRef = Location.Ref.make({ directory: AbsolutePath.make(second.path) })
             const firstContext = yield* locations.contextEffect(firstRef)
             const secondContext = yield* locations.contextEffect(secondRef)
-            const received = { first: 0, second: 0 }
+            const received = { first: 0, second: 0, global: 0 }
             yield* bus.subscribe(Config.Event.Updated).pipe(
               Stream.runForEach(() => Effect.sync(() => received.first++)),
               Effect.provideContext(firstContext),
@@ -474,12 +474,18 @@ describe("LocationServiceMap", () => {
               Effect.provideContext(secondContext),
               Effect.forkScoped({ startImmediately: true }),
             )
+            yield* bus.subscribe(Config.Event.Updated).pipe(
+              Stream.runForEach(() => Effect.sync(() => received.global++)),
+              Effect.forkScoped({ startImmediately: true }),
+            )
             yield* Effect.sleep("10 millis")
 
             yield* bus.publish(Config.Event.Updated, {}, { location: firstRef })
+            yield* bus.publish(Config.Event.Updated, {}, { location: secondRef })
+            yield* bus.publish(Config.Event.Updated, {})
             yield* Effect.sleep("10 millis")
 
-            expect(received).toEqual({ first: 1, second: 0 })
+            expect(received).toEqual({ first: 2, second: 2, global: 3 })
           }),
         ),
       ),

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -7,6 +7,8 @@ import { Agent } from "@opencode-ai/core/agent"
 import { Bus } from "@opencode-ai/core/bus"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { Tool } from "@opencode-ai/core/tool"
@@ -24,10 +26,15 @@ describe("Plugin", () => {
     Effect.gen(function* () {
       const plugins = yield* Plugin.Service
       const bus = yield* Bus.Service
+      const location = yield* Location.Service
       const host = yield* PluginHost.make(plugins)
       const received = yield* host.event.subscribe().pipe(
         Stream.filter((event) => event.type === "config.updated"),
         Stream.runHead,
+        Effect.provideService(
+          Location.Service,
+          Location.Service.of({ ...location, directory: AbsolutePath.make(location.directory + "-other") }),
+        ),
         Effect.forkScoped({ startImmediately: true }),
       )
       yield* Effect.sleep("10 millis")

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -28,7 +28,7 @@ describe("Plugin", () => {
       const bus = yield* Bus.Service
       const location = yield* Location.Service
       const host = yield* PluginHost.make(plugins)
-      const received = yield* host.event.subscribe().pipe(
+      const received = yield* host.event.subscribe("config.updated").pipe(
         Stream.filter((event) => event.type === "config.updated"),
         Stream.runHead,
         Effect.provideService(
@@ -39,6 +39,9 @@ describe("Plugin", () => {
       )
       yield* Effect.sleep("10 millis")
 
+      yield* bus.publish(Agent.Event.Updated, {})
+      yield* Effect.sleep("10 millis")
+      expect(received.pollUnsafe()).toBeUndefined()
       yield* bus.publish(ConfigSchema.Event.Updated, {})
 
       expect((yield* Fiber.join(received)).valueOrUndefined?.type).toBe("config.updated")

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -86,11 +86,8 @@ describe("fromPromise", () => {
         define({
           id: "promise-event-lifecycle",
           setup: async (ctx) => {
-            void ctx.event
-              .subscribe("config.updated")
-              [Symbol.asyncIterator]()
-              .next()
-              .catch(() => undefined)
+            const iterator = ctx.event.subscribe("config.updated")[Symbol.asyncIterator]()
+            void iterator.next().catch(() => undefined)
             await started
           },
         }),

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Message, SystemPart } from "@opencode-ai/ai"
-import { DateTime, Effect, Schema } from "effect"
+import { DateTime, Effect, Schema, Stream } from "effect"
 import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Model } from "@opencode-ai/core/model"
@@ -19,7 +19,10 @@ import { Project } from "@opencode-ai/core/project"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { define } from "@opencode-ai/plugin/promise/plugin"
 import { Money } from "@opencode-ai/schema/money"
+import { Config } from "@opencode-ai/schema/config"
+import { Event } from "@opencode-ai/schema/event"
 import type { SessionHooks } from "@opencode-ai/plugin/effect/session"
+import type { EventSelection } from "@opencode-ai/plugin/effect/event"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 import { host as testHost } from "./host"
@@ -27,6 +30,41 @@ import { host as testHost } from "./host"
 const it = testEffect(PluginTestLayer)
 
 describe("fromPromise", () => {
+  it.effect("forwards selected public event types", () =>
+    Effect.gen(function* () {
+      let selected: readonly string[] | undefined
+      let received: unknown
+      const host = testHost({
+        event: {
+          subscribe: (selection?: EventSelection) => {
+            selected = selection === undefined ? undefined : typeof selection === "string" ? [selection] : selection
+            return Stream.make({
+              id: Event.ID.create(),
+              created: DateTime.makeUnsafe(1),
+              type: Config.Event.Updated.type,
+              data: {},
+            })
+          },
+        },
+      })
+
+      yield* PluginPromise.fromPromise(
+        define({
+          id: "promise-selected-events",
+          setup: async (ctx) => {
+            for await (const event of ctx.event.subscribe("config.updated")) {
+              received = event
+              break
+            }
+          },
+        }),
+      ).effect(host)
+
+      expect(selected).toEqual(["config.updated"])
+      expect(received).toMatchObject({ type: "config.updated", created: 1 })
+    }),
+  )
+
   it.effect("adapts session creation through the protocol schema", () =>
     Effect.gen(function* () {
       let seen: unknown

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -65,6 +65,43 @@ describe("fromPromise", () => {
     }),
   )
 
+  it.effect("closes active event iterators with the plugin scope", () =>
+    Effect.gen(function* () {
+      let begin: (() => void) | undefined
+      let released = false
+      const started = new Promise<void>((resolve) => (begin = resolve))
+      const host = testHost({
+        event: {
+          subscribe: () =>
+            Stream.unwrap(
+              Effect.sync(() => {
+                begin?.()
+                return Stream.never
+              }),
+            ).pipe(Stream.ensuring(Effect.sync(() => (released = true)))),
+        },
+      })
+
+      yield* PluginPromise.fromPromise(
+        define({
+          id: "promise-event-lifecycle",
+          setup: async (ctx) => {
+            void ctx.event
+              .subscribe("config.updated")
+              [Symbol.asyncIterator]()
+              .next()
+              .catch(() => undefined)
+            await started
+          },
+        }),
+      )
+        .effect(host)
+        .pipe(Effect.scoped)
+
+      expect(released).toBe(true)
+    }),
+  )
+
   it.effect("adapts session creation through the protocol schema", () =>
     Effect.gen(function* () {
       let seen: unknown

--- a/packages/core/test/worktree.test.ts
+++ b/packages/core/test/worktree.test.ts
@@ -3,7 +3,7 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { and, eq, isNull } from "drizzle-orm"
-import { Effect, Fiber, Stream } from "effect"
+import { Deferred, Effect, Fiber, Stream } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -126,6 +126,37 @@ describe("Worktree", () => {
         .pipe(Effect.flip)
       expect(error).toBeInstanceOf(Worktree.StrategyUnavailableError)
       if (error instanceof Worktree.StrategyUnavailableError) expect(error.strategy).toBe(unavailable)
+    }),
+  )
+
+  it.live("coalesces concurrent boot refreshes by project", () =>
+    Effect.gen(function* () {
+      const input = yield* setup()
+      const worktrees = yield* Worktree.Service
+      const started = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      let calls = 0
+      yield* worktrees.register({
+        id: Worktree.StrategyID.make("coalesced-test"),
+        create: (input) => Effect.succeed({ directory: input.directory }),
+        remove: () => Effect.void,
+        list: () =>
+          Effect.gen(function* () {
+            calls++
+            yield* Deferred.succeed(started, undefined)
+            yield* Deferred.await(release)
+            return []
+          }),
+      })
+
+      const first = yield* worktrees.refreshAfterBoot({ projectID: input.projectID }).pipe(Effect.forkScoped)
+      yield* Deferred.await(started)
+      const second = yield* worktrees.refreshAfterBoot({ projectID: input.projectID }).pipe(Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      expect(calls).toBe(1)
+      yield* Deferred.succeed(release, undefined)
+      expect(yield* Fiber.join(second)).toEqual(yield* Fiber.join(first))
     }),
   )
 

--- a/packages/core/test/worktree.test.ts
+++ b/packages/core/test/worktree.test.ts
@@ -155,8 +155,9 @@ describe("Worktree", () => {
       yield* Effect.yieldNow
 
       expect(calls).toBe(1)
+      yield* Fiber.interrupt(first)
       yield* Deferred.succeed(release, undefined)
-      expect(yield* Fiber.join(second)).toEqual(yield* Fiber.join(first))
+      expect(yield* Fiber.join(second)).toEqual({ updated: [], removed: [] })
     }),
   )
 

--- a/packages/plugin/src/effect/event.ts
+++ b/packages/plugin/src/effect/event.ts
@@ -1,3 +1,10 @@
-import type { EventApi } from "@opencode-ai/client/effect/api"
+import type { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
+import type { Stream } from "effect"
 
-export interface EventDomain extends Pick<EventApi<unknown>, "subscribe"> {}
+export type PluginEvent = Exclude<OpenCodeEvent, { readonly type: "server.connected" }>
+export type EventTypes = readonly [PluginEvent["type"], ...PluginEvent["type"][]]
+export type EventSelection = PluginEvent["type"] | EventTypes
+
+export interface EventDomain {
+  readonly subscribe: (selection?: EventSelection) => Stream.Stream<PluginEvent>
+}

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -88,9 +88,7 @@ export function fromPromise(plugin: Plugin) {
         const eventIterators = new Set<AsyncIterator<PromiseEvent>>()
         yield* Effect.addFinalizer(() =>
           Effect.promise(async () => {
-            await Promise.all(
-              Array.from(eventIterators, (iterator) => (iterator.return ? iterator.return() : undefined)),
-            )
+            await Promise.all(Array.from(eventIterators, (iterator) => Promise.resolve(iterator.return?.())))
           }),
         )
 

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -85,6 +85,14 @@ export function fromPromise(plugin: Plugin) {
         const WebSearchEndpoints = ClientApi.groups["server.websearch"].endpoints
         const scope = yield* Scope.Scope
         const context = yield* Effect.context<Scope.Scope>()
+        const eventIterators = new Set<AsyncIterator<PromiseEvent>>()
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(async () => {
+            await Promise.all(
+              Array.from(eventIterators, (iterator) => (iterator.return ? iterator.return() : undefined)),
+            )
+          }),
+        )
 
         // Run a hook registration on the plugin scope and resolve once it is registered.
         const register = (effect: Effect.Effect<HostRegistration, never, Scope.Scope>): Promise<Registration> =>
@@ -151,11 +159,12 @@ export function fromPromise(plugin: Plugin) {
           },
           event: {
             subscribe: (selection?: EventSelection) =>
-              Stream.toAsyncIterable(
+              eventIterable(
                 host.event.subscribe(selection).pipe(
                   Stream.mapEffect((event) => Schema.encodeUnknownEffect(OpenCodeEvent)(event)),
                   Stream.map((event) => event as unknown as PromiseEvent),
                 ),
+                eventIterators,
               ),
           },
           integration: {
@@ -308,6 +317,41 @@ export function fromPromise(plugin: Plugin) {
         yield* Effect.addFinalizer(() => Effect.promise(() => Promise.resolve(cleanup())))
       }),
   })
+}
+
+function eventIterable<E>(stream: Stream.Stream<PromiseEvent, E>, active: Set<AsyncIterator<PromiseEvent>>) {
+  const iterable = Stream.toAsyncIterable(stream)
+  return {
+    [Symbol.asyncIterator]() {
+      const source = iterable[Symbol.asyncIterator]()
+      let done = false
+      const forget = () => active.delete(iterator)
+      const iterator: AsyncIterator<PromiseEvent> = {
+        next: async () => {
+          try {
+            const result = await source.next()
+            if (result.done) {
+              done = true
+              forget()
+            }
+            return result
+          } catch (error) {
+            done = true
+            forget()
+            throw error
+          }
+        },
+        return: async () => {
+          if (done) return { done: true, value: undefined }
+          done = true
+          forget()
+          return source.return ? source.return() : { done: true, value: undefined }
+        },
+      }
+      active.add(iterator)
+      return iterator
+    },
+  }
 }
 
 function attempt<A>(evaluate: (signal: AbortSignal) => PromiseLike<A>) {

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -4,6 +4,7 @@ import { HttpApiEndpoint, HttpApiSchema } from "effect/unstable/httpapi"
 import { define } from "../effect/plugin.js"
 import type { Context, Plugin } from "./plugin.js"
 import type { Info } from "./tool.js"
+import type { EventSelection } from "./event.js"
 
 type HostRegistration = { readonly dispose: Effect.Effect<void> }
 type Registration = { readonly dispose: () => Promise<void> }
@@ -149,9 +150,9 @@ export function fromPromise(plugin: Plugin) {
             reload: () => run(host.command.reload()),
           },
           event: {
-            subscribe: () =>
+            subscribe: (selection?: EventSelection) =>
               Stream.toAsyncIterable(
-                host.event.subscribe().pipe(
+                host.event.subscribe(selection).pipe(
                   Stream.mapEffect((event) => Schema.encodeUnknownEffect(OpenCodeEvent)(event)),
                   Stream.map((event) => event as unknown as PromiseEvent),
                 ),

--- a/packages/plugin/src/promise/event.ts
+++ b/packages/plugin/src/promise/event.ts
@@ -1,3 +1,9 @@
-import type { EventApi } from "@opencode-ai/client/promise/api"
+import type { OpenCodeEventEncoded } from "@opencode-ai/protocol/groups/event"
 
-export interface EventDomain extends Pick<EventApi, "subscribe"> {}
+export type PluginEvent = Exclude<OpenCodeEventEncoded, { readonly type: "server.connected" }>
+export type EventTypes = readonly [PluginEvent["type"], ...PluginEvent["type"][]]
+export type EventSelection = PluginEvent["type"] | EventTypes
+
+export interface EventDomain {
+  readonly subscribe: (selection?: EventSelection) => AsyncIterable<PluginEvent>
+}

--- a/packages/server/src/event-feed.ts
+++ b/packages/server/src/event-feed.ts
@@ -2,6 +2,7 @@ export * as EventFeed from "./event-feed"
 
 import { Bus } from "@opencode-ai/core/bus"
 import { Event } from "@opencode-ai/schema/event"
+import { EventManifest } from "@opencode-ai/schema/event-manifest"
 import { isOpenCodeEvent, OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
 import { Cause, Context, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
 
@@ -27,9 +28,15 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@opencode/server/EventFeed") {}
 
 const encode = Schema.encodeUnknownSync(OpenCodeEvent)
+const encoders = new Map<string, (event: unknown) => unknown>(
+  EventManifest.ServerDefinitions.map((definition) => {
+    const encode = Schema.encodeUnknownSync(definition)
+    return [definition.type, encode] as const
+  }),
+)
 
 export function frame(event: OpenCodeEvent) {
-  return `data: ${JSON.stringify(encode(event))}\n\n`
+  return `data: ${JSON.stringify(encoders.get(event.type)?.(event) ?? encode(event))}\n\n`
 }
 
 export const make = Effect.fn("EventFeed.make")(function* (

--- a/packages/www/content/docs/build/plugins.mdx
+++ b/packages/www/content/docs/build/plugins.mdx
@@ -181,8 +181,15 @@ and plugin options.
 | `ctx.skill`            | `list`, `transform`, `reload`                                                                |
 | `ctx.tool`             | `transform` and `hook`                                                                       |
 | `ctx.aisdk`            | `hook`                                                                                       |
-| `ctx.event`            | `subscribe` to the current public server event stream                                        |
+| `ctx.event`            | `subscribe()` to all public events, one event type, or a non-empty list of event types       |
 | `ctx.options`          | Readonly options from the matching config object                                             |
+
+Pass the event type at subscription time when the plugin only handles selected events:
+
+```ts
+ctx.event.subscribe("config.updated")
+ctx.event.subscribe(["session.created", "session.agent.selected"])
+```
 
 ### Transform hooks
 


### PR DESCRIPTION
## DB-only base -> PR benchmark

This deterministic benchmark loaded six real Session histories from `opencode.db` and inferred exactly one full-value live event for each stored text, reasoning, and tool-input part. It used stored IDs, timestamps, Locations, and complete values. It did not split values or invent event timing.

| Metric | Base `79fc74af` | PR | Change |
| --- | ---: | ---: | ---: |
| Stored inferred events per iteration | 4,894 | 4,894 | 0% |
| Iterations | 100 | 100 | 0% |
| Total event encodes | 489,400 | 489,400 | 0% |
| Encoded data | 304 MB | 304 MB | 0% |
| Elapsed time | 10,505.9 ms | 7,286.9 ms | -30.6% |
| Throughput | 46,583 events/s | 67,162 events/s | +44.2% |
| Measured process CPU | 1.034 cores | 1.008 cores | -2.5% |

Exact-type EventFeed encoding improved this DB-derived fixed-cost benchmark by 44.2% while encoding the same real values and byte volume.

### Validation limit

`opencode.db` does not store ephemeral provider fragment boundaries or timing. No synthetic fragment structure or rates are used as production evidence. This benchmark validates per-event encoding cost only; it does not claim a historical streaming event rate or total server CPU reduction.

## Summary

- accumulate streamed tool inputs as chunks and join once at the terminal boundary
- route selected internal Bus subscriptions before enqueue while preserving cross-type order
- route Location-scoped events before enqueue and bind plugin streams to their host Location
- expose source-filtered event selection through the public Effect and Promise plugin contexts
- share ripgrep inventories by physical scan root and coalesce active worktree refreshes by project
- make shared scans and refreshes own their work independently of any one Location waiter
- index routed Bus subscriptions by event type so unrelated routes are not scanned per event
- encode public SSE events with the cached schema for their exact event type

## Plugin boundary

Plugins use one public API in both runtimes:

```ts
ctx.event.subscribe()
ctx.event.subscribe("config.updated")
ctx.event.subscribe(["session.created", "session.agent.selected"])
```

`PluginHost` owns the translation from public protocol event names to internal Bus definitions. Built-in plugins use the same API as third-party plugins. The network client API is unchanged, and the network-only `server.connected` marker is excluded from plugin event selections.

Promise event iterators are owned by the plugin scope and close during plugin replacement or unload. Unknown event names fail before subscription instead of being ignored.

## Commit log

1. `32e98e690b perf(ai): accumulate tool input fragments linearly`
2. `54bf747315 perf(core): narrow internal bus subscriptions`
3. `ccbe9007c2 perf(core): route located events before enqueue`
4. `cac4188169 perf(core): share project file discovery`
5. `eebb4531df perf(core): index routed bus subscriptions`
6. `d4d02ee8ba perf(server): encode events by exact type`
7. `808704261f refactor(plugin): expose selected event subscriptions`
8. `c2c161156b fix(core): align shared work lifecycles`
9. `4b51aa291f fix(plugin): close event iterators on unload`
10. `9d9d1aeaec fix(plugin): finalize event iterator cleanup`

## Testing

- `bun typecheck` in `packages/ai`
- `bun typecheck` in `packages/plugin`
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/server`
- 11 focused AI stream tests
- 125 focused Core Bus, Location, plugin, config, search, and worktree tests
- 5 Server EventFeed tests
- 3 plugin contract tests
- Promise plugin selection and unload lifecycle tests
- shared scan and refresh cancellation tests
- Prettier check on all changed files
- Oxlint on all changed files: 0 errors
- full workspace pre-push typecheck passed 32 of 33 packages; unrelated `packages/www` setup could not resolve `@astrojs/mdx`

## Notes

- no Protocol or Server `HttpApi` change
- no generated client change
- network client event subscription is unchanged
- explicit worktree refresh remains forced; only concurrent boot refreshes coalesce
- FFF instances and complete Location graphs remain isolated