### PR TITLE
docs: add voice input via MCP server guide

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -17,6 +17,10 @@
             "group": "Getting started",
             "pages": ["index", "quickstart", "development"],
             "openapi": "https://opencode.ai/openapi.json"
+          },
+          {
+            "group": "Guides",
+            "pages": ["essentials/voice-input"]
           }
         ]
       }

--- a/packages/docs/essentials/voice-input.mdx
+++ b/packages/docs/essentials/voice-input.mdx
@@ -1,0 +1,92 @@
+---
+title: "Voice input"
+description: "Use voice input in your terminal with OpenCode via a local MCP server"
+icon: "microphone"
+---
+
+Speak your prompts instead of typing them. The voice input MCP server records audio
+from your microphone, transcribes it locally with Whisper, and optionally types the
+result at your cursor — all 100% offline, no cloud API required.
+
+It works with any MCP-compatible tool (OpenCode, Claude Code, Cursor), and is useful
+anywhere you'd rather dictate than type.
+
+## Install
+
+The server is published as a standalone package:
+
+```bash
+npm install -g @yuvarjbhado/voice-mcp
+```
+
+Or run it on demand with `npx`:
+
+```bash
+npx -y @yuvarjbhado/voice-mcp
+```
+
+## Prerequisites
+
+- **Recording tool**: `sox` (macOS/Linux) or `ffmpeg` (Windows / fallback)
+  ```bash
+  brew install sox          # macOS
+  sudo apt install sox      # Linux
+  scoop install ffmpeg      # Windows
+  ```
+- **Transcription engine**: local [faster-whisper](https://github.com/SYSTRAN/faster-whisper)
+  ```bash
+  pip install faster-whisper
+  ```
+
+## Configure
+
+Add the server to your OpenCode config (usually `~/.config/opencode/config.json`):
+
+```json
+{
+  "mcp": {
+    "voice": {
+      "command": "npx",
+      "args": ["-y", "@yuvarjbhado/voice-mcp"]
+    }
+  }
+}
+```
+
+Restart OpenCode to load the server, then invoke it from a session:
+
+```
+@voice voice_transcribe
+@voice voice_type
+@voice voice_status
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `voice_transcribe` | Record audio and return the transcribed text. |
+| `voice_type` | Record, transcribe, and type the text at the cursor position. |
+| `voice_status` | Report whether recording and transcription are available. |
+
+Both `voice_transcribe` and `voice_type` accept optional arguments:
+
+- `duration` (number, default `10`) — recording length in seconds
+- `language` (string, default auto-detect) — e.g. `en`, `es`, `fr`
+
+## Configuration
+
+The transcription model can be tuned with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WHISPER_MODEL` | `base` | Model size (`tiny`, `base`, `small`, `medium`, `large-v3`) |
+| `WHISPER_DEVICE` | `auto` | `cpu`, `cuda`, or `auto` |
+| `WHISPER_COMPUTE` | `int8` | Compute type (`int8`, `float16`, `float32`) |
+
+## Privacy
+
+Audio is captured locally and transcribed on your machine with faster-whisper.
+Nothing is sent to a remote server.
+
+Source: [YuvrajSinghBhadoria2/opencode-voice-mcp](https://github.com/YuvrajSinghBhadoria2/opencode-voice-mcp)


### PR DESCRIPTION
### Issue for this PR

Closes #41413

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a documentation page describing how to use voice input in OpenCode (and other MCP-compatible tools) via a local, 100% offline MCP server.

- New page: `packages/docs/essentials/voice-input.mdx`
- Wired into `docs.json` navigation under a new "Guides" group

The server records microphone audio, transcribes locally with faster-whisper, and optionally types at the cursor. No cloud API required. It implements the feature requested in #41413.

The package is published under `@yuvarjbhado/voice-mcp` (the `@opencode-ai` org is not owned by the author), so the install/config snippets use that scope. Happy to adjust naming/location if maintainers prefer it bundled in-repo instead.

### How did you verify your code works?

- Validated the new page renders as valid MDX (frontmatter matches the `essentials/*.mdx` style)
- Previewed in the local docs site build

### Screenshots / recordings

_Not applicable — this is a documentation-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
