### PR TITLE
fix(llm): preserve mid-stream transport diagnostics

### DIFF
--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -358,7 +358,9 @@ const errorKind = (error: unknown) => {
   const cause = HttpClientError.isHttpClientError(error) && "cause" in error.reason ? error.reason.cause : error
   const tags = [
     HttpClientError.isHttpClientError(error) ? error.reason._tag : undefined,
-    cause instanceof Error ? cause.name : undefined,
+    // A plain `Error` contributes nothing but noise here ("DecodeError:Error:ECONNRESET"),
+    // so only keep a subclass name that actually identifies the failure.
+    cause instanceof Error && cause.name !== "Error" ? cause.name : undefined,
     errorCode(cause),
   ].filter((tag): tag is string => tag !== undefined)
   return tags.length ? tags.join(":") : "Unknown"

--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -1,4 +1,4 @@
-import { Cause, Context, Effect, Layer, Random } from "effect"
+import { Cause, Context, Effect, Layer, Random, Stream } from "effect"
 import {
   FetchHttpClient,
   Headers,
@@ -213,11 +213,15 @@ const responseHttp = (input: {
   readonly body: ReturnType<typeof responseBody>
   readonly requestId?: string | undefined
   readonly rateLimit?: HttpRateLimitDetails | undefined
+  readonly bytesRead?: number | undefined
+  readonly chunksRead?: number | undefined
 }) =>
   new HttpContext({
     request: requestDetails(input.request, input.redactedNames),
     response: responseDetails(input.response, input.redactedNames),
     ...input.body,
+    bytesRead: input.bytesRead,
+    chunksRead: input.chunksRead,
     requestId: input.requestId,
     rateLimit: input.rateLimit,
   })
@@ -342,6 +346,87 @@ const toHttpError = (redactedNames: ReadonlyArray<string | RegExp>) => (error: u
   })
 }
 
+const errorCode = (error: unknown) =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (typeof error.code === "string" || typeof error.code === "number")
+    ? String(error.code)
+    : undefined
+
+const errorKind = (error: unknown) => {
+  const cause = HttpClientError.isHttpClientError(error) && "cause" in error.reason ? error.reason.cause : error
+  const tags = [
+    HttpClientError.isHttpClientError(error) ? error.reason._tag : undefined,
+    cause instanceof Error ? cause.name : undefined,
+    errorCode(cause),
+  ].filter((tag): tag is string => tag !== undefined)
+  return tags.length ? tags.join(":") : "Unknown"
+}
+
+const responseStreamError =
+  (input: {
+    readonly request: HttpClientRequest.HttpClientRequest
+    readonly response: HttpClientResponse.HttpClientResponse
+    readonly redactedNames: ReadonlyArray<string | RegExp>
+    readonly bytesRead: () => number
+    readonly chunksRead: () => number
+  }) =>
+  (error: unknown) => {
+    const headers = normalizedHeaders(input.response.headers)
+    const retryAfter = retryAfterMs(headers)
+    const rateLimit = rateLimitDetails(headers, retryAfter)
+    const kind = errorKind(error)
+    return new LLMError({
+      module: "RequestExecutor",
+      method: "execute",
+      reason: new TransportReason({
+        message: `HTTP response stream failed: ${kind}`,
+        kind,
+        url: redactUrl(input.request.url),
+        http: responseHttp({
+          request: input.request,
+          response: input.response,
+          redactedNames: input.redactedNames,
+          body: {},
+          requestId: requestId(headers),
+          rateLimit,
+          bytesRead: input.bytesRead(),
+          chunksRead: input.chunksRead(),
+        }),
+      }),
+    })
+  }
+
+function withStreamDiagnostics(
+  response: HttpClientResponse.HttpClientResponse,
+  request: HttpClientRequest.HttpClientRequest,
+  redactedNames: ReadonlyArray<string | RegExp>,
+) {
+  const progress = { bytesRead: 0, chunksRead: 0 }
+  const stream = response.stream.pipe(
+    Stream.tap((chunk) =>
+      Effect.sync(() => {
+        progress.bytesRead += chunk.byteLength
+        progress.chunksRead += 1
+      }),
+    ),
+    Stream.mapError(
+      responseStreamError({
+        request,
+        response,
+        redactedNames,
+        bytesRead: () => progress.bytesRead,
+        chunksRead: () => progress.chunksRead,
+      }),
+    ),
+  )
+  const next = Object.create(Object.getPrototypeOf(response))
+  Object.defineProperties(next, Object.getOwnPropertyDescriptors(response))
+  Object.defineProperty(next, "stream", { value: stream, configurable: true })
+  return next as HttpClientResponse.HttpClientResponse
+}
+
 const retryDelay = (error: LLMError, attempt: number) => {
   if (error.retryAfterMs !== undefined) return Effect.succeed(Math.min(error.retryAfterMs, MAX_DELAY_MS))
   return Random.nextBetween(
@@ -372,7 +457,11 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient> = Layer.e
         const redactedNames = yield* Headers.CurrentRedactedNames
         return yield* http
           .execute(request)
-          .pipe(Effect.mapError(toHttpError(redactedNames)), Effect.flatMap(statusError(request, redactedNames)))
+          .pipe(
+            Effect.mapError(toHttpError(redactedNames)),
+            Effect.flatMap(statusError(request, redactedNames)),
+            Effect.map((response) => withStreamDiagnostics(response, request, redactedNames)),
+          )
       })
     return Service.of({
       execute: (request) => retryStatusFailures(executeOnce(request)),

--- a/packages/llm/src/route/transport/http.ts
+++ b/packages/llm/src/route/transport/http.ts
@@ -5,7 +5,7 @@ import { render as renderEndpoint } from "../endpoint"
 import { Framing, type Framing as FramingDef } from "../framing"
 import type { Transport, TransportPrepareInput } from "./index"
 import * as ProviderShared from "../../protocols/shared"
-import { mergeJsonRecords, type LLMRequest } from "../../schema"
+import { LLMError, mergeJsonRecords, type LLMRequest } from "../../schema"
 
 export type JsonRequestInput<Body> = TransportPrepareInput<Body>
 
@@ -136,11 +136,13 @@ export const httpJson = <Body, Frame>(input: HttpJsonInput<Body, Frame>): HttpJs
             prepared.framing.frame(
               response.stream.pipe(
                 Stream.mapError((error) =>
-                  ProviderShared.eventError(
-                    `${request.model.provider}/${request.model.route.id}`,
-                    `Failed to read ${request.model.provider}/${request.model.route.id} stream`,
-                    ProviderShared.errorText(error),
-                  ),
+                  error instanceof LLMError
+                    ? error
+                    : ProviderShared.eventError(
+                        `${request.model.provider}/${request.model.route.id}`,
+                        `Failed to read ${request.model.provider}/${request.model.route.id} stream`,
+                        ProviderShared.errorText(error),
+                      ),
                 ),
               ),
             ),

--- a/packages/llm/src/schema/errors.ts
+++ b/packages/llm/src/schema/errors.ts
@@ -27,6 +27,8 @@ export class HttpContext extends Schema.Class<HttpContext>("LLM.HttpContext")({
   response: Schema.optional(HttpResponseDetails),
   body: Schema.optional(Schema.String),
   bodyTruncated: Schema.optional(Schema.Boolean),
+  bytesRead: Schema.optional(Schema.Number),
+  chunksRead: Schema.optional(Schema.Number),
   requestId: Schema.optional(Schema.String),
   rateLimit: Schema.optional(HttpRateLimitDetails),
 }) {}

--- a/packages/llm/test/executor.test.ts
+++ b/packages/llm/test/executor.test.ts
@@ -491,7 +491,7 @@ describe("RequestExecutor", () => {
       expectLLMError(error)
       expect(error.reason).toMatchObject({
         _tag: "Transport",
-        kind: "DecodeError:Error:ECONNRESET",
+        kind: "DecodeError:ECONNRESET",
         http: {
           requestId: "req_mid",
           response: { status: 200 },

--- a/packages/llm/test/executor.test.ts
+++ b/packages/llm/test/executor.test.ts
@@ -455,4 +455,51 @@ describe("RequestExecutor", () => {
       expect(yield* Ref.get(attempts)).toBe(1)
     }),
   )
+
+  it.effect("preserves HTTP diagnostics for midstream body failures", () =>
+    Effect.gen(function* () {
+      const chunk = sseRaw(`data: ${JSON.stringify(deltaChunk({ role: "assistant", content: "Hello" }))}`)
+      const cause = Object.assign(new Error("socket reset secret-token"), { code: "ECONNRESET" })
+      const state = { sent: false }
+      const body = new ReadableStream({
+        pull(controller) {
+          if (state.sent) {
+            controller.error(cause)
+            return
+          }
+          state.sent = true
+          controller.enqueue(new TextEncoder().encode(chunk))
+        },
+      })
+      const model = OpenAIChat.route
+        .with({ endpoint: { baseURL: "https://api.openai.test/v1" } })
+        .model({ id: "gpt-4o-mini" })
+      const error = yield* LLMClient.generate(LLM.request({ model, prompt: "Say hello." })).pipe(
+        Effect.provide(
+          dynamicResponse((input) =>
+            Effect.succeed(
+              input.respond(body, {
+                status: 200,
+                headers: { "content-type": "text/event-stream", "x-request-id": "req_mid" },
+              }),
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expectLLMError(error)
+      expect(error.reason).toMatchObject({
+        _tag: "Transport",
+        kind: "DecodeError:Error:ECONNRESET",
+        http: {
+          requestId: "req_mid",
+          response: { status: 200 },
+          bytesRead: Buffer.byteLength(chunk),
+          chunksRead: 1,
+        },
+      })
+      expect(JSON.stringify(error.reason)).not.toContain("secret-token")
+    }),
+  )
 })

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -632,7 +632,7 @@ describe("OpenAI Chat route", () => {
       ])
       const error = yield* LLMClient.generate(request).pipe(Effect.provide(layer), Effect.flip)
 
-      expect(error.reason).toMatchObject({ _tag: "Transport", kind: "DecodeError:Error" })
+      expect(error.reason).toMatchObject({ _tag: "Transport", kind: "DecodeError" })
     }),
   )
 

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -632,7 +632,7 @@ describe("OpenAI Chat route", () => {
       ])
       const error = yield* LLMClient.generate(request).pipe(Effect.provide(layer), Effect.flip)
 
-      expect(error.message).toContain("Failed to read openai/openai-chat stream")
+      expect(error.reason).toMatchObject({ _tag: "Transport", kind: "DecodeError:Error" })
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #42482

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a response body failed partway through streaming, the error surfaced as a generic `Decode error (200 POST ...)`. The native cause and the response metadata were lost, so an incident could only be diagnosed as "something failed after a 200".

`RequestExecutor` now wraps the response stream before it reaches framing. A `Stream.tap` counts bytes and chunks as they are consumed, and `Stream.mapError` turns a stream failure into a `Transport` error carrying the request id, status, rate-limit headers, and how far the body got. The error kind is assembled from the `HttpClientError` reason plus the underlying error's name and `code`, which is what separates an `ECONNRESET` from a malformed frame.

The diagnostics go through the existing `responseHttp` path, so header redaction still applies and the raw cause message is not echoed into the error.

Worth flagging for review: the openai-chat stream read failure now reports a structured `Transport` reason instead of the `Failed to read openai/openai-chat stream` string, and I updated that assertion to match.

### How did you verify your code works?

Added a test in `packages/llm/test/executor.test.ts` that errors a `ReadableStream` after one SSE chunk and asserts the transport kind, request id, and byte/chunk counts. It fails on `dev` and passes with this change. Full `packages/llm` suite: 299 pass, 30 skip, 0 fail. `bun typecheck` clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
