### PR TITLE
fix: keep tool child stdin closed and run tool commands non-interactively

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -116,7 +116,7 @@ export const make = Effect.gen(function* () {
     Sink.isSink(x) ? "pipe" : x
 
   const stdin = (opts: ChildProcess.CommandOptions): ChildProcess.StdinConfig => {
-    const cfg: ChildProcess.StdinConfig = { stream: "pipe", encoding: "utf-8", endOnDone: true }
+    const cfg: ChildProcess.StdinConfig = { stream: "ignore", encoding: "utf-8", endOnDone: true }
     if (Predicate.isUndefined(opts.stdin)) return cfg
     if (typeof opts.stdin === "string") return { ...cfg, stream: opts.stdin }
     if (Stream.isStream(opts.stdin)) return { ...cfg, stream: opts.stdin }

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -158,6 +158,8 @@ const layer = Layer.effectDiscard(
               const command = ChildProcess.make(input.command, [], {
                 cwd: target.canonical,
                 shell,
+                extendEnv: true,
+                env: { CI: "1", npm_config_yes: "true", GIT_TERMINAL_PROMPT: "0", NONINTERACTIVE: "1" },
                 stdin: "ignore",
                 detached: process.platform !== "win32",
                 forceKillAfter: Duration.seconds(3),

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -291,10 +291,11 @@ const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan,
 })
 
 function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv) {
+  const nonInteractiveEnv = { CI: "1", npm_config_yes: "true", GIT_TERMINAL_PROMPT: "0", NONINTERACTIVE: "1" }
   if (process.platform === "win32" && Shell.ps(shell)) {
     return ChildProcess.make(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command], {
       cwd,
-      env,
+      env: { ...env, ...nonInteractiveEnv },
       stdin: "ignore",
       detached: false,
     })
@@ -303,7 +304,7 @@ function cmd(shell: string, command: string, cwd: string, env: NodeJS.ProcessEnv
   return ChildProcess.make(command, [], {
     shell,
     cwd,
-    env,
+    env: { ...env, ...nonInteractiveEnv },
     stdin: "ignore",
     detached: process.platform !== "win32",
   })


### PR DESCRIPTION
Issue for this PR
Closes #42773

Type of change
- Bug fix
- New feature
- Refactor / code improvement

What does this PR do?
On Windows, tool commands that prompt for input on stdin (e.g. npm exec asking "Ok to proceed? (y)") hang — the prompt shows up but nothing typed reaches the process, because the child's stdin is an open pipe nothing closes, and the TUI owns the console input.

Changes:
- Spawner default for child stdin changed from open pipe to closed ("ignore"). Callers passing explicit stdin are unaffected.
- Shell/bash tool commands now get CI=1, npm_config_yes=true, GIT_TERMINAL_PROMPT=0, NONINTERACTIVE=1, so tools like npm skip interactive prompts.

How did you verify your code works?
Reproduced on Windows: npm exec with an open stdin pipe hangs; with CI=1 or npm_config_yes=true it completes. Checked no tests rely on the old default.

Screenshots / recordings
N/A (not a UI change)

Checklist
- I have tested my changes locally
- I have not included unrelated changes in this PR