### PR TITLE
fix(app): browse subfolders in the open project dialog

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -1,6 +1,8 @@
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
+import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
 import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
@@ -8,7 +10,13 @@ import { createMemo, createResource, createSignal } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { useGlobal } from "@/context/global"
-import { cleanPickerInput, createDirectorySearch, displayPickerPath } from "./directory-picker-domain"
+import {
+  cleanPickerInput,
+  createDirectorySearch,
+  displayPickerPath,
+  normalizePickerDrive,
+  pickerParent,
+} from "./directory-picker-domain"
 import type { Path } from "@opencode-ai/sdk/v2/client"
 
 interface DialogSelectDirectoryProps {
@@ -58,6 +66,26 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   const [filter, setFilter] = createSignal("")
   let list: ListRef | undefined
+  let searchWrapper: HTMLDivElement | undefined
+
+  const focusSearch = () => {
+    searchWrapper?.querySelector<HTMLInputElement>('[data-slot="input-input"]')?.focus()
+  }
+
+  const current = createMemo(() => {
+    const value = cleanPickerInput(filter())
+    if (!value) return ""
+    const absolute = value === "~" ? home() : value.startsWith("~/") ? home() + value.slice(1) : value
+    return normalizePickerDrive(absolute).replace(/\/+$/, "")
+  })
+
+  const navigate = (absolute: string) => {
+    const target = normalizePickerDrive(absolute).replace(/\/+$/, "")
+    if (!target || target === current()) return
+    const path = displayPickerPath(target, "", home())
+    list?.setFilter(path.endsWith("/") ? path : path + "/")
+    focusSearch()
+  }
 
   const missingHome = createMemo(() => !sync.data.path.home)
   const [fallbackPath] = createResource(
@@ -130,9 +158,23 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   return (
     <Dialog title={props.title ?? language.t("command.project.open")}>
-      <List
-        class="px-3"
-        search={{ placeholder: language.t("dialog.directory.search.placeholder"), autofocus: true }}
+      <div ref={searchWrapper}>
+        <List
+          class="px-3"
+          search={{
+            placeholder: language.t("dialog.directory.search.placeholder"),
+            autofocus: true,
+            action: (
+              <IconButton
+                icon="arrow-up"
+                variant="ghost"
+                title={language.t("dialog.directory.parent")}
+                aria-label={language.t("dialog.directory.parent")}
+                disabled={!current()}
+                onClick={() => navigate(pickerParent(current()))}
+              />
+            ),
+          }}
         emptyMessage={language.t("dialog.directory.empty")}
         loadingMessage={language.t("common.loading")}
         items={items}
@@ -191,10 +233,26 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
                   <span class="text-text-weak whitespace-nowrap">/</span>
                 </div>
               </div>
+              <span
+                data-directory-enter
+                role="button"
+                tabindex={-1}
+                title={language.t("common.open")}
+                aria-label={language.t("common.open")}
+                class="shrink-0 flex items-center rounded p-1 -mr-1 text-icon-weak hover:text-icon-base"
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  navigate(item.absolute)
+                }}
+              >
+                <Icon name="chevron-right" size="small" />
+              </span>
             </div>
           )
         }}
       </List>
+      </div>
     </Dialog>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Fixes #42784

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The directory picker used in the web UI (server mode) lists only the direct children of the home folder. Folders can't be opened, so subfolders are only reachable through the Tab autocomplete in the search box, which isn't discoverable.

Folder rows now have a chevron that navigates into that folder (the list refreshes to show its children), and an up button next to the search box goes back one level. Clicking a row still selects the folder, as before. The desktop tree picker is untouched.

### How did you verify your code works?

Ran the backend and app dev servers locally and clicked through the dialog: chevron enters a folder and lists its children, the up button returns to the parent, and row click still selects. Also ran `bun typecheck` and the picker + i18n parity tests, all passing.

### Screenshots / recordings

Before:

<img width="1280" height="800" alt="directory-picker-before" src="https://github.com/user-attachments/assets/813e9b13-7dc2-43a9-a801-043d1bba6fdf" />

After:

<img width="1280" height="800" alt="directory-picker-after" src="https://github.com/user-attachments/assets/fa8b478f-e247-4767-989a-c0422469994d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
