### PR TITLE
fix(core): run dynamic provider fallback after plugin hooks

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -63,6 +63,7 @@ import { AgentPlugin } from "./agent.js"
 import { CommandPlugin } from "./command.js"
 import { PlanPlugin } from "./plan.js"
 import { ModelsDevPlugin } from "./models-dev.js"
+import { DynamicProviderPlugin } from "./provider/dynamic.js"
 import { ProviderPlugins } from "./provider.js"
 import { WebSearchPlugins } from "./websearch/index.js"
 import { PluginRuntime } from "./runtime.js"
@@ -229,6 +230,9 @@ const post = [
   ConfigWebSearchPlugin.Plugin,
   VariantPlugin.Plugin,
   ConfigPolicyPlugin.Plugin,
+  // Registered last so plugin-supplied `sdk` hooks can claim a package before
+  // this falls back to installing it from npm.
+  DynamicProviderPlugin,
 ] as const satisfies readonly InternalPlugin[]
 
 export const list = Effect.fn("PluginInternal.list")(function* () {

--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -7,7 +7,6 @@ import { CloudflareAIGatewayPlugin } from "./provider/cloudflare-ai-gateway.js"
 import { CloudflareWorkersAIPlugin } from "./provider/cloudflare-workers-ai.js"
 import { CoherePlugin } from "./provider/cohere.js"
 import { DeepInfraPlugin } from "./provider/deepinfra.js"
-import { DynamicProviderPlugin } from "./provider/dynamic.js"
 import { GatewayPlugin } from "./provider/gateway.js"
 import { GithubCopilotPlugin } from "./provider/github-copilot.js"
 import { GitLabPlugin } from "./provider/gitlab.js"
@@ -62,5 +61,4 @@ export const ProviderPlugins: PluginInternal.InternalPlugin[] = [
   VenicePlugin,
   XAIPlugin,
   ZenmuxPlugin,
-  DynamicProviderPlugin,
 ]

--- a/packages/core/src/plugin/provider/dynamic.ts
+++ b/packages/core/src/plugin/provider/dynamic.ts
@@ -13,9 +13,23 @@ export const DynamicProviderPlugin = define({
       Effect.fn(function* (evt) {
         if (evt.sdk) return
 
-        const installedPath = evt.package.startsWith("file://")
-          ? evt.package
-          : (yield* npm.add(evt.package).pipe(Effect.orDie)).entrypoint
+        // A package that cannot be installed is not necessarily a mistake: plugins
+        // may use the name purely as a routing key for their own hook. Decline
+        // rather than dying so an unclaimed package reports that no plugin
+        // supplied an SDK instead of an unrelated npm failure.
+        const installed = evt.package.startsWith("file://")
+          ? { entrypoint: evt.package }
+          : yield* npm.add(evt.package).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logDebug("dynamic provider package could not be installed", {
+                  package: evt.package,
+                  cause,
+                }).pipe(Effect.as(undefined)),
+              ),
+            )
+        if (!installed) return
+
+        const installedPath = installed.entrypoint
         if (!installedPath) throw new Error(`Package ${evt.package} has no import entrypoint`)
 
         const mod = (yield* Effect.promise(() =>

--- a/packages/core/test/plugin/provider-dynamic.test.ts
+++ b/packages/core/test/plugin/provider-dynamic.test.ts
@@ -11,6 +11,7 @@ import { Model } from "@opencode-ai/core/model"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { DynamicProviderPlugin } from "@opencode-ai/core/plugin/provider/dynamic"
+import { ProviderPlugins } from "@opencode-ai/core/plugin/provider"
 import { Provider } from "@opencode-ai/core/provider"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
@@ -46,6 +47,15 @@ function tempEntrypoint(source: string) {
 }
 
 describe("DynamicProviderPlugin", () => {
+  it.effect("is not registered in ProviderPlugins", () =>
+    Effect.sync(() => {
+      // ProviderPlugins is registered in the internal `pre` list, ahead of plugins
+      // loaded from config. This fallback belongs in `post` so plugin-supplied
+      // `sdk` hooks can claim a package before it is fetched from npm.
+      expect(ProviderPlugins.map((item) => item.id)).not.toContain("opencode.provider.dynamic")
+    }),
+  )
+
   it.effect("creates an SDK from a provider factory export", () =>
     Effect.gen(function* () {
       const aisdk = yield* AISDK.Service
@@ -79,6 +89,40 @@ describe("DynamicProviderPlugin", () => {
         options: { name: "custom", marker: "dynamic" },
         sdk,
       })
+      expect(result.sdk).toBe(sdk)
+    }),
+  )
+
+  it.effect("does not prevent a later hook from claiming a package it cannot resolve", () =>
+    Effect.gen(function* () {
+      const aisdk = yield* AISDK.Service
+      const sdk = { marker: "from-later-plugin" }
+      let laterHookRan = false
+
+      // A package that is not on npm is legitimate here: plugins may use the name
+      // purely as a routing key for their own hook.
+      yield* addPlugin(
+        Npm.Service.of({
+          add: () => Effect.fail(new Npm.InstallFailedError({ add: ["@example/missing"], dir: "", cause: "E404" })),
+          which: () => Effect.succeed(undefined),
+        }),
+      )
+      yield* aisdk.hook.sdk((event) => {
+        laterHookRan = true
+        event.sdk = sdk
+      })
+
+      const result = yield* aisdk.runSDK({
+        model: Model.Info.make({
+          ...Model.Info.default(Provider.ID.make("custom"), Model.ID.make("test-model")),
+          modelID: Model.ID.make("test-model"),
+          package: Provider.aisdk("@example/missing"),
+        }),
+        package: "@example/missing",
+        options: { name: "custom" },
+      })
+
+      expect(laterHookRan).toBe(true)
       expect(result.sdk).toBe(sdk)
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #42788

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A plugin that registers a provider with an `aisdk:` package that is not on npm never gets its `ctx.aisdk.hook("sdk", ...)` callback invoked, and the session fails with `UnsupportedPackageError`.

`DynamicProviderPlugin` was in `PluginInternal.pre`, so its hook always ran before hooks from config-loaded plugins. For an unrecognised package it calls `npm.add(...)` with `Effect.orDie`, and the 404 defect aborts the whole `runSDK` hook chain, skipping every hook registered after it. Built-in providers were unaffected because their own hooks set `evt.sdk` earlier, so the `if (evt.sdk) return` guard short-circuited before the npm call.

Two changes:

- Move it to `post` so it runs after plugin hooks. It is a last-resort resolver, so it should only run once nothing else has claimed the package.
- Decline instead of dying when the package cannot be installed. The name may only be a routing key for a plugin's own hook, so an unclaimed package now reports that no plugin supplied an SDK rather than an unrelated npm failure.

Using a package name that is not on npm is an established pattern here: `GithubCopilotPlugin` sets `model.package = "@ai-sdk/github-copilot"`, claims it in its own `sdk` hook, and supplies the SDK from a local module, and that name is not published. It works only because `ProviderPlugins` is ordered ahead of `DynamicProviderPlugin` within `pre`, which a config-loaded plugin cannot do.

I confirmed the ordering with temporary logging of each hook index in `AISDK.run`: hooks 0-21 completed, index 22 (this plugin) entered and never finished, and the chain ended there.

### How did you verify your code works?

Reproduced first on the released `0.0.0-next-17444` binary using the standalone plugin in #42788: the hook never ran and the session failed with `UnsupportedPackageError`. After the fix, running the server from source, the same plugin's hook runs and can supply an SDK. I also confirmed a real third-party provider plugin now completes requests end to end.

Added two tests in `packages/core/test/plugin/provider-dynamic.test.ts`:

- a later hook still claims a package this plugin cannot resolve (fails on `v2`, passes here)
- this plugin is not in `ProviderPlugins`, which is registered ahead of config plugins

From `packages/core`: `bun test test/plugin/` passes (218), `bun typecheck` clean, and `oxlint` reports no new warnings on the changed files.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

