### PR TITLE
docs(core): fix opencode skill source link

### DIFF
--- a/packages/core/src/plugin/skill/opencode.md
+++ b/packages/core/src/plugin/skill/opencode.md
@@ -68,7 +68,7 @@ every field, examples, config locations, and links to dedicated feature guides.
 For any request to migrate OpenCode configuration, agents, commands, skills,
 plugins, integrations, or other behavior from V1 to V2, read the full
 [migration guide](https://opencode.ai/v2/docs/migrate-v1) before acting. In
-the repository, its source is `packages/www/content/docs/(Get started)/migrate-v1.mdx`.
+the repository, its source is `packages/www/content/docs/migrate-v1.mdx`.
 
 V1 config files and `.opencode/` definitions are intended to remain compatible.
 The only intentional breaking changes are the server API and plugin API. Native


### PR DESCRIPTION
## Summary

- update the built-in OpenCode skill to reference the current V1 migration guide source path
- remove the stale `(Get started)` directory from the contributor-facing path

## Testing

- `bun test test/plugin/skill.test.ts` from `packages/core`
- repository pre-push typecheck (33 tasks)