### PR TITLE
docs(ecosystem): add opencode-acpx plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-acpx](https://github.com/intellectronica/opencode-acpx)                                  | Use Cursor, Claude, Codex, Grok, Hermes and other ACP agents as OpenCode providers                 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [`opencode-acpx`](https://github.com/intellectronica/opencode-acpx) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-acpx` enables using ACP agents (Cursor, Claude, Codex, Grok, Hermes, and custom agents) as first-class OpenCode providers via `acpx`.

### How did you verify your code works?

- Verified table row formatting and column alignment match existing entries.
- Verified Prettier check passes (`bunx prettier --check packages/web/src/content/docs/ecosystem.mdx`).

### Screenshots / recordings

N/A (documentation only)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR