### PR TITLE
fix(tui): preserve path suffix in prompt footer

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1851,12 +1851,10 @@ export function Prompt(props: PromptProps) {
                 flexGrow={1}
                 flexShrink={1}
                 minWidth={0}
-                ref={(renderable: BoxRenderable) =>
-                  setTimeout(() => {
-                    if (!renderable.isDestroyed) setLocationWidth(renderable.width)
-                  }, 0)
-                }
-                on:resized={(event: { width: number }) => setLocationWidth(event.width)}
+                onSizeChange={function (this: BoxRenderable) {
+                  const width = this.width
+                  queueMicrotask(() => setLocationWidth(width))
+                }}
               >
                 <Switch>
                   <Match when={status() === "running"}>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -71,6 +71,7 @@ import { DialogImagePreview } from "../dialog-image-preview"
 import { useDirectoryRecents } from "../../prompt/directory-recents"
 import { directoryRecentValue } from "../../prompt/directory-completion"
 import { useWorkingDirectoryActions } from "../../ui/working-directory-actions"
+import { truncateFilePath } from "../../ui/file-path"
 
 export type PromptProps = {
   sessionID?: string
@@ -1555,6 +1556,12 @@ export function Prompt(props: PromptProps) {
     const branch = data.location.vcs.info(location)?.branch.current
     return branch ? `${directory}:${branch}` : directory
   })
+  const [locationWidth, setLocationWidth] = createSignal(dimensions().width)
+  const locationLabelDisplay = createMemo(() => {
+    const label = locationLabel()
+    if (!label) return
+    return truncateFilePath(label, locationWidth())
+  })
   const locationActions = useWorkingDirectoryActions({
     directory: () => footerLocation()?.directory,
     onMove: () => void move.open(),
@@ -1840,7 +1847,17 @@ export function Prompt(props: PromptProps) {
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
           <Slot path="prompt.footer" input={footerInput()}>
             <Slot path="prompt.footer.status" input={footerInput()}>
-              <box flexGrow={1} flexShrink={1} minWidth={0}>
+              <box
+                flexGrow={1}
+                flexShrink={1}
+                minWidth={0}
+                ref={(renderable: BoxRenderable) =>
+                  setTimeout(() => {
+                    if (!renderable.isDestroyed) setLocationWidth(renderable.width)
+                  }, 0)
+                }
+                on:resized={(event: { width: number }) => setLocationWidth(event.width)}
+              >
                 <Switch>
                   <Match when={status() === "running"}>
                     <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
@@ -1877,7 +1894,7 @@ export function Prompt(props: PromptProps) {
                     </box>
                   </Match>
                   <Match when={true}>
-                    <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
+                    <Show when={!props.hint && locationLabelDisplay()} fallback={props.hint ?? <text />}>
                       {(location) => (
                         <text
                           id="prompt.footer.location"

--- a/packages/tui/test/ui/file-path.test.ts
+++ b/packages/tui/test/ui/file-path.test.ts
@@ -14,6 +14,10 @@ describe("truncateFilePath", () => {
     expect(truncateFilePath(path, 19)).toBe("…/dialog-select.tsx")
   })
 
+  test("preserves the working directory and branch suffix", () => {
+    expect(truncateFilePath("~/code/experiments/category-theory:main", 30)).toBe("…/experi…/category-theory:main")
+  })
+
   test("uses remaining width for part of a long parent segment", () => {
     const path = "/private/var/folders/run-17f048ec-dbb2-4b36-860c-98637bb51a8d/files"
     expect(truncateFilePath(path, 40)).toBe("/…/run-17f048ec-dbb2-4b36-860c-98…/files")


### PR DESCRIPTION
## What

Make the prompt footer truncate working-directory labels as paths, preserving the final directory and Git branch when footer shortcuts leave limited space.

## Before / After

**Before:** The footer passed the complete `directory:branch` string to OpenTUI's generic text truncation. Long paths were cut through the repository name, for example `~/code/experiments...ategory-theory:main`.

**After:** The footer measures its actual flex-allocated width and uses the existing path-aware truncator. It removes distant parent components first, partially shortens the nearest parent only when useful, and retains the final directory and branch.

## How

- `packages/tui/src/component/prompt/index.tsx` tracks the prompt status cell's initial and resized width, then applies `truncateFilePath` to the location label.
- `packages/tui/test/ui/file-path.test.ts` covers a working-directory label with a branch suffix.

## Testing

- `bun run test test/ui/file-path.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- Repository pre-push typecheck, 33 packages passed
- OpenCode Drive at 70 columns against this worktree, verified the 31-column footer renders `/…/run-32bc4fb6-e3e…/files:main`

## Demo

Simulated local project rendered through the real TUI with OpenCode Drive at 70 columns:

![Prompt footer preserving the final directory and Git branch](https://github.com/user-attachments/assets/6309299d-2b3b-4899-8c67-a5a769b110be)
