### PR TITLE
refactor(opencode): compact background task messages

### DIFF
--- a/packages/opencode/src/cli/cmd/run/tool.ts
+++ b/packages/opencode/src/cli/cmd/run/tool.ts
@@ -761,6 +761,11 @@ function taskResult(output: string): string | undefined {
     return undefined
   }
 
+  const task = output.match(/^<<<TASK [^\n]+>>>\n?([\s\S]*)$/)
+  if (task) {
+    return task[1].trim() || undefined
+  }
+
   const match = output.match(/<task_result>\s*([\s\S]*?)\s*<\/task_result>/)
   if (match) {
     return match[1].trim() || undefined

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -28,17 +28,8 @@ const BACKGROUND_DESCRIPTION = [
   "Use background only for independent work that can run while you continue elsewhere.",
   "You will be notified automatically when it finishes.",
 ].join(" ")
-const BACKGROUND_STARTED = [
-  "The task is working in the background. You will be notified automatically when it finishes.",
-  "DO NOT sleep, poll for progress, ask the task for status, or duplicate this task's work — avoid working with the same files or topics it is using.",
-  "Work on non-overlapping tasks, or briefly tell the user what you launched and end your response.",
-].join("\n")
-const BACKGROUND_UPDATED = [
-  "Additional context sent to the running background task.",
-  "The task is still working in the background. You will be notified automatically when it finishes.",
-  "DO NOT sleep, poll for progress, ask the task for status, or duplicate this task's work — avoid working with the same files or topics it is using.",
-  "Work on non-overlapping tasks, or briefly tell the user what you sent and end your response.",
-].join("\n")
+const BACKGROUND_STARTED = "Result arrives automatically; don't poll or work on its files/topics."
+const BACKGROUND_UPDATED = "Context sent; result arrives automatically; don't poll or work on its files/topics."
 
 const BaseParameterFields = {
   description: Schema.String.annotate({ description: "A short (3-5 words) description of the task" }),
@@ -64,18 +55,12 @@ export const Parameters = Schema.Struct({
 function renderOutput(input: {
   sessionID: SessionID
   state: "running" | "completed" | "error"
-  summary?: string
+  title: string
   text: string
 }) {
-  const tag = input.state === "error" ? "task_error" : "task_result"
-  return [
-    `<task id="${input.sessionID}" state="${input.state}">`,
-    ...(input.summary ? [`<summary>${input.summary}</summary>`] : []),
-    `<${tag}>`,
-    input.text,
-    `</${tag}>`,
-    "</task>",
-  ].join("\n")
+  const state = input.state === "error" ? "FAILED" : input.state.toUpperCase()
+  const title = input.title.replace(/\s+/g, " ").replaceAll(">>>", "> > >").trim()
+  return [`<<<TASK ${input.sessionID} ${state}: ${title}>>>`, input.text].join("\n")
 }
 
 export const TaskTool = Tool.define(
@@ -230,10 +215,7 @@ export const TaskTool = Tool.define(
                 text: renderOutput({
                   sessionID: nextSession.id,
                   state,
-                  summary:
-                    state === "completed"
-                      ? `Background task completed: ${params.description}`
-                      : `Background task failed: ${params.description}`,
+                  title: params.description,
                   text,
                 }),
               },
@@ -264,7 +246,7 @@ export const TaskTool = Tool.define(
           output: renderOutput({
             sessionID: nextSession.id,
             state: "running",
-            summary: "Background task updated",
+            title: params.description,
             text: BACKGROUND_UPDATED,
           }),
         }
@@ -296,7 +278,7 @@ export const TaskTool = Tool.define(
           output: renderOutput({
             sessionID: nextSession.id,
             state: "running",
-            summary: "Background task started",
+            title: params.description,
             text: BACKGROUND_STARTED,
           }),
         }
@@ -330,7 +312,12 @@ export const TaskTool = Tool.define(
             return {
               title: params.description,
               metadata,
-              output: renderOutput({ sessionID: nextSession.id, state: "completed", text: result?.output ?? "" }),
+              output: renderOutput({
+                sessionID: nextSession.id,
+                state: "completed",
+                title: params.description,
+                text: result?.output ?? "",
+              }),
             }
           }),
         (_, exit) =>

--- a/packages/opencode/test/cli/run/entry.body.test.ts
+++ b/packages/opencode/test/cli/run/entry.body.test.ts
@@ -234,13 +234,7 @@ describe("run entry body", () => {
               subagent_type: "explore",
             },
             title: "",
-            output: [
-              '<task id="child-1" state="completed">',
-              "<task_result>",
-              "# Findings\n\n- Footer stays live",
-              "</task_result>",
-              "</task>",
-            ].join("\n"),
+            output: ["<<<TASK child-1 COMPLETED: Inspect reducer>>>", "# Findings\n\n- Footer stays live"].join("\n"),
             metadata: {
               sessionId: "child-1",
             },
@@ -264,9 +258,7 @@ describe("run entry body", () => {
               subagent_type: "explore",
             },
             title: "",
-            output: ['<task id="child-1" state="completed">', "<task_result>", "", "</task_result>", "</task>"].join(
-              "\n",
-            ),
+            output: "<<<TASK child-1 COMPLETED: Inspect reducer>>>\n",
             metadata: {
               sessionId: "child-1",
             },

--- a/packages/opencode/test/cli/run/scrollback.surface.test.ts
+++ b/packages/opencode/test/cli/run/scrollback.surface.test.ts
@@ -1059,15 +1059,12 @@ test("renders promoted task markdown without a leading blank row", async () => {
             subagent_type: "explore",
           },
           output: [
-            '<task id="child-1" state="completed">',
-            "<task_result>",
+            "<<<TASK child-1 COMPLETED: Explore run.ts>>>",
             "Location: `/tmp/run.ts`",
             "",
             "Summary:",
             "- Local interactive mode",
             "- Attach mode",
-            "</task_result>",
-            "</task>",
           ].join("\n"),
           metadata: {
             sessionId: "child-1",

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -249,9 +249,37 @@ describe("tool.task", () => {
       expect(kids).toHaveLength(1)
       expect(kids[0]?.id).toBe(child.id)
       expect(result.metadata.sessionId).toBe(child.id)
-      expect(result.output).toContain(`<task id="${child.id}" state="completed">`)
+      expect(result.output).toBe(`<<<TASK ${child.id} COMPLETED: inspect bug>>>\nresumed`)
       expect(seen?.sessionID).toBe(child.id)
       expect(seen?.variant).toBe("xhigh")
+    }),
+  )
+
+  it.instance("renders a compact task envelope with a single-line title", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        {
+          description: "inspect\nbug >>> now",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: stubOps() },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toBe(`<<<TASK ${result.metadata.sessionId} COMPLETED: inspect bug > > > now>>>\ndone`)
     }),
   )
 
@@ -383,7 +411,7 @@ describe("tool.task", () => {
       expect(kids).toHaveLength(1)
       expect(kids[0]?.id).toBe(result.metadata.sessionId)
       expect(result.metadata.sessionId).not.toBe("ses_missing")
-      expect(result.output).toContain(`<task id="${result.metadata.sessionId}" state="completed">`)
+      expect(result.output).toBe(`<<<TASK ${result.metadata.sessionId} COMPLETED: inspect bug>>>\ncreated`)
       expect(seen?.sessionID).toBe(result.metadata.sessionId)
     }),
   )
@@ -622,7 +650,9 @@ describe("tool.task", () => {
 
       const result = yield* Fiber.join(fiber)
       expect(result.metadata.background).toBe(true)
-      expect(result.output).toContain(`state="running"`)
+      expect(result.output).toBe(
+        `<<<TASK ${result.metadata.sessionId} RUNNING: inspect bug>>>\nResult arrives automatically; don't poll or work on its files/topics.`,
+      )
       expect((yield* jobs.get(result.metadata.sessionId))?.status).toBe("running")
       expect(runs).toBe(1)
 
@@ -666,7 +696,9 @@ describe("tool.task", () => {
 
       const job = yield* jobs.get(result.metadata.sessionId)
       expect(result.metadata.background).toBe(true)
-      expect(result.output).toContain(`state="running"`)
+      expect(result.output).toBe(
+        `<<<TASK ${result.metadata.sessionId} RUNNING: inspect bug>>>\nResult arrives automatically; don't poll or work on its files/topics.`,
+      )
       expect(job?.status).toBe("running")
     }),
   )
@@ -727,7 +759,9 @@ describe("tool.task", () => {
 
       expect(result.metadata.sessionId).toBe(started.metadata.sessionId)
       expect(result.metadata.background).toBe(true)
-      expect(result.output).toContain("Background task updated")
+      expect(result.output).toBe(
+        `<<<TASK ${result.metadata.sessionId} RUNNING: add investigation scope>>>\nContext sent; result arrives automatically; don't poll or work on its files/topics.`,
+      )
       first.resolve()
       expect((yield* jobs.get(started.metadata.sessionId))?.status).toBe("running")
       expect((yield* Effect.promise(() => updated.promise)).parts).toEqual([


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces repeated XML-like background-task wrappers with a compact, opener-only task header. Running messages retain the automatic-delivery, no-polling, and file/topic isolation rules; terminal messages carry the result directly. The CLI still renders both new and existing saved task outputs.

### How did you verify your code works?

- 52 focused task and CLI rendering tests
- `bun typecheck` in `packages/opencode`
- Prettier check for changed files

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR