### PR TITLE
fix(tui): scope session picker by directory

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -55,8 +55,7 @@ export function DialogSessionList() {
           ...(allProjects
             ? {}
             : {
-                project: current.project.id,
-                subpath: path.relative(current.project.directory, current.directory).replaceAll("\\", "/"),
+                directory: current.directory,
               }),
           ...(query ? { search: query } : {}),
           limit: 50,

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -1,6 +1,7 @@
 import { createMemo, createResource, createSignal, onMount, Show } from "solid-js"
 import path from "path"
 import type { SessionInfo } from "@opencode-ai/client"
+import { Project } from "@opencode-ai/schema/project"
 import { TextAttributes } from "@opentui/core"
 import type { RGBA } from "@opentui/core"
 import { useDialog } from "../ui/dialog"
@@ -54,9 +55,12 @@ export function DialogSessionList() {
         const response = await client.api.session.list({
           ...(allProjects
             ? {}
-            : {
-                directory: current.directory,
-              }),
+            : current.project.id === Project.ID.global
+              ? { directory: current.directory }
+              : {
+                  project: current.project.id,
+                  subpath: path.relative(current.project.directory, current.directory).replaceAll("\\", "/"),
+                }),
           ...(query ? { search: query } : {}),
           limit: 50,
           order: "desc",


### PR DESCRIPTION
## What

Scope the TUI session picker’s “current directory” mode by exact session directory when the current location uses the shared `global` project ID.

This fixes the picker showing unrelated sessions for non-Git directories while hiding the session that actually belongs to the current directory.

## Before / After

**Before**

1. Open OpenCode in a non-Git directory such as `/Users/kit/code/open-source/opxy`.
2. Open **Switch session** with the picker scoped to the current directory.
3. The dialog title correctly says `Sessions for opxy`, but the list contains sessions from unrelated directories and omits the OP-XY session.

Non-Git directories use the shared `global` project ID. At a project root, `path.relative(current.project.directory, current.directory)` is an empty string, so the scoped request was serialized without an effective subpath constraint. The server therefore returned recent sessions for the entire `global` project. Once that async response completed, it replaced the picker’s correctly directory-filtered local session list.

**After**

For the `global` fallback, the scoped request sends `directory: current.directory`. The server returns only root sessions whose persisted location exactly matches the directory shown in the picker title.

Real projects continue to use `project + subpath`, preserving the existing behavior that groups the same logical project path across worktrees. The all-projects `ctrl+a` mode remains unfiltered.

## How

- `packages/tui/src/component/dialog-session-list.tsx`: use the session list API’s exact `directory` filter when `current.project.id === Project.ID.global`; retain `project + subpath` for real projects.
- The global fallback now matches the component’s existing in-memory predicate, which already compares `session.location.directory === current.directory`.

## Scope

This only changes the TUI session picker’s scoped request for locations outside a detected project. It does not change real-project/worktree scoping, project detection, session persistence, API semantics, or all-projects mode.

## Testing

- `bun typecheck` in `packages/tui`
- `bun turbo typecheck --concurrency=3` across the workspace (pre-push hook)
- `git diff --check`
- Live TUI via `bun run dev:live /Users/kit/code/open-source/opxy` against the elected V2 server:
  - verified `Sessions for opxy` shows only `OP-XY USB-C access check`
  - verified `ctrl+a` switches to all projects and back to the single scoped result
- Verified the equivalent API request with `directory=/Users/kit/code/open-source/opxy`, `parentID=null`, and descending order returns only the OP-XY root session
- Verified the OpenCode project resolves to a non-global project ID and its existing project-scoped API query continues to include sessions across worktrees
