### PR TITLE
fix(app): restore scroll position when navigating between parent and child sessions

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -71,7 +71,7 @@ import {
   SessionComposerRegion,
 } from "@/pages/session/composer"
 import { createOpenReviewFile, createSessionTabs, createSizing, shouldShowFileTree } from "@/pages/session/helpers"
-import { MessageTimeline } from "@/pages/session/timeline/message-timeline"
+import { MessageTimeline, timelineCache } from "@/pages/session/timeline/message-timeline"
 import { createTimelineModel } from "@/pages/session/timeline/model"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -1506,6 +1506,9 @@ export default function Page() {
       (id, previous) => {
         if (!id || !previous || id === previous) return
         if (location.hash || store.messageId || ui.pendingMessage) return
+        // If the session has a cached scroll offset, we're returning to a
+        // previously viewed position — don't auto-scroll to bottom.
+        if (timelineCache.get(sessionKey())?.scrollOffset !== undefined) return
         autoScroll.resume()
       },
     ),
@@ -1572,6 +1575,11 @@ export default function Page() {
     scroller = el
     autoScroll.scrollRef(el)
     if (!el) return
+    // If restoring from cache, pause auto-scroll so the cached position
+    // is preserved instead of jumping to the bottom on first observation.
+    if (timelineCache.get(sessionKey())?.scrollOffset !== undefined) {
+      autoScroll.pause()
+    }
     scheduleScrollState(el)
     fill()
   }
@@ -1978,6 +1986,8 @@ export default function Page() {
     autoScroll: {
       pause: autoScroll.pause,
       forceScrollToBottom: () => {
+        // If restoring from cache, keep the user's previous position.
+        if (timelineCache.get(sessionKey())?.scrollOffset !== undefined) return
         autoScroll.resume()
         scrollToEnd()
       },

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -88,7 +88,7 @@ type FramedTimelineRow = Exclude<TimelineRow.TimelineRow, { _tag: "TurnGap" }>
 type TimelineRowByTag<T extends TimelineRow.TimelineRow["_tag"]> = Extract<TimelineRow.TimelineRow, { _tag: T }>
 
 const timelineFallbackItemSize = 60
-const timelineCache = new Map<string, { measurements: VirtualItem[]; toolOpen: Record<string, boolean | undefined> }>()
+export const timelineCache = new Map<string, { measurements: VirtualItem[]; toolOpen: Record<string, boolean | undefined>; scrollOffset?: number }>()
 
 const taskDescription = (part: PartType, sessionID: string) => {
   if (part.type !== "tool" || part.tool !== "task") return
@@ -270,7 +270,9 @@ export function MessageTimeline(props: {
   const ownerSessionKey = sessionKey()
   const cached = timelineCache.get(ownerSessionKey)
   const initialMeasurements = cached?.measurements
-  const coldBottomMount = !initialMeasurements?.length && props.shouldAnchorBottom()
+  const cachedScrollOffset = cached?.scrollOffset
+  const isRestoring = cachedScrollOffset !== undefined
+  const coldBottomMount = !initialMeasurements?.length && !isRestoring && props.shouldAnchorBottom()
   const platform = usePlatform()
 
   const [listRoot, setListRoot] = createSignal<HTMLDivElement>()
@@ -419,7 +421,10 @@ export function MessageTimeline(props: {
     },
     getScrollElement: () => listRoot() ?? null,
     observeElementOffset: observeElementOffsetReconnectAware,
-    initialOffset: () => (props.shouldAnchorBottom() ? Number.MAX_SAFE_INTEGER : 0),
+    initialOffset: () => {
+      if (isRestoring) return cachedScrollOffset
+      return props.shouldAnchorBottom() ? Number.MAX_SAFE_INTEGER : 0
+    },
     initialMeasurementsCache: initialMeasurements,
     estimateSize: () => timelineFallbackItemSize,
     scrollToFn: (offset, options, instance) => {
@@ -510,16 +515,17 @@ export function MessageTimeline(props: {
   let overscanFrame: number | undefined
   onMount(() => {
     overscanFrame = requestAnimationFrame(() => {
-      if (props.shouldAnchorBottom()) virtualizer.scrollToEnd()
+      if (!isRestoring && props.shouldAnchorBottom()) virtualizer.scrollToEnd()
       overscanFrame = requestAnimationFrame(() => {
         overscanFrame = undefined
         if (renderOverscan() < 20) setRenderOverscan(20)
-        if (props.shouldAnchorBottom()) virtualizer.scrollToEnd()
+        if (!isRestoring && props.shouldAnchorBottom()) virtualizer.scrollToEnd()
       })
     })
   })
 
   const maybeAnchorBottom = () => {
+    if (isRestoring) return
     if (timelineRows().length === 0) return
     if (!props.shouldAnchorBottom() || props.hasScrollGesture()) return
     if (resizePinFrame !== undefined) cancelAnimationFrame(resizePinFrame)
@@ -542,7 +548,11 @@ export function MessageTimeline(props: {
   onCleanup(() => {
     clearPrependAnchor()
     timelineCache.delete(ownerSessionKey)
-    timelineCache.set(ownerSessionKey, { measurements: virtualizer.takeSnapshot(), toolOpen: { ...toolOpen } })
+    timelineCache.set(ownerSessionKey, {
+      measurements: virtualizer.takeSnapshot(),
+      toolOpen: { ...toolOpen },
+      scrollOffset: listRoot()?.scrollTop,
+    })
     while (timelineCache.size > 16) timelineCache.delete(timelineCache.keys().next().value!)
     if (resizePinFrame !== undefined) cancelAnimationFrame(resizePinFrame)
     if (overscanFrame !== undefined) cancelAnimationFrame(overscanFrame)


### PR DESCRIPTION
### Issue for this PR

Closes #42806

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web app lost scroll position when navigating between parent and child sessions. Two primary paths were affected:

1. **"Back to main session"** click in the composer area
2. **Breadcrumb parent title** click in the timeline header

Both called `navigate(parentHref)`, which mounted the parent session fresh, and `autoScroll.resume()` scrolled straight to the bottom. No scroll position was ever saved.

**How it works:**

The `timelineCache` (a per-session-key cache that already cached virtualizer measurements and tool open/close state) now also saves `scrollOffset` on cleanup via `listRoot()?.scrollTop`. When the same session is remounted, three guards prevent the scroll-to-bottom:

1. **`timelineCache` in the virtualizer** — `initialOffset` uses the cached offset instead of `MAX_SAFE_INTEGER`. `onMount` and `maybeAnchorBottom` skip their `scrollToEnd()` calls when restoring.

2. **`session.tsx` session-switch effect** — `on(() => params.id)` skips `autoScroll.resume()` when the target session has a cached offset.

3. **`session.tsx` scroll-ref callback** — `setScrollRef` calls `autoScroll.pause()` when restoring from cache, preventing the auto-scroll resize observer from overriding the restored position. The user can re-engage auto-scroll by manually scrolling to the bottom.

4. **`useSessionHashScroll.forceScrollToBottom`** — returns early when the cache has an offset, so `applyHash` with no hash does not force-scroll away from the restored position.

### How did you verify your code works?

- `bun typecheck` from `packages/app` — passes
- `bun run test` from `packages/app` — 721 pass, 1 fail (pre-existing `desktop-native.test.ts` Unicode locale test, unchanged)
- `bun typecheck` from `packages/session-ui` — passes
- `bun typecheck` from `packages/tui` — passes
- `bun typecheck` from `packages/opencode` — passes
- Pre-push hook `bun turbo typecheck` — 30/30 successful

### Screenshots / recordings

No screenshot; this is a navigation scroll behavior fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
