### PR TITLE
fix(session): delete reverted messages boundary-last and tie-break ids by raw order

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -106,7 +106,13 @@ const layer = Layer.effect(
       const index = msgs.findIndex((msg) => msg.info.id === messageID)
       const target = index < 0 ? undefined : msgs[index]
       const remove = index < 0 ? [] : msgs.slice(index + (session.revert.partID ? 1 : 0))
-      for (const msg of remove) {
+      // Newest-first, so the boundary message is removed last and acts as its own progress
+      // marker. Each removal is a separate durable transaction: if this loop is interrupted
+      // partway, the surviving boundary lets the next cleanup locate the remaining rows and
+      // finish. Deleting the boundary first would strand them -- the next findIndex returns
+      // -1, remove is empty, and clearRevert below still discards the only marker that could
+      // have found them, so they silently rejoin the transcript.
+      for (const msg of remove.toReversed()) {
         yield* sessions.removeMessage({ sessionID, messageID: msg.info.id })
       }
       if (session.revert.partID && target) {
@@ -115,7 +121,9 @@ const layer = Layer.effect(
         if (idx >= 0) {
           const removeParts = target.parts.slice(idx)
           target.parts = target.parts.slice(0, idx)
-          for (const part of removeParts) {
+          // Same reasoning as the message loop above: the boundary part is removed last so an
+          // interrupted cleanup stays resumable.
+          for (const part of removeParts.toReversed()) {
             yield* sessions.removePart({ sessionID, messageID: target.info.id, partID: part.id })
           }
         }

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -52,7 +52,11 @@ function search<T>(items: T[], target: string, key: (item: T) => string) {
 }
 
 function compareMessage(a: Message, b: Message) {
-  return a.time.created - b.time.created || a.id.localeCompare(b.id)
+  // Raw comparison, not localeCompare: storage pages with ORDER BY time_created, id under
+  // SQLite's BINARY collation, so locale collation can order a same-millisecond pair the
+  // opposite way here. localeCompare also returns 0 for canonically-equivalent distinct ids,
+  // which would make this sort input-order dependent.
+  return a.time.created - b.time.created || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
 }
 
 const messageKey = (message: Message) => message.time.created + message.id

--- a/packages/web/src/components/Share.tsx
+++ b/packages/web/src/components/Share.tsx
@@ -76,7 +76,11 @@ export default function Share(props: {
     messages: {},
   })
   const messages = createMemo(() =>
-    Object.values(store.messages).toSorted((a, b) => a.time.created - b.time.created || a.id.localeCompare(b.id)),
+    // Raw id comparison rather than localeCompare, matching the BINARY collation storage
+    // orders by. See the note on compareMessage in packages/tui/src/context/sync.tsx.
+    Object.values(store.messages).toSorted(
+      (a, b) => a.time.created - b.time.created || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    ),
   )
   const [connectionStatus, setConnectionStatus] = createSignal<[Status, string?]>(["disconnected"])
 


### PR DESCRIPTION
### Issue for this PR

Closes #42816

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two fixes to the ID rollover ordering work.

**1. Revert cleanup deletes the boundary message first.**

`SessionRevert.cleanup` removes messages from the revert boundary onward. The boundary is `remove[0]` when no `partID` is set, and each `removeMessage` commits separately. If that loop is interrupted, the boundary is already gone but the rest are not. The next cleanup calls `findIndex` for the boundary, gets `-1`, so `remove` is empty and it deletes nothing. `clearRevert()` still runs at the end, discarding the marker that could have located those rows. They stay in the session permanently and get sent to the model on the next turn.

Using `.toReversed()` deletes the boundary last, so it works as a progress marker. An interrupted cleanup then leaves a state the next one can finish. The part loop below it has the same problem and the same fix.

**2. The `localeCompare` tie-break does not match storage order.**

Storage pages with `ORDER BY time_created, id`, and SQLite's default collation is BINARY. `sync.tsx` and `Share.tsx` tie-break the same data with `localeCompare`, which is locale collation. For two messages sharing a `time.created` these can return opposite results, so the client and the database can disagree about which comes first. Ids minted in the same millisecond by different processes share the timestamp prefix, so the random mixed case suffix decides, and that is exactly where the two collations differ.

`localeCompare` can also return 0 for two distinct strings that are canonically equivalent. `MessageID` only requires a `msg` prefix, so two different primary keys can compare equal and the sort becomes dependent on input order.

Raw `<` and `>` match what storage already does.

### How did you verify your code works?

Read the affected paths and traced the interruption sequence above. Confirmed `toReversed()` is already used elsewhere in the repo, so there are no target or lib concerns.

Both fixes have been running in our fork for a day. We hit the same rollover in production on 2026-08-14, wrote the same core fix independently, then found yours had landed. These two turned up while auditing ours.

I have not run the full test suite against this branch.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR