### PR TITLE
fix(app): show new session header immediately

### DIFF
--- a/packages/app/src/pages/session/timeline/controller.tsx
+++ b/packages/app/src/pages/session/timeline/controller.tsx
@@ -94,7 +94,7 @@ export function createTimelineController(input: {
       fallback: language.t("command.session.new"),
     })
   })
-  const showHeader = createMemo(() => !!(titleValue() || input.session.data.parentID()))
+  const showHeader = createMemo(() => !!input.session.identity.sessionID())
   const projection = createTimelineProjection({
     messages: input.session.history.messages,
     userMessages: input.userMessages,


### PR DESCRIPTION
### Issue for this PR

Closes #42821

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A persisted session has an ID before title generation finishes. Use that ID as the session header visibility condition. This shows the header during the first response and for error-only sessions, while drafts without an ID keep the current behavior.

The previous title and parent checks are redundant because both values come from session information loaded by the same ID.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/app`.
- Ran the 32 unit tests in `packages/app/src/pages/session/timeline`.

### Screenshots / recordings

The issue describes the visible before state. This change keeps the existing header design and shows it earlier in the session lifecycle.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
