### PR TITLE
fix(app): release virtualized timeline elements

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1203,6 +1203,8 @@ function MessageTimelineView(
 
     onCleanup(() => {
       if (contentMeasureFrame !== undefined) cancelAnimationFrame(contentMeasureFrame)
+      // Solid runs cleanup before it disconnects the row, so defer TanStack's null-ref cleanup.
+      queueMicrotask(() => virtualizer.measureElement(null))
     })
 
     return (


### PR DESCRIPTION
## Summary

- release disconnected timeline row elements from TanStack Virtual after Solid removes them

## Investigation

A renderer heap snapshot showed that `Virtualizer2.elementsCache` retained removed timeline rows. In one long session, the renderer retained about 37,500 detached DOM nodes, including 110 session-turn roots and 1,621 animated-number cells. V8 used about 73 MB after garbage collection, while the renderer used more than 600 MB of private memory.

Solid runs owner cleanup before it disconnects the row element. The deferred `measureElement(null)` call lets TanStack remove disconnected cache entries and stop observing them.

TanStack documents `measureElement(null)` as the supported cleanup path. TanStack Virtual PR #1148 also confirms that this call removes disconnected `elementsCache` entries by reference. Solid callback refs receive the created element but do not provide React's null-on-unmount callback, so the timeline performs the cleanup explicitly after DOM removal.

## Commits

1. `fix(app): release virtualized timeline elements`

## Testing

- full repository type check: 33 tasks passed across 39 packages
- app unit tests: 689 passed, 12 skipped
- app browser tests: 42 passed
- app package type check passed
- Prettier and `git diff --check` passed
