### PR TITLE
refactor(core): use numeric event timestamps

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -20,7 +20,6 @@ import type { InstructionEntry } from "@opencode-ai/schema/instruction-entry"
 import type { Schema } from "effect"
 import type { EventLog } from "@opencode-ai/schema/event-log"
 import type { Shell } from "@opencode-ai/schema/shell"
-import type { DateTime } from "effect"
 import type { Provider } from "@opencode-ai/schema/provider"
 import type { Integration } from "@opencode-ai/schema/integration"
 import type { Form } from "@opencode-ai/schema/form"
@@ -316,7 +315,7 @@ export type Endpoint5_31Output =
   | (
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.created"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -336,7 +335,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.agent.selected"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -349,7 +348,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.model.selected"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -362,7 +361,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.moved"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -376,7 +375,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.renamed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -385,7 +384,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.deleted"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -394,7 +393,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.forked"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -410,7 +409,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.inbox.delivered"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -419,7 +418,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.inbox.enqueued"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -432,7 +431,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.inbox.cancelled"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -441,7 +440,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.inbox.delivery.changed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -454,7 +453,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.execution.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -463,7 +462,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.execution.succeeded"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -472,7 +471,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.execution.failed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -484,7 +483,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.execution.interrupted"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -493,7 +492,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.instructions.updated"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -506,7 +505,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.synthetic"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -520,7 +519,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.skill.activated"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -534,7 +533,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.shell.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -543,7 +542,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.shell.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -561,7 +560,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.step.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -576,7 +575,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.step.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -598,7 +597,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.step.failed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -622,7 +621,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.text.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -635,7 +634,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.text.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -650,7 +649,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.reasoning.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -664,7 +663,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.reasoning.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -679,7 +678,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.input.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -693,7 +692,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.input.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -707,7 +706,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.called"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -723,7 +722,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.success"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -759,7 +758,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.tool.failed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -798,7 +797,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.retry.scheduled"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -813,7 +812,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.compaction.started"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -827,7 +826,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.compaction.ended"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -841,7 +840,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.compaction.failed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -855,7 +854,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.revert.staged"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -864,7 +863,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.revert.cleared"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -873,7 +872,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.revert.committed"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
@@ -882,7 +881,7 @@ export type Endpoint5_31Output =
         }
       | {
           readonly id: Event.ID
-          readonly created: DateTime.Utc
+          readonly created: number
           readonly metadata?: { readonly [x: string]: unknown } | undefined
           readonly type: "session.usage.recorded"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -1,6 +1,6 @@
 export * as Bus from "./bus.js"
 
-import { Cause, Context, DateTime, Effect, Layer, Option, PubSub, Schema, Stream } from "effect"
+import { Cause, Clock, Context, Effect, Layer, Option, PubSub, Schema, Stream } from "effect"
 import { Event } from "@opencode-ai/schema/event"
 import type { EventLog } from "@opencode-ai/schema/event-log"
 import { and, asc, eq, gt, lte, sql } from "drizzle-orm"
@@ -47,7 +47,7 @@ export const reserveSequence = Effect.fn("Bus.reserveSequence")(function* (
 export type SerializedEvent = {
   readonly id: Event.ID
   readonly type: string
-  readonly created?: DateTime.Utc
+  readonly created?: number
   readonly seq: number
   readonly aggregateID: string
   readonly data: Record<string, unknown>
@@ -74,7 +74,7 @@ const decodeSerializedEvent = (event: SerializedEvent): Event.Payload => {
   }
   return {
     id: event.id,
-    created: event.created ?? DateTime.makeUnsafe(0),
+    created: event.created ?? 0,
     type: definition.type,
     durable: envelope(event.aggregateID, event.seq, definition.durable.version),
     data: Schema.decodeUnknownSync(definition.data)(event.data),
@@ -283,7 +283,7 @@ export function configured(options?: Options) {
                               if (
                                 stored?.id === event.id &&
                                 stored.type === versionedType(definition.type, durable.version) &&
-                                stored.created === DateTime.toEpochMillis(event.created ?? DateTime.makeUnsafe(0)) &&
+                                stored.created === (event.created ?? 0) &&
                                 isDeepStrictEqual(stored.data, encoded)
                               ) {
                                 if (input.ownerID && row?.ownerID == null) {
@@ -358,7 +358,7 @@ export function configured(options?: Options) {
                                     id: event.id,
                                     aggregate_id: aggregateID,
                                     seq,
-                                    created: DateTime.toEpochMillis(event.created ?? DateTime.makeUnsafe(0)),
+                                    created: event.created ?? 0,
                                     type: versionedType(definition.type, durable.version),
                                     data: encoded,
                                   },
@@ -455,7 +455,7 @@ export function configured(options?: Options) {
               definition,
               {
                 id: options?.id ?? Event.ID.create(),
-                created: yield* DateTime.now,
+                created: yield* Clock.currentTimeMillis,
                 ...(options?.metadata ? { metadata: options.metadata } : {}),
                 type: definition.type,
                 ...(location ? { location } : {}),
@@ -491,7 +491,7 @@ export function configured(options?: Options) {
                   commit: options?.commit,
                   event: {
                     id: options?.id ?? Event.ID.create(),
-                    created: yield* DateTime.now,
+                    created: yield* Clock.currentTimeMillis,
                     ...(options?.metadata ? { metadata: options.metadata } : {}),
                     type: definition.type,
                     ...(location ? { location } : {}),
@@ -571,7 +571,7 @@ export function configured(options?: Options) {
                                 id: event.id,
                                 aggregate_id: aggregateID,
                                 seq,
-                                created: DateTime.toEpochMillis(event.created),
+                                created: event.created,
                                 type: versionedType(item.definition.type, item.definition.durable.version),
                                 data: encoded,
                               })
@@ -619,7 +619,7 @@ export function configured(options?: Options) {
                 Effect.gen(function* () {
                   const payload = {
                     id: event.id,
-                    created: event.created ?? DateTime.makeUnsafe(0),
+                    created: event.created ?? 0,
                     type: definition.type,
                     data: Schema.decodeUnknownSync(definition.data)(event.data),
                   } as Event.Payload
@@ -733,7 +733,7 @@ export function configured(options?: Options) {
                 return [
                   decodeSerializedEvent({
                     id: event.id,
-                    created: DateTime.makeUnsafe(event.created),
+                    created: event.created,
                     aggregateID: event.aggregate_id,
                     seq: event.seq,
                     type: event.type,

--- a/packages/core/src/session/inbox.ts
+++ b/packages/core/src/session/inbox.ts
@@ -161,7 +161,7 @@ export const admit = Effect.fn("SessionInbox.admit")(function* (
         const base = {
           id: request.id,
           sessionID: request.sessionID,
-          timeCreated: event.created,
+          timeCreated: DateTime.makeUnsafe(event.created),
         }
         return Effect.succeed(Info.make({ ...base, ...request.item }))
       }),
@@ -196,7 +196,7 @@ export const projectAdmitted = Effect.fn("SessionInbox.projectAdmitted")(functio
     readonly id: SessionMessage.ID
     readonly sessionID: SessionSchema.ID
     readonly item: Item
-    readonly timeCreated: DateTime.Utc
+    readonly timeCreated: number
   },
 ) {
   const message = yield* db
@@ -222,7 +222,7 @@ export const projectAdmitted = Effect.fn("SessionInbox.projectAdmitted")(functio
               : encodeMove(request.item.payload),
       delivery: request.item.delivery,
       enqueued_seq: request.enqueuedSeq,
-      time_created: DateTime.toEpochMillis(request.timeCreated),
+      time_created: request.timeCreated,
     })
     .onConflictDoNothing()
     .returning({ id: SessionInboxTable.id })

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -26,6 +26,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
   type DraftTool = WritableDraft<SessionMessage.AssistantTool>
   type DraftText = WritableDraft<SessionMessage.AssistantText>
   type DraftReasoning = WritableDraft<SessionMessage.AssistantReasoning>
+  const created = DateTime.makeUnsafe(event.created)
 
   const latestTool = (assistant: DraftAssistant | undefined, id?: string) =>
     assistant?.content.findLast(
@@ -70,7 +71,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               metadata: event.metadata,
               agent: event.data.agent,
               previous,
-              time: { created: event.created },
+              time: { created },
             }),
           )
         })
@@ -85,7 +86,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               metadata: event.metadata,
               model: event.data.model,
               previous,
-              time: { created: event.created },
+              time: { created },
             }),
           )
         })
@@ -101,7 +102,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               projectID: event.data.projectID,
               subpath: event.data.subpath,
               previous: yield* adapter.getLocation(),
-              time: { created: event.created },
+              time: { created },
             }),
           )
         })
@@ -126,7 +127,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             text: event.data.text,
             description: `Instructions updated: ${Object.keys(event.data.delta).join(", ")}`,
             metadata: event.metadata,
-            time: { created: event.created },
+            time: { created },
           }),
         )
       },
@@ -138,7 +139,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             metadata: event.data.metadata,
             id: SessionMessage.ID.fromEvent(event.id),
             type: "synthetic",
-            time: { created: event.created },
+            time: { created },
           }),
         )
       },
@@ -151,7 +152,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             name: event.data.name,
             text: event.data.text,
             metadata: event.metadata,
-            time: { created: event.created },
+            time: { created },
           }),
         )
       },
@@ -164,7 +165,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             shellID: event.data.shell.id,
             command: event.data.shell.command,
             status: event.data.shell.status,
-            time: { created: event.created },
+            time: { created },
           }),
         )
       },
@@ -177,7 +178,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
                 draft.status = event.data.shell.status
                 draft.exit = event.data.shell.exit
                 draft.output = event.data.output
-                draft.time.completed = event.created
+                draft.time.completed = created
               }),
             )
           }
@@ -205,7 +206,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             yield* adapter.updateAssistant(
               produce(currentAssistant, (draft) => {
                 draft.retry = undefined
-                draft.time.completed = event.created
+                draft.time.completed = created
               }),
             )
           }
@@ -216,7 +217,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               agent: event.data.agent,
               model: event.data.model,
               metadata: event.metadata,
-              time: { created: event.created },
+              time: { created },
               content: [],
               snapshot: event.data.snapshot ? { start: event.data.snapshot } : undefined,
             }),
@@ -225,7 +226,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
       },
       "session.step.ended": (event) => {
         return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
-          draft.time.completed = event.created
+          draft.time.completed = created
           draft.finish = event.data.finish
           draft.cost = event.data.cost
           draft.tokens = event.data.tokens
@@ -239,7 +240,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
       },
       "session.step.failed": (event) => {
         return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
-          draft.time.completed = event.created
+          draft.time.completed = created
           draft.finish = "error"
           draft.error = castDraft(event.data.error)
           draft.retry = undefined
@@ -277,7 +278,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
                 type: "tool",
                 id: event.data.id,
                 name: event.data.name,
-                time: { created: event.created },
+                time: { created },
                 state: SessionMessage.ToolStateStreaming.make({ status: "streaming", input: "" }),
               }),
             ),
@@ -296,7 +297,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           if (match) {
             match.executed = event.data.executed
             match.providerState = event.data.state
-            match.time.ran = event.created
+            match.time.ran = created
             match.state = castDraft(
               SessionMessage.ToolStateRunning.make({
                 status: "running",
@@ -315,7 +316,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           if (match && match.state.status === "running") {
             match.executed = event.data.executed || match.executed === true
             match.providerResultState = event.data.resultState
-            match.time.completed = event.created
+            match.time.completed = created
             match.state = castDraft(
               SessionMessage.ToolStateCompleted.make({
                 status: "completed",
@@ -333,7 +334,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           if (match && (match.state.status === "streaming" || match.state.status === "running")) {
             match.executed = event.data.executed || match.executed === true
             match.providerResultState = event.data.resultState
-            match.time.completed = event.created
+            match.time.completed = created
             match.state = castDraft(
               SessionMessage.ToolStateError.make({
                 status: "error",
@@ -354,7 +355,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
                 type: "reasoning",
                 text: "",
                 state: event.data.state,
-                time: { created: event.created },
+                time: { created },
               }),
             ),
           )
@@ -365,7 +366,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
           const match = latestReasoning(draft)
           if (match) {
             match.text = event.data.text
-            match.time = { created: match.time?.created ?? event.created, completed: event.created }
+            match.time = { created: match.time?.created ?? created, completed: created }
             if (event.data.state !== undefined) match.state = event.data.state
           }
         })
@@ -389,7 +390,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             reason: event.data.reason,
             summary: "",
             recent: event.data.recent ?? "",
-            time: { created: event.created },
+            time: { created },
           }),
         ),
       "session.compaction.ended": (event) => {
@@ -414,7 +415,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
               reason: event.data.reason,
               summary: event.data.text,
               recent: event.data.recent,
-              time: { created: event.created },
+              time: { created },
             }),
           )
         })
@@ -429,7 +430,7 @@ export function update(adapter: Adapter, event: SessionEvent.DurableEvent) {
             metadata: current?.metadata ?? event.metadata,
             reason: event.data.reason,
             error: event.data.error,
-            time: current?.time ?? { created: event.created },
+            time: current?.time ?? { created },
           })
           if (current?.status === "running") return yield* adapter.updateCompaction(failed)
           yield* adapter.appendMessage(failed)

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -162,8 +162,8 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
       tokens_reasoning: 0,
       tokens_cache_read: 0,
       tokens_cache_write: 0,
-      time_created: DateTime.toEpochMillis(event.created),
-      time_updated: DateTime.toEpochMillis(event.created),
+      time_created: event.created,
+      time_updated: event.created,
     })
     .onConflictDoNothing()
     .returning({ sessionID: SessionTable.id })
@@ -411,8 +411,8 @@ const layer = Layer.effectDiscard(
             agent: event.data.agent,
             model: event.data.model,
             version: event.data.version,
-            time_created: DateTime.toEpochMillis(event.created),
-            time_updated: DateTime.toEpochMillis(event.created),
+            time_created: event.created,
+            time_updated: event.created,
           })
           .onConflictDoNothing()
           .returning({ sessionID: SessionTable.id })
@@ -431,7 +431,7 @@ const layer = Layer.effectDiscard(
             path: event.data.subpath,
             ...(event.data.projectID ? { project_id: event.data.projectID } : {}),
             workspace_id: event.data.location.workspaceID ? Workspace.ID.make(event.data.location.workspaceID) : null,
-            time_updated: DateTime.toEpochMillis(event.created),
+            time_updated: event.created,
           })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
@@ -487,7 +487,7 @@ const layer = Layer.effectDiscard(
         yield* run(db, event)
         yield* db
           .update(SessionTable)
-          .set({ agent: event.data.agent, time_updated: DateTime.toEpochMillis(event.created) })
+          .set({ agent: event.data.agent, time_updated: event.created })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)
@@ -498,7 +498,7 @@ const layer = Layer.effectDiscard(
         yield* run(db, event)
         yield* db
           .update(SessionTable)
-          .set({ model: event.data.model, time_updated: DateTime.toEpochMillis(event.created) })
+          .set({ model: event.data.model, time_updated: event.created })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)
@@ -507,7 +507,7 @@ const layer = Layer.effectDiscard(
     yield* bus.project(SessionEvent.Renamed, (event) =>
       db
         .update(SessionTable)
-        .set({ title: event.data.title, time_updated: DateTime.toEpochMillis(event.created) })
+        .set({ title: event.data.title, time_updated: event.created })
         .where(eq(SessionTable.id, event.data.sessionID))
         .run()
         .pipe(Effect.orDie),
@@ -535,7 +535,7 @@ const layer = Layer.effectDiscard(
                 files: input.payload.files,
                 agents: input.payload.agents,
                 skills: input.payload.skills,
-                time: { created: event.created },
+                time: { created: DateTime.makeUnsafe(event.created) },
               }
             : {
                 id: input.id,
@@ -543,7 +543,7 @@ const layer = Layer.effectDiscard(
                 text: input.payload.text,
                 description: input.payload.description,
                 metadata: input.payload.metadata,
-                time: { created: event.created },
+                time: { created: DateTime.makeUnsafe(event.created) },
               },
         )
       }),
@@ -561,7 +561,7 @@ const layer = Layer.effectDiscard(
         })
         yield* db
           .update(SessionTable)
-          .set({ time_updated: DateTime.toEpochMillis(event.created) })
+          .set({ time_updated: event.created })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)
@@ -640,7 +640,7 @@ const layer = Layer.effectDiscard(
           .update(SessionTable)
           .set({
             revert: { ...revert, files: revert.files ? [...revert.files] : undefined },
-            time_updated: DateTime.toEpochMillis(event.created),
+            time_updated: event.created,
           })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
@@ -650,7 +650,7 @@ const layer = Layer.effectDiscard(
     yield* bus.project(SessionEvent.RevertEvent.Cleared, (event) =>
       db
         .update(SessionTable)
-        .set({ revert: null, time_updated: DateTime.toEpochMillis(event.created) })
+        .set({ revert: null, time_updated: event.created })
         .where(eq(SessionTable.id, event.data.sessionID))
         .run()
         .pipe(Effect.orDie, Effect.asVoid),
@@ -685,7 +685,7 @@ const layer = Layer.effectDiscard(
           .pipe(Effect.orDie)
         yield* db
           .update(SessionTable)
-          .set({ revert: null, time_updated: DateTime.toEpochMillis(event.created) })
+          .set({ revert: null, time_updated: event.created })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)

--- a/packages/core/test/bus.test.ts
+++ b/packages/core/test/bus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Schema, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Schema, Stream } from "effect"
 import { Bus } from "@opencode-ai/core/bus"
 import { Event } from "@opencode-ai/schema/event"
 import { Session } from "@opencode-ai/schema/session"
@@ -422,7 +422,7 @@ describe("Bus", () => {
       const { db } = yield* Database.Service
       const aggregateID = Event.ID.create()
 
-      yield* bus.publish(SyncMessage, { id: aggregateID, text: "first" })
+      const event = yield* bus.publish(SyncMessage, { id: aggregateID, text: "first" })
       const rows = yield* db
         .select()
         .from(EventTable)
@@ -433,6 +433,7 @@ describe("Bus", () => {
       expect(rows).toHaveLength(1)
       expect(rows[0]?.type).toBe(Bus.versionedType(SyncMessage.type, 1))
       expect(rows[0]?.aggregate_id).toBe(aggregateID)
+      expect(rows[0]?.created).toBe(event.created)
     }),
   )
 
@@ -706,7 +707,7 @@ describe("Bus", () => {
 
       yield* bus.replay({
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -726,7 +727,7 @@ describe("Bus", () => {
 
       yield* bus.replay({
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -763,7 +764,7 @@ describe("Bus", () => {
         const exit = yield* bus
           .replay({
             id: Event.ID.create(),
-            created: DateTime.makeUnsafe(0),
+            created: 0,
             type: Bus.versionedType(DurableMessage.type, 1),
             seq: 1,
             aggregateID: envelopeAggregateID,
@@ -797,7 +798,7 @@ describe("Bus", () => {
 
       yield* bus.replay({
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -806,7 +807,7 @@ describe("Bus", () => {
       const exit = yield* bus
         .replay({
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 5,
           aggregateID,
@@ -831,14 +832,14 @@ describe("Bus", () => {
 
       yield* bus.replay({
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(SessionEvent.InstructionsUpdated.type, 2),
         seq: 0,
         aggregateID,
         data: { sessionID: aggregateID, delta: { "core/context": "0".repeat(64) } },
       })
 
-      expect(received[0]?.created).toEqual(DateTime.makeUnsafe(0))
+      expect(received[0]?.created).toBe(0)
     }),
   )
 
@@ -867,7 +868,7 @@ describe("Bus", () => {
       const exit = yield* bus
         .replay({
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: "unknown.event.1",
           seq: 0,
           aggregateID: Event.ID.create(),
@@ -895,7 +896,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 1,
           aggregateID,
@@ -915,7 +916,7 @@ describe("Bus", () => {
       const id = Event.ID.create()
       const replayed = {
         id,
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -972,7 +973,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 0,
           aggregateID,
@@ -1001,7 +1002,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 1,
           aggregateID,
@@ -1012,7 +1013,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 2,
           aggregateID,
@@ -1045,7 +1046,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 0,
           aggregateID,
@@ -1058,7 +1059,7 @@ describe("Bus", () => {
         .replay(
           {
             id: Event.ID.create(),
-            created: DateTime.makeUnsafe(0),
+            created: 0,
             type: Bus.versionedType(DurableMessage.type, 1),
             seq: 1,
             aggregateID,
@@ -1080,7 +1081,7 @@ describe("Bus", () => {
       yield* bus.listen((event) => Effect.sync(() => received.push(event)))
       const replayed = {
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -1101,7 +1102,7 @@ describe("Bus", () => {
       const aggregateID = Session.ID.create()
       const replayed = {
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -1126,7 +1127,7 @@ describe("Bus", () => {
       const id = Event.ID.create()
       yield* bus.replay({
         id,
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,
@@ -1136,7 +1137,7 @@ describe("Bus", () => {
       const exit = yield* bus
         .replay({
           id,
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 1,
           aggregateID,
@@ -1159,7 +1160,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 0,
           aggregateID,
@@ -1170,7 +1171,7 @@ describe("Bus", () => {
       yield* bus.replay(
         {
           id: Event.ID.create(),
-          created: DateTime.makeUnsafe(0),
+          created: 0,
           type: Bus.versionedType(DurableMessage.type, 1),
           seq: 1,
           aggregateID,
@@ -1232,7 +1233,7 @@ describe("Bus", () => {
 
       yield* bus.replay({
         id: Event.ID.create(),
-        created: DateTime.makeUnsafe(0),
+        created: 0,
         type: Bus.versionedType(DurableMessage.type, 1),
         seq: 0,
         aggregateID,

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1002,7 +1002,7 @@ test("reconciles only changed MCP server config", async () => {
         const publishUpdate = () =>
           PubSub.publish(updates, {
             id: ID.create(),
-            created: DateTime.makeUnsafe(0),
+            created: 0,
             type: Event.Updated.type,
             data: {},
           } satisfies Payload<typeof Event.Updated>)

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -599,7 +599,7 @@ describe("Session.create", () => {
         .all()
         .pipe(Effect.orDie)).map((event) => ({
         id: event.id,
-        created: DateTime.makeUnsafe(event.created),
+        created: event.created,
         aggregateID: event.aggregate_id,
         seq: event.seq,
         type: event.type,

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -760,7 +760,7 @@ describe("Session.prompt", () => {
       yield* Effect.forEach(
         recorded.map((event) => ({
           id: event.id,
-          created: DateTime.makeUnsafe(event.created),
+          created: event.created,
           aggregateID: event.aggregate_id,
           seq: event.seq,
           type: event.type,

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -75,7 +75,7 @@ import { SessionSystemPrompt } from "@opencode-ai/core/session/system-prompt"
 import { ID } from "@opencode-ai/core/model"
 import { Location } from "@opencode-ai/core/location"
 import { Provider } from "@opencode-ai/core/provider"
-import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { asc, desc, eq } from "drizzle-orm"
@@ -672,7 +672,7 @@ const replaySessionProjection = (id: Session.ID) =>
     yield* Effect.forEach(
       recorded.map((event) => ({
         id: event.id,
-        created: DateTime.makeUnsafe(event.created),
+        created: event.created,
         aggregateID: event.aggregate_id,
         seq: event.seq,
         type: event.type,
@@ -1479,7 +1479,7 @@ describe("SessionRunnerLLM", () => {
       yield* Effect.forEach(
         recorded.map((event) => ({
           id: event.id,
-          created: DateTime.makeUnsafe(event.created),
+          created: event.created,
           aggregateID: event.aggregate_id,
           seq: event.seq,
           type: event.type,

--- a/packages/protocol/test/event.test.ts
+++ b/packages/protocol/test/event.test.ts
@@ -1,9 +1,33 @@
 import { expect, test } from "bun:test"
-import { isOpenCodeEvent } from "../src/groups/event.js"
+import { isOpenCodeEvent, type OpenCodeEvent, type OpenCodeEventEncoded } from "../src/groups/event.js"
+
+type JsonShape<Value> = Value extends string | number | boolean | null
+  ? Value
+  : Value extends undefined
+    ? never
+    : Value extends ReadonlyArray<infer Item>
+      ? ReadonlyArray<JsonShape<Item>>
+      : Value extends object
+        ? {
+            readonly [Key in keyof Value as undefined extends Value[Key] ? never : Key]: JsonShape<Value[Key]>
+          } & {
+            readonly [Key in keyof Value as undefined extends Value[Key] ? Key : never]?: JsonShape<
+              Exclude<Value[Key], undefined>
+            >
+          }
+        : Value
+
+// JSON.stringify omits undefined object properties, so normalize them before
+// requiring every runtime event shape to fit its encoded wire contract.
+const wireReady: [JsonShape<OpenCodeEvent>] extends [JsonShape<OpenCodeEventEncoded>] ? true : false = true
 
 test("classifies public events by type", () => {
   expect(isOpenCodeEvent({ type: "server.connected" })).toBe(true)
   expect(isOpenCodeEvent({ type: "mcp.status.changed" })).toBe(true)
   expect(isOpenCodeEvent({ type: "mcp.resources.changed" })).toBe(true)
   expect(isOpenCodeEvent({ type: "mcp.tools.changed" })).toBe(false)
+})
+
+test("keeps public event runtime values within the encoded contract", () => {
+  expect(wireReady).toBe(true)
 })

--- a/packages/schema/src/event.ts
+++ b/packages/schema/src/event.ts
@@ -4,7 +4,7 @@ import { Schema, SchemaTransformation } from "effect"
 import { optional } from "./schema.js"
 import { ascending } from "./identifier.js"
 import { Location } from "./location.js"
-import { DateTimeUtcFromMillis, statics } from "./schema.js"
+import { statics } from "./schema.js"
 
 export const ID = Schema.String.check(Schema.isStartsWith("evt_")).pipe(
   Schema.brand("Event.ID"),
@@ -60,7 +60,7 @@ export type Data<D extends Definition> = Schema.Schema.Type<D["data"]>
 type PayloadBase<D extends Definition> = {
   readonly id: ID
   readonly type: D["type"]
-  readonly created: typeof DateTimeUtcFromMillis.Type
+  readonly created: number
   readonly data: Data<D>
   readonly location?: Location.Ref
   readonly metadata?: Record<string, unknown>
@@ -100,7 +100,7 @@ export function durable<
   })
   return Schema.Struct({
     id: ID,
-    created: DateTimeUtcFromMillis,
+    created: Schema.Finite,
     metadata: optional(Schema.Record(Schema.String, Schema.Unknown)),
     type: Schema.Literal(input.type),
     durable,
@@ -125,7 +125,7 @@ export function ephemeral<
   const data = Schema.Struct(input.schema)
   return Schema.Struct({
     id: ID,
-    created: DateTimeUtcFromMillis,
+    created: Schema.Finite,
     metadata: optional(Schema.Record(Schema.String, Schema.Unknown)),
     type: Schema.Literal(input.type),
     location: optional(Location.Ref),

--- a/packages/server/src/event-feed.ts
+++ b/packages/server/src/event-feed.ts
@@ -2,7 +2,7 @@ export * as EventFeed from "./event-feed"
 
 import { Bus } from "@opencode-ai/core/bus"
 import { Event } from "@opencode-ai/schema/event"
-import { isOpenCodeEvent, OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
+import { isOpenCodeEvent, type OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
 import { Cause, Context, Effect, Layer, Queue, Schema, Scope, Stream } from "effect"
 
 export const SubscriberCapacity = 4_096
@@ -26,10 +26,8 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/server/EventFeed") {}
 
-const encode = Schema.encodeUnknownSync(OpenCodeEvent)
-
 export function frame(event: OpenCodeEvent) {
-  return `data: ${JSON.stringify(encode(event))}\n\n`
+  return `data: ${JSON.stringify(event)}\n\n`
 }
 
 export const make = Effect.fn("EventFeed.make")(function* (

--- a/packages/server/test/event-feed.test.ts
+++ b/packages/server/test/event-feed.test.ts
@@ -2,8 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Agent } from "@opencode-ai/core/agent"
 import { Bus } from "@opencode-ai/core/bus"
 import { Event } from "@opencode-ai/schema/event"
-import { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
-import { DateTime, Deferred, Effect, Exit, Fiber, Option, Schema, Stream } from "effect"
+import { Deferred, Effect, Exit, Fiber, Option, Schema, Stream } from "effect"
 import { it } from "../../core/test/lib/effect"
 import { EventFeed } from "../src/event-feed"
 
@@ -11,14 +10,14 @@ const Internal = Bus.ephemeral({ type: "test.internal", schema: { value: Schema.
 
 const event = (id: string): Event.Payload<typeof Agent.Event.Updated> => ({
   id: Event.ID.make(`evt_${id}`),
-  created: DateTime.makeUnsafe(Date.now()),
+  created: Date.now(),
   type: Agent.Event.Updated.type,
   data: {},
 })
 
 const internal = (value: string): Event.Payload<typeof Internal> => ({
   id: Event.ID.create(),
-  created: DateTime.makeUnsafe(Date.now()),
+  created: Date.now(),
   type: Internal.type,
   data: { value },
 })
@@ -40,9 +39,7 @@ function makeSource() {
 describe("EventFeed", () => {
   test("preserves the public SSE frame encoding", () => {
     const payload = event("wire")
-    expect(EventFeed.frame(payload)).toBe(
-      `data: ${JSON.stringify(Schema.encodeUnknownSync(OpenCodeEvent)(payload))}\n\n`,
-    )
+    expect(EventFeed.frame(payload)).toBe(`data: ${JSON.stringify(payload)}\n\n`)
   })
 
   it.effect("encodes once and delivers the same frame to every subscriber", () =>


### PR DESCRIPTION
## Summary

- represent V2 event `created` values as finite epoch-millisecond numbers at runtime instead of `DateTime.Utc`
- persist and replay the same numeric timestamp without round-trip DateTime conversion, converting only when projecting into DateTime-based session domain models
- serialize public EventFeed frames directly with `JSON.stringify(event)`
- add a protocol contract check requiring JSON-normalized runtime event values to fit the encoded public event contract
- regenerate the Effect client API so Effect clients and plugins expose numeric event timestamps

## Compatibility

The network and durable representations are unchanged: `created` remains an epoch-millisecond number. The intentional public API change is limited to Effect runtime event types, which now expose `number` rather than `DateTime.Utc`; Promise clients already exposed the encoded numeric type. Event sequence ordering and durable payload encoding are unchanged.

The contract check normalizes `undefined` object fields because `JSON.stringify` omits them, then requires every runtime event shape to be assignable to its encoded shape. This is narrower and more appropriate than banning schema transformations: public events legitimately use brands/refinements, optional-key encodings, durable-version normalization, and decode defaults that remain safe for direct serialization.

This builds on `fix(core): batch streamed session deltas` (`4fee4d7d86`). Batched delta events now carry the same wire-native numeric envelope as every other public event, and direct EventFeed serialization is safe because the complete public event union is guarded against runtime shapes that do not fit its encoded contract.

## Testing

- `bun run generate` in `packages/client`
- `bun test test/event.test.ts test/event-manifest.test.ts` and `bun typecheck` in `packages/schema`
- `bun test test/event.test.ts` and `bun typecheck` in `packages/protocol`
- `bun test test/bus.test.ts test/session-projector.test.ts` in `packages/core`
- `bun test test/session-create.test.ts test/session-prompt.test.ts` in `packages/core`
- `bun test test/mcp.test.ts` in `packages/core`
- `bun test test/event-feed.test.ts` in `packages/server`
- `bun test test/contract-identity.test.ts` and `bun typecheck` in `packages/client`
- `bun typecheck` in `packages/plugin` and `packages/cli`
- targeted `oxlint` completed with no errors

Aggregate `core`, `server`, `sdk-next`, `tui`, and pre-push monorepo typechecks remain blocked by unrelated ambient `Request`/`Response`/`Headers` declaration failures (the pre-push run first fails in `packages/script/src/index.ts` via `codemode`). No changed file reports a type error, and the directly affected leaf-package typechecks above pass.