### PR TITLE
feat(core): add Incus workspace forks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1025,6 +1025,19 @@
         "typescript": "catalog:",
       },
     },
+    "packages/workspace-incus": {
+      "name": "@opencode-ai/workspace-incus",
+      "version": "0.0.0",
+      "dependencies": {
+        "@opencode-ai/core": "workspace:*",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@tsconfig/bun": "catalog:",
+        "@types/bun": "catalog:",
+        "@typescript/native-preview": "catalog:",
+      },
+    },
     "packages/www": {
       "name": "@opencode-ai/www",
       "dependencies": {
@@ -2064,6 +2077,8 @@
     "@opencode-ai/util": ["@opencode-ai/util@workspace:packages/util"],
 
     "@opencode-ai/web": ["@opencode-ai/web@workspace:packages/web"],
+
+    "@opencode-ai/workspace-incus": ["@opencode-ai/workspace-incus@workspace:packages/workspace-incus"],
 
     "@opencode-ai/www": ["@opencode-ai/www@workspace:packages/www"],
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -95,7 +95,7 @@ type CreateBaseInput = {
   model?: Model.Ref
 }
 type CreateInput = CreateBaseInput &
-  ({ location: Location.Ref; parentID?: never } | { parentID: SessionSchema.ID; location?: never })
+  ({ location: Location.Ref; parentID?: never } | { parentID: SessionSchema.ID; location?: Location.Ref })
 
 type CompactInput = {
   id?: SessionMessage.ID
@@ -361,7 +361,7 @@ const layer = Layer.effect(
         if (recorded) return recorded
         const parent = input.parentID ? yield* store.get(input.parentID) : undefined
         if (input.parentID && parent === undefined) return yield* new NotFoundError({ sessionID: input.parentID })
-        const location = parent?.location ?? input.location
+        const location = input.location ?? parent?.location
         if (location === undefined)
           return yield* Effect.die(new Error("Session.create requires either location or an existing parentID"))
         const project = yield* projects.resolve(location.directory)

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -2,19 +2,21 @@ export * as SubagentTool from "./subagent.js"
 
 import { ToolFailure } from "@opencode-ai/ai"
 import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
-import { Effect, Schema, Scope } from "effect"
+import { Effect, Option, Schema, Scope } from "effect"
 import { Agent } from "../../agent.js"
 import { Config } from "../../config.js"
 import { PluginRuntime } from "../../plugin/runtime.js"
 import { Permission } from "../../permission.js"
 import { SessionSchema } from "../../session/schema.js"
+import { Workspace } from "../../workspace.js"
 
 export const name = "subagent"
 
 const NO_TEXT = "Subagent completed without a text response."
-const backgroundStarted = (sessionID: SessionSchema.ID) =>
+const backgroundStarted = (sessionID: SessionSchema.ID, workspaceID?: Workspace.ID) =>
   [
     `The subagent is working in the background (id: ${sessionID}). You will be notified automatically when it finishes.`,
+    ...(workspaceID ? [`It is isolated in workspace ${workspaceID}.`] : []),
     "DO NOT sleep, poll for progress, ask the subagent for status, or duplicate this subagent's work; avoid working with the same files or topics it is using.",
     "Work on non-overlapping tasks, or briefly tell the user what you launched and end your response.",
   ].join("\n")
@@ -31,6 +33,7 @@ export const Input = Schema.Struct({
 
 export const Output = Schema.Struct({
   sessionID: SessionSchema.ID,
+  workspaceID: Schema.optionalKey(Workspace.ID),
   status: Schema.Literals(["completed", "running"]),
   output: Schema.String,
 })
@@ -49,6 +52,7 @@ export const Plugin = {
     const agents = yield* Agent.Service
     const config = yield* Config.Service
     const permission = yield* Permission.Service
+    const workspaces = Option.getOrUndefined(yield* Effect.serviceOption(Workspace.Service))
     const scope = yield* Scope.Scope
 
     // Concatenate the child's final completed assistant text. Distinguishes "completed with no
@@ -165,9 +169,24 @@ export const Plugin = {
 
               // Model selection is policy/config/session state, not an LLM-facing tool argument.
               const model = agent.model ?? parent.model
+              if (parent.location.workspaceID && !workspaces)
+                return yield* new ToolFailure({ message: "Workspace forking is unavailable in this server profile" })
+              const fork =
+                parent.location.workspaceID && workspaces
+                  ? yield* workspaces.fork(parent.location.workspaceID).pipe(
+                      Effect.mapError(
+                        (error) =>
+                          new ToolFailure({
+                            message: `Failed to fork workspace ${parent.location.workspaceID}`,
+                            error,
+                          }),
+                      ),
+                    )
+                  : undefined
               const child = yield* runtime.session
                 .create({
                   parentID: context.sessionID,
+                  location: fork ? { ...parent.location, workspaceID: fork.id } : undefined,
                   title: input.description,
                   agent: Agent.ID.make(input.agent),
                   model,
@@ -175,6 +194,9 @@ export const Plugin = {
                   // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
                 })
                 .pipe(
+                  Effect.onError(() =>
+                    fork && workspaces ? workspaces.destroy(fork.id).pipe(Effect.ignore) : Effect.void,
+                  ),
                   Effect.mapError(
                     (error) => new ToolFailure({ message: `Parent session not found: ${context.sessionID}`, error }),
                   ),
@@ -187,7 +209,15 @@ export const Plugin = {
                 // The child session owns its agent/model (set at create); prompt only admits input.
                 yield* runtime.session.prompt({
                   sessionID: child.id,
-                  text: ["You are a subagent spawned by another session.", input.prompt].join("\n"),
+                  text: [
+                    "You are a subagent spawned by another session.",
+                    ...(fork
+                      ? [
+                          `You are working in isolated workspace ${fork.id}. Commit all intended changes before your final response and include the commit hash.`,
+                        ]
+                      : []),
+                    input.prompt,
+                  ].join("\n"),
                   resume: false,
                 })
                 yield* runtime.session.resume(child.id)
@@ -207,8 +237,9 @@ export const Plugin = {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {
                   sessionID: child.id,
+                  ...(fork ? { workspaceID: fork.id } : {}),
                   status: "running" as const,
-                  output: backgroundStarted(child.id),
+                  output: backgroundStarted(child.id, fork?.id),
                 }
               }
 
@@ -223,19 +254,29 @@ export const Plugin = {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {
                   sessionID: child.id,
+                  ...(fork ? { workspaceID: fork.id } : {}),
                   status: "running" as const,
-                  output: backgroundStarted(child.id),
+                  output: backgroundStarted(child.id, fork?.id),
                 }
               }
               if (result?.info.status === "error")
                 return yield* new ToolFailure({ message: result.info.error ?? "Subagent failed" })
               if (result?.info.status === "cancelled") return yield* new ToolFailure({ message: "Subagent cancelled" })
-              return { sessionID: child.id, status: "completed" as const, output: result?.info.output ?? NO_TEXT }
+              return {
+                sessionID: child.id,
+                ...(fork ? { workspaceID: fork.id } : {}),
+                status: "completed" as const,
+                output: result?.info.output ?? NO_TEXT,
+              }
             }).pipe(
               Effect.map((output) => ({
                 output,
                 content: output.output,
-                metadata: { sessionID: output.sessionID, status: output.status },
+                metadata: {
+                  sessionID: output.sessionID,
+                  ...(output.workspaceID ? { workspaceID: output.workspaceID } : {}),
+                  status: output.status,
+                },
               })),
             ),
         }),

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -27,6 +27,9 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("Workspace.Not
 
 export interface Interface {
   readonly create: (provider: string) => Effect.Effect<Info, WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  readonly fork: (
+    source: ID,
+  ) => Effect.Effect<Info, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
   readonly connect: (
     workspaceID: ID,
   ) => Effect.Effect<EnvironmentDriver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
@@ -152,15 +155,12 @@ const layer = (options: Options) =>
       return Service.of({
         create: Effect.fn("Workspace.create")(function* (provider) {
           const driver = yield* registry.get(provider)
-          const workspaceID = ID.create()
-          const result = yield* driver.create({ workspaceID })
-          const now = yield* Clock.currentTimeMillis
-          yield* db
-            .insert(WorkspaceTable)
-            .values({ id: workspaceID, provider, binding: result.binding, created_at: now, last_used_at: now })
-            .run()
-            .pipe(Effect.orDie)
-          return new Info({ id: workspaceID, provider, binding: result.binding, createdAt: now, lastUsedAt: now })
+          return yield* createWorkspace(driver, provider)
+        }),
+        fork: Effect.fn("Workspace.fork")(function* (sourceID) {
+          const source = yield* load(sourceID)
+          const driver = yield* registry.get(source.provider)
+          return yield* createWorkspace(driver, source.provider, source)
         }),
         connect: Effect.fn("Workspace.connect")(function* (workspaceID) {
           const spawner = make((command) =>
@@ -209,6 +209,27 @@ const layer = (options: Options) =>
           )
         }),
       })
+
+      function createWorkspace(
+        driver: WorkspaceDriver.Interface,
+        provider: string,
+        source?: typeof WorkspaceTable.$inferSelect,
+      ) {
+        return Effect.gen(function* () {
+          const workspaceID = ID.create()
+          const result = yield* driver.create({
+            workspaceID,
+            source: source ? { workspaceID: ID.make(source.id), binding: source.binding } : undefined,
+          })
+          const now = yield* Clock.currentTimeMillis
+          yield* db
+            .insert(WorkspaceTable)
+            .values({ id: workspaceID, provider, binding: result.binding, created_at: now, last_used_at: now })
+            .run()
+            .pipe(Effect.orDie)
+          return new Info({ id: workspaceID, provider, binding: result.binding, createdAt: now, lastUsedAt: now })
+        })
+      }
     }),
   )
 

--- a/packages/core/src/workspace/driver.ts
+++ b/packages/core/src/workspace/driver.ts
@@ -23,9 +23,15 @@ export class ProviderNotFound extends Schema.TaggedErrorClass<ProviderNotFound>(
   provider: Schema.String,
 }) {}
 
+export interface Source {
+  readonly workspaceID: Workspace.ID
+  readonly binding: Binding
+}
+
 export interface Interface {
   readonly create: (input: {
     readonly workspaceID: Workspace.ID
+    readonly source?: Source
   }) => Effect.Effect<{ readonly binding: Binding }, Error>
   readonly connect: (input: {
     readonly workspaceID: Workspace.ID

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -70,7 +70,7 @@ const logEvents = (session: Session.Interface, sessionID: Session.ID, follow?: b
 const assertCreateInputTypes = (session: Session.Interface) => {
   // @ts-expect-error location or parentID is required.
   session.create({})
-  // @ts-expect-error child sessions inherit their parent's location.
+  // Child sessions may explicitly override their parent's location for isolated workspaces.
   session.create({ parentID: Session.ID.create(), location })
 }
 void assertCreateInputTypes
@@ -215,6 +215,17 @@ describe("Session.create", () => {
       const child = yield* session.create({ parentID: parent.id, title: "child" })
 
       expect(child).toMatchObject({ parentID: parent.id, location })
+    }),
+  )
+
+  it.effect("uses an explicit child location for workspace isolation", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const parent = yield* session.create({ location })
+      const isolated = Location.Ref.make({ directory: location.directory, workspaceID: Workspace.ID.create() })
+      const child = yield* session.create({ parentID: parent.id, location: isolated, title: "child" })
+
+      expect(child).toMatchObject({ parentID: parent.id, location: isolated })
     }),
   )
 

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -28,6 +28,9 @@ import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Permission } from "@opencode-ai/core/permission"
 import { SubagentTool } from "@opencode-ai/core/tool/plugin/subagent"
 import { Tool } from "@opencode-ai/core/tool"
+import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
@@ -112,6 +115,7 @@ const nodes = LayerNode.group([
   SessionExecution.node,
   PluginRuntime.providerNode,
   LocationServiceMap.node,
+  Workspace.node,
 ])
 const replacements = [
   [SessionExecution.node, executionNode],
@@ -119,6 +123,23 @@ const replacements = [
 ] satisfies LayerNode.Replacements
 const productionIt = testEffect(AppNodeBuilder.build(nodes, replacements))
 const it = testEffect(AppNodeBuilder.build(nodes, [...replacements, [PluginSupervisor.node, subagentPluginSupervisor]]))
+const workspaceCreates: Array<WorkspaceDriver.Source | undefined> = []
+const workspaceDriver = WorkspaceDriver.make({
+  create: ({ workspaceID, source }) => {
+    workspaceCreates.push(source)
+    return Effect.succeed({ binding: { workspaceID } })
+  },
+  connect: () => Effect.succeed(makeMemoryDriver()),
+  suspendForIdle: () => Effect.void,
+  destroy: () => Effect.void,
+})
+const workspaceIt = testEffect(
+  AppNodeBuilder.build(nodes, [
+    ...replacements,
+    [PluginSupervisor.node, subagentPluginSupervisor],
+    [WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: workspaceDriver })],
+  ]),
+)
 
 const withSubagent = (location: Location.Ref) =>
   Effect.gen(function* () {
@@ -321,6 +342,46 @@ describe("SubagentTool", () => {
           })
           const fallbackChild = yield* sessions.get(outputSessionID(fallback.metadata))
           expect(fallbackChild).toMatchObject({ parentID: parent.id, model: parentModel })
+        }),
+      ),
+    ),
+  )
+
+  workspaceIt.live("forks workspace-backed subagents into isolated locations", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          workspaceCreates.splice(0)
+          const workspaces = yield* Workspace.Service
+          const base = yield* workspaces.create("fake")
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path), workspaceID: base.id })
+          const sessions = yield* Session.Service
+          const parent = yield* sessions.create({ location, model: parentModel })
+          yield* withSubagent(parent.location)
+          const locations = yield* LocationServiceMap.Service
+          const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
+
+          const settled = yield* executeTool(registry, {
+            sessionID: parent.id,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-isolated-subagent",
+              name: SubagentTool.name,
+              input: { agent: "reviewer", description: "isolated", prompt: "change this" },
+            },
+          })
+          const child = yield* sessions.get(outputSessionID(settled.metadata))
+
+          expect(child.location.workspaceID).not.toBe(base.id)
+          expect(settled.metadata).toMatchObject({ workspaceID: child.location.workspaceID })
+          expect(workspaceCreates[1]).toEqual({ workspaceID: base.id, binding: base.binding })
+          expect((yield* sessions.inbox(child.id)).find((message) => message.type === "user")?.payload.text).toContain(
+            `You are working in isolated workspace ${child.location.workspaceID}`,
+          )
         }),
       ),
     ),

--- a/packages/core/test/workspace.test.ts
+++ b/packages/core/test/workspace.test.ts
@@ -12,13 +12,17 @@ import { TestClock } from "effect/testing"
 import { ChildProcess } from "effect/unstable/process"
 import { testEffect } from "./lib/effect"
 
-const calls: Array<{ readonly operation: string; readonly binding?: WorkspaceDriver.Binding }> = []
+const calls: Array<{
+  readonly operation: string
+  readonly binding?: WorkspaceDriver.Binding
+  readonly source?: WorkspaceDriver.Source
+}> = []
 const memory = makeMemoryDriver()
 let failConnect = false
 
 const driver = WorkspaceDriver.make({
-  create: ({ workspaceID }) => {
-    calls.push({ operation: "create" })
+  create: ({ workspaceID, source }) => {
+    calls.push({ operation: "create", source })
     return Effect.succeed({ binding: { workspaceID, generation: 0 } })
   },
   connect: ({ binding }) => {
@@ -39,7 +43,7 @@ const driver = WorkspaceDriver.make({
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([Database.node, Workspace.configured({ idleThreshold: "5 minutes", pollInterval: "1 minute" })]),
-    [[WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: driver })]],
+    [[WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: driver, other: driver })]],
   ),
 )
 
@@ -91,6 +95,17 @@ it.effect("persists the workspace lifecycle and reconnects after idle suspension
 
     yield* workspace.destroy(created.id)
     expect(calls.at(-1)?.operation).toBe("destroy")
+  }),
+)
+
+it.effect("forks from a workspace owned by the same provider", () =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+    const source = yield* workspace.create("fake")
+    const fork = yield* workspace.fork(source.id)
+
+    expect(fork.id).not.toBe(source.id)
+    expect(calls[1]?.source).toEqual({ workspaceID: source.id, binding: source.binding })
   }),
 )
 

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -64,6 +64,7 @@ export const create = Effect.fn("OpenCode.create")(function* (options: CreateOpt
     events: client.event,
     workspace: {
       create: ({ provider }: { readonly provider: string }) => workspace.create(provider),
+      fork: ({ source }: { readonly source: Workspace.ID }) => workspace.fork(source),
       destroy: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => workspace.destroy(workspaceID),
     },
     // The embedded host contributes plugins through the ordinary discovery flow:

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -438,10 +438,14 @@ it.live("embedded client is available as a Layer service", () =>
 it.live("configures workspace providers through the SDK facade", () =>
   withEmbedded("opencode-embedded-workspace-", (fixture) =>
     Effect.gen(function* () {
-      const calls: Array<{ readonly operation: string; readonly workspaceID: string }> = []
+      const calls: Array<{
+        readonly operation: string
+        readonly workspaceID: string
+        readonly source?: WorkspaceDriver.Source
+      }> = []
       const driver = WorkspaceDriver.make({
-        create: ({ workspaceID }) => {
-          calls.push({ operation: "create", workspaceID })
+        create: ({ workspaceID, source }) => {
+          calls.push({ operation: "create", workspaceID, source })
           return Effect.succeed({ binding: { externalID: workspaceID } })
         },
         connect: ({ workspaceID }) => {
@@ -459,7 +463,14 @@ it.live("configures workspace providers through the SDK facade", () =>
 
       expect(workspace.provider).toBe("fake")
       expect(workspace.binding).toEqual({ externalID: workspace.id })
-      expect(calls).toEqual([{ operation: "create", workspaceID: workspace.id }])
+      expect(calls).toEqual([{ operation: "create", workspaceID: workspace.id, source: undefined }])
+
+      const fork = yield* opencode.workspace.fork({ source: workspace.id })
+      expect(calls[1]).toEqual({
+        operation: "create",
+        workspaceID: fork.id,
+        source: { workspaceID: workspace.id, binding: workspace.binding },
+      })
 
       const workspaceLocation = fixture.sdk.Location.Ref.make({
         directory: fixture.sdk.AbsolutePath.make("/"),
@@ -469,7 +480,7 @@ it.live("configures workspace providers through the SDK facade", () =>
       expect(session.location.workspaceID).toBe(workspace.id)
 
       yield* opencode.workspace.destroy({ workspaceID: workspace.id })
-      expect(calls.map((call) => call.operation)).toEqual(["create", "destroy"])
+      expect(calls.map((call) => call.operation)).toEqual(["create", "create", "destroy"])
       expect((yield* opencode.workspace.destroy({ workspaceID: workspace.id }).pipe(Effect.flip))._tag).toBe(
         "Workspace.NotFound",
       )

--- a/packages/workspace-incus/README.md
+++ b/packages/workspace-incus/README.md
@@ -1,0 +1,34 @@
+# Incus workspace provider
+
+This package turns an Incus container or VM into an opencode workspace. New workspaces copy a stopped blueprint instance; forks copy an existing workspace. All child processes and default filesystem operations cross `incus exec`, so the coordinator does not need a shared checkout.
+
+The blueprint and workspace instances may be containers or VMs. Containers fork faster; VMs provide a stronger kernel boundary.
+
+When a session already has a workspace, the built-in `subagent` tool snapshots and forks it automatically. The child session receives the forked workspace ID and is instructed to commit its changes. Local sessions keep the existing shared-directory behavior.
+
+```ts
+import { IncusWorkspace } from "@opencode-ai/workspace-incus"
+import { OpenCode } from "@opencode-ai/sdk-next"
+import { Effect } from "effect"
+
+const program = Effect.gen(function* () {
+  const incus = yield* IncusWorkspace.make({
+    remote: "IncusMini",
+    project: "opencode",
+    blueprint: "opencode-blueprint",
+    user: 1000,
+    group: 1000,
+  })
+  const opencode = yield* OpenCode.create({ workspaceProviders: { incus } })
+
+  const base = yield* opencode.workspace.create({ provider: "incus" })
+  const fork = yield* opencode.workspace.fork({ source: base.id })
+  return { opencode, base, fork }
+})
+```
+
+The coordinator needs the `incus` CLI and access to the configured remote/project. Use a dedicated Incus project and a restricted client certificate or broker; do not give the coordinator unrestricted access to the Incus server.
+
+The blueprint should be stopped and should contain the repository at the same absolute path used in session locations. It also needs the tools agents will invoke (`git`, a POSIX shell, coreutils, language runtimes, and project dependencies). No provider credentials are copied into workspace bindings or forwarded from the coordinator environment; only environment variables explicitly attached to each child-process command cross the boundary.
+
+Forks take a temporary Incus snapshot before copying, then remove it. The project therefore needs permission to create snapshots. Workspace bindings contain only the remote, project, instance name, lifecycle state, and format version.

--- a/packages/workspace-incus/package.json
+++ b/packages/workspace-incus/package.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@opencode-ai/workspace-incus",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsgo -b"
+  },
+  "dependencies": {
+    "@opencode-ai/core": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@tsconfig/bun": "catalog:",
+    "@types/bun": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/packages/workspace-incus/src/incus.ts
+++ b/packages/workspace-incus/src/incus.ts
@@ -1,0 +1,215 @@
+import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
+import { Effect, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+
+export interface Options {
+  readonly blueprint: string
+  readonly remote?: string
+  readonly project?: string
+  readonly blueprintRemote?: string
+  readonly blueprintProject?: string
+  readonly binary?: string
+  readonly instancePrefix?: string
+  readonly user?: number
+  readonly group?: number
+}
+
+interface Binding extends WorkspaceDriver.Binding {
+  readonly version: 1
+  readonly remote: string
+  readonly project: string
+  readonly instance: string
+  readonly state: "running" | "stopped"
+}
+
+export const make = (options: Options) =>
+  ChildProcessSpawner.ChildProcessSpawner.use((spawner) => Effect.succeed(makeWith(spawner, options)))
+
+export const makeWith = (
+  host: ChildProcessSpawner.ChildProcessSpawner["Service"],
+  options: Options,
+): WorkspaceDriver.Interface => {
+  const binary = options.binary ?? "incus"
+  const remote = options.remote ?? "local"
+  const project = options.project ?? "default"
+  const blueprintRemote = options.blueprintRemote ?? remote
+  const blueprintProject = options.blueprintProject ?? project
+  const prefix = options.instancePrefix ?? "opencode-"
+
+  const command = (args: ReadonlyArray<string>) => ChildProcess.make(binary, args)
+  const run = Effect.fn("IncusWorkspace.run")(function* (args: ReadonlyArray<string>) {
+    const result = yield* Effect.scoped(
+      host.spawn(command(args)).pipe(
+        Effect.flatMap((handle) =>
+          Effect.all(
+            {
+              output: Stream.mkString(Stream.decodeText(handle.all)),
+              code: handle.exitCode,
+            },
+            { concurrency: "unbounded" },
+          ),
+        ),
+      ),
+    ).pipe(
+      Effect.mapError(
+        (cause) => new WorkspaceDriver.Error({ message: `Failed to run ${binary} ${args.join(" ")}`, cause }),
+      ),
+    )
+    if (Number(result.code) === 0) return result.output
+    return yield* new WorkspaceDriver.Error({
+      message: `${binary} ${args.join(" ")} exited with code ${result.code}: ${result.output.trim()}`,
+    })
+  })
+
+  const lifecycle = (operation: string, binding: Binding, extra: ReadonlyArray<string> = []) =>
+    run([operation, `${binding.remote}:${binding.instance}`, "--project", binding.project, ...extra])
+
+  const start = (binding: Binding) =>
+    lifecycle("start", binding).pipe(Effect.as({ ...binding, state: "running" } satisfies Binding))
+
+  const parse = (value: WorkspaceDriver.Binding) => {
+    const version = value.version
+    const binding: Binding | undefined =
+      version === 1 &&
+      typeof value.remote === "string" &&
+      typeof value.project === "string" &&
+      typeof value.instance === "string" &&
+      (value.state === "running" || value.state === "stopped")
+        ? {
+            version,
+            remote: value.remote,
+            project: value.project,
+            instance: value.instance,
+            state: value.state,
+          }
+        : undefined
+    return binding
+      ? Effect.succeed(binding)
+      : Effect.fail(new WorkspaceDriver.Error({ message: "Invalid Incus workspace binding" }))
+  }
+
+  return WorkspaceDriver.make({
+    create: ({ workspaceID, source }) =>
+      Effect.gen(function* () {
+        const instance = `${prefix}${workspaceID.replaceAll("_", "-")}`
+        const sourceBinding = source ? yield* parse(source.binding) : undefined
+        const sourceRemote = sourceBinding?.remote ?? blueprintRemote
+        const sourceProject = sourceBinding?.project ?? blueprintProject
+        const binding: Binding = { version: 1, remote, project, instance, state: "stopped" }
+        const copy = (sourceInstance: string) =>
+          run([
+            "copy",
+            `${sourceRemote}:${sourceInstance}`,
+            `${remote}:${instance}`,
+            "--project",
+            sourceProject,
+            "--target-project",
+            project,
+            "--instance-only",
+          ])
+        if (!sourceBinding) yield* copy(options.blueprint)
+        if (sourceBinding) {
+          const snapshot = `opencode-fork-${workspaceID.replaceAll("_", "-")}`
+          yield* run([
+            "snapshot",
+            "create",
+            `${sourceRemote}:${sourceBinding.instance}`,
+            snapshot,
+            "--project",
+            sourceProject,
+            "--no-expiry",
+          ])
+          yield* copy(`${sourceBinding.instance}/${snapshot}`).pipe(
+            Effect.ensuring(
+              run([
+                "snapshot",
+                "delete",
+                `${sourceRemote}:${sourceBinding.instance}`,
+                snapshot,
+                "--project",
+                sourceProject,
+              ]).pipe(Effect.ignore),
+            ),
+          )
+        }
+        const running = yield* start(binding).pipe(
+          Effect.onError(() => lifecycle("delete", binding, ["--force"]).pipe(Effect.ignore)),
+        )
+        return { binding: running }
+      }),
+    connect: ({ binding, saveBinding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        const active = current.state === "running" ? current : yield* start(current)
+        if (active !== current) yield* saveBinding(active)
+        return {
+          spawner: ChildProcessSpawner.make((input) => host.spawn(remoteCommand(input, active, options))),
+        }
+      }),
+    suspendForIdle: ({ binding, saveBinding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        if (current.state === "stopped") return
+        yield* lifecycle("stop", current, ["--force"])
+        yield* saveBinding({ ...current, state: "stopped" } satisfies Binding)
+      }),
+    destroy: ({ binding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        yield* lifecycle("delete", current, ["--force"])
+      }),
+  })
+}
+
+const remoteCommand = (command: ChildProcess.Command, binding: Binding, options: Options): ChildProcess.Command => {
+  if (command._tag === "PipedCommand")
+    return remoteCommand(command.left, binding, options).pipe(
+      ChildProcess.pipeTo(remoteCommand(command.right, binding, options), command.options),
+    )
+
+  const environment = Object.entries(command.options.env ?? {}).flatMap(([key, value]) =>
+    value === undefined ? [] : ["--env", `${key}=${value}`],
+  )
+  const identity = [
+    ...(options.user === undefined ? [] : ["--user", String(options.user)]),
+    ...(options.group === undefined ? [] : ["--group", String(options.group)]),
+  ]
+  const executable = shellCommand(command)
+  return ChildProcess.make(
+    options.binary ?? "incus",
+    [
+      "exec",
+      `${binding.remote}:${binding.instance}`,
+      "--project",
+      binding.project,
+      "--force-noninteractive",
+      ...(command.options.cwd ? ["--cwd", command.options.cwd] : []),
+      ...identity,
+      ...environment,
+      "--",
+      executable.command,
+      ...executable.args,
+    ],
+    transportOptions(command.options),
+  )
+}
+
+const shellCommand = (command: ChildProcess.StandardCommand) => {
+  if (!command.options.shell) return { command: command.command, args: command.args }
+  const shell = typeof command.options.shell === "string" ? command.options.shell : "/bin/sh"
+  return {
+    command: shell,
+    args: ["-c", [command.command, ...command.args].map(shellQuote).join(" ")],
+  }
+}
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
+
+const transportOptions = (options: ChildProcess.CommandOptions): ChildProcess.CommandOptions => ({
+  detached: options.detached,
+  stdin: options.stdin,
+  stdout: options.stdout,
+  stderr: options.stderr,
+  killSignal: options.killSignal,
+  forceKillAfter: options.forceKillAfter,
+})

--- a/packages/workspace-incus/src/index.ts
+++ b/packages/workspace-incus/src/index.ts
@@ -1,0 +1,1 @@
+export * as IncusWorkspace from "./incus.js"

--- a/packages/workspace-incus/test/incus.test.ts
+++ b/packages/workspace-incus/test/incus.test.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { Effect, Sink, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { ExitCode, makeHandle, ProcessId } from "effect/unstable/process/ChildProcessSpawner"
+import { IncusWorkspace } from "../src"
+
+const text = new TextEncoder()
+
+const host = (commands: Array<ChildProcess.Command>, failures: Set<string> = new Set()) =>
+  ChildProcessSpawner.make((command) => {
+    commands.push(command)
+    const operation = command._tag === "StandardCommand" ? command.args[0] : "pipeline"
+    const code = failures.has(operation ?? "") ? 1 : 0
+    const output = code === 0 ? new Uint8Array() : text.encode(`${operation} failed`)
+    return Effect.succeed(
+      makeHandle({
+        pid: ProcessId(commands.length),
+        exitCode: Effect.succeed(ExitCode(code)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: Sink.drain,
+        stdout: Stream.empty,
+        stderr: Stream.empty,
+        all: output.length === 0 ? Stream.empty : Stream.make(output),
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      }),
+    )
+  })
+
+const standard = (command: ChildProcess.Command) => {
+  expect(command._tag).toBe("StandardCommand")
+  if (command._tag !== "StandardCommand") throw new Error("Expected a standard command")
+  return command
+}
+
+test("copies a blueprint and manages the instance lifecycle", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = IncusWorkspace.makeWith(host(commands), {
+    remote: "IncusMini",
+    project: "opencode",
+    blueprint: "blueprint",
+    user: 1000,
+    group: 1000,
+  })
+  const workspaceID = Workspace.ID.create()
+  const created = await Effect.runPromise(driver.create({ workspaceID }))
+
+  expect(standard(commands[0]).args).toEqual([
+    "copy",
+    "IncusMini:blueprint",
+    `IncusMini:opencode-${workspaceID.replaceAll("_", "-")}`,
+    "--project",
+    "opencode",
+    "--target-project",
+    "opencode",
+    "--instance-only",
+  ])
+  expect(standard(commands[1]).args[0]).toBe("start")
+
+  const saved: Array<Record<string, unknown>> = []
+  const environment = await Effect.runPromise(
+    Effect.scoped(
+      driver.connect({
+        workspaceID,
+        binding: created.binding,
+        saveBinding: (binding) => Effect.sync(() => saved.push(binding)),
+      }),
+    ),
+  )
+  await Effect.runPromise(
+    Effect.scoped(
+      environment.spawner.spawn(
+        ChildProcess.make("git", ["status", "--short"], {
+          cwd: "/workspace/repo",
+          env: { CI: "1", OMITTED: undefined },
+        }),
+      ),
+    ),
+  )
+  const exec = standard(commands.at(-1)!)
+  expect(exec.args).toEqual([
+    "exec",
+    `IncusMini:opencode-${workspaceID.replaceAll("_", "-")}`,
+    "--project",
+    "opencode",
+    "--force-noninteractive",
+    "--cwd",
+    "/workspace/repo",
+    "--user",
+    "1000",
+    "--group",
+    "1000",
+    "--env",
+    "CI=1",
+    "--",
+    "git",
+    "status",
+    "--short",
+  ])
+  expect(exec.args.join(" ")).not.toContain("OMITTED")
+
+  await Effect.runPromise(
+    driver.suspendForIdle({
+      workspaceID,
+      binding: created.binding,
+      saveBinding: (binding) => Effect.sync(() => saved.push(binding)),
+    }),
+  )
+  expect(standard(commands.at(-1)!).args[0]).toBe("stop")
+  expect(saved.at(-1)).toMatchObject({ state: "stopped" })
+
+  await Effect.runPromise(driver.destroy({ workspaceID, binding: saved.at(-1)! }))
+  expect(standard(commands.at(-1)!).args[0]).toBe("delete")
+})
+
+test("forks from the source workspace binding", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = IncusWorkspace.makeWith(host(commands), {
+    remote: "target",
+    project: "target-project",
+    blueprint: "unused",
+  })
+  const sourceID = Workspace.ID.create()
+  await Effect.runPromise(
+    driver.create({
+      workspaceID: Workspace.ID.create(),
+      source: {
+        workspaceID: sourceID,
+        binding: {
+          version: 1,
+          remote: "source",
+          project: "source-project",
+          instance: "source-instance",
+          state: "running",
+        },
+      },
+    }),
+  )
+
+  expect(standard(commands[0]).args.slice(0, 3)).toEqual(["snapshot", "create", "source:source-instance"])
+  expect(standard(commands[1]).args.slice(0, 7)).toEqual([
+    "copy",
+    expect.stringMatching(/^source:source-instance\/opencode-fork-wrk-/),
+    expect.stringMatching(/^target:opencode-wrk-/),
+    "--project",
+    "source-project",
+    "--target-project",
+    "target-project",
+  ])
+  expect(standard(commands[2]).args.slice(0, 3)).toEqual(["snapshot", "delete", "source:source-instance"])
+})
+
+test("removes a partial instance when startup fails", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = IncusWorkspace.makeWith(host(commands, new Set(["start"])), {
+    blueprint: "blueprint",
+  })
+  const result = await Effect.runPromiseExit(driver.create({ workspaceID: Workspace.ID.create() }))
+
+  expect(result._tag).toBe("Failure")
+  expect(commands.map((command) => standard(command).args[0])).toEqual(["copy", "start", "delete"])
+})

--- a/packages/workspace-incus/tsconfig.json
+++ b/packages/workspace-incus/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noUncheckedIndexedAccess": false,
+    "outDir": "node_modules/.ts-dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- add an Incus-backed workspace provider for container or VM blueprints
- add snapshot-based workspace forking and expose it through SDK Next
- fork workspace-backed subagents into isolated child locations
- stop idle instances, wake them on demand, and clean up failed starts

## Validation

- `packages/workspace-incus`: 3 tests, typecheck, lint
- `packages/core`: workspace, session-create, and subagent tests; typecheck
- `packages/sdk-next`: embedded tests; typecheck
- full monorepo typecheck via pre-push hook