### PR TITLE
feat(core): add Docker blueprint workspaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1025,6 +1025,19 @@
         "typescript": "catalog:",
       },
     },
+    "packages/workspace-docker": {
+      "name": "@opencode-ai/workspace-docker",
+      "version": "0.0.0",
+      "dependencies": {
+        "@opencode-ai/core": "workspace:*",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@tsconfig/bun": "catalog:",
+        "@types/bun": "catalog:",
+        "@typescript/native-preview": "catalog:",
+      },
+    },
     "packages/www": {
       "name": "@opencode-ai/www",
       "dependencies": {
@@ -2064,6 +2077,8 @@
     "@opencode-ai/util": ["@opencode-ai/util@workspace:packages/util"],
 
     "@opencode-ai/web": ["@opencode-ai/web@workspace:packages/web"],
+
+    "@opencode-ai/workspace-docker": ["@opencode-ai/workspace-docker@workspace:packages/workspace-docker"],
 
     "@opencode-ai/www": ["@opencode-ai/www@workspace:packages/www"],
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -95,7 +95,7 @@ type CreateBaseInput = {
   model?: Model.Ref
 }
 type CreateInput = CreateBaseInput &
-  ({ location: Location.Ref; parentID?: never } | { parentID: SessionSchema.ID; location?: never })
+  ({ location: Location.Ref; parentID?: never } | { parentID: SessionSchema.ID; location?: Location.Ref })
 
 type CompactInput = {
   id?: SessionMessage.ID
@@ -361,7 +361,7 @@ const layer = Layer.effect(
         if (recorded) return recorded
         const parent = input.parentID ? yield* store.get(input.parentID) : undefined
         if (input.parentID && parent === undefined) return yield* new NotFoundError({ sessionID: input.parentID })
-        const location = parent?.location ?? input.location
+        const location = input.location ?? parent?.location
         if (location === undefined)
           return yield* Effect.die(new Error("Session.create requires either location or an existing parentID"))
         const project = yield* projects.resolve(location.directory)

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -2,19 +2,21 @@ export * as SubagentTool from "./subagent.js"
 
 import { ToolFailure } from "@opencode-ai/ai"
 import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
-import { Effect, Schema, Scope } from "effect"
+import { Effect, Option, Schema, Scope } from "effect"
 import { Agent } from "../../agent.js"
 import { Config } from "../../config.js"
 import { PluginRuntime } from "../../plugin/runtime.js"
 import { Permission } from "../../permission.js"
 import { SessionSchema } from "../../session/schema.js"
+import { Workspace } from "../../workspace.js"
 
 export const name = "subagent"
 
 const NO_TEXT = "Subagent completed without a text response."
-const backgroundStarted = (sessionID: SessionSchema.ID) =>
+const backgroundStarted = (sessionID: SessionSchema.ID, workspaceID?: Workspace.ID) =>
   [
     `The subagent is working in the background (id: ${sessionID}). You will be notified automatically when it finishes.`,
+    ...(workspaceID ? [`It is isolated in workspace ${workspaceID}.`] : []),
     "DO NOT sleep, poll for progress, ask the subagent for status, or duplicate this subagent's work; avoid working with the same files or topics it is using.",
     "Work on non-overlapping tasks, or briefly tell the user what you launched and end your response.",
   ].join("\n")
@@ -31,6 +33,7 @@ export const Input = Schema.Struct({
 
 export const Output = Schema.Struct({
   sessionID: SessionSchema.ID,
+  workspaceID: Schema.optionalKey(Workspace.ID),
   status: Schema.Literals(["completed", "running"]),
   output: Schema.String,
 })
@@ -49,6 +52,7 @@ export const Plugin = {
     const agents = yield* Agent.Service
     const config = yield* Config.Service
     const permission = yield* Permission.Service
+    const workspaces = Option.getOrUndefined(yield* Effect.serviceOption(Workspace.Service))
     const scope = yield* Scope.Scope
 
     // Concatenate the child's final completed assistant text. Distinguishes "completed with no
@@ -165,9 +169,24 @@ export const Plugin = {
 
               // Model selection is policy/config/session state, not an LLM-facing tool argument.
               const model = agent.model ?? parent.model
+              if (parent.location.workspaceID && !workspaces)
+                return yield* new ToolFailure({ message: "Workspace forking is unavailable in this server profile" })
+              const fork =
+                parent.location.workspaceID && workspaces
+                  ? yield* workspaces.fork(parent.location.workspaceID).pipe(
+                      Effect.mapError(
+                        (error) =>
+                          new ToolFailure({
+                            message: `Failed to fork workspace ${parent.location.workspaceID}`,
+                            error,
+                          }),
+                      ),
+                    )
+                  : undefined
               const child = yield* runtime.session
                 .create({
                   parentID: context.sessionID,
+                  location: fork ? { ...parent.location, workspaceID: fork.id } : undefined,
                   title: input.description,
                   agent: Agent.ID.make(input.agent),
                   model,
@@ -175,6 +194,9 @@ export const Plugin = {
                   // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
                 })
                 .pipe(
+                  Effect.onError(() =>
+                    fork && workspaces ? workspaces.destroy(fork.id).pipe(Effect.ignore) : Effect.void,
+                  ),
                   Effect.mapError(
                     (error) => new ToolFailure({ message: `Parent session not found: ${context.sessionID}`, error }),
                   ),
@@ -187,7 +209,15 @@ export const Plugin = {
                 // The child session owns its agent/model (set at create); prompt only admits input.
                 yield* runtime.session.prompt({
                   sessionID: child.id,
-                  text: ["You are a subagent spawned by another session.", input.prompt].join("\n"),
+                  text: [
+                    "You are a subagent spawned by another session.",
+                    ...(fork
+                      ? [
+                          `You are working in isolated workspace ${fork.id}. Commit all intended changes before your final response and include the commit hash.`,
+                        ]
+                      : []),
+                    input.prompt,
+                  ].join("\n"),
                   resume: false,
                 })
                 yield* runtime.session.resume(child.id)
@@ -207,8 +237,9 @@ export const Plugin = {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {
                   sessionID: child.id,
+                  ...(fork ? { workspaceID: fork.id } : {}),
                   status: "running" as const,
-                  output: backgroundStarted(child.id),
+                  output: backgroundStarted(child.id, fork?.id),
                 }
               }
 
@@ -223,19 +254,29 @@ export const Plugin = {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {
                   sessionID: child.id,
+                  ...(fork ? { workspaceID: fork.id } : {}),
                   status: "running" as const,
-                  output: backgroundStarted(child.id),
+                  output: backgroundStarted(child.id, fork?.id),
                 }
               }
               if (result?.info.status === "error")
                 return yield* new ToolFailure({ message: result.info.error ?? "Subagent failed" })
               if (result?.info.status === "cancelled") return yield* new ToolFailure({ message: "Subagent cancelled" })
-              return { sessionID: child.id, status: "completed" as const, output: result?.info.output ?? NO_TEXT }
+              return {
+                sessionID: child.id,
+                ...(fork ? { workspaceID: fork.id } : {}),
+                status: "completed" as const,
+                output: result?.info.output ?? NO_TEXT,
+              }
             }).pipe(
               Effect.map((output) => ({
                 output,
                 content: output.output,
-                metadata: { sessionID: output.sessionID, status: output.status },
+                metadata: {
+                  sessionID: output.sessionID,
+                  ...(output.workspaceID ? { workspaceID: output.workspaceID } : {}),
+                  status: output.status,
+                },
               })),
             ),
         }),

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -27,6 +27,9 @@ export class NotFound extends Schema.TaggedErrorClass<NotFound>()("Workspace.Not
 
 export interface Interface {
   readonly create: (provider: string) => Effect.Effect<Info, WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  readonly fork: (
+    source: ID,
+  ) => Effect.Effect<Info, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
   readonly connect: (
     workspaceID: ID,
   ) => Effect.Effect<EnvironmentDriver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
@@ -152,15 +155,12 @@ const layer = (options: Options) =>
       return Service.of({
         create: Effect.fn("Workspace.create")(function* (provider) {
           const driver = yield* registry.get(provider)
-          const workspaceID = ID.create()
-          const result = yield* driver.create({ workspaceID })
-          const now = yield* Clock.currentTimeMillis
-          yield* db
-            .insert(WorkspaceTable)
-            .values({ id: workspaceID, provider, binding: result.binding, created_at: now, last_used_at: now })
-            .run()
-            .pipe(Effect.orDie)
-          return new Info({ id: workspaceID, provider, binding: result.binding, createdAt: now, lastUsedAt: now })
+          return yield* createWorkspace(driver, provider)
+        }),
+        fork: Effect.fn("Workspace.fork")(function* (sourceID) {
+          const source = yield* load(sourceID)
+          const driver = yield* registry.get(source.provider)
+          return yield* createWorkspace(driver, source.provider, source)
         }),
         connect: Effect.fn("Workspace.connect")(function* (workspaceID) {
           const spawner = make((command) =>
@@ -209,6 +209,27 @@ const layer = (options: Options) =>
           )
         }),
       })
+
+      function createWorkspace(
+        driver: WorkspaceDriver.Interface,
+        provider: string,
+        source?: typeof WorkspaceTable.$inferSelect,
+      ) {
+        return Effect.gen(function* () {
+          const workspaceID = ID.create()
+          const result = yield* driver.create({
+            workspaceID,
+            source: source ? { workspaceID: ID.make(source.id), binding: source.binding } : undefined,
+          })
+          const now = yield* Clock.currentTimeMillis
+          yield* db
+            .insert(WorkspaceTable)
+            .values({ id: workspaceID, provider, binding: result.binding, created_at: now, last_used_at: now })
+            .run()
+            .pipe(Effect.orDie)
+          return new Info({ id: workspaceID, provider, binding: result.binding, createdAt: now, lastUsedAt: now })
+        })
+      }
     }),
   )
 

--- a/packages/core/src/workspace/driver.ts
+++ b/packages/core/src/workspace/driver.ts
@@ -23,9 +23,15 @@ export class ProviderNotFound extends Schema.TaggedErrorClass<ProviderNotFound>(
   provider: Schema.String,
 }) {}
 
+export interface Source {
+  readonly workspaceID: Workspace.ID
+  readonly binding: Binding
+}
+
 export interface Interface {
   readonly create: (input: {
     readonly workspaceID: Workspace.ID
+    readonly source?: Source
   }) => Effect.Effect<{ readonly binding: Binding }, Error>
   readonly connect: (input: {
     readonly workspaceID: Workspace.ID

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -70,7 +70,7 @@ const logEvents = (session: Session.Interface, sessionID: Session.ID, follow?: b
 const assertCreateInputTypes = (session: Session.Interface) => {
   // @ts-expect-error location or parentID is required.
   session.create({})
-  // @ts-expect-error child sessions inherit their parent's location.
+  // Child sessions may explicitly override their parent's location for isolated workspaces.
   session.create({ parentID: Session.ID.create(), location })
 }
 void assertCreateInputTypes
@@ -215,6 +215,17 @@ describe("Session.create", () => {
       const child = yield* session.create({ parentID: parent.id, title: "child" })
 
       expect(child).toMatchObject({ parentID: parent.id, location })
+    }),
+  )
+
+  it.effect("uses an explicit child location for workspace isolation", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const parent = yield* session.create({ location })
+      const isolated = Location.Ref.make({ directory: location.directory, workspaceID: Workspace.ID.create() })
+      const child = yield* session.create({ parentID: parent.id, location: isolated, title: "child" })
+
+      expect(child).toMatchObject({ parentID: parent.id, location: isolated })
     }),
   )
 

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -28,6 +28,9 @@ import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Permission } from "@opencode-ai/core/permission"
 import { SubagentTool } from "@opencode-ai/core/tool/plugin/subagent"
 import { Tool } from "@opencode-ai/core/tool"
+import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
@@ -112,6 +115,7 @@ const nodes = LayerNode.group([
   SessionExecution.node,
   PluginRuntime.providerNode,
   LocationServiceMap.node,
+  Workspace.node,
 ])
 const replacements = [
   [SessionExecution.node, executionNode],
@@ -119,6 +123,23 @@ const replacements = [
 ] satisfies LayerNode.Replacements
 const productionIt = testEffect(AppNodeBuilder.build(nodes, replacements))
 const it = testEffect(AppNodeBuilder.build(nodes, [...replacements, [PluginSupervisor.node, subagentPluginSupervisor]]))
+const workspaceCreates: Array<WorkspaceDriver.Source | undefined> = []
+const workspaceDriver = WorkspaceDriver.make({
+  create: ({ workspaceID, source }) => {
+    workspaceCreates.push(source)
+    return Effect.succeed({ binding: { workspaceID } })
+  },
+  connect: () => Effect.succeed(makeMemoryDriver()),
+  suspendForIdle: () => Effect.void,
+  destroy: () => Effect.void,
+})
+const workspaceIt = testEffect(
+  AppNodeBuilder.build(nodes, [
+    ...replacements,
+    [PluginSupervisor.node, subagentPluginSupervisor],
+    [WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: workspaceDriver })],
+  ]),
+)
 
 const withSubagent = (location: Location.Ref) =>
   Effect.gen(function* () {
@@ -321,6 +342,46 @@ describe("SubagentTool", () => {
           })
           const fallbackChild = yield* sessions.get(outputSessionID(fallback.metadata))
           expect(fallbackChild).toMatchObject({ parentID: parent.id, model: parentModel })
+        }),
+      ),
+    ),
+  )
+
+  workspaceIt.live("forks workspace-backed subagents into isolated locations", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          workspaceCreates.splice(0)
+          const workspaces = yield* Workspace.Service
+          const base = yield* workspaces.create("fake")
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path), workspaceID: base.id })
+          const sessions = yield* Session.Service
+          const parent = yield* sessions.create({ location, model: parentModel })
+          yield* withSubagent(parent.location)
+          const locations = yield* LocationServiceMap.Service
+          const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
+
+          const settled = yield* executeTool(registry, {
+            sessionID: parent.id,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-isolated-subagent",
+              name: SubagentTool.name,
+              input: { agent: "reviewer", description: "isolated", prompt: "change this" },
+            },
+          })
+          const child = yield* sessions.get(outputSessionID(settled.metadata))
+
+          expect(child.location.workspaceID).not.toBe(base.id)
+          expect(settled.metadata).toMatchObject({ workspaceID: child.location.workspaceID })
+          expect(workspaceCreates[1]).toEqual({ workspaceID: base.id, binding: base.binding })
+          expect((yield* sessions.inbox(child.id)).find((message) => message.type === "user")?.payload.text).toContain(
+            `You are working in isolated workspace ${child.location.workspaceID}`,
+          )
         }),
       ),
     ),

--- a/packages/core/test/workspace.test.ts
+++ b/packages/core/test/workspace.test.ts
@@ -12,13 +12,17 @@ import { TestClock } from "effect/testing"
 import { ChildProcess } from "effect/unstable/process"
 import { testEffect } from "./lib/effect"
 
-const calls: Array<{ readonly operation: string; readonly binding?: WorkspaceDriver.Binding }> = []
+const calls: Array<{
+  readonly operation: string
+  readonly binding?: WorkspaceDriver.Binding
+  readonly source?: WorkspaceDriver.Source
+}> = []
 const memory = makeMemoryDriver()
 let failConnect = false
 
 const driver = WorkspaceDriver.make({
-  create: ({ workspaceID }) => {
-    calls.push({ operation: "create" })
+  create: ({ workspaceID, source }) => {
+    calls.push({ operation: "create", source })
     return Effect.succeed({ binding: { workspaceID, generation: 0 } })
   },
   connect: ({ binding }) => {
@@ -39,7 +43,7 @@ const driver = WorkspaceDriver.make({
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([Database.node, Workspace.configured({ idleThreshold: "5 minutes", pollInterval: "1 minute" })]),
-    [[WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: driver })]],
+    [[WorkspaceDriver.node, WorkspaceDriver.registryNode({ fake: driver, other: driver })]],
   ),
 )
 
@@ -91,6 +95,17 @@ it.effect("persists the workspace lifecycle and reconnects after idle suspension
 
     yield* workspace.destroy(created.id)
     expect(calls.at(-1)?.operation).toBe("destroy")
+  }),
+)
+
+it.effect("forks from a workspace owned by the same provider", () =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+    const source = yield* workspace.create("fake")
+    const fork = yield* workspace.fork(source.id)
+
+    expect(fork.id).not.toBe(source.id)
+    expect(calls[1]?.source).toEqual({ workspaceID: source.id, binding: source.binding })
   }),
 )
 

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -64,6 +64,7 @@ export const create = Effect.fn("OpenCode.create")(function* (options: CreateOpt
     events: client.event,
     workspace: {
       create: ({ provider }: { readonly provider: string }) => workspace.create(provider),
+      fork: ({ source }: { readonly source: Workspace.ID }) => workspace.fork(source),
       destroy: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => workspace.destroy(workspaceID),
     },
     // The embedded host contributes plugins through the ordinary discovery flow:

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -438,10 +438,14 @@ it.live("embedded client is available as a Layer service", () =>
 it.live("configures workspace providers through the SDK facade", () =>
   withEmbedded("opencode-embedded-workspace-", (fixture) =>
     Effect.gen(function* () {
-      const calls: Array<{ readonly operation: string; readonly workspaceID: string }> = []
+      const calls: Array<{
+        readonly operation: string
+        readonly workspaceID: string
+        readonly source?: WorkspaceDriver.Source
+      }> = []
       const driver = WorkspaceDriver.make({
-        create: ({ workspaceID }) => {
-          calls.push({ operation: "create", workspaceID })
+        create: ({ workspaceID, source }) => {
+          calls.push({ operation: "create", workspaceID, source })
           return Effect.succeed({ binding: { externalID: workspaceID } })
         },
         connect: ({ workspaceID }) => {
@@ -459,7 +463,14 @@ it.live("configures workspace providers through the SDK facade", () =>
 
       expect(workspace.provider).toBe("fake")
       expect(workspace.binding).toEqual({ externalID: workspace.id })
-      expect(calls).toEqual([{ operation: "create", workspaceID: workspace.id }])
+      expect(calls).toEqual([{ operation: "create", workspaceID: workspace.id, source: undefined }])
+
+      const fork = yield* opencode.workspace.fork({ source: workspace.id })
+      expect(calls[1]).toEqual({
+        operation: "create",
+        workspaceID: fork.id,
+        source: { workspaceID: workspace.id, binding: workspace.binding },
+      })
 
       const workspaceLocation = fixture.sdk.Location.Ref.make({
         directory: fixture.sdk.AbsolutePath.make("/"),
@@ -469,7 +480,7 @@ it.live("configures workspace providers through the SDK facade", () =>
       expect(session.location.workspaceID).toBe(workspace.id)
 
       yield* opencode.workspace.destroy({ workspaceID: workspace.id })
-      expect(calls.map((call) => call.operation)).toEqual(["create", "destroy"])
+      expect(calls.map((call) => call.operation)).toEqual(["create", "create", "destroy"])
       expect((yield* opencode.workspace.destroy({ workspaceID: workspace.id }).pipe(Effect.flip))._tag).toBe(
         "Workspace.NotFound",
       )

--- a/packages/workspace-docker/README.md
+++ b/packages/workspace-docker/README.md
@@ -1,0 +1,45 @@
+# Docker workspace provider
+
+This package boots opencode workspaces from an immutable Docker snapshot on the coordinator host. It is designed for a long-lived development VM such as `devbox`: Docker and every blueprint build, snapshot image, workspace container, and checkout stay inside that VM. The opencode coordinator and model loop stay outside the workspace containers and only control them.
+
+A blueprint is the environment recipe; its build produces a frozen snapshot image. New root workspaces create fresh containers from that snapshot. The snapshot is never updated by a session. Forks use `docker commit --pause=true` to capture a mutable source workspace, create a child container from that temporary image, and immediately remove the temporary image tag. The repository must live in the container root filesystem; Docker volumes are intentionally not used because `docker commit` does not include them.
+
+When a session already has a workspace, the built-in `subagent` tool forks it automatically. The child session receives the forked workspace ID and is instructed to commit its changes. Local sessions keep the existing shared-directory behavior.
+
+Build a repository-specific blueprint into a deliberately versioned snapshot inside `devbox`:
+
+```sh
+docker build \
+  -f packages/workspace-docker/blueprint/Dockerfile \
+  --build-arg REPOSITORY=https://github.com/you/project.git \
+  --build-arg REF=your-branch \
+  --build-arg WORKSPACE_DIR=/absolute/path/used/by/the/coordinator \
+  -t opencode-snapshot:v1 \
+  .
+```
+
+Treat the resulting tag as immutable. When you intentionally change the base environment, build a new version instead of moving an existing tag. A Git repository is included here only because this example produces a ready-to-use project snapshot; Git is not part of workspace identity or forking.
+
+The absolute checkout path must match the session location used by the coordinator. This keeps project discovery correct while all actual file and process operations run inside the container.
+
+```ts
+import { DockerWorkspace } from "@opencode-ai/workspace-docker"
+import { OpenCode } from "@opencode-ai/sdk-next"
+import { Effect } from "effect"
+
+const program = Effect.gen(function* () {
+  const docker = yield* DockerWorkspace.make({
+    snapshot: "opencode-snapshot:v1",
+    user: "1000:1000",
+    cpus: 4,
+    memory: "8g",
+  })
+  const opencode = yield* OpenCode.create({ workspaceProviders: { docker } })
+
+  const base = yield* opencode.workspace.create({ provider: "docker" })
+  const fork = yield* opencode.workspace.fork({ source: base.id })
+  return { opencode, base, fork }
+})
+```
+
+The coordinator needs access only to its local Docker daemon. Containers never receive the Docker socket, host mounts, or coordinator environment by default. Only environment variables explicitly attached to a child-process command cross the boundary. Set `network: "none"` when a task does not need network access.

--- a/packages/workspace-docker/blueprint/Dockerfile
+++ b/packages/workspace-docker/blueprint/Dockerfile
@@ -1,0 +1,42 @@
+FROM debian:trixie-slim
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BUN_VERSION=1.3.14
+ARG TARGETARCH
+ARG REPOSITORY
+ARG REF=v2
+ARG WORKSPACE_DIR=/workspace
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    fd-find \
+    git \
+    jq \
+    node-gyp \
+    nodejs \
+    openssh-client \
+    python3 \
+    ripgrep \
+    unzip \
+    xz-utils \
+    zip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN case "$TARGETARCH" in amd64) bun_arch=x64 ;; arm64) bun_arch=aarch64 ;; *) exit 1 ;; esac \
+  && curl -fsSL "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${bun_arch}.zip" -o /tmp/bun.zip \
+  && mkdir -p /opt/bun \
+  && unzip -q /tmp/bun.zip -d /opt/bun \
+  && ln -s "/opt/bun/bun-linux-${bun_arch}/bun" /usr/local/bin/bun \
+  && rm /tmp/bun.zip
+
+RUN useradd --create-home --uid 1000 --shell /bin/bash opencode \
+  && test -n "$REPOSITORY" \
+  && git clone --branch "$REF" --single-branch "$REPOSITORY" "$WORKSPACE_DIR" \
+  && chown -R opencode:opencode "$WORKSPACE_DIR"
+
+USER opencode
+WORKDIR ${WORKSPACE_DIR}
+RUN bun install --frozen-lockfile

--- a/packages/workspace-docker/package.json
+++ b/packages/workspace-docker/package.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@opencode-ai/workspace-docker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsgo -b"
+  },
+  "dependencies": {
+    "@opencode-ai/core": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@tsconfig/bun": "catalog:",
+    "@types/bun": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/packages/workspace-docker/src/docker.ts
+++ b/packages/workspace-docker/src/docker.ts
@@ -1,0 +1,177 @@
+import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
+import { Effect, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+
+export interface Options {
+  /** Immutable image produced by a blueprint build. Prefer a digest or versioned tag. */
+  readonly snapshot: string
+  readonly binary?: string
+  readonly containerPrefix?: string
+  readonly user?: string
+  readonly network?: string
+  readonly cpus?: number
+  readonly memory?: string
+}
+
+interface Binding extends WorkspaceDriver.Binding {
+  readonly version: 1
+  readonly container: string
+  readonly state: "running" | "stopped"
+}
+
+export const make = (options: Options) =>
+  ChildProcessSpawner.ChildProcessSpawner.use((spawner) => Effect.succeed(makeWith(spawner, options)))
+
+export const makeWith = (
+  host: ChildProcessSpawner.ChildProcessSpawner["Service"],
+  options: Options,
+): WorkspaceDriver.Interface => {
+  const binary = options.binary ?? "docker"
+  const prefix = options.containerPrefix ?? "opencode-"
+
+  const command = (args: ReadonlyArray<string>) => ChildProcess.make(binary, args)
+  const run = Effect.fn("DockerWorkspace.run")(function* (args: ReadonlyArray<string>) {
+    const result = yield* Effect.scoped(
+      host.spawn(command(args)).pipe(
+        Effect.flatMap((handle) =>
+          Effect.all(
+            {
+              output: Stream.mkString(Stream.decodeText(handle.all)),
+              code: handle.exitCode,
+            },
+            { concurrency: "unbounded" },
+          ),
+        ),
+      ),
+    ).pipe(
+      Effect.mapError(
+        (cause) => new WorkspaceDriver.Error({ message: `Failed to run ${binary} ${args.join(" ")}`, cause }),
+      ),
+    )
+    if (Number(result.code) === 0) return result.output
+    return yield* new WorkspaceDriver.Error({
+      message: `${binary} ${args.join(" ")} exited with code ${result.code}: ${result.output.trim()}`,
+    })
+  })
+
+  const start = (binding: Binding) =>
+    run(["start", binding.container]).pipe(Effect.as({ ...binding, state: "running" } satisfies Binding))
+
+  const parse = (value: WorkspaceDriver.Binding) => {
+    const version = value.version
+    const binding: Binding | undefined =
+      version === 1 && typeof value.container === "string" && (value.state === "running" || value.state === "stopped")
+        ? { version, container: value.container, state: value.state }
+        : undefined
+    return binding
+      ? Effect.succeed(binding)
+      : Effect.fail(new WorkspaceDriver.Error({ message: "Invalid Docker workspace binding" }))
+  }
+
+  const create = (container: string, snapshot: string, workspaceID: string) =>
+    run([
+      "create",
+      "--name",
+      container,
+      "--label",
+      `opencode.workspace=${workspaceID}`,
+      "--init",
+      ...(options.user ? ["--user", options.user] : []),
+      ...(options.network ? ["--network", options.network] : []),
+      ...(options.cpus === undefined ? [] : ["--cpus", String(options.cpus)]),
+      ...(options.memory ? ["--memory", options.memory] : []),
+      "--entrypoint",
+      "/bin/sh",
+      snapshot,
+      "-c",
+      "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+    ])
+
+  return WorkspaceDriver.make({
+    create: ({ workspaceID, source }) =>
+      Effect.gen(function* () {
+        const container = `${prefix}${workspaceID.replaceAll("_", "-")}`
+        const binding: Binding = { version: 1, container, state: "stopped" }
+        const sourceBinding = source ? yield* parse(source.binding) : undefined
+        const temporaryImage = sourceBinding ? `${container}-snapshot` : undefined
+        if (sourceBinding && temporaryImage)
+          yield* run(["commit", "--pause=true", sourceBinding.container, temporaryImage])
+        yield* create(container, temporaryImage ?? options.snapshot, workspaceID).pipe(
+          Effect.ensuring(
+            temporaryImage ? run(["image", "rm", "--force", temporaryImage]).pipe(Effect.ignore) : Effect.void,
+          ),
+        )
+        const running = yield* start(binding).pipe(
+          Effect.onError(() => run(["rm", "--force", "--volumes", container]).pipe(Effect.ignore)),
+        )
+        return { binding: running }
+      }),
+    connect: ({ binding, saveBinding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        const active = current.state === "running" ? current : yield* start(current)
+        if (active !== current) yield* saveBinding(active)
+        return {
+          spawner: ChildProcessSpawner.make((input) => host.spawn(containerCommand(input, active, options))),
+        }
+      }),
+    suspendForIdle: ({ binding, saveBinding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        if (current.state === "stopped") return
+        yield* run(["stop", "--time", "10", current.container])
+        yield* saveBinding({ ...current, state: "stopped" } satisfies Binding)
+      }),
+    destroy: ({ binding }) =>
+      Effect.gen(function* () {
+        const current = yield* parse(binding)
+        yield* run(["rm", "--force", "--volumes", current.container])
+      }),
+  })
+}
+
+const containerCommand = (command: ChildProcess.Command, binding: Binding, options: Options): ChildProcess.Command => {
+  if (command._tag === "PipedCommand")
+    return containerCommand(command.left, binding, options).pipe(
+      ChildProcess.pipeTo(containerCommand(command.right, binding, options), command.options),
+    )
+
+  const environment = Object.entries(command.options.env ?? {}).flatMap(([key, value]) =>
+    value === undefined ? [] : ["--env", `${key}=${value}`],
+  )
+  const executable = shellCommand(command)
+  return ChildProcess.make(
+    options.binary ?? "docker",
+    [
+      "exec",
+      "--interactive",
+      ...(command.options.cwd ? ["--workdir", command.options.cwd] : []),
+      ...(options.user ? ["--user", options.user] : []),
+      ...environment,
+      binding.container,
+      executable.command,
+      ...executable.args,
+    ],
+    transportOptions(command.options),
+  )
+}
+
+const shellCommand = (command: ChildProcess.StandardCommand) => {
+  if (!command.options.shell) return { command: command.command, args: command.args }
+  const shell = typeof command.options.shell === "string" ? command.options.shell : "/bin/sh"
+  return {
+    command: shell,
+    args: ["-c", [command.command, ...command.args].map(shellQuote).join(" ")],
+  }
+}
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
+
+const transportOptions = (options: ChildProcess.CommandOptions): ChildProcess.CommandOptions => ({
+  detached: options.detached,
+  stdin: options.stdin,
+  stdout: options.stdout,
+  stderr: options.stderr,
+  killSignal: options.killSignal,
+  forceKillAfter: options.forceKillAfter,
+})

--- a/packages/workspace-docker/src/index.ts
+++ b/packages/workspace-docker/src/index.ts
@@ -1,0 +1,1 @@
+export * as DockerWorkspace from "./docker.js"

--- a/packages/workspace-docker/test/docker.test.ts
+++ b/packages/workspace-docker/test/docker.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "bun:test"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { Effect, Sink, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { ExitCode, makeHandle, ProcessId } from "effect/unstable/process/ChildProcessSpawner"
+import { DockerWorkspace } from "../src"
+
+const text = new TextEncoder()
+
+const host = (commands: Array<ChildProcess.Command>, failures: Set<string> = new Set()) =>
+  ChildProcessSpawner.make((command) => {
+    commands.push(command)
+    const operation = command._tag === "StandardCommand" ? command.args[0] : "pipeline"
+    const code = failures.has(operation ?? "") ? 1 : 0
+    const output = code === 0 ? new Uint8Array() : text.encode(`${operation} failed`)
+    return Effect.succeed(
+      makeHandle({
+        pid: ProcessId(commands.length),
+        exitCode: Effect.succeed(ExitCode(code)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: Sink.drain,
+        stdout: Stream.empty,
+        stderr: Stream.empty,
+        all: output.length === 0 ? Stream.empty : Stream.make(output),
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      }),
+    )
+  })
+
+const standard = (command: ChildProcess.Command) => {
+  expect(command._tag).toBe("StandardCommand")
+  if (command._tag !== "StandardCommand") throw new Error("Expected a standard command")
+  return command
+}
+
+test("creates a workspace from the immutable snapshot and manages its lifecycle", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = DockerWorkspace.makeWith(host(commands), {
+    snapshot: "blueprint-snapshot:v1",
+    user: "1000:1000",
+    cpus: 4,
+    memory: "8g",
+  })
+  const workspaceID = Workspace.ID.create()
+  const created = await Effect.runPromise(driver.create({ workspaceID }))
+  const container = `opencode-${workspaceID.replaceAll("_", "-")}`
+
+  expect(standard(commands[0]).args).toEqual([
+    "create",
+    "--name",
+    container,
+    "--label",
+    `opencode.workspace=${workspaceID}`,
+    "--init",
+    "--user",
+    "1000:1000",
+    "--cpus",
+    "4",
+    "--memory",
+    "8g",
+    "--entrypoint",
+    "/bin/sh",
+    "blueprint-snapshot:v1",
+    "-c",
+    "trap 'exit 0' TERM INT; while :; do sleep 3600; done",
+  ])
+  expect(standard(commands[1]).args).toEqual(["start", container])
+
+  const saved: Array<Record<string, unknown>> = []
+  const environment = await Effect.runPromise(
+    Effect.scoped(
+      driver.connect({
+        workspaceID,
+        binding: created.binding,
+        saveBinding: (binding) => Effect.sync(() => saved.push(binding)),
+      }),
+    ),
+  )
+  await Effect.runPromise(
+    Effect.scoped(
+      environment.spawner.spawn(
+        ChildProcess.make("git", ["status", "--short"], {
+          cwd: "/workspace",
+          env: { CI: "1", OMITTED: undefined },
+        }),
+      ),
+    ),
+  )
+  expect(standard(commands.at(-1)!).args).toEqual([
+    "exec",
+    "--interactive",
+    "--workdir",
+    "/workspace",
+    "--user",
+    "1000:1000",
+    "--env",
+    "CI=1",
+    container,
+    "git",
+    "status",
+    "--short",
+  ])
+
+  await Effect.runPromise(
+    driver.suspendForIdle({
+      workspaceID,
+      binding: created.binding,
+      saveBinding: (binding) => Effect.sync(() => saved.push(binding)),
+    }),
+  )
+  expect(standard(commands.at(-1)!).args).toEqual(["stop", "--time", "10", container])
+  expect(saved.at(-1)).toMatchObject({ state: "stopped" })
+
+  await Effect.runPromise(driver.destroy({ workspaceID, binding: saved.at(-1)! }))
+  expect(standard(commands.at(-1)!).args).toEqual(["rm", "--force", "--volumes", container])
+})
+
+test("forks through a paused commit and removes the temporary image", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = DockerWorkspace.makeWith(host(commands), { snapshot: "unused" })
+  await Effect.runPromise(
+    driver.create({
+      workspaceID: Workspace.ID.create(),
+      source: {
+        workspaceID: Workspace.ID.create(),
+        binding: { version: 1, container: "source-container", state: "running" },
+      },
+    }),
+  )
+
+  expect(standard(commands[0]).args).toEqual([
+    "commit",
+    "--pause=true",
+    "source-container",
+    expect.stringMatching(/^opencode-wrk-.*-snapshot$/),
+  ])
+  expect(standard(commands[1]).args[0]).toBe("create")
+  expect(standard(commands[2]).args).toEqual([
+    "image",
+    "rm",
+    "--force",
+    expect.stringMatching(/^opencode-wrk-.*-snapshot$/),
+  ])
+  expect(standard(commands[3]).args[0]).toBe("start")
+})
+
+test("removes a partial container when startup fails", async () => {
+  const commands: Array<ChildProcess.Command> = []
+  const driver = DockerWorkspace.makeWith(host(commands, new Set(["start"])), { snapshot: "blueprint-snapshot:v1" })
+  const result = await Effect.runPromiseExit(driver.create({ workspaceID: Workspace.ID.create() }))
+
+  expect(result._tag).toBe("Failure")
+  expect(commands.map((command) => standard(command).args[0])).toEqual(["create", "start", "rm"])
+})

--- a/packages/workspace-docker/tsconfig.json
+++ b/packages/workspace-docker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig.json",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noUncheckedIndexedAccess": false,
+    "outDir": "node_modules/.ts-dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- add a local Docker workspace provider built around immutable blueprint snapshots
- keep the opencode coordinator and model loop outside workspace containers
- expose workspace forking through SDK Next
- fork workspace-backed subagents into isolated child containers
- stop idle containers, wake them on demand, and clean up failed starts
- include a repository-specific blueprint Dockerfile for devbox-local snapshot builds

## Runtime model

- blueprint: environment recipe
- snapshot: frozen, versioned Docker image produced by the blueprint
- workspace: mutable container created from the snapshot
- fork: point-in-time copy of a workspace filesystem; never writes back to the base snapshot

Containers receive no Docker socket, host mounts, or coordinator environment by default.

## Validation

- `packages/workspace-docker`: 3 tests, typecheck, lint
- `packages/core`: workspace, session-create, and subagent tests; typecheck
- `packages/sdk-next`: embedded tests; typecheck
- full monorepo typecheck via pre-push hook
- live on `devbox`: built `opencode-snapshot:v1`, created a root workspace, mutated it, forked it, verified inherited state and parent/child divergence, then destroyed both containers