### PR TITLE
fix(session-ui): prevent variant select overlap on mobile

### DIFF
--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -197,7 +197,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
 
         <div class="flex h-11 items-center px-2">
           <div
-            class="flex min-w-0 flex-1 items-center gap-1"
+            class="flex min-w-0 flex-1 items-center gap-1 [&>*]:min-w-0"
             aria-hidden={state.mode === "shell"}
             inert={state.mode === "shell" ? true : undefined}
             style={buttons()}
@@ -560,6 +560,7 @@ export function PromptInputV2Select(props: {
 }) {
   return (
     <TooltipV2
+      class="min-w-0"
       placement="top"
       value={
         <>
@@ -573,7 +574,7 @@ export function PromptInputV2Select(props: {
           as={ButtonV2}
           variant="ghost-muted"
           size="normal"
-          class={`max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
+          class={`min-w-0 max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
           aria-label={props.title}
         >
           {props.currentIcon}


### PR DESCRIPTION
### Issue for this PR

Closes #42834

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On mobile/narrow viewports (320-390px), the reasoning-effort (variant) select in the v2 prompt input overlapped the send button, making the "thinking strength" option unclickable.

In the prompt-input DockTray, the attach/model/variant selects live inside a `flex min-w-0 flex-1` container. Their wrapping `TooltipV2`/menu layers defaulted to `min-width: auto`, so they could not shrink. On narrow screens the variant select overflowed onto the fixed send button (which sits outside the flex container) and was visually hidden/covered.

3 small class changes in `packages/session-ui/src/v2/components/prompt-input/index.tsx`:
- Add `[&>*]:min-w-0` to the tray's flex container so every direct child can shrink
- Add `min-w-0` to the `PromptInputV2Select` tooltip wrapper
- Add `min-w-0` to the select trigger button (complements existing `max-w-[220px]`)

### How did you verify your code works?

Verified at 320/360/375/390px widths: no overlap; model select shrinks (220→~177px) and variant select stays fully visible.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
