### PR TITLE
fix(acp): prefer default agent's model over config default for new sessions

### DIFF
--- a/packages/opencode/src/acp/directory.ts
+++ b/packages/opencode/src/acp/directory.ts
@@ -121,6 +121,11 @@ export const loaderLayer = Layer.effect(
             [agent.list(), agent.defaultInfo(), command.list(), provider.defaultModel().pipe(Effect.option)],
             { concurrency: "unbounded" },
           )
+          const agentModel = defaultAgent.model
+            ? providers[defaultAgent.model.providerID]?.models[defaultAgent.model.modelID]
+              ? { providerID: defaultAgent.model.providerID, modelID: defaultAgent.model.modelID }
+              : undefined
+            : undefined
           return build({
             directory,
             providers,
@@ -133,7 +138,11 @@ export const loaderLayer = Layer.effect(
               })),
             defaultModeID: defaultAgent.name,
             commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
-            ...(defaultModel._tag === "Some" ? { defaultModel: defaultModel.value } : {}),
+            ...(agentModel
+              ? { defaultModel: agentModel }
+              : defaultModel._tag === "Some"
+                ? { defaultModel: defaultModel.value }
+                : {}),
           })
         }).pipe(Effect.provideService(InstanceRef, ctx))
       }),

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -748,8 +748,17 @@ async function loadDirectorySnapshot(sdk: OpencodeClient, directory: string) {
       ProviderV2.ID,
       Provider.Info
     >
+    const defaultAgent = agents.find((agent) => agent.mode === "primary" && agent.hidden !== true)
+    const defaultAgentModel = defaultAgent?.model
+      ? providers[ProviderV2.ID.make(defaultAgent.model.providerID)]?.models[ModelV2.ID.make(defaultAgent.model.modelID)]
+        ? {
+            providerID: ProviderV2.ID.make(defaultAgent.model.providerID),
+            modelID: ModelV2.ID.make(defaultAgent.model.modelID),
+          }
+        : undefined
+      : undefined
     const defaultModelStarted = performance.now()
-    const defaultModel = defaultModelFromConfig(configResponse?.data?.model, providers)
+    const defaultModel = defaultAgentModel ?? defaultModelFromConfig(configResponse?.data?.model, providers)
     ACPProfile.duration("acp.directory.defaultModel.resolve", defaultModelStarted, { configured: !!defaultModel })
     const modes = agents
       .filter((agent) => agent.mode !== "subagent" && agent.hidden !== true)
@@ -775,7 +784,7 @@ async function loadDirectorySnapshot(sdk: OpencodeClient, directory: string) {
       directory,
       providers,
       modes,
-      defaultModeID: agents.find((agent) => agent.mode === "primary" && agent.hidden !== true)?.name ?? "build",
+      defaultModeID: defaultAgent?.name ?? "build",
       commands: commands.toSorted((a, b) => a.name.localeCompare(b.name)),
       ...(defaultModel ? { defaultModel } : {}),
     })

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -731,6 +731,46 @@ describe("ACP service sessions", () => {
     expect(result.configOptions?.find((option) => option.id === "model")?.currentValue).toBe("test/configured-model")
   })
 
+  it("prefers the default agent's assigned model over the configured model", async () => {
+    const sdk = {
+      config: {
+        providers: () => Promise.resolve({ data: { providers: [provider], default: { test: modelID } } }),
+        get: () => Promise.resolve({ data: { model: "test/configured-model" } }),
+      },
+      app: {
+        agents: () =>
+          Promise.resolve({
+            data: [
+              {
+                name: "build",
+                mode: "primary",
+                permission: [],
+                options: {},
+                model: { providerID: "test", modelID: "second-model" },
+              },
+            ],
+          }),
+        skills: () => Promise.resolve({ data: [] }),
+      },
+      command: {
+        list: () => Promise.resolve({ data: [] }),
+      },
+      session: {
+        create: (input: { model?: { id?: string } }) => Promise.resolve({ data: { id: input.model?.id } }),
+        list: () => Promise.resolve({ data: [] }),
+      },
+      mcp: {
+        add: () => Promise.resolve({ data: {} }),
+      },
+    } as unknown as OpencodeClient
+    const service = ACPService.make({ sdk })
+
+    const result = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+    expect(result.sessionId).toBe("second-model")
+    expect(result.configOptions?.find((option) => option.id === "model")?.currentValue).toBe("test/second-model")
+  })
+
   it("does not scan last-used sessions when resolving the new session default", async () => {
     const historyCalls: string[] = []
     const sdk = {


### PR DESCRIPTION
### Issue for this PR

Closes #42835

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP session creation (`session/new`) resolved the default model via `selectDefaultModel(snapshot)`, which reads the configured `model` (or falls back to the first provider model) — the default agent's **assigned** model was never considered. Since ACP passes that resolved model explicitly to `session.create` / `session.prompt`, the server-side precedence `input.model ?? agent.model ?? currentModel` (packages/opencode/src/session/prompt.ts) never reaches `agent.model`: ACP clients (e.g. Zed) start sessions with the wrong model whenever agents declare per-agent models (oh-my-openagent style configs).

This PR makes the default model resolution prefer the default agent's assigned model when it resolves to a discovered provider model, falling back to the configured default otherwise. Both snapshot construction paths apply the same precedence:

- `loadDirectorySnapshot` (packages/opencode/src/acp/service.ts) — SDK-based path
- `loaderLayer` (packages/opencode/src/acp/directory.ts) — Layer-based path

Client-explicit model selection (config option updates, prompt params) is unchanged and still wins.

### How did you verify your code works?

- New test `prefers the default agent's assigned model over the configured model` in packages/opencode/test/acp/service-session.test.ts — RED before the fix (session created with configured model), GREEN after (session created with agent model)
- Full ACP suite: 129 pass / 0 fail (10 files)
- `tsgo --noEmit` typecheck clean
- Real-surface QA: built binary + `opencode acp` against a config with a default agent carrying an assigned model — `session/new` returns the agent's model in the model config option and the session row persists it (pre-fix: first provider model)

### Screenshots / recordings

N/A (protocol layer change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR