### PR TITLE
fix(cli): expose durable event persistence

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -117,7 +117,7 @@ for (const item of targets) {
       autoloadTsconfig: true,
       autoloadPackageJson: true,
       target: target.replace(binary, "bun") as Bun.Build.CompileTarget,
-      executablePath,
+      ...(executablePath ? { executablePath } : {}),
       outfile: path.join(outdir, name, "bin", binary),
       execArgv: [`--user-agent=${binary}/${Script.version}`, "--use-system-ca", "--"],
       windows: {},

--- a/packages/cli/script/service-smoke.ts
+++ b/packages/cli/script/service-smoke.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { Service } from "@opencode-ai/client/effect/service"
+import { OpenCode } from "@opencode-ai/client"
 import { ServiceStatus } from "@opencode-ai/protocol/groups/health"
 import { Schema } from "effect"
 import fs from "node:fs/promises"
@@ -19,6 +20,7 @@ const env = {
   HOME: root,
   USERPROFILE: root,
   OPENCODE_DB: path.join(root, "opencode.db"),
+  OPENCODE_EVENTS_PERSIST: "1",
   OPENCODE_TEST_HOME: root,
   XDG_CACHE_HOME: path.join(root, "cache"),
   XDG_CONFIG_HOME: path.join(root, "config"),
@@ -40,6 +42,11 @@ try {
   const token = encodeURIComponent(credential)
   const health = await waitForReady(info.url, headers)
   if (health.pid !== info.pid) throw new Error("Health process does not match registration")
+  const client = OpenCode.make({ baseUrl: info.url, headers })
+  const session = await client.session.create({})
+  const log = []
+  for await (const event of client.session.log({ sessionID: session.id, follow: false })) log.push(event)
+  if (!log.some((event) => event.type === "session.created")) throw new Error("Compiled service did not persist events")
   const tokenHealth = await fetch(new URL(`/api/health?auth_token=${token}`, info.url), {
     signal: AbortSignal.timeout(5_000),
   })

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -90,6 +90,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
                 ? "opencode.db"
                 : `opencode-${OPENCODE_CHANNEL.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`),
           },
+          events: { persist: truthy(process.env.OPENCODE_EVENTS_PERSIST) },
           models: {
             url: process.env.OPENCODE_MODELS_URL,
             file: process.env.OPENCODE_MODELS_PATH,

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -1,10 +1,8 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { Service, type Info } from "@opencode-ai/client/effect/service"
-import { Session } from "@opencode-ai/schema/session"
 import { Global } from "@opencode-ai/util/global"
 import { OPENCODE_VERSION } from "../src/version"
 import { expect, test } from "bun:test"
-import { Database } from "bun:sqlite"
 import { Effect, Schema } from "effect"
 import fs from "node:fs/promises"
 import os from "node:os"
@@ -128,41 +126,6 @@ test("managed service writes its registration once", async () => {
   }
 }, 30_000)
 
-test("managed service persists durable events when configured", async () => {
-  const service = await startManagedService("opencode-service-events-", false, {
-    OPENCODE_EVENTS_PERSIST: "1",
-  })
-  try {
-    await waitForStatus(service.info, 200)
-    const response = await fetch(new URL("/api/session", service.info.url), {
-      method: "POST",
-      headers: {
-        authorization: "Basic " + btoa(`opencode:${service.info.password}`),
-        "content-type": "application/json",
-      },
-      body: "{}",
-    })
-    expect(response.status).toBe(200)
-    const session = await Schema.decodeUnknownPromise(Schema.Struct({ data: Session.Info }))(await response.json())
-    await Effect.runPromise(Service.stop({ file: service.registration }).pipe(Effect.provide(NodeFileSystem.layer)))
-    await service.owner.exited
-
-    const database = new Database(path.join(service.root, "opencode.db"), { readonly: true })
-    try {
-      const event = database
-        .query<{ type: string }, [string]>(
-          "SELECT type FROM event WHERE aggregate_id = ? AND type = 'session.created.1'",
-        )
-        .get(session.data.id)
-      expect(event?.type).toBe("session.created.1")
-    } finally {
-      database.close()
-    }
-  } finally {
-    await stopManagedService(service)
-  }
-}, 30_000)
-
 test("deleting a managed service registration stops its owner", async () => {
   const service = await startManagedService("opencode-service-delete-")
   try {
@@ -178,7 +141,7 @@ test("deleting a managed service registration stops its owner", async () => {
 test("deleting a failed service registration stops its owner", async () => {
   const service = await startManagedService("opencode-service-failed-delete-", true)
   try {
-    await waitForStatus(service.info, 500)
+    await waitForFailed(service.info)
     await fs.rm(service.registration)
     expect(await waitForExit(service.owner)).toBe(true)
     await expectPortAvailable(service.port)
@@ -503,7 +466,7 @@ test("a failed service stays registered and owns the selected port until stopped
 
   try {
     const info = await waitForInfo(registration)
-    await waitForStatus(info, 500)
+    await waitForFailed(info)
     expect(owner.exitCode).toBe(null)
 
     const contender = Bun.spawn(command, { env, stderr: "pipe", stdout: "ignore" })
@@ -536,17 +499,17 @@ async function waitForInfo(file: string, accept: (info: Info) => boolean = () =>
   throw new Error("Timed out waiting for service registration")
 }
 
-async function waitForStatus(info: Info, expected: number) {
+async function waitForFailed(info: Info) {
   for (let attempt = 0; attempt < 400; attempt++) {
     const status = await fetch(new URL("/api/health", info.url), {
       headers: { authorization: "Basic " + btoa(`opencode:${info.password}`) },
     })
       .then((response) => response.status)
       .catch(() => undefined)
-    if (status === expected) return
+    if (status === 500) return
     await Bun.sleep(50)
   }
-  throw new Error(`Timed out waiting for service status ${expected}`)
+  throw new Error("Timed out waiting for service boot failure")
 }
 
 async function availablePort() {
@@ -570,7 +533,7 @@ function serviceEnv(root: string) {
   }
 }
 
-async function startManagedService(prefix: string, failBoot = false, environment: Record<string, string> = {}) {
+async function startManagedService(prefix: string, failBoot = false) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
   const port = await availablePort()
   const registration = path.join(root, "state", "opencode", "service-local.json")
@@ -578,11 +541,7 @@ async function startManagedService(prefix: string, failBoot = false, environment
   if (failBoot) await fs.mkdir(path.join(root, "database"))
   await fs.writeFile(path.join(root, "config", "opencode", "service-local.json"), JSON.stringify({ port }))
   const owner = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
-    env: {
-      ...serviceEnv(root),
-      ...environment,
-      ...(failBoot ? { OPENCODE_DB: path.join(root, "database") } : {}),
-    },
+    env: failBoot ? { ...serviceEnv(root), OPENCODE_DB: path.join(root, "database") } : serviceEnv(root),
     stderr: "pipe",
     stdout: "ignore",
   })

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -133,6 +133,7 @@ test("managed service persists durable events when configured", async () => {
     OPENCODE_EVENTS_PERSIST: "1",
   })
   try {
+    await waitForStatus(service.info, 200)
     const response = await fetch(new URL("/api/session", service.info.url), {
       method: "POST",
       headers: {
@@ -177,7 +178,7 @@ test("deleting a managed service registration stops its owner", async () => {
 test("deleting a failed service registration stops its owner", async () => {
   const service = await startManagedService("opencode-service-failed-delete-", true)
   try {
-    await waitForFailed(service.info)
+    await waitForStatus(service.info, 500)
     await fs.rm(service.registration)
     expect(await waitForExit(service.owner)).toBe(true)
     await expectPortAvailable(service.port)
@@ -502,7 +503,7 @@ test("a failed service stays registered and owns the selected port until stopped
 
   try {
     const info = await waitForInfo(registration)
-    await waitForFailed(info)
+    await waitForStatus(info, 500)
     expect(owner.exitCode).toBe(null)
 
     const contender = Bun.spawn(command, { env, stderr: "pipe", stdout: "ignore" })
@@ -535,17 +536,17 @@ async function waitForInfo(file: string, accept: (info: Info) => boolean = () =>
   throw new Error("Timed out waiting for service registration")
 }
 
-async function waitForFailed(info: Info) {
+async function waitForStatus(info: Info, expected: number) {
   for (let attempt = 0; attempt < 400; attempt++) {
     const status = await fetch(new URL("/api/health", info.url), {
       headers: { authorization: "Basic " + btoa(`opencode:${info.password}`) },
     })
       .then((response) => response.status)
       .catch(() => undefined)
-    if (status === 500) return
+    if (status === expected) return
     await Bun.sleep(50)
   }
-  throw new Error("Timed out waiting for service boot failure")
+  throw new Error(`Timed out waiting for service status ${expected}`)
 }
 
 async function availablePort() {

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -1,8 +1,10 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { Service, type Info } from "@opencode-ai/client/effect/service"
+import { Session } from "@opencode-ai/schema/session"
 import { Global } from "@opencode-ai/util/global"
 import { OPENCODE_VERSION } from "../src/version"
 import { expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
 import { Effect, Schema } from "effect"
 import fs from "node:fs/promises"
 import os from "node:os"
@@ -121,6 +123,40 @@ test("managed service writes its registration once", async () => {
     expect(after.ino).toBe(before.ino)
     expect(after.mtimeMs).toBe(before.mtimeMs)
     expect(await Bun.file(service.registration).json()).toEqual(service.info)
+  } finally {
+    await stopManagedService(service)
+  }
+}, 30_000)
+
+test("managed service persists durable events when configured", async () => {
+  const service = await startManagedService("opencode-service-events-", false, {
+    OPENCODE_EVENTS_PERSIST: "1",
+  })
+  try {
+    const response = await fetch(new URL("/api/session", service.info.url), {
+      method: "POST",
+      headers: {
+        authorization: "Basic " + btoa(`opencode:${service.info.password}`),
+        "content-type": "application/json",
+      },
+      body: "{}",
+    })
+    expect(response.status).toBe(200)
+    const session = await Schema.decodeUnknownPromise(Schema.Struct({ data: Session.Info }))(await response.json())
+    await Effect.runPromise(Service.stop({ file: service.registration }).pipe(Effect.provide(NodeFileSystem.layer)))
+    await service.owner.exited
+
+    const database = new Database(path.join(service.root, "opencode.db"), { readonly: true })
+    try {
+      const event = database
+        .query<{ type: string }, [string]>(
+          "SELECT type FROM event WHERE aggregate_id = ? AND type = 'session.created.1'",
+        )
+        .get(session.data.id)
+      expect(event?.type).toBe("session.created.1")
+    } finally {
+      database.close()
+    }
   } finally {
     await stopManagedService(service)
   }
@@ -533,7 +569,7 @@ function serviceEnv(root: string) {
   }
 }
 
-async function startManagedService(prefix: string, failBoot = false) {
+async function startManagedService(prefix: string, failBoot = false, environment: Record<string, string> = {}) {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix))
   const port = await availablePort()
   const registration = path.join(root, "state", "opencode", "service-local.json")
@@ -541,7 +577,11 @@ async function startManagedService(prefix: string, failBoot = false) {
   if (failBoot) await fs.mkdir(path.join(root, "database"))
   await fs.writeFile(path.join(root, "config", "opencode", "service-local.json"), JSON.stringify({ port }))
   const owner = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
-    env: failBoot ? { ...serviceEnv(root), OPENCODE_DB: path.join(root, "database") } : serviceEnv(root),
+    env: {
+      ...serviceEnv(root),
+      ...environment,
+      ...(failBoot ? { OPENCODE_DB: path.join(root, "database") } : {}),
+    },
     stderr: "pipe",
     stdout: "ignore",
   })

--- a/packages/www/content/docs/troubleshooting.mdx
+++ b/packages/www/content/docs/troubleshooting.mdx
@@ -124,6 +124,9 @@ The database normally lives at:
 
 `OPENCODE_DB` can override the database location.
 
+Set `OPENCODE_EVENTS_PERSIST=1` before starting a server to retain durable event payloads for historical reads. Existing
+events are not backfilled; restart a managed service after enabling it.
+
 <Callout type="warning">
   Do not delete or edit service files or the database while troubleshooting. Use the service commands to manage the
   daemon, and make a backup before inspecting persistent data with external tools.


### PR DESCRIPTION
### Issue for this PR

Closes #42839

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Maps `OPENCODE_EVENTS_PERSIST=1` to the existing `ServerOptions.events.persist` setting. The existing compiled-service smoke enables it and verifies historical `session.created` replay through the public client.

Also omits `executablePath` when no alternate Bun release is requested, preserving Bun's default compiler behavior and allowing the existing smoke check to run on the repository's pinned Bun version.

### How did you verify your code works?

- `bun run script/build.ts --single --skip-install && bun run script/service-smoke.ts` in `packages/cli`
- `bun typecheck` in `packages/cli`
- `bun typecheck && bun validate && bun run build` in `packages/www`
- Full workspace typecheck from the pre-push hook

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR