### PR TITLE
docs: add LLMTR provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1885,6 +1885,55 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### LLMTR
+
+[LLMTR](https://llmtr.com) is an OpenAI-compatible AI gateway. A single API key gives access to models from OpenAI, Anthropic, Google, Qwen, xAI, Mistral, DeepSeek, and others, alongside its own models hosted in Turkey for data residency.
+
+1. Head over to the [LLMTR dashboard](https://llmtr.com), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **LLMTR**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your LLMTR API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model.
+
+   ```txt
+   /models
+   ```
+
+   The Turkey-hosted `llmtr/*` models are preloaded. To use any other model from the [LLMTR catalog](https://llmtr.com/models), add its id to your opencode config.
+
+   ```json title="opencode.json"
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "llmtr": {
+         "models": {
+           "anthropic/claude-opus-4.8": {
+             "name": "Claude Opus 4.8"
+           },
+           "openai/gpt-5.4": {
+             "name": "GPT-5.4"
+           }
+         }
+       }
+     }
+   }
+   ```
+
+---
+
 ### Poolside
 
 [Poolside](https://poolside.ai) provides access to its models through an OpenAI-compatible API.


### PR DESCRIPTION
### Issue for this PR

Closes #42866

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the missing LLMTR section to the provider directory in `providers.mdx`. One file, docs only.

LLMTR already works in opencode — it is in models.dev and live in the catalog mirror (`llmtr`, npm `@ai-sdk/openai-compatible`, env `LLMTR_API_KEY`), so it resolves through the generic openai-compatible path with no runtime code. The only thing missing was the docs entry, so this is purely that.

I put it after LLM Gateway and before Poolside, and followed the same four-step connect/models shape the neighbouring entries use. The config snippet uses the existing "add a model to an existing provider" pattern from the OpenRouter and LLM Gateway sections rather than any new syntax, because the models.dev snapshot only carries the Turkey-hosted `llmtr/*` ids — anything else from the gateway has to be named in config.

### How did you verify your code works?

Docs build, on this branch:

- `bun run --cwd packages/web build` → `[build] Complete!`, exit 0. The section renders at `/docs/providers` with anchor `id="llmtr"`.
- `prettier --check packages/web/src/content/docs/providers.mdx` → `All matched files use Prettier code style!`
- `bun run lint` (oxlint) reports one error and 4855 warnings, but they are all pre-existing on `dev` and in `.ts`/`.tsx` files; oxlint does not process `.mdx`.

Provider behaviour, on the released `opencode-ai@1.18.18` with `LLMTR_API_KEY` set:

- `opencode models` lists the `llmtr/*` catalog models.
- `opencode run --model llmtr/gemma-4 "Reply with exactly: OK"` → `OK`.
- With the exact config snippet from this PR in `opencode.json`, `opencode models` gains `llmtr/anthropic/claude-opus-4.8` and `llmtr/openai/gpt-5.4`, and `opencode run --model llmtr/anthropic/claude-opus-4.8` returns a real response. Both ids were also checked directly against `POST /v1/chat/completions` (HTTP 200).

I deliberately did not name `llmtr/sincap` anywhere: it is retired and returns HTTP 410. It is still in the models.dev snapshot; a separate PR fixes that catalog drift.

### Screenshots / recordings

Not a UI change — content added to an existing docs page.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Context: this was previously #31315 / #31316. The PR was closed by the automated PR-cleanup bot and the issue by the 60-day stale bot, not on technical merit, and neither can be reopened, so this is a refile against current `dev`.
