### PR TITLE
fix(install): honor OPENCODE_INSTALL_DIR and XDG_BIN_DIR as documented

### DIFF
--- a/install
+++ b/install
@@ -65,7 +65,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-INSTALL_DIR=$HOME/.opencode/bin
+# Resolve the installation directory in the priority order documented in the
+# README: $OPENCODE_INSTALL_DIR, $XDG_BIN_DIR, $HOME/bin, then the default.
+if [ -n "${OPENCODE_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR=$OPENCODE_INSTALL_DIR
+elif [ -n "${XDG_BIN_DIR:-}" ]; then
+    INSTALL_DIR=$XDG_BIN_DIR
+elif [ -d "$HOME/bin" ] || mkdir -p "$HOME/bin" 2>/dev/null; then
+    INSTALL_DIR=$HOME/bin
+else
+    INSTALL_DIR=$HOME/.opencode/bin
+fi
 mkdir -p "$INSTALL_DIR"
 
 # If --binary is provided, skip all download/detection logic


### PR DESCRIPTION
## What

The README documents a priority order for the installation directory:

1. `$OPENCODE_INSTALL_DIR`
2. `$XDG_BIN_DIR`
3. `$HOME/bin` (if it exists or can be created)
4. `$HOME/.opencode/bin` (default)

with examples like `OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash`. The install script, however, hardcoded `INSTALL_DIR=$HOME/.opencode/bin` and never read any of these variables.

This PR makes the script implement the documented behavior.

## Changes

- `install`: resolve `INSTALL_DIR` in the documented priority order before `mkdir -p`
- `$HOME/bin` is used when it exists or can be created (matches the README wording "if it exists or can be created")

## Verification

- `bash -n install` passes
- Behavior tested with a fake `$HOME` across four cases:
  - `OPENCODE_INSTALL_DIR` set → installed to it
  - only `XDG_BIN_DIR` set → installed to it
  - neither set, `$HOME/bin` absent → created and used
  - neither set, `$HOME/bin` present → used
- Default install path (`$HOME/.opencode/bin`) unchanged when no variables are set