### PR TITLE
fix(opencode): expand single-line selection to enclosing LSP symbol

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -841,9 +841,9 @@ const layer = Layer.effect(
                       let r: LSP.Range | undefined
                       if ("range" in symbol) r = symbol.range
                       else if ("location" in symbol) r = symbol.location.range
-                      if (r?.start?.line && r?.start?.line === start) {
-                        start = r.start.line
-                        end = r?.end?.line ?? start
+                      if (r && r.start.line + 1 === start) {
+                        start = r.start.line + 1
+                        end = r.end.line + 1
                         break
                       }
                     }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -156,6 +156,39 @@ const lsp = Layer.succeed(
   }),
 )
 
+const lspWithSymbol = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () =>
+      Effect.succeed([
+        {
+          name: "fn",
+          kind: 12,
+          location: {
+            uri: "file:///fn.ts",
+            range: {
+              start: { line: 1, character: 0 },
+              end: { line: 4, character: 0 },
+            },
+          },
+        },
+      ]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
 const processorCreateStarted: Array<() => void> = []
 const blockingProcessor = Layer.succeed(
   SessionProcessor.Service,
@@ -255,6 +288,14 @@ const withMcpInstructions = testEffect(
 )
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
 const unixNoLLMServer = process.platform !== "win32" ? noLLMServer.instance : noLLMServer.instance.skip
+const lspSymbolInstance = testEffect(
+  LayerNode.compile(promptRoot, [
+    [SessionSummary.node, summary],
+    [LSP.node, lspWithSymbol],
+    [MCP.node, makeMcp()],
+    [RuntimeFlags.node, runtimeFlags],
+  ]),
+)
 
 // Config that registers a custom "test" provider with a "test-model" model
 // so provider model lookup succeeds inside the loop.
@@ -2174,6 +2215,45 @@ noLLMServer.instance(
       expect(text[0]?.startsWith("Called the Read tool with the following input:")).toBe(true)
       expect(text[1]?.includes("Read tool failed to read")).toBe(true)
       expect(text[2]).toBe("after-file")
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+lspSymbolInstance.instance(
+  "expands single-line file selection to enclosing symbol",
+  () =>
+    Effect.gen(function* () {
+      const { directory: dir } = yield* TestInstance
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      const testFile = path.join(dir, "fn.ts")
+      yield* writeText(testFile, "line1\nline2\nline3\nline4\nline5\n")
+
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          {
+            type: "file",
+            mime: "text/plain",
+            url: `file://${testFile}?start=2&end=2`,
+            filename: "fn.ts",
+          },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const text = msg.parts
+        .filter((part) => part.type === "text")
+        .map((part) => part.text)
+        .join("\n")
+      expect(text).toContain('"offset":2')
+      expect(text).toContain('"limit":4')
 
       yield* sessions.remove(session.id)
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #42887

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Single-line file selection (startLine === endLine) was never expanded to its enclosing symbol. The check compared .start.line (LSP 0-based) against start (1-based, parsed from the ?start= query param), so it never matched. The ?.start?.line && guard also skipped symbols on LSP line 0.

Convert the LSP line to 1-based before comparing and assigning, keeping start/end 1-based for the Read tool offset/limit math.

### How did you verify your code works?

Traced the index conventions: start feeds the Read tool offset, which is 1-based (	ool/read.ts does opts.offset - 1), while LSP documentSymbol ranges are 0-based (lsp/diagnostic.ts does ange.start.line + 1 for display). The old comparison mixed the two and could never match; the fix converts to 1-based before comparing.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR