### PR TITLE
fix(session): don't clobber user's model swap on model-less prompts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -670,12 +670,16 @@ const layer = Layer.effect(
       }
 
       const current = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
-      if (
-        current.agent !== info.agent ||
-        current.model?.providerID !== info.model.providerID ||
-        current.model?.id !== info.model.modelID ||
-        (current.model?.variant === "default" ? undefined : current.model?.variant) !== info.model.variant
-      ) {
+      const hasNoStoredModel = current.model == null
+      const storedModelDiffers =
+        current.model != null &&
+        (current.model.providerID !== info.model.providerID ||
+          current.model.id !== info.model.modelID ||
+          (current.model.variant === "default" ? undefined : current.model.variant) !== info.model.variant)
+      // A model-less prompt (no input.model) resolves from the agent fallback;
+      // never let that overwrite a model the user explicitly stored on the session.
+      const wouldClobberStoredModel = input.model == null && storedModelDiffers
+      if ((current.agent !== info.agent || storedModelDiffers || hasNoStoredModel) && !wouldClobberStoredModel) {
         yield* sessions.setAgentModel({
           sessionID: input.sessionID,
           agent: info.agent,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2440,3 +2440,123 @@ noLLMServer.instance(
     }),
   30_000,
 )
+
+
+// Model-swap survival: a model-less prompt (e.g. plugin completion-reminder)
+// must not overwrite a model the user explicitly stored on the session.
+
+noLLMServer.instance(
+  "model-less prompt does not clobber user's stored model swap",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      // User explicitly swaps to kimi — the session row should persist it.
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        model: { providerID: ProviderV2.ID.make("opencode"), modelID: ModelV2.ID.make("kimi-k2.5-free") },
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      const afterSwap = yield* sessions.get(session.id)
+      expect(afterSwap.model?.id).toBe(ModelV2.ID.make("kimi-k2.5-free"))
+
+      // A model-less prompt (as OMO completion-reminders send) resolves the
+      // agent's configured model for the turn — that design is preserved (see
+      // "applies agent variant only when using agent model" above).  But it
+      // must NOT overwrite the user's swap in the session row.
+      const match = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "reminder" }],
+      })
+      if (match.info.role !== "user") throw new Error("expected user message")
+      // The turn uses the agent's model (existing design, unchanged).
+      expect(match.info.model.modelID).toBe(ModelV2.ID.make("test-model"))
+      // The session row keeps the user's swap — the fix.
+      const afterReminder = yield* sessions.get(session.id)
+      expect(afterReminder.model?.id).toBe(ModelV2.ID.make("kimi-k2.5-free"))
+
+      yield* sessions.remove(session.id)
+    }),
+  {
+    config: {
+      ...cfg,
+      provider: {
+        ...cfg.provider,
+        test: {
+          ...cfg.provider.test,
+          models: {
+            "test-model": {
+              ...cfg.provider.test.models["test-model"],
+              variants: { xhigh: {}, high: {} },
+            },
+          },
+        },
+      },
+      agent: {
+        build: {
+          model: "test/test-model",
+          variant: "xhigh",
+        },
+      },
+    },
+  },
+  90_000,
+)
+
+// Fresh-session initialization: a model-less first prompt persists the agent's
+// model to the session row (no existing user swap to protect).
+
+noLLMServer.instance(
+  "model-less first prompt on fresh session persists agent model to row",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      const match = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "fresh start" }],
+      })
+      if (match.info.role !== "user") throw new Error("expected user message")
+      expect(match.info.model.modelID).toBe(ModelV2.ID.make("test-model"))
+
+      // The session row should now carry the agent's model.
+      const row = yield* sessions.get(session.id)
+      expect(row.model?.id).toBe(ModelV2.ID.make("test-model"))
+
+      yield* sessions.remove(session.id)
+    }),
+  {
+    config: {
+      ...cfg,
+      provider: {
+        ...cfg.provider,
+        test: {
+          ...cfg.provider.test,
+          models: {
+            "test-model": {
+              ...cfg.provider.test.models["test-model"],
+              variants: { xhigh: {}, high: {} },
+            },
+          },
+        },
+      },
+      agent: {
+        build: {
+          model: "test/test-model",
+          variant: "xhigh",
+        },
+      },
+    },
+  },
+  90_000,
+)


### PR DESCRIPTION
### Issue for this PR

Closes #42893

### Type of change

- [x] Bug fix

### What does this PR do?

A model-less prompt (no `input.model` — e.g. plugin completion-reminders via `promptAsync`) resolves from the agent fallback (`ag.model`) for the turn. The existing design (PR #26765) intentionally uses the agent's model when no explicit model is given — this is correct for the turn's model and is preserved.

However, `setAgentModel` then overwrites the session row to the resolved model, permanently destroying a model the user explicitly stored via a prior swap. The TUI is unaffected (always sends `draft.model` explicitly), but `opencode serve` / mobile clients lose the swap on the next plugin reminder.

**The fix:** guard the `setAgentModel` write in `createUserMessage` — skip it when:
1. The prompt carried no explicit model (`input.model == null`), AND
2. The session already has a stored model that differs from the agent's resolved model (`storedModelDiffers`)

Fresh sessions (no stored model) still persist the agent's model on the first model-less prompt (`hasNoStoredModel` guard), and explicit-model prompts always persist normally. The model-resolution precedence is unchanged — model-less prompts still use the agent's model for the turn.

### How did you verify your code works?

- **New regression test**: `"model-less prompt does not clobber user's stored model swap"` — creates a session, swaps to `kimi-k2.5-free`, sends a model-less prompt with an agent carrying `test/test-model`, asserts the turn uses `test-model` (design preserved) but the session row stays `kimi-k2.5-free` (the fix). Verified RED→GREEN.
- **Fresh-session test**: `"model-less first prompt on fresh session persists agent model to row"` — confirms the `hasNoStoredModel` guard fires `setAgentModel` on a fresh session so the row is initialized.
- **Existing test preserved**: `"applies agent variant only when using agent model"` (the test that pins the agent-model design from #26765) still passes — model-less prompts still use the agent's model for the turn.
- **Full suite**: 46 pass / 14 skip / 0 fail across `test/session/prompt.test.ts`.
- **Typecheck**: 30/30 packages clean (turbo typecheck).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR