### PR TITLE
fix(xai): split fat Responses text deltas for smoother streaming

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -6,6 +6,7 @@ import { Cause, Context, Effect, Layer, Schema, Scope } from "effect"
 import { ModelV2 } from "./model"
 import { ProviderV2 } from "./provider"
 import { State } from "./state"
+import { XaiSSE } from "./util/xai-sse"
 
 type SDK = any
 
@@ -114,8 +115,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
       ...opts,
       timeout: false,
     })
-    if (!chunkAbortCtl || typeof chunkTimeout !== "number") return res
-    return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+    const streamed = pkg === "@ai-sdk/xai" ? XaiSSE.wrap(res) : res
+    if (!chunkAbortCtl || typeof chunkTimeout !== "number") return streamed
+    return wrapSSE(streamed, chunkTimeout, chunkAbortCtl)
   }
 
   return options

--- a/packages/core/src/util/xai-sse.ts
+++ b/packages/core/src/util/xai-sse.ts
@@ -1,0 +1,97 @@
+export namespace XaiSSE {
+  export const CHUNK = 32
+
+  const SPLIT_TYPES = new Set(["response.reasoning_text.delta", "response.output_text.delta"])
+
+  export function splitText(text: string, size = CHUNK): string[] {
+    if (text.length <= size) return [text]
+    const out: string[] = []
+    let i = 0
+    while (i < text.length) {
+      let end = Math.min(i + size, text.length)
+      if (end < text.length) {
+        const window = text.slice(end, Math.min(end + 16, text.length))
+        const sp = window.search(/[\s\n]/)
+        if (sp >= 0) end += sp + 1
+      }
+      out.push(text.slice(i, end))
+      i = end
+    }
+    return out
+  }
+
+  function eventType(block: string): string | undefined {
+    const eventLine = block.match(/^event:\s*(.+)$/m)
+    if (eventLine) return eventLine[1].trim()
+    const dataLine = block.match(/^data:\s*(.+)$/m)
+    if (!dataLine) return
+    try {
+      const parsed = JSON.parse(dataLine[1])
+      return typeof parsed?.type === "string" ? parsed.type : undefined
+    } catch {
+      return
+    }
+  }
+
+  function dataPayload(block: string): { obj: Record<string, unknown> } | undefined {
+    const dataLine = block.match(/^data:\s*(.+)$/m)
+    if (!dataLine) return
+    try {
+      const obj = JSON.parse(dataLine[1])
+      if (!obj || typeof obj !== "object") return
+      return { obj: obj as Record<string, unknown> }
+    } catch {
+      return
+    }
+  }
+
+  function replaceData(block: string, obj: unknown): string {
+    return block.replace(/^data:\s*.+$/m, `data: ${JSON.stringify(obj)}`)
+  }
+
+  export function expandBlock(block: string): string[] {
+    const type = eventType(block)
+    const payload = dataPayload(block)
+    if (type && SPLIT_TYPES.has(type) && payload && typeof payload.obj.delta === "string") {
+      const pieces = splitText(payload.obj.delta)
+      if (pieces.length <= 1) return [block]
+      return pieces.map((delta) => replaceData(block, { ...payload.obj, delta }))
+    }
+    return [block]
+  }
+
+  export function wrap(res: Response): Response {
+    if (!res.body) return res
+    if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+
+    const decoder = new TextDecoder()
+    const encoder = new TextEncoder()
+    let buffer = ""
+    const stream = res.body.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          buffer += decoder.decode(chunk, { stream: true })
+          const parts = buffer.split("\n\n")
+          buffer = parts.pop() ?? ""
+          for (const part of parts) {
+            for (const kept of expandBlock(part)) {
+              controller.enqueue(encoder.encode(kept + "\n\n"))
+            }
+          }
+        },
+        flush(controller) {
+          buffer += decoder.decode()
+          if (!buffer.trim()) return
+          for (const kept of expandBlock(buffer)) {
+            controller.enqueue(encoder.encode(kept))
+          }
+        },
+      }),
+    )
+    return new Response(stream, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    })
+  }
+}

--- a/packages/core/test/util/xai-sse.test.ts
+++ b/packages/core/test/util/xai-sse.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { XaiSSE } from "../../src/util/xai-sse"
+
+function sse(type: string, data: Record<string, unknown>) {
+  return `event: ${type}\ndata: ${JSON.stringify({ type, ...data })}`
+}
+
+describe("XaiSSE.splitText", () => {
+  test("keeps short text intact", () => {
+    expect(XaiSSE.splitText("hello")).toEqual(["hello"])
+  })
+
+  test("splits long text near word boundaries", () => {
+    const text = "The quick brown fox jumps over the lazy dog and then keeps going for a while."
+    const parts = XaiSSE.splitText(text)
+    expect(parts.length).toBeGreaterThan(1)
+    expect(parts.join("")).toBe(text)
+    expect(parts.every((part) => part.length <= XaiSSE.CHUNK + 16)).toBe(true)
+  })
+})
+
+describe("XaiSSE.expandBlock", () => {
+  test("splits fat reasoning and output text deltas", () => {
+    const text = "x".repeat(XaiSSE.CHUNK * 3)
+    const reasoning = XaiSSE.expandBlock(sse("response.reasoning_text.delta", { delta: text }))
+    const output = XaiSSE.expandBlock(sse("response.output_text.delta", { delta: text }))
+    expect(reasoning.length).toBeGreaterThan(1)
+    expect(output.length).toBeGreaterThan(1)
+    expect(reasoning.map((block) => JSON.parse(block.match(/^data: (.+)$/m)![1]).delta).join("")).toBe(text)
+    expect(output.map((block) => JSON.parse(block.match(/^data: (.+)$/m)![1]).delta).join("")).toBe(text)
+  })
+
+  test("leaves reasoning summary events untouched", () => {
+    const block = sse("response.reasoning_summary_text.delta", { delta: "summary " + "y".repeat(80) })
+    expect(XaiSSE.expandBlock(block)).toEqual([block])
+  })
+
+  test("leaves non-text events untouched", () => {
+    const block = sse("response.created", { response: { id: "r1" } })
+    expect(XaiSSE.expandBlock(block)).toEqual([block])
+  })
+})
+
+describe("XaiSSE.wrap", () => {
+  test("re-emits split SSE events from a fat reasoning delta", async () => {
+    const text = "word ".repeat(20)
+    const body = `${sse("response.reasoning_text.delta", { item_id: "rs_1", delta: text })}\n\n`
+    const res = XaiSSE.wrap(
+      new Response(body, {
+        headers: { "content-type": "text/event-stream" },
+      }),
+    )
+    const raw = await res.text()
+    const deltas = [...raw.matchAll(/^data: (.+)$/gm)].map((match) => JSON.parse(match[1]).delta)
+    expect(deltas.length).toBeGreaterThan(1)
+    expect(deltas.join("")).toBe(text)
+  })
+})

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -7,6 +7,7 @@ import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
 import { NoSuchModelError, type Provider as SDK } from "ai"
 import { Npm } from "@opencode-ai/core/npm"
 import { Hash } from "@opencode-ai/core/util/hash"
+import { XaiSSE } from "@opencode-ai/core/util/xai-sse"
 import { Plugin } from "../plugin"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { type LanguageModelV3 } from "@ai-sdk/provider"
@@ -1763,8 +1764,10 @@ const layer = Layer.effect(
             timeout: false,
           }).finally(() => headerTimeoutCtl?.clear())
 
-          if (!chunkAbortCtl) return res
-          return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+          const streamed =
+            model.api.npm === "@ai-sdk/xai" || model.providerID === "xai" ? XaiSSE.wrap(res) : res
+          if (!chunkAbortCtl) return streamed
+          return wrapSSE(streamed, chunkTimeout, chunkAbortCtl)
         }
 
         const bundledLoader = BUNDLED_PROVIDERS[model.api.npm]


### PR DESCRIPTION
## What

xAI Responses often ships `response.reasoning_text.delta` and `response.output_text.delta` as large SSE chunks. OpenCode forwards each delta immediately, so TUI/ACP thought and message panes refresh in blocks.

This re-chunks those two event types on word boundaries (~32 chars) in the existing xAI fetch wrapper. Other events, including reasoning summaries, are left untouched.

## Why not a plugin

The same SSE wrap already lives in `packages/core/src/aisdk.ts` and the legacy provider fetch path. Putting the split there makes TUI, ACP, and desktop all smoother without extra config.

## Test plan

- [x] `bun test test/util/xai-sse.test.ts` in `packages/core`
- [ ] Stream grok-4.6 in TUI and confirm thoughts/text tick in smaller pieces
- [ ] Confirm reasoning summaries still arrive and still replace the live thought at the end (this PR does not disable summaries)