### PR TITLE
feat(tui): add Odin syntax highlighting

### DIFF
--- a/packages/tui/src/parsers-config.ts
+++ b/packages/tui/src/parsers-config.ts
@@ -382,5 +382,14 @@ export default {
         ],
       },
     },
+    {
+      filetype: "odin",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-odin/releases/download/v1.3.0/tree-sitter-odin.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/helix-editor/helix/16d06643a4444ee297058e608c1de1a5bd8db083/runtime/queries/odin/highlights.scm",
+        ],
+      },
+    },
   ],
 }

--- a/packages/tui/src/util/filetype.ts
+++ b/packages/tui/src/util/filetype.ts
@@ -118,6 +118,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".tfvars": "terraform-vars",
   ".hcl": "hcl",
   ".nix": "nix",
+  ".odin": "odin",
   ".typ": "typst",
   ".typc": "typst",
 }

--- a/packages/tui/test/util/filetype.test.ts
+++ b/packages/tui/test/util/filetype.test.ts
@@ -6,6 +6,7 @@ describe("util.filetype", () => {
     expect(filetype("component.tsx")).toBe("typescript")
     expect(filetype("script.js")).toBe("typescript")
     expect(filetype("main.py")).toBe("python")
+    expect(filetype("main.odin")).toBe("odin")
     expect(filetype("README.unknown")).toBeUndefined()
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #40889

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Odin syntax highlighting to the V2 TUI. It registers the released Odin Tree-sitter WASM with a pinned Helix highlight query, maps `.odin` files to the parser, and tests the filetype mapping.

### How did you verify your code works?

- Ran the targeted TUI filetype test.
- Ran the TUI typecheck and Prettier check.
- Ran the repository pre-push typecheck successfully across 30 packages.
- Verified that the pinned Tree-sitter WASM and highlight query URLs resolve.

### Screenshots / recordings

Not included. The change adds parser-backed highlighting without changing TUI layout or controls.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
