### PR TITLE
fix(tui): sort child sessions by created time, not session ID

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -208,7 +208,7 @@ export function Session() {
     const parentID = session()?.parentID ?? session()?.id
     return sync.data.session
       .filter((x) => x.parentID === parentID || x.id === parentID)
-      .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+      .toSorted((a, b) => b.time.created - a.time.created)
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const messagesBeforeRevert = () => {


### PR DESCRIPTION
### Issue for this PR

Closes #42905

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`session.child.first` (Ctrl+X+Down) and the Left/Right child cycle sorted sibling sessions by session ID string. Session IDs are descending-encoded timestamps that wrap around at 2^48, so once the encoding wraps the ID order no longer matches creation order and "first child" lands on an old subagent instead of the newest.

The fix sorts `children()` in `packages/tui/src/routes/session/index.tsx` by `time.created` descending instead of by session ID. This is the ordering the ID sort was already encoding — "first child" keeps meaning newest-created, but is now stable across the wrap. The footer `(N of M)` counter already sorts by `time.created` ascending, so navigation and the counter stay consistent (Ctrl+X+Down lands on `M of M`).

### How did you verify your code works?

- Reproduced the wrap: session IDs are `~current` where `current = timestamp_ms * 0x1000 + counter`, truncated to 48 bits. The last wrap occurred at 2026-08-14 11:19:55 UTC.
- Checked against real session data: in an 829-child session spanning the wrap, the smallest-ID child was created minutes before the wrap while the actual newest child ranked ~756th in ID order; the new sort puts the newest-created child first.
- `bun typecheck` passes in `packages/tui`.

### Screenshots / recordings

Not included — this changes which session navigation lands on, not how the UI looks, so there is nothing visual to capture.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR