### PR TITLE
fix(opencode): apply long context config pricing

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1447,6 +1447,19 @@ const layer = Layer.effect(
               if (model.id && model.id !== modelID) return modelID
               return existingModel?.name ?? modelID
             })
+            const longContext = model.cost?.context_over_200k
+            const optionalLongContext = longContext
+              ? {
+                  experimentalOver200K: {
+                    input: longContext.input,
+                    output: longContext.output,
+                    cache: {
+                      read: longContext.cache_read ?? 0,
+                      write: longContext.cache_write ?? 0,
+                    },
+                  },
+                }
+              : {}
             const parsedModel: Model = {
               id: ModelV2.ID.make(modelID),
               api: {
@@ -1493,6 +1506,7 @@ const layer = Layer.effect(
                   read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
                   write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
                 },
+                ...optionalLongContext,
               },
               options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
               limit: {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1448,18 +1448,17 @@ const layer = Layer.effect(
               return existingModel?.name ?? modelID
             })
             const longContext = model.cost?.context_over_200k
-            const optionalLongContext = longContext
+            const longContextCost = longContext
               ? {
-                  experimentalOver200K: {
-                    input: longContext.input,
-                    output: longContext.output,
-                    cache: {
-                      read: longContext.cache_read ?? 0,
-                      write: longContext.cache_write ?? 0,
-                    },
+                  input: longContext.input,
+                  output: longContext.output,
+                  cache: {
+                    read: longContext.cache_read ?? 0,
+                    write: longContext.cache_write ?? 0,
                   },
                 }
-              : {}
+              : existingModel?.cost.experimentalOver200K
+            const optionalLongContext = longContextCost ? { experimentalOver200K: longContextCost } : {}
             const parsedModel: Model = {
               id: ModelV2.ID.make(modelID),
               api: {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -997,6 +997,7 @@ it.instance(
         usage: new Usage({ inputTokens, outputTokens: 0, totalTokens: inputTokens }),
       }).cost
     expect(estimate(199_000)).toBe(0.398)
+    expect(estimate(200_000)).toBe(0.4)
     expect(estimate(201_000)).toBe(0.804)
   }),
   {
@@ -1013,6 +1014,34 @@ it.instance(
               },
             },
           },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "preserves Grok long-context pricing when config omits it",
+  Effect.gen(function* () {
+    yield* set("XAI_API_KEY", "test-api-key")
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("xai")].models["grok-4.5"]
+    expect(model.cost.experimentalOver200K).toEqual({
+      input: 4,
+      output: 12,
+      cache: { read: 1, write: 0 },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: new Usage({ inputTokens: 201_000, outputTokens: 0, totalTokens: 201_000 }),
+    })
+    expect(result.cost).toBe(0.804)
+  }),
+  {
+    config: {
+      provider: {
+        xai: {
+          models: { "grok-4.5": {} },
         },
       },
     },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -15,6 +15,8 @@ import { Config } from "@/config/config"
 import { Env } from "../../src/env"
 import { Plugin } from "../../src/plugin/index"
 import { Provider } from "@/provider/provider"
+import { Session as SessionNs } from "@/session/session"
+import { Usage } from "@opencode-ai/llm"
 
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Filesystem } from "@/util/filesystem"
@@ -972,6 +974,45 @@ it.instance(
       provider: {
         anthropic: {
           models: { "claude-sonnet-4-20250514": { cost: { input: 999, output: 888 } } },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "uses configured Grok long-context pricing for local session estimates",
+  Effect.gen(function* () {
+    yield* set("XAI_API_KEY", "test-api-key")
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("xai")].models["grok-4.5"]
+    expect(model.cost.experimentalOver200K).toEqual({
+      input: 4,
+      output: 12,
+      cache: { read: 1, write: 0 },
+    })
+    const estimate = (inputTokens: number) =>
+      SessionNs.getUsage({
+        model,
+        usage: new Usage({ inputTokens, outputTokens: 0, totalTokens: inputTokens }),
+      }).cost
+    expect(estimate(199_000)).toBe(0.398)
+    expect(estimate(201_000)).toBe(0.804)
+  }),
+  {
+    config: {
+      provider: {
+        xai: {
+          models: {
+            "grok-4.5": {
+              cost: {
+                input: 2,
+                output: 6,
+                cache_read: 0.5,
+                context_over_200k: { input: 4, output: 12, cache_read: 1 },
+              },
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
### Issue for this PR

Closes #42910 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a bug where locally computed costs do not account for context tiered pricing. For models with higher pricing above a context threshold (e.g. 200k), the local pricing logic continued using the lower tier after the session crossed that threshold.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Wrote two tests to verify locally with tiered Grok model:
 - 199K and 200K tokens use the base rate.  201K tokens uses the long context rate
 - existing long context pricing remains when config does not provide an override

If we want extra confidence, I can build an opencode version off of this change, and retest the grok scenario I flagged in the linked issue. Let me know.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
