### PR TITLE
fix: adopt new worktree when a project repository is moved

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -6,6 +6,8 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { existsSync } from "fs"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
@@ -51,13 +53,23 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
                 worktree: input.worktree,
                 project: input.project,
               }
-            : yield* project.fromDirectory(input.directory).pipe(
-                Effect.map((result) => ({
-                  directory: input.directory,
+            : yield* Effect.gen(function* () {
+                const result = yield* project.fromDirectory(input.directory)
+                // If the requested directory no longer exists (e.g. the repository
+                // was moved after the project was created), boot into the directory
+                // the project actually resolved to instead of failing on the stale
+                // path. Only do this for resolved git projects, otherwise keep the
+                // requested directory untouched.
+                const directory =
+                  existsSync(input.directory) || result.project.id === ProjectV2.ID.global
+                    ? input.directory
+                    : result.sandbox
+                return {
+                  directory,
                   worktree: result.sandbox,
                   project: result.project,
-                })),
-              )
+                }
+              })
         yield* bootstrap.run.pipe(Effect.provideService(InstanceRef, ctx))
         return ctx
       }).pipe(Effect.withSpan("InstanceStore.boot"))

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -232,9 +232,19 @@ const layer = Layer.effect(
 
       if (flags.experimentalIconDiscovery) yield* discover(existing).pipe(Effect.ignore, Effect.forkIn(scope))
 
+      // If the project's canonical worktree no longer exists on disk but the
+      // repository still resolves to a valid checkout, the repo has been moved
+      // or renamed. Adopt the resolved git worktree so the project stays usable
+      // and clients stop referencing the dead path.
+      const adoptWorktree =
+        projectID !== ProjectV2.ID.global &&
+        data.directory !== existing.worktree &&
+        !(yield* fs.exists(existing.worktree).pipe(Effect.orDie))
+
       const result: Info = {
         ...existing,
-        worktree: projectID === ProjectV2.ID.global ? worktree : existing.worktree,
+        worktree:
+          projectID === ProjectV2.ID.global ? worktree : adoptWorktree ? data.directory : existing.worktree,
         vcs: data.vcs?.type ?? fakeVcs,
         time: { ...existing.time, updated: Date.now() },
       }
@@ -293,6 +303,15 @@ const layer = Layer.effect(
           .update(SessionTable)
           .set({ project_id: projectID })
           .where(and(eq(SessionTable.project_id, ProjectV2.ID.global), eq(SessionTable.directory, data.directory)))
+          .run()
+          .pipe(Effect.orDie)
+      }
+
+      if (adoptWorktree) {
+        yield* db
+          .update(SessionTable)
+          .set({ directory: data.directory })
+          .where(and(eq(SessionTable.project_id, projectID), eq(SessionTable.directory, existing.worktree)))
           .run()
           .pipe(Effect.orDie)
       }

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Deferred, Effect, Fiber, Layer } from "effect"
+import path from "path"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { registerDisposer } from "../../src/effect/instance-registry"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
@@ -47,6 +48,19 @@ describe("InstanceStore", () => {
 
       expect(ctx.directory).toBe(dir)
       expect(ctx.worktree).toBe(dir)
+    }),
+  )
+
+  it.live("boots into the resolved worktree when the requested directory no longer exists", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped({ git: true })
+      const stale = path.join(tmp, "gone")
+      const store = yield* InstanceStore.Service
+
+      const ctx = yield* store.load({ directory: stale })
+
+      expect(ctx.directory).toBe(tmp)
+      expect(ctx.worktree).toBe(tmp)
     }),
   )
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Project } from "@/project/project"
 import { $ } from "bun"
 import path from "path"
+import * as fs from "fs/promises"
 import { tmpdirScoped } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
 import { Database } from "@opencode-ai/core/database/database"
@@ -359,6 +360,29 @@ describe("Project.fromDirectory with worktrees", () => {
       const next = yield* project.fromDirectory(clone)
 
       expect(next.project.id).toBe(result.project.id)
+    }),
+  )
+
+  it.live("adopts a moved checkout as the project worktree when the original is gone", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      yield* Effect.promise(() => $`git remote add origin git@github.com:Test-Org/Moved-Repo.git`.cwd(tmp).quiet())
+
+      const result = yield* project.fromDirectory(tmp)
+      expect(result.project.worktree).toBe(tmp)
+
+      const moved = tmp + "-moved"
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => $`rm -rf ${moved}`.quiet().nothrow()).pipe(Effect.ignore),
+      )
+      yield* Effect.promise(() => fs.rename(tmp, moved))
+
+      const next = yield* project.fromDirectory(moved)
+
+      expect(next.project.id).toBe(result.project.id)
+      expect(next.project.worktree).toBe(moved)
+      expect(next.sandbox).toBe(moved)
     }),
   )
 


### PR DESCRIPTION
## Problem

When a project's repository is moved or renamed on disk (e.g. the folder is moved to a parent directory), opencode keeps using the **old** worktree path:

- `Project.fromDirectory` always keeps `existing.worktree` for existing (non-global) projects, even when that path no longer exists. The resolved new checkout is only ever added to `sandboxes`, never adopted as the project's worktree.
- `InstanceStore.boot` uses the requested directory verbatim as the instance/session directory. If a client passes a stale path (as the desktop does from its persisted project state), the instance boots with a non-existent directory.

The result: "New conversation" fails with `ENOENT` / `FileSystem.realPath` errors until the user manually edits the database. Repros happen whenever the repo root is moved up to its parent (e.g. `G:/.../AlgoTrading/EA Admirals` -> `G:/.../AlgoTrading`), so the old worktree is now a dead child of the new git root.

## Fix

Two complementary server-side changes:

1. **`Project.fromDirectory`** (`packages/opencode/src/project/project.ts`): if the project's canonical `worktree` no longer exists on disk and the repository still resolves to a valid checkout, adopt the resolved git worktree (`data.directory`) as the new canonical worktree. Existing sessions rooted at the old worktree are re-pointed to the new directory, so old conversations keep working.
2. **`InstanceStore.boot`** (`packages/opencode/src/project/instance-store.ts`): when the requested directory does not exist but `fromDirectory` resolved it to a non-global git project, boot the instance in the resolved worktree (`result.sandbox`) instead of the stale path. This makes both new sessions and loading old sessions succeed even when a client passes a path that no longer exists.

## Tests

- `Project.fromDirectory with worktrees > adopts a moved checkout as the project worktree when the original is gone` — moves a repo and asserts the project adopts the new worktree.
- `InstanceStore > boots into the resolved worktree when the requested directory no longer exists` — loads an instance at a non-existent child of a git root and asserts it boots into the resolved worktree.

Both new tests pass; the existing `project` and `instance-store` suites pass (47/47). `tsgo --noEmit` and `oxlint` are clean on the touched files.