### PR TITLE
feat(lsp): add Marksman language server for Markdown

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -58,6 +58,7 @@ export const builtinServerIds = [
   "tinymist",
   "haskell-language-server",
   "julials",
+  "marksman",
 ]
 
 export const requiresExtensionsForCustomServers = Schema.makeFilter<

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1981,3 +1981,20 @@ export const JuliaLS: Info = {
     }
   },
 }
+
+export const Marksman: Info = {
+  id: "marksman",
+  extensions: [".md", ".markdown"],
+  root: NearestRoot([".git", ".marksman.toml"]),
+  async spawn(root) {
+    const bin = which("marksman")
+    if (!bin) {
+      return
+    }
+    return {
+      process: spawn(bin, ["server"], {
+        cwd: root,
+      }),
+    }
+  },
+}

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -30,6 +30,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | julials            | .jl                                                                 | `julia` and `LanguageServer.jl` installed                    |
 | kotlin-ls          | .kt, .kts                                                           | Auto-installs for Kotlin projects                            |
 | lua-ls             | .lua                                                                | Auto-installs for Lua projects                               |
+| marksman           | .md, .markdown                                                      | `marksman` command available                                 |
 | nixd               | .nix                                                                | `nixd` command available                                     |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` command available                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                               |


### PR DESCRIPTION
### Issue for this PR

None.

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for using https://github.com/artempyanykh/marksman as an LSP for Markdown.

### How did you verify your code works?

Deployed the Nix flake for this branch and verified by having an LLM create and navigate a fake notes collection.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
