### PR TITLE
docs: add ClawMetry to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [ClawMetry](https://github.com/vivekchand/clawmetry)                                       | Zero-config local dashboard for OpenCode sessions, tokens, costs |
 
 ---
 


### PR DESCRIPTION
Adds ClawMetry to the Projects table, per the note on the ecosystem page inviting these PRs. It is a local dashboard that reads OpenCode session history and shows sessions, tokens, costs, and tool calls.