### PR TITLE
fix(core): reduce Windows server CPU under parallel sessions

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -22,10 +22,13 @@ import {
   ProcessId,
 } from "effect/unstable/process/ChildProcessSpawner"
 import * as NodeChildProcess from "node:child_process"
+import { extname, isAbsolute } from "node:path"
 import { PassThrough } from "node:stream"
 import launch from "cross-spawn"
 import { makeGlobalNode } from "./effect/app-node"
 import { filesystem, path } from "./effect/app-node-platform"
+
+const nativeWindowsExtensions = new Set([".com", ".exe"])
 
 const toError = (err: unknown): Error => (err instanceof globalThis.Error ? err : new globalThis.Error(String(err)))
 
@@ -267,7 +270,15 @@ export const make = Effect.gen(function* () {
   const spawn = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-      const proc = launch(command.command, command.args, opts)
+      const extension = extname(command.command).toLowerCase()
+      const native =
+        process.platform === "win32" &&
+        !opts.shell &&
+        isAbsolute(command.command) &&
+        nativeWindowsExtensions.has(extension)
+      const proc = native
+        ? NodeChildProcess.spawn(command.command, command.args, opts)
+        : launch(command.command, command.args, opts)
       let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -190,6 +190,13 @@ export const layerWith = (options?: LayerOptions) =>
           return created
         })
 
+      const resolveLocation = Effect.fnUntraced(function* (location: Location.Ref | undefined) {
+        if (location) return location
+        const service = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+        if (!service) return
+        return { directory: service.directory, workspaceID: service.workspaceID }
+      })
+
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
           yield* PubSub.shutdown(pubsub.all)
@@ -418,12 +425,7 @@ export const layerWith = (options?: LayerOptions) =>
 
       function publish<D extends Definition>(definition: D, data: Data<D>, options?: PublishOptions) {
         return Effect.gen(function* () {
-          const serviceLocation = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
-          const location =
-            options?.location ??
-            (serviceLocation
-              ? { directory: serviceLocation.directory, workspaceID: serviceLocation.workspaceID }
-              : undefined)
+          const location = yield* resolveLocation(options?.location)
           return yield* publishEvent(
             definition,
             {

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -1,6 +1,6 @@
 export * as EventV2 from "./event"
 
-import { Cause, Context, Effect, Layer, Option, PubSub, Queue, Schema, Stream } from "effect"
+import { Cause, Context, Effect, Layer, Option, PubSub, Queue, Schema, Stream, SynchronizedRef } from "effect"
 import { Event } from "@opencode-ai/schema/event"
 import type { Data, Definition, Payload } from "@opencode-ai/schema/event"
 import { and, asc, eq, gt, inArray } from "drizzle-orm"
@@ -172,7 +172,7 @@ export const layerWith = (options?: LayerOptions) =>
     Service,
     Effect.gen(function* () {
       const pubsub = {
-        all: yield* PubSub.unbounded<Payload>(),
+        all: yield* SynchronizedRef.make<PubSub.PubSub<Payload> | undefined>(undefined),
         durable: new Map<string, Set<PubSub.PubSub<void>>>(),
         typed: new Map<string, PubSub.PubSub<Payload>>(),
       }
@@ -190,6 +190,16 @@ export const layerWith = (options?: LayerOptions) =>
           return created
         })
 
+      const allEvents = () =>
+        SynchronizedRef.modifyEffect(
+          pubsub.all,
+          Effect.fnUntraced(function* (current) {
+            if (current) return [current, current] as const
+            const created = yield* PubSub.unbounded<Payload>()
+            return [created, created] as const
+          }),
+        )
+
       const resolveLocation = Effect.fnUntraced(function* (location: Location.Ref | undefined) {
         if (location) return location
         const service = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
@@ -199,7 +209,8 @@ export const layerWith = (options?: LayerOptions) =>
 
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
-          yield* PubSub.shutdown(pubsub.all)
+          const all = yield* SynchronizedRef.get(pubsub.all)
+          if (all) yield* PubSub.shutdown(all)
           yield* Effect.forEach(
             pubsub.durable.values(),
             (pubsubs) => Effect.forEach(pubsubs, PubSub.shutdown, { discard: true }),
@@ -419,7 +430,8 @@ export const layerWith = (options?: LayerOptions) =>
           )
           const typed = pubsub.typed.get(event.type)
           if (typed) yield* PubSub.publish(typed, event)
-          yield* PubSub.publish(pubsub.all, event)
+          const all = yield* SynchronizedRef.get(pubsub.all)
+          if (all) yield* PubSub.publish(all, event)
         })
       }
 
@@ -538,7 +550,7 @@ export const layerWith = (options?: LayerOptions) =>
           Stream.map((event) => event as Payload<D>),
         )
 
-      const streamAll = (): Stream.Stream<Payload> => Stream.fromPubSub(pubsub.all)
+      const streamAll = (): Stream.Stream<Payload> => Stream.unwrap(allEvents().pipe(Effect.map(Stream.fromPubSub)))
 
       const readAfter = (aggregateID: string, after: number) =>
         (options?.beforeAggregateRead?.(aggregateID) ?? Effect.void).pipe(

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -3,7 +3,7 @@ export * as EventV2 from "./event"
 import { Cause, Context, Effect, Layer, Option, PubSub, Queue, Schema, Stream, SynchronizedRef } from "effect"
 import { Event } from "@opencode-ai/schema/event"
 import type { Data, Definition, Payload } from "@opencode-ai/schema/event"
-import { and, asc, eq, gt, inArray } from "drizzle-orm"
+import { and, asc, eq, gt, inArray, placeholder } from "drizzle-orm"
 import { Database } from "./database/database"
 import { EventSequenceTable, EventTable } from "./event/sql"
 import { Location } from "./location"
@@ -180,6 +180,16 @@ export const layerWith = (options?: LayerOptions) =>
       // TODO: Bind durable projectors to exact type+version before supporting incompatible historical payloads.
       const listeners = new Array<Subscriber>()
       const { db } = yield* Database.Service
+      const sequenceByAggregate = db
+        .select({ seq: EventSequenceTable.seq, ownerID: EventSequenceTable.owner_id })
+        .from(EventSequenceTable)
+        .where(eq(EventSequenceTable.aggregate_id, placeholder("aggregateID")))
+        .prepare()
+      const positionByEventID = db
+        .select({ aggregateID: EventTable.aggregate_id, seq: EventTable.seq })
+        .from(EventTable)
+        .where(eq(EventTable.id, placeholder("eventID")))
+        .prepare()
 
       const getOrCreate = (definition: Definition) =>
         Effect.gen(function* () {
@@ -258,12 +268,7 @@ export const layerWith = (options?: LayerOptions) =>
                     .transaction(
                       () =>
                         Effect.gen(function* () {
-                          const row = yield* db
-                            .select({ seq: EventSequenceTable.seq, ownerID: EventSequenceTable.owner_id })
-                            .from(EventSequenceTable)
-                            .where(eq(EventSequenceTable.aggregate_id, aggregateID))
-                            .get()
-                            .pipe(Effect.orDie)
+                          const row = yield* sequenceByAggregate.get({ aggregateID }).pipe(Effect.orDie)
                           const latest = row?.seq ?? -1
                           const encoded = Schema.encodeUnknownSync(definition.data)(event.data) as Record<
                             string,
@@ -318,12 +323,7 @@ export const layerWith = (options?: LayerOptions) =>
                               }),
                             )
                           }
-                          const stored = yield* db
-                            .select({ aggregateID: EventTable.aggregate_id, seq: EventTable.seq })
-                            .from(EventTable)
-                            .where(eq(EventTable.id, event.id))
-                            .get()
-                            .pipe(Effect.orDie)
+                          const stored = yield* positionByEventID.get({ eventID: event.id }).pipe(Effect.orDie)
                           if (stored)
                             yield* Effect.die(
                               new InvalidDurableEventError({

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -28,8 +28,9 @@ export const ripgrepLayer = Layer.effect(
     const ripgrep = yield* Ripgrep.Service
     const scope = yield* Scope.Scope
     const state = {
-      files: [] as string[],
-      directories: [] as string[],
+      files: [] as Fuzzysort.Prepared[],
+      directories: [] as Fuzzysort.Prepared[],
+      combined: undefined as Fuzzysort.Prepared[] | undefined,
     }
     const directories = new Set<string>()
     yield* ripgrep
@@ -39,10 +40,17 @@ export const ripgrepLayer = Layer.effect(
         limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
         onEntry: (entry) =>
           Effect.sync(() => {
-            state.files.push(entry.path)
+            state.files.push(fuzzysort.prepare(entry.path))
+            state.combined = undefined
             const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
+            parts.slice(0, -1).reduce((parent, part) => {
+              const current = parent ? `${parent}/${part}` : part
+              const directory = current + path.sep
+              if (directories.has(directory)) return current
+              directories.add(directory)
+              state.directories.push(fuzzysort.prepare(directory))
+              return current
+            }, "")
           }),
       })
       .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
@@ -105,7 +113,7 @@ export const ripgrepLayer = Layer.effect(
               ? state.files
               : input.type === "directory"
                 ? state.directories
-                : [...state.files, ...state.directories]
+                : (state.combined ??= [...state.files, ...state.directories])
           return fuzzysort.go(input.query, items, { limit: input.limit ?? 50 }).map((item) => {
             const relative = item.target
             const type = relative.endsWith(path.sep) ? ("directory" as const) : ("file" as const)

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -441,19 +441,18 @@ const layer = Layer.effect(
       },
       env: Record<string, string>,
     ) {
-      const list = (args: string[]) =>
-        repositoryOperation("refresh", input.repository, args, { env }).pipe(
-          Effect.map((result) => result.text.split("\0").filter(Boolean)),
-        )
-      const [tracked, untracked] = yield* Effect.all(
-        [
-          list(["diff-files", "--name-only", "-z", "--", input.scope]),
-          list(["ls-files", "--others", "--exclude-standard", "-z", "--", input.scope]),
-        ],
-        { concurrency: 2 },
-      )
-      const candidates = Array.from(new Set([...tracked, ...untracked]))
+      const entries = (yield* repositoryOperation(
+        "refresh",
+        input.repository,
+        ["ls-files", "--modified", "--deleted", "--others", "--exclude-standard", "-t", "-z", "--", input.scope],
+        { env },
+      )).text
+        .split("\0")
+        .filter(Boolean)
+        .map((entry) => ({ tag: entry[0], path: entry.slice(2) }))
+      const candidates = Array.from(new Set(entries.map((entry) => entry.path)))
       if (!candidates.length) return false
+      const untracked = entries.filter((entry) => entry.tag === "?").map((entry) => entry.path)
       const ignored = input.ignores
         ? new Set(
             (yield* repositoryOperation("refresh", input.ignores, ["check-ignore", "--no-index", "--stdin", "-z"], {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -10,6 +10,9 @@ import { AppProcess } from "./process"
 import { makeGlobalNode } from "./effect/app-node"
 import { File } from "./file"
 import { KeyedMutex } from "./effect/keyed-mutex"
+import { which } from "./util/which"
+
+const gitExecutable = which("git") ?? "git"
 
 export class Repository extends Schema.Class<Repository>("Git.Repository")({
   worktree: AbsolutePath,
@@ -324,7 +327,7 @@ const layer = Layer.effect(
       const env = { GIT_OPTIONAL_LOCKS: "0", ...options?.env }
       const result = yield* proc
         .run(
-          ChildProcess.make("git", repositoryArgs(repository, args), {
+          ChildProcess.make(gitExecutable, repositoryArgs(repository, args), {
             cwd: repository.worktree,
             env,
             extendEnv: true,
@@ -505,11 +508,15 @@ const layer = Layer.effect(
       if (!input.paths.length) return new Set<RelativePath>()
       const result = yield* proc
         .run(
-          ChildProcess.make("git", repositoryArgs(input.repository, ["check-ignore", "--no-index", "--stdin", "-z"]), {
-            cwd: input.repository.worktree,
-            env: { GIT_OPTIONAL_LOCKS: "0" },
-            extendEnv: true,
-          }),
+          ChildProcess.make(
+            gitExecutable,
+            repositoryArgs(input.repository, ["check-ignore", "--no-index", "--stdin", "-z"]),
+            {
+              cwd: input.repository.worktree,
+              env: { GIT_OPTIONAL_LOCKS: "0" },
+              extendEnv: true,
+            },
+          ),
           { stdin: input.paths.join("\0") + "\0" },
         )
         .pipe(
@@ -825,7 +832,7 @@ const layer = Layer.effect(
     }) {
       const result = yield* proc
         .run(
-          ChildProcess.make("git", ["apply", "-"], {
+          ChildProcess.make(gitExecutable, ["apply", "-"], {
             cwd: input.path,
             extendEnv: true,
             stdin: Stream.make(new TextEncoder().encode(input.changes)),
@@ -892,7 +899,7 @@ const layer = Layer.effect(
       cwd = repository.worktree,
     ) {
       const result = yield* proc
-        .run(ChildProcess.make("git", args, { cwd, extendEnv: true, stdin: "ignore" }))
+        .run(ChildProcess.make(gitExecutable, args, { cwd, extendEnv: true, stdin: "ignore" }))
         .pipe(
           Effect.mapError(
             (cause) => new WorktreeError({ operation, directory: worktreeDirectory, message: cause.message, cause }),
@@ -992,7 +999,7 @@ function execute(cwd: string, proc: AppProcess.Interface) {
   return (args: string[]) =>
     proc
       .run(
-        ChildProcess.make("git", args, {
+        ChildProcess.make(gitExecutable, args, {
           cwd,
           extendEnv: true,
           stdin: "ignore",

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -124,26 +124,20 @@ export interface Interface {
     readonly list: (repository: Repository) => Effect.Effect<readonly Worktree[], WorktreeError>
   }
   readonly index: {
-    /** Refresh only the requested project-relative scope, preserving all other entries. */
-    readonly refresh: (input: {
-      repository: Repository
-      scope: RelativePath
-      ignores?: Repository
-      maximumUntrackedFileBytes?: number
-    }) => Effect.Effect<{ readonly skipped: readonly RelativePath[] }, OperationError>
     readonly ignored: (input: {
       repository: Repository
       paths: readonly RelativePath[]
     }) => Effect.Effect<ReadonlySet<RelativePath>, OperationError>
   }
   readonly tree: {
+    readonly head: (repository: Repository) => Effect.Effect<TreeID, OperationError>
     readonly capture: (input: {
       repository: Repository
+      base: TreeID
       scopes: readonly RelativePath[]
       ignores?: Repository
       maximumUntrackedFileBytes?: number
     }) => Effect.Effect<TreeID, OperationError>
-    readonly write: (repository: Repository) => Effect.Effect<TreeID, OperationError>
     readonly files: (input: {
       repository: Repository
       from: TreeID
@@ -327,11 +321,12 @@ const layer = Layer.effect(
       args: string[],
       options?: { stdin?: string; env?: Record<string, string> },
     ) {
+      const env = { GIT_OPTIONAL_LOCKS: "0", ...options?.env }
       const result = yield* proc
         .run(
           ChildProcess.make("git", repositoryArgs(repository, args), {
             cwd: repository.worktree,
-            env: options?.env,
+            env,
             extendEnv: true,
           }),
           { stdin: options?.stdin },
@@ -420,20 +415,34 @@ const layer = Layer.effect(
               }),
           ),
         )
-      yield* fs
-        .copyFile(path.join(input.seed.gitDirectory, "index"), path.join(input.gitDirectory, "index"))
-        .pipe(Effect.catch(() => Effect.void))
       return repository
     })
 
-    const refresh = Effect.fn("Git.index.refresh")(function* (input: {
-      repository: Repository
-      scope: RelativePath
-      ignores?: Repository
-      maximumUntrackedFileBytes?: number
-    }) {
+    const withTemporaryIndex = <A, E, R>(
+      repository: Repository,
+      name: string,
+      use: (env: Record<string, string>) => Effect.Effect<A, E, R>,
+    ) =>
+      Effect.acquireUseRelease(
+        Effect.sync(() => path.join(repository.gitDirectory, `${name}-${randomUUID()}.index`)),
+        (index) => use({ GIT_INDEX_FILE: index }),
+        (index) =>
+          Effect.forEach([index, index + ".lock"], (file) => fs.remove(file).pipe(Effect.catch(() => Effect.void)), {
+            discard: true,
+          }),
+      )
+
+    const refresh = Effect.fnUntraced(function* (
+      input: {
+        repository: Repository
+        scope: RelativePath
+        ignores?: Repository
+        maximumUntrackedFileBytes?: number
+      },
+      env: Record<string, string>,
+    ) {
       const list = (args: string[]) =>
-        repositoryOperation("refresh", input.repository, args).pipe(
+        repositoryOperation("refresh", input.repository, args, { env }).pipe(
           Effect.map((result) => result.text.split("\0").filter(Boolean)),
         )
       const [tracked, untracked] = yield* Effect.all(
@@ -476,14 +485,14 @@ const layer = Layer.effect(
           "refresh",
           input.repository,
           ["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"],
-          { stdin: remove.join("\0") + "\0" },
+          { env, stdin: remove.join("\0") + "\0" },
         )
       if (stage.length)
         yield* repositoryOperation(
           "refresh",
           input.repository,
           ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"],
-          { stdin: stage.join("\0") + "\0" },
+          { env, stdin: stage.join("\0") + "\0" },
         )
       return { skipped }
     })
@@ -497,6 +506,7 @@ const layer = Layer.effect(
         .run(
           ChildProcess.make("git", repositoryArgs(input.repository, ["check-ignore", "--no-index", "--stdin", "-z"]), {
             cwd: input.repository.worktree,
+            env: { GIT_OPTIONAL_LOCKS: "0" },
             extendEnv: true,
           }),
           { stdin: input.paths.join("\0") + "\0" },
@@ -527,22 +537,29 @@ const layer = Layer.effect(
       )
     })
 
-    const writeTree = Effect.fn("Git.tree.write")(function* (repository: Repository) {
-      return TreeID.make((yield* repositoryOperation("write_tree", repository, ["write-tree"])).text.trim())
+    const writeTree = Effect.fn("Git.tree.write")(function* (repository: Repository, env?: Record<string, string>) {
+      return TreeID.make((yield* repositoryOperation("write_tree", repository, ["write-tree"], { env })).text.trim())
+    })
+
+    const headTree = Effect.fn("Git.tree.head")(function* (repository: Repository) {
+      return TreeID.make(
+        (yield* repositoryOperation("write_tree", repository, ["rev-parse", "HEAD^{tree}"])).text.trim(),
+      )
     })
 
     const captureTree = Effect.fn("Git.tree.capture")(
       (input: {
         repository: Repository
+        base: TreeID
         scopes: readonly RelativePath[]
         ignores?: Repository
         maximumUntrackedFileBytes?: number
       }) =>
-        locked(
-          input.repository,
+        withTemporaryIndex(input.repository, "capture", (env) =>
           Effect.gen(function* () {
-            yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }), { discard: true })
-            return yield* writeTree(input.repository)
+            yield* repositoryOperation("refresh", input.repository, ["read-tree", input.base], { env })
+            yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }, env), { discard: true })
+            return yield* writeTree(input.repository, env)
           }),
         ),
     )
@@ -642,47 +659,42 @@ const layer = Layer.effect(
         files: ReadonlyMap<RelativePath, TreeID>
         context?: number
       }) =>
-        locked(
-          input.repository,
+        withTemporaryIndex(input.repository, "preview", (env) =>
           Effect.gen(function* () {
-            const index = path.join(input.repository.gitDirectory, `preview-${randomUUID()}.index`)
-            const env = { GIT_INDEX_FILE: index }
-            return yield* Effect.gen(function* () {
-              yield* repositoryOperation("diff", input.repository, ["read-tree", input.current], { env })
-              yield* Effect.forEach(
-                input.files,
-                ([file, tree]) =>
-                  Effect.gen(function* () {
-                    const source = yield* entry(input.repository, tree, file)
-                    if (!source) {
-                      yield* repositoryOperation(
-                        "diff",
-                        input.repository,
-                        ["update-index", "--force-remove", "--", file],
-                        { env },
-                      )
-                      return
-                    }
+            yield* repositoryOperation("diff", input.repository, ["read-tree", input.current], { env })
+            yield* Effect.forEach(
+              input.files,
+              ([file, tree]) =>
+                Effect.gen(function* () {
+                  const source = yield* entry(input.repository, tree, file)
+                  if (!source) {
                     yield* repositoryOperation(
                       "diff",
                       input.repository,
-                      ["update-index", "--add", "--cacheinfo", source.mode, source.object, file],
+                      ["update-index", "--force-remove", "--", file],
                       { env },
                     )
-                  }),
-                { discard: true },
-              )
-              const target = TreeID.make(
-                (yield* repositoryOperation("diff", input.repository, ["write-tree"], { env })).text.trim(),
-              )
-              return yield* treeDiff({
-                repository: input.repository,
-                from: input.current,
-                to: target,
-                context: input.context,
-                paths: Array.from(input.files.keys()),
-              })
-            }).pipe(Effect.ensuring(fs.remove(index).pipe(Effect.catch(() => Effect.void))))
+                    return
+                  }
+                  yield* repositoryOperation(
+                    "diff",
+                    input.repository,
+                    ["update-index", "--add", "--cacheinfo", source.mode, source.object, file],
+                    { env },
+                  )
+                }),
+              { discard: true },
+            )
+            const target = TreeID.make(
+              (yield* repositoryOperation("diff", input.repository, ["write-tree"], { env })).text.trim(),
+            )
+            return yield* treeDiff({
+              repository: input.repository,
+              from: input.current,
+              to: target,
+              context: input.context,
+              paths: Array.from(input.files.keys()),
+            })
           }),
         ),
     )
@@ -691,27 +703,41 @@ const layer = Layer.effect(
       (input: { repository: Repository; files: ReadonlyMap<RelativePath, TreeID> }) =>
         locked(
           input.repository,
-          Effect.forEach(
-            input.files,
-            ([file, tree]) =>
-              Effect.gen(function* () {
-                if (yield* entry(input.repository, tree, file)) {
-                  yield* repositoryOperation("restore", input.repository, ["checkout", tree, "--", file])
-                  return
-                }
-                yield* fs.remove(path.join(input.repository.worktree, file), { recursive: true, force: true }).pipe(
-                  Effect.mapError(
-                    (cause) =>
-                      new OperationError({
-                        operation: "restore",
-                        directory: input.repository.worktree,
-                        message: `Failed to remove ${file}`,
-                        cause,
-                      }),
-                  ),
-                )
-              }),
-            { discard: true },
+          withTemporaryIndex(input.repository, "restore", (env) =>
+            Effect.gen(function* () {
+              const files = yield* Effect.forEach(input.files, ([file, tree]) =>
+                Effect.gen(function* () {
+                  const source = yield* entry(input.repository, tree, file)
+                  if (!source) {
+                    yield* fs.remove(path.join(input.repository.worktree, file), { recursive: true, force: true }).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new OperationError({
+                            operation: "restore",
+                            directory: input.repository.worktree,
+                            message: `Failed to remove ${file}`,
+                            cause,
+                          }),
+                      ),
+                    )
+                    return
+                  }
+                  yield* repositoryOperation(
+                    "restore",
+                    input.repository,
+                    ["update-index", "--add", "--cacheinfo", source.mode, source.object, file],
+                    { env },
+                  )
+                  return file
+                }),
+              )
+              const checkout = files.filter((file): file is RelativePath => file !== undefined)
+              if (!checkout.length) return
+              yield* repositoryOperation("restore", input.repository, ["checkout-index", "--force", "--stdin", "-z"], {
+                env,
+                stdin: checkout.join("\0") + "\0",
+              })
+            }),
           ),
         ),
     )
@@ -719,10 +745,14 @@ const layer = Layer.effect(
     const checkoutTree = Effect.fn("Git.tree.checkout")((input: { repository: Repository; tree: TreeID }) =>
       locked(
         input.repository,
-        Effect.gen(function* () {
-          yield* repositoryOperation("restore", input.repository, ["read-tree", input.tree])
-          yield* repositoryOperation("restore", input.repository, ["checkout-index", "--all", "--force"])
-        }),
+        withTemporaryIndex(input.repository, "checkout", (env) =>
+          Effect.gen(function* () {
+            yield* repositoryOperation("restore", input.repository, ["read-tree", input.tree], { env })
+            yield* repositoryOperation("restore", input.repository, ["checkout-index", "--all", "--force"], {
+              env,
+            })
+          }),
+        ),
       ),
     )
 
@@ -929,10 +959,10 @@ const layer = Layer.effect(
       sync: { fetchRemotes: fetch, fetchBranch, checkoutRemoteBranch: checkout, resetHard: reset },
       change: { capture, apply, discard },
       worktree: { create: worktreeCreate, remove: worktreeRemove, list: worktreeList },
-      index: { refresh, ignored },
+      index: { ignored },
       tree: {
+        head: headTree,
         capture: captureTree,
-        write: writeTree,
         files: treeFiles,
         diff: treeDiff,
         preview,

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -453,7 +453,7 @@ const layer = Layer.effect(
         { concurrency: 2 },
       )
       const candidates = Array.from(new Set([...tracked, ...untracked]))
-      if (!candidates.length) return
+      if (!candidates.length) return false
       const ignored = input.ignores
         ? new Set(
             (yield* repositoryOperation("refresh", input.ignores, ["check-ignore", "--no-index", "--stdin", "-z"], {
@@ -496,6 +496,7 @@ const layer = Layer.effect(
           ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"],
           { env, stdin: stage.join("\0") + "\0" },
         )
+      return true
     })
 
     const ignored = Effect.fn("Git.index.ignored")(function* (input: {
@@ -559,7 +560,8 @@ const layer = Layer.effect(
         withTemporaryIndex(input.repository, "capture", (env) =>
           Effect.gen(function* () {
             yield* repositoryOperation("refresh", input.repository, ["read-tree", input.base], { env })
-            yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }, env), { discard: true })
+            const changed = yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }, env))
+            if (!changed.some(Boolean)) return input.base
             return yield* writeTree(input.repository, env)
           }),
         ),

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -453,7 +453,7 @@ const layer = Layer.effect(
         { concurrency: 2 },
       )
       const candidates = Array.from(new Set([...tracked, ...untracked]))
-      if (!candidates.length) return { skipped: [] }
+      if (!candidates.length) return
       const ignored = input.ignores
         ? new Set(
             (yield* repositoryOperation("refresh", input.ignores, ["check-ignore", "--no-index", "--stdin", "-z"], {
@@ -463,22 +463,24 @@ const layer = Layer.effect(
               .filter(Boolean),
           )
         : new Set<string>()
-      const allowed = candidates.filter((item) => !ignored.has(item))
+      const allowed = new Set(candidates.filter((item) => !ignored.has(item)))
       const maximum = input.maximumUntrackedFileBytes
-      const skipped = maximum
-        ? (yield* Effect.forEach(
-            untracked.filter((item) => allowed.includes(item)),
-            (item) =>
-              fs.stat(path.join(input.repository.worktree, item)).pipe(
-                Effect.map((info) =>
-                  info.type === "File" && Number(info.size) > maximum ? RelativePath.make(item) : undefined,
+      const skipped = new Set(
+        maximum
+          ? (yield* Effect.forEach(
+              untracked.filter((item) => allowed.has(item)),
+              (item) =>
+                fs.stat(path.join(input.repository.worktree, item)).pipe(
+                  Effect.map((info) =>
+                    info.type === "File" && Number(info.size) > maximum ? RelativePath.make(item) : undefined,
+                  ),
+                  Effect.catch(() => Effect.succeed(undefined)),
                 ),
-                Effect.catch(() => Effect.succeed(undefined)),
-              ),
-            { concurrency: 8 },
-          )).filter((item): item is RelativePath => item !== undefined)
-        : []
-      const stage = allowed.filter((item) => !skipped.includes(RelativePath.make(item)))
+              { concurrency: 8 },
+            )).filter((item): item is RelativePath => item !== undefined)
+          : [],
+      )
+      const stage = candidates.filter((item) => allowed.has(item) && !skipped.has(RelativePath.make(item)))
       const remove = [...ignored, ...skipped]
       if (remove.length)
         yield* repositoryOperation(
@@ -494,7 +496,6 @@ const layer = Layer.effect(
           ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"],
           { env, stdin: stage.join("\0") + "\0" },
         )
-      return { skipped }
     })
 
     const ignored = Effect.fn("Git.index.ignored")(function* (input: {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -11,6 +11,7 @@ import { makeGlobalNode } from "./effect/app-node"
 import { File } from "./file"
 import { KeyedMutex } from "./effect/keyed-mutex"
 import { which } from "./util/which"
+import { EffectFlock } from "./util/effect-flock"
 
 const gitExecutable = which("git") ?? "git"
 
@@ -18,6 +19,7 @@ export class Repository extends Schema.Class<Repository>("Git.Repository")({
   worktree: AbsolutePath,
   gitDirectory: AbsolutePath,
   commonDirectory: AbsolutePath,
+  alternateObjectDirectories: Schema.optional(Schema.Array(AbsolutePath)),
 }) {}
 
 export const ChangeSet = Schema.String.pipe(Schema.brand("Git.ChangeSet"))
@@ -174,9 +176,27 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const proc = yield* AppProcess.Service
+    const flock = yield* EffectFlock.Service
     const locks = KeyedMutex.makeUnsafe<string>()
     const locked = <A, E, R>(repository: Repository, effect: Effect.Effect<A, E, R>) =>
       locks.withLock(repository.gitDirectory)(effect)
+
+    const lockedObjects = (repository: Repository, effect: Effect.Effect<TreeID, OperationError>) =>
+      locked(
+        repository,
+        flock.withLock(effect, `git-objects:${repository.gitDirectory}`).pipe(
+          Effect.mapError((cause) =>
+            cause instanceof OperationError
+              ? cause
+              : new OperationError({
+                  operation: "write_tree",
+                  directory: repository.gitDirectory,
+                  message: cause._tag === "LockTimeoutError" ? `Timed out waiting for ${cause.key}` : cause.detail,
+                  cause,
+                }),
+          ),
+        ),
+      )
 
     const discover = Effect.fn("Git.repo.discover")(function* (input: AbsolutePath) {
       const dotgit = yield* fs.up({ targets: [".git"], start: input }).pipe(
@@ -324,7 +344,13 @@ const layer = Layer.effect(
       args: string[],
       options?: { stdin?: string; env?: Record<string, string> },
     ) {
-      const env = { GIT_OPTIONAL_LOCKS: "0", ...options?.env }
+      const env = {
+        GIT_OPTIONAL_LOCKS: "0",
+        ...(repository.alternateObjectDirectories?.length
+          ? { GIT_ALTERNATE_OBJECT_DIRECTORIES: repository.alternateObjectDirectories.join(path.delimiter) }
+          : {}),
+        ...options?.env,
+      }
       const result = yield* proc
         .run(
           ChildProcess.make(gitExecutable, repositoryArgs(repository, args), {
@@ -374,6 +400,9 @@ const layer = Layer.effect(
         worktree: input.worktree,
         gitDirectory: input.gitDirectory,
         commonDirectory: input.gitDirectory,
+        alternateObjectDirectories: input.seed
+          ? [AbsolutePath.make(path.join(input.seed.commonDirectory, "objects"))]
+          : undefined,
       })
       yield* repositoryOperation("create", repository, ["init"])
       yield* Effect.forEach(
@@ -390,34 +419,6 @@ const layer = Layer.effect(
         ([key, value]) => repositoryOperation("create", repository, ["config", key, value]),
         { discard: true },
       )
-      if (!input.seed) return repository
-      yield* fs.ensureDir(path.join(input.gitDirectory, "objects", "info")).pipe(
-        Effect.mapError(
-          (cause) =>
-            new OperationError({
-              operation: "create",
-              directory: input.gitDirectory,
-              message: "Failed to configure shared Git objects",
-              cause,
-            }),
-        ),
-      )
-      yield* fs
-        .writeFileString(
-          path.join(input.gitDirectory, "objects", "info", "alternates"),
-          path.join(input.seed.commonDirectory, "objects") + "\n",
-        )
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new OperationError({
-                operation: "create",
-                directory: input.gitDirectory,
-                message: "Failed to configure shared Git objects",
-                cause,
-              }),
-          ),
-        )
       return repository
     })
 
@@ -435,7 +436,7 @@ const layer = Layer.effect(
           }),
       )
 
-    const refresh = Effect.fnUntraced(function* (
+    const inspect = Effect.fnUntraced(function* (
       input: {
         repository: Repository
         scope: RelativePath
@@ -454,7 +455,7 @@ const layer = Layer.effect(
         .filter(Boolean)
         .map((entry) => ({ tag: entry[0], path: entry.slice(2) }))
       const candidates = Array.from(new Set(entries.map((entry) => entry.path)))
-      if (!candidates.length) return false
+      if (!candidates.length) return
       const untracked = entries.filter((entry) => entry.tag === "?").map((entry) => entry.path)
       const ignored = input.ignores
         ? new Set(
@@ -484,21 +485,28 @@ const layer = Layer.effect(
       )
       const stage = candidates.filter((item) => allowed.has(item) && !skipped.has(RelativePath.make(item)))
       const remove = [...ignored, ...skipped]
-      if (remove.length)
+      return { remove, stage }
+    })
+
+    const applyIndexChanges = Effect.fnUntraced(function* (
+      repository: Repository,
+      changes: { readonly remove: readonly string[]; readonly stage: readonly string[] },
+      env: Record<string, string>,
+    ) {
+      if (changes.remove.length)
         yield* repositoryOperation(
           "refresh",
-          input.repository,
+          repository,
           ["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"],
-          { env, stdin: remove.join("\0") + "\0" },
+          { env, stdin: changes.remove.join("\0") + "\0" },
         )
-      if (stage.length)
+      if (changes.stage.length)
         yield* repositoryOperation(
           "refresh",
-          input.repository,
+          repository,
           ["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"],
-          { env, stdin: stage.join("\0") + "\0" },
+          { env, stdin: changes.stage.join("\0") + "\0" },
         )
-      return true
     })
 
     const ignored = Effect.fn("Git.index.ignored")(function* (input: {
@@ -566,9 +574,19 @@ const layer = Layer.effect(
         withTemporaryIndex(input.repository, "capture", (env) =>
           Effect.gen(function* () {
             yield* repositoryOperation("refresh", input.repository, ["read-tree", input.base], { env })
-            const changed = yield* Effect.forEach(input.scopes, (scope) => refresh({ ...input, scope }, env))
-            if (!changed.some(Boolean)) return input.base
-            return yield* writeTree(input.repository, env)
+            const changes = (yield* Effect.forEach(input.scopes, (scope) => inspect({ ...input, scope }, env))).filter(
+              (value): value is NonNullable<typeof value> => value !== undefined,
+            )
+            if (!changes.length) return input.base
+            return yield* lockedObjects(
+              input.repository,
+              Effect.gen(function* () {
+                yield* Effect.forEach(changes, (change) => applyIndexChanges(input.repository, change, env), {
+                  discard: true,
+                })
+                return yield* writeTree(input.repository, env)
+              }),
+            )
           }),
         ),
     )
@@ -982,7 +1000,11 @@ const layer = Layer.effect(
   }),
 )
 
-export const node = makeGlobalNode({ service: Service, layer: layer, deps: [FSUtil.node, AppProcess.node] })
+export const node = makeGlobalNode({
+  service: Service,
+  layer: layer,
+  deps: [FSUtil.node, AppProcess.node, EffectFlock.node],
+})
 
 interface Result {
   readonly exitCode: number

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -187,15 +187,15 @@ const layer = Layer.effect(
 
       const cwd = path.dirname(dotgit)
       const git = run(cwd, proc)
-      const topLevel = yield* git(["rev-parse", "--show-toplevel"])
-      const gitDir = yield* git(["rev-parse", "--git-dir"])
-      const commonDir = yield* git(["rev-parse", "--git-common-dir"])
-      if (gitDir.exitCode !== 0 || commonDir.exitCode !== 0) return undefined
+      const result = yield* git(["rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir"])
+      if (result.exitCode !== 0) return undefined
+      const [topLevel, gitDir, commonDir] = result.text.split("\n").map((value) => value.trim())
+      if (!topLevel || !gitDir || !commonDir) return undefined
 
       return new Repository({
-        worktree: AbsolutePath.make(topLevel.exitCode === 0 ? resolvePath(cwd, topLevel.text) : cwd),
-        gitDirectory: AbsolutePath.make(resolvePath(cwd, gitDir.text)),
-        commonDirectory: AbsolutePath.make(resolvePath(cwd, commonDir.text)),
+        worktree: AbsolutePath.make(resolvePath(cwd, topLevel)),
+        gitDirectory: AbsolutePath.make(resolvePath(cwd, gitDir)),
+        commonDirectory: AbsolutePath.make(resolvePath(cwd, commonDir)),
       })
     })
 

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -35,6 +35,7 @@ const RawMatch = Schema.Struct({
     ),
   }),
 })
+const decodeRawMatch = Schema.decodeUnknownEffect(RawMatch)
 
 type RawMatchData = (typeof RawMatch.Type)["data"]
 
@@ -240,7 +241,7 @@ const layer = Layer.effect(
               Effect.flatMap((json) => {
                 if (!json || typeof json !== "object" || !("type" in json) || json.type !== "match")
                   return Effect.succeed(undefined)
-                return Schema.decodeUnknownEffect(RawMatch)(json).pipe(
+                return decodeRawMatch(json).pipe(
                   Effect.map((match) => ({
                     ...match.data,
                     path: { text: match.data.path.text.replace(/^\.[\\/]/, "") },

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -7,12 +7,13 @@ export type MemoryState = {
   messages: SessionMessage.Message[]
 }
 
+export type AssistantEdit = (assistant: WritableDraft<SessionMessage.Assistant>) => void
+export type ShellEdit = (shell: WritableDraft<SessionMessage.Shell>) => void
+
 export interface Adapter {
-  readonly getCurrentAssistant: () => Effect.Effect<SessionMessage.Assistant | undefined>
-  readonly getAssistant: (messageID: SessionMessage.ID) => Effect.Effect<SessionMessage.Assistant | undefined>
-  readonly getCurrentShell: (callID: string) => Effect.Effect<SessionMessage.Shell | undefined>
-  readonly updateAssistant: (assistant: SessionMessage.Assistant) => Effect.Effect<void>
-  readonly updateShell: (shell: SessionMessage.Shell) => Effect.Effect<void>
+  readonly editCurrentAssistant: (edit: AssistantEdit) => Effect.Effect<void>
+  readonly editAssistant: (messageID: SessionMessage.ID, edit: AssistantEdit) => Effect.Effect<void>
+  readonly editCurrentShell: (callID: string, edit: ShellEdit) => Effect.Effect<void>
   readonly appendMessage: (message: SessionMessage.Message) => Effect.Effect<void>
 }
 
@@ -25,46 +26,31 @@ export function memory(state: MemoryState): Adapter {
     state.messages.findLastIndex((message) => message.type === "shell" && message.callID === callID)
 
   return {
-    getCurrentAssistant() {
+    editCurrentAssistant(edit) {
       return Effect.sync(() => {
         const index = latestAssistantIndex()
         if (index < 0) return
         const assistant = state.messages[index]
-        return assistant?.type === "assistant" && !assistant.time.completed ? assistant : undefined
+        if (assistant?.type !== "assistant" || assistant.time.completed) return
+        state.messages[index] = produce(assistant, edit)
       })
     },
-    getAssistant(messageID) {
+    editAssistant(messageID, edit) {
       return Effect.sync(() => {
         const index = assistantIndex(messageID)
         if (index < 0) return
         const assistant = state.messages[index]
-        return assistant?.type === "assistant" ? assistant : undefined
+        if (assistant?.type !== "assistant") return
+        state.messages[index] = produce(assistant, edit)
       })
     },
-    getCurrentShell(callID) {
+    editCurrentShell(callID, edit) {
       return Effect.sync(() => {
         const index = activeShellIndex(callID)
         if (index < 0) return
         const shell = state.messages[index]
-        return shell?.type === "shell" ? shell : undefined
-      })
-    },
-    updateAssistant(assistant) {
-      return Effect.sync(() => {
-        const index = assistantIndex(assistant.id)
-        if (index < 0) return
-        const current = state.messages[index]
-        if (current?.type !== "assistant") return
-        state.messages[index] = assistant
-      })
-    },
-    updateShell(shell) {
-      return Effect.sync(() => {
-        const index = activeShellIndex(shell.callID)
-        if (index < 0) return
-        const current = state.messages[index]
-        if (current?.type !== "shell") return
-        state.messages[index] = shell
+        if (shell?.type !== "shell") return
+        state.messages[index] = produce(shell, edit)
       })
     },
     appendMessage(message) {
@@ -93,10 +79,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
     assistant?.content.findLast((item): item is DraftReasoning => item.type === "reasoning" && item.id === reasoningID)
 
   const updateOwnedAssistant = (messageID: SessionMessage.ID, recipe: (draft: DraftAssistant) => void) =>
-    Effect.gen(function* () {
-      const assistant = yield* adapter.getAssistant(messageID)
-      if (assistant) yield* adapter.updateAssistant(produce(assistant, recipe))
-    })
+    adapter.editAssistant(messageID, recipe)
 
   return Effect.gen(function* () {
     yield* SessionEvent.All.match(event, {
@@ -171,28 +154,16 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
         )
       },
       "session.next.shell.ended": (event) => {
-        return Effect.gen(function* () {
-          const currentShell = yield* adapter.getCurrentShell(event.data.callID)
-          if (currentShell) {
-            yield* adapter.updateShell(
-              produce(currentShell, (draft) => {
-                draft.output = event.data.output
-                draft.time.completed = event.data.timestamp
-              }),
-            )
-          }
+        return adapter.editCurrentShell(event.data.callID, (shell) => {
+          shell.output = event.data.output
+          shell.time.completed = event.data.timestamp
         })
       },
       "session.next.step.started": (event) => {
         return Effect.gen(function* () {
-          const currentAssistant = yield* adapter.getCurrentAssistant()
-          if (currentAssistant) {
-            yield* adapter.updateAssistant(
-              produce(currentAssistant, (draft) => {
-                draft.time.completed = event.data.timestamp
-              }),
-            )
-          }
+          yield* adapter.editCurrentAssistant((assistant) => {
+            assistant.time.completed = event.data.timestamp
+          })
           yield* adapter.appendMessage(
             SessionMessage.Assistant.make({
               id: event.data.assistantMessageID,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -14,6 +14,7 @@ import { SessionInput } from "./input"
 import { WorkspaceV2 } from "../workspace"
 import { MessageTable, PartTable, SessionInputTable, SessionMessageTable, SessionTable } from "./sql"
 import type { DeepMutable } from "../schema"
+import { castDraft } from "immer"
 
 type DatabaseService = Database.Interface["db"]
 
@@ -130,7 +131,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
     }
     const appendMessage = (message: SessionMessage.Message) => insertMessage(db, event, message)
     const adapter: SessionMessageUpdater.Adapter = {
-      getCurrentAssistant() {
+      editCurrentAssistant(edit) {
         return Effect.gen(function* () {
           // A newer turn supersedes stale incomplete rows; never resume an older assistant projection.
           const row = yield* db
@@ -145,10 +146,12 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
             .pipe(Effect.orDie)
           if (!row) return
           const message = decodeRow(row)
-          return message.type === "assistant" && !message.time.completed ? message : undefined
+          if (message.type !== "assistant" || message.time.completed) return
+          edit(castDraft(message))
+          yield* updateMessage(message)
         })
       },
-      getAssistant(messageID) {
+      editAssistant(messageID, edit) {
         return Effect.gen(function* () {
           const row = yield* db
             .select()
@@ -164,10 +167,12 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
             .pipe(Effect.orDie)
           if (!row) return
           const message = decodeRow(row)
-          return message.type === "assistant" ? message : undefined
+          if (message.type !== "assistant") return
+          edit(castDraft(message))
+          yield* updateMessage(message)
         })
       },
-      getCurrentShell(callID) {
+      editCurrentShell(callID, edit) {
         return Effect.gen(function* () {
           const rows = yield* db
             .select()
@@ -176,13 +181,14 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
             .orderBy(desc(SessionMessageTable.seq))
             .all()
             .pipe(Effect.orDie)
-          return rows
+          const message = rows
             .map(decodeRow)
             .find((message): message is SessionMessage.Shell => message.type === "shell" && message.callID === callID)
+          if (!message) return
+          edit(castDraft(message))
+          yield* updateMessage(message)
         })
       },
-      updateAssistant: updateMessage,
-      updateShell: updateMessage,
       appendMessage,
     }
     yield* SessionMessageUpdater.update(adapter, event)

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -1,6 +1,6 @@
 export * as SessionProjector from "./projector"
 
-import { and, desc, eq, gt, or, sql } from "drizzle-orm"
+import { and, desc, eq, gt, or, placeholder, sql } from "drizzle-orm"
 import { DateTime, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
 import { EventV2 } from "../event"
@@ -26,6 +26,46 @@ const messageSelection = {
   type: SessionMessageTable.type,
   data: SessionMessageTable.data,
 }
+
+function prepareMessageReads(db: DatabaseService) {
+  return {
+    currentAssistant: db
+      .select(messageSelection)
+      .from(SessionMessageTable)
+      .where(
+        and(eq(SessionMessageTable.session_id, placeholder("sessionID")), eq(SessionMessageTable.type, "assistant")),
+      )
+      .orderBy(desc(SessionMessageTable.seq))
+      .limit(1)
+      .prepare(),
+    assistant: db
+      .select(messageSelection)
+      .from(SessionMessageTable)
+      .where(
+        and(
+          eq(SessionMessageTable.id, placeholder("messageID")),
+          eq(SessionMessageTable.session_id, placeholder("sessionID")),
+          eq(SessionMessageTable.type, "assistant"),
+        ),
+      )
+      .prepare(),
+    shell: db
+      .select(messageSelection)
+      .from(SessionMessageTable)
+      .where(
+        and(
+          eq(SessionMessageTable.session_id, placeholder("sessionID")),
+          eq(SessionMessageTable.type, "shell"),
+          eq(sql<string>`json_extract(${SessionMessageTable.data}, '$.callID')`, placeholder("callID")),
+        ),
+      )
+      .orderBy(desc(SessionMessageTable.seq))
+      .limit(1)
+      .prepare(),
+  }
+}
+
+type MessageReads = ReturnType<typeof prepareMessageReads>
 
 export class SessionAlreadyProjected extends Error {}
 
@@ -115,7 +155,7 @@ function applyUsage(
     .pipe(Effect.orDie)
 }
 
-function run(db: DatabaseService, event: SessionEvent.Event) {
+function run(db: DatabaseService, reads: MessageReads, event: SessionEvent.Event) {
   return Effect.gen(function* () {
     const updateMessage = (message: SessionMessage.Message) => {
       if (event.durable === undefined) return Effect.die("Durable Session event is missing aggregate sequence")
@@ -138,16 +178,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       editCurrentAssistant(edit) {
         return Effect.gen(function* () {
           // A newer turn supersedes stale incomplete rows; never resume an older assistant projection.
-          const row = yield* db
-            .select(messageSelection)
-            .from(SessionMessageTable)
-            .where(
-              and(eq(SessionMessageTable.session_id, event.data.sessionID), eq(SessionMessageTable.type, "assistant")),
-            )
-            .orderBy(desc(SessionMessageTable.seq))
-            .limit(1)
-            .get()
-            .pipe(Effect.orDie)
+          const row = yield* reads.currentAssistant.get({ sessionID: event.data.sessionID }).pipe(Effect.orDie)
           if (!row) return
           const message = decodeAssistant({ ...row.data, id: row.id, type: row.type })
           if (message.time.completed) return
@@ -157,18 +188,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       },
       editAssistant(messageID, edit) {
         return Effect.gen(function* () {
-          const row = yield* db
-            .select(messageSelection)
-            .from(SessionMessageTable)
-            .where(
-              and(
-                eq(SessionMessageTable.id, messageID),
-                eq(SessionMessageTable.session_id, event.data.sessionID),
-                eq(SessionMessageTable.type, "assistant"),
-              ),
-            )
-            .get()
-            .pipe(Effect.orDie)
+          const row = yield* reads.assistant.get({ messageID, sessionID: event.data.sessionID }).pipe(Effect.orDie)
           if (!row) return
           const message = decodeAssistant({ ...row.data, id: row.id, type: row.type })
           edit(castDraft(message))
@@ -177,20 +197,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       },
       editCurrentShell(callID, edit) {
         return Effect.gen(function* () {
-          const row = yield* db
-            .select(messageSelection)
-            .from(SessionMessageTable)
-            .where(
-              and(
-                eq(SessionMessageTable.session_id, event.data.sessionID),
-                eq(SessionMessageTable.type, "shell"),
-                eq(sql<string>`json_extract(${SessionMessageTable.data}, '$.callID')`, callID),
-              ),
-            )
-            .orderBy(desc(SessionMessageTable.seq))
-            .limit(1)
-            .get()
-            .pipe(Effect.orDie)
+          const row = yield* reads.shell.get({ callID, sessionID: event.data.sessionID }).pipe(Effect.orDie)
           if (!row) return
           const message = decodeShell({ ...row.data, id: row.id, type: row.type })
           edit(castDraft(message))
@@ -225,6 +232,8 @@ const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const events = yield* EventV2.Service
     const { db } = yield* Database.Service
+    const reads = prepareMessageReads(db)
+    const projectMessage = (event: SessionEvent.Event) => run(db, reads, event)
     yield* events.project(SessionV1.Event.Created, (event) =>
       Effect.gen(function* () {
         const stored = yield* db
@@ -346,7 +355,7 @@ const layer = Layer.effectDiscard(
         .set({ agent: event.data.agent, time_updated: DateTime.toEpochMillis(event.data.timestamp) })
         .where(eq(SessionTable.id, event.data.sessionID))
         .run()
-        .pipe(Effect.orDie, Effect.andThen(run(db, event))),
+        .pipe(Effect.orDie, Effect.andThen(projectMessage(event))),
     )
     yield* events.project(SessionEvent.ModelSwitched, (event) =>
       Effect.gen(function* () {
@@ -356,7 +365,7 @@ const layer = Layer.effectDiscard(
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)
-        yield* run(db, event)
+        yield* projectMessage(event)
       }),
     )
     yield* events.project(SessionEvent.Prompted, (event) =>
@@ -370,7 +379,7 @@ const layer = Layer.effectDiscard(
           timeCreated: event.data.timestamp,
           promotedSeq: event.durable.seq,
         })
-        yield* run(db, event)
+        yield* projectMessage(event)
       }),
     )
     yield* events.project(SessionEvent.PromptAdmitted, (event) =>
@@ -386,25 +395,25 @@ const layer = Layer.effectDiscard(
         })
       }),
     )
-    yield* events.project(SessionEvent.ContextUpdated, (event) => run(db, event))
-    yield* events.project(SessionEvent.Synthetic, (event) => run(db, event))
-    yield* events.project(SessionEvent.Shell.Started, (event) => run(db, event))
-    yield* events.project(SessionEvent.Shell.Ended, (event) => run(db, event))
-    yield* events.project(SessionEvent.Step.Started, (event) => run(db, event))
-    yield* events.project(SessionEvent.Step.Ended, (event) => run(db, event))
-    yield* events.project(SessionEvent.Step.Failed, (event) => run(db, event))
-    yield* events.project(SessionEvent.Text.Started, (event) => run(db, event))
-    yield* events.project(SessionEvent.Text.Ended, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Input.Started, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Input.Ended, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Called, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Progress, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Success, (event) => run(db, event))
-    yield* events.project(SessionEvent.Tool.Failed, (event) => run(db, event))
-    yield* events.project(SessionEvent.Reasoning.Started, (event) => run(db, event))
-    yield* events.project(SessionEvent.Reasoning.Ended, (event) => run(db, event))
-    // yield* events.project(SessionEvent.Retried, (event) => run(db, event))
-    yield* events.project(SessionEvent.Compaction.Ended, (event) => run(db, event))
+    yield* events.project(SessionEvent.ContextUpdated, projectMessage)
+    yield* events.project(SessionEvent.Synthetic, projectMessage)
+    yield* events.project(SessionEvent.Shell.Started, projectMessage)
+    yield* events.project(SessionEvent.Shell.Ended, projectMessage)
+    yield* events.project(SessionEvent.Step.Started, projectMessage)
+    yield* events.project(SessionEvent.Step.Ended, projectMessage)
+    yield* events.project(SessionEvent.Step.Failed, projectMessage)
+    yield* events.project(SessionEvent.Text.Started, projectMessage)
+    yield* events.project(SessionEvent.Text.Ended, projectMessage)
+    yield* events.project(SessionEvent.Tool.Input.Started, projectMessage)
+    yield* events.project(SessionEvent.Tool.Input.Ended, projectMessage)
+    yield* events.project(SessionEvent.Tool.Called, projectMessage)
+    yield* events.project(SessionEvent.Tool.Progress, projectMessage)
+    yield* events.project(SessionEvent.Tool.Success, projectMessage)
+    yield* events.project(SessionEvent.Tool.Failed, projectMessage)
+    yield* events.project(SessionEvent.Reasoning.Started, projectMessage)
+    yield* events.project(SessionEvent.Reasoning.Ended, projectMessage)
+    // yield* events.project(SessionEvent.Retried, projectMessage)
+    yield* events.project(SessionEvent.Compaction.Ended, projectMessage)
     yield* events.project(SessionEvent.RevertEvent.Staged, (event) =>
       db
         .update(SessionTable)

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -18,8 +18,14 @@ import { castDraft } from "immer"
 
 type DatabaseService = Database.Interface["db"]
 
-const decodeMessage = Schema.decodeUnknownSync(SessionMessage.Message)
+const decodeAssistant = Schema.decodeUnknownSync(SessionMessage.Assistant)
+const decodeShell = Schema.decodeUnknownSync(SessionMessage.Shell)
 const encodeMessage = Schema.encodeSync(SessionMessage.Message)
+const messageSelection = {
+  id: SessionMessageTable.id,
+  type: SessionMessageTable.type,
+  data: SessionMessageTable.data,
+}
 
 export class SessionAlreadyProjected extends Error {}
 
@@ -111,8 +117,6 @@ function applyUsage(
 
 function run(db: DatabaseService, event: SessionEvent.Event) {
   return Effect.gen(function* () {
-    const decodeRow = (row: typeof SessionMessageTable.$inferSelect) =>
-      decodeMessage({ ...row.data, id: row.id, type: row.type })
     const updateMessage = (message: SessionMessage.Message) => {
       if (event.durable === undefined) return Effect.die("Durable Session event is missing aggregate sequence")
       const encoded = encodeMessage(message)
@@ -135,7 +139,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
         return Effect.gen(function* () {
           // A newer turn supersedes stale incomplete rows; never resume an older assistant projection.
           const row = yield* db
-            .select()
+            .select(messageSelection)
             .from(SessionMessageTable)
             .where(
               and(eq(SessionMessageTable.session_id, event.data.sessionID), eq(SessionMessageTable.type, "assistant")),
@@ -145,8 +149,8 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
             .get()
             .pipe(Effect.orDie)
           if (!row) return
-          const message = decodeRow(row)
-          if (message.type !== "assistant" || message.time.completed) return
+          const message = decodeAssistant({ ...row.data, id: row.id, type: row.type })
+          if (message.time.completed) return
           edit(castDraft(message))
           yield* updateMessage(message)
         })
@@ -154,7 +158,7 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       editAssistant(messageID, edit) {
         return Effect.gen(function* () {
           const row = yield* db
-            .select()
+            .select(messageSelection)
             .from(SessionMessageTable)
             .where(
               and(
@@ -166,25 +170,29 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
             .get()
             .pipe(Effect.orDie)
           if (!row) return
-          const message = decodeRow(row)
-          if (message.type !== "assistant") return
+          const message = decodeAssistant({ ...row.data, id: row.id, type: row.type })
           edit(castDraft(message))
           yield* updateMessage(message)
         })
       },
       editCurrentShell(callID, edit) {
         return Effect.gen(function* () {
-          const rows = yield* db
-            .select()
+          const row = yield* db
+            .select(messageSelection)
             .from(SessionMessageTable)
-            .where(and(eq(SessionMessageTable.session_id, event.data.sessionID), eq(SessionMessageTable.type, "shell")))
+            .where(
+              and(
+                eq(SessionMessageTable.session_id, event.data.sessionID),
+                eq(SessionMessageTable.type, "shell"),
+                eq(sql<string>`json_extract(${SessionMessageTable.data}, '$.callID')`, callID),
+              ),
+            )
             .orderBy(desc(SessionMessageTable.seq))
-            .all()
+            .limit(1)
+            .get()
             .pipe(Effect.orDie)
-          const message = rows
-            .map(decodeRow)
-            .find((message): message is SessionMessage.Shell => message.type === "shell" && message.callID === callID)
-          if (!message) return
+          if (!row) return
+          const message = decodeShell({ ...row.data, id: row.id, type: row.type })
           edit(castDraft(message))
           yield* updateMessage(message)
         })

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -317,11 +317,13 @@ const layer = Layer.effect(
           if (stepSettlement && !publisher.hasProviderError()) {
             const endSnapshot = yield* snapshots.capture()
             const files =
-              startSnapshot && endSnapshot
-                ? yield* snapshots
-                    .files({ from: startSnapshot, to: endSnapshot })
-                    .pipe(Effect.catch(() => Effect.succeed(undefined)))
-                : undefined
+              !startSnapshot || !endSnapshot
+                ? undefined
+                : startSnapshot === endSnapshot
+                  ? []
+                  : yield* snapshots
+                      .files({ from: startSnapshot, to: endSnapshot })
+                      .pipe(Effect.catch(() => Effect.succeed(undefined)))
             yield* withPublication(
               events.publish(SessionEvent.Step.Ended, {
                 sessionID: session.id,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -218,6 +218,7 @@ const layer = Layer.effect(
       const publisher = createLLMEventPublisher(events, {
         sessionID: session.id,
         agent: agent.id,
+        location: session.location,
         model: {
           id: ModelV2.ID.make(model.id),
           providerID: ProviderV2.ID.make(model.provider),

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -1,6 +1,7 @@
 import { ToolOutput, type LLMEvent, type ProviderMetadata, type ToolResultValue, type Usage } from "@opencode-ai/llm"
 import { DateTime, Effect } from "effect"
 import { EventV2 } from "../../event"
+import { Location } from "../../location"
 import { ModelV2 } from "../../model"
 import { SessionEvent } from "../event"
 import { SessionMessage } from "../message"
@@ -10,6 +11,7 @@ type Input = {
   readonly sessionID: SessionSchema.ID
   readonly agent: string
   readonly model: ModelV2.Ref
+  readonly location: Location.Ref
   readonly snapshot?: string
 }
 
@@ -52,6 +54,8 @@ const settledOutput = (value: ToolOutput | undefined, result: ToolResultValue): 
 
 /** Persist one provider turn without executing tools or starting a continuation turn. */
 export const createLLMEventPublisher = (events: EventV2.Interface, input: Input) => {
+  const publishEvent = <D extends EventV2.Definition>(definition: D, data: EventV2.Data<D>) =>
+    events.publish(definition, data, { location: input.location })
   const tools = new Map<
     string,
     {
@@ -75,7 +79,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     if (assistantMessageID !== undefined) return assistantMessageID
     assistantMessageID = SessionMessage.ID.create()
     assistantActive = true
-    yield* events.publish(SessionEvent.Step.Started, {
+    yield* publishEvent(SessionEvent.Step.Started, {
       ...input,
       assistantMessageID,
       timestamp: yield* timestamp,
@@ -120,7 +124,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
 
   const text = fragments("text", (textID, value) =>
     Effect.gen(function* () {
-      yield* events.publish(SessionEvent.Text.Ended, {
+      yield* publishEvent(SessionEvent.Text.Ended, {
         sessionID: input.sessionID,
         assistantMessageID: yield* currentAssistantMessageID(),
         timestamp: yield* timestamp,
@@ -131,7 +135,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
   )
   const reasoning = fragments("reasoning", (reasoningID, value, providerMetadata) =>
     Effect.gen(function* () {
-      yield* events.publish(SessionEvent.Reasoning.Ended, {
+      yield* publishEvent(SessionEvent.Reasoning.Ended, {
         sessionID: input.sessionID,
         assistantMessageID: yield* currentAssistantMessageID(),
         timestamp: yield* timestamp,
@@ -145,7 +149,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     Effect.gen(function* () {
       const tool = tools.get(callID)
       if (!tool) return yield* Effect.die(`Tool input end before start: ${callID}`)
-      yield* events.publish(SessionEvent.Tool.Input.Ended, {
+      yield* publishEvent(SessionEvent.Tool.Input.Ended, {
         sessionID: input.sessionID,
         timestamp: yield* timestamp,
         assistantMessageID: tool.assistantMessageID,
@@ -174,7 +178,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
       providerExecuted: false,
     })
     yield* toolInput.start(event.id)
-    yield* events.publish(SessionEvent.Tool.Input.Started, {
+    yield* publishEvent(SessionEvent.Tool.Input.Started, {
       sessionID: input.sessionID,
       timestamp: yield* timestamp,
       assistantMessageID,
@@ -202,7 +206,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     const assistantMessageID = yield* startAssistant()
     assistantActive = false
     assistantFailed = true
-    yield* events.publish(SessionEvent.Step.Failed, {
+    yield* publishEvent(SessionEvent.Step.Failed, {
       sessionID: input.sessionID,
       timestamp: yield* timestamp,
       assistantMessageID,
@@ -217,7 +221,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     for (const [callID, tool] of tools) {
       if (tool.settled || (hostedOnly && !tool.providerExecuted)) continue
       tool.settled = true
-      yield* events.publish(SessionEvent.Tool.Failed, {
+      yield* publishEvent(SessionEvent.Tool.Failed, {
         sessionID: input.sessionID,
         timestamp: yield* timestamp,
         assistantMessageID: tool.assistantMessageID,
@@ -242,7 +246,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         return
       case "text-start":
         yield* text.start(event.id)
-        yield* events.publish(SessionEvent.Text.Started, {
+        yield* publishEvent(SessionEvent.Text.Started, {
           sessionID: input.sessionID,
           assistantMessageID: yield* startAssistant(),
           timestamp: yield* timestamp,
@@ -251,7 +255,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         return
       case "text-delta":
         yield* text.append(event.id, event.text)
-        yield* events.publish(SessionEvent.Text.Delta, {
+        yield* publishEvent(SessionEvent.Text.Delta, {
           sessionID: input.sessionID,
           assistantMessageID: yield* currentAssistantMessageID(),
           timestamp: yield* timestamp,
@@ -264,7 +268,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         return
       case "reasoning-start":
         yield* reasoning.start(event.id)
-        yield* events.publish(SessionEvent.Reasoning.Started, {
+        yield* publishEvent(SessionEvent.Reasoning.Started, {
           sessionID: input.sessionID,
           assistantMessageID: yield* startAssistant(),
           timestamp: yield* timestamp,
@@ -274,7 +278,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         return
       case "reasoning-delta":
         yield* reasoning.append(event.id, event.text)
-        yield* events.publish(SessionEvent.Reasoning.Delta, {
+        yield* publishEvent(SessionEvent.Reasoning.Delta, {
           sessionID: input.sessionID,
           assistantMessageID: yield* currentAssistantMessageID(),
           timestamp: yield* timestamp,
@@ -295,7 +299,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           return yield* Effect.die(`Tool input name changed for ${event.id}: ${tool.name} -> ${event.name}`)
         if (tool.inputEnded) return yield* Effect.die(`Tool input delta after end: ${event.id}`)
         yield* toolInput.append(event.id, event.text)
-        yield* events.publish(SessionEvent.Tool.Input.Delta, {
+        yield* publishEvent(SessionEvent.Tool.Input.Delta, {
           sessionID: input.sessionID,
           timestamp: yield* timestamp,
           assistantMessageID: tool.assistantMessageID,
@@ -317,7 +321,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         tool.called = true
         tool.providerExecuted = event.providerExecuted === true
         tool.providerMetadata = event.providerMetadata
-        yield* events.publish(SessionEvent.Tool.Called, {
+        yield* publishEvent(SessionEvent.Tool.Called, {
           sessionID: input.sessionID,
           timestamp: yield* timestamp,
           assistantMessageID: tool.assistantMessageID,
@@ -347,7 +351,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           ...(event.providerMetadata === undefined ? {} : { metadata: event.providerMetadata }),
         }
         if ("error" in result) {
-          yield* events.publish(SessionEvent.Tool.Failed, {
+          yield* publishEvent(SessionEvent.Tool.Failed, {
             sessionID: input.sessionID,
             timestamp: yield* timestamp,
             assistantMessageID: tool.assistantMessageID,
@@ -358,7 +362,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           })
           return
         }
-        yield* events.publish(SessionEvent.Tool.Success, {
+        yield* publishEvent(SessionEvent.Tool.Success, {
           sessionID: input.sessionID,
           timestamp: yield* timestamp,
           assistantMessageID: tool.assistantMessageID,
@@ -377,7 +381,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           return yield* Effect.die(`Tool error name changed for ${event.id}: ${tool.name} -> ${event.name}`)
         if (tool.settled) return yield* Effect.die(`Duplicate tool error: ${event.id}`)
         tool.settled = true
-        yield* events.publish(SessionEvent.Tool.Failed, {
+        yield* publishEvent(SessionEvent.Tool.Failed, {
           sessionID: input.sessionID,
           timestamp: yield* timestamp,
           assistantMessageID: tool.assistantMessageID,

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -236,10 +236,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     return tool ? Effect.succeed(tool.assistantMessageID) : Effect.die(`Unknown tool call: ${callID}`)
   }
 
-  const publish = Effect.fn("SessionRunner.publishLLMEvent")(function* (
-    event: LLMEvent,
-    outputPaths: ReadonlyArray<string> = [],
-  ) {
+  const publish = Effect.fnUntraced(function* (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) {
     switch (event.type) {
       case "step-start":
         return

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -2,7 +2,7 @@ export * as Snapshot from "./snapshot"
 
 import { makeLocationNode } from "./effect/app-node"
 import path from "path"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Ref, Schema } from "effect"
 import { Config } from "./config"
 import { File } from "./file"
 import { FSUtil } from "./fs-util"
@@ -96,6 +96,7 @@ const layer = Layer.effect(
       ? AbsolutePath.make(yield* fs.realPath(source.worktree).pipe(Effect.orDie))
       : location.project.directory
     const gitDirectory = AbsolutePath.make(path.join(global.data, "snapshot", location.project.id, Hash.fast(worktree)))
+    const latest = yield* Ref.make<Git.TreeID | undefined>(undefined)
 
     const scope = Effect.fnUntraced(function* () {
       const relative = path.relative(worktree, location.directory)
@@ -126,19 +127,29 @@ const layer = Layer.effect(
       return Config.latest(yield* config.entries(), "snapshots") !== false
     })
 
+    const captureTree = Effect.fnUntraced(function* () {
+      if (!source) return yield* new Error({ operation: "capture", message: "Project is not a Git repository" })
+      const repo = yield* repository()
+      const base =
+        (yield* Ref.get(latest)) ??
+        (yield* git.tree.head(source).pipe(Effect.mapError((cause) => failure("capture", cause))))
+      const tree = yield* git.tree
+        .capture({
+          repository: repo,
+          base,
+          scopes: [yield* scope()],
+          ignores: source,
+          maximumUntrackedFileBytes: 2 * 1024 * 1024,
+        })
+        .pipe(Effect.mapError((cause) => failure("capture", cause)))
+      yield* Ref.set(latest, tree)
+      return tree
+    })
+
     const capture = Effect.fn("Snapshot.capture")(function* () {
       if (!(yield* enabled())) return undefined
-      return yield* Effect.gen(function* () {
-        const repo = yield* repository()
-        return ID.make(
-          yield* git.tree.capture({
-            repository: repo,
-            scopes: [yield* scope()],
-            ignores: source,
-            maximumUntrackedFileBytes: 2 * 1024 * 1024,
-          }),
-        )
-      }).pipe(
+      return yield* captureTree().pipe(
+        Effect.map(ID.make),
         Effect.catch((cause) => Effect.logWarning("failed to capture snapshot", { cause }).pipe(Effect.as(undefined))),
       )
     })
@@ -190,14 +201,7 @@ const layer = Layer.effect(
       if (!(yield* enabled())) return yield* new Error({ operation: "preview", message: "Snapshots are disabled" })
       const repo = yield* repository().pipe(Effect.mapError((cause) => failure("preview", cause)))
       const files = yield* plan("preview", input)
-      const current = yield* git.tree
-        .capture({
-          repository: repo,
-          scopes: Array.from(files.keys()),
-          ignores: source,
-          maximumUntrackedFileBytes: 2 * 1024 * 1024,
-        })
-        .pipe(Effect.mapError((cause) => failure("preview", cause)))
+      const current = yield* captureTree().pipe(Effect.mapError((cause) => failure("preview", cause)))
       return yield* git.tree
         .preview({
           repository: repo,

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -112,6 +112,7 @@ const layer = Layer.effect(
           worktree,
           gitDirectory,
           commonDirectory: gitDirectory,
+          alternateObjectDirectories: [AbsolutePath.make(path.join(source.commonDirectory, "objects"))],
         })
       return yield* git.repo
         .create({

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -75,6 +75,9 @@ export function make<
 >(config: Config<Input, Output, Structured>): Definition<Input, Structured> {
   const tool = Object.freeze({}) as Definition<Input, Structured>
   const definitions = new Map<string, ToolDefinition>()
+  const decodeInput = Schema.decodeUnknownEffect(config.input)
+  const encodeOutput = Schema.encodeEffect(config.output)
+  const encodeStructured = config.structured ? Schema.encodeEffect(config.structured) : undefined
   runtimes.set(tool, {
     definition: (name) => {
       const cached = definitions.get(name)
@@ -89,16 +92,16 @@ export function make<
       return definition
     },
     settle: (call, context) =>
-      Schema.decodeUnknownEffect(config.input)(call.input).pipe(
+      decodeInput(call.input).pipe(
         Effect.mapError((error) => new ToolFailure({ message: `Invalid tool input: ${error.message}` })),
         Effect.flatMap((input) =>
           config.execute(input, context).pipe(
             Effect.flatMap((output) =>
-              Schema.encodeEffect(config.output)(output).pipe(
+              encodeOutput(output).pipe(
                 Effect.flatMap((output) => {
-                  if (!config.structured || !config.toStructuredOutput)
+                  if (!encodeStructured || !config.toStructuredOutput)
                     return Effect.succeed({ output, structured: output })
-                  return Schema.encodeEffect(config.structured)(config.toStructuredOutput({ input, output })).pipe(
+                  return encodeStructured(config.toStructuredOutput({ input, output })).pipe(
                     Effect.map((structured) => ({ output, structured })),
                   )
                 }),

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -121,6 +121,7 @@ describe("Git trees", () => {
         await initRepo(root.path)
         await fs.mkdir(path.join(root.path, "scope"))
         await fs.writeFile(path.join(root.path, "scope", "tracked.txt"), "one\n")
+        await fs.writeFile(path.join(root.path, "scope", "removed.txt"), "remove\n")
         await fs.writeFile(path.join(root.path, "outside.txt"), "outside\n")
         await $`git add .`.cwd(root.path).quiet()
         await $`git commit -m initial`.cwd(root.path).quiet()
@@ -136,17 +137,20 @@ describe("Git trees", () => {
       yield* Effect.promise(async () => {
         await fs.writeFile(path.join(root.path, "scope", "tracked.txt"), "two\n")
         await fs.writeFile(path.join(root.path, "scope", "added.txt"), "added\n")
+        await fs.rm(path.join(root.path, "scope", "removed.txt"))
         await fs.writeFile(path.join(root.path, "outside.txt"), "changed outside\n")
       })
       const after = yield* git.tree.capture({ repository, base: before, scopes: [RelativePath.make("scope")] })
 
       expect(yield* git.tree.files({ repository, from: before, to: after })).toEqual([
         RelativePath.make("scope/added.txt"),
+        RelativePath.make("scope/removed.txt"),
         RelativePath.make("scope/tracked.txt"),
       ])
       const diffs = yield* git.tree.diff({ repository, from: before, to: after, context: 1 })
       expect(diffs.map((item) => [item.path, item.status])).toEqual([
         [RelativePath.make("scope/added.txt"), "added"],
+        [RelativePath.make("scope/removed.txt"), "deleted"],
         [RelativePath.make("scope/tracked.txt"), "modified"],
       ])
 

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -179,7 +179,8 @@ describe("Git trees", () => {
           const git = yield* Git.Service
           const source = yield* git.repo.discover(AbsolutePath.make(root.path))
           if (!source) throw new Error("Repository not found")
-          const storage = AbsolutePath.make(path.join(root.path, ".snapshot"))
+          const storage = AbsolutePath.make(`${root.path}-snapshot`)
+          yield* Effect.addFinalizer(() => Effect.promise(() => fs.rm(storage, { recursive: true, force: true })))
           const repository = yield* git.repo.create({ worktree: source.worktree, gitDirectory: storage, seed: source })
           const base = yield* git.tree.head(source)
           yield* Effect.promise(() => fs.writeFile(path.join(storage, "index.lock"), ""))

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -130,16 +130,15 @@ describe("Git trees", () => {
       if (!source) throw new Error("Repository not found")
       const storage = AbsolutePath.make(path.join(root.path, ".snapshot"))
       const repository = yield* git.repo.create({ worktree: source.worktree, gitDirectory: storage, seed: source })
-      yield* git.index.refresh({ repository, scope: RelativePath.make("scope") })
-      const before = yield* git.tree.write(repository)
+      const base = yield* git.tree.head(source)
+      const before = yield* git.tree.capture({ repository, base, scopes: [RelativePath.make("scope")] })
 
       yield* Effect.promise(async () => {
         await fs.writeFile(path.join(root.path, "scope", "tracked.txt"), "two\n")
         await fs.writeFile(path.join(root.path, "scope", "added.txt"), "added\n")
         await fs.writeFile(path.join(root.path, "outside.txt"), "changed outside\n")
       })
-      yield* git.index.refresh({ repository, scope: RelativePath.make("scope") })
-      const after = yield* git.tree.write(repository)
+      const after = yield* git.tree.capture({ repository, base: before, scopes: [RelativePath.make("scope")] })
 
       expect(yield* git.tree.files({ repository, from: before, to: after })).toEqual([
         RelativePath.make("scope/added.txt"),
@@ -160,5 +159,42 @@ describe("Git trees", () => {
       expect(yield* read(path.join(root.path, "scope", "added.txt"))).toBe("added\n")
       expect(yield* read(path.join(root.path, "outside.txt"))).toBe("changed outside\n")
     }),
+  )
+
+  it.live("captures concurrently with an existing shared index lock", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (root) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(async () => {
+            await initRepo(root.path)
+            await fs.writeFile(path.join(root.path, "tracked.txt"), "one\n")
+            await $`git add .`.cwd(root.path).quiet()
+            await $`git commit -m initial`.cwd(root.path).quiet()
+          })
+          const git = yield* Git.Service
+          const source = yield* git.repo.discover(AbsolutePath.make(root.path))
+          if (!source) throw new Error("Repository not found")
+          const storage = AbsolutePath.make(path.join(root.path, ".snapshot"))
+          const repository = yield* git.repo.create({ worktree: source.worktree, gitDirectory: storage, seed: source })
+          const base = yield* git.tree.head(source)
+          yield* Effect.promise(() => fs.writeFile(path.join(storage, "index.lock"), ""))
+
+          const trees = yield* Effect.all(
+            [
+              git.tree.capture({ repository, base, scopes: [RelativePath.make(".")] }),
+              git.tree.capture({ repository, base, scopes: [RelativePath.make(".")] }),
+            ],
+            { concurrency: "unbounded" },
+          )
+
+          expect(trees[0]).toBe(trees[1])
+          expect(yield* Effect.promise(() => fs.stat(path.join(storage, "index.lock")))).toBeDefined()
+          expect(
+            (yield* Effect.promise(() => fs.readdir(storage))).filter((file) => file.startsWith("capture-")),
+          ).toEqual([])
+        }),
+      (root) => Effect.promise(() => root[Symbol.asyncDispose]()),
+    ),
   )
 })

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -430,9 +430,12 @@ describe("SessionProjector", () => {
         time: { created: DateTime.makeUnsafe(1), completed: DateTime.makeUnsafe(2) },
       })
 
-      expect(
-        yield* SessionMessageUpdater.memory({ messages: [stale, completed] }).getCurrentAssistant(),
-      ).toBeUndefined()
+      const messages: SessionMessage.Message[] = [stale, completed]
+      yield* SessionMessageUpdater.memory({ messages }).editCurrentAssistant((assistant) => {
+        assistant.time.completed = DateTime.makeUnsafe(3)
+      })
+      expect(messages[0]).not.toHaveProperty("time.completed")
+      expect(messages[1]).toMatchObject({ time: { completed: DateTime.makeUnsafe(2) } })
     }),
   )
 

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -8,6 +8,8 @@ import { SessionV2 } from "@opencode-ai/core/session"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { createLLMEventPublisher } from "@opencode-ai/core/session/runner/publish-llm-event"
+import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 
 const sessionID = SessionV2.ID.make("ses_tool_event_test")
 const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
@@ -41,6 +43,7 @@ const capture = () => {
     publisher: createLLMEventPublisher(events, {
       sessionID,
       agent: "build",
+      location: Location.Ref.make({ directory: AbsolutePath.make("/project") }),
       model: {
         id: ModelV2.ID.make("model"),
         providerID: ProviderV2.ID.make("provider"),

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -83,6 +83,66 @@ describe("Snapshot", () => {
     ),
   )
 
+  testEffect(Layer.empty).live("isolates captures from existing Git index locks", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await $`git init`.cwd(project).quiet()
+            await $`git config core.fsmonitor false`.cwd(project).quiet()
+            await $`git config commit.gpgsign false`.cwd(project).quiet()
+            await $`git config user.email test@opencode.test`.cwd(project).quiet()
+            await $`git config user.name Test`.cwd(project).quiet()
+            await $`git add .`.cwd(project).quiet()
+            await $`git commit -m initial`.cwd(project).quiet()
+            await fs.writeFile(path.join(project, ".git", "index.lock"), "")
+          })
+
+          const projectID = yield* Effect.gen(function* () {
+            return (yield* Location.Service).project.id
+          }).pipe(
+            Effect.provide(
+              AppNodeBuilder.build(Location.boundNode(Location.Ref.make({ directory: AbsolutePath.make(project) }))),
+            ),
+          )
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            const before = yield* snapshot.capture()
+            expect(before).toBeDefined()
+            if (!before) return
+
+            const storage = path.join(
+              tmp.path,
+              "snapshot",
+              projectID,
+              Hash.fast(yield* Effect.promise(() => fs.realpath(project))),
+            )
+            yield* Effect.promise(async () => {
+              await fs.writeFile(path.join(storage, "index.lock"), "")
+              await fs.writeFile(path.join(project, "tracked.txt"), "two\n")
+            })
+
+            const after = yield* snapshot.capture()
+            expect(after).toBeDefined()
+            if (!after) return
+            expect(yield* snapshot.files({ from: before, to: after })).toEqual([RelativePath.make("tracked.txt")])
+            expect(yield* Effect.promise(() => fs.stat(path.join(storage, "index.lock")))).toBeDefined()
+            expect(
+              (yield* Effect.promise(() => fs.readdir(storage))).filter(
+                (file) => file.startsWith("capture-") || file.startsWith("checkout-") || file.startsWith("restore-"),
+              ),
+            ).toEqual([])
+          }).pipe(Effect.provide(snapshotLayer(tmp.path, project)))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   testEffect(Layer.empty).live("isolates snapshot indexes by canonical Git worktree", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -700,10 +700,7 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
   return [{ ...state, lifecycle: Lifecycle.stepStart(state.lifecycle, events) }, [...events, result]]
 }
 
-const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(function* (
-  state: ParserState,
-  event: AnthropicEvent,
-) {
+const onContentBlockDelta = Effect.fnUntraced(function* (state: ParserState, event: AnthropicEvent) {
   const delta = event.delta
 
   if (delta?.type === "text_delta" && delta.text) {

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -786,10 +786,7 @@ const onReasoningSummaryPartDone = (state: ParserState, event: OpenAIResponsesEv
   ]
 }
 
-const onFunctionCallArgumentsDelta = Effect.fn("OpenAIResponses.onFunctionCallArgumentsDelta")(function* (
-  state: ParserState,
-  event: OpenAIResponsesEvent,
-) {
+const onFunctionCallArgumentsDelta = Effect.fnUntraced(function* (state: ParserState, event: OpenAIResponsesEvent) {
   if (!event.item_id || !event.delta) return [state, NO_EVENTS] satisfies StepResult
   const result = ToolStream.appendExisting(
     ADAPTER,

--- a/packages/server/src/handlers/event.ts
+++ b/packages/server/src/handlers/event.ts
@@ -1,25 +1,27 @@
 import { EventV2 } from "@opencode-ai/core/event"
 import { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
-import { Effect, Schema, Stream } from "effect"
+import { Cache, Effect, Schema, Stream } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import * as Sse from "effect/unstable/encoding/Sse"
 import { Api } from "../api"
 
 const subscriberCapacity = 256
+const encodeEvent = Schema.encodeUnknownSync(OpenCodeEvent)
+const textEncoder = new TextEncoder()
+const heartbeat = textEncoder.encode(": heartbeat\n\n")
 
-function eventData(data: unknown): Sse.Event {
-  return {
-    _tag: "Event",
-    event: "message",
-    id: undefined,
-    data: JSON.stringify(Schema.encodeUnknownSync(OpenCodeEvent)(data)),
-  }
+function eventFrame(event: unknown) {
+  return textEncoder.encode(`data: ${JSON.stringify(encodeEvent(event))}\n\n`)
 }
 
 export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers) =>
   Effect.gen(function* () {
     const events = yield* EventV2.Service
+    const frames = yield* Cache.make<object, Uint8Array>({
+      capacity: subscriberCapacity * 2,
+      timeToLive: "1 minute",
+      lookup: (event) => Effect.sync(() => eventFrame(event)),
+    })
     return handlers.handleRaw("event.subscribe", () =>
       Effect.gen(function* () {
         const connected = {
@@ -33,19 +35,16 @@ export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers)
             const live = yield* EventV2.allBounded(events, subscriberCapacity)
             return Stream.make(connected).pipe(Stream.concat(live))
           }),
-        ).pipe(Stream.map(eventData), Stream.pipeThroughChannel(Sse.encode()))
-        const heartbeat = Stream.tick("15 seconds").pipe(Stream.map(() => ": heartbeat\n\n"))
-        return HttpServerResponse.stream(
-          output.pipe(Stream.merge(heartbeat, { haltStrategy: "left" }), Stream.encodeText),
-          {
-            contentType: "text/event-stream",
-            headers: {
-              "Cache-Control": "no-cache, no-transform",
-              "X-Accel-Buffering": "no",
-              "X-Content-Type-Options": "nosniff",
-            },
+        ).pipe(Stream.mapEffect((event) => Cache.get(frames, event)))
+        const heartbeats = Stream.tick("15 seconds").pipe(Stream.map(() => heartbeat))
+        return HttpServerResponse.stream(output.pipe(Stream.merge(heartbeats, { haltStrategy: "left" })), {
+          contentType: "text/event-stream",
+          headers: {
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            "X-Content-Type-Options": "nosniff",
           },
-        )
+        })
       }),
     )
   }),

--- a/packages/server/src/handlers/event.ts
+++ b/packages/server/src/handlers/event.ts
@@ -1,6 +1,6 @@
 import { EventV2 } from "@opencode-ai/core/event"
 import { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
-import { Cache, Effect, Schema, Stream } from "effect"
+import { Effect, Schema, Stream } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
@@ -17,11 +17,7 @@ function eventFrame(event: unknown) {
 export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers) =>
   Effect.gen(function* () {
     const events = yield* EventV2.Service
-    const frames = yield* Cache.make<object, Uint8Array>({
-      capacity: subscriberCapacity * 2,
-      timeToLive: "1 minute",
-      lookup: (event) => Effect.sync(() => eventFrame(event)),
-    })
+    const frames = new WeakMap<object, Uint8Array>()
     return handlers.handleRaw("event.subscribe", () =>
       Effect.gen(function* () {
         const connected = {
@@ -35,7 +31,15 @@ export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers)
             const live = yield* EventV2.allBounded(events, subscriberCapacity)
             return Stream.make(connected).pipe(Stream.concat(live))
           }),
-        ).pipe(Stream.mapEffect((event) => Cache.get(frames, event)))
+        ).pipe(
+          Stream.map((event) => {
+            const frame = frames.get(event)
+            if (frame) return frame
+            const encoded = eventFrame(event)
+            frames.set(event, encoded)
+            return encoded
+          }),
+        )
         const heartbeats = Stream.tick("15 seconds").pipe(Stream.map(() => heartbeat))
         return HttpServerResponse.stream(output.pipe(Stream.merge(heartbeats, { haltStrategy: "left" })), {
           contentType: "text/event-stream",


### PR DESCRIPTION
# Making parallel OpenCode sessions cheap on Windows

## TL;DR

**Live Event throughput with four SSE subscribers: 77,537 -> 145,942 delivered Events/s (+88.2%), with 48.4% less CPU work.**

The local 81.7-second profile spent most active samples starting processes, resolving executables, and repeatedly attempting snapshots. The table gives the evidence for each commit. Percentages are overlapping profile paths and must not be added together.

| Commit | What changed | What it fixes | Rough local impact |
| --- | --- | --- | --- |
| `2f6c8dc` | Give every snapshot capture, preview, restore, and checkout a disposable `GIT_INDEX_FILE` | Shared OpenCode `index.lock` contention and permanent failure after a crash | Removes the failure source behind the 73.8% post-start process path; stale lock stays untouched |
| `b065474` | Skip `git diff --name-only` when start and end tree IDs match | One unnecessary process on unchanged steps | 1 of 7 original unchanged-step Git processes, about 14% |
| `07e95a6` | Replace repeated array membership scans with sets | Quadratic filtering when a snapshot has many candidates | About 5,483 candidates in the reproduced stale-index state; changes local filtering from O(n²) to O(n) |
| `0845afe` | Return the immutable base tree when no candidate changed | Unnecessary `git write-tree` for clean captures | 4 to 3 Git processes per isolated clean capture, 25% |
| `3199136` | Replace `diff-files` plus `ls-files --others` with one tagged `ls-files` scan | Two child processes for one status question | 3 to 2 Git processes per clean capture, 33% |
| `218b926` | Resolve `git.exe` once and directly spawn absolute native executables | Repeated `PATH`, `PATHEXT`, `which`, `isexe`, `statSync`, and shebang checks | Targets 11.2% of post-start samples |
| `508a8c0` | Read worktree, Git directory, and common directory with one `rev-parse` | Three sequential processes for repository discovery | 3 to 1 processes per discovery, 67% |
| `f913182` | Compile the event encoder once, render SSE directly, and cache bytes across subscribers | Schema, JSON, SSE channel, and text encoding repeated for each client | Targets the 1.9% post-start SSE path and removes its per-client multiplier |
| `f25c107` | Use `Effect.fnUntraced` for per-delta provider and Session handlers | A span, call-site `Error`, async context work, and export data for every streamed delta | Targets the 4.4% post-start OpenTelemetry path |
| `514728c` | Bind Session location once in the LLM publisher | Ambient Effect service lookup and location allocation on every event | Removes one context lookup and one location allocation per streamed event |
| `3fe7972` | Create the wildcard PubSub only when `events.all()` is consumed | One unused PubSub publish in the normal bounded-listener server path | Removes one PubSub operation per event |
| `e69235b` | Hoist ripgrep and tool Schema codecs | Repeated codec-wrapper construction for every grep row and tool call | Removes repeated setup from two hot parts of the 6.2% post-start Schema path |
| `e89d4e8` | Append new directories once, prepare fuzzysort targets once, and cache the combined list | Rebuilding the complete directory array for every file and preparing every target for every query | Targets the 5.8% total-profile Windows search path, mainly startup and autocomplete |
| `6ced7d8` | Let each message adapter own edits; SQLite mutates its private decoded value | Immer proxy creation, copy tracking, and freezing around every projected edit | Removes one Immer object graph per durable message edit in the 2.4% SQLite path |
| `b3c0c6d` | Select only used message fields and filter shells by `callID` in SQLite | Loading and decoding every historical shell row | Shell lookup changes from O(shell history) to one indexed result-shaped read |
| `3f00002` | Prepare three projected-message reads once | Rebuilding the same Drizzle select statements for every event | Removes query builder, SQL conversion, field ordering, and mapper setup from each message edit |
| `99e676f` | Prepare aggregate-sequence and Event-ID reads once | Two repeated SQL builds on every durable event | Removes two Drizzle builds per durable publication |
| `026c172` | Pass object alternates by environment and lock only changed object publication | Concurrent Windows Git writers racing to create the same read-only loose object | Live result improved from 7/10 to 10/10 parallel captures; clean captures remain lock-free |
| `1b10d35` | Replace the Effect frame cache with a weak object-identity cache | Cache fibers, TTL state, and strong frame retention cost more than encoding | Four subscribers: 48.4% less CPU work and 88.2% more delivered throughput; peak RSS unchanged |

## What the profile actually showed

The profile covered 81.7 seconds and contained 4,820 samples. The first 10.4 seconds included server startup. I used sample counts for ranking because the profile contains long wall-time gaps. Assigning a multi-second gap to the next sampled frame would incorrectly make SSE or tracing look like a multi-second synchronous call.

| Path | All samples | After startup |
| --- | ---: | ---: |
| Complete `cross-spawn` ancestry | 57.0% | 73.8% |
| Native `spawn` | 40.4% | 54.8% |
| Windows executable `statSync` lookup | 10.5% | 11.2% |
| Building snapshot candidate input | 2.6% | 3.2% |
| Effect Schema ancestry | 7.8% | 6.2% |
| OpenTelemetry ancestry | 6.9% | 4.4% |
| SQLite and Drizzle ancestry | 3.1% | 2.4% |
| SSE encoding | 1.4% | 1.9% |

The categories overlap. For example, Schema work can run inside an Event path that also has tracing.

The matching server log supplied the missing command context:

- The profiled server attempted 36 snapshots during the capture.
- A second server process attempted 2 more snapshots in the same period.
- Every attempt failed on the same app-owned `index.lock`.
- The lock was zero bytes and had not changed since June 2.
- The old snapshot index saw 2,302 tracked changes and 3,181 untracked files, or about 5,483 candidates, before each failed write.

This was not a retry timer. Every normal model step asked for another start or end snapshot, so active Sessions repeatedly entered the same expensive failure path.

## Why snapshots started so many processes

The runner takes one snapshot before the physical model attempt and another after provider and tool work:

- [start snapshot](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/runner/llm.ts#L217-L227)
- [end snapshot and file comparison](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/runner/llm.ts#L319-L336)

Before this branch, a clean unchanged step used:

```text
start: diff-files + ls-files + write-tree
end:   diff-files + ls-files + write-tree
diff:  diff --name-only

total: 7 Git processes
```

Ten Sessions that reached the same boundary could therefore request about 70 Git processes. Windows process creation made this much more visible than Linux or macOS.

## The old mutable-index design

OpenCode keeps snapshot objects in an app-owned Git repository under the OpenCode data directory. The user repository and the snapshot repository have different indexes:

```text
user:     <project>/.git/index
OpenCode: <data>/snapshot/<project>/<worktree>/index
```

This correctly prevents a user `git add` from fighting with an OpenCode `git add`. It does not prevent two OpenCode server processes from sharing the same OpenCode index. Git protects a mutable index by creating `index.lock`, writing the new index, and renaming it into place. A process crash can leave the lock behind.

The supplied machine had exactly this state. The best fix was not a larger stale-lock manager. It was to remove the shared mutable index.

## Disposable indexes and immutable trees

Git supports an alternate index with [`GIT_INDEX_FILE`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITINDEXFILEcode). Git still creates a mandatory lock next to that alternate index, but every capture now has a unique path:

```text
capture-a.index
capture-a.index.lock

capture-b.index
capture-b.index.lock
```

The lock gives one capture crash-safe index writes. It cannot block another capture, another Session, or a later server process.

The capture flow is now:

```text
create unique temporary index path
read immutable base tree into temporary index
inspect the requested Location scope
return the base tree if nothing changed
apply changed paths to the temporary index
write an immutable tree object
delete the temporary index and its private lock
```

The implementation is in the deep Git boundary:

- [temporary index lifetime](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/git.ts#L425-L437)
- [one tagged status scan and linear candidate planning](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/git.ts#L439-L508)
- [tree capture orchestration](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/git.ts#L560-L590)
- [Location-owned immutable tree chain](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/snapshot.ts#L98-L153)

The design follows Git's plumbing model:

- [`git read-tree`](https://git-scm.com/docs/git-read-tree) reads an immutable tree into an index. Its `-i` documentation explicitly describes temporary indexes.
- [`git write-tree`](https://git-scm.com/docs/git-write-tree) creates an immutable tree object from a fully merged index.
- [`GIT_OPTIONAL_LOCKS=0`](https://git-scm.com/docs/git#Documentation/git.txt-codeGITOPTIONALLOCKScode) prevents read commands from doing optional index refresh writes. It does not disable mandatory private-index locks.

The first capture starts from the source `HEAD` tree. Later captures start from the last successful Location tree. OpenCode does not read, modify, or delete the user's index or the legacy OpenCode index.

## Shared object storage is a different concurrency problem

Git indexes are mutable. Git blobs and trees are content-addressed and immutable. The private snapshot repository still shares one object directory so that stored tree IDs remain available after a server restart.

The clean fixture tests passed with concurrent object writes. The live Windows repository found a real platform edge: two Git processes can race to create the same loose object. Git makes completed loose objects read-only on Windows. The losing writer can then receive `Permission denied`.

The final design keeps the common path simple:

1. Read the base tree into a private index.
2. Run one status scan.
3. Return immediately when clean.
4. Only a changed capture acquires the existing stale-safe Effect file lock before it writes blobs and trees.

See [changed-object publication](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/git.ts#L184-L202). Source objects are exposed with `GIT_ALTERNATE_OBJECT_DIRECTORIES`; no persisted alternate file is needed. Git documents persistent alternates in [`objects/info/alternates`](https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-objectsinfoalternates); the environment form gives the same read path without another mutable app file.

This lock is not a replacement index lock. Clean captures do not acquire it. It protects the one shared resource that remains: changed object publication.

## Process count after the snapshot changes

For the first clean model step:

```text
start: resolve HEAD tree + read-tree + tagged ls-files
end:   read-tree + tagged ls-files
diff:  skipped because tree IDs match

total: 5 Git processes
```

Later clean steps reuse the previous immutable tree and use 4 Git processes. This is down from 7. Changed captures use extra processes only for the actual add, tree write, and changed-file report.

The branch also resolves `git.exe` once. The native Windows fast path is deliberately narrow:

- [cached Git executable](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/git.ts#L16-L16)
- [absolute `.exe` and `.com` fast path](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/cross-spawn-spawner.ts#L268-L282)

Shell commands, shebang scripts, `.cmd`, and `.bat` files still use `cross-spawn`. This preserves Windows script behavior while removing repeated `which`, `isexe`, and shebang reads for Git.

## Removing work from every streamed event

After snapshots, the next repeated path was model output. A provider can emit many text, reasoning, and tool-input deltas for one physical attempt.

### Encode once per event, not once per client

The old server route created a Schema encoder wrapper, encoded the Event, called `JSON.stringify`, allocated an SSE Event, ran the Effect SSE channel, and encoded text for every subscriber.

The new route:

- compiles the Schema encoder once;
- renders the exact `data: <json>\n\n` frame directly;
- stores encoded bytes in a `WeakMap` keyed by the shared Event object;
- shares one encoding across concurrent subscribers;
- pre-encodes the heartbeat.

See [the Event handler](https://github.com/Hona/opencode/blob/1b10d3559ddbf83120dcc79f5334c32dce2439b6/packages/server/src/handlers/event.ts#L8-L53).

### Keep useful spans, remove per-delta spans

Named `Effect.fn` handlers create trace spans and call-site stack data. That is useful for a request, step, tool, or compaction operation. It is high-cardinality noise for each token delta.

The per-delta handlers now use `Effect.fnUntraced`, while coarse operational spans remain. The Session location is also bound once when the publisher is created, so each Event does not search ambient Effect context and allocate another location value.

See [the bound publisher and untraced event path](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/runner/publish-llm-event.ts#L53-L86) and [per-delta publication](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/runner/publish-llm-event.ts#L243-L310).

This intentionally reduces trace detail. It does not change Session events, ordering, or persistence.

## Making the remaining CPU proportional to real work

### Windows file search

Windows uses the ripgrep and fuzzysort search path. The old index callback rebuilt `Array.from(directories)` for every file and repeatedly sliced and joined path prefixes. Each autocomplete query also rebuilt the mixed target list and prepared targets again.

The new path appends each directory once, prepares each target when it enters the index, and invalidates the combined list only when a new file arrives. See [filesystem search indexing](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/filesystem/search.ts#L30-L61) and [the cached query target list](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/filesystem/search.ts#L108-L124). Fuzzysort documents prepared targets in its [`prepare` API](https://github.com/farzher/fuzzysort#prepare).

### Effect Schema codecs

Stable ripgrep and tool schemas now create their decoder and encoder functions once:

- [ripgrep decoder](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/ripgrep.ts#L22-L39)
- [tool codecs](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/tool/tool.ts#L71-L105)

Schema validation remains at the same boundaries. Only repeated wrapper construction is removed.

### SQLite projectors

The message updater now tells its adapter to edit an assistant or shell. The memory adapter keeps Immer and immutable replacement. The SQLite adapter owns a newly decoded private value, so it applies the edit directly and encodes it once.

The projector also:

- selects only `id`, `type`, and `data`;
- decodes the known assistant or shell member schema;
- uses `json_extract(..., '$.callID')` and `limit 1` for shell lookup;
- prepares three message reads once per projector layer;
- prepares two durable Event reads once per Event layer.

See [message edit ownership](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/message-updater.ts#L10-L86), [prepared projector reads](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/session/projector.ts#L20-L68), and [prepared durable Event reads](https://github.com/Hona/opencode/blob/026c172a84e4a91fbb8e70de3d01da7d056cc0db/packages/core/src/event.ts#L175-L195). Drizzle describes prepared placeholders in its [prepared statement guide](https://orm.drizzle.team/docs/perf-queries).

Prepared queries still execute through the current Effect transaction service. The transaction and rollback tests pass.

## Live Windows verification with the broken state left in place

The final Snapshot service was run directly against `C:\Repos\sst\opencode` and the same app data used by the profile.

The zero-byte June 2 `index.lock` remained present before and after the run. Its length and timestamps did not change.

| Workload | Successful captures | Wall time | Process CPU |
| --- | ---: | ---: | ---: |
| 10 parallel captures before changed-object publication lock | 7/10 | 9,373 ms | 531 ms |
| 10 parallel captures after final design | 10/10 | 4,491 ms | 609 ms |
| 10 sequential captures after final design | 10/10 | 13,217 ms | 204 ms |

The parallel CPU value includes real changed-object publication. The sequential run shows about 20 ms of OpenCode process CPU per capture while most wall time is Windows child-process latency. This is a focused Snapshot benchmark, not a replacement full-server profile.

## Replaying a real 18-Session Event workload

The original CPU profile gave stack samples, but it could not recover Event payloads, delta boundaries, or timing. I therefore attached a local recorder to the elected OpenCode service for 10 minutes while 18 real Sessions were active.

The raw trace stayed on the local machine. It contains 4,932 SSE Events, 10.26 MB of frames, 722 tool calls, 515 reasoning deltas, 82 text deltas, and tool-success frames up to 115 KB. Nothing in the benchmark invents prompt text, tool output, delta sizes, Event order, or inter-arrival timing.

The installed service was newer than both commits under test. It had moved the old `data.timestamp` value to top-level `created`, renamed `session.next.*` Events to `session.*`, and added several operational Event types. The replay adapter therefore does only source-defined version conversions:

- move the captured `created` millisecond value back to `data.timestamp`;
- restore the target's `session.next.*` names;
- restore `callID`, provider metadata, structured tool output, and reasoning IDs from captured values according to the target publisher source;
- require the target Schema to decode and re-encode every adapted payload without another data change;
- exclude new Event types that have no target equivalent.

This validates 4,305 of 4,931 non-connection Events, or 87.3% by count and 97.0% by captured bytes. The excluded 3.0% of bytes is mainly newer shell lifecycle, inbox, execution, instruction, and usage Events.

### Harness

Each measured process uses the exact target commit, a fresh isolated SQLite database, the production `EventV2.publish` path, the production Server Event handler, and real streamed SSE response bodies. The harness is in-process, so it excludes TCP cost and includes both the publisher and the SSE readers in the same Bun process.

The harness performs 100 unmeasured live-Event warm-up publications, forces a full GC, then records wall time, `process.cpuUsage()`, and RSS every 5 ms. A result of 100% CPU means one full core. Every run verifies that every selected Event reaches every subscriber. A 128-Event delivery window prevents the production 256-Event bounded subscriber queue from overflowing.

Maximum-throughput results are medians. The aggregate test uses five alternating base/candidate runs. The live-only test uses seven alternating runs and repeats the same 607-Event live trace 100 times. Later cycles change only the Event ID so every publication has real object identity and cannot reuse an earlier cycle's cached frame.

### Live delta and fan-out path

This isolates the non-durable Event and SSE path. One cycle contains the real captured delta sizes and mix; 100 cycles provide 60,700 source Events and enough CPU time for stable measurement.

| Subscribers | Baseline delivered Events/s | Candidate delivered Events/s | Throughput | Baseline CPU | Candidate CPU | CPU work | Baseline peak RSS | Candidate peak RSS |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 59,235 | 57,608 | -2.7% | 1,297 ms at 125.0% | 1,375 ms at 129.1% | +6.0% | 407.5 MiB | 410.5 MiB |
| 2 | 72,495 | 98,637 | +36.1% | 2,156 ms at 125.9% | 1,610 ms at 126.0% | -25.3% | 410.9 MiB | 411.5 MiB |
| 4 | 77,537 | 145,942 | +88.2% | 3,907 ms at 123.0% | 2,015 ms at 125.6% | -48.4% | 414.7 MiB | 413.8 MiB |

The first cache implementation used Effect `Cache`. Replay showed that its fibers, TTL state, and strong retention made the candidate 27% to 66% slower. The final handler uses a `WeakMap<Event, Uint8Array>`: one subscriber is effectively neutral, while additional subscribers share the exact encoded frame with no retained Event lifetime.

### Aggregate publication path

This publishes all 4,305 compatible Events, including durable SQLite commits, and delivers the stream to each subscriber. Windows SQLite wall time varied widely between runs, so CPU work is the more stable aggregate signal.

| Subscribers | Baseline delivered Events/s | Candidate delivered Events/s | Throughput | Baseline CPU | Candidate CPU | CPU work | Baseline peak RSS | Candidate peak RSS |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 389 | 339 | -12.8% | 6,000 ms at 49.9% | 5,625 ms at 43.0% | -6.3% | 351.4 MiB | 330.9 MiB |
| 2 | 734 | 731 | -0.4% | 6,094 ms at 47.2% | 4,422 ms at 40.1% | -27.4% | 384.4 MiB | 355.2 MiB |
| 4 | 1,462 | 1,576 | +7.8% | 5,172 ms at 43.9% | 4,156 ms at 48.9% | -19.6% | 394.6 MiB | 376.7 MiB |

At four subscribers, the aggregate candidate uses 19.6% less CPU work, delivers 7.8% more frames per second, and peaks 17.9 MiB lower. The higher candidate CPU percentage is not more CPU work: the candidate finishes sooner, so its reduced CPU time is concentrated into less wall time.

### Original-timing paced replay

The same 4,305 Events were also replayed once at their captured inter-arrival times for 592.38 seconds with four subscribers. The base and candidate used isolated databases and ran together at this low average load.

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Delivered Events/s | 29.069 | 29.069 | paced workload |
| Process CPU time | 14,297 ms | 13,579 ms | -5.0% |
| Average CPU, one core = 100% | 2.41% | 2.29% | -0.12 points |
| Peak RSS | 282.8 MiB | 366.8 MiB | +84.0 MiB |
| RSS growth during replay | 0.85 MiB | 0.23 MiB | -0.62 MiB |

Throughput is equal by design because the original timing controls publication. The candidate uses 5.0% less CPU work at that cadence. The single-run total RSS difference was present before measurement began, while measured replay growth was lower for the candidate. Use the repeated unpaced median for the more stable peak-RSS comparison.

Raw aggregate results remain local. The sensitive replay trace was deleted after the benchmark. The PR reports only aggregate counts and medians.

## Verification

- Pre-push workspace typecheck: 30 tasks passed.
- Core focused suites: 73 tests passed.
- LLM provider suites: 82 tests passed.
- Native Windows executable and `.cmd` routing: 2 focused tests passed.
- V2 HTTP Event integration: 3 tests passed.
- Core, server, LLM, CLI, and `sdk-next` package typechecks passed.

Repository-wide lint remains blocked by one pre-existing octal escape error in `packages/session-ui/src/v2/components/prompt-input/index.tsx`. It also reports 4,854 existing warnings. No changed file produced a lint error.

## Compatibility and tradeoffs

- Public Protocol and Server `HttpApi` contracts do not change.
- Snapshot tree IDs and restore behavior do not change.
- The user Git index is never modified by snapshot capture.
- Legacy app snapshot `index` and `index.lock` files are ignored, not migrated or deleted.
- Clean captures do not acquire the object publication lock.
- Changed captures serialize immutable object publication across server processes on Windows.
- Per-delta trace spans are removed. Coarse operational spans remain.
- SSE bytes remain standard `data:` frames with the existing heartbeat and response headers.

The result keeps the normal flow visible: read a base tree, inspect one scope, return immediately when clean, and publish immutable objects only when files changed.



