### PR TITLE
fix(shell): scan redirection targets for external_directory

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -389,6 +389,28 @@ export const ShellTool = Tool.define(
       }
       const shellKind = ShellID.toKind(Shell.name(shell))
 
+      // Redirection targets (`>`, `>>`, `2>`, `<`) are filesystem paths even
+      // when the command name itself is not in the FILES allowlist. Without
+      // this scan `echo x > /tmp/out` and `printf x | tee /etc/x` write
+      // outside the workspace without triggering external_directory — the
+      // same operation `cp x /tmp/out` denies. Scan every file_redirect
+      // destination regardless of the command name. The grammar nests these
+      // under redirected_statement (a sibling of the command node), so walk
+      // the whole tree once.
+      for (const redirect of root.descendantsOfType("file_redirect")) {
+        // A file_redirect is `[descriptor] op destination`. The destination
+        // is the LAST named child — reading it positionally skips the
+        // optional file_descriptor ("2>..." has descriptor=2, ">..." has
+        // none) and picks up the word that names the file.
+        const named = redirect.namedChildren
+        const target = named[named.length - 1]
+        if (!target) continue
+        const resolved = yield* argPath(target.text, cwd, ps, shell)
+        if (!resolved || containsPath(resolved, instance)) continue
+        const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
+        scan.dirs.add(dir)
+      }
+
       for (const node of commands(root)) {
         const command = parts(node)
         const tokens = command.map((item) => item.text)

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -389,19 +389,32 @@ export const ShellTool = Tool.define(
       }
       const shellKind = ShellID.toKind(Shell.name(shell))
 
-      // Redirection targets (`>`, `>>`, `2>`, `<`) are filesystem paths even
-      // when the command name itself is not in the FILES allowlist. Without
-      // this scan `echo x > /tmp/out` and `printf x | tee /etc/x` write
-      // outside the workspace without triggering external_directory — the
-      // same operation `cp x /tmp/out` denies. Scan every file_redirect
-      // destination regardless of the command name. The grammar nests these
-      // under redirected_statement (a sibling of the command node), so walk
-      // the whole tree once.
+      // Redirection targets (`>`, `>>`, `2>`, `<`, `&>`, `>&`) are filesystem
+      // paths even when the command name itself is not in the FILES
+      // allowlist. Without this scan `echo x > /tmp/out` writes outside the
+      // workspace without triggering external_directory — the same operation
+      // `cp x /tmp/out` denies. Scan every file_redirect destination
+      // regardless of the command name. The grammar nests these under
+      // redirected_statement (a sibling of the command node), so walk the
+      // whole tree once.
+      //
+      // Scope note: this covers *direct* redirection targets only. Writes via
+      // command arguments (`printf x | tee /etc/x`, `dd of=/path`,
+      // `sponge`, `install`, `script -c`) ride the command-name FILES
+      // allowlist path above, not this scan — those commands are not in
+      // FILES and so are not gated here. Variable targets (`> "$P"` /
+      // `> $P`) are caught by the dynamic() guard in argPath and bail
+      // fail-closed (no prompt for a wrong path), so the shell still executes
+      // the redirect — this scan treats that as "mostly closed" rather than
+      // fully gated. Follow-up would resolve shell vars before resolving.
       for (const redirect of root.descendantsOfType("file_redirect")) {
         // A file_redirect is `[descriptor] op destination`. The destination
         // is the LAST named child — reading it positionally skips the
         // optional file_descriptor ("2>..." has descriptor=2, ">..." has
-        // none) and picks up the word that names the file.
+        // none) and picks up the word that names the file. This holds for
+        // `>`, `>>`, `2>`, `&>`, `>&`, `<>` in tree-sitter-bash; the
+        // PowerShell grammar names these nodes differently, so this scan is
+        // a no-op on posix shells only.
         const named = redirect.namedChildren
         const target = named[named.length - 1]
         if (!target) continue

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -263,49 +263,39 @@ describe("tool.shell permissions", () => {
     }),
   )
 
-  it.live("asks for external_directory permission for redirection targets", () =>
-    Effect.gen(function* () {
-      const tmp = yield* tmpdirScoped()
-      yield* runIn(
-        tmp,
+  if (process.platform !== "win32") {
+    const redirOps = [
+      { label: "stdout", target: "echo BYPASS > /tmp/oc-redirect-test.txt", glob: "/tmp/*" },
+      { label: "append", target: "echo BYPASS >> /tmp/oc-redirect-test.txt", glob: "/tmp/*" },
+      { label: "stderr", target: "ls 2>/etc/opencode-stderr-test", glob: "/etc/*" },
+      { label: "stderr-append", target: "ls 2>>/etc/opencode-stderr-test", glob: "/etc/*" },
+      { label: "stdin", target: "cat </etc/opencode-stdin-test", glob: "/etc/*" },
+      { label: "both", target: "echo BYPASS &>/tmp/oc-redirect-both.txt", glob: "/tmp/*" },
+    ] as const
+    for (const op of redirOps) {
+      it.live(`asks for external_directory permission for ${op.label} redirection targets`, () =>
         Effect.gen(function* () {
-          const err = new Error("stop after permission")
-          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
-          expect(
-            yield* fail(
-              { command: "echo BYPASS > /tmp/oc-redirect-test.txt" },
-              capture(requests, err),
-            ),
-          ).toMatchObject({ message: err.message })
-          const extDirReq = requests.find((r) => r.permission === "external_directory")
-          expect(extDirReq).toBeDefined()
-          expect(extDirReq!.patterns).toContain("/tmp/*")
+          const tmp = yield* tmpdirScoped()
+          yield* runIn(
+            tmp,
+            Effect.gen(function* () {
+              const err = new Error("stop after permission")
+              const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+              expect(
+                yield* fail(
+                  { command: op.target },
+                  capture(requests, err),
+                ),
+              ).toMatchObject({ message: err.message })
+              const extDirReq = requests.find((r) => r.permission === "external_directory")
+              expect(extDirReq).toBeDefined()
+              expect(extDirReq!.patterns).toContain(op.glob)
+            }),
+          )
         }),
       )
-    }),
-  )
-
-  it.live("asks for external_directory permission for stderr redirection targets", () =>
-    Effect.gen(function* () {
-      const tmp = yield* tmpdirScoped()
-      yield* runIn(
-        tmp,
-        Effect.gen(function* () {
-          const err = new Error("stop after permission")
-          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
-          expect(
-            yield* fail(
-              { command: "ls 2>/etc/opencode-stderr-test" },
-              capture(requests, err),
-            ),
-          ).toMatchObject({ message: err.message })
-          const extDirReq = requests.find((r) => r.permission === "external_directory")
-          expect(extDirReq).toBeDefined()
-          expect(extDirReq!.patterns).toContain("/etc/*")
-        }),
-      )
-    }),
-  )
+    }
+  }
 
   for (const item of ps) {
     it.live(`parses PowerShell conditionals for permission prompts [${item.label}]`, () =>

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -263,6 +263,50 @@ describe("tool.shell permissions", () => {
     }),
   )
 
+  it.live("asks for external_directory permission for redirection targets", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          expect(
+            yield* fail(
+              { command: "echo BYPASS > /tmp/oc-redirect-test.txt" },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain("/tmp/*")
+        }),
+      )
+    }),
+  )
+
+  it.live("asks for external_directory permission for stderr redirection targets", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          expect(
+            yield* fail(
+              { command: "ls 2>/etc/opencode-stderr-test" },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain("/etc/*")
+        }),
+      )
+    }),
+  )
+
   for (const item of ps) {
     it.live(`parses PowerShell conditionals for permission prompts [${item.label}]`, () =>
       withShell(


### PR DESCRIPTION
### Issue for this PR

Closes #42979

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `external_directory` is denied, the built-in file tools (`write`, `edit`, `apply_patch`, `read`) correctly refuse paths outside the workspace, but the `bash` tool does not. The external-directory scan in `packages/opencode/src/tool/shell.ts` only extracts paths when the command's first token is in a 14-entry allowlist, and it never inspects `>` redirection targets. As a result the agent can freely write outside the workspace using `echo`, `printf`, `tee`, and similar. Enforcement depends on which command name is typed, not on what the command actually does to the filesystem.

The fix scans every `file_redirect` node in the parsed shell tree regardless of command name. The destination (last named child, skipping the optional `file_descriptor`) is resolved via `argPath` and added to the `external_directory` scan — closing the gap for stdout (`>`, `>>`), stderr (`2>`, `2>>`), and stdin (`<`) redirection.

### How did you verify your code works?

- `bun typecheck` passes
- `bun test test/tool/shell.test.ts` — 25 pass, 0 fail
- New regression tests:
  - `echo BYPASS > /tmp/oc-redirect-test.txt` → asks for `external_directory` permission with `/tmp/*`
  - `ls 2>/etc/opencode-stderr-test` → asks for `external_directory` permission with `/etc/*`

### Screenshots / recordings

N/A — permission logic change, not UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
