### PR TITLE
feat(app): show MCP call details

### DIFF
--- a/packages/session-ui/src/components/basic-tool.tsx
+++ b/packages/session-ui/src/components/basic-tool.tsx
@@ -3,10 +3,11 @@ import { animate, type AnimationPlaybackControls } from "motion"
 import { useI18n } from "@opencode-ai/ui/context/i18n"
 import { createStore } from "solid-js/store"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
-import type { IconProps } from "@opencode-ai/ui/icon"
+import { Icon, type IconProps } from "@opencode-ai/ui/icon"
 import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
 
 export type TriggerTitle = {
+  icon?: IconProps["name"]
   title: string
   titleClass?: string
   subtitle?: string
@@ -195,6 +196,13 @@ export function BasicTool(props: BasicToolProps) {
             <Match when={isTriggerTitle(props.trigger) && props.trigger}>
               {(title) => (
                 <div data-slot="basic-tool-tool-info-structured">
+                  <Show when={title().icon}>
+                    {(icon) => (
+                      <span data-slot="basic-tool-tool-indicator">
+                        <Icon name={icon()} size="small" />
+                      </span>
+                    )}
+                  </Show>
                   <div data-slot="basic-tool-tool-info-main">
                     <span
                       data-slot="basic-tool-tool-title"
@@ -333,6 +341,7 @@ export function GenericTool(props: {
       icon="mcp"
       status={props.status}
       trigger={{
+        icon: "mcp",
         title: i18n.t("ui.basicTool.called", { tool: props.tool }),
         subtitle: label(props.input),
         args: args(props.input),

--- a/packages/session-ui/src/components/basic-tool.tsx
+++ b/packages/session-ui/src/components/basic-tool.tsx
@@ -1,10 +1,12 @@
 import { createEffect, For, Match, on, onCleanup, onMount, Show, Switch, type Accessor, type JSX } from "solid-js"
 import { animate, type AnimationPlaybackControls } from "motion"
+import stripAnsi from "strip-ansi"
 import { useI18n } from "@opencode-ai/ui/context/i18n"
 import { createStore } from "solid-js/store"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { Icon, type IconProps } from "@opencode-ai/ui/icon"
 import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
+import { ConsoleOutput } from "./console-output"
 
 export type TriggerTitle = {
   icon?: IconProps["name"]
@@ -333,13 +335,26 @@ export function GenericTool(props: {
   status?: string
   hideDetails?: boolean
   input?: Record<string, unknown>
+  output?: string
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }) {
   const i18n = useI18n()
+  const text = () => {
+    const input = JSON.stringify(props.input ?? {}, null, 2)
+    const output = stripAnsi(props.output ?? "").replace(/\r\n?/g, "\n")
+    return `${input}${output ? "\n\n" + output : ""}`
+  }
 
   return (
     <BasicTool
       icon="mcp"
       status={props.status}
+      defaultOpen={props.defaultOpen}
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      allowOpenWhilePending
       trigger={{
         icon: "mcp",
         title: i18n.t("ui.basicTool.called", { tool: props.tool }),
@@ -347,6 +362,8 @@ export function GenericTool(props: {
         args: args(props.input),
       }}
       hideDetails={props.hideDetails}
-    />
+    >
+      <ConsoleOutput copy={text()}>{text()}</ConsoleOutput>
+    </BasicTool>
   )
 }

--- a/packages/session-ui/src/components/console-output.tsx
+++ b/packages/session-ui/src/components/console-output.tsx
@@ -1,0 +1,46 @@
+import { createSignal, type JSX } from "solid-js"
+import { useI18n } from "@opencode-ai/ui/context/i18n"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { writeClipboard } from "./write-clipboard"
+
+export function ConsoleOutput(props: { copy: string; children: JSX.Element }) {
+  const i18n = useI18n()
+  const [copied, setCopied] = createSignal(false)
+
+  const copy = async () => {
+    if (!props.copy) return
+    if (!(await writeClipboard(props.copy))) return
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div data-component="bash-output" dir="ltr">
+      <div data-slot="bash-copy">
+        <TooltipV2 value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")} placement="top">
+          <IconButtonV2
+            icon={<IconV2 name={copied() ? "check" : "outline-copy"} size="small" />}
+            size="normal"
+            variant="ghost-muted"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={copy}
+            aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
+          />
+        </TooltipV2>
+      </div>
+      <div
+        data-slot="bash-scroll"
+        data-scrollable
+        tabIndex={0}
+        role="region"
+        aria-label={i18n.t("ui.scrollView.ariaLabel")}
+      >
+        <pre data-slot="bash-pre">
+          <code>{props.children}</code>
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -65,30 +65,8 @@ import { animate } from "motion"
 import { attached, inline, kind, typeLabel } from "./message-file"
 import { readPartText } from "./message-part-text"
 import { SessionProgressIndicatorV2 } from "../v2/components/session-progress-indicator-v2"
-
-async function writeClipboard(text: string): Promise<boolean> {
-  const body = typeof document === "undefined" ? undefined : document.body
-  if (body) {
-    const textarea = document.createElement("textarea")
-    textarea.value = text
-    textarea.setAttribute("readonly", "")
-    textarea.style.position = "fixed"
-    textarea.style.opacity = "0"
-    textarea.style.pointerEvents = "none"
-    body.appendChild(textarea)
-    textarea.select()
-    const copied = document.execCommand("copy")
-    body.removeChild(textarea)
-    if (copied) return true
-  }
-
-  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
-  if (!clipboard?.writeText) return false
-  return clipboard.writeText(text).then(
-    () => true,
-    () => false,
-  )
-}
+import { ConsoleOutput } from "./console-output"
+import { writeClipboard } from "./write-clipboard"
 
 function ShellSubmessage(props: { text: string; animate?: boolean }) {
   let widthRef: HTMLSpanElement | undefined
@@ -2130,46 +2108,6 @@ ToolRegistry.register({
 })
 
 ToolRegistry.register({ name: "subagent", render: ToolRegistry.render("task") })
-
-function ConsoleOutput(props: { copy: string; children: JSX.Element }) {
-  const i18n = useI18n()
-  const [copied, setCopied] = createSignal(false)
-
-  const copy = async () => {
-    if (!props.copy) return
-    if (!(await writeClipboard(props.copy))) return
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  return (
-    <div data-component="bash-output" dir="ltr">
-      <div data-slot="bash-copy">
-        <TooltipV2 value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")} placement="top">
-          <IconButtonV2
-            icon={<IconV2 name={copied() ? "check" : "outline-copy"} size="small" />}
-            size="normal"
-            variant="ghost-muted"
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={copy}
-            aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
-          />
-        </TooltipV2>
-      </div>
-      <div
-        data-slot="bash-scroll"
-        data-scrollable
-        tabIndex={0}
-        role="region"
-        aria-label={i18n.t("ui.scrollView.ariaLabel")}
-      >
-        <pre data-slot="bash-pre">
-          <code>{props.children}</code>
-        </pre>
-      </div>
-    </div>
-  )
-}
 
 ToolRegistry.register({
   name: "execute",

--- a/packages/session-ui/src/components/write-clipboard.ts
+++ b/packages/session-ui/src/components/write-clipboard.ts
@@ -1,0 +1,23 @@
+export async function writeClipboard(text: string): Promise<boolean> {
+  const body = typeof document === "undefined" ? undefined : document.body
+  if (body) {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.opacity = "0"
+    textarea.style.pointerEvents = "none"
+    body.appendChild(textarea)
+    textarea.select()
+    const copied = document.execCommand("copy")
+    body.removeChild(textarea)
+    if (copied) return true
+  }
+
+  const clipboard = typeof navigator === "undefined" ? undefined : navigator.clipboard
+  if (!clipboard?.writeText) return false
+  return clipboard.writeText(text).then(
+    () => true,
+    () => false,
+  )
+}


### PR DESCRIPTION
## Summary
- show the existing Settings MCP icon on generic timeline tool calls
- expand successful calls to show formatted parameters and result
- share the existing console output and clipboard behavior across Execute, Shell, and generic tools
- keep failures on the standard ToolErrorCard path

## Testing
- bun test (packages/session-ui)
- bun typecheck (packages/session-ui)
- bun typecheck (packages/ui)
- bun typecheck (packages/app)
- bun run build (packages/app)