### PR TITLE
fix(core): activate discovered LM Studio provider

### DIFF
--- a/packages/core/src/plugin/provider/lmstudio.ts
+++ b/packages/core/src/plugin/provider/lmstudio.ts
@@ -51,6 +51,7 @@ export function make(origin = "http://127.0.0.1:1234", interval: Duration.Input 
         }
         catalog.provider.update(providerID, (provider) => {
           provider.name = "LM Studio"
+          provider.activation = "enabled"
           provider.package = "@opencode-ai/ai/providers/openai-compatible"
           provider.settings = {
             baseURL: source.current.baseURL,

--- a/packages/core/test/plugin/provider-lmstudio.test.ts
+++ b/packages/core/test/plugin/provider-lmstudio.test.ts
@@ -95,6 +95,7 @@ describe("LMStudioPlugin", () => {
           expect(yield* catalog.provider.get(providerID)).toEqual({
             id: providerID,
             name: "LM Studio",
+            activation: "enabled",
             package: "@opencode-ai/ai/providers/openai-compatible",
             settings: { baseURL: `${server.url.origin}/v1`, provider: "lmstudio", apiKey: "" },
           })


### PR DESCRIPTION
## Summary
- mark the LM Studio provider enabled after live model discovery succeeds
- update the provider fixture for the required activation field

## Testing
- `bun test test/plugin/provider-lmstudio.test.ts` in `packages/core`
- `bun typecheck` in `packages/core`
- repository-wide pre-push typecheck