### PR TITLE
fix(skill): escape XML context values

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -319,7 +319,7 @@ const layer = Layer.effect(
 )
 
 export function fmt(list: Info[], opts: { verbose: boolean }) {
-  const described = list.filter((skill) => skill.description !== undefined)
+  const described = list.filter((skill): skill is Info & { description: string } => skill.description !== undefined)
   if (described.length === 0) return "No skills are currently available."
   if (opts.verbose) {
     return [
@@ -329,7 +329,7 @@ export function fmt(list: Info[], opts: { verbose: boolean }) {
         .flatMap((skill) => [
           "  <skill>",
           `    <name>${skill.name}</name>`,
-          `    <description>${skill.description}</description>`,
+          `    <description>${escapeHtml(skill.description)}</description>`,
           `    <location>${escapeHtml(skill.location)}</location>`,
           "  </skill>",
         ]),

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -328,7 +328,7 @@ export function fmt(list: Info[], opts: { verbose: boolean }) {
         .toSorted((a, b) => a.name.localeCompare(b.name))
         .flatMap((skill) => [
           "  <skill>",
-          `    <name>${skill.name}</name>`,
+          `    <name>${escapeHtml(skill.name)}</name>`,
           `    <description>${escapeHtml(skill.description)}</description>`,
           `    <location>${escapeHtml(skill.location)}</location>`,
           "  </skill>",

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { Effect, Schema } from "effect"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { escapeHtml } from "@/util/html"
 import { Skill } from "../skill"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
@@ -55,7 +56,7 @@ export const SkillTool = Tool.define(
               "Note: file list is sampled.",
               "",
               "<skill_files>",
-              files.map((file) => `<file>${path.resolve(dir, file.path)}</file>`).join("\n"),
+              files.map((file) => `<file>${escapeHtml(path.resolve(dir, file.path))}</file>`).join("\n"),
               "</skill_files>",
               "</skill_content>",
             ].join("\n"),

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -46,7 +46,7 @@ export const SkillTool = Tool.define(
           return {
             title: `Loaded skill: ${info.name}`,
             output: [
-              `<skill_content name="${info.name}">`,
+              `<skill_content name="${escapeHtml(info.name)}">`,
               `# Skill: ${info.name}`,
               "",
               info.content.trim(),

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -64,13 +64,13 @@ const withHome = <A, E, R>(home: string, self: Effect.Effect<A, E, R>) =>
   )
 
 describe("skill", () => {
-  it.effect("formats verbose locations as XML-safe filesystem paths", () =>
+  it.effect("formats verbose skill metadata as XML-safe values", () =>
     Effect.sync(() => {
       const output = Skill.fmt(
         [
           {
             name: "tagged-skill",
-            description: "A tagged skill.",
+            description: "Compare A < B & C.",
             location: "/tmp/plugin.git#v1.3.0/SKILL.md",
             content: "",
           },
@@ -86,6 +86,8 @@ describe("skill", () => {
 
       expect(output).toContain("<location>/tmp/plugin.git#v1.3.0/SKILL.md</location>")
       expect(output).toContain("<location>&lt;built-in&gt;</location>")
+      expect(output).toContain("<description>Compare A &lt; B &amp; C.</description>")
+      expect(output).not.toContain("<description>Compare A < B & C.</description>")
       expect(output).not.toContain("file://")
       expect(output).not.toContain("%23")
     }),

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -69,7 +69,7 @@ describe("skill", () => {
       const output = Skill.fmt(
         [
           {
-            name: "tagged-skill",
+            name: "tagged<&skill",
             description: "Compare A < B & C.",
             location: "/tmp/plugin.git#v1.3.0/SKILL.md",
             content: "",
@@ -84,6 +84,8 @@ describe("skill", () => {
         { verbose: true },
       )
 
+      expect(output).toContain("<name>tagged&lt;&amp;skill</name>")
+      expect(output).not.toContain("<name>tagged<&skill</name>")
       expect(output).toContain("<location>/tmp/plugin.git#v1.3.0/SKILL.md</location>")
       expect(output).toContain("<location>&lt;built-in&gt;</location>")
       expect(output).toContain("<description>Compare A &lt; B &amp; C.</description>")

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -48,7 +48,7 @@ Use this skill.
 `,
         ),
       )
-      yield* Effect.promise(() => Bun.write(path.join(skill, "scripts", "demo.txt"), "demo"))
+      yield* Effect.promise(() => Bun.write(path.join(skill, "scripts", "demo&notes.txt"), "demo"))
 
       const home = process.env.OPENCODE_TEST_HOME
       process.env.OPENCODE_TEST_HOME = dir
@@ -80,7 +80,8 @@ Use this skill.
       }
 
       const result = yield* tool.execute({ name: "tool-skill" }, ctx)
-      const file = path.resolve(skill, "scripts", "demo.txt")
+      const file = path.resolve(skill, "scripts", "demo&notes.txt")
+      const escapedFile = file.replaceAll("&", "&amp;")
 
       expect(requests.length).toBe(1)
       expect(requests[0].permission).toBe("skill")
@@ -89,7 +90,8 @@ Use this skill.
       expect(result.metadata.dir).toBe(skill)
       expect(result.output).toContain(`<skill_content name="tool-skill">`)
       expect(result.output).toContain(`Base directory for this skill: ${skill}`)
-      expect(result.output).toContain(`<file>${file}</file>`)
+      expect(result.output).toContain(`<file>${escapedFile}</file>`)
+      expect(result.output).not.toContain(`<file>${file}</file>`)
     }),
   )
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -38,7 +38,7 @@ describe("tool.skill", () => {
         Bun.write(
           path.join(skill, "SKILL.md"),
           `---
-name: tool-skill
+name: 'tool<&"skill'
 description: Skill for tool tests.
 ---
 
@@ -48,7 +48,7 @@ Use this skill.
 `,
         ),
       )
-      yield* Effect.promise(() => Bun.write(path.join(skill, "scripts", "demo&notes.txt"), "demo"))
+      yield* Effect.promise(() => Bun.write(path.join(skill, "scripts", "demo&<notes>.txt"), "demo"))
 
       const home = process.env.OPENCODE_TEST_HOME
       process.env.OPENCODE_TEST_HOME = dir
@@ -79,16 +79,17 @@ Use this skill.
           }),
       }
 
-      const result = yield* tool.execute({ name: "tool-skill" }, ctx)
-      const file = path.resolve(skill, "scripts", "demo&notes.txt")
-      const escapedFile = file.replaceAll("&", "&amp;")
+      const result = yield* tool.execute({ name: 'tool<&"skill' }, ctx)
+      const file = path.resolve(skill, "scripts", "demo&<notes>.txt")
+      const escapedFile = path.resolve(skill, "scripts", "demo&amp;&lt;notes&gt;.txt")
 
       expect(requests.length).toBe(1)
       expect(requests[0].permission).toBe("skill")
-      expect(requests[0].patterns).toContain("tool-skill")
-      expect(requests[0].always).toContain("tool-skill")
+      expect(requests[0].patterns).toContain('tool<&"skill')
+      expect(requests[0].always).toContain('tool<&"skill')
       expect(result.metadata.dir).toBe(skill)
-      expect(result.output).toContain(`<skill_content name="tool-skill">`)
+      expect(result.output).toContain(`<skill_content name="tool&lt;&amp;&quot;skill">`)
+      expect(result.output).not.toContain(`<skill_content name="tool<&"skill">`)
       expect(result.output).toContain(`Base directory for this skill: ${skill}`)
       expect(result.output).toContain(`<file>${escapedFile}</file>`)
       expect(result.output).not.toContain(`<file>${file}</file>`)


### PR DESCRIPTION
### Issue for this PR

Closes #43012

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Skill names, descriptions, and sampled file paths were inserted into XML-like model context without consistently escaping metacharacters. These values can contain characters such as `<`, `>`, `&`, or quotes and make the model-visible structure malformed or ambiguous.

This reuses the existing `escapeHtml` helper at the XML serialization points and adds regression coverage for element text, attribute values, and file paths. The non-verbose listing remains unchanged because it emits Markdown rather than XML.

### How did you verify your code works?

- Focused and adjacent tests: 27 passed across skill formatting, discovery, tool execution, and `escapeHtml`
- Full `packages/opencode` suite: 3316 passed, 0 failed, 22 skipped, 1 todo
- `bun run typecheck`
- Prettier check on the four changed files

### Screenshots / recordings

Not applicable; this does not change the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
