### PR TITLE
feat(app): add vertical session tabs option

### DIFF
--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -369,6 +369,20 @@ export const SettingsGeneralV2: Component<{
           </div>
         </SettingsRowV2>
 
+        <Show when={!mobile()}>
+          <SettingsRowV2
+            title={language.t("settings.general.row.verticalTabs.title")}
+            description={language.t("settings.general.row.verticalTabs.description")}
+          >
+            <div data-action="settings-vertical-tabs">
+              <Switch
+                checked={settings.general.verticalTabs()}
+                onChange={(checked) => settings.general.setVerticalTabs(checked)}
+              />
+            </div>
+          </SettingsRowV2>
+        </Show>
+
         <Show when={mobile() && import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"}>
           <SettingsRowV2
             title={language.t("settings.general.row.mobileTitlebarBottom.title")}

--- a/packages/app/src/components/titlebar-tab-nav.css
+++ b/packages/app/src/components/titlebar-tab-nav.css
@@ -59,6 +59,15 @@
   background: var(--tab-separator);
 }
 
+/* Vertical tabs stack, so the separator becomes a rule above each tab. */
+[data-titlebar-tab-slot][data-orientation="vertical"]:not(:first-child):not([data-active="true"])::before {
+  top: -3.75px;
+  inset-inline-start: 8px;
+  inset-inline-end: 8px;
+  width: auto;
+  height: 1.5px;
+}
+
 [data-titlebar-tab-slot][data-active="true"] + [data-titlebar-tab-slot]::before {
   display: none;
 }
@@ -131,18 +140,20 @@
   display: none;
 }
 
+/* Icon-only collapse for very narrow tabs. Scoped to horizontal slots: a vertical
+   rail is narrow by design but still has room for the title. */
 @container (max-width: 64px) {
-  [data-titlebar-tab-link] {
+  [data-titlebar-tab-slot]:not([data-orientation="vertical"]) [data-titlebar-tab-link] {
     justify-content: center;
     gap: 0;
     padding-inline: 0;
   }
 
-  [data-titlebar-tab-title] {
+  [data-titlebar-tab-slot]:not([data-orientation="vertical"]) [data-titlebar-tab-title] {
     display: none;
   }
 
-  [data-slot="tab-close"] {
+  [data-titlebar-tab-slot]:not([data-orientation="vertical"]) [data-slot="tab-close"] {
     right: auto;
     left: 50%;
     transform: translateX(-50%);

--- a/packages/app/src/components/titlebar-tab-rail.ts
+++ b/packages/app/src/components/titlebar-tab-rail.ts
@@ -1,0 +1,18 @@
+import { createSignal } from "solid-js"
+
+// Mount point for the vertical tab rail.
+//
+// The tab strip's controller state (current tab, draft creation, reorder,
+// close, keyboard shortcuts) all lives inside titlebar.tsx's v2 branch, but the
+// titlebar itself is a fixed 36px row (`h-9` plus a hard `min-height`), so a
+// full-height rail cannot be a DOM child of it.
+//
+// Rather than hoist that state into a new context — which would mean
+// duplicating route→tab matching and re-registering commands elsewhere — the
+// layout publishes an empty slot element here and the titlebar portals the
+// strip into it. The strip keeps its existing owner and reactivity; only its
+// DOM position moves. A portal (not `position: absolute`) is what lets the rail
+// participate in layout so `<main>` reflows beside it instead of being covered.
+const [railMount, setRailMount] = createSignal<HTMLElement | undefined>()
+
+export { railMount, setRailMount }

--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -4,7 +4,7 @@ import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { isSortable, useSortable } from "@dnd-kit/solid/sortable"
 import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
-import { RestrictToHorizontalAxis } from "@dnd-kit/abstract/modifiers"
+import { RestrictToHorizontalAxis, RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers"
 import { RestrictToElement } from "@dnd-kit/dom/modifiers"
 import { arrayMove } from "@dnd-kit/helpers"
 import { tabHref, tabKey, type SessionTab, type Tab } from "@/context/tabs"
@@ -27,6 +27,7 @@ function SessionTabSlot(props: {
   index: () => number
   active: () => boolean
   forceTruncate: boolean
+  vertical?: boolean
   session: () => Session | undefined
   fallbackTitle?: string
   onRename: (title: string) => Promise<void>
@@ -49,7 +50,14 @@ function SessionTabSlot(props: {
       data-titlebar-tab-slot
       data-tab-key={props.id}
       data-active={props.active()}
-      class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
+      data-orientation={props.vertical ? "vertical" : "horizontal"}
+      classList={{
+        "relative flex": true,
+        "w-56 min-w-7 max-w-56 flex-shrink": !props.vertical,
+        // Vertical tabs fill the rail width; shrink-0 stops the flex column
+        // from collapsing them to zero height.
+        "w-full shrink-0": props.vertical,
+      }}
     >
       <TabNavItem
         ref={(el) => {
@@ -63,7 +71,7 @@ function SessionTabSlot(props: {
         onNavigate={() => props.onNavigate(ref)}
         onClose={props.onClose}
         active={props.active()}
-        forceTruncate={props.forceTruncate}
+        forceTruncate={props.vertical ? false : props.forceTruncate}
         dragging={sortable.isDragSource()}
       />
     </div>
@@ -76,6 +84,7 @@ function SessionTabEntry(props: {
   index: () => number
   active: () => boolean
   forceTruncate: boolean
+  vertical?: boolean
   serverCtx: () => ServerCtx | undefined
   onVisibleChange: (visible: boolean) => void
   onNavigate: (element: HTMLDivElement) => void
@@ -157,6 +166,7 @@ function SessionTabEntry(props: {
         index={props.index}
         active={props.active}
         forceTruncate={props.forceTruncate}
+        vertical={props.vertical}
         session={session}
         fallbackTitle={persisted()?.title ?? (missingSession() ? language.t("session.tab.unknown") : undefined)}
         onRename={rename}
@@ -173,6 +183,7 @@ function DraftTabSlot(props: {
   index: () => number
   active: () => boolean
   title: string
+  vertical?: boolean
   onNavigate: (element: HTMLDivElement) => void
   onClose: () => void
 }) {
@@ -192,7 +203,12 @@ function DraftTabSlot(props: {
       data-titlebar-tab-slot
       data-tab-key={props.id}
       data-active={props.active()}
-      class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
+      data-orientation={props.vertical ? "vertical" : "horizontal"}
+      classList={{
+        "relative flex": true,
+        "w-56 min-w-7 max-w-56 flex-shrink": !props.vertical,
+        "w-full shrink-0": props.vertical,
+      }}
     >
       <DraftTabItem
         ref={(el) => {
@@ -213,6 +229,8 @@ export function TitlebarTabStrip(props: {
   tabs: Tab[]
   currentTab: () => Tab | undefined
   forceTruncate: boolean
+  /** Stack tabs in a column instead of a row, flipping scroll/drag/fade axes with it. */
+  vertical?: boolean
   onNavigate: (tab: Tab, el?: HTMLDivElement) => void
   onClose: (tab: Tab) => void
   onReorder: (keys: string[]) => void
@@ -256,7 +274,11 @@ export function TitlebarTabStrip(props: {
 
   function refreshOverflow() {
     if (!scrollRef) return
-    props.onOverflowChange(scrollRef.scrollWidth > scrollRef.clientWidth)
+    // Measure whichever axis actually scrolls: vertical tabs are full-width, so a
+    // width-based probe would report "never overflowing".
+    props.onOverflowChange(
+      props.vertical ? scrollRef.scrollHeight > scrollRef.clientHeight : scrollRef.scrollWidth > scrollRef.clientWidth,
+    )
   }
 
   createResizeObserver(
@@ -281,14 +303,23 @@ export function TitlebarTabStrip(props: {
   createEffect(() => {
     props.tabs.length
     visibleTabIds()
+    props.vertical
     refreshOverflow()
   })
 
   return (
-    <div data-slot="titlebar-tabs" class="relative min-w-0">
+    <div
+      data-slot="titlebar-tabs"
+      data-orientation={props.vertical ? "vertical" : "horizontal"}
+      classList={{ relative: true, "min-w-0": !props.vertical, "min-h-0 w-full flex-1": props.vertical }}
+    >
       <div
         data-slot="titlebar-tabs-scroll"
-        class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
+        classList={{
+          "flex no-scrollbar [app-region:no-drag]": true,
+          "min-w-0 flex-row items-center gap-1.5 overflow-x-auto": !props.vertical,
+          "min-h-0 h-full flex-col items-stretch gap-1.5 overflow-y-auto": props.vertical,
+        }}
         ref={scrollRef}
       >
         <DragDropProvider
@@ -301,10 +332,18 @@ export function TitlebarTabStrip(props: {
                 (event.target instanceof Element && !!event.target.closest('[contenteditable="true"]')),
             }),
           ]}
-          modifiers={[RestrictToHorizontalAxis, RestrictToElement.configure({ element: () => listRef })]}
+          modifiers={[
+            props.vertical ? RestrictToVerticalAxis : RestrictToHorizontalAxis,
+            RestrictToElement.configure({ element: () => listRef }),
+          ]}
           plugins={(defaults) => [
             ...defaults.filter((plugin) => plugin !== Accessibility),
-            AutoScroller.configure({ acceleration: 8, threshold: { x: 0.05, y: 0 } }),
+            // Autoscroll only along the scrolling axis; the unused axis would let a
+            // drag scroll the strip into empty space.
+            AutoScroller.configure({
+              acceleration: 8,
+              threshold: props.vertical ? { x: 0, y: 0.05 } : { x: 0.05, y: 0 },
+            }),
             Feedback.configure({ dropAnimation: null }),
           ]}
           onDragStart={(event) => {
@@ -332,7 +371,16 @@ export function TitlebarTabStrip(props: {
             }
           }}
         >
-          <div data-titlebar-tab-list class="flex w-full min-w-0 flex-row items-center" ref={listRef}>
+          <div
+            data-titlebar-tab-list
+            data-orientation={props.vertical ? "vertical" : "horizontal"}
+            classList={{
+              "flex w-full": true,
+              "min-w-0 flex-row items-center": !props.vertical,
+              "flex-col items-stretch": props.vertical,
+            }}
+            ref={listRef}
+          >
             <For each={props.tabs}>
               {(tab) => {
                 const id = tabKey(tab)
@@ -353,6 +401,7 @@ export function TitlebarTabStrip(props: {
                       index={visibleIndex}
                       active={() => props.currentTab() === tab}
                       forceTruncate={props.forceTruncate}
+                      vertical={props.vertical}
                       serverCtx={serverCtx}
                       onVisibleChange={(visible) => setVisibility(id, visible)}
                       onNavigate={(element) => {
@@ -371,6 +420,7 @@ export function TitlebarTabStrip(props: {
                     index={visibleIndex}
                     active={() => props.currentTab() === tab}
                     title={language.t("command.session.new")}
+                    vertical={props.vertical}
                     onNavigate={(element) => {
                       ref = element
                       props.onNavigate(tab, element)
@@ -383,16 +433,35 @@ export function TitlebarTabStrip(props: {
           </div>
         </DragDropProvider>
       </div>
-      <div
-        data-slot="titlebar-tabs-fade-left"
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-[linear-gradient(to_right,var(--v2-background-bg-deep),transparent)]"
-      />
-      <div
-        data-slot="titlebar-tabs-fade-right"
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-[linear-gradient(to_left,var(--v2-background-bg-deep),transparent)]"
-      />
+      {/* Fades mark scrollable overflow, so they follow the scroll axis. */}
+      <Show
+        when={props.vertical}
+        fallback={
+          <>
+            <div
+              data-slot="titlebar-tabs-fade-left"
+              aria-hidden="true"
+              class="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-[linear-gradient(to_right,var(--v2-background-bg-deep),transparent)]"
+            />
+            <div
+              data-slot="titlebar-tabs-fade-right"
+              aria-hidden="true"
+              class="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-[linear-gradient(to_left,var(--v2-background-bg-deep),transparent)]"
+            />
+          </>
+        }
+      >
+        <div
+          data-slot="titlebar-tabs-fade-top"
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-x-0 top-0 z-10 h-4 bg-[linear-gradient(to_bottom,var(--v2-background-bg-deep),transparent)]"
+        />
+        <div
+          data-slot="titlebar-tabs-fade-bottom"
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-4 bg-[linear-gradient(to_top,var(--v2-background-bg-deep),transparent)]"
+        />
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/components/titlebar.css
+++ b/packages/app/src/components/titlebar.css
@@ -29,7 +29,7 @@
   background-image: var(--active-bg);
 }
 
-@keyframes titlebar-tab-fade-left {
+@keyframes titlebar-tab-fade-start {
   from {
     visibility: hidden;
   }
@@ -38,7 +38,7 @@
   }
 }
 
-@keyframes titlebar-tab-fade-right {
+@keyframes titlebar-tab-fade-end {
   from {
     visibility: visible;
   }
@@ -47,7 +47,7 @@
   }
 }
 
-/* The narrow ranges preserve the binary thresholds of scrollLeft > 0 and
+/* The narrow ranges preserve the binary thresholds of scroll offset > 0 and
    remaining scroll distance > 1px. Hidden defaults make an inactive timeline
    (no overflow) a no-op. Unsupported browsers also degrade to no fades. */
 [data-slot="titlebar-tabs"] {
@@ -63,14 +63,22 @@
     scroll-timeline: --titlebar-tabs-scroll x;
   }
 
-  [data-slot="titlebar-tabs-fade-left"] {
-    animation: titlebar-tab-fade-left linear both;
+  /* Vertical tabs scroll on the block axis; left on x the timeline never advances
+     and the fades stay permanently hidden. */
+  [data-slot="titlebar-tabs"][data-orientation="vertical"] [data-slot="titlebar-tabs-scroll"] {
+    scroll-timeline: --titlebar-tabs-scroll y;
+  }
+
+  [data-slot="titlebar-tabs-fade-left"],
+  [data-slot="titlebar-tabs-fade-top"] {
+    animation: titlebar-tab-fade-start linear both;
     animation-timeline: --titlebar-tabs-scroll;
     animation-range: 0 0.1px;
   }
 
-  [data-slot="titlebar-tabs-fade-right"] {
-    animation: titlebar-tab-fade-right linear both;
+  [data-slot="titlebar-tabs-fade-right"],
+  [data-slot="titlebar-tabs-fade-bottom"] {
+    animation: titlebar-tab-fade-end linear both;
     animation-timeline: --titlebar-tabs-scroll;
     animation-range: calc(100% - 1.1px) calc(100% - 1px);
   }

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -10,6 +10,7 @@ import {
   Switch,
   untrack,
 } from "solid-js"
+import { Portal } from "solid-js/web"
 import { createStore } from "solid-js/store"
 import { useLocation, useNavigate, useParams } from "@solidjs/router"
 import { IconButton } from "@opencode-ai/ui/icon-button"
@@ -29,6 +30,7 @@ import { useSettings } from "@/context/settings"
 import { WindowsAppMenu } from "./windows-app-menu"
 import { applyPath, backPath, forwardPath } from "./titlebar-history"
 import { TitlebarTabStrip } from "@/components/titlebar-tab-strip"
+import { railMount } from "@/components/titlebar-tab-rail"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createMediaQuery } from "@solid-primitives/media"
 import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/components/titlebar-session-events"
@@ -73,6 +75,8 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
   const params = useParams()
   const useV2Titlebar = createMemo(() => settings.general.newLayoutDesigns())
   const mobile = createMediaQuery("(max-width: 767px)")
+  // A 224px rail would swallow a phone screen, so the rail is desktop-only.
+  const verticalTabs = createMemo(() => useV2Titlebar() && !mobile() && settings.general.verticalTabs())
   const bottom = createMemo(() => useV2Titlebar() && mobile() && settings.general.mobileTitlebarPosition() === "bottom")
 
   const mac = createMemo(() => platform.platform === "desktop" && platform.os === "macos")
@@ -395,21 +399,36 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                   />
                 </TooltipV2>
 
-                <TitlebarTabStrip
-                  tabs={tabsStore}
-                  currentTab={currentTab}
-                  forceTruncate={tabsAreOverflowing()}
-                  onOverflowChange={setTabsAreOverflowing}
-                  onNavigate={(tab, el) => {
-                    tabs.select(tab)
-                    el?.scrollIntoView({ behavior: "instant" })
-                  }}
-                  onClose={(tab) => {
-                    const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                    if (index !== -1) tabsStoreActions.closeTab(index)
-                  }}
-                  onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                />
+                {(() => {
+                  const strip = (vertical: boolean) => (
+                    <TitlebarTabStrip
+                      tabs={tabsStore}
+                      currentTab={currentTab}
+                      vertical={vertical}
+                      forceTruncate={tabsAreOverflowing()}
+                      onOverflowChange={setTabsAreOverflowing}
+                      onNavigate={(tab, el) => {
+                        tabs.select(tab)
+                        el?.scrollIntoView({ behavior: "instant", block: "nearest" })
+                      }}
+                      onClose={(tab) => {
+                        const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                        if (index !== -1) tabsStoreActions.closeTab(index)
+                      }}
+                      onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                    />
+                  )
+
+                  // The vertical rail is owned by the layout (see titlebar-tab-rail.ts
+                  // for why this is a portal). Waiting on the mount element matters:
+                  // the layout has not attached its ref on first paint, and Portal
+                  // throws on an undefined target.
+                  return (
+                    <Show when={verticalTabs()} fallback={strip(false)}>
+                      <Show when={railMount()}>{(mount) => <Portal mount={mount()}>{strip(true)}</Portal>}</Show>
+                    </Show>
+                  )
+                })()}
                 <TooltipV2
                   placement="bottom"
                   value={

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -34,6 +34,7 @@ export interface Settings {
     editToolPartsExpanded: boolean
     showCustomAgents: boolean
     mobileTitlebarPosition: "top" | "bottom"
+    verticalTabs: boolean
     newLayoutDesigns?: boolean
     layoutTransitionEligible?: boolean
     agentVisibilityInitialized?: boolean
@@ -195,6 +196,7 @@ const defaultSettings: Settings = {
     editToolPartsExpanded: false,
     showCustomAgents: false,
     mobileTitlebarPosition: "top",
+    verticalTabs: false,
   },
   appearance: {
     fontSize: 14,
@@ -427,6 +429,10 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setMobileTitlebarPosition(value: "top" | "bottom") {
           setStore("general", "mobileTitlebarPosition", value)
+        },
+        verticalTabs: withFallback(() => store.general?.verticalTabs, defaultSettings.general.verticalTabs),
+        setVerticalTabs(value: boolean) {
+          setStore("general", "verticalTabs", value)
         },
         newLayoutDesigns,
         setNewLayoutDesigns(value: boolean) {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -937,6 +937,9 @@ export const dict = {
   "settings.general.row.showTerminal.description": "Show the terminal button in the desktop title bar",
   "settings.general.row.showStatus.title": "Server status",
   "settings.general.row.showStatus.description": "Show the server status button in the title bar",
+  "settings.general.row.verticalTabs.title": "Vertical tabs",
+  "settings.general.row.verticalTabs.description":
+    "Stack session tabs in a sidebar on the left instead of a row in the title bar",
   "settings.general.row.mobileTitlebarBottom.title": "Bottom navigation",
   "settings.general.row.mobileTitlebarBottom.description":
     "Place the title bar and session tabs at the bottom of the screen on mobile",

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,13 +1,16 @@
-import { createEffect, Suspense, type ParentProps } from "solid-js"
+import { createEffect, Show, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { setRailMount } from "@/components/titlebar-tab-rail"
 import { usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
+  const settings = useSettings()
   const [state, setState] = createStore({ debugTools: true })
 
   createEffect(() => setV2Toast(true))
@@ -38,9 +41,24 @@ export default function NewLayout(props: ParentProps) {
             : undefined
         }
       />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
+      {/* Row wrapper so the tab rail and the content sit side by side. With vertical
+          tabs off this collapses to a single full-width child. */}
+      <div class="flex-1 min-h-0 min-w-0 flex flex-row">
+        <Show when={settings.general.verticalTabs()}>
+          <div
+            data-slot="titlebar-tab-rail"
+            // `contain-strict` on <main> makes it an independent layout root, so the
+            // rail needs its own explicit width and shrink-0 to avoid being squeezed
+            // to zero by a wide session view. `p-2` matches the `m-2` inset on the
+            // content card so the first tab lines up with the panel beside it.
+            class="w-56 shrink-0 min-h-0 flex flex-col overflow-hidden bg-v2-background-bg-deep p-2 gap-1.5"
+            ref={(el) => setRailMount(el)}
+          />
+        </Show>
+        <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
+          <Suspense>{props.children}</Suspense>
+        </main>
+      </div>
       {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
       <TabsInfoPopup />
       <ToastRegion v2 />


### PR DESCRIPTION
Adds a `Vertical tabs` setting that stacks session tabs in a full-height rail on the left instead of a row in the title bar. Off by default; the horizontal strip is untouched when disabled. Mobile keeps the horizontal strip either way, since a 224px rail would swallow a phone screen.

Motivation: the horizontal strip gives each tab ~224px before it starts truncating, so with more than a handful of sessions open the titles stop being distinguishable. A rail trades horizontal space for a readable list.

Two choices worth flagging for review:

The strip is portaled into a slot the layout owns rather than rendered in place. The title bar is a fixed 36px row, so a full-height rail cannot be its DOM child — but all the tab controller state (route matching, draft creation, command registration) lives in that component. A portal moves only the DOM position and keeps `<main>` reflowing beside the rail instead of being covered by it, without hoisting that state into a new context.

Both axes stay live behind a `vertical` prop rather than one replacing the other: scroll axis, drag modifier, autoscroll threshold, overflow probe, edge fades, separator geometry and the narrow-tab container query all differ per orientation. The overflow probe in particular has to measure the axis actually in use — vertical tabs are full-width, so a width-based check would report "never overflowing".

---
Prepared by an AI agent on behalf of @cmsflash-aire.