### PR TITLE
fix(tui): pick redo target by message order, not ID

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -656,7 +656,9 @@ export function Session() {
         dialog.clear()
         const messageID = session()?.revert?.messageID
         if (!messageID) return
-        const message = messages().find((x) => x.role === "user" && x.id > messageID)
+        const boundary = messages().findIndex((item) => item.id === messageID)
+        if (boundary === -1) return
+        const message = messages().find((item, index) => index > boundary && item.role === "user")
         if (!message) {
           void sdk.client.session.unrevert({
             sessionID: route.sessionID,


### PR DESCRIPTION
### Issue for this PR

Closes #43034

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI redo command picked its target with `x.id > revert.messageID`. The message
list is ordered by `time.created` (#40994), so on a session whose IDs are not in
chronological order that lookup can return a message *before* the revert boundary.
Redo then stages the revert further back than it already was, and the next turn
commits it — the messages in between are deleted.

The fix looks the revert message up by position and takes the next user message
after it, which is what the web client's redo already does
(`packages/app/src/pages/session/use-session-commands.tsx`) and what `/undo` and
`revertRevertedMessages` in the same TUI file were converted to in #40994. If the
revert message isn't in the loaded list we bail instead of guessing, same as the
web client.

Three lines, no behaviour change on sessions with in-order IDs: there, the first
user message with a higher ID *is* the next one positionally.

### How did you verify your code works?

- `bun run --cwd packages/tui typecheck` — clean.
- `bun test` in `packages/tui` — 193 pass, 1 skip, 0 fail (same as before the change).
- Compared old vs new selection on a message list whose ID order is inverted
  relative to `time.created`: the old predicate returns index 0 (before the
  boundary), the new one returns the next user message after the boundary, or
  nothing when the boundary is already the last user message (so redo clears the
  revert, which is correct).
- `bunx oxlint` and `bunx prettier --check` on the touched file: no new warnings.

I did not add a test: the redo command lives inside the `Session()` route
component, and there is no fixture in `packages/tui/test` that mounts a route
(the existing tests cover the sync store, utils and exported pure helpers). #40994
added tests for the same reason only where the code was already reachable. Happy to
add one if you'd like the selection pulled into a testable helper.

### Screenshots / recordings

_Not a visual change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

