### PR TITLE
fix(opencode): handle literal Windows archive paths

### DIFF
--- a/packages/opencode/src/util/archive.ts
+++ b/packages/opencode/src/util/archive.ts
@@ -3,11 +3,14 @@ import * as Process from "./process"
 
 export async function extractZip(zipPath: string, destDir: string) {
   if (process.platform === "win32") {
-    const winZipPath = path.resolve(zipPath)
-    const winDestDir = path.resolve(destDir)
     // $global:ProgressPreference suppresses PowerShell's blue progress bar popup
-    const cmd = `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path '${winZipPath}' -DestinationPath '${winDestDir}' -Force`
-    await Process.run(["powershell", "-NoProfile", "-NonInteractive", "-Command", cmd])
+    const cmd = `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath $env:OPENCODE_ARCHIVE_PATH -DestinationPath $env:OPENCODE_ARCHIVE_DESTINATION -Force`
+    await Process.run(["powershell", "-NoProfile", "-NonInteractive", "-Command", cmd], {
+      env: {
+        OPENCODE_ARCHIVE_PATH: path.resolve(zipPath),
+        OPENCODE_ARCHIVE_DESTINATION: path.resolve(destDir),
+      },
+    })
     return
   }
 

--- a/packages/opencode/test/util/archive.test.ts
+++ b/packages/opencode/test/util/archive.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Archive } from "@/util/archive"
+import { Process } from "@/util/process"
+import { tmpdir } from "../fixture/fixture"
+
+test("extractZip handles literal Windows paths", async () => {
+  if (process.platform !== "win32") return
+
+  await using tmp = await tmpdir()
+  const source = path.join(tmp.path, "source.txt")
+  const archive = path.join(tmp.path, "archive.zip")
+  await Bun.write(source, "content")
+  await Process.run(
+    [
+      "powershell",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "Compress-Archive -LiteralPath $env:OPENCODE_TEST_SOURCE -DestinationPath $env:OPENCODE_TEST_ARCHIVE -Force",
+    ],
+    {
+      env: {
+        OPENCODE_TEST_SOURCE: source,
+        OPENCODE_TEST_ARCHIVE: archive,
+      },
+    },
+  )
+
+  const literal = path.join(tmp.path, "archive's [copy].zip")
+  const destination = path.join(tmp.path, "destination's [copy]")
+  await fs.rename(archive, literal)
+  await Archive.extractZip(literal, destination)
+
+  expect(await Bun.file(path.join(destination, "source.txt")).text()).toBe("content")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #43036

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pass Windows archive and destination paths through child-process environment variables instead of interpolating them into a PowerShell command.

It also switches `Expand-Archive` from `-Path` to `-LiteralPath`. This preserves apostrophes in valid paths and prevents characters such as `[` and `]` from being interpreted as wildcards.

A Windows regression test covers archive and destination paths containing both kinds of characters.

### How did you verify your code works?

- Ran `bun test test/util`
- 120 tests passed with 0 failures
- Verified extraction using paths such as `archive's [copy].zip` and `destination's [copy]`
- Ran Prettier checks on the changed files

### Screenshots / recordings

N/A — this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR