### PR TITLE
fix(opencode): let a global config patch remove an entry with null

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -190,3 +190,31 @@ export const Info = Schema.Struct({
 }).annotate({ identifier: "Config" })
 
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
+
+const Removable = <S extends Schema.Top>(value: S) => Schema.Record(Schema.String, Schema.NullOr(value))
+
+/**
+ * `Config` as accepted by a PATCH request body.
+ *
+ * Identical to `Info` except that every map-shaped field accepts `null` as a
+ * member value, following JSON Merge Patch (RFC 7396) where `null` means
+ * "remove this member". A merge patch cannot otherwise express a removal:
+ * omitting a key preserves it, and `{}` is a no-op, so without `null` a client
+ * can add and change config entries but never delete one.
+ *
+ * `null` is deliberately NOT part of `Info` itself, so it stays invalid inside
+ * an on-disk config file — it is a request-body verb, not a config value.
+ */
+export const Patch = Schema.Struct({
+  ...Info.fields,
+  command: Schema.optional(Removable(ConfigCommandV1.Info)),
+  references: Schema.optional(Removable(ConfigReference.Entry)),
+  reference: Schema.optional(Removable(ConfigReference.Entry)),
+  mode: Schema.optional(Removable(ConfigAgentV1.Info)),
+  agent: Schema.optional(Removable(ConfigAgentV1.Info)),
+  provider: Schema.optional(Removable(ConfigProviderV1.Info)),
+  mcp: Schema.optional(Removable(Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })]))),
+  tools: Schema.optional(Removable(Schema.Boolean)),
+}).annotate({ identifier: "ConfigPatch" })
+
+export type Patch = DeepMutable<Schema.Schema.Type<typeof Patch>>

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -210,8 +210,32 @@ export const Patch = Schema.Struct({
   command: Schema.optional(Removable(ConfigCommandV1.Info)),
   references: Schema.optional(Removable(ConfigReference.Entry)),
   reference: Schema.optional(Removable(ConfigReference.Entry)),
-  mode: Schema.optional(Removable(ConfigAgentV1.Info)),
-  agent: Schema.optional(Removable(ConfigAgentV1.Info)),
+  // `mode` and `agent` keep the exact named-key shape `Info` declares — only
+  // the open rest becomes removable. The built-in agents are not deletable
+  // (there is no config entry to remove), and leaving them as-is keeps a plain
+  // `Config` assignable to `ConfigPatch` for existing callers: the named
+  // optional keys are what put `undefined` in the index signature, and making
+  // them nullable would drop it.
+  mode: Schema.optional(
+    Schema.StructWithRest(
+      Schema.Struct({ build: Schema.optional(ConfigAgentV1.Info), plan: Schema.optional(ConfigAgentV1.Info) }),
+      [Removable(ConfigAgentV1.Info)],
+    ),
+  ),
+  agent: Schema.optional(
+    Schema.StructWithRest(
+      Schema.Struct({
+        plan: Schema.optional(ConfigAgentV1.Info),
+        build: Schema.optional(ConfigAgentV1.Info),
+        general: Schema.optional(ConfigAgentV1.Info),
+        explore: Schema.optional(ConfigAgentV1.Info),
+        title: Schema.optional(ConfigAgentV1.Info),
+        summary: Schema.optional(ConfigAgentV1.Info),
+        compaction: Schema.optional(ConfigAgentV1.Info),
+      }),
+      [Removable(ConfigAgentV1.Info)],
+    ),
+  ),
   provider: Schema.optional(Removable(ConfigProviderV1.Info)),
   mcp: Schema.optional(Removable(Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })]))),
   tools: Schema.optional(Removable(Schema.Boolean)),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -114,6 +114,11 @@ type Info = ConfigV1.Info & {
   plugin_origins?: ConfigPlugin.Origin[]
 }
 
+// A PATCH body: `Info`, but map members may be `null` to remove them (RFC 7396).
+type Patch = ConfigV1.Patch & {
+  plugin_origins?: ConfigPlugin.Origin[]
+}
+
 type State = {
   config: Info
   directories: string[]
@@ -126,7 +131,7 @@ export interface Interface {
   readonly getGlobal: () => Effect.Effect<Info>
   readonly getConsoleState: () => Effect.Effect<ConsoleState>
   readonly update: (config: Info) => Effect.Effect<void>
-  readonly updateGlobal: (config: Info) => Effect.Effect<{ info: Info; changed: boolean }>
+  readonly updateGlobal: (config: Patch) => Effect.Effect<{ info: Info; changed: boolean }>
   readonly invalidate: () => Effect.Effect<void>
   readonly directories: () => Effect.Effect<string[]>
   readonly waitForDependencies: () => Effect.Effect<void>
@@ -165,8 +170,25 @@ function writable(info: Info) {
   return next
 }
 
-function writableGlobal(info: Info) {
-  const next = writable(info)
+/**
+ * A patch body removes a config entry by setting it to `null`, as in JSON
+ * Merge Patch (RFC 7396) — there is no other way for a merge to express a
+ * deletion, since an omitted key means "leave this alone".
+ *
+ * JSON has no `undefined`, but both write paths below already drop a member
+ * whose value is `undefined` — jsonc-parser's `modify` deletes the key, and
+ * `JSON.stringify` omits it — so translating `null` to `undefined` here is all
+ * a removal needs. Recursive, so nested entries (`provider.<id>`,
+ * `agent.<name>`) can be removed and not just top-level keys.
+ */
+function withRemovals(patch: unknown): unknown {
+  if (patch === null) return undefined
+  if (!isRecord(patch)) return patch
+  return Object.fromEntries(Object.entries(patch).map(([key, value]) => [key, withRemovals(value)]))
+}
+
+function writableGlobal(info: Patch) {
+  const next = writable(withRemovals(info) as Info)
   // When a user changes config from a value back to default in the Desktop app, we don't want to leave a blank `"shell": "",` key
   if ("shell" in next && next.shell === "") return { ...next, shell: undefined }
   return next
@@ -634,7 +656,7 @@ const layer = Layer.effect(
       yield* invalidateGlobal
     })
 
-    const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Info) {
+    const updateGlobal = Effect.fn("Config.updateGlobal")(function* (config: Patch) {
       const file = globalConfigFile()
       const before = (yield* readConfigFile(file)) ?? "{}"
       const patch = writableGlobal(config)
@@ -647,7 +669,10 @@ const layer = Layer.effect(
         const serialized = JSON.stringify(merged, null, 2)
         changed = serialized !== before
         if (changed) yield* fs.writeFileString(file, serialized).pipe(Effect.orDie)
-        next = merged
+        // Re-read from the serialized form rather than returning `merged`: a
+        // removed member is still present-but-undefined in the merge result,
+        // which `Info` does not accept. Mirrors the jsonc branch below.
+        next = ConfigParse.schema(ConfigV1.Info, ConfigParse.jsonc(serialized, file), file)
       } else {
         const updated = patchJsonc(before, patch)
         next = ConfigParse.schema(ConfigV1.Info, ConfigParse.jsonc(updated, file), file)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/global.ts
@@ -101,14 +101,15 @@ export const GlobalApi = HttpApi.make("global").add(
         }),
       ),
       HttpApiEndpoint.patch("configUpdate", GlobalPaths.config, {
-        payload: ConfigV1.Info,
+        payload: ConfigV1.Patch,
         success: described(ConfigV1.Info, "Successfully updated global config"),
         error: HttpApiError.BadRequest,
       }).annotateMerge(
         OpenApi.annotations({
           identifier: "global.config.update",
           summary: "Update global configuration",
-          description: "Update global OpenCode configuration settings and preferences.",
+          description:
+            'Update global OpenCode configuration settings and preferences. The body is merged into the existing config, so omitted keys are left as they are. To remove an entry from a map-shaped field, set it to `null` (as in JSON Merge Patch): `{"provider":{"my-endpoint":null}}` deletes the `my-endpoint` provider.',
         }),
       ),
       HttpApiEndpoint.post("dispose", GlobalPaths.dispose, {

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -97,6 +97,7 @@ function matchLegacyOpenApi(input: Record<string, unknown>) {
   }
   normalizeComponentNames(spec)
   collapseDuplicateComponents(spec)
+  collapseConfigPatch(spec)
   applyLegacySchemaOverrides(spec)
   normalizeComponentDescriptions(spec)
   addLegacyErrorSchemas(spec)
@@ -227,6 +228,33 @@ function collapseDuplicateComponents(spec: OpenApiSpec) {
     rewriteRefs(spec, name, base)
     delete schemas[name]
   }
+}
+
+/**
+ * `ConfigPatch` exists so a PATCH body can carry `null` to remove a config
+ * entry. Once `stripOptionalNull` has run, it is structurally identical to
+ * `Config` — the whole difference is the nullability the published spec
+ * deliberately does not carry — so publish it as `Config` and keep the SDK
+ * surface unchanged. Without this, the generated client would rename the
+ * request parameter (`config` -> `configPatch`), a breaking change for every
+ * existing caller.
+ *
+ * `collapseDuplicateComponents` can't do this: it only merges names that
+ * differ by a trailing digit. The structural check is not decoration — if the
+ * two ever genuinely diverge, publishing one as the other would ship a spec
+ * that lies about the request body, so fail loudly instead.
+ */
+function collapseConfigPatch(spec: OpenApiSpec) {
+  const schemas = spec.components?.schemas
+  if (!schemas?.ConfigPatch || !schemas.Config) return
+  if (stableSchema(schemas.ConfigPatch, schemas) !== stableSchema(schemas.Config, schemas)) {
+    throw new Error(
+      "ConfigPatch is no longer structurally identical to Config once nulls are stripped. " +
+        "Publish it as its own component and accept the SDK parameter rename, or realign the two.",
+    )
+  }
+  rewriteRefs(spec, "ConfigPatch", "Config")
+  delete schemas.ConfigPatch
 }
 
 function normalizeComponentNames(spec: OpenApiSpec) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -397,6 +397,123 @@ it.effect("updates global config and omits empty shell key in jsonc", () =>
   ),
 )
 
+it.effect("removes a nested member when the global patch sets it to null in json", () =>
+  withGlobalConfig(
+    {
+      config: {
+        provider: { keep: { options: { baseURL: "http://keep" } }, drop: { options: { baseURL: "http://drop" } } },
+      },
+    },
+    ({ dir }) =>
+      Effect.gen(function* () {
+        const result = yield* Config.use.updateGlobal({ provider: { drop: null } })
+
+        const writtenConfig: any = yield* FSUtil.use.readJson(path.join(dir, "opencode.json"))
+        expect(writtenConfig.provider).not.toHaveProperty("drop")
+        expect(writtenConfig.provider).toHaveProperty("keep")
+        expect(result.changed).toBe(true)
+        expect(result.info.provider).not.toHaveProperty("drop")
+        expect(result.info.provider).toHaveProperty("keep")
+      }),
+  ),
+)
+
+it.effect("removes a nested member when the global patch sets it to null in jsonc", () =>
+  withGlobalConfig(
+    {
+      config: {
+        provider: { keep: { options: { baseURL: "http://keep" } }, drop: { options: { baseURL: "http://drop" } } },
+      },
+      name: "opencode.jsonc",
+    },
+    ({ dir }) =>
+      Effect.gen(function* () {
+        const result = yield* Config.use.updateGlobal({ provider: { drop: null } })
+
+        const file = path.join(dir, "opencode.jsonc")
+        const writtenConfig = yield* FSUtil.use.readFileString(file)
+        expect(writtenConfig).not.toContain("drop")
+        expect(writtenConfig).toContain("keep")
+        expect(result.changed).toBe(true)
+        expect(result.info.provider).not.toHaveProperty("drop")
+      }),
+  ),
+)
+
+it.effect("preserves comments and unrelated keys when a null removal is applied to jsonc", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    const file = path.join(dir, "opencode.jsonc")
+    yield* FSUtil.use.writeFileString(
+      file,
+      [
+        "{",
+        "  // a comment that must survive",
+        '  "model": "test/model",',
+        '  "provider": {',
+        '    "keep": { "options": { "baseURL": "http://keep" } },',
+        '    "drop": { "options": { "baseURL": "http://drop" } }',
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    )
+
+    yield* withGlobalConfigDir(
+      dir,
+      Effect.gen(function* () {
+        yield* Config.use.updateGlobal({ provider: { drop: null } })
+        const written = yield* FSUtil.use.readFileString(file)
+        expect(written).toContain("// a comment that must survive")
+        expect(written).toContain('"model": "test/model"')
+        expect(written).toContain("keep")
+        expect(written).not.toContain("drop")
+      }),
+    )
+  }),
+)
+
+it.effect("applies additions and removals in the same global patch", () =>
+  withGlobalConfig(
+    {
+      config: {
+        provider: { keep: { options: { baseURL: "http://keep" } }, drop: { options: { baseURL: "http://drop" } } },
+      },
+      name: "opencode.jsonc",
+    },
+    ({ dir }) =>
+      Effect.gen(function* () {
+        yield* Config.use.updateGlobal({
+          provider: { drop: null, added: { options: { baseURL: "http://added" } } },
+        })
+
+        const file = path.join(dir, "opencode.jsonc")
+        const written = yield* FSUtil.use.readFileString(file)
+        const parsed = ConfigParse.schema(ConfigV1.Info, ConfigParse.jsonc(written, file), file)
+        expect(parsed.provider).not.toHaveProperty("drop")
+        expect(parsed.provider).toHaveProperty("keep")
+        expect(parsed.provider?.added?.options?.baseURL).toBe("http://added")
+      }),
+  ),
+)
+
+it.effect("is a no-op when a null removal targets a member that is already absent", () =>
+  withGlobalConfig(
+    { config: { provider: { keep: { options: { baseURL: "http://keep" } } } }, name: "opencode.jsonc" },
+    ({ dir }) =>
+      Effect.gen(function* () {
+        const file = path.join(dir, "opencode.jsonc")
+        const before = yield* FSUtil.use.readFileString(file)
+
+        const result = yield* Config.use.updateGlobal({ provider: { missing: null } })
+
+        expect(yield* FSUtil.use.readFileString(file)).toBe(before)
+        expect(result.changed).toBe(false)
+        expect(result.info.provider).toHaveProperty("keep")
+      }),
+  ),
+)
+
 it.instance(
   "loads formatter boolean config",
   Effect.gen(function* () {

--- a/packages/opencode/test/fixture/config.ts
+++ b/packages/opencode/test/fixture/config.ts
@@ -8,7 +8,10 @@ export function make(overrides: Partial<Config.Interface> = {}) {
     getGlobal: () => Effect.succeed({}),
     getConsoleState: () => Effect.succeed(emptyConsoleState),
     update: () => Effect.void,
-    updateGlobal: (config) => Effect.succeed({ info: config, changed: false }),
+    // A patch may carry `null` members (RFC 7396 removals) that `Info` does
+    // not accept; the real service resolves them against the file, so the stub
+    // just reports an empty config rather than echoing the patch back.
+    updateGlobal: () => Effect.succeed({ info: {}, changed: false }),
     invalidate: () => Effect.void,
     directories: () => Effect.succeed([]),
     waitForDependencies: () => Effect.void,

--- a/packages/opencode/test/server/httpapi-global.test.ts
+++ b/packages/opencode/test/server/httpapi-global.test.ts
@@ -17,6 +17,10 @@ import { authorizationLayer } from "../../src/server/routes/instance/httpapi/mid
 import { schemaErrorLayer } from "../../src/server/routes/instance/httpapi/middleware/schema-error"
 import { testEffect } from "../lib/effect"
 
+// Captures the patch the route hands to Config.updateGlobal so the tests can
+// assert on what survived payload decoding.
+const patches: unknown[] = []
+
 const apiLayer = HttpRouter.serve(
   HttpApiBuilder.layer(RootHttpApi).pipe(
     Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),
@@ -29,7 +33,15 @@ const apiLayer = HttpRouter.serve(
 ).pipe(
   Layer.provideMerge(NodeHttpServer.layerTest),
   Layer.provide(Layer.mock(Auth.Service)({})),
-  Layer.provide(Layer.mock(Config.Service)({})),
+  Layer.provide(
+    Layer.mock(Config.Service)({
+      updateGlobal: (config) =>
+        Effect.sync(() => {
+          patches.push(config)
+          return { info: {}, changed: false }
+        }),
+    }),
+  ),
   Layer.provide(Layer.mock(MoveSession.Service)({})),
   Layer.provide(
     Layer.mock(Installation.Service)({
@@ -61,6 +73,34 @@ describe("global HttpApi", () => {
 
       expect(response.status).toBe(400)
       expect(yield* response.json).toEqual({ success: false, error: "Invalid request body" })
+    }),
+  )
+
+  // A config patch is a JSON Merge Patch (RFC 7396), where `null` removes a
+  // member. Without this the endpoint can add and change config entries but
+  // never delete one, because omitting a key preserves it.
+  it.live("accepts a null member in a config patch as a removal", () =>
+    Effect.gen(function* () {
+      patches.length = 0
+
+      const response = yield* HttpClientRequest.patch(GlobalPaths.config).pipe(
+        HttpClientRequest.setBody(HttpBody.jsonUnsafe({ provider: { drop: null }, username: "kept" })),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(200)
+      expect(patches).toEqual([{ provider: { drop: null }, username: "kept" }])
+    }),
+  )
+
+  it.live("still rejects a malformed member in a config patch", () =>
+    Effect.gen(function* () {
+      const response = yield* HttpClientRequest.patch(GlobalPaths.config).pipe(
+        HttpClientRequest.setBody(HttpBody.jsonUnsafe({ provider: { bad: 42 } })),
+        HttpClient.execute,
+      )
+
+      expect(response.status).toBe(400)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/43033

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

__Below description is AI generated but double checked. Same for the code__

`PATCH /global/config` merges its body into the existing config, so an omitted key is preserved and `{}` is a no-op. There was no way to express a removal: the payload schema rejected `null`, so a client could add and change config entries but never delete one.

Both write paths already drop a member whose value is `undefined` (jsonc-parser's `modify` deletes the key, `JSON.stringify` omits it) — the gap was only that JSON cannot carry `undefined` over the wire.

Accept `null` as a member value on the map-shaped config fields and translate it to a removal, the way JSON Merge Patch (RFC 7396) does. `null` stays invalid inside an on-disk config file: it is a request-body verb, not a config value.

Scoped to map-shaped fields, since that is where entries are created and can't be removed. Scalar keys are untouched — clearing `shell` with `""` behaves exactly as before. `mode`/`agent` keep the exact named-key shape `Info` declares; only the open rest is removable, since a built-in agent has no config entry to delete.

**The published spec and the generated SDK are deliberately unchanged** — byte-identical apart from one doc comment. `ConfigPatch` is collapsed back onto `Config` when the public spec is built, because `@hey-api` derives the request parameter name from the body's component name: shipping it as its own component would turn `client.global.config.update({ config })` into `update({ configPatch })`, which breaks at runtime as well as compile time (the old key is silently dropped and an empty body sent). `collapseConfigPatch` asserts the two are structurally identical after `stripOptionalNull` and throws otherwise, so it can't quietly start publishing a spec that misdescribes the request body.

**Trade-off:** `null` is documented in prose (the endpoint description) rather than in the type, so a TypeScript client needs a cast to pass it.

**The cleaner end state, if you want it:** publish `ConfigPatch` as its own component and take the parameter rename as an intentional breaking change in a versioned SDK release — then the removal is typed and discoverable, and the in-repo call site is a one-line fix. That felt like your call to make rather than something to fold into a bug fix, so I took the non-breaking route; happy to flip it.

### How did you verify your code works?

- Tested locally
- `bun run typecheck` in `packages/core` and `packages/opencode`, plus tests added and run locally:
- `test/config/config.test.ts` — a `null` member removes the entry in both `opencode.json` and `opencode.jsonc`; comments and unrelated keys survive the jsonc removal; additions and removals apply in the same patch; a `null` for an already-absent entry is a true no-op (file byte-identical, `changed: false`).
- `test/server/httpapi-global.test.ts` — a `null` member is accepted through the route (200) and reaches `Config.updateGlobal` intact; a malformed member (`{"provider":{"bad":42}}`) is still rejected 400, so validation isn't weakened.
- `test/server/httpapi-public-openapi.test.ts` passes with the spec change.

I regenerated the SDK locally to confirm the only diff is the endpoint doc comment, but left generated files out of this PR since the generate workflow rebuilds them on `dev`.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
