### PR TITLE
feat(cli): add opencode_d wrapper running identically to the built binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,30 @@ opencode web             # Start server + open web interface
 opencode <directory>     # Start TUI in specific directory
 ```
 
+### Running dev with the caller's working directory
+
+`bun dev` runs from `packages/opencode`, so `process.cwd()` is the opencode
+package directory rather than the project you are working on. This means the
+shell tool and instance root default to `packages/opencode`, not your actual
+project — different from how the built `opencode` binary behaves.
+
+`bin/dev.ts` fixes this. It `chdir`s back to a directory you pass as its first
+argument before loading `src/index.ts`, so `process.cwd()` matches the caller's
+working directory just like the production binary.
+
+```bash
+# From packages/opencode, run opencode against /path/to/project:
+bun run --conditions=browser bin/dev.ts /path/to/project run "hello"
+bun run --conditions=browser bin/dev.ts /path/to/project          # TUI
+```
+
+For convenience, `packages/opencode/script/opencode_d` is a wrapper that
+invokes the launcher with the caller's cwd. Symlink it onto your `PATH`:
+
+```bash
+ln -s "$(pwd)/packages/opencode/script/opencode_d" ~/.local/bin/opencode_d
+```
+
 ### Running the API Server
 
 To start the OpenCode headless API server:

--- a/packages/opencode/bin/dev.ts
+++ b/packages/opencode/bin/dev.ts
@@ -1,0 +1,8 @@
+// Dev-only launcher: chdir to the caller's project (passed as $1) before
+// loading the real entrypoint, so process.cwd() matches the built binary.
+const originalPwd = process.argv[2]
+if (originalPwd) {
+  process.chdir(originalPwd)
+  process.argv.splice(2, 1)
+}
+await import("../src/index")

--- a/packages/opencode/script/opencode_d
+++ b/packages/opencode/script/opencode_d
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# opencode_d — run opencode from source, behaving like the production-built
+# `opencode` binary. See CONTRIBUTING.md → "Running dev with the caller's
+# working directory" for details.
+#
+# Symlink this script onto your PATH and call it as you would `opencode`:
+#   ln -s "$(pwd)/packages/opencode/script/opencode_d" ~/.local/bin/opencode_d
+#   opencode_d --help
+#   opencode_d run "hello"
+#   opencode_d                  # start TUI in the current directory
+set -euo pipefail
+
+ORIGINAL_PWD="$PWD"
+
+# Resolve the opencode repo root from this script's location so the wrapper
+# works regardless of where it's invoked from (including via a symlink).
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+cd "$REPO_ROOT/packages/opencode"
+
+# opencode reads process.env.PWD for the project root; `cd` above overwrote it.
+export PWD="$ORIGINAL_PWD"
+
+exec bun run --conditions=browser bin/dev.ts "$ORIGINAL_PWD" "$@"

--- a/packages/opencode/script/opencode_d
+++ b/packages/opencode/script/opencode_d
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # opencode_d — run opencode from source, behaving like the production-built
 # `opencode` binary. See CONTRIBUTING.md → "Running dev with the caller's
 # working directory" for details.
@@ -8,18 +8,40 @@
 #   opencode_d --help
 #   opencode_d run "hello"
 #   opencode_d                  # start TUI in the current directory
-set -euo pipefail
+set -eu
 
-ORIGINAL_PWD="$PWD"
+# Snapshot the caller's environment so we can restore it after the `cd` into
+# the repo. We never mutate the caller's PWD/OLDPWD beyond this script — bun
+# inherits the restored values via exec.
+caller_pwd="$PWD"
+caller_oldpwd="${OLDPWD-}"
 
 # Resolve the opencode repo root from this script's location so the wrapper
 # works regardless of where it's invoked from (including via a symlink).
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# POSIX-compliant symlink resolution: no `readlink -f` (GNU coreutils only;
+# stock macOS readlink lacks -f on versions < 13).
+script=$0
+while [ -L "$script" ]; do
+  dir=$(cd -- "$(dirname -- "$script")" && pwd)
+  script=$(readlink -- "$script")
+  case $script in
+    /*) ;;
+    *) script=$dir/$script ;;
+  esac
+done
+script_dir=$(cd -- "$(dirname -- "$script")" && pwd)
+repo_root=$(cd -- "$script_dir/../../.." && pwd)
 
-cd "$REPO_ROOT/packages/opencode"
+cd -- "$repo_root/packages/opencode"
 
-# opencode reads process.env.PWD for the project root; `cd` above overwrote it.
-export PWD="$ORIGINAL_PWD"
+# opencode reads process.env.PWD for the project root; the `cd` above
+# overwrote it. Restore PWD and OLDPWD to the caller's view so the launched
+# process sees the same working-directory state as a production invocation.
+PWD=$caller_pwd
+export PWD
+if [ -n "$caller_oldpwd" ]; then
+  OLDPWD=$caller_oldpwd
+  export OLDPWD
+fi
 
-exec bun run --conditions=browser bin/dev.ts "$ORIGINAL_PWD" "$@"
+exec bun run --conditions=browser bin/dev.ts "$caller_pwd" "$@"


### PR DESCRIPTION
### Issue for this PR

Closes #47283

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

There's no practical way to use bun run to start the source version of opencode as we would the binary.
That's because bun dev runs from packages/opencode, so process.cwd() is the package dir rather than the caller's project — the shell tool and instance root default to the wrong directory, unlike the built opencode binary.

This adds bin/dev.ts, a thin entrypoint that chdir's back to the caller's project (passed as $1) before loading src/index.ts, restoring the correct working directory. The @opentui/solid preload has already registered by then, so .tsx transpilation keeps working.

[`packages/opencode/script/opencode_d`](packages/opencode/script/opencode_d) is a wrapper that resolves the repo root and invokes the launcher with the caller's cwd. Symlink it onto your PATH and use it as a drop-in for the production opencode command:

```shell
  ln -s .../packages/opencode/script/opencode_d ~/.local/bin/opencode_d
  opencode_d run "hello"
  opencode_d # start TUI in the current directory
```

### How did you verify your code works?

Dogfood! I use that daily.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._