### PR TITLE
feat(plugin): add interactive question() tool-context method with prefilled answers

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -108,6 +108,18 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const hidden = createMemo(() => Math.max(0, Math.min(1, collapse())))
   const optionsOff = createMemo(() => hidden() > 0.98)
 
+  // Pre-fill the custom textarea with a question's proposed content (e.g. a
+  // review/edit workflow) so the user can revise it before submitting.
+  createEffect(() => {
+    const proposed = question()?.default
+    const tab = store.tab
+    if (!proposed) return
+    if (store.customOn[tab]) return
+    if ((store.custom[tab] ?? "") !== "") return
+    setStore("custom", tab, proposed)
+    setStore("customOn", tab, true)
+  })
+
   const customUpdate = (value: string, selected: boolean = on()) => {
     const prev = input().trim()
     const next = value.trim()

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -109,14 +109,20 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
   const optionsOff = createMemo(() => hidden() > 0.98)
 
   // Pre-fill the custom textarea with a question's proposed content (e.g. a
-  // review/edit workflow) so the user can revise it before submitting.
+  // review/edit workflow) so the user can revise it before submitting. This runs
+  // at most once per tab (Prefilled latch) so clearing the field — or toggling
+  // the "type your own" box, which resets customOn — can never re-insert the
+  // proposal. Bail when the question forbids custom answers, so a hidden field
+  // is not silently marked as an active submitted answer.
+  const prefilled = new Set<number>()
   createEffect(() => {
-    const proposed = question()?.default
+    const current = question()
     const tab = store.tab
-    if (!proposed) return
-    if (store.customOn[tab]) return
-    if ((store.custom[tab] ?? "") !== "") return
-    setStore("custom", tab, proposed)
+    if (!current?.default) return
+    if (current.custom === false) return
+    if (prefilled.has(tab)) return
+    prefilled.add(tab)
+    setStore("custom", tab, current.default)
     setStore("customOn", tab, true)
   })
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -102,6 +102,7 @@ const layer = Layer.effect(
     const task = yield* TaskTool
     const read = yield* ReadTool
     const question = yield* QuestionTool
+    const questionService = yield* Question.Service
     const todo = yield* TodoWriteTool
     const lsptool = yield* LspTool
     const plan = yield* PlanExitTool
@@ -148,6 +149,21 @@ const layer = Layer.effect(
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
                   ask: (req) => bridge.promise(toolCtx.ask(req)),
+                  question: (input) =>
+                    bridge.promise(
+                      questionService.ask({
+                        sessionID: toolCtx.sessionID,
+                        questions: input.questions.map((q) => ({
+                          question: q.question,
+                          header: q.header,
+                          options: q.options.map((o) => ({ label: o.label, description: o.description })),
+                          multiple: q.multiple,
+                          custom: q.custom,
+                          default: q.default,
+                        })),
+                        tool: toolCtx.callID ? { messageID: toolCtx.messageID, callID: toolCtx.callID } : undefined,
+                      }),
+                    ),
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -17,6 +17,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { ToolJsonSchema } from "@/tool/json-schema"
 import { MessageID, SessionID } from "@/session/schema"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Question } from "@/question"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { MCP } from "@/mcp"
@@ -567,6 +568,76 @@ describe("tool.registry", () => {
       const registry = yield* ToolRegistry.Service
       const ids = yield* registry.ids()
       expect(ids).toContain("cowsay")
+    }),
+  )
+
+  // Captures what the plugin `question()` bridge forwards to Question.Service.ask,
+  // covering both the with- and without-callID tool contexts.
+  const askedInputs: unknown[] = []
+  const compileReplacements: any[] = [
+    ...(replacements as unknown as Array<unknown>),
+    [Question.node, Layer.mock(Question.Service, {
+      ask: (input: unknown): any =>
+        Effect.sync(() => {
+          askedInputs.push(input)
+          return [["A"]]
+        }),
+    })],
+  ]
+  const withQuestion = testEffect(
+    LayerNode.compile(LayerNode.group([ToolRegistry.node, Agent.node]), compileReplacements),
+  )
+
+  withQuestion.instance("bridges plugin question() to Question.Service.ask (exact payload, with and without callID)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const pluginTool = pathToFileURL(path.resolve(import.meta.dir, "../../../plugin/src/tool.ts")).href
+      const tools = path.join(test.directory, ".opencode", "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "ask.ts"),
+          [
+            `import { tool } from ${JSON.stringify(pluginTool)}`,
+            "export default tool({",
+            "  description: 'asker',",
+            "  args: {},",
+            "  execute: async (args: any, ctx: any) => {",
+            "    await ctx.question({ questions: [{ question: 'Q?', header: 'H', options: [{ label: 'A', description: 'D' }], default: 'prefill' }] })",
+            "    return 'asked'",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const agents = yield* Agent.Service
+      const loaded = (yield* registry.all()).find((tool) => tool.id === "ask")
+      if (!loaded) throw new Error("ask plugin tool was not loaded")
+      const agent = (yield* agents.defaultInfo()).name
+      const ctx: any = {
+        sessionID: SessionID.make("ses_q"),
+        messageID: MessageID.make("msg_q"),
+        agent,
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      }
+
+      yield* loaded.execute({}, ctx)
+      const noCallID = askedInputs[0] as { sessionID: string; tool?: unknown; questions: unknown[] }
+      expect(noCallID.sessionID).toBe("ses_q")
+      expect(noCallID.tool).toBeUndefined()
+      expect(noCallID.questions).toMatchObject([
+        { question: "Q?", header: "H", options: [{ label: "A", description: "D" }], default: "prefill" },
+      ])
+
+      yield* loaded.execute({}, { ...ctx, callID: "call_1" })
+      const withCallID = askedInputs[1] as { tool?: { messageID: string; callID: string } }
+      expect(withCallID.tool).toEqual({ messageID: "msg_q", callID: "call_1" })
     }),
   )
 })

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -17,6 +17,12 @@ export type ToolContext = {
   abort: AbortSignal
   metadata(input: { title?: string; metadata?: { [key: string]: any } }): void
   ask(input: AskInput): Promise<void>
+  /**
+   * Present an interactive question popup (the same modal the `question`
+   * tool uses) and wait for the user's answer. Resolves with the selected
+   * labels per question, in order; rejects if the user dismisses the modal.
+   */
+  question(input: QuestionInput): Promise<ReadonlyArray<QuestionAnswer>>
 }
 
 type AskInput = {
@@ -25,6 +31,30 @@ type AskInput = {
   always: string[]
   metadata: { [key: string]: any }
 }
+
+export type QuestionOption = {
+  label: string
+  description: string
+}
+
+export type QuestionInfo = {
+  question: string
+  header: string
+  options: ReadonlyArray<QuestionOption>
+  multiple?: boolean
+  custom?: boolean
+  /**
+   * Pre-fills the custom answer field with this text, so callers can present
+   * proposed content for the user to review and edit before submitting.
+   */
+  default?: string
+}
+
+export type QuestionInput = {
+  questions: ReadonlyArray<QuestionInfo>
+}
+
+export type QuestionAnswer = ReadonlyArray<string>
 
 export type ToolAttachment = {
   type: "file"

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -19,8 +19,10 @@ export type ToolContext = {
   ask(input: AskInput): Promise<void>
   /**
    * Present an interactive question popup (the same modal the `question`
-   * tool uses) and wait for the user's answer. Resolves with the selected
-   * labels per question, in order; rejects if the user dismisses the modal.
+   * tool uses) and wait for the user's answer. Resolves with one label list
+   * per question, **in the same order as `input.questions`** (callers zip them
+   * by index); for a `multiple: true` question the list holds all selected
+   * labels. Rejects if the user dismisses the modal.
    */
   question(input: QuestionInput): Promise<ReadonlyArray<QuestionAnswer>>
 }

--- a/packages/schema/src/question.ts
+++ b/packages/schema/src/question.ts
@@ -37,6 +37,9 @@ export const Info = Schema.Struct({
   custom: Schema.Boolean.pipe(optional).annotate({
     description: "Allow typing a custom answer (default: true)",
   }),
+  default: Schema.String.pipe(optional).annotate({
+    description: "Pre-fill the custom answer field with this text (for review/edit workflows)",
+  }),
 }).annotate({ identifier: "QuestionV2.Info" })
 export interface Info extends Schema.Schema.Type<typeof Info> {}
 

--- a/packages/schema/src/v1/question.ts
+++ b/packages/schema/src/v1/question.ts
@@ -27,6 +27,9 @@ const base = {
 export const Info = Schema.Struct({
   ...base,
   custom: Schema.optional(Schema.Boolean).annotate({ description: "Allow typing a custom answer (default: true)" }),
+  default: Schema.optional(Schema.String).annotate({
+    description: "Pre-fill the custom answer field with this text (for review/edit workflows)",
+  }),
 }).annotate({ identifier: "QuestionInfo" })
 export const Prompt = Schema.Struct(base).annotate({ identifier: "QuestionPrompt" })
 export const Tool = Schema.Struct({ messageID: SessionV1.MessageID, callID: Schema.String }).annotate({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -718,6 +718,10 @@ export type QuestionInfo = {
   options: Array<QuestionOption>
   multiple?: boolean
   custom?: boolean
+  /**
+   * Pre-fill the custom answer field with this text (for review/edit workflows)
+   */
+  default?: string
 }
 
 export type QuestionTool = {


### PR DESCRIPTION
### Issue for this PR

Closes #43068 (notebook memory feature) — the interactive `question()` review/edit helper powers the notebook `notes_commit` approval UX (a proposed summary, editable by the user, per note).

### Type of change

- [x] New feature

### What does this PR do?

Adds `question()` to the plugin `ToolContext`: presents the same modal as the `question` tool and resolves with the selected labels per question, in order, rejecting when the user dismisses the modal. Bridged to `Question.Service` in the registry. `QuestionInfo` gains an optional `default` that pre-fills the custom answer textarea, enabling review/edit workflows. The app question dock pre-fills from `default`; v1 + v2 schema and generated sdk types carry the field.

### How did you verify your code works?

- `bun typecheck` green.
- The `default` pre-fill is additive to the existing question dock.

### Screenshots / recordings

N/A — no visual change beyond the pre-filled textarea in an existing modal.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
