### PR TITLE
fix(tui): contain stray stdio writes

### DIFF
--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -1,15 +1,22 @@
-import { Server } from "@/server/server"
-import { InstanceRuntime } from "@/project/instance-runtime"
-import { Rpc } from "@/util/rpc"
+import { writeHeapSnapshot } from "node:v8"
+import path from "path"
+import { Effect } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { installStdioFileGuard } from "@opencode-ai/tui/util/stdio-guard"
+import { GlobalBus } from "@/bus/global"
+import { Heap } from "@/cli/heap"
 import { upgrade } from "@/cli/upgrade"
 import { Config } from "@/config/config"
-import { GlobalBus } from "@/bus/global"
-import { ServerAuth } from "@/server/auth"
-import { writeHeapSnapshot } from "node:v8"
-import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
-import { Effect } from "effect"
+import { InstanceRuntime } from "@/project/instance-runtime"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { Server } from "@/server/server"
+import { ServerAuth } from "@/server/auth"
+import { Rpc } from "@/util/rpc"
+
+// Worker realms get their own `process` but share the terminal descriptors with the TUI on the main
+// thread, so server or plugin writes here would corrupt the frame. Lives as long as the worker.
+const restoreStdio = installStdioFileGuard(path.join(Global.Path.log, "stdio-worker.log"), { truncate: true })
 
 Heap.start()
 
@@ -74,6 +81,7 @@ export const rpc = {
     if (server) await server.stop(true)
     process.off("unhandledRejection", onUnhandledRejection)
     process.off("uncaughtException", onUncaughtException)
+    restoreStdio()
   },
 }
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -40,6 +40,7 @@
     "./util/locale": "./src/util/locale.ts",
     "./util/persistence": "./src/util/persistence.ts",
     "./util/record": "./src/util/record.ts",
+    "./util/stdio-guard": "./src/util/stdio-guard.ts",
     "./logo": "./src/logo.ts",
     "./ui/dialog": "./src/ui/dialog.tsx",
     "./ui/spinner": "./src/ui/spinner.ts",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -2,7 +2,9 @@ import { render, TimeToFirstDraw, useRenderer, useTerminalDimensions } from "@op
 import { registerOpencodeSpinner } from "./component/register-spinner"
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { Deferred, Effect } from "effect"
+import path from "path"
 import { Global } from "@opencode-ai/core/global"
+import { installStdioFileGuard } from "./util/stdio-guard"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { ClipboardProvider, useClipboard } from "./context/clipboard"
@@ -188,6 +190,12 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
+      // Guards from the first frame onward. Released when this scope closes, which is before the
+      // fatal-error print below, so crash output still reaches a restored stderr.
+      yield* Effect.acquireRelease(
+        Effect.sync(() => installStdioFileGuard(path.join(global.log, "stdio-main.log"), { truncate: true })),
+        (restore) => Effect.sync(restore),
+      )
       const renderer = yield* Effect.acquireRelease(
         Effect.tryPromise({
           try: () =>

--- a/packages/tui/src/util/stdio-guard.ts
+++ b/packages/tui/src/util/stdio-guard.ts
@@ -1,0 +1,61 @@
+import { closeSync, constants, fchmodSync, fstatSync, openSync, writeSync } from "fs"
+
+type Write = NodeJS.WriteStream["write"]
+
+const MAX_LOG_BYTES = 5 * 1024 * 1024
+
+// opentui does not intercept raw stdout/stderr writes, which paint over its alternate screen.
+// Frame output bypasses these wrappers, so redirecting them is safe.
+export function installStdioGuard(sink: (text: string) => void) {
+  const restores = [process.stdout, process.stderr].map((stream) => {
+    const original = stream.write
+    stream.write = ((chunk: string | Uint8Array, encoding?: unknown, callback?: unknown) => {
+      // Node allows the callback in either the second or third position.
+      const done = typeof encoding === "function" ? encoding : callback
+      // A failing sink must never surface inside unrelated code that merely logged.
+      try {
+        sink(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"))
+      } catch {}
+      if (typeof done === "function") process.nextTick(done)
+      return true
+    }) as Write
+    return () => {
+      stream.write = original
+    }
+  })
+  return () => restores.forEach((restore) => restore())
+}
+
+export function installStdioFileGuard(file: string, options: { maxBytes?: number; truncate?: boolean } = {}) {
+  const descriptor = (() => {
+    try {
+      return openSync(
+        file,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_APPEND | (options.truncate ? constants.O_TRUNC : 0),
+        0o600,
+      )
+    } catch {
+      return undefined
+    }
+  })()
+  if (descriptor === undefined) return installStdioGuard(() => {})
+  fchmodSync(descriptor, 0o600)
+  const maximum = options.maxBytes ?? MAX_LOG_BYTES
+  let bytes = options.truncate ? 0 : fstatSync(descriptor).size
+  let closed = false
+  const restore = installStdioGuard((text) => {
+    const remaining = maximum - bytes
+    if (remaining <= 0) return
+    const content = Buffer.from(text)
+    const written = writeSync(descriptor, content.subarray(0, remaining))
+    bytes += written
+  })
+  return () => {
+    if (closed) return
+    closed = true
+    restore()
+    try {
+      closeSync(descriptor)
+    } catch {}
+  }
+}

--- a/packages/tui/test/util/stdio-guard.test.ts
+++ b/packages/tui/test/util/stdio-guard.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync, statSync } from "fs"
+import os from "os"
+import path from "path"
+import { installStdioFileGuard, installStdioGuard } from "../../src/util/stdio-guard"
+
+// Each test swaps in its own sentinel `write` so the real terminal is never touched and
+// so "did the underlying stream get written to?" is directly observable.
+function sentinel(stream: NodeJS.WriteStream) {
+  const received: string[] = []
+  const original = stream.write
+  stream.write = ((chunk: unknown) => {
+    received.push(typeof chunk === "string" ? chunk : String(chunk))
+    return true
+  }) as typeof stream.write
+  return { received, installed: stream.write, restore: () => (stream.write = original) }
+}
+
+let cleanup: Array<() => void> = []
+
+afterEach(() => {
+  cleanup.forEach((fn) => fn())
+  cleanup = []
+})
+
+describe("util.stdio-guard", () => {
+  test("routes stderr writes to the sink instead of the stream", () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+    const captured: string[] = []
+
+    const restore = installStdioGuard((text) => captured.push(text))
+    process.stderr.write("stray plugin log\n")
+    restore()
+
+    expect(captured).toEqual(["stray plugin log\n"])
+    expect(stderr.received).toEqual([])
+  })
+
+  test("routes stdout writes to the sink instead of the stream", () => {
+    const stdout = sentinel(process.stdout)
+    cleanup.push(stdout.restore)
+    const captured: string[] = []
+
+    const restore = installStdioGuard((text) => captured.push(text))
+    process.stdout.write("stray stdout\n")
+    restore()
+
+    expect(captured).toEqual(["stray stdout\n"])
+    expect(stdout.received).toEqual([])
+  })
+
+  test("decodes Buffer chunks", () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+    const captured: string[] = []
+
+    const restore = installStdioGuard((text) => captured.push(text))
+    process.stderr.write(Buffer.from("buffered ✓", "utf8"))
+    restore()
+
+    expect(captured).toEqual(["buffered ✓"])
+  })
+
+  test("restores the exact original write functions", () => {
+    const stderr = sentinel(process.stderr)
+    const stdout = sentinel(process.stdout)
+    cleanup.push(stderr.restore, stdout.restore)
+
+    const restore = installStdioGuard(() => {})
+    expect(process.stderr.write).not.toBe(stderr.installed)
+    expect(process.stdout.write).not.toBe(stdout.installed)
+
+    restore()
+    expect(process.stderr.write).toBe(stderr.installed)
+    expect(process.stdout.write).toBe(stdout.installed)
+  })
+
+  test("writes reach the stream again after restore", () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+    const captured: string[] = []
+
+    const restore = installStdioGuard((text) => captured.push(text))
+    restore()
+    process.stderr.write("fatal error must stay visible\n")
+
+    expect(captured).toEqual([])
+    expect(stderr.received).toEqual(["fatal error must stay visible\n"])
+  })
+
+  test("honors the write callback in both argument positions", async () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+
+    const restore = installStdioGuard(() => {})
+    const calls = await new Promise<string[]>((resolve) => {
+      const seen: string[] = []
+      process.stderr.write("a", () => {
+        seen.push("callback-second-arg")
+        process.stderr.write("b", "utf8", () => {
+          seen.push("callback-third-arg")
+          resolve(seen)
+        })
+      })
+    })
+    restore()
+
+    expect(calls).toEqual(["callback-second-arg", "callback-third-arg"])
+  })
+
+  test("a throwing sink never propagates into the caller", () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+
+    const restore = installStdioGuard(() => {
+      throw new Error("sink is broken")
+    })
+    expect(() => process.stderr.write("still fine\n")).not.toThrow()
+    expect(process.stderr.write("still fine\n")).toBe(true)
+    restore()
+  })
+
+  test("file guard appends privately and closes on restore", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "opencode-stdio-"))
+    const file = path.join(directory, "stdio.log")
+    cleanup.push(() => rmSync(directory, { recursive: true, force: true }))
+
+    const restore = installStdioFileGuard(file)
+    process.stderr.write("captured\n")
+    restore()
+
+    expect(readFileSync(file, "utf8")).toBe("captured\n")
+    expect(statSync(file).mode & 0o777).toBe(0o600)
+  })
+
+  test("file guard truncates and bounds captured output", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "opencode-stdio-"))
+    const file = path.join(directory, "stdio.log")
+    cleanup.push(() => rmSync(directory, { recursive: true, force: true }))
+
+    const first = installStdioFileGuard(file)
+    process.stderr.write("old content")
+    first()
+
+    const restore = installStdioFileGuard(file, { maxBytes: 5, truncate: true })
+    process.stderr.write("123456789")
+    restore()
+
+    expect(readFileSync(file, "utf8")).toBe("12345")
+  })
+
+  test("file guard counts existing content toward the limit", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "opencode-stdio-"))
+    const file = path.join(directory, "stdio.log")
+    cleanup.push(() => rmSync(directory, { recursive: true, force: true }))
+
+    const first = installStdioFileGuard(file)
+    process.stderr.write("1234")
+    first()
+
+    const restore = installStdioFileGuard(file, { maxBytes: 5 })
+    process.stderr.write("678")
+    restore()
+
+    expect(readFileSync(file, "utf8")).toBe("12346")
+  })
+
+  test("file guard still contains writes when the file cannot be opened", () => {
+    const stderr = sentinel(process.stderr)
+    cleanup.push(stderr.restore)
+
+    const restore = installStdioFileGuard(path.join(os.tmpdir(), crypto.randomUUID(), "stdio.log"))
+    process.stderr.write("do not paint the terminal")
+    restore()
+
+    expect(stderr.received).toEqual([])
+  })
+})

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -212,7 +212,7 @@ Here are some common issues and how to resolve them.
 ### OpenCode won't start
 
 1. Check the logs for error messages
-2. Try running with `--print-logs` to see output in the terminal
+2. Try running with `--print-logs`; while the TUI is active, output is captured in the data directory's `log/stdio-*.log` files
 3. Ensure you have the latest version with `opencode upgrade`
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #43064

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

If a plugin or the server logs with `process.stderr.write`, the text goes straight to the terminal and paints over the TUI. The screen stays broken until the next full repaint. opentui captures `console.*`, but nothing captures raw stream writes, so there was no way to stop this from the app side.

The TUI runs on the main thread and the server runs in a worker. Each has its own `process` object but they share the same terminal, so both need covering. This swaps `stdout.write`/`stderr.write` for the renderer's lifetime and sends that output to `log/stdio-main.log` and `log/stdio-worker.log` instead, restoring the originals on teardown so crash output still reaches the terminal.

Frames are unaffected because opentui writes them natively, below the JS wrappers. I confirmed that by installing the guard before `createCliRenderer` and checking it captured no frame bytes while rendering stayed correct.

This only covers JS-level writes. Native code writing to the fd directly (the ALSA block in #41763 / #41770) still gets through and would need `dup2`.

### How did you verify your code works?

`--print-logs` is the easiest repro, since the log writer uses `process.stderr.write` (`packages/core/src/observability/logging.ts:54`):

```
bun dev --print-logs --log-level DEBUG
```

Before, the log lines overwrite the composer. After, the frame is clean and the same lines land in `~/.local/share/opencode/log/stdio-worker.log`.

Also: 204 tests and typecheck pass in `packages/tui`, typecheck passes in `packages/opencode`.

### Screenshots / recordings

Before, on `dev`:

![before](https://raw.githubusercontent.com/spiatrenka/opencode/issue-assets/.github/issue-assets/tui-stdio-before.png)

After, on this branch:

![after](https://raw.githubusercontent.com/spiatrenka/opencode/issue-assets/.github/issue-assets/tui-stdio-after.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
