### PR TITLE
fix(ai): preserve Gemini prompt safety blocks

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -517,31 +517,30 @@ const mapFinishReason = (finishReason: string | undefined, hasToolCalls: boolean
 
 const finish = (state: ParserState): ReadonlyArray<LLMEvent> => {
   const promptBlockReason = state.finishReason === undefined ? state.promptFeedback?.blockReason : undefined
-  return state.finishReason || state.usage || promptBlockReason
-    ? (() => {
-        const events: LLMEvent[] = []
-        const lifecycle = state.reasoningSignature
-          ? Lifecycle.reasoningEnd(
-              state.lifecycle,
-              events,
-              "reasoning-0",
-              googleMetadata({ thoughtSignature: state.reasoningSignature }),
-            )
-          : state.lifecycle
-        Lifecycle.finish(lifecycle, events, {
-          reason: {
-            normalized: promptBlockReason === undefined ? mapFinishReason(state.finishReason, state.hasToolCalls) : "content-filter",
-            raw: state.finishReason ?? promptBlockReason,
-          },
-          usage: state.usage,
-          providerMetadata:
-            state.promptFeedback === undefined
-              ? undefined
-              : googleMetadata({ promptFeedback: state.promptFeedback }),
-        })
-        return events
-      })()
-    : []
+  const finishReason = state.finishReason ?? promptBlockReason
+  if (finishReason === undefined && state.usage === undefined) return []
+
+  const events: LLMEvent[] = []
+  const lifecycle = state.reasoningSignature
+    ? Lifecycle.reasoningEnd(
+        state.lifecycle,
+        events,
+        "reasoning-0",
+        googleMetadata({ thoughtSignature: state.reasoningSignature }),
+      )
+    : state.lifecycle
+  Lifecycle.finish(lifecycle, events, {
+    reason: {
+      normalized: promptBlockReason === undefined
+        ? mapFinishReason(finishReason, state.hasToolCalls)
+        : "content-filter",
+      raw: finishReason,
+    },
+    usage: state.usage,
+    providerMetadata:
+      state.promptFeedback === undefined ? undefined : googleMetadata({ promptFeedback: state.promptFeedback }),
+  })
+  return events
 }
 
 const step = (state: ParserState, event: GeminiEvent) => {

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -190,8 +190,19 @@ const GeminiCandidate = Schema.Struct({
   finishReason: Schema.optional(Schema.String),
 })
 
+const GeminiPromptFeedback = Schema.StructWithRest(
+  Schema.Struct({
+    blockReason: Schema.optional(Schema.String),
+    blockReasonMessage: Schema.optional(Schema.String),
+    safetyRatings: Schema.optional(Schema.Unknown),
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+)
+type GeminiPromptFeedback = Schema.Schema.Type<typeof GeminiPromptFeedback>
+
 const GeminiEvent = Schema.Struct({
   candidates: optionalArray(GeminiCandidate),
+  promptFeedback: Schema.optional(GeminiPromptFeedback),
   usageMetadata: Schema.optional(GeminiUsage),
 })
 type GeminiEvent = Schema.Schema.Type<typeof GeminiEvent>
@@ -200,6 +211,7 @@ interface ParserState {
   readonly finishReason?: string
   readonly hasToolCalls: boolean
   readonly nextToolCallId: number
+  readonly promptFeedback?: GeminiPromptFeedback
   readonly usage?: Usage
   readonly lifecycle: Lifecycle.State
   readonly reasoningSignature?: string
@@ -503,8 +515,9 @@ const mapFinishReason = (finishReason: string | undefined, hasToolCalls: boolean
   return "unknown"
 }
 
-const finish = (state: ParserState): ReadonlyArray<LLMEvent> =>
-  state.finishReason || state.usage
+const finish = (state: ParserState): ReadonlyArray<LLMEvent> => {
+  const promptBlockReason = state.finishReason === undefined ? state.promptFeedback?.blockReason : undefined
+  return state.finishReason || state.usage || promptBlockReason
     ? (() => {
         const events: LLMEvent[] = []
         const lifecycle = state.reasoningSignature
@@ -517,18 +530,24 @@ const finish = (state: ParserState): ReadonlyArray<LLMEvent> =>
           : state.lifecycle
         Lifecycle.finish(lifecycle, events, {
           reason: {
-            normalized: mapFinishReason(state.finishReason, state.hasToolCalls),
-            raw: state.finishReason,
+            normalized: promptBlockReason === undefined ? mapFinishReason(state.finishReason, state.hasToolCalls) : "content-filter",
+            raw: state.finishReason ?? promptBlockReason,
           },
           usage: state.usage,
+          providerMetadata:
+            state.promptFeedback === undefined
+              ? undefined
+              : googleMetadata({ promptFeedback: state.promptFeedback }),
         })
         return events
       })()
     : []
+}
 
 const step = (state: ParserState, event: GeminiEvent) => {
   const nextState = {
     ...state,
+    promptFeedback: event.promptFeedback ?? state.promptFeedback,
     usage: event.usageMetadata ? (mapUsage(event.usageMetadata) ?? state.usage) : state.usage,
   }
   const candidate = event.candidates?.[0]

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -862,6 +862,51 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("preserves candidate-less prompt safety blocks as content-filter outcomes", () =>
+    Effect.gen(function* () {
+      const blocked = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              promptFeedback: {
+                blockReason: "FUTURE_SAFETY_REASON",
+                blockReasonMessage: "Prompt blocked",
+                safetyRatings: [{ category: "HARM_CATEGORY_HARASSMENT", blocked: true }],
+              },
+            }),
+          ),
+        ),
+      )
+      const blockedWithUsage = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { promptFeedback: { blockReason: "SAFETY" } },
+              { usageMetadata: { promptTokenCount: 7, totalTokenCount: 7 } },
+            ),
+          ),
+        ),
+      )
+
+      expect(blocked.events.map((event) => event.type)).toEqual(["step-start", "step-finish", "finish"])
+      expect(blocked.events.at(-1)).toMatchObject({
+        type: "finish",
+        reason: { normalized: "content-filter", raw: "FUTURE_SAFETY_REASON" },
+        providerMetadata: {
+          google: {
+            promptFeedback: {
+              blockReason: "FUTURE_SAFETY_REASON",
+              blockReasonMessage: "Prompt blocked",
+              safetyRatings: [{ category: "HARM_CATEGORY_HARASSMENT", blocked: true }],
+            },
+          },
+        },
+      })
+      expect(blockedWithUsage.finishReason).toEqual({ normalized: "content-filter", raw: "SAFETY" })
+      expect(blockedWithUsage.usage).toMatchObject({ inputTokens: 7, totalTokens: 7 })
+    }),
+  )
+
   it.effect("maps current blocking and invalid-output finish reasons", () =>
     Effect.gen(function* () {
       const reasons = [


### PR DESCRIPTION
## Summary

- decode Gemini prompt feedback from streamed responses
- map candidate-less prompt blocks to `content-filter` terminal outcomes
- preserve prompt feedback diagnostics and usage in provider metadata

## Testing

- `bun test test/provider/gemini.test.ts`
- `bun typecheck`
- `bun run build`
- pre-push monorepo typecheck

Related to #41932