### PR TITLE
feat(ai): configure local reasoning controls

### DIFF
--- a/packages/ai/src/providers/openai-compatible.ts
+++ b/packages/ai/src/providers/openai-compatible.ts
@@ -1,4 +1,4 @@
-import { ProviderID, type ModelID } from "../schema/index.js"
+import { ProviderID, type ModelID, type ReasoningEffort } from "../schema/index.js"
 import * as OpenAICompatibleChat from "../protocols/openai-compatible-chat.js"
 import type { RouteDefaultsInput } from "../route/client.js"
 import { AuthOptions, type ProviderAuthOption } from "../route/auth-options.js"
@@ -19,6 +19,7 @@ export interface Settings extends ProviderPackage.Settings {
   readonly apiKey?: string
   readonly baseURL: string
   readonly provider?: string
+  readonly reasoningEffort?: ReasoningEffort
 }
 
 export type FamilyModelOptions = Omit<RouteDefaultsInput, "providerOptions"> &
@@ -75,6 +76,8 @@ export const model: ProviderPackage.Definition<Settings, OpenAIProviderOptionsIn
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
     limits: settings.limits,
     provider: settings.provider,
+    providerOptions:
+      settings.reasoningEffort === undefined ? undefined : { openai: { reasoningEffort: settings.reasoningEffort } },
   }).model(modelID)
 
 export const baseten = define(profiles.baseten)

--- a/packages/ai/test/provider-package.test.ts
+++ b/packages/ai/test/provider-package.test.ts
@@ -106,6 +106,18 @@ describe("provider package entrypoints", () => {
     })
   })
 
+  test("maps OpenAI-compatible Chat reasoning effort onto the executable model", async () => {
+    const OpenAICompatible = await import("@opencode-ai/ai/providers/openai-compatible")
+    const selected = OpenAICompatible.model("custom-model", {
+      baseURL: "https://chat.example.test/v1",
+      provider: "example",
+      reasoningEffort: "high",
+    })
+
+    expect(String(selected.provider)).toBe("example")
+    expect(selected.route.defaults.providerOptions).toEqual({ openai: { reasoningEffort: "high" } })
+  })
+
   test("maps Anthropic-compatible settings onto the executable model", async () => {
     const AnthropicCompatible = await import("@opencode-ai/ai/providers/anthropic-compatible")
     const selected = AnthropicCompatible.model("compatible-model", {

--- a/packages/core/src/plugin/provider/lmstudio.ts
+++ b/packages/core/src/plugin/provider/lmstudio.ts
@@ -6,6 +6,7 @@ import { Config } from "../../config.js"
 import { Model } from "../../model.js"
 import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { LocalReasoning } from "./local-reasoning.js"
 
 const providerID = "lmstudio"
 
@@ -23,6 +24,10 @@ const RemoteModel = Schema.Struct({
   capabilities: Schema.Struct({
     vision: Schema.Boolean,
     trained_for_tool_use: Schema.Boolean,
+    reasoning: Schema.Struct({
+      allowed_options: Schema.Array(Schema.Literals(["off", "on", "low", "medium", "high"])),
+      default: Schema.Literals(["off", "on", "low", "medium", "high"]),
+    }).pipe(Schema.optional),
   }).pipe(Schema.optional),
 })
 
@@ -70,6 +75,7 @@ export function make(origin = "http://127.0.0.1:1234", interval: Duration.Input 
               input: ["text", ...(item.capabilities?.vision ? ["image"] : [])],
               output: ["text"],
             }
+            model.variants = LocalReasoning.fromOptions(item.capabilities?.reasoning?.allowed_options ?? [])
             model.limit = {
               context:
                 item.loaded_instances.length === 0

--- a/packages/core/src/plugin/provider/local-reasoning.ts
+++ b/packages/core/src/plugin/provider/local-reasoning.ts
@@ -1,0 +1,47 @@
+export * as LocalReasoning from "./local-reasoning.js"
+
+import { Model } from "../../model.js"
+
+type Option = "off" | "on" | "low" | "medium" | "high"
+
+export function fromOptions(options: readonly Option[]) {
+  return variants(
+    options.map((option) => {
+      if (option === "off") return ["none", "none"] as const
+      if (option === "on") return ["thinking", "medium"] as const
+      return [option, option] as const
+    }),
+  )
+}
+
+export function infer(engine: "ollama" | "vllm", model: string) {
+  const id = model.toLowerCase().replaceAll("_", "-")
+  if (id.includes("gpt-oss") || id.includes("gptoss"))
+    return variants([
+      ["low", "low"],
+      ["medium", "medium"],
+      ["high", "high"],
+    ])
+  if (id.includes("deepseek-v4") || id.includes("deepseekv4"))
+    return variants([
+      ["none", "none"],
+      ["high", "high"],
+      ["max", "max"],
+    ])
+  if (id.includes("qwen3") || id.includes("gemma-4") || id.includes("gemma4")) return toggle()
+  return engine === "ollama" ? toggle() : []
+}
+
+function toggle() {
+  return variants([
+    ["none", "none"],
+    ["thinking", "medium"],
+  ])
+}
+
+function variants(items: ReadonlyArray<readonly [id: string, effort: string]>) {
+  return items.map(([id, effort]) => ({
+    id: Model.VariantID.make(id),
+    settings: { reasoningEffort: effort },
+  }))
+}

--- a/packages/core/src/plugin/provider/ollama.ts
+++ b/packages/core/src/plugin/provider/ollama.ts
@@ -6,6 +6,7 @@ import { Config } from "../../config.js"
 import { Model } from "../../model.js"
 import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { LocalReasoning } from "./local-reasoning.js"
 
 const providerID = "ollama"
 
@@ -96,6 +97,9 @@ export function make(origin = "http://127.0.0.1:11434", interval: Duration.Input
               input: ["text", ...(item.show.capabilities?.includes("vision") ? ["image"] : [])],
               output: ["text"],
             }
+            model.variants = item.show.capabilities?.includes("thinking")
+              ? LocalReasoning.infer("ollama", `${item.model} ${model.family ?? ""}`)
+              : []
             model.limit = {
               context:
                 Object.entries(item.show.model_info ?? {}).flatMap(([key, value]) =>

--- a/packages/core/src/plugin/provider/vllm.ts
+++ b/packages/core/src/plugin/provider/vllm.ts
@@ -6,6 +6,7 @@ import { Config } from "../../config.js"
 import { Model } from "../../model.js"
 import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { LocalReasoning } from "./local-reasoning.js"
 
 const providerID = "vllm"
 
@@ -55,6 +56,7 @@ export function make(origin = "http://127.0.0.1:8000", interval: Duration.Input 
             model.name = item.id
             // Tool calling depends on vLLM server flags and parsers that model discovery does not report.
             model.capabilities = { tools: false, input: ["text"], output: ["text"] }
+            model.variants = LocalReasoning.infer("vllm", item.id)
             model.limit = { context: item.max_model_len ?? 0, output: 0 }
           })
         }

--- a/packages/core/test/plugin/provider-lmstudio.test.ts
+++ b/packages/core/test/plugin/provider-lmstudio.test.ts
@@ -60,7 +60,11 @@ describe("LMStudioPlugin", () => {
                   architecture: "gemma4",
                   loaded_instances: [{ config: { context_length: 32_768 } }, { config: { context_length: 16_384 } }],
                   max_context_length: 262_144,
-                  capabilities: { vision: true, trained_for_tool_use: true },
+                  capabilities: {
+                    vision: true,
+                    trained_for_tool_use: true,
+                    reasoning: { allowed_options: ["off", "on"], default: "on" },
+                  },
                 },
                 {
                   type: "llm",
@@ -105,6 +109,10 @@ describe("LMStudioPlugin", () => {
             name: "Gemma 4 26B A4B",
             capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
             limit: { context: 16_384, output: 0 },
+            variants: [
+              { id: "none", settings: { reasoningEffort: "none" } },
+              { id: "thinking", settings: { reasoningEffort: "medium" } },
+            ],
           })
           expect(yield* catalog.model.get(providerID, Model.ID.make("deepseek-r1"))).toMatchObject({
             capabilities: { tools: false, input: ["text"], output: ["text"] },

--- a/packages/core/test/plugin/provider-ollama.test.ts
+++ b/packages/core/test/plugin/provider-ollama.test.ts
@@ -54,6 +54,7 @@ describe("OllamaPlugin", () => {
                 return Response.json({
                   models: [
                     summary("gemma3:4b", "gemma-digest", "gemma3"),
+                    summary("gpt-oss:20b", "gpt-oss-digest", "gptoss"),
                     summary("nomic-embed", "embed-digest"),
                     summary("removed-model", "removed-digest"),
                   ],
@@ -65,10 +66,12 @@ describe("OllamaPlugin", () => {
               return Response.json(
                 body.model === "gemma3:4b"
                   ? {
-                      capabilities: ["completion", "tools", "vision"],
+                      capabilities: ["completion", "tools", "vision", "thinking"],
                       model_info: { "gemma3.context_length": 131_072 },
                     }
-                  : show({ family: "nomic-bert", capabilities: ["embedding"], context: 8192 }),
+                  : body.model === "gpt-oss:20b"
+                    ? show({ family: "gptoss", capabilities: ["completion", "thinking"], context: 131_072 })
+                    : show({ family: "nomic-bert", capabilities: ["embedding"], context: 8192 }),
               )
             },
           }),
@@ -99,6 +102,17 @@ describe("OllamaPlugin", () => {
             family: "gemma3",
             capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
             limit: { context: 131_072, output: 0 },
+            variants: [
+              { id: "none", settings: { reasoningEffort: "none" } },
+              { id: "thinking", settings: { reasoningEffort: "medium" } },
+            ],
+          })
+          expect(yield* catalog.model.get(providerID, Model.ID.make("gpt-oss:20b"))).toMatchObject({
+            variants: [
+              { id: "low", settings: { reasoningEffort: "low" } },
+              { id: "medium", settings: { reasoningEffort: "medium" } },
+              { id: "high", settings: { reasoningEffort: "high" } },
+            ],
           })
           expect(yield* catalog.model.get(providerID, Model.ID.make("nomic-embed"))).toBeUndefined()
           expect(requests).toContainEqual({ method: "GET", path: "/api/tags" })

--- a/packages/core/test/plugin/provider-vllm.test.ts
+++ b/packages/core/test/plugin/provider-vllm.test.ts
@@ -63,7 +63,10 @@ describe("VLLMPlugin", () => {
               state.models++
               return Response.json({
                 object: "list",
-                data: [remoteModel("Qwen/Qwen3-Coder", 65_536), remoteModel("foreign-model", 4096, "other")],
+                data: [
+                  remoteModel("deepseek-ai/DeepSeek-V4-Flash", 65_536),
+                  remoteModel("foreign-model", 4096, "other"),
+                ],
               })
             },
           }),
@@ -82,7 +85,7 @@ describe("VLLMPlugin", () => {
 
           state.healthy = true
           const model = yield* eventually(
-            catalog.model.get(providerID, Model.ID.make("Qwen/Qwen3-Coder")),
+            catalog.model.get(providerID, Model.ID.make("deepseek-ai/DeepSeek-V4-Flash")),
             (item) => item !== undefined,
           )
           expect(yield* catalog.provider.get(providerID)).toEqual({
@@ -94,10 +97,15 @@ describe("VLLMPlugin", () => {
           })
           expect((yield* catalog.provider.available()).map((provider) => provider.id)).toContain(providerID)
           expect(model).toMatchObject({
-            modelID: "Qwen/Qwen3-Coder",
-            name: "Qwen/Qwen3-Coder",
+            modelID: "deepseek-ai/DeepSeek-V4-Flash",
+            name: "deepseek-ai/DeepSeek-V4-Flash",
             capabilities: { tools: false, input: ["text"], output: ["text"] },
             limit: { context: 65_536, output: 0 },
+            variants: [
+              { id: "none", settings: { reasoningEffort: "none" } },
+              { id: "high", settings: { reasoningEffort: "high" } },
+              { id: "max", settings: { reasoningEffort: "max" } },
+            ],
           })
           expect(yield* catalog.model.get(providerID, Model.ID.make("foreign-model"))).toBeUndefined()
         }),

--- a/packages/www/content/docs/(Configure)/models.mdx
+++ b/packages/www/content/docs/(Configure)/models.mdx
@@ -165,8 +165,7 @@ OpenCode automatically discovers language models from an Ollama server listening
 ```
 
 OpenCode refreshes the inventory in the background and reads context, vision, and tool-use capabilities from Ollama.
-Thinking-capable models also expose reasoning variants. GPT-OSS exposes `low`, `medium`, and `high`; DeepSeek V4
-exposes `none`, `high`, and `max`; other thinking models expose `none` and `thinking`.
+Thinking-capable models also expose reasoning variants.
 Embedding-only models are excluded because they cannot drive a session. Disable discovery with
 `"plugins": ["-opencode.provider.ollama"]`.
 
@@ -201,9 +200,9 @@ address, `http://127.0.0.1:1234`. Discovered models use the `lmstudio` provider 
 }
 ```
 
-OpenCode refreshes the inventory in the background and reads context, vision, tool-use capabilities, and available
-reasoning controls from LM Studio. Reasoning controls become model variants; toggle-style `off` and `on` options appear
-as `none` and `thinking`. Embedding models are excluded because they cannot drive a session. Disable discovery with
+OpenCode refreshes the inventory in the background and reads context, vision, tool-use, and reasoning capabilities from
+LM Studio. Available reasoning controls become model variants. Embedding models are excluded because they cannot drive
+a session. Disable discovery with
 `"plugins": ["-opencode.provider.lmstudio"]`.
 
 For a different host or port, configure the OpenAI-compatible base URL. Models are still discovered automatically:
@@ -242,8 +241,7 @@ text input and output, but not vision or tools. Tool calling is conservative bec
 flags such as `--enable-auto-tool-choice` and `--tool-call-parser`, which model discovery does not report. Disable
 discovery with `"plugins": ["-opencode.provider.vllm"]`.
 
-Recognized DeepSeek V4, GPT-OSS, Qwen3, and Gemma 4 model IDs expose their supported reasoning variants. Models served
-under custom aliases can define variants explicitly in provider configuration.
+Recognized reasoning models expose reasoning variants.
 
 For a different endpoint or an authenticated server, configure its OpenAI-compatible base URL:
 

--- a/packages/www/content/docs/(Configure)/models.mdx
+++ b/packages/www/content/docs/(Configure)/models.mdx
@@ -165,6 +165,8 @@ OpenCode automatically discovers language models from an Ollama server listening
 ```
 
 OpenCode refreshes the inventory in the background and reads context, vision, and tool-use capabilities from Ollama.
+Thinking-capable models also expose reasoning variants. GPT-OSS exposes `low`, `medium`, and `high`; DeepSeek V4
+exposes `none`, `high`, and `max`; other thinking models expose `none` and `thinking`.
 Embedding-only models are excluded because they cannot drive a session. Disable discovery with
 `"plugins": ["-opencode.provider.ollama"]`.
 
@@ -199,8 +201,9 @@ address, `http://127.0.0.1:1234`. Discovered models use the `lmstudio` provider 
 }
 ```
 
-OpenCode refreshes the inventory in the background and reads context, vision, and tool-use capabilities from LM
-Studio. Embedding models are excluded because they cannot drive a session. Disable discovery with
+OpenCode refreshes the inventory in the background and reads context, vision, tool-use capabilities, and available
+reasoning controls from LM Studio. Reasoning controls become model variants; toggle-style `off` and `on` options appear
+as `none` and `thinking`. Embedding models are excluded because they cannot drive a session. Disable discovery with
 `"plugins": ["-opencode.provider.lmstudio"]`.
 
 For a different host or port, configure the OpenAI-compatible base URL. Models are still discovered automatically:
@@ -238,6 +241,9 @@ OpenCode checks vLLM's `/health` endpoint and refreshes `/v1/models` in the back
 text input and output, but not vision or tools. Tool calling is conservative because vLLM enables it with server-level
 flags such as `--enable-auto-tool-choice` and `--tool-call-parser`, which model discovery does not report. Disable
 discovery with `"plugins": ["-opencode.provider.vllm"]`.
+
+Recognized DeepSeek V4, GPT-OSS, Qwen3, and Gemma 4 model IDs expose their supported reasoning variants. Models served
+under custom aliases can define variants explicitly in provider configuration.
 
 For a different endpoint or an authenticated server, configure its OpenAI-compatible base URL:
 


### PR DESCRIPTION
## summary
- lower native OpenAI-compatible `reasoningEffort` settings into Chat Completions requests
- expose sparse reasoning variants from LM Studio metadata and Ollama/vLLM model profiles
- document local reasoning controls while preserving conservative vLLM tool capabilities

## testing
- `cd packages/ai && bun test test/provider-package.test.ts`
- `cd packages/core && bun test test/plugin/provider-lmstudio.test.ts test/plugin/provider-ollama.test.ts test/plugin/provider-vllm.test.ts`
- `cd packages/ai && bun typecheck`
- `cd packages/core && bun typecheck`
- Prettier and `git diff --check`