### PR TITLE
fix(core): make Google Vertex models work with ADC credentials

### DIFF
--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -55,8 +55,13 @@ export const ModelsDevPlugin = define({
 })
 
 function environmentNames(provider: ModelsDev.Snapshot) {
-  if (provider.info.id !== Provider.ID.azure) return [...provider.environment]
-  return [...provider.environment.filter((name) => name.endsWith("_API_KEY")), "AZURE_COGNITIVE_SERVICES_API_KEY"]
+  if (provider.info.id === Provider.ID.azure)
+    return [...provider.environment.filter((name) => name.endsWith("_API_KEY")), "AZURE_COGNITIVE_SERVICES_API_KEY"]
+  // models.dev advertises project, location, and the ADC credentials file path for
+  // Vertex. Those configure Google auth rather than carrying a key, so only the
+  // Express Mode key may become a credential; GoogleVertexPlugin handles activation.
+  if (provider.info.id === Provider.ID.googleVertex) return ["GOOGLE_VERTEX_API_KEY"]
+  return [...provider.environment]
 }
 
 function snapshots(data: readonly ModelsDev.Snapshot[]) {

--- a/packages/core/src/plugin/provider/google-vertex.ts
+++ b/packages/core/src/plugin/provider/google-vertex.ts
@@ -71,6 +71,9 @@ export const GoogleVertexPlugin = define({
         const project = resolveProject(item.provider.settings ?? {})
         const location = String(resolveLocation(item.provider.settings ?? {}))
         evt.provider.update(item.provider.id, (provider) => {
+          // Vertex authenticates through ADC rather than a key credential, so a
+          // resolvable project is what makes the provider usable.
+          if (project && provider.activation === "auto") provider.activation = "enabled"
           provider.settings = {
             ...provider.settings,
             ...(project ? { project } : {}),

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -48,6 +48,17 @@ const builtins = new Map<string, () => Promise<unknown>>([
   ["@opencode-ai/ai/providers/azure/chat", () => import("@opencode-ai/ai/providers/azure/chat")],
   ["@opencode-ai/ai/providers/azure/responses", () => import("@opencode-ai/ai/providers/azure/responses")],
   ["@opencode-ai/ai/providers/google", () => import("@opencode-ai/ai/providers/google")],
+  ["@opencode-ai/ai/providers/google-vertex", () => import("@opencode-ai/ai/providers/google-vertex")],
+  ["@opencode-ai/ai/providers/google-vertex/gemini", () => import("@opencode-ai/ai/providers/google-vertex/gemini")],
+  ["@opencode-ai/ai/providers/google-vertex/chat", () => import("@opencode-ai/ai/providers/google-vertex/chat")],
+  [
+    "@opencode-ai/ai/providers/google-vertex/responses",
+    () => import("@opencode-ai/ai/providers/google-vertex/responses"),
+  ],
+  [
+    "@opencode-ai/ai/providers/google-vertex/messages",
+    () => import("@opencode-ai/ai/providers/google-vertex/messages"),
+  ],
   ["@opencode-ai/ai/providers/openai", () => import("@opencode-ai/ai/providers/openai")],
   ["@opencode-ai/ai/providers/openai/chat", () => import("@opencode-ai/ai/providers/openai/chat")],
   ["@opencode-ai/ai/providers/openai/responses", () => import("@opencode-ai/ai/providers/openai/responses")],

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -426,6 +426,46 @@ describe("ModelsDevPlugin", () => {
     }),
   )
 
+  it.effect("advertises only key-bearing Google Vertex environment variables", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const catalog = yield* Catalog.Service
+
+      yield* ModelsDevPlugin.effect(
+        host({
+          catalog: catalogHost(catalog),
+          integration: integrationHost(integrations),
+        }),
+      ).pipe(
+        Effect.provideService(
+          ModelsDev.Service,
+          ModelsDev.Service.of({
+            get: () =>
+              Effect.succeed([
+                {
+                  info: {
+                    id: Provider.ID.make("google-vertex"),
+                    name: "Google Vertex",
+                    activation: "auto",
+                    package: Provider.aisdk("@ai-sdk/google-vertex"),
+                  },
+                  environment: ["GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_APPLICATION_CREDENTIALS"],
+                  models: [],
+                },
+              ] satisfies readonly ModelsDev.Snapshot[]),
+            refresh: () => Effect.void,
+          }),
+        ),
+      )
+
+      // Vertex authenticates through ADC; project, location, and the credentials
+      // file path are configuration, not API keys.
+      expect(yield* integrations.get(Integration.ID.make("google-vertex"))).toMatchObject({
+        methods: [{ type: "key" }, { type: "env", names: ["GOOGLE_VERTEX_API_KEY"] }],
+      })
+    }),
+  )
+
   it.effect("converts reasoning options into settings variants", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/plugin/provider-google-vertex.test.ts
+++ b/packages/core/test/plugin/provider-google-vertex.test.ts
@@ -141,6 +141,52 @@ describe("GoogleVertexPlugin", () => {
     ),
   )
 
+  it.effect("enables the provider when a project resolves and leaves it automatic otherwise", () =>
+    withEnv(
+      {
+        GOOGLE_VERTEX_PROJECT: undefined,
+        GOOGLE_CLOUD_PROJECT: undefined,
+        GCP_PROJECT: undefined,
+        GCLOUD_PROJECT: undefined,
+      },
+      () =>
+        Effect.gen(function* () {
+          const catalog = yield* Catalog.Service
+          yield* catalog.transform((catalog) =>
+            catalog.provider.update(Provider.ID.make("google-vertex"), (provider) => {
+              provider.package = Provider.aisdk("@ai-sdk/google-vertex")
+            }),
+          )
+          yield* addPlugin()
+
+          expect(required(yield* catalog.provider.get(Provider.ID.make("google-vertex"))).activation).toBe("auto")
+        }),
+    ),
+  )
+
+  it.effect("enables the provider when a project resolves from env", () =>
+    withEnv(
+      {
+        GOOGLE_VERTEX_PROJECT: undefined,
+        GOOGLE_CLOUD_PROJECT: "adc-project",
+        GCP_PROJECT: undefined,
+        GCLOUD_PROJECT: undefined,
+      },
+      () =>
+        Effect.gen(function* () {
+          const catalog = yield* Catalog.Service
+          yield* catalog.transform((catalog) =>
+            catalog.provider.update(Provider.ID.make("google-vertex"), (provider) => {
+              provider.package = Provider.aisdk("@ai-sdk/google-vertex")
+            }),
+          )
+          yield* addPlugin()
+
+          expect(required(yield* catalog.provider.get(Provider.ID.make("google-vertex"))).activation).toBe("enabled")
+        }),
+    ),
+  )
+
   it.effect("resolves the advertised GOOGLE_VERTEX_PROJECT env for provider updates and SDKs", () =>
     withEnv(
       {

--- a/packages/core/test/provider.test.ts
+++ b/packages/core/test/provider.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Provider } from "@opencode-ai/core/provider"
+
+describe("Provider", () => {
+  test("loads Vertex native provider entrypoints", async () => {
+    const packages = [
+      "@opencode-ai/ai/providers/google-vertex",
+      "@opencode-ai/ai/providers/google-vertex/gemini",
+      "@opencode-ai/ai/providers/google-vertex/chat",
+      "@opencode-ai/ai/providers/google-vertex/responses",
+      "@opencode-ai/ai/providers/google-vertex/messages",
+    ]
+
+    for (const specifier of packages) {
+      const loaded = await Effect.runPromise(Provider.loadPackage(specifier))
+      expect(loaded.model).toBeFunction()
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

See #43075 for the reported issue.

Closes #43075

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

No `google-vertex` model worked on V2 with ADC credentials. Two unrelated bugs, one commit each.

**Adapters missing from compiled builds.** `Provider.loadPackage` passes `@opencode-ai/ai/*` specifiers straight to `import()`, which the bundler can't follow, so the Vertex adapters never made it into the binary. Other native providers avoid this by sitting in the `builtins` map with literal imports; Vertex was missing. Building with and without the entries confirms it: compiled fails, source works.

**Env vars sent as the API key.** models.dev lists `GOOGLE_VERTEX_PROJECT`, `GOOGLE_VERTEX_LOCATION` and `GOOGLE_APPLICATION_CREDENTIALS` for Vertex, and the first one set becomes a key credential that the resolver passes as `apiKey`. So my credentials file path went out as an API key. Gemini rejected it; the Anthropic adapter throws during construction since it has no API key mode, which surfaced as the misleading `UnsupportedPackageError`. Azure already filters its env list to `_API_KEY` names, so Vertex now does too. ADC then works, since the adapters already fall back to `google-auth-library` when no key is present.

Those env vars also marked the provider available, so `GoogleVertexPlugin` now activates Vertex when a project resolves. It only upgrades `auto`, so explicit enabled or disabled config still wins.

### How did you verify your code works?

Compiled a binary and ran live Vertex prompts with a service account. `claude-sonnet-5@default`, `claude-opus-4-6@default` and `gemini-2.5-pro` all completed real tool calls. Vertex still lists 30 models, so the provider didn't vanish.

New tests cover the built-ins loading, env filtering, and activation. `packages/core` is 1839 pass; the 11 failures are pre-existing on `v2` (git/hg/ripgrep sandbox), confirmed by stashing and re-running. Typecheck and lint clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes
