### PR TITLE
fix(tui): show full tab numbers

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -23,7 +23,7 @@ import {
   NEW_SESSION_TAB_TITLE,
   sessionTabComplete,
   sessionTabDetail,
-  sessionTabShortcutLabel,
+  sessionTabNumberLabel,
   seedSessionTabMotion,
   sessionTabOverflowWidth,
   type SessionTab,
@@ -426,7 +426,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                 const value = session()
                 return value ? data.project.get(value.projectID) : undefined
               })
-              const numberWidth = () => 2
+              const numberWidth = () => Math.max(2, String(items().length).length)
               const restingTitleWidth = () => Math.max(1, width() - numberWidth() - 2)
               const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 1)
               const titleWidth = () => (hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth())
@@ -657,14 +657,14 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       backgroundColor={pulseBackground()}
                       onLevel={setSweepLevel}
                     />
-                    <box zIndex={1} width="100%" flexDirection="row" paddingLeft={1} paddingRight={1}>
+                    <box zIndex={1} width="100%" flexDirection="row" paddingRight={1}>
                       <text
-                        width={numberWidth()}
+                        width={numberWidth() + 1}
                         fg={numberColor()}
                         selectable={false}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
                       >
-                        {sessionTabShortcutLabel(index())}
+                        {sessionTabNumberLabel(index()).padStart(numberWidth())}
                       </text>
                       <text
                         width={titleWidth()}
@@ -1040,8 +1040,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           const glows = () => !selected() && (status().attention || (!status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
           const tabNumber = createMemo(() => items().findIndex((item) => item.sessionID === tab.sessionID) + 1)
-          // Shortcut labels stay one cell wide: 1-9, 0 for ten, then a neutral dot.
-          const numberWidth = () => 2
+          const numberWidth = () => Math.max(2, String(items().length).length)
           // Hovering reveals the close mark, so the title's right bound shifts left of it.
           const restingTitleWidth = () => Math.max(1, width() - 1 - numberWidth())
           const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 2)
@@ -1141,11 +1140,8 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                 onLevel={setSweepLevel}
               />
               <box zIndex={1} width="100%" flexDirection="row">
-                <text width={1} selectable={false}>
-                  {" "}
-                </text>
-                <text width={numberWidth()} fg={numberColor()} selectable={false} attributes={bold()}>
-                  {tab === NEW_SESSION_TAB ? "+" : sessionTabShortcutLabel(tabNumber() - 1)}
+                <text width={numberWidth() + 1} fg={numberColor()} selectable={false} attributes={bold()}>
+                  {(tab === NEW_SESSION_TAB ? "+" : sessionTabNumberLabel(tabNumber() - 1)).padStart(numberWidth())}
                 </text>
                 <text
                   width={availableTitleWidth()}

--- a/packages/tui/src/context/session-tabs-model.ts
+++ b/packages/tui/src/context/session-tabs-model.ts
@@ -7,10 +7,8 @@ export type SessionTabUnread = "activity" | "error"
 
 export const NEW_SESSION_TAB_TITLE = "New session"
 
-export function sessionTabShortcutLabel(index: number) {
-  if (index >= 0 && index < 9) return String(index + 1)
-  if (index === 9) return "0"
-  return "·"
+export function sessionTabNumberLabel(index: number) {
+  return String(index + 1)
 }
 
 export function sessionTabDetail(

--- a/packages/tui/test/context/session-tabs-model.test.ts
+++ b/packages/tui/test/context/session-tabs-model.test.ts
@@ -13,7 +13,7 @@ import {
   sessionTabComplete,
   sessionTabDetail,
   sessionTabOverflowWidth,
-  sessionTabShortcutLabel,
+  sessionTabNumberLabel,
 } from "../../src/context/session-tabs-model"
 
 describe("session tabs", () => {
@@ -25,8 +25,8 @@ describe("session tabs", () => {
     expect(sessionTabDetail("opencode", undefined, "main", true)).toBe("opencode")
   })
 
-  test("labels direct shortcut tabs and marks unbound tabs with a dot", () => {
-    expect(Array.from({ length: 12 }, (_, index) => sessionTabShortcutLabel(index))).toEqual([
+  test("labels tabs by ordinal", () => {
+    expect(Array.from({ length: 12 }, (_, index) => sessionTabNumberLabel(index))).toEqual([
       "1",
       "2",
       "3",
@@ -36,9 +36,9 @@ describe("session tabs", () => {
       "7",
       "8",
       "9",
-      "0",
-      "·",
-      "·",
+      "10",
+      "11",
+      "12",
     ])
   })
 


### PR DESCRIPTION
## What

Show full ordinal numbers in the session tab rail instead of switching from `9` to the `0` shortcut label and then dots.

## Before / After

**Before:** tab 10 rendered as `0`, tabs 11+ rendered as `·`, and the rail no longer communicated their position.

**After:** tabs render as `1`, `2`, … `10`, `11`, and so on. Double-digit numbers consume the existing left padding, keeping every session title in the same column. The horizontal tab strip uses the same labels.

## How

- `packages/tui/src/context/session-tabs-model.ts` now produces ordinal tab labels.
- `packages/tui/src/component/session-tabs.tsx` right-aligns those labels in a number field whose width follows the tab count.
- `packages/tui/test/context/session-tabs-model.test.ts` covers labels through tab 12.

## Testing

- `bun run test test/context/session-tabs-model.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- Full workspace typecheck via the pre-push hook
- Fixture-driven `session-tabs` story exercised through `opencode-drive` with 12 tabs in vertical and horizontal orientations

## Demo

The production session-tabs component rendered by the fixture-driven TUI story at 100x40:

![Tab ordinals aligned through 12](https://github.com/user-attachments/assets/938cf873-7119-4972-a137-2e45252cfad5)