### PR TITLE
fix(tui): expose queued prompt shortcut

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -452,7 +452,6 @@ export function Prompt(props: PromptProps) {
         title: "Queue prompt",
         name: "prompt.queue",
         category: "Prompt",
-        palette: undefined,
         run: async (_input: string | undefined, event?: KeyEvent) => {
           event?.preventDefault()
           event?.stopPropagation()

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -178,7 +178,7 @@ export const Definitions = {
   "session.toggle.thinking": keybind("none", "Toggle thinking blocks visibility"),
 
   "prompt.submit": keybind("none", "Submit prompt"),
-  "prompt.queue": keybind("alt+return", "Queue prompt"),
+  "prompt.queue": keybind("<leader>return", "Queue prompt"),
   "prompt.editor_context.clear": keybind("none", "Clear editor context"),
   "prompt.images.view": keybind("<leader>i", "View image attachments"),
   "prompt.skills": keybind("none", "Open skill selector"),

--- a/packages/tui/src/config/v1/keybind.ts
+++ b/packages/tui/src/config/v1/keybind.ts
@@ -163,7 +163,7 @@ export const Definitions = {
   display_thinking: keybind("none", "Toggle thinking blocks visibility"),
 
   prompt_submit: keybind("none", "Submit prompt"),
-  prompt_queue: keybind("alt+return", "Queue prompt"),
+  prompt_queue: keybind("<leader>return", "Queue prompt"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_images_view: keybind("<leader>i", "View image attachments"),
   prompt_skills: keybind("none", "Open skill selector"),

--- a/packages/tui/src/mini/footer.prompt.tsx
+++ b/packages/tui/src/mini/footer.prompt.tsx
@@ -1050,6 +1050,7 @@ export function createPromptState(input: PromptInput): PromptState {
         id: "prompt.queue",
         title: "Queue prompt",
         group: "Prompt",
+        palette: true,
         run() {
           syncDraft()
           submitPrompt(promptCopy(draft), "queue")

--- a/packages/tui/src/mini/footer.view.tsx
+++ b/packages/tui/src/mini/footer.view.tsx
@@ -595,7 +595,7 @@ export function RunFooterView(props: RunFooterViewProps) {
       {
         id: "session.queued_prompts",
         title: "View queued prompts",
-        group: "Session",
+        group: "Prompt",
         run: openQueuedMenu,
       },
     ],

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1062,7 +1062,7 @@ export function Session(props: { verticalTabsWidth: number }) {
     {
       title: "View queued prompts",
       id: "session.queued_prompts",
-      group: "Session",
+      group: "Prompt",
       enabled: queuedPrompts().length > 0,
       run: openQueuedPrompts,
     },

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -107,6 +107,7 @@ test("preserves migrated v1 keybind defaults", () => {
   const pairs = [
     ["app.exit", "app_exit"],
     ["prompt.paste", "input_paste"],
+    ["prompt.queue", "prompt_queue"],
     ["session.delete", "session_delete"],
     ["session.list", "session_list"],
     ["agent.list", "agent_list"],

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -981,7 +981,8 @@ test("direct footer steers the oldest queued prompt from an empty composer", asy
 
   try {
     await app.renderOnce()
-    app.mockInput.pressEnter({ meta: true })
+    app.mockInput.pressKey("x", { ctrl: true })
+    app.mockInput.pressEnter()
     await Bun.sleep(0)
     expect(steered).toEqual([])
     app.mockInput.pressEnter()
@@ -1034,7 +1035,8 @@ test("direct footer rejects local commands submitted with the queue shortcut", a
   try {
     await app.renderOnce()
     await app.mockInput.typeText("/settings ")
-    app.mockInput.pressEnter({ meta: true })
+    app.mockInput.pressKey("x", { ctrl: true })
+    app.mockInput.pressEnter()
     await Bun.sleep(0)
     expect(submitted).toEqual([])
     expect(statuses).toContain("this prompt cannot be queued")

--- a/packages/tui/test/mini/runtime.boot.test.ts
+++ b/packages/tui/test/mini/runtime.boot.test.ts
@@ -22,7 +22,7 @@ describe("run runtime boot", () => {
     expect(result.keybinds.get("prompt.clear")?.[0]?.key).toBe("ctrl+c")
     expect(result.keybinds.get("input.submit")?.[0]?.key).toBe("return")
     expect(result.keybinds.get("input.newline")?.[0]?.key).toBe("shift+return,ctrl+return,ctrl+j")
-    expect(result.keybinds.get("prompt.queue")?.[0]?.key).toBe("alt+return")
+    expect(result.keybinds.get("prompt.queue")?.[0]?.key).toBe("<leader>return")
   })
 
   test("preserves shared config while resolving independent Mini defaults", async () => {


### PR DESCRIPTION
## What

Make queued prompt submission discoverable and reliable across terminals:

- change the default shortcut from Option+Enter to leader, then Enter
- expose **Queue prompt** in the command palette in both TUI surfaces
- group **Queue prompt** and **View queued prompts** together under Prompt

## Before / After

**Before:** Queue prompt defaulted to `alt+return`, which some terminal configurations did not transmit. The action was also hidden from the command palette, leaving no discoverable fallback.

**After:** Queue prompt defaults to `<leader>return` and appears in the command palette with its resolved shortcut. Queue actions are grouped together under Prompt, and user-configured `prompt.queue` bindings continue to override the default.

## How

- `packages/tui/src/config/keybind.ts` and its v1-compatible mapping change the shared `prompt.queue` default.
- `packages/tui/src/component/prompt/index.tsx` exposes the full TUI command in the palette.
- `packages/tui/src/mini/footer.prompt.tsx` exposes the Mini command in the palette.
- Both session views categorize **View queued prompts** under Prompt.

## Scope

This only changes queued prompt submission discoverability and the default binding. It does not change queue delivery behavior or existing user keybind overrides.

## Testing

- `bun run test` in `packages/tui`, 724 passed and 5 skipped
- `bun typecheck` in `packages/tui`
- repository pre-push typecheck, 33 packages passed
- live PTY run with `bun run dev:live`, verified **Queue prompt** appears in the command palette as `ctrl+x enter`

## Demo

Live V2 TUI command palette using the default `ctrl+x` leader:

https://github.com/user-attachments/assets/07f01095-bb74-465d-a166-b729e19563b7
