### PR TITLE
fix(core): clarify temporary directory guidance

### DIFF
--- a/packages/core/src/instructions/builtins.ts
+++ b/packages/core/src/instructions/builtins.ts
@@ -33,7 +33,7 @@ const layer = Layer.effect(
                   `  Workspace root folder: ${location.project.directory}`,
                   `  Is directory a git repo: ${location.vcs?.type === "git" ? "yes" : "no"}`,
                   `  Platform: ${process.platform}`,
-                  `  Use ${global.tmp} for temporary work outside the workspace; it already exists and is pre-approved for external directory access.`,
+                  `  Prefer ${global.tmp} over generic system temporary directories such as /tmp; it is pre-created and approved for external access.`,
                   "</env>",
                 ].join("\n"),
               ),

--- a/packages/core/test/instructions/builtins.test.ts
+++ b/packages/core/test/instructions/builtins.test.ts
@@ -51,7 +51,7 @@ describe("InstructionBuiltIns", () => {
           `  Workspace root folder: ${projectDirectory}`,
           "  Is directory a git repo: yes",
           `  Platform: ${process.platform}`,
-          `  Use ${temporary} for temporary work outside the workspace; it already exists and is pre-approved for external directory access.`,
+          `  Prefer ${temporary} over generic system temporary directories such as /tmp; it is pre-created and approved for external access.`,
           "</env>",
           "",
           `Today's date: ${localDate(timestamp)}`,


### PR DESCRIPTION
Prefer the pre-created OpenCode temp directory over generic system temporary directories without directing general temporary work or builds outside the workspace.