### PR TITLE
fix(session): guard cost calc against non-numeric provider usage/cost fields

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -383,11 +383,13 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   }
 
   const contextTokens = inputTokens
+  // a malformed tier is dropped rather than trusted: `tiers` that is not an array, a null entry or
+  // a missing `tier` all used to throw here, and a non-numeric `size` must not be coerced to 0
+  // (that would make the tier match every context instead of none)
+  const tiers = input.model.cost?.tiers
   const costInfo =
-    input.model.cost?.tiers
-      // a malformed tier is dropped rather than trusted: a missing `tier` used to throw here,
-      // and a non-numeric `size` must not be coerced to 0 (that would match every context)
-      ?.filter((item) => item.tier?.type === "context" && finite(item.tier.size) && contextTokens > item.tier.size)
+    (Array.isArray(tiers) ? tiers : [])
+      .filter((item) => item?.tier?.type === "context" && finite(item.tier.size) && contextTokens > item.tier.size)
       .sort((a, b) => b.tier.size - a.tier.size)[0] ??
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -401,13 +401,15 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
         ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
         : safe(
             new Decimal(0)
-              .add(new Decimal(num(tokens.input)).mul(num(costInfo?.input)).div(1_000_000))
-              .add(new Decimal(num(tokens.output)).mul(num(costInfo?.output)).div(1_000_000))
-              .add(new Decimal(num(tokens.cache.read)).mul(num(costInfo?.cache?.read)).div(1_000_000))
-              .add(new Decimal(num(tokens.cache.write)).mul(num(costInfo?.cache?.write)).div(1_000_000))
+              // only the cost operands need the guard: every `tokens.*` value already went
+              // through `safe()` above, so it cannot be non-numeric here
+              .add(new Decimal(tokens.input).mul(num(costInfo?.input)).div(1_000_000))
+              .add(new Decimal(tokens.output).mul(num(costInfo?.output)).div(1_000_000))
+              .add(new Decimal(tokens.cache.read).mul(num(costInfo?.cache?.read)).div(1_000_000))
+              .add(new Decimal(tokens.cache.write).mul(num(costInfo?.cache?.write)).div(1_000_000))
               // TODO: update models.dev to have better pricing model, for now:
               // charge reasoning tokens at the same rate as output tokens
-              .add(new Decimal(num(tokens.reasoning)).mul(num(costInfo?.output)).div(1_000_000))
+              .add(new Decimal(tokens.reasoning).mul(num(costInfo?.output)).div(1_000_000))
               .toNumber(),
           ),
     tokens,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -340,9 +340,10 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
     if (!Number.isFinite(value)) return 0
     return Math.max(0, value)
   }
-  // provider cost/usage fields are typed as finite numbers but never decoded against that
-  // schema, so anything non-numeric reaching decimal.js would throw and abort the turn
-  const num = (value: unknown) => (typeof value === "number" && Number.isFinite(value) ? value : 0)
+  // provider cost fields are typed as finite numbers but never decoded against that schema,
+  // so anything non-numeric reaching decimal.js would throw and abort the turn
+  const finite = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value)
+  const num = (value: unknown) => (finite(value) ? value : 0)
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)
   const reasoningTokens = safe(input.usage.reasoningTokens ?? 0)
@@ -384,7 +385,9 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   const contextTokens = inputTokens
   const costInfo =
     input.model.cost?.tiers
-      ?.filter((item) => item.tier.type === "context" && contextTokens > item.tier.size)
+      // a malformed tier is dropped rather than trusted: a missing `tier` used to throw here,
+      // and a non-numeric `size` must not be coerced to 0 (that would match every context)
+      ?.filter((item) => item.tier?.type === "context" && finite(item.tier.size) && contextTokens > item.tier.size)
       .sort((a, b) => b.tier.size - a.tier.size)[0] ??
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K
@@ -393,7 +396,7 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   return {
     cost:
       typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu) && totalNanoAiu >= 0
-        ? new Decimal(num(totalNanoAiu)).div(100_000_000_000).toNumber()
+        ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
         : safe(
             new Decimal(0)
               .add(new Decimal(num(tokens.input)).mul(num(costInfo?.input)).div(1_000_000))

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -343,7 +343,17 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   // provider cost fields are typed as finite numbers but never decoded against that schema,
   // so anything non-numeric reaching decimal.js would throw and abort the turn
   const finite = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value)
-  const num = (value: unknown) => (finite(value) ? value : 0)
+  // decimal.js used to price numeric strings correctly — a hand-written provider config or a
+  // plugin can easily produce one — so keep charging for those rather than silently billing 0.
+  // Only what decimal.js would have thrown on (or would have turned into NaN) degrades to 0.
+  const num = (value: unknown) => {
+    if (finite(value)) return value
+    if (typeof value === "string") {
+      const parsed = Number(value)
+      if (Number.isFinite(parsed)) return parsed
+    }
+    return 0
+  }
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)
   const reasoningTokens = safe(input.usage.reasoningTokens ?? 0)

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -340,6 +340,9 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
     if (!Number.isFinite(value)) return 0
     return Math.max(0, value)
   }
+  // provider cost/usage fields are typed as finite numbers but never decoded against that
+  // schema, so anything non-numeric reaching decimal.js would throw and abort the turn
+  const num = (value: unknown) => (typeof value === "number" && Number.isFinite(value) ? value : 0)
   const inputTokens = safe(input.usage.inputTokens ?? 0)
   const outputTokens = safe(input.usage.outputTokens ?? 0)
   const reasoningTokens = safe(input.usage.reasoningTokens ?? 0)
@@ -390,16 +393,16 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   return {
     cost:
       typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu) && totalNanoAiu >= 0
-        ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
+        ? new Decimal(num(totalNanoAiu)).div(100_000_000_000).toNumber()
         : safe(
             new Decimal(0)
-              .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
-              .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-              .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
-              .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
+              .add(new Decimal(num(tokens.input)).mul(num(costInfo?.input)).div(1_000_000))
+              .add(new Decimal(num(tokens.output)).mul(num(costInfo?.output)).div(1_000_000))
+              .add(new Decimal(num(tokens.cache.read)).mul(num(costInfo?.cache?.read)).div(1_000_000))
+              .add(new Decimal(num(tokens.cache.write)).mul(num(costInfo?.cache?.write)).div(1_000_000))
               // TODO: update models.dev to have better pricing model, for now:
               // charge reasoning tokens at the same rate as output tokens
-              .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+              .add(new Decimal(num(tokens.reasoning)).mul(num(costInfo?.output)).div(1_000_000))
               .toNumber(),
           ),
     tokens,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2044,6 +2044,31 @@ describe("SessionNs.getUsage", () => {
     expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
   })
 
+  test("still prices numeric strings, as decimal.js did before the guard", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: "3",
+        output: "15",
+        cache: { read: "0.3", write: "3.75" },
+      } as unknown as Provider.Model["cost"],
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({
+        inputTokens: 1_000_000,
+        outputTokens: 100_000,
+        totalTokens: 1_100_000,
+        cacheReadInputTokens: 200_000,
+      }),
+      metadata: { anthropic: { cacheCreationInputTokens: 300_000 } },
+    })
+
+    // identical to the all-numeric case below: a numeric string must not bill 0
+    expect(result.cost).toBe(4.185)
+  })
+
   test("keeps the full cost when every provider cost field is a number", () => {
     const model = createModel({
       context: 100_000,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2009,6 +2009,8 @@ describe("SessionNs.getUsage", () => {
         output: 15,
         cache: { read: 0, write: 0 },
         tiers: [
+          // a null entry
+          null,
           // no `tier` key at all
           { input: 5, output: 20, cache: { read: 0, write: 0 } },
           // `tier.size` is not a number
@@ -2023,7 +2025,22 @@ describe("SessionNs.getUsage", () => {
 
     expect(() => SessionNs.getUsage(input)).not.toThrow()
 
-    // both tiers discarded, so the base pricing applies
+    // every tier discarded, so the base pricing applies
+    expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
+  })
+
+  test("ignores a cost.tiers that is not an array", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: { input: 3, output: 15, cache: { read: 0, write: 0 }, tiers: {} } as unknown as Provider.Model["cost"],
+    })
+    const input = {
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    }
+
+    expect(() => SessionNs.getUsage(input)).not.toThrow()
     expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
   })
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2000,6 +2000,33 @@ describe("SessionNs.getUsage", () => {
     expect(Number.isFinite(result.cost)).toBe(true)
   })
 
+  test("ignores malformed cost tiers instead of throwing", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0, write: 0 },
+        tiers: [
+          // no `tier` key at all
+          { input: 5, output: 20, cache: { read: 0, write: 0 } },
+          // `tier.size` is not a number
+          { input: 7, output: 30, cache: { read: 0, write: 0 }, tier: { type: "context", size: {} } },
+        ],
+      } as unknown as Provider.Model["cost"],
+    })
+    const input = {
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    }
+
+    expect(() => SessionNs.getUsage(input)).not.toThrow()
+
+    // both tiers discarded, so the base pricing applies
+    expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
+  })
+
   test("keeps the full cost when every provider cost field is a number", () => {
     const model = createModel({
       context: 100_000,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1956,4 +1956,72 @@ describe("SessionNs.getUsage", () => {
     expect(result.tokens.cache.read).toBe(200)
     expect(result.tokens.cache.write).toBe(300)
   })
+
+  test("degrades to a partial cost when a provider cost field is not a number", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      // a provider whose models.dev cost payload is malformed: `input` is not a number
+      cost: { input: {}, output: 15, cache: { read: 0.3, write: 3.75 } } as unknown as Provider.Model["cost"],
+    })
+    const input = {
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    }
+
+    expect(() => SessionNs.getUsage(input)).not.toThrow()
+
+    const result = SessionNs.getUsage(input)
+
+    // input priced at 0 because the provider field is malformed, output still billed
+    expect(result.cost).toBe(1.5)
+    expect(Number.isFinite(result.cost)).toBe(true)
+  })
+
+  test("degrades to a partial cost when provider cache cost fields are not numbers", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: { input: 3, output: 15, cache: { read: {}, write: {} } } as unknown as Provider.Model["cost"],
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({
+        inputTokens: 1_000_000,
+        outputTokens: 100_000,
+        totalTokens: 1_100_000,
+        cacheReadInputTokens: 200_000,
+      }),
+      metadata: { anthropic: { cacheCreationInputTokens: 300_000 } },
+    })
+
+    // input 500_000 @ 3 + output 100_000 @ 15, cache priced at 0
+    expect(result.cost).toBe(1.5 + 1.5)
+    expect(Number.isFinite(result.cost)).toBe(true)
+  })
+
+  test("keeps the full cost when every provider cost field is a number", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0.3, write: 3.75 },
+      },
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({
+        inputTokens: 1_000_000,
+        outputTokens: 100_000,
+        totalTokens: 1_100_000,
+        cacheReadInputTokens: 200_000,
+      }),
+      metadata: { anthropic: { cacheCreationInputTokens: 300_000 } },
+    })
+
+    // input 500_000 @ 3 + output 100_000 @ 15 + cache read 200_000 @ 0.3 + cache write 300_000 @ 3.75
+    expect(result.cost).toBe(4.185)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #43098

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`getUsage` feeds `model.cost` straight into decimal.js. That payload is never decoded against its schema and `?? 0` only covers null/undefined, so a non-numeric cost field throws `[DecimalError] Invalid argument: [object Object]` and takes the turn down with it — cosmetic on the CLI, where the answer is already printed, but fatal under `opencode acp`, where a tool-using turn dies mid-flight.

The tier selection just above it breaks the same way from the same payload: a `tiers` entry missing its `tier`, a null entry, or a non-array `tiers` each throw a TypeError.

So: non-numeric cost fields now price at 0 and malformed tiers are dropped, and the cost degrades to a partial value instead of aborting. Numeric strings still price as before — decimal.js parsed those fine, and turning them into 0 would trade a crash for silent under-billing.

### How did you verify your code works?

Six unit tests in the existing `getUsage` describe block. I wrote each one first and confirmed it fails on `dev` with the error above before writing the fix.

To confirm it: revert `session.ts` and re-run that file — the four malformed-payload tests fail, the two well-formed ones stay green.

`bun test test/session/compaction.test.ts test/server/negative-tokens-regression.test.ts` → 61 pass, `test/session/llm.test.ts` → 28 pass, `tsgo --noEmit` clean, oxlint no new errors.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
