### PR TITLE
fix(core): fall back on oversized websocket requests v2

### DIFF
--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -50,6 +50,7 @@ interface Channel {
 interface State {
   readonly lock: Semaphore.Semaphore
   closed: boolean
+  httpFallback: boolean
   channel?: Channel
 }
 
@@ -119,7 +120,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
       const state = (sessionID: SessionSchema.ID) => {
         const current = states.get(sessionID)
         if (current) return current
-        const created = { lock: Semaphore.makeUnsafe(1), closed: false }
+        const created = { lock: Semaphore.makeUnsafe(1), closed: false, httpFallback: false }
         states.set(sessionID, created)
         return created
       }
@@ -241,7 +242,9 @@ export const makeLayer = (connector: WebSocketConnector) =>
                           channel.active?.lifecycle.delivery === "terminal" ||
                           (error.reason._tag === "Transport" && error.reason.code === "queue-overflow")
                             ? "accepted"
-                            : "ambiguous",
+                            : error.reason._tag === "Transport" && error.reason.code === "1009"
+                              ? "rejected"
+                              : "ambiguous",
                       }),
                     ),
               ),
@@ -274,6 +277,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
             phase: "queue",
             delivery: "not-sent",
           })
+        if (owner.httpFallback) return fallback(exchange)
         const key = affinity(exchange)
         const now = yield* Clock.currentTimeMillis
         const current = owner.channel
@@ -420,6 +424,26 @@ export const makeLayer = (connector: WebSocketConnector) =>
               yield* poison(owner, channel, error)
             }),
           ),
+          Stream.catch((error) => {
+            if (
+              error.reason._tag !== "Transport" ||
+              error.reason.code !== "1009" ||
+              error.reason.delivery !== "rejected"
+            )
+              return Stream.fail(error)
+            owner.httpFallback = true
+            return Stream.unwrap(
+              Effect.logWarning("session websocket request too large; using http", {
+                sessionTransport: "websocket",
+                phase: "close",
+                delivery: "rejected",
+                code: error.reason.code,
+              }).pipe(
+                Effect.andThen(metric("fallback", { reason: "message_too_large" })),
+                Effect.as(exchange.fallback()),
+              ),
+            )
+          }),
         )
         const complete = Effect.sync(() => {
           if (owner.channel !== channel || channel.pending?.token !== token) return

--- a/packages/core/test/session-model-transport.test.ts
+++ b/packages/core/test/session-model-transport.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "@opencode-ai/ai/route"
 import { SessionModelTransport } from "@opencode-ai/core/session/model-transport"
 import { Session } from "@opencode-ai/schema/session"
-import { Deferred, Effect, Fiber, Metric, Queue, Stream } from "effect"
+import { Cause, Deferred, Effect, Fiber, Metric, Queue, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { Headers } from "effect/unstable/http"
 
@@ -541,6 +541,63 @@ describe("SessionModelTransport", () => {
         )
         expect(result).toEqual(["http"])
         expect(fallbacks).toBe(1)
+      }),
+    )
+  })
+
+  test("falls back to HTTP after close code 1009 and keeps the Session on HTTP", async () => {
+    const messages = queue<string | Uint8Array, AIError>()
+    let opened = 0
+    let fallbacks = 0
+    let closed = 0
+    const connector: WebSocketConnector = {
+      open: () =>
+        Effect.sync(() => {
+          opened++
+          return {
+            sendText: () =>
+              Effect.sync(() => {
+                Queue.failCauseUnsafe(
+                  messages,
+                  Cause.fail(
+                    new AIError({
+                      module: "test",
+                      method: "websocket",
+                      reason: new TransportReason({
+                        message: "message too big",
+                        transport: "websocket",
+                        operation: "read",
+                        code: "1009",
+                        phase: "close",
+                      }),
+                    }),
+                  ),
+                )
+              }),
+            messages: Stream.fromQueue(messages),
+            close: Effect.sync(() => closed++).pipe(Effect.andThen(Queue.shutdown(messages)), Effect.asVoid),
+          }
+        }),
+    }
+    const item = (id: string) =>
+      exchange(id, {
+        fallback: () => {
+          fallbacks++
+          return Stream.make(`http:${id}`)
+        },
+      })
+
+    await run(
+      connector,
+      Effect.gen(function* () {
+        const transport = yield* SessionModelTransport.Service
+        const executor = transport.bind(session)
+
+        expect(yield* collect(executor, item("first"))).toEqual(["http:first"])
+        expect(yield* collect(executor, item("second"))).toEqual(["http:second"])
+        expect(opened).toBe(1)
+        expect(fallbacks).toBe(2)
+        expect(closed).toBe(1)
       }),
     )
   })


### PR DESCRIPTION
## Summary
- classify WebSocket close code 1009 before provider observation as rejected delivery
- retry the current model request immediately through its HTTP fallback
- keep the Session on HTTP after an oversized WebSocket rejection

Fixes #42572

## Reproduction

The current `v2` branch supports Responses WebSockets for capable providers, but keeps them disabled by default. Enable OpenAI WebSockets with `OPENCODE_EXPERIMENTAL_OPENAI_RESPONSES_WEBSOCKET=true`; the built-in OpenAI hook no longer prevents WebSocket selection, so no local source changes are needed.

Without this fix, an oversized WebSocket request rejected with close code `1009` fails instead of recovering over HTTP. With this fix, the rejected request is retried immediately over HTTP, and that Session remains on HTTP for subsequent requests. Other Sessions can continue using WebSockets.

Start the development server in one terminal:

```sh
OPENCODE_PASSWORD=issue-42572 \
OPENCODE_EXPERIMENTAL_OPENAI_RESPONSES_WEBSOCKET=true \
OPENCODE_CONFIG_PROJECT_DISABLE=true \
bun run --cwd packages/cli --conditions=browser src/index.ts \
  --log-level debug serve --hostname 127.0.0.1 --port 4097
```

In another terminal, generate six valid noisy PNGs and submit them through the raw API. Using the raw API avoids the CLI SSE reader's separate 16 MiB event limit.

```sh
ffmpeg -y -loglevel error \
  -f lavfi -i "nullsrc=s=1920x1080:r=1,noise=alls=100:allf=t+u" \
  -frames:v 6 /tmp/opencode-ws-%d.png

SESSION=$(jq -n --arg directory "$PWD" \
  '{model:{providerID:"openai",id:"gpt-5.6-sol"},location:{directory:$directory}}' |
  curl -fsSu opencode:issue-42572 \
    -H "content-type: application/json" \
    --data-binary @- http://127.0.0.1:4097/api/session |
  jq -r .data.id)

jq -n '{
  text:"Reply with only: received",
  files:[range(1;7) as $i | {
    uri:("file:///tmp/opencode-ws-" + ($i|tostring) + ".png"),
    name:("opencode-ws-" + ($i|tostring) + ".png")
  }]
}' |
curl -fsSu opencode:issue-42572 \
  -H "content-type: application/json" \
  --data-binary @- "http://127.0.0.1:4097/api/session/$SESSION/prompt"

while :; do
  RESULT=$(curl -fsSu opencode:issue-42572 \
    "http://127.0.0.1:4097/api/session/$SESSION/message?order=asc&limit=200" |
    jq -c '[.data[] | select(.type == "assistant")][-1] |
      select(.error != null or .time.completed != null) |
      {error, completed:.time.completed}' 2>/dev/null)
  [ -n "$RESULT" ] && printf '%s\n' "$RESULT" && break
  sleep 1
done
```

Observed against real OpenAI infrastructure with a 20,127,431-byte serialized `response.create`:

- Unpatched `v2`: WebSocket closes with code 1009 and the assistant ends with `provider.transport`; there is no HTTP recovery.
- This branch: the same request completes normally over HTTP, and a subsequent prompt in the same Session remains on HTTP without opening another WebSocket.

The warm-up test also exposed a separate V2 parser issue: ChatGPT may emit `codex.rate_limits` before `response.created`, which currently produces `provider.invalid-output`. That is independent of this fallback change.

## Testing
- `bun test test/session-model-transport.test.ts test/session-model-transport-live.test.ts`
- `bun typecheck --force`
- `bunx prettier --check src/session/model-transport.ts test/session-model-transport.test.ts`
