### PR TITLE
fix(ai): default Gemini function args

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -92,7 +92,7 @@ const GeminiFunctionCallPart = Schema.Struct({
   functionCall: Schema.Struct({
     id: Schema.optional(Schema.String),
     name: Schema.String,
-    args: Schema.Unknown,
+    args: Schema.optional(Schema.Unknown),
   }),
   thoughtSignature: Schema.optional(Schema.String),
 })
@@ -586,7 +586,7 @@ const step = (state: ParserState, event: GeminiEvent) => {
     }
 
     if ("functionCall" in part) {
-      const input = part.functionCall.args
+      const input = part.functionCall.args === undefined ? {} : part.functionCall.args
       const id = `tool_${nextToolCallId++}`
       const metadata = {
         ...(part.functionCall.id === undefined ? {} : { functionCallId: part.functionCall.id }),

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -767,6 +767,31 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("defaults omitted function call args to an empty object", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "ping", description: "Ping", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              candidates: [
+                {
+                  content: { role: "model", parts: [{ functionCall: { name: "ping" } }] },
+                  finishReason: "STOP",
+                },
+              ],
+            }),
+          ),
+        ),
+      )
+
+      expect(response.toolCalls).toEqual([{ type: "tool-call", id: "tool_0", name: "ping", input: {} }])
+    }),
+  )
+
   it.effect("maps tool calls without a finish reason", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(


### PR DESCRIPTION
Summary
- allow Gemini function calls to omit args
- normalize omitted arguments to an empty object
- preserve explicitly provided argument values
Related to #41932.


Testing
- bun test test/provider/gemini.test.ts
- bun typecheck
- pre-push monorepo typechec