### PR TITLE
fix(tui): navigate nested subagent sessions

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -82,6 +82,7 @@ import { getRevertDiffFiles } from "../../util/revert-diff"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { LocationProvider } from "../../context/location"
+import { firstChild } from "../../util/session"
 
 addDefaultParsers(parsers.parsers)
 
@@ -440,8 +441,7 @@ export function Session() {
   }
 
   function moveFirstChild() {
-    if (children().length === 1) return
-    const next = children().find((x) => !!x.parentID)
+    const next = firstChild(sync.data.session, session())
     if (next) enterChild(next.id)
   }
 

--- a/packages/tui/src/util/session.ts
+++ b/packages/tui/src/util/session.ts
@@ -1,3 +1,16 @@
+type SessionNode = {
+  id: string
+  parentID?: string
+}
+
+export function firstChild<T extends SessionNode>(sessions: readonly T[], session?: SessionNode) {
+  if (!session) return
+  return sessions
+    .filter((item) => item.parentID === session.id)
+    .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .at(0)
+}
+
 export function isDefaultTitle(title: string) {
   return /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(title)
 }

--- a/packages/tui/test/util/session.test.ts
+++ b/packages/tui/test/util/session.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test"
-import { isDefaultTitle } from "../../src/util/session"
+import { firstChild, isDefaultTitle } from "../../src/util/session"
 
 describe("util.session", () => {
+  test("finds a direct child from a nested session", () => {
+    const sessions = [
+      { id: "root" },
+      { id: "child-a", parentID: "root" },
+      { id: "child-b", parentID: "root" },
+      { id: "grandchild", parentID: "child-b" },
+    ]
+
+    expect(firstChild(sessions, sessions[2])).toEqual(sessions[3])
+  })
+
   test("recognizes generated parent and child titles", () => {
     expect(isDefaultTitle("New session - 2026-06-06T12:34:56.789Z")).toBeTrue()
     expect(isDefaultTitle("Child session - 2026-06-06T12:34:56.789Z")).toBeTrue()


### PR DESCRIPTION
### Issue for this PR

Closes #43082

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Selects the first child of the currently viewed session. Previously, nested sessions reused their parent's sibling group, so navigating down could reopen a sibling instead of the deeper subagent.

### How did you verify your code works?

Added a nested-session regression test. A focused before/after check reproduced the old sibling selection and confirmed the updated selector chooses the grandchild while preserving root and leaf behavior. The package test and typecheck will run in CI because Bun is unavailable in the prepared checkout.

### Screenshots / recordings

Not applicable; this changes session navigation logic only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
