### PR TITLE
fix(mcp): expose structured content to models

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -72,11 +72,10 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
             .filter((text) => text.trim())
             .join("\n\n") || "MCP tool returned an error",
         )
-      if (result.content.length > 0 || result.structuredContent === undefined || result.structuredContent === null)
-        return result
+      if (result.structuredContent === undefined || result.structuredContent === null) return result
       return {
         ...result,
-        content: [{ type: "text" as const, text: JSON.stringify(result.structuredContent) }],
+        content: [...result.content, { type: "text" as const, text: JSON.stringify(result.structuredContent) }],
       }
     },
   })

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -27,14 +27,17 @@ function mcpTool() {
 }
 
 describe("McpCatalog.convertTool", () => {
-  test("preserves content when structuredContent is also present", async () => {
+  test("preserves content and exposes structuredContent when both are present", async () => {
     const content = [{ type: "image" as const, mimeType: "image/png", data: "AAAA" }]
     const structuredContent = { image: { mimeType: "image/png", data: "AAAA" } }
     const converted = McpCatalog.convertTool(mcpTool(), clientReturning({ content, structuredContent }))
 
     const output = await converted.execute?.({}, options)
 
-    expect(output).toMatchObject({ content, structuredContent })
+    expect(output).toMatchObject({
+      content: [...content, { type: "text", text: JSON.stringify(structuredContent) }],
+      structuredContent,
+    })
   })
 
   test("falls back to structuredContent only when content is absent", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #38923

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an MCP tool returns both `content` and `structuredContent`, OpenCode currently keeps the content blocks but the normal session path never exposes the structured result to the model. This appends the compact JSON representation of `structuredContent` while preserving existing text, image, and resource content. The existing both-channels test now verifies that both outputs survive.

### How did you verify your code works?

- `bun test test/mcp/catalog.test.ts` (3 passing)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck` (30 packages passing)

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR