### PR TITLE
fix(ai): settle pending Anthropic tool calls

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -957,7 +957,12 @@ const onMessageDelta = (state: ParserState, event: AnthropicEvent): StepResult =
   ]
 }
 
-const onMessageStop = (state: ParserState): StepResult => {
+const onMessageStop = Effect.fn("AnthropicMessages.onMessageStop")(function* (state: ParserState) {
+  if (Object.values(state.tools).some((tool) => tool !== undefined))
+    return yield* ProviderShared.eventError(
+      ADAPTER,
+      "Anthropic Messages message_stop arrived before content_block_stop for a pending tool call",
+    )
   const events: LLMEvent[] = []
   const lifecycle = Lifecycle.finish(state.lifecycle, events, {
     reason: state.pendingFinish?.reason ?? {
@@ -967,8 +972,8 @@ const onMessageStop = (state: ParserState): StepResult => {
     usage: state.usage,
     providerMetadata: state.pendingFinish?.providerMetadata,
   })
-  return [{ ...state, lifecycle }, events]
-}
+  return [{ ...state, lifecycle }, events] satisfies StepResult
+})
 
 // Prefix `error.type` so overloads, rate limits, and quota errors are visible
 // even when the provider message is generic or empty.
@@ -992,7 +997,7 @@ const step = (state: ParserState, event: AnthropicEvent) => {
   if (event.type === "content_block_delta") return onContentBlockDelta(state, event)
   if (event.type === "content_block_stop") return onContentBlockStop(state, event)
   if (event.type === "message_delta") return Effect.succeed(onMessageDelta(state, event))
-  if (event.type === "message_stop") return Effect.succeed(onMessageStop(state))
+  if (event.type === "message_stop") return onMessageStop(state)
   if (event.type === "error") return onError(event)
   return Effect.succeed<StepResult>([state, NO_EVENTS])
 }

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -958,13 +958,11 @@ const onMessageDelta = (state: ParserState, event: AnthropicEvent): StepResult =
 }
 
 const onMessageStop = Effect.fn("AnthropicMessages.onMessageStop")(function* (state: ParserState) {
-  if (Object.values(state.tools).some((tool) => tool !== undefined))
-    return yield* ProviderShared.eventError(
-      ADAPTER,
-      "Anthropic Messages message_stop arrived before content_block_stop for a pending tool call",
-    )
+  const result = yield* ToolStream.finishAll(ADAPTER, state.tools)
   const events: LLMEvent[] = []
-  const lifecycle = Lifecycle.finish(state.lifecycle, events, {
+  const lifecycle = result.events.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle
+  events.push(...result.events)
+  const finished = Lifecycle.finish(lifecycle, events, {
     reason: state.pendingFinish?.reason ?? {
       normalized: "unknown",
       raw: undefined,
@@ -972,7 +970,7 @@ const onMessageStop = Effect.fn("AnthropicMessages.onMessageStop")(function* (st
     usage: state.usage,
     providerMetadata: state.pendingFinish?.providerMetadata,
   })
-  return [{ ...state, lifecycle }, events] satisfies StepResult
+  return [{ ...state, lifecycle: finished, tools: result.tools }, events] satisfies StepResult
 })
 
 // Prefix `error.type` so overloads, rate limits, and quota errors are visible

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -955,9 +955,9 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
-  it.effect("rejects pending tool calls at message_stop", () =>
+  it.effect("settles pending tool calls at message_stop", () =>
     Effect.gen(function* () {
-      const error = yield* LLMClient.generate(request).pipe(
+      const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
           fixedResponse(
             sseEvents(
@@ -977,13 +977,12 @@ describe("Anthropic Messages route", () => {
             ),
           ),
         ),
-        Effect.flip,
       )
 
-      expect(error.reason).toMatchObject({
-        _tag: "InvalidProviderOutput",
-        message: "Anthropic Messages message_stop arrived before content_block_stop for a pending tool call",
-      })
+      expect(response.toolCalls).toMatchObject([
+        { id: "call_1", name: "lookup", input: { query: "weather" } },
+      ])
+      expect(response.finishReason).toEqual({ normalized: "tool-calls", raw: "tool_use" })
     }),
   )
 

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -955,6 +955,38 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
+  it.effect("rejects pending tool calls at message_stop", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              {
+                type: "content_block_start",
+                index: 0,
+                content_block: { type: "tool_use", id: "call_1", name: "lookup" },
+              },
+              {
+                type: "content_block_delta",
+                index: 0,
+                delta: { type: "input_json_delta", partial_json: '{"query":"weather"}' },
+              },
+              { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } },
+              { type: "message_stop" },
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.reason).toMatchObject({
+        _tag: "InvalidProviderOutput",
+        message: "Anthropic Messages message_stop arrived before content_block_stop for a pending tool call",
+      })
+    }),
+  )
+
   it.effect("assembles and persists multiple tool calls from one Anthropic response", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(


### PR DESCRIPTION
## Summary

- settle pending Anthropic tool blocks when `message_stop` arrives without `content_block_stop`
- strictly parse accumulated input before emitting an executable tool call
- preserve malformed local input as a non-executable `tool-input-error`
- cover a complete pending call finalized by `message_stop`

This follows the official Anthropic TypeScript SDK outcome, which retains accumulated tool blocks in the final message at `message_stop`. `@ai-sdk/anthropic` currently emits tool calls only on `content_block_stop` and otherwise drops the pending call.

Closes one checklist item in #41932.

## Testing

- `bun test test/provider/anthropic-messages.test.ts`
- `bun typecheck`
- `bun run build`
- pre-push monorepo typecheck