### PR TITLE
fix(core): support older previous-channel databases

### DIFF
--- a/packages/core/src/database/v1-migration.bun.ts
+++ b/packages/core/src/database/v1-migration.bun.ts
@@ -114,6 +114,17 @@ type NextProject = {
   readonly commands: string | null
 }
 
+const NEXT_PROJECT_REQUIRED = ["id", "worktree", "time_created", "time_updated", "sandboxes"] as const
+const NEXT_PROJECT_OPTIONAL = [
+  "vcs",
+  "name",
+  "icon_url",
+  "icon_url_override",
+  "icon_color",
+  "time_initialized",
+  "commands",
+] as const
+
 type NextSession = {
   readonly id: string
   readonly project_id: string
@@ -148,6 +159,43 @@ type NextSession = {
   readonly time_archived: number | null
   readonly time_suspended: number | null
 }
+
+const NEXT_SESSION_REQUIRED = [
+  "id",
+  "project_id",
+  "slug",
+  "directory",
+  "version",
+  "cost",
+  "tokens_input",
+  "tokens_output",
+  "tokens_reasoning",
+  "tokens_cache_read",
+  "tokens_cache_write",
+  "time_created",
+  "time_updated",
+] as const
+const NEXT_SESSION_OPTIONAL = [
+  "workspace_id",
+  "parent_id",
+  "fork_session_id",
+  "fork_boundary",
+  "path",
+  "title",
+  "share_url",
+  "summary_additions",
+  "summary_deletions",
+  "summary_files",
+  "summary_diffs",
+  "metadata",
+  "revert",
+  "permission",
+  "agent",
+  "model",
+  "time_compacting",
+  "time_archived",
+  "time_suspended",
+] as const
 
 type NextMessage = {
   readonly id: string
@@ -686,12 +734,12 @@ function importNextDatabase(
         }),
       )
       const projects = new Map(
-        source
-          .query<NextProject, []>("SELECT * FROM project")
-          .all()
-          .map((project) => [project.id, project]),
+        selectNextRows<NextProject>(source, "project", NEXT_PROJECT_REQUIRED, NEXT_PROJECT_OPTIONAL).map((project) => [
+          project.id,
+          project,
+        ]),
       )
-      const sessions = source.query<NextSession, []>("SELECT * FROM session ORDER BY id DESC").all()
+      const sessions = selectNextRows<NextSession>(source, "session", NEXT_SESSION_REQUIRED, NEXT_SESSION_OPTIONAL)
       for (const [index, session] of sessions.entries()) {
         const project = projects.get(session.project_id)
         const projectID = project ? session.project_id : Project.ID.global
@@ -787,6 +835,30 @@ function isNextDatabase(source: SQLiteDatabase) {
       .map((table) => table.name),
   )
   return tables.has("project") && tables.has("session") && tables.has("session_message")
+}
+
+function selectNextRows<A>(
+  source: SQLiteDatabase,
+  table: "project" | "session",
+  required: ReadonlyArray<keyof A & string>,
+  optional: ReadonlyArray<keyof A & string>,
+) {
+  const columns = new Set(
+    source
+      .query<{ name: string }, [string]>("SELECT name FROM pragma_table_info(?)")
+      .all(table)
+      .map((column) => column.name),
+  )
+  const missing = required.filter((column) => !columns.has(column))
+  if (missing.length)
+    throw new Error(`Incompatible opencode-next.db: ${table} is missing required columns: ${missing.join(", ")}`)
+  const projection = [
+    ...required.map((column) => `"${column}"`),
+    ...optional.map((column) => (columns.has(column) ? `"${column}"` : `NULL AS "${column}"`)),
+  ]
+  return source
+    .query<A, []>(`SELECT ${projection.join(", ")} FROM "${table}"${table === "session" ? ' ORDER BY "id" DESC' : ""}`)
+    .all()
 }
 
 function row(

--- a/packages/core/src/database/v1-migration.bun.ts
+++ b/packages/core/src/database/v1-migration.bun.ts
@@ -114,16 +114,22 @@ type NextProject = {
   readonly commands: string | null
 }
 
-const NEXT_PROJECT_REQUIRED = ["id", "worktree", "time_created", "time_updated", "sandboxes"] as const
-const NEXT_PROJECT_OPTIONAL = [
-  "vcs",
-  "name",
-  "icon_url",
-  "icon_url_override",
-  "icon_color",
-  "time_initialized",
-  "commands",
-] as const
+type NextColumns<A> = Record<keyof A, "required" | "nullable" | { readonly fallback: keyof A & string }>
+
+const NEXT_PROJECT_COLUMNS = {
+  id: "required",
+  worktree: "required",
+  vcs: "nullable",
+  name: "nullable",
+  icon_url: "nullable",
+  icon_url_override: { fallback: "icon_url" },
+  icon_color: "nullable",
+  time_created: "required",
+  time_updated: "required",
+  time_initialized: "nullable",
+  sandboxes: "required",
+  commands: "nullable",
+} satisfies NextColumns<NextProject>
 
 type NextSession = {
   readonly id: string
@@ -160,42 +166,40 @@ type NextSession = {
   readonly time_suspended: number | null
 }
 
-const NEXT_SESSION_REQUIRED = [
-  "id",
-  "project_id",
-  "slug",
-  "directory",
-  "version",
-  "cost",
-  "tokens_input",
-  "tokens_output",
-  "tokens_reasoning",
-  "tokens_cache_read",
-  "tokens_cache_write",
-  "time_created",
-  "time_updated",
-] as const
-const NEXT_SESSION_OPTIONAL = [
-  "workspace_id",
-  "parent_id",
-  "fork_session_id",
-  "fork_boundary",
-  "path",
-  "title",
-  "share_url",
-  "summary_additions",
-  "summary_deletions",
-  "summary_files",
-  "summary_diffs",
-  "metadata",
-  "revert",
-  "permission",
-  "agent",
-  "model",
-  "time_compacting",
-  "time_archived",
-  "time_suspended",
-] as const
+const NEXT_SESSION_COLUMNS = {
+  id: "required",
+  project_id: "required",
+  workspace_id: "nullable",
+  parent_id: "nullable",
+  fork_session_id: "nullable",
+  fork_boundary: "nullable",
+  slug: "required",
+  directory: "required",
+  path: "nullable",
+  title: "nullable",
+  version: "required",
+  share_url: "nullable",
+  summary_additions: "nullable",
+  summary_deletions: "nullable",
+  summary_files: "nullable",
+  summary_diffs: "nullable",
+  metadata: "nullable",
+  cost: "required",
+  tokens_input: "required",
+  tokens_output: "required",
+  tokens_reasoning: "required",
+  tokens_cache_read: "required",
+  tokens_cache_write: "required",
+  revert: "nullable",
+  permission: "nullable",
+  agent: "nullable",
+  model: "nullable",
+  time_created: "required",
+  time_updated: "required",
+  time_compacting: "nullable",
+  time_archived: "nullable",
+  time_suspended: "nullable",
+} satisfies NextColumns<NextSession>
 
 type NextMessage = {
   readonly id: string
@@ -734,12 +738,9 @@ function importNextDatabase(
         }),
       )
       const projects = new Map(
-        selectNextRows<NextProject>(source, "project", NEXT_PROJECT_REQUIRED, NEXT_PROJECT_OPTIONAL).map((project) => [
-          project.id,
-          project,
-        ]),
+        selectNextRows<NextProject>(source, "project", NEXT_PROJECT_COLUMNS).map((project) => [project.id, project]),
       )
-      const sessions = selectNextRows<NextSession>(source, "session", NEXT_SESSION_REQUIRED, NEXT_SESSION_OPTIONAL)
+      const sessions = selectNextRows<NextSession>(source, "session", NEXT_SESSION_COLUMNS)
       for (const [index, session] of sessions.entries()) {
         const project = projects.get(session.project_id)
         const projectID = project ? session.project_id : Project.ID.global
@@ -837,25 +838,30 @@ function isNextDatabase(source: SQLiteDatabase) {
   return tables.has("project") && tables.has("session") && tables.has("session_message")
 }
 
-function selectNextRows<A>(
-  source: SQLiteDatabase,
-  table: "project" | "session",
-  required: ReadonlyArray<keyof A & string>,
-  optional: ReadonlyArray<keyof A & string>,
-) {
+function selectNextRows<A>(source: SQLiteDatabase, table: "project" | "session", definition: NextColumns<A>) {
   const columns = new Set(
     source
       .query<{ name: string }, [string]>("SELECT name FROM pragma_table_info(?)")
       .all(table)
       .map((column) => column.name),
   )
-  const missing = required.filter((column) => !columns.has(column))
+  const missing = Object.entries(definition)
+    .filter(([column, strategy]) => strategy === "required" && !columns.has(column))
+    .map(([column]) => column)
   if (missing.length)
     throw new Error(`Incompatible opencode-next.db: ${table} is missing required columns: ${missing.join(", ")}`)
-  const projection = [
-    ...required.map((column) => `"${column}"`),
-    ...optional.map((column) => (columns.has(column) ? `"${column}"` : `NULL AS "${column}"`)),
-  ]
+  const projection = Object.entries(definition).map(([column, strategy]) => {
+    if (columns.has(column)) return `"${column}"`
+    if (
+      typeof strategy === "object" &&
+      strategy !== null &&
+      "fallback" in strategy &&
+      typeof strategy.fallback === "string" &&
+      columns.has(strategy.fallback)
+    )
+      return `"${strategy.fallback}" AS "${column}"`
+    return `NULL AS "${column}"`
+  })
   return source
     .query<A, []>(`SELECT ${projection.join(", ")} FROM "${table}"${table === "session" ? ' ORDER BY "id" DESC' : ""}`)
     .all()

--- a/packages/core/test/v1-migration.test.ts
+++ b/packages/core/test/v1-migration.test.ts
@@ -946,6 +946,54 @@ describe("V1Migration database workflow", () => {
     )
   })
 
+  test("imports previous V2 databases missing newer nullable columns", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "opencode-next.db")
+    const sqlite = await import("bun:sqlite")
+    const source = new sqlite.Database(filename)
+    source.run(`
+      CREATE TABLE project (
+        id text PRIMARY KEY, worktree text NOT NULL, vcs text, name text, icon_url text,
+        time_created integer NOT NULL, time_updated integer NOT NULL, time_initialized integer,
+        sandboxes text NOT NULL
+      );
+      CREATE TABLE session (
+        id text PRIMARY KEY, project_id text NOT NULL, workspace_id text, parent_id text, fork_session_id text,
+        slug text NOT NULL, directory text NOT NULL, path text, title text, version text NOT NULL,
+        share_url text, summary_additions integer, summary_deletions integer, summary_files integer, summary_diffs text,
+        metadata text, cost real DEFAULT 0 NOT NULL, tokens_input integer DEFAULT 0 NOT NULL,
+        tokens_output integer DEFAULT 0 NOT NULL, tokens_reasoning integer DEFAULT 0 NOT NULL,
+        tokens_cache_read integer DEFAULT 0 NOT NULL, tokens_cache_write integer DEFAULT 0 NOT NULL, revert text,
+        permission text, agent text, model text, time_created integer NOT NULL, time_updated integer NOT NULL,
+        time_compacting integer, time_archived integer
+      );
+      CREATE TABLE session_message (
+        id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, seq integer NOT NULL,
+        time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL
+      );
+      INSERT INTO project VALUES ('next-project', '/tmp/next', 'git', 'Source project', NULL, 1, 2, NULL, '[]');
+      INSERT INTO session (
+        id, project_id, slug, directory, title, version, time_created, time_updated
+      ) VALUES ('ses_next', 'next-project', 'next', '/tmp/next', 'Imported', '2', 10, 20);
+    `)
+    source.close()
+
+    await database(
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        expect(yield* V1Migration.run({ nextDatabasePath: filename })).toEqual({ status: "completed" })
+        expect(
+          yield* database.db.get(sql`SELECT fork_boundary, time_suspended FROM session_v2 WHERE id = 'ses_next'`),
+        ).toEqual({ fork_boundary: null, time_suspended: null })
+        expect(
+          yield* database.db.get(
+            sql`SELECT icon_url_override, icon_color, commands FROM project WHERE id = 'next-project'`,
+          ),
+        ).toEqual({ icon_url_override: null, icon_color: null, commands: null })
+      }),
+    )
+  })
+
   test("derives required status from the durable cursor", async () => {
     await database(
       Effect.gen(function* () {

--- a/packages/core/test/v1-migration.test.ts
+++ b/packages/core/test/v1-migration.test.ts
@@ -971,7 +971,9 @@ describe("V1Migration database workflow", () => {
         id text PRIMARY KEY, session_id text NOT NULL, type text NOT NULL, seq integer NOT NULL,
         time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL
       );
-      INSERT INTO project VALUES ('next-project', '/tmp/next', 'git', 'Source project', NULL, 1, 2, NULL, '[]');
+      INSERT INTO project VALUES (
+        'next-project', '/tmp/next', 'git', 'Source project', 'https://example.com/icon.png', 1, 2, NULL, '[]'
+      );
       INSERT INTO session (
         id, project_id, slug, directory, title, version, time_created, time_updated
       ) VALUES ('ses_next', 'next-project', 'next', '/tmp/next', 'Imported', '2', 10, 20);
@@ -987,9 +989,14 @@ describe("V1Migration database workflow", () => {
         ).toEqual({ fork_boundary: null, time_suspended: null })
         expect(
           yield* database.db.get(
-            sql`SELECT icon_url_override, icon_color, commands FROM project WHERE id = 'next-project'`,
+            sql`SELECT icon_url, icon_url_override, icon_color, commands FROM project WHERE id = 'next-project'`,
           ),
-        ).toEqual({ icon_url_override: null, icon_color: null, commands: null })
+        ).toEqual({
+          icon_url: "https://example.com/icon.png",
+          icon_url_override: "https://example.com/icon.png",
+          icon_color: null,
+          commands: null,
+        })
       }),
     )
   })


### PR DESCRIPTION
## What

Make the previous-V2 database importer tolerate older `opencode-next.db` schemas whose optional project or session columns predate the current importer.

Fixes #43139.
Fixes #41341.

## Before / After

**Before:** The importer read `project` and `session` with `SELECT *` into the current TypeScript row shapes. If the source database lacked a newer nullable column such as `icon_url_override`, `fork_boundary`, or `time_suspended`, property access returned `undefined`. Drizzle rendered that value as an empty SQL expression, producing statements like `VALUES (..., , ...)` and failing migration with `SQLiteError: near ",": syntax error`.

**After:** The importer inspects each source table and builds an explicit projection. Existing columns are selected normally, absent optional columns are projected as SQL `NULL`, and absent required columns fail early with a compatibility error naming the table and columns. Historical field backfills, including `icon_url_override` from `icon_url`, are preserved. The destination inserts therefore never receive `undefined` for declared historical fields.

## How

- `packages/core/src/database/v1-migration.bun.ts` defines an exhaustive compatibility strategy for every previous-V2 project and session field. Adding a future field now requires declaring whether it is required, nullable, or copied from an older field.
- `selectNextRows` reads `pragma_table_info`, synthesizes compatible source projections, and preserves session import ordering.
- `packages/core/test/v1-migration.test.ts` creates a real older-shape SQLite database, runs the importer, verifies missing fields arrive as `NULL`, and verifies the historical project icon backfill.

## Scope

This fixes the Core previous-V2 import path. It does not change client migration readiness or restored-session error handling.

## Testing

- `bun run test ./test/v1-migration.test.ts` from `packages/core`: 24 passed
- `bun run test` from `packages/core`: 1,842 passed, 16 skipped
- `bun typecheck` from `packages/core`: passed
- Repository pre-push typecheck: 33 tasks passed
