### PR TITLE
fix(core): include pid in shell.created event

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -241,10 +241,11 @@ export const layer = (options?: ShellSelect.Options) =>
                 .pipe(
                   Effect.mapError((cause) => new AppProcess.AppProcessError({ command: invocation.command, cause })),
                 )
+              const createdInfo = produce(info, (draft) => {
+                draft.pid = handle.pid
+              })
               const session: Active = {
-                info: produce(info, (draft) => {
-                  draft.pid = handle.pid
-                }),
+                info: createdInfo,
                 file,
                 size: 0,
                 done: Deferred.makeUnsafe<Info, NotFoundError>(),
@@ -336,7 +337,7 @@ export const layer = (options?: ShellSelect.Options) =>
                 ),
               )
 
-              yield* bus.publish(Shell.Event.Created, { info: session.info })
+              yield* bus.publish(Shell.Event.Created, { info: createdInfo })
               yield* Deferred.succeed(ready, session)
               // Hold the handle's scope open until the command terminates; closing it earlier would
               // release (kill) the process before its exit is observed.

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -336,7 +336,7 @@ export const layer = (options?: ShellSelect.Options) =>
                 ),
               )
 
-              yield* bus.publish(Shell.Event.Created, { info })
+              yield* bus.publish(Shell.Event.Created, { info: session.info })
               yield* Deferred.succeed(ready, session)
               // Hold the handle's scope open until the command terminates; closing it earlier would
               // release (kill) the process before its exit is observed.

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -1,8 +1,31 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import { Config } from "@opencode-ai/core/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Environment } from "@opencode-ai/core/environment/index"
+import { Bus } from "@opencode-ai/core/bus"
+import { Location } from "@opencode-ai/core/location"
+import { Global } from "@opencode-ai/util/global"
+import { node, Service } from "@opencode-ai/core/shell"
+import { Shell } from "@opencode-ai/schema/shell"
 import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { which } from "@opencode-ai/core/util/which"
+import { Effect, Fiber, Stream } from "effect"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { hostEnvironmentLayer } from "./fixture/environment"
+import { tempGlobalLayer } from "./fixture/global"
+import { tempLocationLayer } from "./fixture/location"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([node, Bus.node]), [
+    [Config.node, Config.testLayer()],
+    [Environment.node, hostEnvironmentLayer],
+    [Global.node, tempGlobalLayer],
+    [Location.node, tempLocationLayer],
+  ]),
+)
 
 const withShell = async (shell: string | undefined, fn: () => void | Promise<void>) => {
   const prev = process.env.SHELL
@@ -21,6 +44,23 @@ const withShell = async (shell: string | undefined, fn: () => void | Promise<voi
 }
 
 describe("shell", () => {
+  it.live("publishes the created shell PID", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const shell = yield* Service
+      const eventFiber = yield* bus
+        .subscribe(Shell.Event.Created)
+        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+      const info = yield* shell.create({ command: "exit 0", timeout: 0 })
+      const event = Array.from(yield* Fiber.join(eventFiber))[0]
+
+      expect(event?.data.info.id).toBe(info.id)
+      expect(typeof event?.data.info.pid).toBe("number")
+      expect(event?.data.info.pid).toBe(info.pid)
+      yield* shell.wait(info.id)
+    }),
+  )
+
   test("normalizes shell names", () => {
     expect(ShellSelect.name("/bin/bash")).toBe("bash")
     if (process.platform === "win32") {

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -149,10 +149,9 @@ describe("shell", () => {
     })
 
     test("normalizes Git Bash shell paths from env", async () => {
-      const bash = ShellSelect.gitbash()
-      if (!bash) return
-      await withShell("NU.EXE", async () => {
-        expect(ShellSelect.name(ShellSelect.acceptable())).not.toBe("nu")
+      const shell = "/cygdrive/c/Program Files/Git/bin/bash.exe"
+      await withShell(shell, async () => {
+        expect(ShellSelect.preferred()).toBe(FSUtil.windowsPath(shell))
       })
     })
 

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -11,21 +11,51 @@ import { Shell } from "@opencode-ai/schema/shell"
 import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { which } from "@opencode-ai/core/util/which"
-import { Effect, Fiber, Stream } from "effect"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { hostEnvironmentLayer } from "./fixture/environment"
 import { tempGlobalLayer } from "./fixture/global"
 import { tempLocationLayer } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(
+const immediateExitEnvironmentLayer = Layer.effect(
+  Environment.Service,
+  Effect.gen(function* () {
+    const environment = yield* Environment.Service
+    return Environment.Service.of({
+      ...environment,
+      spawner: ChildProcessSpawner.make(() =>
+        Effect.succeed(
+          ChildProcessSpawner.makeHandle({
+            pid: ChildProcessSpawner.ProcessId(4242),
+            exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+            isRunning: Effect.succeed(false),
+            kill: () => Effect.void,
+            stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+            stdout: Stream.empty,
+            stderr: Stream.empty,
+            all: Stream.empty,
+            getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+            getOutputFd: () => Stream.empty,
+            unref: Effect.succeed(Effect.void),
+          }),
+        ),
+      ),
+    })
+  }),
+).pipe(Layer.provide(hostEnvironmentLayer))
+
+const shellTestLayer = (environment: Layer.Layer<Environment.Service>) =>
   AppNodeBuilder.build(LayerNode.group([node, Bus.node]), [
     [Config.node, Config.testLayer()],
-    [Environment.node, hostEnvironmentLayer],
+    [Environment.node, environment],
     [Global.node, tempGlobalLayer],
     [Location.node, tempLocationLayer],
-  ]),
-)
+  ])
+
+const it = testEffect(shellTestLayer(hostEnvironmentLayer))
+const immediateExitIt = testEffect(shellTestLayer(immediateExitEnvironmentLayer))
 
 const withShell = async (shell: string | undefined, fn: () => void | Promise<void>) => {
   const prev = process.env.SHELL
@@ -44,20 +74,29 @@ const withShell = async (shell: string | undefined, fn: () => void | Promise<voi
 }
 
 describe("shell", () => {
-  it.live("publishes the created shell PID", () =>
+  immediateExitIt.live("publishes the created shell PID before terminal state", () =>
     Effect.gen(function* () {
       const bus = yield* Bus.Service
       const shell = yield* Service
       const eventFiber = yield* bus
         .subscribe(Shell.Event.Created)
         .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+
       const info = yield* shell.create({ command: "exit 0", timeout: 0 })
       const event = Array.from(yield* Fiber.join(eventFiber))[0]
+      const created = event?.data.info
 
-      expect(event?.data.info.id).toBe(info.id)
-      expect(typeof event?.data.info.pid).toBe("number")
-      expect(event?.data.info.pid).toBe(info.pid)
-      yield* shell.wait(info.id)
+      expect(created?.id).toBe(info.id)
+      expect(created?.pid).toBe(4242)
+      expect(created?.status).toBe("running")
+      expect(created?.exit).toBeUndefined()
+      expect(created?.time.completed).toBeUndefined()
+
+      const terminal = yield* shell.wait(info.id)
+      expect(terminal.pid).toBe(created?.pid)
+      expect(terminal.status).toBe("exited")
+      expect(terminal.exit).toBe(0)
+      expect(terminal.time.completed).toBeDefined()
     }),
   )
 
@@ -110,9 +149,10 @@ describe("shell", () => {
     })
 
     test("normalizes Git Bash shell paths from env", async () => {
-      const shell = "/cygdrive/c/Program Files/Git/bin/bash.exe"
-      await withShell(shell, async () => {
-        expect(ShellSelect.preferred()).toBe(FSUtil.windowsPath(shell))
+      const bash = ShellSelect.gitbash()
+      if (!bash) return
+      await withShell("NU.EXE", async () => {
+        expect(ShellSelect.name(ShellSelect.acceptable())).not.toBe("nu")
       })
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #43078

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Publishes the post-spawn shell info in `shell.created`, so event subscribers receive the spawned process PID. Adds regression coverage verifying the event PID matches the PID returned by `shell.create()`.

### How did you verify your code works?

- `bun test test/shell.test.ts`
- `bun typecheck`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR