### PR TITLE
fix(core): exclude native code mode MCP servers

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -65,6 +65,7 @@ import { AgentPlugin } from "./agent.js"
 import { CommandPlugin } from "./command.js"
 import { PlanPlugin } from "./plan.js"
 import { ModelsDevPlugin } from "./models-dev.js"
+import { MCPCodeModeExclusionPlugin } from "./mcp-codemode-exclusion.js"
 import { ProviderPlugins } from "./provider.js"
 import { WebSearchPlugins } from "./websearch/index.js"
 import { PluginRuntime } from "./runtime.js"
@@ -201,6 +202,7 @@ export type InternalPlugin = Plugin<Requirements | Scope.Scope>
 
 const pre = [
   ConfigMCPPlugin.Plugin,
+  MCPCodeModeExclusionPlugin.Plugin,
   WellKnownPlugin.Plugin,
   AgentPlugin.Plugin,
   PlanPlugin.Plugin,

--- a/packages/core/src/plugin/mcp-codemode-exclusion.ts
+++ b/packages/core/src/plugin/mcp-codemode-exclusion.ts
@@ -1,0 +1,26 @@
+export * as MCPCodeModeExclusionPlugin from "./mcp-codemode-exclusion.js"
+
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Effect } from "effect"
+
+// These servers provide Code Mode, so expose them directly instead of nesting them inside OpenCode Code Mode.
+const urls = [/^https:\/\/mcp\.cloudflare\.com\/mcp$/, /^https:\/\/executor\.sh\/[^/]+\/mcp$/]
+
+export const Plugin = define({
+  id: "opencode.mcp.codemode-exclusion",
+  effect: Effect.fn(function* (ctx) {
+    yield* ctx.mcp.transform((draft) => {
+      for (const [, server] of draft.list()) {
+        if (server.codemode !== undefined) continue
+        if (server.type === "local") {
+          if (server.command[0] === "executor" && server.command[1] === "mcp") server.codemode = false
+          continue
+        }
+        if (!URL.canParse(server.url)) continue
+        const url = new URL(server.url)
+        const endpoint = `${url.origin}${url.pathname.replace(/\/+$/, "")}`
+        if (urls.some((pattern) => pattern.test(endpoint))) server.codemode = false
+      }
+    })
+  }),
+})

--- a/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
+++ b/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
@@ -7,16 +7,43 @@ import { host } from "./host"
 
 it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
   Effect.gen(function* () {
-    const servers: Record<string, Types.DeepMutable<Mcp.ServerConfig>> = {
-      executor: { type: "remote", url: "https://executor.sh/example/mcp?source=opencode" },
-      "executor-local": { type: "local", command: ["executor", "mcp"] },
-      cloudflare: { type: "remote", url: "https://mcp.cloudflare.com/mcp/" },
-      "cloudflare-docs": { type: "remote", url: "https://docs.mcp.cloudflare.com/mcp" },
-      explicit: { type: "remote", url: "https://mcp.cloudflare.com/mcp", codemode: true },
-      "explicit-false": { type: "remote", url: "https://executor.sh/example/mcp", codemode: false },
-      exa: { type: "remote", url: "https://mcp.exa.ai/mcp" },
-      unrelated: { type: "remote", url: "https://example.com/mcp" },
-    }
+    const cases: Array<{
+      name: string
+      server: Types.DeepMutable<Mcp.ServerConfig>
+      codemode: boolean | undefined
+    }> = [
+      {
+        name: "executor remote",
+        server: { type: "remote", url: "https://executor.sh/example/mcp?source=opencode" },
+        codemode: false,
+      },
+      { name: "executor local", server: { type: "local", command: ["executor", "mcp"] }, codemode: false },
+      {
+        name: "cloudflare code mode",
+        server: { type: "remote", url: "https://mcp.cloudflare.com/mcp/" },
+        codemode: false,
+      },
+      {
+        name: "cloudflare docs",
+        server: { type: "remote", url: "https://docs.mcp.cloudflare.com/mcp" },
+        codemode: undefined,
+      },
+      {
+        name: "explicit true",
+        server: { type: "remote", url: "https://mcp.cloudflare.com/mcp", codemode: true },
+        codemode: true,
+      },
+      {
+        name: "explicit false",
+        server: { type: "remote", url: "https://executor.sh/example/mcp", codemode: false },
+        codemode: false,
+      },
+      { name: "exa", server: { type: "remote", url: "https://mcp.exa.ai/mcp" }, codemode: undefined },
+      { name: "unrelated", server: { type: "remote", url: "https://example.com/mcp" }, codemode: undefined },
+    ]
+    const servers: Record<string, Types.DeepMutable<Mcp.ServerConfig>> = Object.fromEntries(
+      cases.map((test) => [test.name, test.server]),
+    )
     const base = host()
 
     yield* MCPCodeModeExclusionPlugin.Plugin.effect(
@@ -45,13 +72,6 @@ it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
       }),
     )
 
-    expect(servers.executor?.codemode).toBe(false)
-    expect(servers["executor-local"]?.codemode).toBe(false)
-    expect(servers.cloudflare?.codemode).toBe(false)
-    expect(servers["cloudflare-docs"]?.codemode).toBeUndefined()
-    expect(servers.explicit?.codemode).toBe(true)
-    expect(servers["explicit-false"]?.codemode).toBe(false)
-    expect(servers.exa?.codemode).toBeUndefined()
-    expect(servers.unrelated?.codemode).toBeUndefined()
+    cases.forEach((test) => expect(servers[test.name]?.codemode).toBe(test.codemode))
   }),
 )

--- a/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
+++ b/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "bun:test"
+import { MCPCodeModeExclusionPlugin } from "@opencode-ai/core/plugin/mcp-codemode-exclusion"
+import type { Mcp } from "@opencode-ai/schema/mcp"
+import { Effect, type Types } from "effect"
+import { it } from "../lib/effect"
+import { host } from "./host"
+
+it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
+  Effect.gen(function* () {
+    const servers: Record<string, Types.DeepMutable<Mcp.ServerConfig>> = {
+      executor: { type: "remote", url: "https://executor.sh/example/mcp?source=opencode" },
+      "executor-local": { type: "local", command: ["executor", "mcp"] },
+      cloudflare: { type: "remote", url: "https://mcp.cloudflare.com/mcp/" },
+      "cloudflare-docs": { type: "remote", url: "https://docs.mcp.cloudflare.com/mcp" },
+      explicit: { type: "remote", url: "https://mcp.cloudflare.com/mcp", codemode: true },
+      "explicit-false": { type: "remote", url: "https://executor.sh/example/mcp", codemode: false },
+      exa: { type: "remote", url: "https://mcp.exa.ai/mcp" },
+      unrelated: { type: "remote", url: "https://example.com/mcp" },
+    }
+    const base = host()
+
+    yield* MCPCodeModeExclusionPlugin.Plugin.effect(
+      host({
+        mcp: {
+          ...base.mcp,
+          transform: (transform) =>
+            Effect.sync(() => {
+              transform({
+                list: () => Object.entries(servers),
+                get: (name) => servers[name],
+                set: () => {
+                  throw new Error("unused")
+                },
+                update: (name, update) => {
+                  const server = servers[name]
+                  if (server) update(server)
+                },
+                remove: (name) => {
+                  delete servers[name]
+                },
+              })
+              return { dispose: Effect.void }
+            }),
+        },
+      }),
+    )
+
+    expect(servers.executor?.codemode).toBe(false)
+    expect(servers["executor-local"]?.codemode).toBe(false)
+    expect(servers.cloudflare?.codemode).toBe(false)
+    expect(servers["cloudflare-docs"]?.codemode).toBeUndefined()
+    expect(servers.explicit?.codemode).toBe(true)
+    expect(servers["explicit-false"]?.codemode).toBe(false)
+    expect(servers.exa?.codemode).toBeUndefined()
+    expect(servers.unrelated?.codemode).toBeUndefined()
+  }),
+)


### PR DESCRIPTION
## Summary

- add an internal MCP Code Mode exclusion plugin
- expose Executor and the Cloudflare API MCP server directly by default
- preserve explicit Code Mode settings and leave Cloudflare product-specific servers unchanged

## Tests

- `bun test test/plugin/mcp-codemode-exclusion.test.ts`
- `bun test test/config/plugin.test.ts`
- `bun typecheck`