### PR TITLE
feat(core): resume subagent sessions

### DIFF
--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -9,7 +9,6 @@ import { Location } from "../location.js"
 import { LocationServiceMap } from "../location-service-map.js"
 import { MCP } from "../mcp/index.js"
 import { Session } from "../session.js"
-import { SessionExecution } from "../session/execution.js"
 
 export interface Interface {
   readonly session: Pick<
@@ -22,10 +21,12 @@ export interface Interface {
     | "command"
     | "rename"
     | "resume"
+    | "switchAgent"
+    | "switchModel"
     | "interrupt"
     | "synthetic"
     | "wait"
-  > & { readonly wakeActive: SessionExecution.Interface["wakeActive"] }
+  >
   readonly job: Pick<Job.Interface, "start" | "wait" | "block" | "background" | "cancel">
   readonly location: {
     readonly agent: {
@@ -76,7 +77,8 @@ export const layerWithCell = (cell: Cell) =>
         command: (input) => require(cell, (runtime) => runtime.session.command(input)),
         rename: (input) => require(cell, (runtime) => runtime.session.rename(input)),
         resume: (sessionID) => require(cell, (runtime) => runtime.session.resume(sessionID)),
-        wakeActive: (sessionID) => require(cell, (runtime) => runtime.session.wakeActive(sessionID)),
+        switchAgent: (input) => require(cell, (runtime) => runtime.session.switchAgent(input)),
+        switchModel: (input) => require(cell, (runtime) => runtime.session.switchModel(input)),
         interrupt: (sessionID) => require(cell, (runtime) => runtime.session.interrupt(sessionID)),
         synthetic: (input) => require(cell, (runtime) => runtime.session.synthetic(input)),
         wait: (sessionID) => require(cell, (runtime) => runtime.session.wait(sessionID)),
@@ -107,11 +109,10 @@ export const providerLayerWithCell = (cell: Cell) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const sessions = yield* Session.Service
-      const execution = yield* SessionExecution.Service
       const jobs = yield* Job.Service
       const locations = yield* LocationServiceMap.Service
       const runtime: Interface = {
-        session: { ...sessions, wakeActive: execution.wakeActive },
+        session: sessions,
         job: jobs,
         location: {
           agent: {
@@ -173,7 +174,7 @@ export const providerNodeWithCell = (cell: Cell) =>
   makeGlobalNode({
     name: "plugin-runtime-provider",
     layer: providerLayerWithCell(cell),
-    deps: [node, Session.node, SessionExecution.node, Job.node, LocationServiceMap.node],
+    deps: [node, Session.node, Job.node, LocationServiceMap.node],
   })
 
 export const providerNode = providerNodeWithCell(defaultCell)

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -9,6 +9,7 @@ import { Location } from "../location.js"
 import { LocationServiceMap } from "../location-service-map.js"
 import { MCP } from "../mcp/index.js"
 import { Session } from "../session.js"
+import { SessionExecution } from "../session/execution.js"
 
 export interface Interface {
   readonly session: Pick<
@@ -24,7 +25,7 @@ export interface Interface {
     | "interrupt"
     | "synthetic"
     | "wait"
-  >
+  > & { readonly wakeActive: SessionExecution.Interface["wakeActive"] }
   readonly job: Pick<Job.Interface, "start" | "wait" | "block" | "background" | "cancel">
   readonly location: {
     readonly agent: {
@@ -75,6 +76,7 @@ export const layerWithCell = (cell: Cell) =>
         command: (input) => require(cell, (runtime) => runtime.session.command(input)),
         rename: (input) => require(cell, (runtime) => runtime.session.rename(input)),
         resume: (sessionID) => require(cell, (runtime) => runtime.session.resume(sessionID)),
+        wakeActive: (sessionID) => require(cell, (runtime) => runtime.session.wakeActive(sessionID)),
         interrupt: (sessionID) => require(cell, (runtime) => runtime.session.interrupt(sessionID)),
         synthetic: (input) => require(cell, (runtime) => runtime.session.synthetic(input)),
         wait: (sessionID) => require(cell, (runtime) => runtime.session.wait(sessionID)),
@@ -105,10 +107,11 @@ export const providerLayerWithCell = (cell: Cell) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const sessions = yield* Session.Service
+      const execution = yield* SessionExecution.Service
       const jobs = yield* Job.Service
       const locations = yield* LocationServiceMap.Service
       const runtime: Interface = {
-        session: sessions,
+        session: { ...sessions, wakeActive: execution.wakeActive },
         job: jobs,
         location: {
           agent: {
@@ -170,7 +173,7 @@ export const providerNodeWithCell = (cell: Cell) =>
   makeGlobalNode({
     name: "plugin-runtime-provider",
     layer: providerLayerWithCell(cell),
-    deps: [node, Session.node, Job.node, LocationServiceMap.node],
+    deps: [node, Session.node, SessionExecution.node, Job.node, LocationServiceMap.node],
   })
 
 export const providerNode = providerNodeWithCell(defaultCell)

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -14,7 +14,7 @@ export const name = "subagent"
 const NO_TEXT = "Subagent completed without a text response."
 const backgroundStarted = (sessionID: SessionSchema.ID) =>
   [
-    `The subagent is working in the background (id: ${sessionID}). You will be notified automatically when it finishes.`,
+    `The subagent is working in the background (sessionID: ${sessionID}). You will be notified automatically when it finishes.`,
     "DO NOT sleep, poll for progress, ask the subagent for status, or duplicate this subagent's work; avoid working with the same files or topics it is using.",
     "Work on non-overlapping tasks, or briefly tell the user what you launched and end your response.",
   ].join("\n")

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -23,6 +23,10 @@ export const Input = Schema.Struct({
   agent: Schema.String.annotate({ description: "The type of specialized agent to use for this task" }),
   description: Schema.String.annotate({ description: "A short 3-5 word label for the task, displayed to the user" }),
   prompt: Schema.String.annotate({ description: "The task for the subagent to perform" }),
+  sessionID: Schema.optionalKey(SessionSchema.ID).annotate({
+    description:
+      "Continue a specific previous subagent conversation by passing its sessionID. Calls without a sessionID start a new conversation.",
+  }),
   background: Schema.optionalKey(Schema.Boolean).annotate({
     description:
       "Run the subagent in the background and return immediately. You will be notified when it completes. DO NOT sleep, poll, or proactively check on its progress.",
@@ -36,7 +40,8 @@ export const Output = Schema.Struct({
 })
 export const description = [
   "Spawns an agent in a child session to work on the specified task.",
-  "Include all relevant context and instructions in the prompt because the child starts with fresh context.",
+  "The output includes a sessionID you can pass back later to continue that specific conversation with the subagent.",
+  "New child sessions start with fresh context, so include all relevant context and instructions when you don't pass a sessionID.",
   "Foreground (default) runs the subagent to completion and returns its final response.",
   "Background mode (background=true) launches it asynchronously and returns immediately; you are notified when it finishes.",
   "Use background only for independent work that can run while you continue elsewhere.",
@@ -50,6 +55,7 @@ export const Plugin = {
     const config = yield* Config.Service
     const permission = yield* Permission.Service
     const scope = yield* Scope.Scope
+    const notifications = new Set<SessionSchema.ID>()
 
     // Concatenate the child's final completed assistant text. Distinguishes "completed with no
     // text" (generic string) from "failed" (the run effect fails, surfaced as a job error).
@@ -77,7 +83,7 @@ export const Plugin = {
     ) {
       yield* runtime.session.synthetic({
         sessionID: parentID,
-        text: `<subagent id="${childID}" state="${state}" description="${description}">\n${text}\n</subagent>`,
+        text: `<subagent sessionID="${childID}" state="${state}" description="${description}">\n${text}\n</subagent>`,
         description,
         metadata: { source: "subagent", childID, agent, state },
       })
@@ -89,6 +95,8 @@ export const Plugin = {
       agent: string,
       description: string,
     ) {
+      if (notifications.has(childID)) return
+      notifications.add(childID)
       yield* runtime.job.wait({ id: childID }).pipe(
         Effect.flatMap((result) => {
           if (result.info?.status === "completed")
@@ -106,6 +114,7 @@ export const Plugin = {
             return injectCompletion(parentID, childID, agent, description, "cancelled", "Subagent cancelled")
           return Effect.void
         }),
+        Effect.ensuring(Effect.sync(() => notifications.delete(childID))),
         Effect.forkIn(scope, { startImmediately: true }),
       )
     })
@@ -163,33 +172,66 @@ export const Plugin = {
                 })
                 .pipe(Effect.mapError((error) => new ToolFailure({ message: `Subagent denied: ${agent.id}`, error })))
 
+              const existing =
+                input.sessionID === undefined
+                  ? undefined
+                  : yield* runtime.session
+                      .get(input.sessionID)
+                      .pipe(
+                        Effect.mapError(
+                          (error) =>
+                            new ToolFailure({ message: `Subagent session not found: ${input.sessionID}`, error }),
+                        ),
+                      )
+              if (existing !== undefined && existing.parentID !== context.sessionID)
+                return yield* new ToolFailure({
+                  message: `Session ${existing.id} is not a child of the current session`,
+                })
+              if (existing !== undefined && existing.agent !== agent.id)
+                return yield* new ToolFailure({
+                  message: `Session ${existing.id} belongs to agent ${existing.agent ?? "unknown"}, not ${agent.id}`,
+                })
+
               // Model selection is policy/config/session state, not an LLM-facing tool argument.
               const model = agent.model ?? parent.model
-              const child = yield* runtime.session
-                .create({
-                  parentID: context.sessionID,
-                  title: input.description,
-                  agent: Agent.ID.make(input.agent),
-                  model,
-                  // TODO(opencode kkdvxn): derive restricted subagent permissions from the parent
-                  // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
-                })
-                .pipe(
-                  Effect.mapError(
-                    (error) => new ToolFailure({ message: `Parent session not found: ${context.sessionID}`, error }),
-                  ),
-                )
+              const child =
+                existing ??
+                (yield* runtime.session
+                  .create({
+                    parentID: context.sessionID,
+                    title: input.description,
+                    agent: Agent.ID.make(input.agent),
+                    model,
+                    // TODO(opencode kkdvxn): derive restricted subagent permissions from the parent
+                    // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
+                  })
+                  .pipe(
+                    Effect.mapError(
+                      (error) => new ToolFailure({ message: `Parent session not found: ${context.sessionID}`, error }),
+                    ),
+                  ))
 
               const background = input.background === true
               yield* context.progress({ sessionID: child.id, status: "running" })
 
-              const run = Effect.gen(function* () {
-                // The child session owns its agent/model (set at create); prompt only admits input.
-                yield* runtime.session.prompt({
+              // Admit every follow-up even when Job.start joins an existing child job.
+              yield* runtime.session
+                .prompt({
                   sessionID: child.id,
-                  text: ["You are a subagent spawned by another session.", input.prompt].join("\n"),
+                  text:
+                    existing === undefined
+                      ? ["You are a subagent spawned by another session.", input.prompt].join("\n")
+                      : input.prompt,
                   resume: false,
                 })
+                .pipe(
+                  Effect.mapError(
+                    (error) => new ToolFailure({ message: `Failed to prompt subagent: ${child.id}`, error }),
+                  ),
+                )
+              yield* runtime.session.wakeActive(child.id)
+
+              const run = Effect.gen(function* () {
                 yield* runtime.session.resume(child.id)
                 return yield* latestAssistantText(child.id)
               }).pipe(Effect.onInterrupt(() => runtime.session.interrupt(child.id)))
@@ -212,13 +254,21 @@ export const Plugin = {
                 }
               }
 
-              const result = yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
-                Effect.onInterrupt(() =>
-                  Effect.all([runtime.session.interrupt(child.id), runtime.job.cancel(child.id)], {
-                    discard: true,
-                  }),
-                ),
-              )
+              const result = notifications.has(child.id)
+                ? yield* runtime.job
+                    .wait({ id: child.id })
+                    .pipe(
+                      Effect.map((result) =>
+                        result.info === undefined ? undefined : { type: "finished" as const, info: result.info },
+                      ),
+                    )
+                : yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
+                    Effect.onInterrupt(() =>
+                      Effect.all([runtime.session.interrupt(child.id), runtime.job.cancel(child.id)], {
+                        discard: true,
+                      }),
+                    ),
+                  )
               if (result?.type === "backgrounded") {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {
@@ -234,7 +284,10 @@ export const Plugin = {
             }).pipe(
               Effect.map((output) => ({
                 output,
-                content: output.output,
+                content:
+                  output.status === "completed"
+                    ? `<subagent sessionID="${output.sessionID}" state="completed">\n${output.output}\n</subagent>`
+                    : output.output,
                 metadata: { sessionID: output.sessionID, status: output.status },
               })),
             ),

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -55,7 +55,9 @@ export const Plugin = {
     const config = yield* Config.Service
     const permission = yield* Permission.Service
     const scope = yield* Scope.Scope
-    const notifications = new Set<SessionSchema.ID>()
+    // One completion observer per job generation. Keyed by child plus start time so a fresh
+    // continuation job is observable even while a settled generation's observer is finalizing.
+    const notifications = new Set<string>()
 
     // Concatenate the child's final completed assistant text. Distinguishes "completed with no
     // text" (generic string) from "failed" (the run effect fails, surfaced as a job error).
@@ -94,9 +96,11 @@ export const Plugin = {
       childID: SessionSchema.ID,
       agent: string,
       description: string,
+      startedAt: number,
     ) {
-      if (notifications.has(childID)) return
-      notifications.add(childID)
+      const key = `${childID}:${startedAt}`
+      if (notifications.has(key)) return
+      notifications.add(key)
       yield* runtime.job.wait({ id: childID }).pipe(
         Effect.flatMap((result) => {
           if (result.info?.status === "completed")
@@ -114,7 +118,7 @@ export const Plugin = {
             return injectCompletion(parentID, childID, agent, description, "cancelled", "Subagent cancelled")
           return Effect.void
         }),
-        Effect.ensuring(Effect.sync(() => notifications.delete(childID))),
+        Effect.ensuring(Effect.sync(() => notifications.delete(key))),
         Effect.forkIn(scope, { startImmediately: true }),
       )
     })
@@ -197,7 +201,8 @@ export const Plugin = {
                       : runtime.session.switchModel({ sessionID: existing.id, model: agent.model }),
                   ),
                   Effect.mapError(
-                    (error) => new ToolFailure({ message: `Subagent session not found: ${existing.id}`, error }),
+                    (error) =>
+                      new ToolFailure({ message: `Failed to switch subagent session agent: ${existing.id}`, error }),
                   ),
                 )
               }
@@ -255,7 +260,7 @@ export const Plugin = {
 
               if (background) {
                 yield* runtime.job.background(info.id)
-                yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
+                yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description, info.started_at)
                 return {
                   sessionID: child.id,
                   status: "running" as const,
@@ -271,16 +276,26 @@ export const Plugin = {
                 ),
               )
               if (result?.type === "backgrounded") {
-                yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
+                yield* notifyWhenDone(
+                  context.sessionID,
+                  child.id,
+                  agent.name,
+                  input.description,
+                  result.info.started_at,
+                )
                 return {
                   sessionID: child.id,
                   status: "running" as const,
                   output: backgroundStarted(child.id),
                 }
               }
+              // Failure surfaces keep the sessionID visible so the model can continue the child.
               if (result?.info.status === "error")
-                return yield* new ToolFailure({ message: result.info.error ?? "Subagent failed" })
-              if (result?.info.status === "cancelled") return yield* new ToolFailure({ message: "Subagent cancelled" })
+                return yield* new ToolFailure({
+                  message: `Subagent failed (sessionID: ${child.id}): ${result.info.error ?? "unknown error"}`,
+                })
+              if (result?.info.status === "cancelled")
+                return yield* new ToolFailure({ message: `Subagent cancelled (sessionID: ${child.id})` })
               return { sessionID: child.id, status: "completed" as const, output: result?.info.output ?? NO_TEXT }
             }).pipe(
               Effect.map((output) => ({

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -217,8 +217,6 @@ export const Plugin = {
                     title: input.description,
                     agent: Agent.ID.make(input.agent),
                     model,
-                    // TODO(opencode kkdvxn): derive restricted subagent permissions from the parent
-                    // session (V1 deriveSubagentSessionPermission). MVP uses the agent's own permissions.
                   })
                   .pipe(
                     Effect.mapError(

--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -187,10 +187,20 @@ export const Plugin = {
                 return yield* new ToolFailure({
                   message: `Session ${existing.id} is not a child of the current session`,
                 })
-              if (existing !== undefined && existing.agent !== agent.id)
-                return yield* new ToolFailure({
-                  message: `Session ${existing.id} belongs to agent ${existing.agent ?? "unknown"}, not ${agent.id}`,
-                })
+              // Continuing with a different agent switches the child, mirroring create semantics
+              // where the agent's configured model wins over the inherited one.
+              if (existing !== undefined && existing.agent !== agent.id) {
+                yield* runtime.session.switchAgent({ sessionID: existing.id, agent: agent.id }).pipe(
+                  Effect.andThen(
+                    agent.model === undefined
+                      ? Effect.void
+                      : runtime.session.switchModel({ sessionID: existing.id, model: agent.model }),
+                  ),
+                  Effect.mapError(
+                    (error) => new ToolFailure({ message: `Subagent session not found: ${existing.id}`, error }),
+                  ),
+                )
+              }
 
               // Model selection is policy/config/session state, not an LLM-facing tool argument.
               const model = agent.model ?? parent.model
@@ -214,7 +224,8 @@ export const Plugin = {
               const background = input.background === true
               yield* context.progress({ sessionID: child.id, status: "running" })
 
-              // Admit every follow-up even when Job.start joins an existing child job.
+              // Standard prompt admission outside the job: Job.start joining a running child skips
+              // its run effect, and the default wake starts an idle child or steers a running one.
               yield* runtime.session
                 .prompt({
                   sessionID: child.id,
@@ -222,14 +233,12 @@ export const Plugin = {
                     existing === undefined
                       ? ["You are a subagent spawned by another session.", input.prompt].join("\n")
                       : input.prompt,
-                  resume: false,
                 })
                 .pipe(
                   Effect.mapError(
                     (error) => new ToolFailure({ message: `Failed to prompt subagent: ${child.id}`, error }),
                   ),
                 )
-              yield* runtime.session.wakeActive(child.id)
 
               const run = Effect.gen(function* () {
                 yield* runtime.session.resume(child.id)
@@ -254,21 +263,13 @@ export const Plugin = {
                 }
               }
 
-              const result = notifications.has(child.id)
-                ? yield* runtime.job
-                    .wait({ id: child.id })
-                    .pipe(
-                      Effect.map((result) =>
-                        result.info === undefined ? undefined : { type: "finished" as const, info: result.info },
-                      ),
-                    )
-                : yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
-                    Effect.onInterrupt(() =>
-                      Effect.all([runtime.session.interrupt(child.id), runtime.job.cancel(child.id)], {
-                        discard: true,
-                      }),
-                    ),
-                  )
+              const result = yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
+                Effect.onInterrupt(() =>
+                  Effect.all([runtime.session.interrupt(child.id), runtime.job.cancel(child.id)], {
+                    discard: true,
+                  }),
+                ),
+              )
               if (result?.type === "backgrounded") {
                 yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                 return {

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -567,7 +567,7 @@ describe("SubagentTool", () => {
             status: "running",
           })
           expect(settled.metadata).toEqual({ sessionID: childID, status: "running" })
-          expect(settled.content).toEqual([{ type: "text", text: expect.stringContaining(`id: ${childID}`) }])
+          expect(settled.content).toEqual([{ type: "text", text: expect.stringContaining(`sessionID: ${childID}`) }])
 
           const admission = Array.from(yield* Fiber.join(admitted))[0]
           expect(admission?.data.item.type).toBe("synthetic")

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -437,7 +437,7 @@ describe("SubagentTool", () => {
     ),
   )
 
-  it.live("rejects unrelated and mismatched child sessions", () =>
+  it.live("rejects unrelated children and switches agents on continuation", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
@@ -453,10 +453,11 @@ describe("SubagentTool", () => {
             title: "other review",
             agent: Agent.ID.make("reviewer"),
           })
-          const mismatched = yield* sessions.create({
+          const switched = yield* sessions.create({
             parentID: parent.id,
             title: "fallback review",
             agent: Agent.ID.make("fallback"),
+            model: parentModel,
           })
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
@@ -480,12 +481,13 @@ describe("SubagentTool", () => {
               message: `Session ${unrelated.id} is not a child of the current session`,
             },
           })
-          expect(yield* call(mismatched.id, "call-mismatched-child")).toEqual({
-            status: "error",
-            error: {
-              type: "tool.execution",
-              message: `Session ${mismatched.id} belongs to agent fallback, not reviewer`,
-            },
+          expect(yield* call(switched.id, "call-switched-child")).toMatchObject({
+            status: "completed",
+            metadata: { sessionID: switched.id, status: "completed" },
+          })
+          expect(yield* sessions.get(switched.id)).toMatchObject({
+            agent: "reviewer",
+            model: childModel,
           })
         }),
       ),

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -462,7 +462,7 @@ describe("SubagentTool", () => {
           yield* withSubagent(parent.location)
           const locations = yield* LocationServiceMap.Service
           const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
-          const call = (sessionID: Session.ID, id: string) =>
+          const call = (sessionID: Session.ID, id: string, agent = "reviewer") =>
             executeTool(registry, {
               sessionID: parent.id,
               ...toolIdentity,
@@ -470,10 +470,18 @@ describe("SubagentTool", () => {
                 type: "tool-call" as const,
                 id,
                 name: SubagentTool.name,
-                input: { agent: "reviewer", description: "follow up", prompt: "continue", sessionID },
+                input: { agent, description: "follow up", prompt: "continue", sessionID },
               },
             })
 
+          const missing = Session.ID.create()
+          expect(yield* call(missing, "call-missing-child")).toEqual({
+            status: "error",
+            error: {
+              type: "tool.execution",
+              message: `Subagent session not found: ${missing}`,
+            },
+          })
           expect(yield* call(unrelated.id, "call-unrelated-child")).toEqual({
             status: "error",
             error: {
@@ -487,6 +495,15 @@ describe("SubagentTool", () => {
           })
           expect(yield* sessions.get(switched.id)).toMatchObject({
             agent: "reviewer",
+            model: childModel,
+          })
+          // Switching to an agent without a configured model keeps the child's current model.
+          expect(yield* call(switched.id, "call-modelless-switch", "fallback")).toMatchObject({
+            status: "completed",
+            metadata: { sessionID: switched.id, status: "completed" },
+          })
+          expect(yield* sessions.get(switched.id)).toMatchObject({
+            agent: "fallback",
             model: childModel,
           })
         }),

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -34,6 +34,8 @@ import { testEffect } from "./lib/effect"
 import { executeTool, registerToolPlugin, toolIdentity } from "./lib/tool"
 
 const childText = "child final response"
+const completedOutput = (sessionID: Session.ID) =>
+  `<subagent sessionID="${sessionID}" state="completed">\n${childText}\n</subagent>`
 const childModel = Model.Ref.make({ id: Model.ID.make("child"), providerID: Provider.ID.make("test") })
 const parentModel = Model.Ref.make({ id: Model.ID.make("parent"), providerID: Provider.ID.make("test") })
 const tokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
@@ -252,7 +254,7 @@ describe("SubagentTool", () => {
           expect(settled).toMatchObject({
             status: "completed",
             metadata: { status: "completed" },
-            content: [{ type: "text", text: childText }],
+            content: [{ type: "text", text: expect.stringContaining(childText) }],
           })
           expect(settled.metadata).toEqual({
             sessionID: outputSessionID(settled.metadata),
@@ -294,9 +296,10 @@ describe("SubagentTool", () => {
           expect(settled).toMatchObject({
             status: "completed",
             metadata: { status: "completed" },
-            content: [{ type: "text", text: childText }],
+            content: [{ type: "text", text: expect.stringContaining(childText) }],
           })
           const child = yield* sessions.get(outputSessionID(settled.metadata))
+          expect(settled.content).toEqual([{ type: "text", text: completedOutput(child.id) }])
           expect(settled.metadata).toEqual({ sessionID: child.id, status: "completed" })
           expect(progress[0]).toEqual({ sessionID: child.id, status: "running" })
           expect(child).toMatchObject({
@@ -321,6 +324,169 @@ describe("SubagentTool", () => {
           })
           const fallbackChild = yield* sessions.get(outputSessionID(fallback.metadata))
           expect(fallbackChild).toMatchObject({ parentID: parent.id, model: parentModel })
+        }),
+      ),
+    ),
+  )
+
+  it.live("continues an existing child session", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path) })
+          const sessions = yield* Session.Service
+          const parent = yield* sessions.create({ location, model: parentModel })
+          yield* withSubagent(parent.location)
+          const locations = yield* LocationServiceMap.Service
+          const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
+
+          const first = yield* executeTool(registry, {
+            sessionID: parent.id,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-subagent-first",
+              name: SubagentTool.name,
+              input: { agent: "reviewer", description: "review", prompt: "review this" },
+            },
+          })
+          const childID = outputSessionID(first.metadata)
+          const second = yield* executeTool(registry, {
+            sessionID: parent.id,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-subagent-second",
+              name: SubagentTool.name,
+              input: {
+                agent: "reviewer",
+                description: "follow up",
+                prompt: "continue this",
+                sessionID: childID,
+              },
+            },
+          })
+
+          expect(outputSessionID(second.metadata)).toBe(childID)
+          expect((yield* sessions.list({ parentID: parent.id })).data).toHaveLength(1)
+          expect((yield* sessions.get(childID)).title).toBe("review")
+          expect(
+            (yield* sessions.inbox(childID)).flatMap((message) =>
+              message.type === "user" ? [message.payload.text] : [],
+            ),
+          ).toEqual(["You are a subagent spawned by another session.\nreview this", "continue this"])
+          expect(second.content).toEqual([{ type: "text", text: completedOutput(childID) }])
+        }),
+      ),
+    ),
+  )
+
+  it.live("steers a running child session in the background", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path) })
+          const sessions = yield* Session.Service
+          const parent = yield* sessions.create({ location, model: parentModel })
+          const child = yield* sessions.create({
+            parentID: parent.id,
+            title: "review",
+            agent: Agent.ID.make("reviewer"),
+            model: childModel,
+          })
+          yield* withSubagent(parent.location)
+          const locations = yield* LocationServiceMap.Service
+          const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
+          const jobs = yield* Job.Service
+          yield* jobs.start({ id: child.id, type: SubagentTool.name, run: Effect.never })
+
+          const result = yield* executeTool(registry, {
+            sessionID: parent.id,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-running-subagent",
+              name: SubagentTool.name,
+              input: {
+                agent: "reviewer",
+                description: "follow up",
+                prompt: "continue while running",
+                sessionID: child.id,
+                background: true,
+              },
+            },
+          })
+
+          expect(result).toMatchObject({
+            status: "completed",
+            metadata: { sessionID: child.id, status: "running" },
+          })
+          expect((yield* sessions.inbox(child.id)).find((message) => message.type === "user")?.payload.text).toBe(
+            "continue while running",
+          )
+          expect((yield* jobs.get(child.id))?.status).toBe("running")
+          yield* jobs.cancel(child.id)
+        }),
+      ),
+    ),
+  )
+
+  it.live("rejects unrelated and mismatched child sessions", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path) })
+          const sessions = yield* Session.Service
+          const parent = yield* sessions.create({ location, model: parentModel })
+          const otherParent = yield* sessions.create({ location, model: parentModel })
+          const unrelated = yield* sessions.create({
+            parentID: otherParent.id,
+            title: "other review",
+            agent: Agent.ID.make("reviewer"),
+          })
+          const mismatched = yield* sessions.create({
+            parentID: parent.id,
+            title: "fallback review",
+            agent: Agent.ID.make("fallback"),
+          })
+          yield* withSubagent(parent.location)
+          const locations = yield* LocationServiceMap.Service
+          const registry = yield* Tool.Service.pipe(Effect.provide(locations.get(parent.location)))
+          const call = (sessionID: Session.ID, id: string) =>
+            executeTool(registry, {
+              sessionID: parent.id,
+              ...toolIdentity,
+              call: {
+                type: "tool-call" as const,
+                id,
+                name: SubagentTool.name,
+                input: { agent: "reviewer", description: "follow up", prompt: "continue", sessionID },
+              },
+            })
+
+          expect(yield* call(unrelated.id, "call-unrelated-child")).toEqual({
+            status: "error",
+            error: {
+              type: "tool.execution",
+              message: `Session ${unrelated.id} is not a child of the current session`,
+            },
+          })
+          expect(yield* call(mismatched.id, "call-mismatched-child")).toEqual({
+            status: "error",
+            error: {
+              type: "tool.execution",
+              message: `Session ${mismatched.id} belongs to agent fallback, not reviewer`,
+            },
+          })
         }),
       ),
     ),
@@ -404,7 +570,7 @@ describe("SubagentTool", () => {
           const admission = Array.from(yield* Fiber.join(admitted))[0]
           expect(admission?.data.item.type).toBe("synthetic")
           if (admission?.data.item.type !== "synthetic") return yield* Effect.die("Expected synthetic inbox item")
-          expect(admission?.data.item.payload.text).toContain(`<subagent id="${childID}" state="completed"`)
+          expect(admission?.data.item.payload.text).toContain(`<subagent sessionID="${childID}" state="completed"`)
           expect(admission?.data.item.payload).toMatchObject({
             description: "background review",
             metadata: {
@@ -418,7 +584,7 @@ describe("SubagentTool", () => {
           yield* SessionInbox.promote(database.db, bus, parent.id, "steer")
           const synthetic = (yield* sessions.context(parent.id)).filter((message) => message.type === "synthetic")
           expect(synthetic).toHaveLength(1)
-          expect(synthetic[0]?.text).toContain(`<subagent id="${childID}" state="completed"`)
+          expect(synthetic[0]?.text).toContain(`<subagent sessionID="${childID}" state="completed"`)
           expect(synthetic[0]?.text).toContain(childText)
         }),
       ),


### PR DESCRIPTION
## Summary
- add an optional `sessionID` argument to the subagent tool to continue an existing child session; calls without it start a new conversation
- admit follow-up prompts through the standard prompt path: an idle child starts a new execution, a running child is steered at its next safe boundary and extends the current busy period
- continuing with a different agent switches the child session's agent (and its model when the agent defines one), mirroring create semantics; unrelated sessions (not a child of the caller) are rejected
- deduplicate background completion notifications so one busy period injects exactly one synthetic completion into the parent
- wrap completed foreground output in `<subagent sessionID="...">` so the model can discover the reusable ID

## Notes
- jobs remain process-local and non-durable; continuation doubles as the post-restart reattach path since the job registry starts empty
- durable completion notification across restarts is out of scope

## Testing
- full `bun test` from `packages/core` (1849 pass, 0 fail)
- `bun typecheck` from `packages/core`
- pre-push repository typecheck (33 packages)