### PR TITLE
feat(opencode): round-robin arrays of provider api keys

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -90,7 +90,11 @@ export const Info = Schema.Struct({
   options: Schema.optional(
     Schema.StructWithRest(
       Schema.Struct({
-        apiKey: Schema.optional(Schema.String),
+        apiKey: Schema.optional(
+          Schema.Union([Schema.String, Schema.mutable(Schema.Array(Schema.String))]).annotate({
+            description: "API key. Pass an array to round-robin requests across multiple keys.",
+          }),
+        ),
         baseURL: Schema.optional(Schema.String),
         enterpriseUrl: Schema.optional(Schema.String).annotate({
           description: "GitHub Enterprise URL for copilot authentication",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1771,9 +1771,22 @@ const layer = Layer.effect(
         delete options["chunkTimeout"]
         delete options["headerTimeout"]
 
+        const apiKeys = Array.isArray(options["apiKey"])
+          ? options["apiKey"].filter((item): item is string => typeof item === "string" && item !== "")
+          : undefined
+        if (apiKeys) options["apiKey"] = apiKeys[0]
+        let rotation = 0
+
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
           const opts = init ?? {}
+          if (apiKeys && apiKeys.length > 1) {
+            const apiKey = apiKeys[rotation++ % apiKeys.length]
+            const headers = new Headers(opts.headers)
+            if (headers.has("Authorization")) headers.set("Authorization", `Bearer ${apiKey}`)
+            if (headers.has("x-api-key")) headers.set("x-api-key", apiKey)
+            opts.headers = headers
+          }
           const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
           const headerTimeoutMs = headerTimeout === false ? undefined : headerTimeout
           const headerTimeoutCtl = typeof headerTimeoutMs === "number" ? timeoutController(headerTimeoutMs) : undefined

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -61,7 +61,13 @@ function statusWithFetch(
     return { type: "unsupported", reason: "OAuth auth requires a provider fetch override" }
   }
 
-  const apiKey = typeof input.provider.options.apiKey === "string" ? input.provider.options.apiKey : input.provider.key
+  // Key pools configured as arrays are round-robined per request by the ai-sdk
+  // fetch path; the experimental native runtime pins the first valid key.
+  const apiKey = Array.isArray(input.provider.options.apiKey)
+    ? input.provider.options.apiKey.find((item) => typeof item === "string" && item !== "")
+    : typeof input.provider.options.apiKey === "string"
+      ? input.provider.options.apiKey
+      : input.provider.key
   if (!apiKey) return { type: "unsupported", reason: "API key is not configured" }
 
   return {

--- a/packages/opencode/test/provider/api-key-rotation.test.ts
+++ b/packages/opencode/test/provider/api-key-rotation.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect } from "bun:test"
+import { createServer, type Server } from "node:http"
+import { streamText } from "ai"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect } from "effect"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { testProviderConfig } from "../lib/test-provider"
+import { Env } from "@/env"
+import { Plugin } from "@/plugin"
+import { Provider } from "@/provider/provider"
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const it = testEffect(
+  LayerNode.compile(LayerNode.group([Provider.node, Env.node, Plugin.node, CrossSpawnSpawner.node])),
+)
+
+it.live("apiKey array round-robins across requests", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => authHeaderServer()),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const language = yield* provider.getLanguage(model)
+          for (let i = 0; i < 3; i++) {
+            const result = streamText({
+              model: language,
+              messages: [{ role: "user", content: "hello" }],
+            })
+            expect(yield* Effect.promise(() => result.text)).toBe("ok")
+          }
+          expect(server.headers).toEqual(["Bearer key-1", "Bearer key-2", "Bearer key-1"])
+        }),
+      { config: providerConfig(server.url) },
+    )
+  }),
+)
+
+it.live("apiKey array of one sends that key", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => authHeaderServer()),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const result = streamText({
+            model: yield* provider.getLanguage(model),
+            messages: [{ role: "user", content: "hello" }],
+          })
+          expect(yield* Effect.promise(() => result.text)).toBe("ok")
+          expect(server.headers).toEqual(["Bearer solo-key"])
+        }),
+      { config: providerConfig(server.url, ["solo-key"]) },
+    )
+  }),
+)
+
+function providerConfig(url: string, keys: string[] = ["key-1", "key-2"]) {
+  const config = testProviderConfig(url)
+  return {
+    ...config,
+    provider: {
+      test: {
+        ...config.provider.test,
+        options: { ...config.provider.test.options, apiKey: keys },
+      },
+    },
+  }
+}
+
+async function authHeaderServer(): Promise<{ server: Server; url: string; headers: string[] }> {
+  const headers: string[] = []
+  const server = createServer((req, res) => {
+    headers.push(req.headers.authorization ?? "")
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.end('data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n')
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port")
+  return { server, url: `http://127.0.0.1:${address.port}`, headers }
+}

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2554,6 +2554,21 @@ Here's an example setting the `apiKey`, `headers`, and model `limit` options.
 Configuration details:
 
 - **apiKey**: Set using `env` variable syntax, [learn more](/docs/config#env-vars).
+- **apiKey pool**: Pass an array to spread requests across multiple keys with round-robin rotation. Useful for staying under per-key rate limits. Each request picks the next key in order. This is config-only — keys added with `/connect` remain a single key per provider.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "myprovider": {
+      "options": {
+        "apiKey": ["sk-key-1", "sk-key-2"]
+      }
+    }
+  }
+}
+```
+
 - **headers**: Custom headers sent with each request.
 - **limit.context**: Maximum input tokens the model accepts.
 - **limit.output**: Maximum tokens the model can generate.


### PR DESCRIPTION
### Issue for this PR

Closes #1326 — also requested in #5391, #42502, #16038, #29085

### Type of change

- [x] New feature

### What does this PR do?

`provider.<id>.options.apiKey` now also accepts an array of keys, rotated round-robin per request:

```json
"options": { "apiKey": ["sk-key-1", "sk-key-2"] }
```

The first key is passed to the AI SDK provider as before, and the fetch wrapper already used for `headerTimeout`/`chunkTimeout` swaps the `Authorization`/`x-api-key` header to the next key on each outgoing request. It only rewrites a header the SDK already set, so all AI SDK providers work without per-provider changes.

Config-only: `/connect`-stored keys stay one-per-provider, and there is no failover on 429 — those could be follow-ups if this lands. The experimental native LLM runtime pins the first valid key.

### How did you verify your code works?

New test `test/provider/api-key-rotation.test.ts`: 3 requests over a 2-key pool hit a local HTTP server with `Bearer key-1`, `Bearer key-2`, `Bearer key-1`; a single-key array sends that key. Full `test/provider/` suite passes (556 tests) and `bun typecheck` is clean in `packages/core` and `packages/opencode`.

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR