### PR TITLE
fix(tui): keep file attachment badge readable with the system theme

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -29,6 +29,7 @@ import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, 
 import { Prompt, type PromptRef } from "../../component/prompt"
 import type {
   AssistantMessage,
+  FilePart,
   Part,
   Provider,
   ToolPart,
@@ -1362,6 +1363,19 @@ export function Session() {
   )
 }
 
+export function FileChip(props: { file: FilePart }) {
+  const { theme } = useTheme()
+  const directory = createMemo(() => props.file.mime === "application/x-directory")
+  return (
+    <text fg={theme.text}>
+      <span style={{ bg: theme.secondary, fg: selectedForeground(theme, theme.secondary) }}>
+        {directory() ? " Directory " : " File "}
+      </span>
+      <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> {props.file.filename} </span>
+    </text>
+  )
+}
+
 function UserMessage(props: {
   message: UserMessage
   parts: Part[]
@@ -1420,19 +1434,7 @@ function UserMessage(props: {
             <text fg={theme.text}>{text()}</text>
             <Show when={files().length}>
               <box flexDirection="row" paddingBottom={metadataVisible() ? 1 : 0} paddingTop={1} gap={1} flexWrap="wrap">
-                <For each={files()}>
-                  {(file) => {
-                    const directory = file.mime === "application/x-directory"
-                    return (
-                      <text fg={theme.text}>
-                        <span style={{ bg: theme.secondary, fg: theme.background }}>
-                          {directory ? " Directory " : " File "}
-                        </span>
-                        <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> {file.filename} </span>
-                      </text>
-                    )
-                  }}
-                </For>
+                <For each={files()}>{(file) => <FileChip file={file} />}</For>
               </box>
             </Show>
             <Show

--- a/packages/tui/test/cli/tui/file-chip.test.tsx
+++ b/packages/tui/test/cli/tui/file-chip.test.tsx
@@ -1,0 +1,158 @@
+/** @jsxImportSource @opentui/solid */
+import { afterEach, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { RGBA, TerminalColors } from "@opentui/core"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { tmpdir } from "../../fixture/fixture"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { generateSystem, setSystemTheme } from "../../../src/theme"
+
+function terminalColors(defaultBackground: string, palette: Array<string | null> = []): TerminalColors {
+  return {
+    palette,
+    defaultForeground: "#c0caf5",
+    defaultBackground,
+    cursorColor: null,
+    mouseForeground: null,
+    mouseBackground: null,
+    tekForeground: null,
+    tekBackground: null,
+    highlightBackground: null,
+    highlightForeground: null,
+  }
+}
+
+// ANSI palette with magenta in slot 5, which the system theme maps to `secondary`
+const palette = [
+  "#1a1b26",
+  "#f7768e",
+  "#9ece6a",
+  "#e0af68",
+  "#7aa2f7",
+  "#bb9af7",
+  "#7dcfff",
+  "#c0caf5",
+]
+
+async function mountChip(root: string) {
+  const state = path.join(root, "state")
+  await mkdir(state, { recursive: true })
+  await Bun.write(path.join(state, "kv.json"), "{}")
+
+  const [{ KVProvider }, { ThemeProvider, useTheme }, { TuiConfigProvider }, { FileChip }] = await Promise.all([
+    import("../../../src/context/kv"),
+    import("../../../src/context/theme"),
+    import("../../../src/config"),
+    import("../../../src/routes/session"),
+  ])
+
+  let themeCtx: ReturnType<typeof useTheme> | undefined
+
+  function Harness() {
+    const resolvedConfig = createTuiResolvedConfig({})
+    const Probe = () => {
+      themeCtx = useTheme()
+      return null
+    }
+    return (
+      <TestTuiContexts
+        directory={root}
+        paths={{
+          home: root,
+          state,
+          worktree: root,
+        }}
+      >
+        <TuiConfigProvider config={resolvedConfig}>
+          <KVProvider>
+            <ThemeProvider mode="dark" source={{ discover: async () => ({}) }}>
+              <Probe />
+              <FileChip
+                file={
+                  {
+                    type: "file",
+                    mime: "text/plain",
+                    filename: "/tmp/todo.md",
+                    url: "file:///tmp/todo.md",
+                  } as never
+                }
+              />
+            </ThemeProvider>
+          </KVProvider>
+        </TuiConfigProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 60, height: 5 })
+  const start = Date.now()
+  while (themeCtx?.ready !== true) {
+    if (Date.now() - start > 5000) throw new Error("timed out waiting for theme provider")
+    await Bun.sleep(10)
+  }
+  return { app, theme: () => themeCtx }
+}
+
+function badgeSpan(app: Awaited<ReturnType<typeof testRender>>) {
+  return app
+    .captureSpans()
+    .lines.flatMap((line) => line.spans)
+    .find((span) => span.text.includes("File"))
+}
+
+// A badge is only readable if its text, composited over its own background,
+// stays distinguishable from that background.
+function visibility(span: { fg: RGBA; bg: RGBA }) {
+  const { fg, bg } = span
+  const r = fg.r * fg.a + bg.r * (1 - fg.a)
+  const g = fg.g * fg.a + bg.g * (1 - fg.a)
+  const b = fg.b * fg.a + bg.b * (1 - fg.a)
+  return Math.abs(r - bg.r) + Math.abs(g - bg.g) + Math.abs(b - bg.b)
+}
+
+let cleanup: (() => void) | undefined
+
+afterEach(() => {
+  cleanup?.()
+  cleanup = undefined
+})
+
+test("file chip badge text is visible with the default theme", async () => {
+  await using tmp = await tmpdir()
+  const { app, theme } = await mountChip(tmp.path)
+  cleanup = () => app.renderer.destroy()
+
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const span = badgeSpan(app)
+  expect(span).toBeDefined()
+  expect(visibility(span!)).toBeGreaterThan(0.1)
+  expect(theme()!.selected).toBe("opencode")
+})
+
+test("file chip badge text stays visible with the generated system theme", async () => {
+  await using tmp = await tmpdir()
+  const { app, theme } = await mountChip(tmp.path)
+  cleanup = () => {
+    theme()?.set("opencode")
+    setSystemTheme(undefined)
+    app.renderer.destroy()
+  }
+
+  // The generated system theme intentionally uses a fully transparent
+  // `background` (alpha 0) so terminal transparency shows through.
+  setSystemTheme(generateSystem(terminalColors("#1a1b26", palette), "dark"))
+  expect(theme()!.set("system")).toBe(true)
+
+  await app.renderOnce()
+  await app.renderOnce()
+
+  const span = badgeSpan(app)
+  expect(span).toBeDefined()
+  // Regression: the badge used `fg: theme.background`, which is transparent in
+  // the generated system theme, so the label blended into its own background.
+  expect(visibility(span!)).toBeGreaterThan(0.1)
+})

--- a/packages/tui/test/cli/tui/file-chip.test.tsx
+++ b/packages/tui/test/cli/tui/file-chip.test.tsx
@@ -36,7 +36,14 @@ const palette = [
   "#c0caf5",
 ]
 
-async function mountChip(root: string) {
+let cleanup: (() => void) | undefined
+
+afterEach(() => {
+  cleanup?.()
+  cleanup = undefined
+})
+
+async function mountChip(root: string, mime = "text/plain") {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
   await Bun.write(path.join(state, "kv.json"), "{}")
@@ -73,7 +80,7 @@ async function mountChip(root: string) {
                 file={
                   {
                     type: "file",
-                    mime: "text/plain",
+                    mime,
                     filename: "/tmp/todo.md",
                     url: "file:///tmp/todo.md",
                   } as never
@@ -87,6 +94,9 @@ async function mountChip(root: string) {
   }
 
   const app = await testRender(() => <Harness />, { width: 60, height: 5 })
+  // Register teardown before the fallible theme wait: if the wait times out,
+  // afterEach still destroys the live renderer instead of leaking it.
+  cleanup = () => app.renderer.destroy()
   const start = Date.now()
   while (themeCtx?.ready !== true) {
     if (Date.now() - start > 5000) throw new Error("timed out waiting for theme provider")
@@ -95,15 +105,17 @@ async function mountChip(root: string) {
   return { app, theme: () => themeCtx }
 }
 
-function badgeSpan(app: Awaited<ReturnType<typeof testRender>>) {
+function badgeSpan(app: Awaited<ReturnType<typeof testRender>>, label: string) {
   return app
     .captureSpans()
     .lines.flatMap((line) => line.spans)
-    .find((span) => span.text.includes("File"))
+    .find((span) => span.text.includes(label))
 }
 
 // A badge is only readable if its text, composited over its own background,
-// stays distinguishable from that background.
+// stays distinguishable from that background. The metric is the Manhattan RGB
+// distance between the composited text and the background; the 0.1 threshold
+// is a small-but-perceptible floor (the pre-fix transparent label scores 0).
 function visibility(span: { fg: RGBA; bg: RGBA }) {
   const { fg, bg } = span
   const r = fg.r * fg.a + bg.r * (1 - fg.a)
@@ -112,22 +124,33 @@ function visibility(span: { fg: RGBA; bg: RGBA }) {
   return Math.abs(r - bg.r) + Math.abs(g - bg.g) + Math.abs(b - bg.b)
 }
 
-let cleanup: (() => void) | undefined
+// Mounts the chip and switches to the generated system theme, which
+// intentionally uses a fully transparent `background` (alpha 0) so terminal
+// transparency shows through. Cleanup also resets the global theme state the
+// switch mutates.
+async function mountSystemChip(root: string, mime: string) {
+  const mounted = await mountChip(root, mime)
+  cleanup = () => {
+    mounted.theme()?.set("opencode")
+    setSystemTheme(undefined)
+    mounted.app.renderer.destroy()
+  }
+  setSystemTheme(generateSystem(terminalColors("#1a1b26", palette), "dark"))
+  expect(mounted.theme()!.set("system")).toBe(true)
 
-afterEach(() => {
-  cleanup?.()
-  cleanup = undefined
-})
+  await mounted.app.renderOnce()
+  await mounted.app.renderOnce()
+  return mounted
+}
 
 test("file chip badge text is visible with the default theme", async () => {
   await using tmp = await tmpdir()
   const { app, theme } = await mountChip(tmp.path)
-  cleanup = () => app.renderer.destroy()
 
   await app.renderOnce()
   await app.renderOnce()
 
-  const span = badgeSpan(app)
+  const span = badgeSpan(app, "File")
   expect(span).toBeDefined()
   expect(visibility(span!)).toBeGreaterThan(0.1)
   expect(theme()!.selected).toBe("opencode")
@@ -135,24 +158,23 @@ test("file chip badge text is visible with the default theme", async () => {
 
 test("file chip badge text stays visible with the generated system theme", async () => {
   await using tmp = await tmpdir()
-  const { app, theme } = await mountChip(tmp.path)
-  cleanup = () => {
-    theme()?.set("opencode")
-    setSystemTheme(undefined)
-    app.renderer.destroy()
-  }
+  const { app, theme } = await mountSystemChip(tmp.path, "text/plain")
 
-  // The generated system theme intentionally uses a fully transparent
-  // `background` (alpha 0) so terminal transparency shows through.
-  setSystemTheme(generateSystem(terminalColors("#1a1b26", palette), "dark"))
-  expect(theme()!.set("system")).toBe(true)
-
-  await app.renderOnce()
-  await app.renderOnce()
-
-  const span = badgeSpan(app)
+  const span = badgeSpan(app, "File")
   expect(span).toBeDefined()
   // Regression: the badge used `fg: theme.background`, which is transparent in
   // the generated system theme, so the label blended into its own background.
+  expect(visibility(span!)).toBeGreaterThan(0.1)
+  // Negative control: the pre-fix label color must score ~invisible here,
+  // proving the visibility assertion above can actually fail.
+  expect(visibility({ fg: theme()!.theme.background, bg: span!.bg })).toBeLessThan(0.01)
+})
+
+test("directory chip badge text stays visible with the generated system theme", async () => {
+  await using tmp = await tmpdir()
+  const { app } = await mountSystemChip(tmp.path, "application/x-directory")
+
+  const span = badgeSpan(app, "Directory")
+  expect(span).toBeDefined()
   expect(visibility(span!)).toBeGreaterThan(0.1)
 })


### PR DESCRIPTION
### Issue for this PR

Closes #43182

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The user-message file chip paints its ` File ` / ` Directory ` label with `fg: theme.background`. Built-in themes define an opaque background, but the generated system theme makes it fully transparent (to respect terminal transparency), so the label blends into the badge — a solid colored block with invisible text.

Fixed by painting the label with `selectedForeground(theme, theme.secondary)` — the helper the `QUEUED` badge just below already uses. It returns an opaque contrasting color when the theme background is transparent and `theme.background` otherwise, so built-in themes render unchanged. The chip is extracted into an exported `FileChip` component for testability.

### How did you verify your code works?

New `test/cli/tui/file-chip.test.tsx` renders `FileChip` under the generated system theme and asserts the label stays distinguishable from the badge background; it fails on `dev` (delta = 0 — the reported bug) and passes with this change. Full `packages/tui` suite: 196 pass, 0 fail; `bun run typecheck`: clean.

### Screenshots / recordings

Before (system theme) — the ` File ` label is invisible, while the `QUEUED` chip below, which already uses `selectedForeground`, stays readable:

![file badge label invisible with system theme](https://raw.githubusercontent.com/wesleywwlam/opencode/pr-assets/file-badge-system-theme-bug.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

