### PR TITLE
fix(tui): always show the variant dialog when selecting a model with variants

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -141,13 +141,11 @@ export function DialogModel(props: { providerID?: string }) {
 
   function onSelect(providerID: string, modelID: string) {
     local.model.set({ providerID, modelID }, { recent: true })
-    const list = local.model.variant.list()
-    const cur = local.model.variant.selected()
-    if (cur === "default" || (cur && list.includes(cur))) {
-      dialog.clear()
-      return
-    }
-    if (list.length > 0) {
+    if (local.model.variant.list().length > 0) {
+      // Always offer the variant choice: DialogVariant pre-selects the saved variant, so keeping it is a
+      // single Enter. The previous early-return made any model with a saved entry (including "default",
+      // which session sync auto-seeds — see #38363) permanently one-click, hiding variants the user was
+      // never shown existed (#30445, #27893).
       dialog.replace(() => <DialogVariant />)
       return
     }


### PR DESCRIPTION
### Issue for this PR

Closes #30445 (and the residue of #27893).

### Type of change

- [x] Bug fix

### What does this PR do?

`DialogModel.onSelect` early-returns whenever the selected model has a saved variant entry — and because session sync auto-seeds `"default"` entries into `model.json` (#38363's trace), **every previously-used model becomes permanently one-click**: the variant dialog never appears again and users are never shown that variants exist. Which models "work" looks random (it's just which ones you haven't used yet) — we burned a real debugging session on exactly this on v1.18.18, with a self-hosted provider whose models all carry variants.

The fix: when the model has variants, always open `DialogVariant`. It already receives `current={local.model.variant.selected()}`, so the saved choice is pre-selected and keeping it is a single **Enter** — the exact UX #30445 proposes. Models without variants keep today's instant selection.

### How did you verify your code works?

`bun run typecheck` (clean); repro traced on v1.18.18: seed a variant entry for a model (use it once), reselect it via /models → dialog skipped before this change, shown with the previous choice pre-selected after.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR