### PR TITLE
perf(app): keep home session index query-local

### DIFF
--- a/packages/app/src/context/global-sync/home-session-index.ts
+++ b/packages/app/src/context/global-sync/home-session-index.ts
@@ -4,8 +4,6 @@ import { SESSION_RECENT_LIMIT, SESSION_RECENT_WINDOW } from "./types"
 
 export const HOME_V2_SESSION_PAGE_LIMIT = 5_000
 
-export const homeSessionIndexKey = (server: string) => ["home", "session-index", server] as const
-
 export async function loadHomeSessionIndex(
   list: (
     input: { limit: number; order: "desc"; cursor?: string },
@@ -35,6 +33,12 @@ export async function loadHomeSessionIndex(
 // seeds createData from a full scan and derives its visible index there.
 export function parseHomeSessionIndex(sessions: SessionInfo[]) {
   return sessions.filter((session) => !session.parentID && typeof session.time.archived !== "number")
+}
+
+export function mergeHomeSessionIndex(fetched: SessionInfo[], known: SessionInfo[]) {
+  return parseHomeSessionIndex([
+    ...new Map([...fetched, ...known].map((session) => [session.id, session] as const)).values(),
+  ])
 }
 
 export function retainHomeSessions(sessions: SessionInfo[], limit: number, now: number) {

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -5,9 +5,8 @@ import { DateTime } from "luxon"
 import { type Accessor, createEffect, createMemo, type JSX, startTransition, untrack } from "solid-js"
 import { useCommand } from "@/context/command"
 import {
-  homeSessionIndexKey,
   loadHomeSessionIndex,
-  parseHomeSessionIndex,
+  mergeHomeSessionIndex,
   retainHomeSessions,
 } from "@/context/global-sync/home-session-index"
 import type { LocalProject } from "@/context/layout"
@@ -53,19 +52,10 @@ export function createHomeSessionsController(home: HomeController) {
     const ctx = home.server.focusedContext()
     const conn = home.server.focused()
     return {
-      queryKey: conn
-        ? homeSessionIndexKey(ServerConnection.key(conn))
-        : (["home", "session-index", "unselected"] as const),
+      queryKey: ["home-sessions", conn] as const,
       enabled: !!ctx && ctx.sdk.connection.status() === "connected",
       queryFn: ctx
-        ? async ({ signal }) => {
-            const index = await loadHomeSessionIndex(
-              (input, options) => ctx.sdk.api.session.list(input, options),
-              signal,
-            )
-            index.forEach(ctx.data.session.remember)
-            return Date.now()
-          }
+        ? ({ signal }) => loadHomeSessionIndex((input, options) => ctx.sdk.api.session.list(input, options), signal)
         : skipToken,
       retry: false,
       staleTime: 30_000,
@@ -76,7 +66,11 @@ export function createHomeSessionsController(home: HomeController) {
   const indexedSessions = createMemo(() => {
     const ctx = home.server.focusedContext()
     if (!ctx) return []
-    return retainHomeSessions(parseHomeSessionIndex(ctx.data.session.list()), HOME_SESSION_LIMIT, Date.now())
+    return retainHomeSessions(
+      mergeHomeSessionIndex(sessionLoad.data ?? [], ctx.data.session.list()),
+      HOME_SESSION_LIMIT,
+      Date.now(),
+    )
   })
   const allRecords = createMemo(() =>
     buildHomeSessionRecords({


### PR DESCRIPTION
## Summary
- keep fetched Home session inventory in the query cache instead of writing each result into the shared Solid store
- merge query results with independently known live sessions, preferring shared entries by session ID
- cover deduplication, live-session merging, and root/archive filtering

## Verification
- `bun test --conditions=solid --preload ./happydom.ts ./src/context/global-sync/home-session-index.test.ts`
- `bun typecheck` in `packages/app`
- repository pre-push typecheck: 33/33 packages passed
- production Home paint benchmark: 67.1 ms stable before, 68.5 ms after (within run-to-run noise)

The baseline benchmark suite also encountered the existing review-pane case where `[data-component="session-review"]` did not appear; the Home paint benchmark passed before and after.