### PR TITLE
fix(app): enable scoped auto-accept settings

### DIFF
--- a/packages/app/e2e/regression/remote-session-settings.spec.ts
+++ b/packages/app/e2e/regression/remote-session-settings.spec.ts
@@ -7,9 +7,78 @@ const serverA = "http://127.0.0.1:4096"
 const serverB = "http://127.0.0.1:4097"
 const directoryA = "C:/server-a"
 const directoryB = "/home/server-b"
+const draftID = "draft_remote_settings_directory"
 const sessionA = session("ses_server_a", directoryA, "Server A session")
 const childSessionA = { ...session("ses_server_a_child", directoryA, "Server A child session"), parentID: sessionA.id }
 const sessionB = session("ses_server_b", directoryB, "Server B session")
+
+test("home settings use the selected project auto-accept scope", async ({ page }) => {
+  const permissionRequests: string[] = []
+  await mockServers(page, permissionRequests)
+  await configureServers(page, [], { server: serverB, directory: directoryB })
+
+  await page.goto("/")
+  await page.keyboard.press("Control+,")
+
+  const autoAccept = page.locator(".settings-v2-dialog").locator('[data-action="settings-auto-accept-permissions"]')
+  const input = autoAccept.getByRole("switch")
+  await expect(autoAccept).toBeVisible()
+  await expect(input).toBeEnabled()
+  permissionRequests.length = 0
+  await autoAccept.locator('[data-slot="switch-control"]').click()
+  await expect(input).toBeChecked()
+  await expect
+    .poll(() =>
+      permissionRequests.some((request) => {
+        const url = new URL(request)
+        return url.origin === serverB && url.searchParams.get("directory") === directoryB
+      }),
+    )
+    .toBe(true)
+  expect(permissionRequests.every((request) => new URL(request).origin === serverB)).toBe(true)
+})
+
+test("draft settings use directory auto-accept", async ({ page }) => {
+  const permissionRequests: string[] = []
+  await mockServers(page, permissionRequests)
+  await configureServers(page, [{ type: "draft", server: serverB, draftID, directory: directoryB }])
+
+  await page.goto(`/new-session?draftId=${draftID}`)
+  await page.keyboard.press("Control+,")
+
+  const autoAccept = page.locator(".settings-v2-dialog").locator('[data-action="settings-auto-accept-permissions"]')
+  const input = autoAccept.getByRole("switch")
+  await expect(autoAccept).toBeVisible()
+  await expect(input).toBeEnabled()
+  permissionRequests.length = 0
+  await autoAccept.locator('[data-slot="switch-control"]').click()
+  await expect(input).toBeChecked()
+  await expect
+    .poll(() =>
+      permissionRequests.some((request) => {
+        const url = new URL(request)
+        return url.origin === serverB && url.searchParams.get("directory") === directoryB
+      }),
+    )
+    .toBe(true)
+  expect(permissionRequests.every((request) => new URL(request).origin === serverB)).toBe(true)
+})
+
+test("settings without active scope keep auto-accept disabled", async ({ page }) => {
+  const permissionRequests: string[] = []
+  await mockServers(page, permissionRequests)
+  await configureServers(page)
+
+  await page.goto("/")
+  await page.keyboard.press("Control+,")
+
+  const autoAccept = page.locator(".settings-v2-dialog").locator('[data-action="settings-auto-accept-permissions"]')
+  const input = autoAccept.getByRole("switch")
+  await expect(autoAccept).toBeVisible()
+  await expect(input).toBeDisabled()
+  await expect(input).not.toBeChecked()
+  expect(permissionRequests).toEqual([])
+})
 
 test("session settings use the remote server context", async ({ page }) => {
   const permissionRequests: string[] = []
@@ -150,14 +219,19 @@ type PermissionResponse = {
   body: unknown
 }
 
-async function configureServers(page: Page, tabs: { type: "session"; server: string; sessionId: string }[] = []) {
+type StoredTab =
+  | { type: "session"; server: string; sessionId: string }
+  | { type: "draft"; server: string; draftID: string; directory: string }
+
+async function configureServers(page: Page, tabs: StoredTab[] = [], home?: { server: string; directory: string }) {
   await page.addInitScript(
-    ({ serverB, tabs }) => {
+    ({ serverB, tabs, home }) => {
       localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
       localStorage.setItem("opencode.global.dat:server", JSON.stringify({ list: [serverB] }))
       localStorage.setItem("opencode.window.browser.dat:tabs", JSON.stringify(tabs))
+      if (home) localStorage.setItem("opencode.global.dat:layout", JSON.stringify({ home: { selection: home } }))
     },
-    { serverB, tabs },
+    { serverB, tabs, home },
   )
 }
 

--- a/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-settings-v2.tsx
@@ -26,16 +26,25 @@ export const DialogSettings: Component<{
   const tabs = useTabs()
   const serverSync = useServerSync()
   const [tab, setTab] = createSignal(props.defaultValue ?? "general")
-  const directory = createMemo(() => {
+  const scope = createMemo(() => {
     const route = layout.route()
-    if (route.type === "dir-new-sesssion") return route.dir
+    if (route.type === "home") {
+      const selection = layout.home.selection()
+      if (!selection.directory) return
+      return selection
+    }
+    if (route.type === "dir-new-sesssion") return { directory: route.dir, server: route.server }
     if (route.type === "draft") {
       const draft = tabs.store.find((item) => item.type === "draft" && item.draftID === route.draftID)
-      return draft?.type === "draft" ? draft.directory : undefined
+      if (draft?.type !== "draft") return
+      return { directory: draft.directory, server: draft.server }
     }
-    if (route.type === "session") return serverSync().session.get(route.sessionId)?.directory
-    return undefined
+    const directory = serverSync().session.get(route.sessionId)?.directory
+    if (!directory) return
+    return { directory, server: route.server }
   })
+  const directory = createMemo(() => scope()?.directory)
+  const scopeServer = createMemo(() => scope()?.server)
 
   const showProviders = () => {
     void dialog.show(() => <DialogSettings sessionID={props.sessionID} defaultValue="providers" />)
@@ -94,7 +103,7 @@ export const DialogSettings: Component<{
           </div>
         </TabsV2.List>
         <TabsV2.Content value="general" class="settings-v2-panel">
-          <SettingsGeneralV2 sessionID={props.sessionID} />
+          <SettingsGeneralV2 sessionID={props.sessionID} directory={directory} server={scopeServer} />
         </TabsV2.Content>
         <TabsV2.Content value="shortcuts" class="settings-v2-panel">
           <SettingsKeybinds v2 />

--- a/packages/app/src/components/settings-v2/general-controllers.ts
+++ b/packages/app/src/components/settings-v2/general-controllers.ts
@@ -2,6 +2,7 @@ import { createMemo, createResource, onMount, type Accessor } from "solid-js"
 import type { ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useTheme } from "@opencode-ai/ui/theme/context"
 import { usePermission } from "@/context/permission"
+import type { ServerConnection } from "@/context/server"
 import { useServerSDK } from "@/context/server-sdk"
 import { useServerSync } from "@/context/server-sync"
 import {
@@ -22,29 +23,45 @@ import { createSoundPreviewController, type ShellOption } from "./general-contro
 export { createShellOptions, createSoundPreviewController } from "./general-controller-behavior"
 export type { ShellOption, ShellSelectOption } from "./general-controller-behavior"
 
-export function createPermissionScopeController(sessionID: Accessor<string | undefined>) {
+export function createPermissionScopeController(
+  sessionID: Accessor<string | undefined>,
+  activeDirectory: Accessor<string | undefined> = () => undefined,
+  activeServer: Accessor<ServerConnection.Key | undefined> = () => undefined,
+) {
   const permission = usePermission()
   const serverSync = useServerSync()
   const directory = createMemo(() => {
     const id = sessionID()
-    if (!id) return undefined
+    if (!id) return activeDirectory()
     return serverSync().session.lineage.peek(id)?.session.directory
   })
+  const state = () => {
+    const server = activeServer()
+    if (!server) return permission
+    return permission.ensureServerState(server)
+  }
 
   return {
     accepting: createMemo(() => {
       const id = sessionID()
       const dir = directory()
-      if (!id || !dir) return false
-      return permission.isAutoAccepting(id, dir)
+      if (!dir) return false
+      if (!id) return state().isAutoAcceptingDirectory(dir)
+      return state().isAutoAccepting(id, dir)
     }),
     enabled: createMemo(() => !!directory()),
     set: (checked: boolean) => {
       const id = sessionID()
       const dir = directory()
-      if (!id || !dir) return
-      if (checked) return permission.enableAutoAccept(id, dir)
-      permission.disableAutoAccept(id, dir)
+      if (!dir) return
+      const api = state()
+      if (!id) {
+        if (api.isAutoAcceptingDirectory(dir) === checked) return
+        api.toggleAutoAcceptDirectory(dir)
+        return
+      }
+      if (checked) return api.enableAutoAccept(id, dir)
+      api.disableAutoAccept(id, dir)
     },
   }
 }

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createMemo, createResource } from "solid-js"
+import { Component, Show, createMemo, createResource, type Accessor } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { SelectV2 } from "@opencode-ai/ui/v2/select-v2"
@@ -7,6 +7,7 @@ import { TextInputV2 } from "@opencode-ai/ui/v2/text-input-v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
+import type { ServerConnection } from "@/context/server"
 import { useUpdaterAction } from "../updater-action"
 import { useSettings } from "@/context/settings"
 import { ExternalLink } from "../external-link"
@@ -273,6 +274,8 @@ const LanguageSetting = () => {
 
 export const SettingsGeneralV2: Component<{
   sessionID?: string
+  directory?: Accessor<string | undefined>
+  server?: Accessor<ServerConnection.Key | undefined>
 }> = (props) => {
   const language = useLanguage()
   const platform = usePlatform()
@@ -280,7 +283,7 @@ export const SettingsGeneralV2: Component<{
   const settings = useSettings()
   const mobile = createMediaQuery("(max-width: 767px)")
   const updater = useUpdaterAction()
-  const permissionScope = createPermissionScopeController(() => props.sessionID)
+  const permissionScope = createPermissionScopeController(() => props.sessionID, props.directory, props.server)
   const shell = createShellSettingsController()
   const appearance = createAppearanceSettingsController()
   const sounds = createSoundSettingsController()


### PR DESCRIPTION
### Issue for this PR

Closes #37617

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Passes the active directory and server into the v2 general settings controller, so auto-accept can be changed from a selected home project, a draft, or a session. The switch stays disabled when there is no active directory.

The server is part of the scope so a remote project's permission request is not sent to whichever server happens to be selected globally. This includes the draft-route fix proposed in #42331 and also covers the selected home project shown in #37617.

### How did you verify your code works?

- `bun run typecheck`
- `bun run typecheck:e2e`
- `bun run build`
- Oxlint on the four changed files: 0 warnings and 0 errors
- Playwright regression tests for home, draft, no-scope, and session settings: 4 passed

### Screenshots / recordings

No styling changes. The disabled state before this fix is described in #37617; the Playwright regression verifies the switch's enabled, disabled, and checked states and the target server/directory.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

