### PR TITLE
fix(opencode): support subagent session tree transfers

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -1,12 +1,31 @@
 import { Session } from "@/session/session"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { MessageV2 } from "../../session/message-v2"
 import { SessionID } from "../../session/schema"
 import { effectCmd, fail } from "../effect-cmd"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
 import { EOL } from "os"
 import { Effect } from "effect"
+import { type SessionTransferArchive, type SessionTransferData } from "./session-transfer"
+
+export const collectSessionTree = Effect.fn("SessionTransfer.collect")(function* (
+  service: Session.Interface,
+  root: Session.Info,
+) {
+  const seen = new Set<Session.Info["id"]>()
+  const visit = (info: Session.Info): Effect.Effect<SessionTransferArchive["sessions"], Session.NotFound> =>
+    Effect.gen(function* () {
+      seen.add(info.id)
+      const messages = yield* service.messages({ sessionID: info.id })
+      // Sort siblings so depth-first exports remain stable across runs.
+      const children = (yield* service.children(info.id))
+        .filter((child) => !seen.has(child.id))
+        .toSorted((a, b) => a.id.localeCompare(b.id))
+      const descendants = yield* Effect.forEach(children, visit)
+      return [{ info, messages }, ...descendants.flat()]
+    })
+  return yield* visit(root)
+})
 
 function redact(kind: string, id: string, value: string) {
   return value.trim() ? `[redacted:${kind}:${id}]` : value
@@ -160,7 +179,7 @@ function part(part: SessionV1.Part): SessionV1.Part {
 
 const partFn = part
 
-function sanitize(data: { info: Session.Info; messages: SessionV1.WithParts[] }) {
+function sanitize(data: SessionTransferData) {
   return {
     info: {
       ...data.info,
@@ -219,6 +238,33 @@ function sanitize(data: { info: Session.Info; messages: SessionV1.WithParts[] })
   }
 }
 
+const deepSessionExport = Effect.fn("Cli.export.deep")(function* (
+  service: Session.Interface,
+  info: Session.Info,
+  sanitizeOutput?: boolean,
+) {
+  const sessions = yield* collectSessionTree(service, info)
+  return {
+    version: 1 as const,
+    rootSessionID: info.id,
+    sessions: sessions.map((item) => (sanitizeOutput ? sanitize(item) : item)),
+  }
+})
+
+const shallowSessionExport = Effect.fn("Cli.export.shallow")(function* (
+  service: Session.Interface,
+  info: Session.Info,
+  sanitizeOutput?: boolean,
+) {
+  const output = { info, messages: yield* service.messages({ sessionID: info.id }) }
+  if ((yield* service.children(info.id)).length > 0) {
+    process.stderr.write(
+      `Warning: session ${info.id} contains subagent transcripts that are not included in the export; use --with-subagents to include them.\n`,
+    )
+  }
+  return sanitizeOutput ? sanitize(output) : output
+})
+
 export const ExportCommand = effectCmd({
   command: "export [sessionID]",
   describe: "export session data as JSON",
@@ -231,13 +277,21 @@ export const ExportCommand = effectCmd({
       .option("sanitize", {
         describe: "redact sensitive transcript and file data",
         type: "boolean",
+      })
+      .option("with-subagents", {
+        describe: "include transcripts from all nested subagent runs",
+        type: "boolean",
       }),
   handler: Effect.fn("Cli.export")(function* (args) {
     return yield* run(args)
   }),
 })
 
-const run = Effect.fn("Cli.export.body")(function* (args: { sessionID?: string; sanitize?: boolean }) {
+const run = Effect.fn("Cli.export.body")(function* (args: {
+  sessionID?: string
+  sanitize?: boolean
+  withSubagents?: boolean
+}) {
   const svc = yield* Session.Service
   let sessionID = args.sessionID ? SessionID.make(args.sessionID) : undefined
   process.stderr.write(`Exporting session: ${sessionID ?? "latest"}\n`)
@@ -281,12 +335,11 @@ const run = Effect.fn("Cli.export.body")(function* (args: { sessionID?: string; 
   // Match legacy try/catch — catches both typed failures and defects
   // (Session.Service.get throws NotFoundError as a defect, not a typed E).
   return yield* Effect.gen(function* () {
-    const sessionInfo = yield* svc.get(sessionID!)
-    const messages = yield* svc.messages({ sessionID: sessionInfo.id })
-
-    const exportData = { info: sessionInfo, messages }
-
-    process.stdout.write(JSON.stringify(args.sanitize ? sanitize(exportData) : exportData, null, 2))
+    const sessionInfo = yield* svc.get(sessionID)
+    const output = args.withSubagents
+      ? yield* deepSessionExport(svc, sessionInfo, args.sanitize)
+      : yield* shallowSessionExport(svc, sessionInfo, args.sanitize)
+    process.stdout.write(JSON.stringify(output, null, 2))
     process.stdout.write(EOL)
   }).pipe(Effect.catchCause(() => fail(`Session not found: ${sessionID!}`)))
 })

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -1,8 +1,6 @@
 import type { Session as SDKSession, Message, Part } from "@opencode-ai/sdk/v2"
-import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Session } from "@/session/session"
-import { MessageV2 } from "../../session/message-v2"
-import { CliError, effectCmd } from "../effect-cmd"
+import { CliError, effectCmd, fail } from "../effect-cmd"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionTable, MessageTable, PartTable } from "@opencode-ai/core/session/sql"
 import { InstanceRef } from "@/effect/instance-ref"
@@ -10,11 +8,14 @@ import { ShareNext } from "@/share/share-next"
 import { EOL } from "os"
 import path from "path"
 import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Effect, Schema } from "effect"
+import { Cause, Effect, Exit, Schema } from "effect"
 import type { InstanceContext } from "@/project/instance-context"
+import { inArray } from "drizzle-orm"
+import { SessionTransferFile } from "./session-transfer"
 
-const decodeMessageInfo = Schema.decodeUnknownSync(SessionV1.Info)
-const decodePart = Schema.decodeUnknownSync(SessionV1.Part)
+function sessionTransferSessions(file: SessionTransferFile) {
+  return "sessions" in file ? file.sessions : [file]
+}
 
 /** Discriminated union returned by the ShareNext API (GET /api/shares/:id/data) */
 export type ShareData =
@@ -89,8 +90,6 @@ export function transformShareData(shareData: ShareData[]): {
   }
 }
 
-type ExportData = { info: SDKSession; messages: Array<{ info: Message; parts: Part[] }> }
-
 export const ImportCommand = effectCmd({
   command: "import <file>",
   describe: "import session data from JSON file or URL",
@@ -110,9 +109,8 @@ export const ImportCommand = effectCmd({
 const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: InstanceContext) {
   const share = yield* ShareNext.Service
   const fs = yield* FSUtil.Service
-  const { db } = yield* Database.Service
 
-  let exportData: ExportData | undefined
+  let raw: unknown
 
   const isUrl = file.startsWith("http://") || file.startsWith("https://")
 
@@ -163,68 +161,139 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
       return
     }
 
-    exportData = transformed
+    raw = transformed
   } else {
-    exportData = (yield* fs
+    raw = yield* fs
       .readJson(file)
-      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))) as ExportData
+      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))
   }
 
-  if (!exportData) {
+  if (!raw) {
     process.stdout.write(`Failed to read session data`)
     process.stdout.write(EOL)
     return
   }
 
-  const info = Schema.decodeUnknownSync(Session.Info)({
-    ...exportData.info,
-    projectID: ctx.project.id,
-    directory: ctx.directory,
-    path: path.relative(path.resolve(ctx.worktree), ctx.directory).replaceAll("\\", "/"),
-  }) as Session.Info
-  const row = Session.toRow(info)
-  yield* db
-    .insert(SessionTable)
-    .values(row)
-    .onConflictDoUpdate({
-      target: SessionTable.id,
-      set: { project_id: row.project_id, directory: row.directory, path: row.path },
-    })
-    .run()
-    .pipe(Effect.orDie)
+  const decoded = Schema.decodeUnknownExit(SessionTransferFile)(raw)
+  if (Exit.isFailure(decoded)) {
+    return yield* fail(`Invalid session data: ${String(Cause.squash(decoded.cause))}`)
+  }
+  const transfer = decoded.value as SessionTransferFile
+  yield* importSessionTransfer(transfer, ctx)
 
-  for (const msg of exportData.messages) {
-    const msgInfo = decodeMessageInfo(msg.info) as SessionV1.Info
-    const { id, sessionID: _, ...msgData } = msgInfo
-    yield* db
-      .insert(MessageTable)
-      .values({
-        id,
-        session_id: row.id,
-        time_created: msgInfo.time?.created ?? Date.now(),
-        data: msgData as never,
-      })
-      .onConflictDoNothing()
-      .run()
-      .pipe(Effect.orDie)
+  process.stdout.write(`Imported session: ${"sessions" in transfer ? transfer.rootSessionID : transfer.info.id}`)
+  process.stdout.write(EOL)
+})
 
-    for (const part of msg.parts) {
-      const partInfo = decodePart(part) as SessionV1.Part
-      const { id: partId, sessionID: _s, messageID, ...partData } = partInfo
-      yield* db
-        .insert(PartTable)
-        .values({
-          id: partId,
-          message_id: messageID,
-          session_id: row.id,
-          data: partData,
-        })
-        .onConflictDoNothing()
-        .run()
-        .pipe(Effect.orDie)
-    }
+export const importSessionTransfer = Effect.fn("Cli.import.transfer")(function* (
+  transfer: SessionTransferFile,
+  ctx: InstanceContext,
+) {
+  if ("sessions" in transfer && !transfer.sessions.some((session) => session.info.id === transfer.rootSessionID)) {
+    yield* fail(`Archive root Session is missing: ${transfer.rootSessionID}`)
   }
 
-  process.stdout.write(`Imported session: ${exportData.info.id}`)
-  process.stdout.write(EOL)
+  const targetPath = path.relative(path.resolve(ctx.worktree), ctx.directory).replaceAll("\\", "/")
+  const records = sessionTransferSessions(transfer).map((data) => ({
+    data,
+    row: Session.toRow({
+      ...data.info,
+      projectID: ctx.project.id,
+      directory: ctx.directory,
+      path: targetPath,
+    }),
+  }))
+  const included = new Set(records.map((record) => record.row.id))
+  const { db } = yield* Database.Service
+
+  yield* db
+    .transaction(
+      (tx) =>
+        Effect.gen(function* () {
+          const existing = yield* tx
+            .select({
+              id: SessionTable.id,
+              projectID: SessionTable.project_id,
+              directory: SessionTable.directory,
+              path: SessionTable.path,
+            })
+            .from(SessionTable)
+            .where(inArray(SessionTable.id, [...included]))
+            .all()
+            .pipe(Effect.orDie)
+          const moving = existing
+            .filter(
+              (session) =>
+                session.projectID !== ctx.project.id ||
+                session.directory !== ctx.directory ||
+                (session.path ?? undefined) !== targetPath,
+            )
+            .map((session) => session.id)
+          if (moving.length > 0) {
+            const children = yield* tx
+              .select({ id: SessionTable.id, parentID: SessionTable.parent_id })
+              .from(SessionTable)
+              .where(inArray(SessionTable.parent_id, moving))
+              .all()
+              .pipe(Effect.orDie)
+            const omitted = children.find((child) => !included.has(child.id))
+            if (omitted) {
+              yield* fail(
+                `Cannot move Session ${omitted.parentID} because subagent Session ${omitted.id} would remain in the current project`,
+              )
+            }
+          }
+
+          yield* Effect.forEach(
+            records,
+            (record) =>
+              Effect.gen(function* () {
+                yield* tx
+                  .insert(SessionTable)
+                  .values(record.row)
+                  .onConflictDoUpdate({
+                    target: SessionTable.id,
+                    set: {
+                      project_id: record.row.project_id,
+                      directory: record.row.directory,
+                      path: record.row.path,
+                    },
+                  })
+                  .run()
+                  .pipe(Effect.orDie)
+
+                const messages = record.data.messages.map((message) => {
+                  const { id, sessionID: _, ...data } = message.info
+                  return {
+                    id,
+                    session_id: record.row.id,
+                    time_created: message.info.time.created,
+                    data: data as never,
+                  }
+                })
+                if (messages.length > 0) {
+                  yield* tx.insert(MessageTable).values(messages).onConflictDoNothing().run().pipe(Effect.orDie)
+                }
+
+                const parts = record.data.messages.flatMap((message) =>
+                  message.parts.map((part) => {
+                    const { id, sessionID: _, messageID: _messageID, ...data } = part
+                    return {
+                      id,
+                      message_id: message.info.id,
+                      session_id: record.row.id,
+                      data,
+                    }
+                  }),
+                )
+                if (parts.length > 0) {
+                  yield* tx.insert(PartTable).values(parts).onConflictDoNothing().run().pipe(Effect.orDie)
+                }
+              }),
+            { discard: true },
+          )
+        }),
+      { behavior: "immediate" },
+    )
+    .pipe(Effect.catchTag("SqlError", (error) => Effect.die(error)))
 })

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -277,10 +277,10 @@ export const importSessionTransfer = Effect.fn("Cli.import.transfer")(function* 
 
                 const parts = record.data.messages.flatMap((message) =>
                   message.parts.map((part) => {
-                    const { id, sessionID: _, messageID: _messageID, ...data } = part
+                    const { id, sessionID: _, messageID, ...data } = part
                     return {
                       id,
-                      message_id: message.info.id,
+                      message_id: messageID,
                       session_id: record.row.id,
                       data,
                     }

--- a/packages/opencode/src/cli/cmd/session-transfer.ts
+++ b/packages/opencode/src/cli/cmd/session-transfer.ts
@@ -1,0 +1,19 @@
+import { Session } from "@/session/session"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Schema, Types } from "effect"
+
+export const SessionTransferData = Schema.Struct({
+  info: Session.Info,
+  messages: Schema.Array(SessionV1.WithParts),
+})
+export type SessionTransferData = Types.DeepMutable<Schema.Schema.Type<typeof SessionTransferData>>
+
+export const SessionTransferArchive = Schema.Struct({
+  version: Schema.Literal(1),
+  rootSessionID: Session.Info.fields.id,
+  sessions: Schema.NonEmptyArray(SessionTransferData),
+})
+export type SessionTransferArchive = Types.DeepMutable<Schema.Schema.Type<typeof SessionTransferArchive>>
+
+export const SessionTransferFile = Schema.Union([SessionTransferArchive, SessionTransferData])
+export type SessionTransferFile = Types.DeepMutable<Schema.Schema.Type<typeof SessionTransferFile>>

--- a/packages/opencode/test/cli/session-transfer.test.ts
+++ b/packages/opencode/test/cli/session-transfer.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Effect, Layer, Schema } from "effect"
+import { inArray } from "drizzle-orm"
+import path from "path"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import { InstanceStore } from "@/project/instance-store"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { InstanceRef } from "@/effect/instance-ref"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { collectSessionTree } from "../../src/cli/cmd/export"
+import { SessionTransferArchive } from "../../src/cli/cmd/session-transfer"
+import { importSessionTransfer } from "../../src/cli/cmd/import"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  LayerNode.compile(
+    LayerNode.group([
+      Session.node,
+      EventV2Bridge.node,
+      SessionProjector.node,
+      CrossSpawnSpawner.node,
+      InstanceStore.node,
+      Database.node,
+    ]),
+    [
+      [RuntimeFlags.node, RuntimeFlags.layer({ experimentalWorkspaces: false })],
+      [
+        InstanceBootstrap.node,
+        Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void })),
+      ],
+    ],
+  ),
+)
+
+const model = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const addMessage = Effect.fn("SessionTransferTest.addMessage")(function* (sessionID: SessionID, text: string) {
+  const service = yield* Session.Service
+  const message: SessionV1.User = {
+    id: MessageID.ascending(),
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "test",
+    model,
+  }
+  yield* service.updateMessage(message)
+  yield* service.updatePart({
+    id: PartID.ascending(),
+    sessionID,
+    messageID: message.id,
+    type: "text",
+    text,
+  })
+})
+
+const targetContext = Effect.fn("SessionTransferTest.targetContext")(function* () {
+  const source = yield* InstanceRef
+  if (!source) return yield* Effect.die(new Error("missing instance context"))
+  const { db } = yield* Database.Service
+  const directory = path.join(source.directory, "target")
+  const projectID = ProjectV2.ID.make("target-project")
+  yield* db
+    .insert(ProjectTable)
+    .values({
+      id: projectID,
+      worktree: AbsolutePath.make(directory),
+      sandboxes: [],
+      time_created: Date.now(),
+      time_updated: Date.now(),
+    })
+    .run()
+    .pipe(Effect.orDie)
+  return {
+    source,
+    target: {
+      directory,
+      worktree: directory,
+      project: {
+        ...source.project,
+        id: projectID,
+        worktree: directory,
+      },
+    },
+  }
+})
+
+describe("session transfer", () => {
+  it.instance("collects and imports nested subagent transcripts", () =>
+    Effect.gen(function* () {
+      const service = yield* Session.Service
+      const root = yield* service.create({ title: "root" })
+      const child = yield* service.create({ title: "child", parentID: root.id })
+      const grandchild = yield* service.create({ title: "grandchild", parentID: child.id })
+      yield* addMessage(root.id, "root message")
+      yield* addMessage(child.id, "child message")
+      yield* addMessage(grandchild.id, "grandchild message")
+
+      const sessions = yield* collectSessionTree(service, root)
+      const second = yield* collectSessionTree(service, root)
+      expect(sessions.map((session) => session.info.id)).toEqual([root.id, child.id, grandchild.id])
+      expect(second.map((session) => session.info.id)).toEqual(sessions.map((session) => session.info.id))
+      expect(sessions.map((session) => session.messages[0]?.parts[0]?.type)).toEqual(["text", "text", "text"])
+
+      const archive: SessionTransferArchive = {
+        version: 1,
+        rootSessionID: root.id,
+        sessions,
+      }
+      expect(() => Schema.decodeUnknownSync(SessionTransferArchive)(JSON.parse(JSON.stringify(archive)))).not.toThrow()
+      const context = yield* targetContext()
+      yield* importSessionTransfer(archive, context.target)
+      yield* importSessionTransfer(archive, context.target)
+
+      const ids = sessions.map((session) => session.info.id)
+      const { db } = yield* Database.Service
+      const rows = yield* db.select().from(SessionTable).where(inArray(SessionTable.id, ids)).all().pipe(Effect.orDie)
+      expect(rows).toHaveLength(3)
+      expect(rows.every((row) => row.project_id === context.target.project.id)).toBe(true)
+      expect(rows.every((row) => row.directory === context.target.directory)).toBe(true)
+      expect(rows.find((row) => row.id === child.id)?.parent_id).toBe(root.id)
+      expect(rows.find((row) => row.id === grandchild.id)?.parent_id).toBe(child.id)
+
+      const messages = yield* db
+        .select()
+        .from(MessageTable)
+        .where(inArray(MessageTable.session_id, ids))
+        .all()
+        .pipe(Effect.orDie)
+      const parts = yield* db
+        .select()
+        .from(PartTable)
+        .where(inArray(PartTable.session_id, ids))
+        .all()
+        .pipe(Effect.orDie)
+      expect(messages).toHaveLength(3)
+      expect(parts).toHaveLength(3)
+      expect(parts.every((part) => messages.some((message) => message.id === part.message_id))).toBe(true)
+    }),
+  )
+
+  // * Some legacy tree transfers will fail after this upgrade; confirm the compatibility tradeoff before shipping.
+  it.instance("rejects a legacy import that would strand a subagent Session", () =>
+    Effect.gen(function* () {
+      const service = yield* Session.Service
+      const root = yield* service.create({ title: "root" })
+      yield* service.create({ title: "child", parentID: root.id })
+      yield* addMessage(root.id, "root message")
+      const legacy = (yield* collectSessionTree(service, root))[0]
+      const context = yield* targetContext()
+
+      const error = yield* importSessionTransfer(legacy, context.target).pipe(Effect.flip)
+      expect(error.message).toContain(`Cannot move Session ${root.id} because subagent Session`)
+
+      const { db } = yield* Database.Service
+      const row = yield* db
+        .select()
+        .from(SessionTable)
+        .where(inArray(SessionTable.id, [root.id]))
+        .get()
+        .pipe(Effect.orDie)
+      expect(row?.project_id).toBe(context.source.project.id)
+      expect(row?.directory).toBe(context.source.directory)
+    }),
+  )
+})

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -475,9 +475,10 @@ If you don't provide a session ID, you'll be prompted to select from available s
 
 #### Flags
 
-| Flag                                     | Description                           |
-| ---------------------------------------- | ------------------------------------- |
-| <nobr><code>{"--sanitize"}</code></nobr> | Redact sensitive transcript/file data |
+| Flag                                           | Description                                       |
+| ---------------------------------------------- | ------------------------------------------------- |
+| <nobr><code>{"--sanitize"}</code></nobr>       | Redact sensitive transcript/file data             |
+| <nobr><code>{"--with-subagents"}</code></nobr> | Include transcripts from all nested subagent runs |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #40352

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode stores subagent runs as separate Sessions linked through `parentID`. Previously, `export` wrote only the Session explicitly selected by the user and omitted its subagent Sessions. When importing an existing Session, `import` also re-scoped only that row, potentially leaving its subagent Sessions in the original project.

This PR adds `export --with-subagents`, which writes the selected Session and all of its descendants to a single archive. `import` accepts both the legacy format and the new archive format, and persists all included Sessions, messages, and parts in one transaction.

**Compatibility Tradeoff**: After upgrading, using a legacy export to **move a parent session with known subagent sessions within the same database will fail**. The user must export it again with `--with-subagents`. The current implementation rejects an incomplete transfer to avoid silently splitting the Session tree.

### How did you verify your code works?

```bash
bun typecheck
# Tasks:    30 successful, 30 total
# Cached:    30 cached, 30 total
# Time:    190ms >>> FULL TURBO
```

```bash
cd packages/opencode && bun test ./test/cli/session-transfer.test.ts ./test/cli/import.test.ts
# bun test v1.3.14 (0d9b296a)
# 
# test/cli/session-transfer.test.ts:
# ✓ session transfer > collects and imports nested subagent transcripts [54.04ms]
# ✓ session transfer > rejects a legacy import that would strand a subagent Session [16.45ms]
# 
# test/cli/import.test.ts:
# ✓ formats import file errors [0.25ms]
# ✓ parses valid share URLs [0.07ms]
# ✓ rejects invalid URLs [0.61ms]
# ✓ only attaches share auth headers for same-origin URLs [0.09ms]
# ✓ transforms share data to storage format [0.12ms]
# ✓ returns null for invalid share data [0.03ms]
# 
#  8 pass
#  0 fail
#  35 expect() calls
# Ran 8 tests across 2 files. [13.51s]
```

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR


