### PR TITLE
fix(console): publish desktop theme schema

### DIFF
--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -7,7 +7,7 @@
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",
     "dev:remote": "VITE_AUTH_URL=https://auth.dev.opencode.ai VITE_STRIPE_PUBLISHABLE_KEY=pk_test_51RtuLNE7fOCwHSD4mewwzFejyytjdGoSDK7CAvhbffwaZnPbNb2rwJICw6LTOXCmWO320fSNXvb5NzI08RZVkAxd00syfqrW7t bun sst shell --stage=dev bun dev",
-    "build": "bun ./script/generate-sitemap.ts && vite build && bun ../../opencode/script/schema.ts ./.output/public/config.json ./.output/public/tui.json",
+    "build": "bun ./script/generate-sitemap.ts && vite build && cp ../../ui/src/theme/desktop-theme.schema.json ./.output/public/desktop-theme.json && bun ../../opencode/script/schema.ts ./.output/public/config.json ./.output/public/tui.json",
     "start": "vite start"
   },
   "dependencies": {


### PR DESCRIPTION
### Issue for this PR

- Closes #43202

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Publishes the desktop theme schema as `/desktop-theme.json` during the console build.
- Matches the schema URL used by desktop custom themes.

### How did you verify your code works?

- Ran `bun run build` from `packages/console/app`.
- Confirmed the generated `desktop-theme.json` matches the source schema.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR