### PR TITLE
fix(tool): trim whitespace from file path args

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -235,6 +235,15 @@ export namespace FSUtil {
     }
   }
 
+  /**
+   * Strip only leading/trailing CR/LF from tool path args.
+   * Local models often emit a trailing newline inside JSON string paths; spaces
+   * remain so intentional names like " draft.md" stay addressable.
+   */
+  export function sanitizeToolPath(p: string): string {
+    return p.replace(/^[\r\n]+|[\r\n]+$/g, "")
+  }
+
   export function normalizePathPattern(p: string): string {
     if (process.platform !== "win32") return p
     if (p === "*") return p

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -118,14 +118,16 @@ const layer = Layer.effect(
     })
 
     const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
-      const relative = !path.isAbsolute(input.path)
-      const absolute = path.resolve(location.directory, input.path)
+      // Local models sometimes emit trailing whitespace/newlines in path args.
+      const inputPath = input.path.trim()
+      const relative = !path.isAbsolute(inputPath)
+      const absolute = path.resolve(location.directory, inputPath)
       const lexicallyInternal = FSUtil.contains(location.directory, absolute)
-      if (relative && !lexicallyInternal) return yield* new PathError({ path: input.path, reason: "relative_escape" })
+      if (relative && !lexicallyInternal) return yield* new PathError({ path: inputPath, reason: "relative_escape" })
 
       const resolved = yield* resolvePath(absolute)
       if (lexicallyInternal && !FSUtil.contains(locationRoot, resolved.canonical)) {
-        return yield* new PathError({ path: input.path, reason: "location_escape" })
+        return yield* new PathError({ path: inputPath, reason: "location_escape" })
       }
 
       const external = !lexicallyInternal

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -118,16 +118,17 @@ const layer = Layer.effect(
     })
 
     const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
-      // Local models sometimes emit trailing whitespace/newlines in path args.
-      const inputPath = input.path.trim()
+      // Local models sometimes emit trailing newlines in path args. Keep original
+      // path in errors for debugging; resolve against the sanitized form only.
+      const inputPath = FSUtil.sanitizeToolPath(input.path)
       const relative = !path.isAbsolute(inputPath)
       const absolute = path.resolve(location.directory, inputPath)
       const lexicallyInternal = FSUtil.contains(location.directory, absolute)
-      if (relative && !lexicallyInternal) return yield* new PathError({ path: inputPath, reason: "relative_escape" })
+      if (relative && !lexicallyInternal) return yield* new PathError({ path: input.path, reason: "relative_escape" })
 
       const resolved = yield* resolvePath(absolute)
       if (lexicallyInternal && !FSUtil.contains(locationRoot, resolved.canonical)) {
-        return yield* new PathError({ path: inputPath, reason: "location_escape" })
+        return yield* new PathError({ path: input.path, reason: "location_escape" })
       }
 
       const external = !lexicallyInternal

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -45,6 +45,21 @@ describe("LocationMutation", () => {
     ),
   )
 
+  it.live("trims surrounding whitespace from path arguments", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const targetPath = path.join(directory, "hello.txt")
+        yield* Effect.promise(() => fs.writeFile(targetPath, "hello"))
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: " hello.txt\n" })
+
+        expect(target).toMatchObject({
+          canonical: yield* Effect.promise(() => fs.realpath(targetPath)),
+          resource: "hello.txt",
+        })
+      }).pipe(provide(directory)),
+    ),
+  )
+
   it.live("resolves an active relative prospective file target", () =>
     withTmp((directory) =>
       Effect.gen(function* () {

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -45,16 +45,44 @@ describe("LocationMutation", () => {
     ),
   )
 
-  it.live("trims surrounding whitespace from path arguments", () =>
+  it.live("strips trailing newlines from path arguments", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
         const targetPath = path.join(directory, "hello.txt")
         yield* Effect.promise(() => fs.writeFile(targetPath, "hello"))
-        const target = yield* (yield* LocationMutation.Service).resolve({ path: " hello.txt\n" })
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: "hello.txt\n" })
 
         expect(target).toMatchObject({
           canonical: yield* Effect.promise(() => fs.realpath(targetPath)),
           resource: "hello.txt",
+        })
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("keeps intentional leading spaces in path arguments", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const targetPath = path.join(directory, " draft.md")
+        yield* Effect.promise(() => fs.writeFile(targetPath, "hello"))
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: " draft.md" })
+
+        expect(target).toMatchObject({
+          canonical: yield* Effect.promise(() => fs.realpath(targetPath)),
+          resource: " draft.md",
+        })
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("keeps the original path in PathError after sanitizing newlines", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip((yield* LocationMutation.Service).resolve({ path: "../outside.txt\n" }))
+        expect(error).toMatchObject({
+          _tag: "LocationMutation.PathError",
+          reason: "relative_escape",
+          path: "../outside.txt\n",
         })
       }).pipe(provide(directory)),
     ),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -68,7 +68,9 @@ export const EditTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          if (!params.filePath) {
+          // Local models sometimes emit trailing whitespace/newlines in filePath.
+          const trimmed = params.filePath.trim()
+          if (!trimmed) {
             throw new Error("filePath is required")
           }
 
@@ -77,9 +79,7 @@ export const EditTool = Tool.define(
           }
 
           const instance = yield* InstanceState.context
-          const filePath = path.isAbsolute(params.filePath)
-            ? params.filePath
-            : path.join(instance.directory, params.filePath)
+          const filePath = path.isAbsolute(trimmed) ? trimmed : path.join(instance.directory, trimmed)
           yield* assertExternalDirectoryEffect(ctx, filePath)
 
           let diff = ""

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -68,9 +68,9 @@ export const EditTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          // Local models sometimes emit trailing whitespace/newlines in filePath.
-          const trimmed = params.filePath.trim()
-          if (!trimmed) {
+          // Local models sometimes emit trailing newlines in filePath.
+          const sanitized = FSUtil.sanitizeToolPath(params.filePath)
+          if (!sanitized) {
             throw new Error("filePath is required")
           }
 
@@ -79,7 +79,7 @@ export const EditTool = Tool.define(
           }
 
           const instance = yield* InstanceState.context
-          const filePath = path.isAbsolute(trimmed) ? trimmed : path.join(instance.directory, trimmed)
+          const filePath = path.isAbsolute(sanitized) ? sanitized : path.join(instance.directory, sanitized)
           yield* assertExternalDirectoryEffect(ctx, filePath)
 
           let diff = ""

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -231,7 +231,8 @@ export const ReadTool = Tool.define<
       ctx: Tool.Context<Metadata>,
     ) {
       const instance = yield* InstanceState.context
-      let filepath = params.filePath
+      let filepath = FSUtil.sanitizeToolPath(params.filePath)
+      if (!filepath) throw new Error("filePath is required")
       if (!path.isAbsolute(filepath)) {
         filepath = path.resolve(instance.directory, filepath)
       }

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -38,9 +38,10 @@ export const WriteTool = Tool.define(
       execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const instance = yield* InstanceState.context
-          const filepath = path.isAbsolute(params.filePath)
-            ? params.filePath
-            : path.join(instance.directory, params.filePath)
+          // Local models sometimes emit trailing whitespace/newlines in filePath.
+          const filePath = params.filePath.trim()
+          if (!filePath) throw new Error("filePath is required")
+          const filepath = path.isAbsolute(filePath) ? filePath : path.join(instance.directory, filePath)
           yield* assertExternalDirectoryEffect(ctx, filepath)
 
           const exists = yield* fs.existsSafe(filepath)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -38,8 +38,8 @@ export const WriteTool = Tool.define(
       execute: (params: { content: string; filePath: string }, ctx: Tool.Context) =>
         Effect.gen(function* () {
           const instance = yield* InstanceState.context
-          // Local models sometimes emit trailing whitespace/newlines in filePath.
-          const filePath = params.filePath.trim()
+          // Local models sometimes emit trailing newlines in filePath.
+          const filePath = FSUtil.sanitizeToolPath(params.filePath)
           if (!filePath) throw new Error("filePath is required")
           const filepath = path.isAbsolute(filePath) ? filePath : path.join(instance.directory, filePath)
           yield* assertExternalDirectoryEffect(ctx, filepath)

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -102,6 +102,16 @@ describe("tool.edit", () => {
       }),
     )
 
+    it.instance("trims whitespace from filePath before creating a file", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "trimmed-edit.txt")
+        yield* run({ filePath: ` ${filepath}\n`, oldString: "", newString: "trimmed edit" })
+
+        expect(yield* load(filepath)).toBe("trimmed edit")
+      }),
+    )
+
     it.instance("rejects empty oldString on existing files and leaves content unchanged", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -102,13 +102,23 @@ describe("tool.edit", () => {
       }),
     )
 
-    it.instance("trims whitespace from filePath before creating a file", () =>
+    it.instance("strips trailing newlines from filePath before creating a file", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
         const filepath = path.join(test.directory, "trimmed-edit.txt")
-        yield* run({ filePath: ` ${filepath}\n`, oldString: "", newString: "trimmed edit" })
+        yield* run({ filePath: `${filepath}\n`, oldString: "", newString: "trimmed edit" })
 
         expect(yield* load(filepath)).toBe("trimmed edit")
+      }),
+    )
+
+    it.instance("keeps intentional leading spaces in file names", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, " draft-edit.md")
+        yield* run({ filePath: filepath, oldString: "", newString: "spaced edit" })
+
+        expect(yield* load(filepath)).toBe("spaced edit")
       }),
     )
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -94,6 +94,18 @@ describe("tool.write", () => {
         expect(content).toBe("relative content")
       }),
     )
+
+    it.instance("trims whitespace from filePath before writing", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "trimmed.txt")
+        yield* run({ filePath: `${filepath}\n`, content: "trimmed path" })
+
+        const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+        expect(content).toBe("trimmed path")
+        expect(yield* Effect.promise(() => fs.readdir(test.directory))).toContain("trimmed.txt")
+      }),
+    )
   })
 
   describe("existing file overwrite", () => {

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -95,7 +95,7 @@ describe("tool.write", () => {
       }),
     )
 
-    it.instance("trims whitespace from filePath before writing", () =>
+    it.instance("strips trailing newlines from filePath before writing", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
         const filepath = path.join(test.directory, "trimmed.txt")
@@ -104,6 +104,18 @@ describe("tool.write", () => {
         const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
         expect(content).toBe("trimmed path")
         expect(yield* Effect.promise(() => fs.readdir(test.directory))).toContain("trimmed.txt")
+      }),
+    )
+
+    it.instance("keeps intentional leading spaces in file names", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, " draft.md")
+        yield* run({ filePath: filepath, content: "spaced name" })
+
+        const content = yield* Effect.promise(() => fs.readFile(filepath, "utf-8"))
+        expect(content).toBe("spaced name")
+        expect(yield* Effect.promise(() => fs.readdir(test.directory))).toContain(" draft.md")
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #43112

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Local models sometimes put trailing newlines inside write/edit path args (for example a trailing newline after ruleset.md). Those tools resolved the strings as-is and created files with unreachable names.

Sanitize tool paths with a shared helper that strips only leading/trailing CR/LF:

- packages/opencode write, edit, and read
- shared LocationMutation.resolve so core mutation tools get the same behavior

Accepted tradeoffs (also covered by tests):

- Intentional leading/trailing spaces in file names are preserved
- PathError keeps the original (unsanitized) path for debugging
- Spaces are not stripped, only CR/LF from model sloppiness

### How did you verify your code works?

From package dirs:

    bun test test/tool/write.test.ts test/tool/edit.test.ts
    bun test test/location-mutation.test.ts

All passed, including trailing-newline sanitization, intentional space-prefixed names, and PathError preserving the original path.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
