### PR TITLE
fix(tool): wrap Effect.promise callbacks in Promise.resolve()

### DIFF
--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -176,7 +176,7 @@ const layer: Layer.Layer<Service, never, Auth.Service | Plugin.Service> = Layer.
         }
       }
 
-      const result = yield* Effect.promise(() => method.authorize(input.inputs))
+      const result = yield* Effect.promise(() => Promise.resolve(method.authorize(input.inputs)))
       pending.set(input.providerID, result)
       return {
         url: result.url,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -151,7 +151,7 @@ const layer = Layer.effect(
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }
-                const result = yield* Effect.promise(() => def.execute(args as any, pluginCtx))
+                const result = yield* Effect.promise(() => Promise.resolve(def.execute(args as any, pluginCtx)))
                 const output = typeof result === "string" ? result : result.output
                 const metadata = typeof result === "string" ? {} : (result.metadata ?? {})
                 const attachments = typeof result === "string" ? undefined : result.attachments

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -569,4 +569,83 @@ describe("tool.registry", () => {
       expect(ids).toContain("cowsay")
     }),
   )
+
+  it.instance("executes a plugin tool whose execute returns a plain string synchronously", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const tools = path.join(test.directory, ".opencode", "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "sync-string.ts"),
+          [
+            "export default {",
+            "  description: 'sync string tool',",
+            "  args: { msg: { type: 'string' } },",
+            "  execute({ msg }) {",
+            "    return `echo: ${msg}`",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const loaded = (yield* registry.all()).find((tool) => tool.id === "sync-string")
+      if (!loaded) throw new Error("sync-string tool was not loaded")
+      const agents = yield* Agent.Service
+      const result = yield* loaded.execute({ msg: "hello" }, {
+        sessionID: SessionID.make("ses_test"),
+        messageID: MessageID.make("msg_test"),
+        agent: (yield* agents.defaultInfo()).name,
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      } satisfies Tool.Context)
+
+      expect(result.output).toBe("echo: hello")
+    }),
+  )
+
+  it.instance("executes a plugin tool whose execute returns a structured object synchronously", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const tools = path.join(test.directory, ".opencode", "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "sync-object.ts"),
+          [
+            "export default {",
+            "  description: 'sync object tool',",
+            "  args: {},",
+            "  execute() {",
+            "    return { output: 'ok', title: 'sync' }",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const loaded = (yield* registry.all()).find((tool) => tool.id === "sync-object")
+      if (!loaded) throw new Error("sync-object tool was not loaded")
+      const agents = yield* Agent.Service
+      const result = yield* loaded.execute({}, {
+        sessionID: SessionID.make("ses_test"),
+        messageID: MessageID.make("msg_test"),
+        agent: (yield* agents.defaultInfo()).name,
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      } satisfies Tool.Context)
+
+      expect(result.output).toBe("ok")
+      expect(result.title).toBe("sync")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35498

### Type of change

- [x] Bug fix

### What does this PR do?

Plugin tools with synchronous (non-async) `execute` functions crash with `w0(()=>X(Q)).then is not a function` because `Effect.promise` calls `.then()` directly on the callback's return value. When `execute` returns a plain string or object (not a Promise), `.then` doesn't exist.

The fix wraps the `execute` return in `Promise.resolve()` at the plugin tool boundary. `Promise.resolve()` is a no-op for existing Promises and coerces plain values into thenables.

Two call sites fixed:
- `packages/opencode/src/tool/registry.ts` — plugin tool `execute`
- `packages/opencode/src/provider/auth.ts` — `method.authorize()` (same non-Promise risk)

### How did you verify your code works?

Two regression tests added to `packages/opencode/test/tool/registry.test.ts`:
1. Plugin tool with sync `execute` returning a plain string — fails before fix, passes after
2. Plugin tool with sync `execute` returning a structured object — fails before fix, passes after

All 17 tests pass (15 existing + 2 new).

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
