### PR TITLE
feat(tui): show timestamps on assistant messages

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1565,6 +1565,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>
+              <Show when={ctx.showTimestamps()}>
+                <span style={{ fg: theme.textMuted }}> · {Locale.todayTimeOrDateTime(props.message.time.created)}</span>
+              </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
               </Show>

--- a/packages/tui/test/util/timestamps.test.ts
+++ b/packages/tui/test/util/timestamps.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { todayTimeOrDateTime, time, datetime } from "../../src/util/locale"
+
+describe("locale timestamps for assistant messages", () => {
+  test("todayTimeOrDateTime returns short time for today", () => {
+    const now = Date.now()
+    const result = todayTimeOrDateTime(now)
+    expect(result).toMatch(/\d/)
+  })
+
+  test("todayTimeOrDateTime returns date+time for past date", () => {
+    const past = new Date(2020, 0, 1).getTime()
+    const result = todayTimeOrDateTime(past)
+    expect(result).toContain("·")
+  })
+
+  test("time returns a short time string", () => {
+    const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
+    const result = time(ts)
+    expect(result).toMatch(/1:34/)
+  })
+
+  test("datetime includes both time and date", () => {
+    const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
+    const result = datetime(ts)
+    expect(result).toContain("·")
+    expect(result).toMatch(/1:34/)
+  })
+})

--- a/packages/tui/test/util/timestamps.test.ts
+++ b/packages/tui/test/util/timestamps.test.ts
@@ -1,29 +1,35 @@
 import { describe, expect, test } from "bun:test"
 import { todayTimeOrDateTime, time, datetime } from "../../src/util/locale"
 
-describe("locale timestamps for assistant messages", () => {
-  test("todayTimeOrDateTime returns short time for today", () => {
-    const now = Date.now()
-    const result = todayTimeOrDateTime(now)
-    expect(result).toMatch(/\d/)
+describe("util.locale", () => {
+  describe("todayTimeOrDateTime", () => {
+    test("returns short time for today", () => {
+      const now = Date.now()
+      const result = todayTimeOrDateTime(now)
+      expect(result).toMatch(/\d{1,2}:\d{2}/)
+    })
+
+    test("returns date+time for past date", () => {
+      const past = new Date(2020, 0, 1).getTime()
+      const result = todayTimeOrDateTime(past)
+      expect(result).toContain("·")
+    })
   })
 
-  test("todayTimeOrDateTime returns date+time for past date", () => {
-    const past = new Date(2020, 0, 1).getTime()
-    const result = todayTimeOrDateTime(past)
-    expect(result).toContain("·")
+  describe("time", () => {
+    test("returns a short time string", () => {
+      const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
+      const result = time(ts)
+      expect(result).toMatch(/\d{1,2}:34/)
+    })
   })
 
-  test("time returns a short time string", () => {
-    const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
-    const result = time(ts)
-    expect(result).toMatch(/1:34/)
-  })
-
-  test("datetime includes both time and date", () => {
-    const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
-    const result = datetime(ts)
-    expect(result).toContain("·")
-    expect(result).toMatch(/1:34/)
+  describe("datetime", () => {
+    test("includes both time and date", () => {
+      const ts = new Date(2026, 7, 18, 13, 34, 25).getTime()
+      const result = datetime(ts)
+      expect(result).toContain("·")
+      expect(result).toMatch(/\d{1,2}:34/)
+    })
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #43243

### Type of change

- [x] New feature

### What does this PR do?

The TUI already has a `/timestamps` toggle that shows timestamps on user messages. This PR extends it to also show `time.created` in the assistant message footer, so both sides of the conversation get timestamps when the toggle is on.

The change is 3 lines in `AssistantMessage` — a `<Show when={ctx.showTimestamps()}>` block that renders `Locale.todayTimeOrDateTime(props.message.time.created)` alongside the existing model name and duration. No new mode, no config changes, no data model changes. The toggle still defaults to "hide" (backward compatible).

### How did you verify your code works?

4 tests in `packages/tui/test/util/timestamps.test.ts` covering `todayTimeOrDateTime`, `time`, and `datetime` formatting with locale-agnostic assertions.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
