### PR TITLE
fix(session): guard malformed cost tiers

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -377,9 +377,15 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   }
 
   const contextTokens = inputTokens
+  // a malformed tier is dropped rather than trusted: `tiers` that is not an array, a null entry or
+  // a missing `tier` each used to throw here. A non-numeric `size` must not be coerced to 0 either,
+  // or the tier would match every context instead of none.
+  const tiers = input.model.cost?.tiers
   const costInfo =
-    input.model.cost?.tiers
-      ?.filter((item) => item.tier.type === "context" && contextTokens > item.tier.size)
+    (Array.isArray(tiers) ? tiers : [])
+      .filter(
+        (item) => item?.tier?.type === "context" && Number.isFinite(item.tier.size) && contextTokens > item.tier.size,
+      )
       .sort((a, b) => b.tier.size - a.tier.size)[0] ??
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -378,14 +378,18 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
 
   const contextTokens = inputTokens
   // a malformed tier is dropped rather than trusted: `tiers` that is not an array, a null entry or
-  // a missing `tier` each used to throw here. A non-numeric `size` must not be coerced to 0 either,
-  // or the tier would match every context instead of none.
+  // a missing `tier` each used to throw here.
   const tiers = input.model.cost?.tiers
   const costInfo =
     (Array.isArray(tiers) ? tiers : [])
-      .filter(
-        (item) => item?.tier?.type === "context" && Number.isFinite(item.tier.size) && contextTokens > item.tier.size,
-      )
+      .filter((item) => {
+        if (item?.tier?.type !== "context") return false
+        // `size` still goes through Number() because the old comparison coerced numeric strings
+        // and a hand-written config can produce one. A size that is unparseable or non-positive
+        // is dropped rather than coerced to 0, which would match every context instead of none.
+        const size = Number(item.tier.size)
+        return Number.isFinite(size) && size > 0 && contextTokens > size
+      })
       .sort((a, b) => b.tier.size - a.tier.size)[0] ??
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -378,12 +378,17 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
 
   const contextTokens = inputTokens
   // a malformed tier is dropped rather than trusted: `tiers` that is not an array, a null entry or
-  // a missing `tier` each used to throw here.
+  // a missing `tier` each used to throw here. A tier whose shape+size are valid but whose pricing is
+  // not a finite number is also discarded, so it falls back to the base rates instead of zeroing cost.
   const tiers = input.model.cost?.tiers
   const costInfo =
     (Array.isArray(tiers) ? tiers : [])
       .filter((item) => {
         if (item?.tier?.type !== "context") return false
+        // a tier whose shape+size are valid but whose pricing is not a finite number
+        // (missing/undefined/numeric-string) must be dropped, not selected: otherwise it
+        // wins the `??` and silently zeroes the cost instead of falling back to base rates.
+        if (!Number.isFinite(item.input) || !Number.isFinite(item.output)) return false
         // `size` still goes through Number() because the old comparison coerced numeric strings
         // and a hand-written config can produce one. A size that is unparseable or non-positive
         // is dropped rather than coerced to 0, which would match every context instead of none.

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1956,6 +1956,50 @@ describe("SessionNs.getUsage", () => {
     },
   )
 
+  test("ignores malformed cost tiers instead of throwing", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0, write: 0 },
+        tiers: [
+          // a null entry
+          null,
+          // no `tier` key at all
+          { input: 5, output: 20, cache: { read: 0, write: 0 } },
+          // `tier.size` is not a number
+          { input: 7, output: 30, cache: { read: 0, write: 0 }, tier: { type: "context", size: {} } },
+        ],
+      } as unknown as Provider.Model["cost"],
+    })
+    const input = {
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    }
+
+    expect(() => SessionNs.getUsage(input)).not.toThrow()
+
+    // every tier discarded, so the base pricing applies
+    expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
+  })
+
+  test("ignores a cost.tiers that is not an array", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: { input: 3, output: 15, cache: { read: 0, write: 0 }, tiers: {} } as unknown as Provider.Model["cost"],
+    })
+    const input = {
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    }
+
+    expect(() => SessionNs.getUsage(input)).not.toThrow()
+    expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
+  })
+
   test("extracts cache write tokens from vertex metadata key", () => {
     const model = createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/google-vertex/anthropic" })
     const result = SessionNs.getUsage({

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -2027,6 +2027,28 @@ describe("SessionNs.getUsage", () => {
     expect(result.cost).toBe(3 + 1.5)
   })
 
+  test("drops a tier with valid shape but no pricing, falling back to base", () => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0, write: 0 },
+        // valid type + size>0, but NO input/output pricing → must not silently zero the cost
+        tiers: [{ tier: { type: "context", size: 5000 } }],
+      } as unknown as Provider.Model["cost"],
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    })
+    // before the fix this pricing-less tier won selection and yielded cost 0; now it is
+    // dropped and the base rates apply
+    expect(result.cost).toBe(3 + 1.5)
+    expect(Number.isNaN(result.cost)).toBe(false)
+  })
+
   test("ignores a cost.tiers that is not an array", () => {
     const model = createModel({
       context: 1_000_000,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1985,6 +1985,48 @@ describe("SessionNs.getUsage", () => {
     expect(SessionNs.getUsage(input).cost).toBe(3 + 1.5)
   })
 
+  test("keeps applying a tier whose size is a numeric string", () => {
+    // the pre-guard comparison coerced `contextTokens > "5000"`, and a hand-written config
+    // can still produce one — the guard must not turn that into a dropped tier
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0, write: 0 },
+        tiers: [{ input: 99, output: 99, cache: { read: 0, write: 0 }, tier: { type: "context", size: "5000" } }],
+      } as unknown as Provider.Model["cost"],
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    })
+
+    // tier rates apply: 1_000_000 @ 99 + 100_000 @ 99
+    expect(result.cost).toBe(99 + 9.9)
+  })
+
+  test.each([0, -1])("drops a tier whose size is %p instead of matching every context", (size) => {
+    const model = createModel({
+      context: 1_000_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0, write: 0 },
+        tiers: [{ input: 99, output: 99, cache: { read: 0, write: 0 }, tier: { type: "context", size } }],
+      } as unknown as Provider.Model["cost"],
+    })
+    const result = SessionNs.getUsage({
+      model,
+      usage: usage({ inputTokens: 1_000_000, outputTokens: 100_000, totalTokens: 1_100_000 }),
+    })
+
+    // falls back to the base rates, not the tier's
+    expect(result.cost).toBe(3 + 1.5)
+  })
+
   test("ignores a cost.tiers that is not an array", () => {
     const model = createModel({
       context: 1_000_000,


### PR DESCRIPTION
### Issue for this PR

Closes #43254

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#43248 guarded the operands that go into decimal.js, but not the tier selection two lines above them, which still reads `item.tier.type` and `item.tier.size` unguarded. `cost()` in `provider/provider.ts` copies `tier: item.tier` straight from the models.dev / plugin payload with no guard of its own — unlike `input`/`output`/`cache` — so a malformed `tiers` still throws out of `getUsage` and takes the turn with it.

Three commits, each closing one way a malformed `cost.tiers` misbehaves:

1. **Crashes.** A `tiers` that is not an array, a null entry, or an entry missing `tier` each threw.
2. **A tier that matches everything.** `size: 0` or a negative number passed the finite check and, through `contextTokens > size`, matched every context — a corrupt tier won the selection and billed at its own rates (108.9 instead of the base 4.5 in the test). Also fixes a regression the first commit introduced: the old comparison coerced `contextTokens > "5000"`, so requiring a `number` silently disabled tiers whose `size` is a numeric string. `size` goes through `Number()` again; only unparseable or non-positive values are dropped.
3. **A tier that zeroes the cost.** An entry with a valid `tier` but no finite `input`/`output` won the selection and, via `?? 0`, produced `cost = 0` instead of falling back to the base rates.

Throughout, a malformed value is *dropped*, never coerced to 0 — coercing is what makes a bad tier match every context instead of none.

### How did you verify your code works?

Each case was reproduced first and confirmed failing on `dev` before writing the fix:

| `cost.tiers` | on `dev` |
| --- | --- |
| `[{ input, output, cache }]` (no `tier`) | `TypeError: undefined is not an object` |
| `[null]` | `TypeError: null is not an object` |
| `{}` (not an array) | `TypeError: ...tiers?.filter is not a function` |
| `[{ …, tier: { type: "context", size: -1 } }]` | billed 108.9 instead of 4.5 |
| `[{ tier: { type: "context", size: 5000 } }]` (no rates) | billed 0 instead of 4.5 |

Five tests in the existing `describe("SessionNs.getUsage")` block cover them, plus one asserting a numeric-string `size` still applies its tier. To confirm: revert `session.ts` and re-run that file.

`bun test test/session/compaction.test.ts` → 61 pass, 1 skip, 0 fail. `test/session/llm.test.ts` + `test/server/negative-tokens-regression.test.ts` → 29 pass. `tsgo --noEmit` clean, prettier and oxlint clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
