### PR TITLE
fix(util): guard child stdin against post-exit EPIPE

### DIFF
--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -514,6 +514,32 @@ test("reports a local MCP server as failed when the location has no execution pl
   )
 })
 
+test("survives a local MCP command that dies before reading stdin", async () => {
+  // The transport flushes the initialize frame into the child's stdin as it exits; the broken
+  // pipe surfaces EPIPE asynchronously, after connect already failed. Unguarded, that error had
+  // no listener and killed the whole process, crash-looping the background service over a single
+  // misconfigured server. The connects are concurrent because the escape is racy.
+  const config = new ConfigMCP.Local({
+    type: "local",
+    command: ["bun", "run", "--cwd", "/nonexistent/mcp/dir", "--silent", "start"],
+  })
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* Effect.forEach(
+        ["one", "two", "three", "four"],
+        (name) =>
+          Effect.gen(function* () {
+            const exit = yield* Effect.exit(Effect.scoped(connect(name, config, import.meta.dir)))
+            expect(Exit.isFailure(exit)).toBe(true)
+          }),
+        { concurrency: "unbounded" },
+      )
+      // Give the async destroy path time to deliver a late EPIPE before the test ends.
+      yield* Effect.sleep(1_000)
+    }),
+  )
+})
+
 test("rejects sends before the stdio transport is started", async () => {
   await Effect.runPromise(
     Effect.scoped(

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -222,6 +222,12 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
     Effect.suspend(() => {
       let sink: Sink.Sink<void, unknown, never, PlatformError.PlatformError> = Sink.drain
       if (Predicate.isNotNull(proc.stdin)) {
+        // A child that exits before its stdin is flushed surfaces EPIPE asynchronously through the
+        // stream's destroy path after the sink has already completed. With no listener attached at
+        // that point the error event is process-fatal: a single misconfigured MCP server command
+        // crash-loops the whole background service. Failures during active writes still reach the
+        // sink through its own error handling below.
+        proc.stdin.on("error", () => {})
         sink = NodeSink.fromWritable({
           evaluate: () => proc.stdin!,
           onError: (err) => toPlatformError("fromWritable(stdin)", toError(err), command),


### PR DESCRIPTION
### Issue for this PR

Closes #43257

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A local MCP server whose command dies instantly (e.g. its configured cwd no longer exists) crashes the whole v2 background service, and the client respawns it forever — the TUI just loops "restarting service".

The crash is an uncaught `EPIPE: broken pipe, send`. The MCP transport writes the initialize frame into the child's stdin while it's exiting; once the sink finishes and `end()` flushes into the broken pipe, the writable's destroy path emits `error` asynchronously. At that point nothing is subscribed to `proc.stdin`'s error event, so it's process-fatal. Bun 1.4 (which the v2 binary ships with) surfaces this late EPIPE; Bun 1.3 doesn't.

Fix: attach a no-op `error` listener to `proc.stdin` in the cross-spawn spawner before wrapping it in the sink. Errors during active writes still reach the sink through its own `onError` and fail the connect with a typed error as before — this only stops the late, post-sink EPIPE from killing the process.

### How did you verify your code works?

- Added a regression test that connects concurrently to a local MCP command that dies before reading stdin. On Bun 1.4.0-canary it fails 3/3 without the fix (uncaught EPIPE) and passes 3/3 with it; on Bun 1.3.14 it passes either way since 1.3 never surfaces the late EPIPE.
- Reproduced the original restart loop with my real config against the installed beta, and confirmed the patched spawner survives the same setup.
- `bun run test` + `bun typecheck` in packages/core and packages/util (2 pre-existing failures in core are unrelated: one needs live AWS creds, one is a flaky watcher test that passes in isolation).

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Made with [Cursor](https://cursor.com)