### PR TITLE
fix(core): keep web search consent out of config

### DIFF
--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -32,6 +32,15 @@ export const Plugin = {
     const forms = yield* Form.Service
     const config = yield* Config.Service
     const websearch = yield* WebSearch.Service
+    const configuredProvider = Effect.fn("WebSearchTool.configuredProvider")(function* (
+      providers: readonly WebSearch.Provider[],
+    ) {
+      const configured = Config.latest(yield* config.entries(), "websearch")
+      if (configured === false) return yield* new WebSearch.DisabledError()
+      if (!configured) return
+      if (configured.provider !== "random") return configured.provider
+      return providers[Math.floor(Math.random() * providers.length)]?.id
+    })
 
     yield* ctx.tool
       .transform((draft) =>
@@ -69,6 +78,8 @@ export const Plugin = {
                           const providers = (yield* ctx.websearch.providers()).data
                           const defaultProvider = providers[0]
                           if (!defaultProvider) return yield* new WebSearch.ProviderRequiredError()
+                          const configured = yield* configuredProvider(providers)
+                          if (configured) return configured
                           const response = yield* forms.ask({
                             sessionID: context.sessionID,
                             title: "Web Search",
@@ -96,10 +107,10 @@ export const Plugin = {
                           })
                           if (response.status === "cancelled")
                             return yield* Effect.fail(new Error("Web search cancelled"))
+                          const answeredConfig = yield* configuredProvider(providers)
+                          if (answeredConfig) return answeredConfig
                           if (response.answer.choice === "disable") {
-                            yield* config.update((draft) => {
-                              draft.websearch = false
-                            })
+                            yield* websearch.setDefault(false)
                             return yield* new WebSearch.DisabledError()
                           }
                           const selection =
@@ -125,17 +136,17 @@ export const Plugin = {
                               : undefined
                           if (selection?.status === "cancelled")
                             return yield* Effect.fail(new Error("Web search cancelled"))
+                          const latest = yield* configuredProvider(providers)
+                          if (latest) return latest
                           const providerID = selection?.answer.provider ?? "random"
                           if (
                             typeof providerID !== "string" ||
                             (providerID !== "random" && !providers.some((provider) => provider.id === providerID))
                           )
                             return yield* new WebSearch.ProviderRequiredError()
-                          yield* config.update((draft) => {
-                            draft.websearch = {
-                              provider: providerID === "random" ? "random" : WebSearch.ID.make(providerID),
-                            }
-                          })
+                          yield* websearch.setDefault(
+                            providerID === "random" ? "random" : WebSearch.ID.make(providerID),
+                          )
                           if (providerID !== "random") return WebSearch.ID.make(providerID)
                           return providers[Math.floor(Math.random() * providers.length)]?.id
                         }),
@@ -206,7 +217,14 @@ export const Plugin = {
 
     yield* ctx.session.hook("context", (event) =>
       Effect.gen(function* () {
-        const disabled = Config.latest(yield* config.entries(), "websearch") === false
+        const configured = Config.latest(yield* config.entries(), "websearch")
+        const disabled =
+          configured === false ||
+          (configured === undefined &&
+            (yield* websearch.default().pipe(
+              Effect.as(false),
+              Effect.catch(() => Effect.succeed(true)),
+            )))
         if (disabled) delete event.tools[name]
       }),
     )

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -1,13 +1,15 @@
 export * as WebSearch from "./websearch.js"
 
 import { WebSearch } from "@opencode-ai/schema/websearch"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Ref, Schema } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "./bus.js"
+import { KV } from "./kv.js"
 import { State } from "./state.js"
 
 export const ID = WebSearch.ID
 export type ID = WebSearch.ID
+export type Selection = ID | "random" | false
 
 export const Provider = WebSearch.Provider
 export type Provider = WebSearch.Provider
@@ -49,6 +51,7 @@ export type Error = ProviderRequiredError | ProviderNotFoundError | DisabledErro
 export interface Interface extends State.Transformable<Draft> {
   readonly providers: () => Effect.Effect<readonly Provider[]>
   readonly default: () => Effect.Effect<Provider | undefined, DisabledError>
+  readonly setDefault: (selection: Selection) => Effect.Effect<void>
   readonly query: (input: Input) => Effect.Effect<Response, Error>
 }
 
@@ -56,29 +59,39 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/We
 
 type Data = {
   readonly providers: Map<ID, ProviderImplementation>
-  selection?: ID | "random" | false
+  selection?: Selection
+  selectionOverridden: boolean
 }
 
 export type Draft = {
   add: (provider: ProviderImplementation) => void
   default: {
-    get: () => ID | "random" | false | undefined
-    set: (selection: ID | "random" | false) => void
+    get: () => Selection | undefined
+    set: (selection: Selection) => void
   }
 }
+
+const selectionKey = "websearch:selection"
+const StoredSelection = Schema.Union([ID, Schema.Literal("random"), Schema.Literal(false)])
 
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
+    const kv = yield* KV.Service
     const decodeResults = Schema.decodeUnknownEffect(Schema.Array(Result))
+    const stored = yield* kv.get(selectionKey)
+    const selection = yield* Ref.make<Selection | undefined>(Schema.is(StoredSelection)(stored) ? stored : undefined)
     const state = State.create<Data, Draft>({
-      initial: () => ({ providers: new Map() }),
+      initial: () => ({ providers: new Map(), selection: Ref.getUnsafe(selection), selectionOverridden: false }),
       draft: (draft) => ({
         add: (provider) => draft.providers.set(provider.id, provider),
         default: {
           get: () => draft.selection,
-          set: (selection) => (draft.selection = selection),
+          set: (selection) => {
+            draft.selection = selection
+            draft.selectionOverridden = true
+          },
         },
       }),
       finalize: () => bus.publish(WebSearch.Event.Updated, {}).pipe(Effect.asVoid),
@@ -120,6 +133,14 @@ const layer = Layer.effect(
         const provider = yield* defaultProvider()
         return provider && { id: provider.id, name: provider.name }
       }),
+      setDefault: Effect.fn("WebSearch.setDefault")(function* (value) {
+        yield* kv.set(selectionKey, value)
+        yield* Ref.set(selection, value)
+        const data = state.get()
+        if (data.selectionOverridden) return
+        data.selection = value
+        yield* bus.publish(WebSearch.Event.Updated, {})
+      }),
       query: Effect.fn("WebSearch.query")(function* (input) {
         const provider = yield* resolve(input)
         const results = yield* provider.execute({ query: input.query }).pipe(
@@ -135,5 +156,5 @@ const layer = Layer.effect(
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Bus.node],
+  deps: [Bus.node, KV.node],
 })

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -19,7 +19,6 @@ import { imagePassthrough } from "./lib/image"
 import { permissionLayer } from "./lib/permission"
 import { toolIdentity, executeTool, registerToolPlugin, toolDefinitions } from "./lib/tool"
 import { webSearchHost } from "./plugin/host"
-import { produce } from "immer"
 
 const webSearchToolNode = makeLocationNode({
   name: "test/websearch-tool-plugin",
@@ -37,6 +36,7 @@ const assertions: Permission.AssertInput[] = []
 const queries: WebSearch.Input[] = []
 const formRequests: Form.CreateInput[] = []
 let selection: WebSearch.ID | "random" | false | undefined
+let configuredSelection: WebSearch.ID | "random" | false | undefined
 const providers = [
   { id: WebSearch.ID.make("exa"), name: "Exa" },
   { id: WebSearch.ID.make("parallel"), name: "Parallel" },
@@ -57,6 +57,7 @@ beforeEach(() => {
   queries.length = 0
   formRequests.length = 0
   selection = undefined
+  configuredSelection = undefined
   providerRequired = false
   formResponse = { status: "cancelled" }
   formResponses.length = 0
@@ -93,6 +94,7 @@ const websearch = Layer.succeed(
         if (selection === false) return yield* new WebSearch.DisabledError()
         return selection ? providers.find((provider) => provider.id === selection) : undefined
       }),
+    setDefault: (value) => Effect.sync(() => (selection = value)),
     query: (input) =>
       Effect.gen(function* () {
         queries.push(input)
@@ -102,6 +104,8 @@ const websearch = Layer.succeed(
           yield* Deferred.await(queryBarrier)
         }
         if (queryError) return yield* queryError
+        if (input.providerID && configuredSelection === input.providerID)
+          return new WebSearch.Response({ providerID: input.providerID, results: result.results })
         if (providerRequired && !selection) return yield* new WebSearch.ProviderRequiredError()
         if (selection)
           return new WebSearch.Response({
@@ -136,21 +140,16 @@ const config = Layer.succeed(
         new Document({
           type: "document",
           info: new Info({
-            websearch: selection === undefined ? undefined : selection === false ? false : { provider: selection },
+            websearch:
+              configuredSelection === undefined
+                ? undefined
+                : configuredSelection === false
+                  ? false
+                  : { provider: configuredSelection },
           }),
         }),
       ]),
-    update: (update) =>
-      Effect.sync(() => {
-        const info = produce(
-          new Info({
-            websearch: selection === undefined ? undefined : selection === false ? false : { provider: selection },
-          }),
-          update,
-        )
-        selection = info.websearch === false ? false : info.websearch?.provider
-        return info
-      }),
+    update: () => Effect.die("runtime web search consent must not update config"),
     changes: () => Stream.never,
   }),
 )
@@ -356,6 +355,25 @@ describe("WebSearchTool registration", () => {
           },
         ],
       })
+    }),
+  )
+
+  it.effect("keeps explicit provider config authoritative when resolving consent", () =>
+    Effect.gen(function* () {
+      configuredSelection = WebSearch.ID.make("exa")
+      providerRequired = true
+      const registry = yield* Tool.Service
+
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-configured", name: "websearch", input: { query: "effect" } },
+        }),
+      ).toMatchObject({ status: "completed", metadata: { provider: "exa" } })
+      expect(selection).toBeUndefined()
+      expect(formRequests).toHaveLength(0)
+      expect(queries).toEqual([{ query: "effect" }, { query: "effect", providerID: WebSearch.ID.make("exa") }])
     }),
   )
 

--- a/packages/core/test/websearch.test.ts
+++ b/packages/core/test/websearch.test.ts
@@ -3,10 +3,11 @@ import { Effect, Exit, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
+import { KV } from "@opencode-ai/core/kv"
 import { WebSearch } from "@opencode-ai/core/websearch"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(AppNodeBuilder.build(LayerNode.group([WebSearch.node, Bus.node])))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([WebSearch.node, Bus.node, KV.node])))
 
 const register = (id: string) =>
   Effect.gen(function* () {
@@ -77,6 +78,29 @@ describe("WebSearch", () => {
       yield* websearch.transform((draft) => draft.default.set(parallel.providerID))
 
       expect((yield* websearch.query({ query: "configured" })).providerID).toBe(parallel.providerID)
+    }),
+  )
+
+  it.effect("persists a runtime default in KV", () =>
+    Effect.gen(function* () {
+      const parallel = yield* register("parallel")
+      const websearch = yield* WebSearch.Service
+      const kv = yield* KV.Service
+      yield* websearch.setDefault(parallel.providerID)
+
+      expect(yield* kv.get("websearch:selection")).toBe(parallel.providerID)
+      expect((yield* websearch.query({ query: "persisted" })).providerID).toBe(parallel.providerID)
+    }),
+  )
+
+  it.effect("gives scoped configuration precedence over stored consent", () =>
+    Effect.gen(function* () {
+      const exa = yield* register("exa")
+      const websearch = yield* WebSearch.Service
+      yield* websearch.setDefault(false)
+      yield* websearch.transform((draft) => draft.default.set(exa.providerID))
+
+      expect((yield* websearch.query({ query: "configured" })).providerID).toBe(exa.providerID)
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #43134

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stores runtime Allow, Choose, and Disable web-search consent in v2 KV. Explicit `websearch` configuration remains authoritative, and fixed-provider, random-provider, and disabled behavior is preserved without editing config files.

### How did you verify your code works?

- 18 focused tests passed.
- `bun typecheck` passed from `packages/core`.
- The push-hook repository typecheck passed all 33 tasks.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
