### PR TITLE
fix(core): migrate standalone small model

### DIFF
--- a/packages/core/src/config/normalize.ts
+++ b/packages/core/src/config/normalize.ts
@@ -149,7 +149,7 @@ export function normalize(input: unknown): Result {
     "agents",
     migratedAgents,
     nativeAgents,
-    isRecord(input.agent) || isRecord(input.mode) || isRecord(input.agents),
+    migratedSmallModel !== undefined || isRecord(input.agent) || isRecord(input.mode) || isRecord(input.agents),
     diagnostics,
   )
 

--- a/packages/core/test/config/normalization.test.ts
+++ b/packages/core/test/config/normalization.test.ts
@@ -150,6 +150,16 @@ describe("ConfigNormalize", () => {
   })
 
   test("migrates the legacy small model to the title agent", () => {
+    const result = normalized({ small_model: "anthropic/claude-haiku-4-5" })
+    expect(result.encoded.agents).toEqual({
+      title: {
+        model: { providerID: "anthropic", model: "claude-haiku-4-5" },
+      },
+    })
+    expect(result.diagnostics).toEqual([])
+  })
+
+  test("merges the legacy small model with the title agent", () => {
     const result = normalized({
       small_model: "anthropic/claude-haiku-4-5",
       agent: { title: { prompt: "Custom title prompt" } },


### PR DESCRIPTION
## Summary
- retain a valid legacy `small_model` migration when no agent maps are configured
- preserve invalid-value behavior without creating an empty `agents` map
- add regression coverage for standalone and merged title-agent configurations

## Testing
- `bun test test/config/normalization.test.ts`
- `bun typecheck` in `packages/core`
- full workspace typecheck via the pre-push hook