### PR TITLE
fix(session): degrade undecodable image attachments instead of failing the prompt

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1015,6 +1015,18 @@ const layer = Layer.effect(
                 (error) => error instanceof Image.ResizerUnavailableError,
                 () => Effect.succeed(part),
               ),
+              Effect.matchEffect({
+                onFailure: (error) =>
+                  Effect.succeed({
+                    id: part.id,
+                    messageID: part.messageID,
+                    sessionID: part.sessionID,
+                    type: "text" as const,
+                    synthetic: true,
+                    text: `[Image "${part.filename ?? part.mime}" could not be processed and was not sent: ${error.message}. Convert it to PNG, JPEG, GIF, or WebP and try again.]`,
+                  }),
+                onSuccess: (value) => Effect.succeed(value),
+              }),
             )
           : Effect.succeed(part),
       )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2103,6 +2103,47 @@ noLLMServer.instance(
 // Missing file handling
 
 noLLMServer.instance(
+  "does not fail the prompt when an image attachment cannot be decoded (unsupported format)",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      // Minimal AVIF payload — valid enough to carry image/avif but not decodable by the photon resizer.
+      const avif = Buffer.from(
+        "AAAAABZmdHlwYXZpZm0wMDEAAAAAAG1pZjEA",
+        "base64",
+      ).toString("base64")
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "please review this image" },
+          {
+            type: "file",
+            mime: "image/avif",
+            url: `data:image/avif;base64,${avif}`,
+            filename: "screenshot.avif",
+          },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const notice = msg.parts.find(
+        (part) =>
+          part.type === "text" && part.synthetic && part.text.includes("could not be processed"),
+      )
+      expect(notice).toBeDefined()
+      expect(notice?.type === "text" && notice.text.includes("screenshot.avif")).toBe(true)
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
   "does not fail the prompt when a file part is missing",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue

Closes #43262

### Type of change

- [x] Bug fix

### What does this PR do?

A user message containing an image in a format the Photon-based resizer cannot decode (e.g. AVIF, HEIC, BMP, TIFF) — or an image too large to be resized below the inline limit — made the **entire prompt request fail** with HTTP 400, so the image message could never be sent.

In `createUserMessage` (`packages/opencode/src/session/prompt.ts`), `image.normalize(part)` was wrapped in a fail-fast `Effect.forEach` that only caught `Image.ResizerUnavailableError`. `Image.DecodeError` / `Image.SizeError` propagated and aborted the whole prompt. The tool-result path (`processor.ts`) already degrades gracefully with `Effect.exit` + filtering + an `[N image omitted...]` note — the user-message path was the asymmetric one.

This PR mirrors that pattern: when normalization fails, the image `file` part is replaced with a synthetic text note (filename + mime + reason + conversion suggestion), and the prompt continues normally.

### How did you verify your code works?

- Added a regression test that prompts with an `image/avif` attachment:
  - **Before the fix**: the test fails with `ImageDecodeError` aborting the whole prompt.
  - **After the fix**: the prompt succeeds and the message contains the synthetic "could not be processed" text note.
- `bun test test/session/prompt.test.ts` — 57 pass, 1 unrelated pre-existing glob timeout (also fails on clean `dev`), 1 env skip.
- `bun test test/image/image.test.ts` — 5 pass.
- `bun run typecheck` (packages/opencode) — clean.
- `bunx oxlint` on both changed files — no errors; no new warnings in the changed lines.
