### PR TITLE
fix(core): reduce noisy tracing spans

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -109,7 +109,7 @@ const layer = Layer.effect(
       get: Effect.fn("Agent.get")(function* (id) {
         return state.get().agents.get(id)
       }),
-      resolve: Effect.fn("Agent.resolve")(function* (id) {
+      resolve: Effect.fnUntraced(function* (id) {
         if (id !== undefined) return state.get().agents.get(ID.make(id))
         return selectedDefault()
       }),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -426,7 +426,7 @@ export const layer = (options?: Options) =>
       )
 
       return Service.of({
-        entries: Effect.fn("Config.entries")(function* () {
+        entries: Effect.fnUntraced(function* () {
           return configs
         }),
         update,

--- a/packages/core/src/database/drizzle/effect-sqlite/session.ts
+++ b/packages/core/src/database/drizzle/effect-sqlite/session.ts
@@ -120,9 +120,13 @@ export class EffectSQLiteSession<TRelations extends AnyRelations> extends SQLite
 
   private execute(query: Query, params: unknown[], method: SQLiteExecuteMethod | "values") {
     const statement = this.client.unsafe(query.sql, params)
-    if (method === "values") return statement.values
-    if (method === "get") return statement.withoutTransform.pipe(Effect.map((rows) => rows[0]))
-    return statement.withoutTransform
+    if (method === "values") return statement.values.pipe(Effect.withTracerEnabled(false))
+    if (method === "get")
+      return statement.withoutTransform.pipe(
+        Effect.map((rows) => rows[0]),
+        Effect.withTracerEnabled(false),
+      )
+    return statement.withoutTransform.pipe(Effect.withTracerEnabled(false))
   }
 
   private isInTransaction() {

--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -138,7 +138,7 @@ export const make = Effect.gen(function* () {
     scope: yield* Scope.Scope,
   }
 
-  const settle = Effect.fn("Job.settle")(function* (id: string, token: object, exit: Exit.Exit<string, unknown>) {
+  const settle = Effect.fnUntraced(function* (id: string, token: object, exit: Exit.Exit<string, unknown>) {
     const completed_at = yield* Clock.currentTimeMillis
     const result = yield* SynchronizedRef.modify(state.jobs, (jobs): readonly [FinishResult, Map<string, Active>] => {
       const job = jobs.get(id)
@@ -170,7 +170,7 @@ export const make = Effect.gen(function* () {
     return result.info
   })
 
-  const fork = Effect.fn("Job.fork")(function* (
+  const fork = Effect.fnUntraced(function* (
     scope: Scope.Scope,
     id: string,
     token: object,
@@ -192,7 +192,7 @@ export const make = Effect.gen(function* () {
     return snapshot(job)
   })
 
-  const start: Interface["start"] = Effect.fn("Job.start")(function* (input) {
+  const start: Interface["start"] = Effect.fnUntraced(function* (input) {
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const id = input.id ?? Identifier.ascending("job")
@@ -247,7 +247,7 @@ export const make = Effect.gen(function* () {
     return { info: snapshot(job), timedOut: true }
   })
 
-  const removeBlock = Effect.fn("Job.removeBlock")(function* (input: BlockInput) {
+  const removeBlock = Effect.fnUntraced(function* (input: BlockInput) {
     yield* SynchronizedRef.update(state.jobs, (jobs) => {
       const job = jobs.get(input.id)
       if (!job || job.info.status !== "running" || job.isBackgrounded) return jobs
@@ -258,7 +258,7 @@ export const make = Effect.gen(function* () {
     })
   })
 
-  const block: Interface["block"] = Effect.fn("Job.block")(function* (input) {
+  const block: Interface["block"] = Effect.fnUntraced(function* (input) {
     const result = yield* SynchronizedRef.modify(state.jobs, (jobs): readonly [BlockStart, Map<string, Active>] => {
       const job = jobs.get(input.id)
       if (!job) return [{ type: "missing" }, jobs]

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -65,7 +65,7 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
     const location = yield* Location.Service
 
-    const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
+    const resolve = Effect.fnUntraced(function* (input: ResolveInput) {
       const absolute = path.resolve(location.directory, input.path)
       if (FSUtil.contains(location.directory, absolute)) {
         return {

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -152,14 +152,14 @@ const layer = Layer.effect(
       )
     })
 
-    const configured = Effect.fn("Permission.configured")(function* (sessionID: SessionSchema.ID, agentID?: Agent.ID) {
+    const configured = Effect.fnUntraced(function* (sessionID: SessionSchema.ID, agentID?: Agent.ID) {
       const session = yield* sessions.get(sessionID)
       if (!session) return yield* new SessionErrors.NotFoundError({ sessionID })
       const agent = yield* agents.resolve(agentID ?? session.agent)
       return agent?.permissions ?? missingAgentPermissions
     })
 
-    const allowsAll = Effect.fn("Permission.allowsAll")(function* (input: {
+    const allowsAll = Effect.fnUntraced(function* (input: {
       readonly sessionID: SessionSchema.ID
       readonly action: string
       readonly agent?: Agent.ID

--- a/packages/core/src/permission/saved.ts
+++ b/packages/core/src/permission/saved.ts
@@ -39,7 +39,7 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const { db } = yield* Database.Service
 
-    const list = Effect.fn("PermissionSaved.list")(function* (input?: ListInput) {
+    const list = Effect.fnUntraced(function* (input?: ListInput) {
       const rows = yield* db
         .select()
         .from(PermissionTable)

--- a/packages/core/src/plugin/hooks.ts
+++ b/packages/core/src/plugin/hooks.ts
@@ -68,7 +68,7 @@ const layer = Layer.effect(
       return { dispose }
     })
 
-    const trigger: Interface["trigger"] = Effect.fn("PluginHooks.trigger")(function* (domain, name, event) {
+    const trigger: Interface["trigger"] = Effect.fnUntraced(function* (domain, name, event) {
       for (const callback of callbacks.get(key(domain, name)) ?? []) {
         const result: Effect.Effect<void, Failures[typeof domain][typeof name]> = Reflect.apply(callback, undefined, [
           event,

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -54,7 +54,7 @@ const layer = Layer.effect(
     const decodeMessage = Schema.decodeUnknownEffect(SessionMessage.Info)
 
     return Service.of({
-      get: Effect.fn("SessionStore.get")(function* (sessionID) {
+      get: Effect.fnUntraced(function* (sessionID) {
         const row = yield* db.select().from(SessionTable).where(eq(SessionTable.id, sessionID)).get().pipe(Effect.orDie)
         return row ? fromRow(row) : undefined
       }),

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -101,7 +101,7 @@ export const layer = (options?: ShellSelect.Options) =>
         }),
       )
 
-      const require = Effect.fn("Shell.require")(function* (id: Shell.ID) {
+      const require = Effect.fnUntraced(function* (id: Shell.ID) {
         const session = sessions.get(id)
         if (!session) return yield* new NotFoundError({ id })
         return session
@@ -153,7 +153,7 @@ export const layer = (options?: ShellSelect.Options) =>
 
       const name = () => resolve().pipe(Effect.map(ShellSelect.name))
 
-      const output = Effect.fn("Shell.output")(function* (id: Shell.ID, input?: Shell.OutputInput) {
+      const output = Effect.fnUntraced(function* (id: Shell.ID, input?: Shell.OutputInput) {
         const session = yield* require(id)
         const cursor = input?.cursor ?? 0
         const limit = input?.limit ?? 65536

--- a/packages/core/src/shell/parse.ts
+++ b/packages/core/src/shell/parse.ts
@@ -153,7 +153,7 @@ const ARITY: Record<string, number> = {
   "yarn run": 3,
 }
 
-export const scan = Effect.fn("ShellParse.scan")(function* (
+export const scan = Effect.fnUntraced(function* (
   command: string,
   shell: string,
   cwd: string,
@@ -163,7 +163,7 @@ export const scan = Effect.fn("ShellParse.scan")(function* (
   return yield* scanLegacy(command, shell, cwd)
 })
 
-const scanLegacy = Effect.fn("ShellParse.scanLegacy")(function* (command: string, shell: string, cwd: string) {
+const scanLegacy = Effect.fnUntraced(function* (command: string, shell: string, cwd: string) {
   const parsers = yield* Effect.promise(load)
   const powershell = ShellSelect.ps(shell)
   const tree = (powershell ? parsers.ps : parsers.bash).parse(command)

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -97,10 +97,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
   const materialize = Effect.fnUntraced(function* () {
     const next = options.initial()
     const api = options.draft(next)
-    for (const transform of transforms)
-      yield* apply(transform.run, api).pipe(
-        Effect.withSpan("State.reload.update", { attributes: { state: options.name ?? "anonymous" } }),
-      )
+    for (const transform of transforms) yield* apply(transform.run, api)
     yield* commit(next)
   })
 

--- a/packages/core/src/tool-output.ts
+++ b/packages/core/src/tool-output.ts
@@ -51,7 +51,7 @@ const layer = Layer.effect(
     const global = yield* Global.Service
     const directory = path.join(global.data, DIRECTORY)
 
-    const truncate = Effect.fn("ToolOutput.truncate")(function* (result: Result) {
+    const truncate = Effect.fnUntraced(function* (result: Result) {
       if (result.metadata?.truncated !== undefined) return result
       const content =
         typeof result.content === "string" ? [{ type: "text" as const, text: result.content }] : (result.content ?? [])

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -50,7 +50,7 @@ const layer = Layer.effect(
     const image = yield* Image.Service
 
     type NormalizedItem = Tool.Content | "decode" | "size"
-    const normalizeImages = Effect.fn("Tool.normalizeImages")(function* (content: ReadonlyArray<Tool.Content>) {
+    const normalizeImages = Effect.fnUntraced(function* (content: ReadonlyArray<Tool.Content>) {
       const normalized = yield* Effect.forEach(content, (item): Effect.Effect<NormalizedItem> => {
         if (item.type !== "file" || !item.mime.startsWith("image/")) return Effect.succeed(item)
         const base64 = /^data:[^,]*;base64,(.*)$/s.exec(item.uri)?.[1]

--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -208,7 +208,7 @@ export const Plugin = {
               )
               yield* context.progress({ shellID: info.id })
 
-              const captureShell = Effect.fn("ShellTool.captureShell")(function* () {
+              const captureShell = Effect.fnUntraced(function* () {
                 const configured = Config.latest(yield* config.entries(), "tool_output")
                 const maxLines = configured?.max_lines ?? ToolOutput.MAX_LINES
                 const maxBytes = configured?.max_bytes ?? ToolOutput.MAX_BYTES
@@ -228,7 +228,7 @@ export const Plugin = {
                 }
               })
 
-              const settleShell = Effect.fn("ShellTool.settleShell")(function* () {
+              const settleShell = Effect.fnUntraced(function* () {
                 const final = yield* shell.wait(info.id)
                 const capture = yield* captureShell()
 

--- a/packages/core/test/database-drizzle.test.ts
+++ b/packages/core/test/database-drizzle.test.ts
@@ -6,7 +6,7 @@ import { expect, test } from "bun:test"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import { eq, sql } from "drizzle-orm"
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
-import { Effect } from "effect"
+import { Effect, Tracer } from "effect"
 import type { SqlClient as SqlClientService } from "effect/unstable/sql/SqlClient"
 import { isSqlError } from "effect/unstable/sql/SqlError"
 import { EffectDrizzleSqlite } from "@opencode-ai/core/database/drizzle"
@@ -47,6 +47,31 @@ test("selects rows through Effect-yieldable query builders", async () => {
       expect(yield* db.select({ id: users.id }).from(users).where(eq(users.name, "Ada")).get()).toEqual({ id: 1 })
     }),
   )
+})
+
+test("suppresses statement spans", async () => {
+  const spans: Tracer.NativeSpan[] = []
+  const tracer = Tracer.make({
+    span(options) {
+      const span = new Tracer.NativeSpan(options)
+      spans.push(span)
+      return span
+    },
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const db = yield* makeDb
+      yield* db.transaction((tx) => tx.insert(users).values({ name: "Grace" }))
+      yield* db.select().from(users)
+    }).pipe(
+      Effect.provideService(Tracer.Tracer, tracer),
+      Effect.provide(SqliteClient.layer({ filename: ":memory:", disableWAL: true })),
+      Effect.scoped,
+    ),
+  )
+
+  expect(spans.map((span) => span.name)).not.toContain("sql.execute")
 })
 
 test("commits successful transactions", async () => {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reduces trace amplification during parallel tool execution by removing low-value helper spans and disabling per-statement `sql.execute` spans at the Drizzle execution boundary.

A captured batch of 80 no-op shell tools produced 5,470 spans. `sql.execute` accounted for 1,728 spans and roughly half of the encoded trace bytes, while cheap config, session, permission, shell, parser, and job helpers contributed most of the remainder. The removed wrappers are now `Effect.fnUntraced`, so spans created by meaningful nested operations remain attached to the previous parent. Tool, shell, permission, session, model, HTTP, plugin-loading, and other operation boundaries remain traced.

Based on the captured span histogram, the same workload should emit roughly 802 spans instead of 5,470, an estimated 85% reduction.

### How did you verify your code works?

- `bun typecheck` in `packages/core`
- 92 focused Core tests covering database execution, state, jobs, shell parsing and execution, permissions, location mutation, tool output, and plugin hooks
- Monorepo typecheck run by the push hook
- Added a regression test verifying Drizzle statements do not emit `sql.execute`
- `git diff --check`

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
