### PR TITLE
docs(ecosystem): add opencode-roundtable

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -82,3 +82,4 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+| [opencode-roundtable](https://github.com/NeoMei/opencode-roundtable) | Multi-agent roundtable discussion skill with meeting minutes |


### PR DESCRIPTION
Adds [opencode-roundtable](https://github.com/NeoMei/opencode-roundtable) to the Agents section of the ecosystem page.

A multi-agent roundtable discussion (圆桌讨论) skill for opencode — TUI/CLI/Desktop. User picks members (role, persona, model per member via inline cards); each member is a real subagent run via `opencode run -m provider/model`, a neutral host summarizes each round, and on termination a structured meeting-minutes Markdown file is written. Uses only built-in primitives (`question` / `bash` / `write`), no plugin required.

Ported from [dsh-roundtable](https://github.com/NeoMei/dsh-roundtable); the same SKILL.md stays dual-env compatible with DSH via runtime tool detection.