### PR TITLE
docs(ecosystem): add @neomei/opencode-feishu

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [@neomei/opencode-feishu](https://github.com/NeoMei/opencode-feishu)                               | Chat with OpenCode in Feishu/Lark — streaming replies, tool status, and group chat support         |
 
 ---
 


### PR DESCRIPTION
Adds [@neomei/opencode-feishu](https://github.com/NeoMei/opencode-feishu) to the Ecosystem plugins list.

A Feishu/Lark integration for OpenCode — chat with OpenCode in private or group chats with streaming replies, tool status notifications, and QR-code setup. Published on npm as `@neomei/opencode-feishu`.