### PR TITLE
fix(app): clamp message page requests to the server limit

### DIFF
--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -267,6 +267,39 @@ describe("server session", () => {
     expect(store.data.message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
   })
 
+  test("clamps oversized message requests to the server page limit", async () => {
+    const requests: { sessionID: string; limit: number; cursor?: string }[] = []
+    const all = Array.from({ length: 400 }, (_, index) => ({
+      id: `msg_${String(399 - index).padStart(3, "0")}`,
+      type: "user" as const,
+      text: "hello",
+      time: { created: 400 - index },
+    }))
+    const client = {
+      session: {
+        messages: () => {
+          throw new Error("legacy message endpoint called")
+        },
+      },
+    } as unknown as OpencodeClient
+    const messageApi = {
+      list: async (input: { sessionID: string; limit: number; cursor?: string }) => {
+        requests.push(input)
+        const start = input.cursor ? Number(input.cursor) : 0
+        const page = all.slice(start, start + input.limit)
+        const end = start + page.length
+        return { data: page, cursor: { previous: null, next: end < all.length ? String(end) : null } }
+      },
+    } as unknown as MessageApi
+    const store = createServerSession(client, {} as SessionApi, messageApi)
+    store.remember(session("root"))
+
+    await store.sync("root", { messageLimit: 400 })
+
+    expect(requests.map((request) => request.limit)).toEqual([200, 200])
+    expect(store.data.message.root).toHaveLength(400)
+  })
+
   test("extends a current page to include the user for split assistant turns", async () => {
     const user = { id: "msg_1_user", type: "user", text: "hello", time: { created: 1 } } as const
     const assistant = (id: string, created: number) => ({

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -29,6 +29,8 @@ const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const initialMessagePageSize = 20
 const historyMessagePageSize = 200
+// SessionMessagesQuery in @opencode-ai/protocol rejects anything above this.
+const messagePageMax = 200
 const sessionInfoLimit = 2_048
 const emptyIDs: ReadonlySet<string> = new Set()
 
@@ -536,14 +538,19 @@ export function createServerSession(
 
   const fetchMessages = async (sessionID: string, limit: number, before?: string, onAttempt?: () => void) => {
     if (messageApi && (await options?.protocol) !== "v1") {
+      const pageSize = Math.min(Math.max(limit, 1), messagePageMax)
       const request = (cursor?: string) =>
         (options?.retry ?? retry)(() => {
           onAttempt?.()
-          return messageApi.list(cursor ? { sessionID, limit, cursor } : { sessionID, limit, order: "desc" })
+          return messageApi.list(
+            cursor ? { sessionID, limit: pageSize, cursor } : { sessionID, limit: pageSize, order: "desc" },
+          )
         })
       const first = await request(before)
       const pages = [first]
-      while (pages.at(-1)?.cursor.next && needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) {
+      while (pages.at(-1)?.cursor.next) {
+        const underfilled = limit > messagePageMax && pages.reduce((total, page) => total + page.data.length, 0) < limit
+        if (!underfilled && !needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) break
         const response = await request(pages.at(-1)!.cursor.next ?? undefined)
         pages.push(response)
         if (!response.data.length) break


### PR DESCRIPTION
### Issue for this PR

Closes #43279

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The server caps the message list `limit` at 200, but the app can ask for more than that and get a hard `InvalidRequestError` back.

`fetchMessages` was passing its `limit` argument straight through to `messageApi.list`. That argument is not always a page size — `sync()` passes `meta.limit[sessionID]`, which is the number of messages currently retained for the session. Once you scroll back through history (200 per page) that count goes over 200, and the next re-sync sends an out-of-range limit. Switching back to a session tab re-syncs, so in practice the timeline breaks on tab switch.

Two changes in `fetchMessages`:

- clamp the per-request page size to 200 so we never send an invalid query
- when the requested `limit` is above the cap, keep following `cursor.next` until that many messages have been collected

Clamping alone would silently shrink the retained window back to 200 on every re-sync, so anything you had scrolled back to would disappear, hence the second change. Paging to refill keeps the existing behaviour of `meta.limit` intact.

Below the cap nothing changes — `pageSize` equals `limit` and the extra loop condition is false, so the request shape and the existing `needsOlderTurnRoot` paging are byte-identical.

### How did you verify your code works?

Added `clamps oversized message requests to the server page limit` in `server-session.test.ts`. It drives `sync("root", { messageLimit: 400 })` against a paging mock and asserts the requests are `[200, 200]` and all 400 messages land.

Confirmed it is a real regression test — on `dev` without the source change it fails with `Received: [400]`, which is the exact value the server rejects.

`bun test src/context/server-session.test.ts` in `packages/app`: 75 pass, 0 fail. Full `src/context` run goes from 260 to 261 passing with the same pre-existing failures.

To confirm by hand: open a session with 400+ messages in the web UI, scroll back two pages, switch to another session tab and back. Before this change that throws `Unknown error`; after it, the history loads.

### Screenshots / recordings

Not a visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
