### PR TITLE
fix(core): expose valid subagent IDs in the subagent tool

### DIFF
--- a/packages/core/src/tool/plugin/subagent.ts
+++ b/packages/core/src/tool/plugin/subagent.ts
@@ -22,19 +22,31 @@ const backgroundResult = (sessionID: SessionSchema.ID) => ({
   ].join("\n"),
 })
 
-export const Input = Schema.Struct({
-  agent: Schema.String.annotate({ description: "The type of specialized agent to use for this task" }),
-  description: Schema.String.annotate({ description: "A short 3-5 word label for the task, displayed to the user" }),
-  prompt: Schema.String.annotate({ description: "The task for the subagent to perform" }),
-  sessionID: Schema.optionalKey(SessionSchema.ID).annotate({
-    description:
-      "Continue a specific previous subagent conversation by passing its sessionID. Calls without a sessionID start a new conversation.",
-  }),
-  background: Schema.optionalKey(Schema.Boolean).annotate({
-    description:
-      "Run the subagent in the background and return immediately. You will be notified when it completes. DO NOT sleep, poll, or proactively check on its progress.",
-  }),
-})
+const makeInput = (agentDescription: string) =>
+  Schema.Struct({
+    agent: Schema.String.annotate({ description: agentDescription }),
+    description: Schema.String.annotate({ description: "A short 3-5 word label for the task, displayed to the user" }),
+    prompt: Schema.String.annotate({ description: "The task for the subagent to perform" }),
+    sessionID: Schema.optionalKey(SessionSchema.ID).annotate({
+      description:
+        "Continue a specific previous subagent conversation by passing its sessionID. Calls without a sessionID start a new conversation.",
+    }),
+    background: Schema.optionalKey(Schema.Boolean).annotate({
+      description:
+        "Run the subagent in the background and return immediately. You will be notified when it completes. DO NOT sleep, poll, or proactively check on its progress.",
+    }),
+  })
+
+export const Input = makeInput("The type of specialized agent to use for this task")
+
+export const describeAgents = (agents: readonly Agent.Info[]) => {
+  const ids = agents
+    .filter((agent) => agent.mode !== "primary" && !agent.hidden)
+    .map((agent) => agent.id)
+  return ids.length > 0
+    ? `The type of specialized agent to use for this task. Available agent IDs: ${ids.join(", ")}`
+    : "The type of specialized agent to use for this task"
+}
 
 export const Output = Schema.Struct({
   sessionID: SessionSchema.ID,
@@ -58,6 +70,10 @@ export const Plugin = {
     const config = yield* Config.Service
     const permission = yield* Permission.Service
     const scope = yield* Scope.Scope
+    // Surface the exact, currently valid subagent IDs so the model can discover them instead
+    // of guessing (e.g. "explorer" vs the actual "explore"). The catalog is Location-specific
+    // and mode-aware; per-caller permission filtering still happens at execution time below.
+    const agentDescription = describeAgents(yield* agents.list())
     // One completion observer per job generation. Keyed by child plus start time so a fresh
     // continuation job is observable even while a settled generation's observer is finalizing.
     const notifications = new Set<string>()
@@ -132,7 +148,7 @@ export const Plugin = {
           name,
           options: { codemode: false },
           description,
-          input: Input,
+          input: makeInput(agentDescription),
           output: Output,
           execute: (input, context) =>
             Effect.gen(function* () {

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { Effect, Fiber, Layer, Schema, Stream } from "effect"
 import path from "path"
 import { Money } from "@opencode-ai/schema/money"
@@ -608,4 +608,26 @@ describe("SubagentTool", () => {
       ),
     ),
   )
+
+  test("describes subagent-capable agent IDs in the agent input", () => {
+    const agent = (id: string, mode: Agent.Info["mode"], hidden = false): Agent.Info => ({
+      ...Agent.Info.default(Agent.ID.make(id)),
+      id: Agent.ID.make(id),
+      mode,
+      hidden,
+    })
+    const described = SubagentTool.describeAgents([
+      agent("reviewer", "subagent"),
+      agent("fallback", "subagent"),
+      agent("primary", "primary"),
+      agent("stealth", "all", true),
+      agent("helper", "all"),
+    ])
+    expect(described).toContain("reviewer")
+    expect(described).toContain("fallback")
+    expect(described).toContain("helper")
+    expect(described).not.toContain("primary")
+    expect(described).not.toContain("stealth")
+    expect(SubagentTool.describeAgents([])).toBe("The type of specialized agent to use for this task")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #36761

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `subagent` tool described its `agent` field only as "The type of specialized agent to use for this task" without listing valid IDs, so models guessed plausible names (e.g. `explorer` instead of the actual `explore`) and valid delegation attempts failed at execution time with `Unknown agent: explorer`.

This surfaces the exact, currently valid subagent IDs to the model. At tool registration the plugin lists the Location's agents via `Agent.Service.list()`, filters to subagent-capable ones (`mode !== "primary"` and not `hidden`, so `subagent` and `all` modes are included), and appends them to the `agent` input description:

`The type of specialized agent to use for this task. Available agent IDs: explore, plan, ...`

The catalog is Location-specific and mode-aware by construction; per-caller permission filtering is unchanged and still happens at execution time via the existing `permission.assert` in `execute`. The schema otherwise stays a free-form string (agents are runtime-configurable, so a `Schema.Literals` union would be stale). If no subagent-capable agents exist the description falls back to the previous text.

The exported `Input` schema is preserved for external consumers; the input factory now takes the agent description so registration can inject the catalog without dropping the `sessionID` continuation field.

### How did you verify your code works?

- `bun test ./test/tool-subagent.test.ts` from `packages/core`: 10 passed (added a focused test for `describeAgents`: subagent + all modes included, primary and hidden excluded, empty fallback)
- `bun test` from `packages/core`: 1854 passed, 16 skipped (4 pre-existing Ripgrep timeouts under parallel load, pass in isolation with and without this change)
- `bun typecheck` from `packages/core` and repo-wide `bun typecheck` (33 tasks): passed

Note: prior implementation #36883 was closed by the automated PR cleanup before review; this PR keeps the `sessionID` field that one accidentally dropped and adds regression coverage.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR