### PR TITLE
fix(cli): preserve clean build manifest

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,8 +42,8 @@
     "solid-js": "catalog:",
     "tree-sitter-bash": "0.25.0",
     "tree-sitter-powershell": "0.25.10",
-    "web-tree-sitter": "0.25.10",
     "uqr": "0.1.3",
+    "web-tree-sitter": "0.25.10",
     "ws": "8.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Issue for this PR

Closes #43097

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The CLI build runs `bun install` to prepare OpenTUI dependencies. Bun normalizes dependency ordering during that install, but `web-tree-sitter` was checked in before `uqr`, so a successful build modified `packages/cli/package.json`.

This reorders those two existing entries to match the Bun-generated order. No dependency versions or build behavior change.

### How did you verify your code works?

Ran `bun run build --single --skip-web-ui` from `packages/cli`. The build completed successfully, `bun.lock` remained unchanged, and the only source diff was the intended manifest reorder. The pre-push full repository typecheck also completed with all 33 tasks successful.

### Screenshots / recordings

Not applicable; this is not a UI change.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._