### PR TITLE
fix(core): coalesce queued compactions

### DIFF
--- a/packages/core/src/session/inbox.ts
+++ b/packages/core/src/session/inbox.ts
@@ -180,13 +180,27 @@ export const admitCompaction = Effect.fn("SessionInbox.admitCompaction")(functio
   bus: Bus.Interface,
   input: { readonly id: SessionMessage.ID; readonly sessionID: SessionSchema.ID; readonly delivery: Delivery },
 ) {
-  const admitted = yield* admit(db, bus, {
-    id: input.id,
-    sessionID: input.sessionID,
-    item: Item.make({ type: "compaction", payload: {}, delivery: input.delivery }),
-  })
-  if (admitted.type === "compaction") return admitted
-  return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+  return yield* serialized(
+    input.sessionID,
+    Effect.gen(function* () {
+      const exact = yield* find(db, input.id)
+      if (exact) {
+        if (exact.type === "compaction" && exact.sessionID === input.sessionID) return exact
+        return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+      }
+      if (yield* promotedFromMessage(db, input.sessionID, input.id, input.delivery))
+        return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+      const pending = (yield* list(db, input.sessionID)).find((item) => item.type === "compaction")
+      if (pending) return pending
+      const admitted = yield* admit(db, bus, {
+        id: input.id,
+        sessionID: input.sessionID,
+        item: Item.make({ type: "compaction", payload: {}, delivery: input.delivery }),
+      })
+      if (admitted.type === "compaction") return admitted
+      return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+    }),
+  )
 })
 
 export const projectAdmitted = Effect.fn("SessionInbox.projectAdmitted")(function* (

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -73,7 +73,7 @@ const it = testEffect(
 )
 
 describe("Session.compact", () => {
-  it.effect("durably stacks manual compaction", () =>
+  it.effect("durably coalesces manual compaction", () =>
     Effect.gen(function* () {
       requests = []
       const session = yield* Session.Service
@@ -102,17 +102,32 @@ describe("Session.compact", () => {
       const first = yield* session.compact({ sessionID: created.id })
       const second = yield* session.compact({ sessionID: created.id })
 
-      expect(second.id).not.toBe(first.id)
+      expect(second.id).toBe(first.id)
       expect(requests).toHaveLength(0)
       expect(yield* session.inbox(created.id)).toEqual([
         expect.objectContaining({ id: first.id, type: "compaction", delivery: "queue" }),
-        expect.objectContaining({ id: second.id, type: "compaction", delivery: "queue" }),
       ])
       expect((yield* session.context(created.id)).find((message) => message.id === first.id)).toBeUndefined()
 
       const steered = yield* session.create({ location })
       const steer = yield* session.compact({ sessionID: steered.id, delivery: "steer" })
       expect(steer).toMatchObject({ type: "compaction", delivery: "steer" })
+    }),
+  )
+
+  it.effect("coalesces concurrent manual compaction", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const created = yield* session.create({ location })
+      const admitted = yield* Effect.all(
+        [SessionMessage.ID.create(), SessionMessage.ID.create()].map((id) =>
+          session.compact({ id, sessionID: created.id }),
+        ),
+        { concurrency: "unbounded" },
+      )
+
+      expect(admitted[1]?.id).toBe(admitted[0]?.id)
+      expect(yield* session.inbox(created.id)).toHaveLength(1)
     }),
   )
 })


### PR DESCRIPTION
## What

Prevent one session from accumulating multiple queued compaction requests.

Repeated `/compact` calls now return the existing queued compaction instead of admitting another inbox item.

## Before / After

**Before**

Each `/compact` call minted a new message ID and admitted a new compaction row, so repeated calls produced multiple `Compaction queued` entries.

**After**

Compaction admission is serialized with the existing per-session inbox mutex. While holding that lock, admission returns the existing queued compaction when present; otherwise it follows the existing admission path.

The first request keeps its ID and delivery mode. Once it leaves the inbox, a later compaction can be queued normally.

## How

- `packages/core/src/session/inbox.ts`
  - Reuses `SessionInbox.serialized`, `find`, `promotedFromMessage`, and `list`.
  - Preserves existing explicit message-ID conflict behavior.
  - Coalesces only queued inbox compactions; running-compaction semantics are unchanged.
- `packages/core/test/session-compact.test.ts`
  - Covers sequential and concurrent process-local coalescing.

## Scope

- No database index or migration.
- No schema, protocol, server, runner, or UI changes.
- No new cross-process guarantees; this follows the current single-server, process-local session architecture.

## Testing

- `bun run test session-compact.test.ts` from `packages/core`: 2 passed, 0 failed.
- `bun typecheck` from `packages/core`.
- Push hook: all 33 workspace typecheck tasks passed.
