### PR TITLE
fix(app): keep prompt submit visible on narrow displays

### DIFF
--- a/packages/app/e2e/regression/prompt-thinking-level.spec.ts
+++ b/packages/app/e2e/regression/prompt-thinking-level.spec.ts
@@ -7,7 +7,8 @@ const directory = "C:/OpenCode/PromptThinkingLevelRegression"
 const projectID = "proj_prompt_thinking_level_regression"
 const sessionID = "ses_prompt_thinking_level_regression"
 
-test("shows the V2 thinking level control while relevant", async ({ page }) => {
+test("keeps V2 prompt controls and submit accessible on narrow displays", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 })
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -26,7 +27,7 @@ test("shows the V2 thinking level control while relevant", async ({ page }) => {
           models: {
             "thinking-model": {
               id: "thinking-model",
-              name: "Thinking Model",
+              name: "A long thinking model name for narrow layouts",
               limit: { context: 200_000 },
               variants: { high: {} },
             },
@@ -57,9 +58,17 @@ test("shows the V2 thinking level control while relevant", async ({ page }) => {
   const composer = page.locator('[data-component="prompt-input-v2"]')
   const input = composer.locator('[data-component="prompt-input"]')
   const control = composer.getByRole("button", { name: "Choose model variant" })
+  const controls = composer.locator('[data-slot="prompt-controls"]')
+  const submit = composer.locator('[data-action="prompt-submit"]')
   await expectAppVisible(composer)
 
   await idleComposer(page)
+  await expect(submit).toBeVisible()
+  expect(await controls.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true)
+  const [controlsBox, submitBox] = await Promise.all([controls.boundingBox(), submit.boundingBox()])
+  expect(controlsBox).not.toBeNull()
+  expect(submitBox).not.toBeNull()
+  expect(submitBox!.x).toBeGreaterThanOrEqual(controlsBox!.x + controlsBox!.width)
   await expect(control).toBeVisible()
 
   await control.click()

--- a/packages/app/e2e/regression/prompt-thinking-level.spec.ts
+++ b/packages/app/e2e/regression/prompt-thinking-level.spec.ts
@@ -64,7 +64,6 @@ test("keeps V2 prompt controls and submit accessible on narrow displays", async 
 
   await idleComposer(page)
   await expect(submit).toBeVisible()
-  expect(await controls.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true)
   const [controlsBox, submitBox] = await Promise.all([controls.boundingBox(), submit.boundingBox()])
   expect(controlsBox).not.toBeNull()
   expect(submitBox).not.toBeNull()

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -517,7 +517,7 @@ function PromptInputV2ModelControl(props: {
               data-control-type="dialog"
               variant="ghost-muted"
               size="normal"
-              class="min-w-0 max-w-[220px] justify-start ![font-weight:440] group"
+              class="min-w-0 max-w-[220px] shrink-0 justify-start ![font-weight:440] group"
               classList={{ "animate-in fade-in": shouldAnimate() }}
               style={{ height: "28px" }}
               onClick={props.onUnpaidClick}
@@ -534,7 +534,7 @@ function PromptInputV2ModelControl(props: {
                 variant="ghost-muted"
                 size="normal"
                 style={{ height: "28px" }}
-                class="min-w-0 max-w-[220px] justify-start ![font-weight:440] group"
+                class="min-w-0 max-w-[220px] shrink-0 justify-start ![font-weight:440] group"
                 classList={{ "animate-in fade-in": shouldAnimate() }}
                 data-action="prompt-model"
                 data-control-type="popover"

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -26,7 +26,7 @@ import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { showToast } from "@/utils/toast"
-import { PromptInputV2, type PromptInputV2Suggestion } from "@opencode-ai/session-ui/v2/prompt-input"
+import { promptInputV2ControlClass, PromptInputV2, type PromptInputV2Suggestion } from "@opencode-ai/session-ui/v2/prompt-input"
 import {
   createPromptInputV2Controller,
   createPromptInputV2State,
@@ -517,7 +517,7 @@ function PromptInputV2ModelControl(props: {
               data-control-type="dialog"
               variant="ghost-muted"
               size="normal"
-              class="min-w-0 max-w-[220px] shrink-0 justify-start ![font-weight:440] group"
+              class={`min-w-0 ${promptInputV2ControlClass} group`}
               classList={{ "animate-in fade-in": shouldAnimate() }}
               style={{ height: "28px" }}
               onClick={props.onUnpaidClick}
@@ -534,7 +534,7 @@ function PromptInputV2ModelControl(props: {
                 variant="ghost-muted"
                 size="normal"
                 style={{ height: "28px" }}
-                class="min-w-0 max-w-[220px] shrink-0 justify-start ![font-weight:440] group"
+                class={`min-w-0 ${promptInputV2ControlClass} group`}
                 classList={{ "animate-in fade-in": shouldAnimate() }}
                 data-action="prompt-model"
                 data-control-type="popover"

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -517,7 +517,7 @@ function PromptInputV2ModelControl(props: {
               data-control-type="dialog"
               variant="ghost-muted"
               size="normal"
-              class={`min-w-0 ${promptInputV2ControlClass} group`}
+              class={`${promptInputV2ControlClass} group`}
               classList={{ "animate-in fade-in": shouldAnimate() }}
               style={{ height: "28px" }}
               onClick={props.onUnpaidClick}
@@ -534,7 +534,7 @@ function PromptInputV2ModelControl(props: {
                 variant="ghost-muted"
                 size="normal"
                 style={{ height: "28px" }}
-                class={`min-w-0 ${promptInputV2ControlClass} group`}
+                class={`${promptInputV2ControlClass} group`}
                 classList={{ "animate-in fade-in": shouldAnimate() }}
                 data-action="prompt-model"
                 data-control-type="popover"

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -239,7 +239,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
         </div>
 
         <div class="flex h-11 min-w-0 items-center px-2">
-          <div class="relative min-w-0 flex-1">
+          <div class="relative flex h-full min-w-0 flex-1 items-center">
             <div
               ref={setControls}
               data-slot="prompt-controls"
@@ -309,7 +309,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 aria-label={i18n.t("ui.promptInput.scrollControlsLeft")}
                 onClick={() => scrollControls(-1)}
               >
-                <IconV2 name="chevron-down" class="rotate-90" />
+                <IconV2 name="chevron-down" class="size-6 translate-y-[0.5px] rotate-90" />
               </button>
             </Show>
             <Show when={controlsScroll().right}>
@@ -320,19 +320,21 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 aria-label={i18n.t("ui.promptInput.scrollControlsRight")}
                 onClick={() => scrollControls(1)}
               >
-                <IconV2 name="chevron-down" class="-rotate-90" />
+                <IconV2 name="chevron-down" class="size-6 translate-y-[0.5px] -rotate-90" />
               </button>
             </Show>
           </div>
-          <PromptInputV2SubmitButton
-            mode={state.mode}
-            stopping={view.submit.stopping()}
-            disabled={!props.controller.canSubmit()}
-            sendLabel={i18n.t("ui.promptInput.send")}
-            stopLabel={i18n.t("ui.promptInput.stop")}
-            onSubmit={props.controller.submit}
-            onStop={props.controller.stop}
-          />
+          <div class="ml-1 flex shrink-0">
+            <PromptInputV2SubmitButton
+              mode={state.mode}
+              stopping={view.submit.stopping()}
+              disabled={!props.controller.canSubmit()}
+              sendLabel={i18n.t("ui.promptInput.send")}
+              stopLabel={i18n.t("ui.promptInput.stop")}
+              onSubmit={props.controller.submit}
+              onStop={props.controller.stop}
+            />
+          </div>
         </div>
       </form>
     </div>

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -195,9 +195,10 @@ export function PromptInputV2(props: PromptInputV2Props) {
           </Show>
         </div>
 
-        <div class="flex h-11 items-center px-2">
+        <div class="flex h-11 min-w-0 items-center px-2">
           <div
-            class="flex min-w-0 flex-1 items-center gap-1"
+            data-slot="prompt-controls"
+            class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto no-scrollbar"
             aria-hidden={state.mode === "shell"}
             inert={state.mode === "shell" ? true : undefined}
             style={buttons()}
@@ -573,7 +574,7 @@ export function PromptInputV2Select(props: {
           as={ButtonV2}
           variant="ghost-muted"
           size="normal"
-          class={`max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
+          class={`max-w-[220px] shrink-0 justify-start ![font-weight:440] ${props.class ?? ""}`}
           aria-label={props.title}
         >
           {props.currentIcon}
@@ -691,7 +692,7 @@ export function PromptInputV2SubmitButton(props: {
         tabIndex={props.mode === "normal" ? undefined : -1}
         icon={props.stopping ? "stop" : props.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
         variant="primary"
-        class="size-7 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50"
+        class="relative z-10 size-7 shrink-0 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50 max-sm:size-10 max-sm:p-[12px]"
         style={{
           "background-image":
             "linear-gradient(180deg,var(--v2-alpha-light-20) 0%,var(--v2-alpha-light-0) 100%),linear-gradient(90deg,var(--v2-background-bg-contrast) 0%,var(--v2-background-bg-contrast) 100%)",

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, For, Show, type Accessor, type JSX } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
@@ -34,6 +34,8 @@ export type {
 
 export type PromptInputV2Mode = "normal" | "shell"
 
+export const promptInputV2ControlClass = "max-w-[220px] shrink-0 justify-start ![font-weight:440]"
+
 export type PromptInputV2Props = {
   controller: PromptInputV2Interaction
   disabled?: boolean
@@ -57,11 +59,52 @@ export function PromptInputV2(props: PromptInputV2Props) {
     props.controller.onCursor(promptInputV2Cursor(editor))
   }
   const mode = createMemo(() => state.mode)
+  const [controlsScroll, setControlsScroll] = createSignal({ left: false, right: false })
   const buttons = createMemo(() => ({
     opacity: mode() === "normal" ? 1 : 0,
     "pointer-events": mode() === "normal" ? ("auto" as const) : ("none" as const),
     transition: "opacity 200ms ease",
   }))
+  let controls: HTMLDivElement | undefined
+  let controlsResizeObserver: ResizeObserver | undefined
+  let controlsMutationObserver: MutationObserver | undefined
+
+  function updateControlsScroll() {
+    if (!controls) return
+    const container = controls.getBoundingClientRect()
+    let left = false
+    let right = false
+    for (const control of controls.children) {
+      const bounds = control.getBoundingClientRect()
+      left ||= bounds.left < container.left - 1
+      right ||= bounds.right > container.right + 1
+    }
+    setControlsScroll({
+      left,
+      right,
+    })
+  }
+
+  function setControls(element: HTMLDivElement) {
+    controls = element
+    controlsResizeObserver?.disconnect()
+    controlsMutationObserver?.disconnect()
+    controlsResizeObserver = new ResizeObserver(updateControlsScroll)
+    controlsMutationObserver = new MutationObserver(updateControlsScroll)
+    controlsResizeObserver.observe(element)
+    controlsMutationObserver.observe(element, { childList: true, subtree: true, characterData: true })
+    requestAnimationFrame(updateControlsScroll)
+  }
+
+  function scrollControls(left: number) {
+    if (!controls) return
+    controls.scrollBy({ left: left * Math.max(controls.clientWidth - 32, 1), behavior: "smooth" })
+  }
+
+  onCleanup(() => {
+    controlsResizeObserver?.disconnect()
+    controlsMutationObserver?.disconnect()
+  })
 
   createEffect(() => {
     const parts = props.controller.parts()
@@ -196,63 +239,89 @@ export function PromptInputV2(props: PromptInputV2Props) {
         </div>
 
         <div class="flex h-11 min-w-0 items-center px-2">
-          <div
-            data-slot="prompt-controls"
-            class="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto no-scrollbar"
-            aria-hidden={state.mode === "shell"}
-            inert={state.mode === "shell" ? true : undefined}
-            style={buttons()}
-          >
-            <PromptInputV2AddMenu
-              disabled={state.mode === "shell"}
-              title={i18n.t("ui.promptInput.add")}
-              keybind={props.attachKeybind ?? ["Mod", "U"]}
-              attachLabel={i18n.t("ui.promptInput.attachments")}
-              attachShortcut={props.attachShortcut ?? "Mod+U"}
-              commandsLabel={i18n.t("ui.promptInput.commands")}
-              contextLabel={i18n.t("ui.promptInput.context")}
-              shellLabel={i18n.t("ui.promptInput.shell")}
-              onAttach={props.controller.attach}
-              onCommands={props.controller.openCommands}
-              onContext={props.controller.openContext}
-              onShell={props.controller.openShell}
-            />
-            <Show when={view.agent} keyed>
-              {(control) => (
-                <PromptInputV2ConfiguredSelect
-                  title={i18n.t("ui.promptInput.chooseAgent")}
-                  keybind={["Mod", "."]}
-                  control={control}
-                />
-              )}
-            </Show>
-            <Show
-              when={props.modelControl}
-              fallback={
-                <Show when={view.model} keyed>
-                  {(control) => (
-                    <PromptInputV2ConfiguredSelect
-                      title={i18n.t("ui.promptInput.chooseModel")}
-                      keybind={["Mod", "M"]}
-                      control={control}
-                      model
-                    />
-                  )}
-                </Show>
-              }
+          <div class="relative min-w-0 flex-1">
+            <div
+              ref={setControls}
+              data-slot="prompt-controls"
+              class="flex min-w-0 items-center gap-1 overflow-x-auto no-scrollbar"
+              aria-hidden={state.mode === "shell"}
+              inert={state.mode === "shell" ? true : undefined}
+              style={buttons()}
+              onScroll={updateControlsScroll}
             >
-              {props.modelControl}
-            </Show>
-            <Show when={(props.variantControlVisible ?? true) && view.variant} keyed>
-              {(control) => (
-                <Show when={control.options().length > 1}>
+              <PromptInputV2AddMenu
+                disabled={state.mode === "shell"}
+                title={i18n.t("ui.promptInput.add")}
+                keybind={props.attachKeybind ?? ["Mod", "U"]}
+                attachLabel={i18n.t("ui.promptInput.attachments")}
+                attachShortcut={props.attachShortcut ?? "Mod+U"}
+                commandsLabel={i18n.t("ui.promptInput.commands")}
+                contextLabel={i18n.t("ui.promptInput.context")}
+                shellLabel={i18n.t("ui.promptInput.shell")}
+                onAttach={props.controller.attach}
+                onCommands={props.controller.openCommands}
+                onContext={props.controller.openContext}
+                onShell={props.controller.openShell}
+              />
+              <Show when={view.agent} keyed>
+                {(control) => (
                   <PromptInputV2ConfiguredSelect
-                    title={i18n.t("ui.promptInput.chooseVariant")}
-                    keybind={["Shift", "Mod", "D"]}
+                    title={i18n.t("ui.promptInput.chooseAgent")}
+                    keybind={["Mod", "."]}
                     control={control}
                   />
-                </Show>
-              )}
+                )}
+              </Show>
+              <Show
+                when={props.modelControl}
+                fallback={
+                  <Show when={view.model} keyed>
+                    {(control) => (
+                      <PromptInputV2ConfiguredSelect
+                        title={i18n.t("ui.promptInput.chooseModel")}
+                        keybind={["Mod", "M"]}
+                        control={control}
+                        model
+                      />
+                    )}
+                  </Show>
+                }
+              >
+                {props.modelControl}
+              </Show>
+              <Show when={(props.variantControlVisible ?? true) && view.variant} keyed>
+                {(control) => (
+                  <Show when={control.options().length > 1}>
+                    <PromptInputV2ConfiguredSelect
+                      title={i18n.t("ui.promptInput.chooseVariant")}
+                      keybind={["Shift", "Mod", "D"]}
+                      control={control}
+                    />
+                  </Show>
+                )}
+              </Show>
+            </div>
+            <Show when={controlsScroll().left}>
+              <button
+                type="button"
+                class="absolute inset-y-0 left-0 z-10 flex w-10 items-center justify-start text-v2-icon-icon-muted"
+                style={{ "background-image": "linear-gradient(to right,var(--v2-background-bg-base),transparent)" }}
+                aria-label={i18n.t("ui.promptInput.scrollControlsLeft")}
+                onClick={() => scrollControls(-1)}
+              >
+                <IconV2 name="chevron-down" class="-rotate-90" />
+              </button>
+            </Show>
+            <Show when={controlsScroll().right}>
+              <button
+                type="button"
+                class="absolute inset-y-0 right-0 z-10 flex w-10 items-center justify-end text-v2-icon-icon-muted"
+                style={{ "background-image": "linear-gradient(to left,var(--v2-background-bg-base),transparent)" }}
+                aria-label={i18n.t("ui.promptInput.scrollControlsRight")}
+                onClick={() => scrollControls(1)}
+              >
+                <IconV2 name="chevron-down" class="rotate-90" />
+              </button>
             </Show>
           </div>
           <PromptInputV2SubmitButton
@@ -574,7 +643,7 @@ export function PromptInputV2Select(props: {
           as={ButtonV2}
           variant="ghost-muted"
           size="normal"
-          class={`max-w-[220px] shrink-0 justify-start ![font-weight:440] ${props.class ?? ""}`}
+          class={`${promptInputV2ControlClass} ${props.class ?? ""}`}
           aria-label={props.title}
         >
           {props.currentIcon}
@@ -692,7 +761,7 @@ export function PromptInputV2SubmitButton(props: {
         tabIndex={props.mode === "normal" ? undefined : -1}
         icon={props.stopping ? "stop" : props.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
         variant="primary"
-        class="relative z-10 size-7 shrink-0 rounded-md p-[6px] text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50 max-sm:size-10 max-sm:p-[12px]"
+        class="size-10 shrink-0 rounded-md p-3 text-v2-icon-icon-muted shadow-[var(--v2-elevation-button-contrast)] disabled:opacity-50"
         style={{
           "background-image":
             "linear-gradient(180deg,var(--v2-alpha-light-20) 0%,var(--v2-alpha-light-0) 100%),linear-gradient(90deg,var(--v2-background-bg-contrast) 0%,var(--v2-background-bg-contrast) 100%)",

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -34,7 +34,7 @@ export type {
 
 export type PromptInputV2Mode = "normal" | "shell"
 
-export const promptInputV2ControlClass = "max-w-[220px] shrink-0 justify-start ![font-weight:440]"
+export const promptInputV2ControlClass = "min-w-0 max-w-[220px] shrink-0 justify-start ![font-weight:440]"
 
 export type PromptInputV2Props = {
   controller: PromptInputV2Interaction
@@ -243,7 +243,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
             <div
               ref={setControls}
               data-slot="prompt-controls"
-              class="flex min-w-0 items-center gap-1 overflow-x-auto no-scrollbar"
+              class="flex w-full min-w-0 items-center gap-1 overflow-x-auto no-scrollbar [&>*]:shrink-0"
               aria-hidden={state.mode === "shell"}
               inert={state.mode === "shell" ? true : undefined}
               style={buttons()}
@@ -309,7 +309,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 aria-label={i18n.t("ui.promptInput.scrollControlsLeft")}
                 onClick={() => scrollControls(-1)}
               >
-                <IconV2 name="chevron-down" class="-rotate-90" />
+                <IconV2 name="chevron-down" class="rotate-90" />
               </button>
             </Show>
             <Show when={controlsScroll().right}>
@@ -320,7 +320,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 aria-label={i18n.t("ui.promptInput.scrollControlsRight")}
                 onClick={() => scrollControls(1)}
               >
-                <IconV2 name="chevron-down" class="rotate-90" />
+                <IconV2 name="chevron-down" class="-rotate-90" />
               </button>
             </Show>
           </div>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -136,6 +136,8 @@ export const dict: Record<string, string> = {
   "ui.promptInput.chooseAgent": "Choose agent",
   "ui.promptInput.chooseModel": "Choose model",
   "ui.promptInput.chooseVariant": "Choose model variant",
+  "ui.promptInput.scrollControlsLeft": "Scroll prompt controls left",
+  "ui.promptInput.scrollControlsRight": "Scroll prompt controls right",
   "ui.promptInput.send": "Send",
   "ui.promptInput.stop": "Stop",
 


### PR DESCRIPTION
### Issue for this PR

Closes #43295

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On narrow viewports, prompt controls can overflow into the submit button and receive taps intended for send. This keeps the submit button in its own non-shrinking space, makes excess controls horizontally scrollable, and keeps individual selectors from shrinking into the submit area.

The regression test uses a 320 px viewport with a long model name and verifies that the controls overflow within their scroll container while the submit button remains outside it.

### How did you verify your code works?

Added regression test.

### Screenshots / recordings

BEFORE:
<img width="240" height="124" alt="image" src="https://github.com/user-attachments/assets/a32fa316-8a38-4771-a987-4303a5659d58" />


AFTER: (note that the selector also becomes scrollable so the user can slide back and forth to see more, or click/tap the chevrons to see more to the right or to the left)
<img width="273" height="125" alt="image" src="https://github.com/user-attachments/assets/fdc5fd78-73e6-484e-a069-29bd86f2e15c" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
