### PR TITLE
docs: add SuperCompress MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,51 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### SuperCompress
+
+Add the [SuperCompress](https://www.supercompress.dev) MCP server to compress bulky tool dumps, logs, diffs, and pasted context before they burn tokens. Compresses **context only** — never the user’s ask.
+
+One-shot install (detects OpenCode and writes this config for you):
+
+```bash
+npm install -g supercompress-proxy
+supercompress setup
+```
+
+Or add it manually:
+
+```jsonc title="opencode.jsonc" {4-14}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "supercompress": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "supercompress-proxy", "supercompress-mcp"],
+      "enabled": true,
+      "timeout": 60000,
+      "environment": {
+        "SUPERCOMPRESS_CONFIG_DIR": "{env:HOME}/.supercompress"
+      }
+    }
+  }
+}
+```
+
+Link your account once (`supercompress connect` or the MCP `connect_account` tool), then restart OpenCode so the server loads.
+
+Tools: `compress_context`, `connect_account`, `usage_summary`.
+
+```txt "use compress_context"
+Compress this tool dump for the current question. use compress_context
+```
+
+Optionally add guidance to [AGENTS.md](/docs/rules/):
+
+```md title="AGENTS.md"
+When tool dumps, logs, diffs, or pasted blobs are large, call SuperCompress `compress_context` with the dump as `context` and the user question as `query`. Prefer `~/.supercompress/inbox/latest.md` when it exists. Never compress the user’s ask.
+```
+
+Docs: [Coding agents](https://docs.supercompress.dev/coding-agents) · [Benchmarks](https://www.supercompress.dev/benchmarks)


### PR DESCRIPTION
## Summary
- Add a **SuperCompress** example under MCP server docs (same style as Sentry / Context7 / Grep).
- Covers one-shot `supercompress setup`, manual `opencode.jsonc` local MCP, tools, and optional `AGENTS.md` guidance.
- Compression targets bulky **context** only — not the user ask.

## Why
OpenCode already invites PRs for documenting common MCP servers. SuperCompress is an MCP-native compression path used with coding agents (including OpenCode via `supercompress setup`).

## Test plan
- [ ] Docs page renders the new section under Examples
- [ ] JSONC example matches OpenCode local MCP schema (`type: local`, `command` array, `timeout`, `environment`)
- [ ] Links resolve (site + coding-agents docs)


Made with [Cursor](https://cursor.com)