### PR TITLE
feat(opencode): make generated title length configurable

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -74,6 +74,10 @@ export const Info = Schema.Struct({
   model: Schema.optional(Schema.String).annotate({
     description: "Model to use in the format of provider/model, eg anthropic/claude-2",
   }),
+  title_max_words: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(1))).annotate({
+    description:
+      "Maximum number of words in a generated session title. Omit for the default title style, which targets 50 characters instead of a word count.",
+  }),
   small_model: Schema.optional(Schema.String).annotate({
     description: "Small model to use for tasks like title generation in the format of provider/model",
   }),

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -14,6 +14,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_TITLE_SHORT from "./prompt/title-short.txt"
 import { Permission } from "@/permission"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Global } from "@opencode-ai/core/global"
@@ -245,7 +246,11 @@ const layer = Layer.effect(
               }),
               user,
             ),
-            prompt: PROMPT_TITLE,
+            // A user `agent.title.prompt` still wins over this: the config loop
+            // below overwrites `prompt` unconditionally.
+            prompt: cfg.title_max_words
+              ? PROMPT_TITLE_SHORT.replaceAll("{{MAX_WORDS}}", String(cfg.title_max_words))
+              : PROMPT_TITLE,
           },
           summary: {
             name: "summary",

--- a/packages/opencode/src/agent/prompt/title-short.txt
+++ b/packages/opencode/src/agent/prompt/title-short.txt
@@ -1,0 +1,58 @@
+You are a title generator. You output ONLY a thread title. Nothing else.
+
+<task>
+Generate an extremely short label that would help the user find this conversation later.
+
+Follow all rules in <rules>
+Use the <examples> so you know what a good title looks like.
+Your output must be:
+- A single line
+- AT MOST {{MAX_WORDS}} WORDS. NEVER MORE.
+- No explanations
+</task>
+
+<rules>
+- LENGTH IS THE MOST IMPORTANT RULE: the title must contain {{MAX_WORDS}} words or fewer.
+  {{MAX_WORDS}} is a hard ceiling, not a target.
+- Before you answer, count the words in your draft title. If the count is greater than
+  {{MAX_WORDS}}, delete the least important words until at most {{MAX_WORDS}} remain,
+  then count again. A stack of nouns still counts: "LangFuse trace inspection" is THREE
+  words, so it is wrong whenever the limit is 2.
+- When a subject has a qualifier and a category, keep the subject and drop the category
+  ("Paper visualization website" → "Paper visualization")
+- you MUST use the same language as the user message you are summarizing
+- Name the subject, not the action - drop verbs unless the verb IS the subject
+- Never include tool names in the title (e.g. "read tool", "bash tool", "edit tool")
+- Keep exact: technical terms, numbers, filenames, HTTP codes
+- A filename or an error code alone is a great title
+- Remove: the, this, my, a, an, and all other filler words
+- Do not pad the title to reach the limit - one strong word beats three weak ones
+- Never assume tech stack
+- Never use tools
+- NEVER respond to questions, just generate a title for the conversation
+- The title should NEVER include "summarizing" or "generating" when generating a title
+- DO NOT SAY YOU CANNOT GENERATE A TITLE OR COMPLAIN ABOUT THE INPUT
+- Always output something meaningful, even if the input is minimal.
+- If the user message is short or conversational (e.g. "hello", "lol", "what's up", "hey"):
+  → use a short label for the tone (such as Greeting, Quick check-in, Small talk, etc.)
+</rules>
+
+<examples>
+These show the style at a two-word limit; scale the detail to the configured limit.
+Counting demonstration at a limit of 2:
+  draft "E2E eval onboarding design" = 4 words → too long → "Eval onboarding" = 2 words → OK
+  draft "Phone coding agent support" = 4 words → too long → "Mobile agents" = 2 words → OK
+"debug 500 errors in production" → Production 500s
+"refactor user service" → User service
+"why is app.js failing" → app.js failure
+"implement rate limiting" → Rate limiting
+"how do I connect postgres to my API" → Postgres connection
+"best practices for React hooks" → React hooks
+"@src/auth.ts can you add refresh token support" → Refresh tokens
+"@utils/parser.ts this is broken" → Parser bug
+"look at @config.json" → config.json
+"@App.tsx add dark mode toggle" → Dark mode
+"is the dev instance of opencode down" → Dev instance
+"can we switch to vertical tabs" → Vertical tabs
+"find the most similar already-checked E2E eval for the diligence bench PR" → Diligence bench
+</examples>

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -399,6 +399,21 @@ You can also configure [local models](/docs/models#local). [Learn more](/docs/mo
 
 ---
 
+### Session titles
+
+You can cap the length of generated session titles with the `title_max_words` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "title_max_words": 3
+}
+```
+
+When unset, titles target 50 characters rather than a word count. Setting it switches the title agent to a prompt that caps titles at that many words, which helps when a narrow session list would otherwise truncate them mid-phrase.
+
+---
+
 ### Policies
 
 Use the `experimental.policies` option to allow or deny OpenCode actions on configured resources. Currently, policies can control which providers OpenCode may use.


### PR DESCRIPTION
### Issue for this PR

Closes #43118

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `title_max_words` config value. When set, the title agent uses a prompt that caps titles at that many words. When unset, behavior is unchanged.

Stating the limit alone was not enough. With only "at most N words" in the prompt, the model kept returning noun piles one word over ("LangFuse trace inspection" at a limit of 2), the same way on every rerun rather than occasionally. The prompt therefore makes the model count its draft and cut, and shows one worked counting example.

### How did you verify your code works?

Ran `bun typecheck` (no new errors) and built the binary. Ran the title agent over 5 real sessions at limits 2 and 4, comparing against the existing prompt on the same inputs: over-limit output went 2/5 -> 1/5 at limit 2, and 0/5 at limit 4. The existing prompt was 1/5 on those same inputs, so the harder cases are not a regression from this change.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_Opened by an agent on my behalf._