### PR TITLE
fix(session): degrade undecodable image attachments instead of failing the prompt

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1015,6 +1015,18 @@ const layer = Layer.effect(
                 (error) => error instanceof Image.ResizerUnavailableError,
                 () => Effect.succeed(part),
               ),
+              Effect.matchEffect({
+                onFailure: (error) =>
+                  Effect.succeed({
+                    id: part.id,
+                    messageID: part.messageID,
+                    sessionID: part.sessionID,
+                    type: "text" as const,
+                    synthetic: true,
+                    text: `[Image "${part.filename ?? part.mime}" could not be processed and was not sent: ${error.message}. Convert it to PNG, JPEG, GIF, or WebP and try again.]`,
+                  }),
+                onSuccess: (value) => Effect.succeed(value),
+              }),
             )
           : Effect.succeed(part),
       )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1015,6 +1015,8 @@ const layer = Layer.effect(
                 (error) => error instanceof Image.ResizerUnavailableError,
                 () => Effect.succeed(part),
               ),
+              // Ordering is load-bearing: the catch above passes resizer failures through
+              // unchanged; any other normalize failure degrades to a synthetic text part.
               Effect.matchEffect({
                 onFailure: (error) =>
                   Effect.succeed({

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -50,6 +50,7 @@ import { Truncate } from "@/tool/truncate"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Format } from "../../src/format"
+import { TestConfig } from "../fixture/config"
 import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
@@ -208,6 +209,13 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
+const promptReplacement = [
+  [SessionSummary.node, summary],
+  [LSP.node, lsp],
+  [MCP.node, makeMcp()],
+  [RuntimeFlags.node, runtimeFlags],
+] as const
+
 function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
   const replacements = [
     [SessionSummary.node, summary],
@@ -238,6 +246,13 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
 function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
   return makePrompt(input)
 }
+
+const tinyImageServer = testEffect(
+  LayerNode.compile(promptRoot, [
+    ...promptReplacement,
+    [Config.node, TestConfig.layer({ get: () => Effect.succeed({ attachment: { image: { max_base64_bytes: 1 } } }) })],
+  ] as const),
+)
 
 const it = testEffect(makeHttp())
 const noLLMServer = testEffect(makeHttpNoLLMServer())
@@ -2137,6 +2152,83 @@ noLLMServer.instance(
       )
       expect(notice).toBeDefined()
       expect(notice?.type === "text" && notice.text.includes("screenshot.avif")).toBe(true)
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+tinyImageServer.instance(
+  "does not fail the prompt when an image attachment exceeds the size limit",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      // Valid 1x1 PNG — decodes fine but exceeds the 1-byte max_base64_bytes limit.
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+        "base64",
+      ).toString("base64")
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "please review this image" },
+          {
+            type: "file",
+            mime: "image/png",
+            url: `data:image/png;base64,${png}`,
+            filename: "screenshot.png",
+          },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const notice = msg.parts.find(
+        (part) =>
+          part.type === "text" && part.synthetic && part.text.includes("could not be processed"),
+      )
+      expect(notice).toBeDefined()
+      expect(notice?.type === "text" && notice.text.includes("screenshot.png")).toBe(true)
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
+  "does not fail the prompt when an image attachment has an invalid data URL",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "please review this image" },
+          {
+            type: "file",
+            mime: "image/png",
+            url: "http://example.com/not-a-data-url.png",
+            filename: "screenshot.png",
+          },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const notice = msg.parts.find(
+        (part) =>
+          part.type === "text" && part.synthetic && part.text.includes("could not be processed"),
+      )
+      expect(notice).toBeDefined()
+      expect(notice?.type === "text" && notice.text.includes("screenshot.png")).toBe(true)
 
       yield* sessions.remove(session.id)
     }),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2103,6 +2103,47 @@ noLLMServer.instance(
 // Missing file handling
 
 noLLMServer.instance(
+  "does not fail the prompt when an image attachment cannot be decoded (unsupported format)",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      // Minimal AVIF payload — valid enough to carry image/avif but not decodable by the photon resizer.
+      const avif = Buffer.from(
+        "AAAAABZmdHlwYXZpZm0wMDEAAAAAAG1pZjEA",
+        "base64",
+      ).toString("base64")
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "please review this image" },
+          {
+            type: "file",
+            mime: "image/avif",
+            url: `data:image/avif;base64,${avif}`,
+            filename: "screenshot.avif",
+          },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const notice = msg.parts.find(
+        (part) =>
+          part.type === "text" && part.synthetic && part.text.includes("could not be processed"),
+      )
+      expect(notice).toBeDefined()
+      expect(notice?.type === "text" && notice.text.includes("screenshot.avif")).toBe(true)
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
   "does not fail the prompt when a file part is missing",
   () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2153,6 +2153,11 @@ noLLMServer.instance(
       expect(notice).toBeDefined()
       expect(notice?.type === "text" && notice.text.includes("screenshot.avif")).toBe(true)
 
+      // original text survives and stays before the degradation notice
+      const texts = msg.parts.map((part) => (part.type === "text" ? part.text : ""))
+      expect(texts).toContain("please review this image")
+      expect(texts.indexOf("please review this image")).toBeLessThan(texts.indexOf(notice?.type === "text" ? notice.text : ""))
+
       yield* sessions.remove(session.id)
     }),
   { config: cfg },
@@ -2194,6 +2199,11 @@ tinyImageServer.instance(
       expect(notice).toBeDefined()
       expect(notice?.type === "text" && notice.text.includes("screenshot.png")).toBe(true)
 
+      // original text survives and stays before the degradation notice
+      const texts = msg.parts.map((part) => (part.type === "text" ? part.text : ""))
+      expect(texts).toContain("please review this image")
+      expect(texts.indexOf("please review this image")).toBeLessThan(texts.indexOf(notice?.type === "text" ? notice.text : ""))
+
       yield* sessions.remove(session.id)
     }),
   { config: cfg },
@@ -2229,6 +2239,55 @@ noLLMServer.instance(
       )
       expect(notice).toBeDefined()
       expect(notice?.type === "text" && notice.text.includes("screenshot.png")).toBe(true)
+
+      // original text survives and stays before the degradation notice
+      const texts = msg.parts.map((part) => (part.type === "text" ? part.text : ""))
+      expect(texts).toContain("please review this image")
+      expect(texts.indexOf("please review this image")).toBeLessThan(texts.indexOf(notice?.type === "text" ? notice.text : ""))
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
+  "keeps a valid image as a file part when a sibling image degrades",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      // Valid 1x1 PNG (decodes fine under the default limit) alongside an undecodable AVIF.
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+        "base64",
+      ).toString("base64")
+      const avif = Buffer.from(
+        "AAAAABZmdHlwYXZpZm0wMDEAAAAAAG1pZjEA",
+        "base64",
+      ).toString("base64")
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "please review these images" },
+          { type: "file", mime: "image/png", url: `data:image/png;base64,${png}`, filename: "ok.png" },
+          { type: "file", mime: "image/avif", url: `data:image/avif;base64,${avif}`, filename: "bad.avif" },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+      const notice = msg.parts.find(
+        (part) =>
+          part.type === "text" && part.synthetic && part.text.includes("could not be processed"),
+      )
+      expect(notice).toBeDefined()
+      const validFile = msg.parts.find((part) => part.type === "file" && part.filename === "ok.png")
+      expect(validFile).toBeDefined()
+      const texts = msg.parts.map((part) => (part.type === "text" ? part.text : ""))
+      expect(texts.indexOf("please review these images")).toBeLessThan(texts.indexOf(notice?.type === "text" ? notice.text : ""))
 
       yield* sessions.remove(session.id)
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #43262

### Type of change

- [x] Bug fix

### What does this PR do?

A user message containing an image in a format the Photon-based resizer cannot decode (e.g. AVIF, HEIC, BMP, TIFF), or an image too large to be resized below the inline limit, made the entire prompt request fail with HTTP 400, so the image message could never be sent.

In `createUserMessage` (`packages/opencode/src/session/prompt.ts`), `image.normalize(part)` was wrapped in a fail-fast `Effect.forEach` that only caught `Image.ResizerUnavailableError`. `Image.DecodeError` and `Image.SizeError` propagated and aborted the whole prompt. The tool-result path (`processor.ts`) already degrades gracefully with `Effect.exit` + filtering + an `[N image omitted...]` note, so the user-message path was the asymmetric one.

This PR mirrors that pattern: when normalization fails, the image `file` part is replaced with a synthetic text note (filename + mime + reason + a conversion suggestion), and the prompt continues normally.

### How did you verify your code works?

- Added a regression test that prompts with an `image/avif` attachment.
  - Before the fix: the test fails with `ImageDecodeError` aborting the whole prompt.
  - After the fix: the prompt succeeds and the message contains the synthetic "could not be processed" text note.
- `bun test test/session/prompt.test.ts` — 57 pass, 1 unrelated pre-existing glob timeout (also fails on clean `dev`), 1 env skip.
- `bun test test/image/image.test.ts` — 5 pass.
- `bun run typecheck` (packages/opencode) — clean.
- `bunx oxlint` on both changed files — no errors; no new warnings in the changed lines.

### Screenshots / recordings

N/A — behavioral fix in the session prompt path, covered by the regression test above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
