### PR TITLE
fix(core): resolve Windows shells installed as app-execution aliases

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,7 +1,7 @@
 export * as Shell from "./shell"
 
 import path from "path"
-import { spawn, type ChildProcess } from "child_process"
+import { spawn, spawnSync, type ChildProcess } from "child_process"
 import { readFile } from "fs/promises"
 import { statSync } from "fs"
 import { setTimeout as sleep } from "node:timers/promises"
@@ -92,7 +92,18 @@ function resolve(file: string) {
     if (stat(shell)?.isFile()) return shell
     return
   }
-  return which(shell) ?? undefined
+  const found = which(shell)
+  if (found) return found
+  // Store/MSIX installs expose their executable as a Windows app-execution alias, an
+  // AppExecLink reparse point that stat and which cannot see even though CreateProcess
+  // resolves it by name. where.exe does see it, so it separates "installed as an alias"
+  // from "not installed" and keeps a configured shell like pwsh from silently falling back.
+  if (process.platform === "win32" && meta(shell) && aliased(shell)) return shell
+  return undefined
+}
+
+function aliased(file: string) {
+  return spawnSync("where.exe", [file], { stdio: "ignore", windowsHide: true }).status === 0
 }
 
 function win() {

--- a/packages/core/test/shell.test.ts
+++ b/packages/core/test/shell.test.ts
@@ -49,6 +49,15 @@ describe("shell", () => {
     })
   })
 
+  test("falls back for known shell families that are not installed", async () => {
+    if (process.platform !== "win32") return
+    await withShell(undefined, () => {
+      // ksh is in the shell metadata table but is not present on Windows. Resolution must not
+      // trust a bare name just because the family is known, only when the OS can actually find it.
+      expect(Shell.acceptable("ksh")).toBe(Shell.acceptable())
+    })
+  })
+
   test("falls back for terminal-only acceptable shells", () => {
     expect(Shell.name(Shell.acceptable("fish"))).not.toBe("fish")
     expect(Shell.name(Shell.acceptable("nu"))).not.toBe("nu")


### PR DESCRIPTION
### Issue for this PR

Closes #41426

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, a configured `shell: "pwsh"` is silently ignored and commands run under PowerShell 5.1 instead.

When PowerShell 7 is installed from the Store/MSIX package, `pwsh` on PATH is a Windows **app-execution alias**: a zero-byte `AppExecLink` reparse point, not a real executable. `CreateProcess` resolves it by name, but `stat` does not see it. `Shell.resolve()` goes through `which()`, which stats candidates, so the alias resolves to nothing and `select()` falls back to `win()[0]` — Windows PowerShell 5.1 — without reporting that the configured shell was not found.

Measured on Windows 11 with a Store-installed alias:

```
fs.existsSync(<alias>)   -> false
fs.statSync(<alias>)     -> undefined
spawnSync("winget", ...) -> status 0
```

When `which()` finds nothing on Windows for a name we already recognise as a shell, this falls back to `where.exe`, which does resolve aliases, and returns the bare name so `CreateProcess` performs the lookup. `where.exe` distinguishes the two cases cleanly: exit 0 for an installed alias (`winget`), exit 1 for something genuinely absent (`pwsh` when not installed, `zsh`, `ksh`).

The fallback is deliberately narrow — Windows only, only after `which()` has already failed, and only for names in the existing shell table — so an unrelated missing binary still resolves to `undefined` as before.

### How did you verify your code works?

- Added a test asserting a shell name that resolves to nothing stays `undefined`, guarding the case where `where.exe` might otherwise return a non-shell match.
- `bun test test/shell.test.ts` in `packages/core` passes (12/12), and the dependent `shell`/`bash` tool suites in `packages/opencode` still pass.
- Verified the alias behaviour directly on Windows 11 with the numbers above, using `winget` as a stand-in alias, and confirmed `where.exe` exits 1 for shells that are actually absent.
- `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
