### PR TITLE
fix(tui): open subagent panel from footer

### DIFF
--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -51,27 +51,18 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
             <box flexDirection="row" flexShrink={1} minWidth={0}>
               <Show when={live()}>
                 <box
-                  flexDirection="row"
                   flexShrink={0}
-                  backgroundColor={
-                    liveHovered()
-                      ? props.context.theme.background.action.primary.focused
-                      : props.context.theme.background.action.primary.default
-                  }
                   onMouseOver={() => setLiveHovered(true)}
                   onMouseOut={() => setLiveHovered(false)}
-                  onMouseDown={() => setLiveHovered(true)}
                   onMouseUp={() => props.context.keymap.dispatch("session.child.first")}
                 >
                   <text
-                    fg={
-                      liveHovered()
-                        ? props.context.theme.text.action.primary.focused
-                        : props.context.theme.text.action.primary.default
-                    }
+                    fg={liveHovered() ? props.context.theme.text.default : props.context.theme.text.subdued}
                     wrapMode="none"
                   >
-                    <Show when={shortcut("session.child.first")}>{(value) => <>{value()} </>}</Show>
+                    <Show when={shortcut("session.child.first")}>
+                      {(value) => <span style={{ fg: props.context.theme.text.default }}>{value()} </span>}
+                    </Show>
                     <Show when={subagents()}>{(value) => <>{value()}</>}</Show>
                     <Show when={subagents() && shells()}> · </Show>
                     <Show when={shells()}>{(value) => <>{value()}</>}</Show>

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -1,5 +1,5 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
-import { createMemo, Match, Show, Switch } from "solid-js"
+import { createMemo, createSignal, Match, Show, Switch } from "solid-js"
 import { contextUsage, formatContextUsage } from "../../util/session"
 import { useTerminalDimensions } from "@opentui/solid"
 
@@ -10,6 +10,7 @@ const money = new Intl.NumberFormat("en-US", {
 
 export function PromptFooter(props: { context: Plugin.Context; sessionID?: string; mode: "normal" | "shell" }) {
   const dimensions = useTerminalDimensions()
+  const [liveHovered, setLiveHovered] = createSignal(false)
   const subagents = createMemo(() => {
     if (!props.sessionID) return 0
     const count = props.context.data.session
@@ -47,16 +48,43 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
       <Match when={props.mode === "normal"}>
         <Switch>
           <Match when={live() || status().length > 0}>
-            <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
-              <Show when={live() && shortcut("session.child.first")}>
-                {(value) => <span style={{ fg: props.context.theme.text.default }}>{value()} </span>}
+            <box flexDirection="row" flexShrink={1} minWidth={0}>
+              <Show when={live()}>
+                <box
+                  flexDirection="row"
+                  flexShrink={0}
+                  backgroundColor={
+                    liveHovered()
+                      ? props.context.theme.background.action.primary.focused
+                      : props.context.theme.background.action.primary.default
+                  }
+                  onMouseOver={() => setLiveHovered(true)}
+                  onMouseOut={() => setLiveHovered(false)}
+                  onMouseDown={() => setLiveHovered(true)}
+                  onMouseUp={() => props.context.keymap.dispatch("session.child.first")}
+                >
+                  <text
+                    fg={
+                      liveHovered()
+                        ? props.context.theme.text.action.primary.focused
+                        : props.context.theme.text.action.primary.default
+                    }
+                    wrapMode="none"
+                  >
+                    <Show when={shortcut("session.child.first")}>{(value) => <>{value()} </>}</Show>
+                    <Show when={subagents()}>{(value) => <>{value()}</>}</Show>
+                    <Show when={subagents() && shells()}> · </Show>
+                    <Show when={shells()}>{(value) => <>{value()}</>}</Show>
+                  </text>
+                </box>
               </Show>
-              <Show when={subagents()}>{(value) => <span>{value()}</span>}</Show>
-              <Show when={subagents() && shells()}> · </Show>
-              <Show when={shells()}>{(value) => <span>{value()}</span>}</Show>
-              <Show when={live() && status().length > 0}> · </Show>
-              <Show when={status().length > 0}>{status().join(" · ")}</Show>
-            </text>
+              <Show when={status().length > 0}>
+                <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
+                  <Show when={live()}> · </Show>
+                  {status().join(" · ")}
+                </text>
+              </Show>
+            </box>
           </Match>
           <Match when={dimensions().width >= 44}>
             <text fg={props.context.theme.text.default} flexShrink={0}>

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -1,18 +1,28 @@
 /** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
-import { RGBA } from "@opentui/core"
+import { BoxRenderable, RGBA } from "@opentui/core"
 import { testRender } from "@opentui/solid"
 import type { Context } from "@opencode-ai/plugin/tui/context"
 import { PromptFooter } from "../../src/feature-plugins/prompt/footer"
 
 test("prompt footer separates simultaneous subagent, shell, and usage status", async () => {
   const color = RGBA.fromInts(200, 200, 200)
+  const focused = RGBA.fromInts(40, 40, 40)
+  const dispatched: string[] = []
   const context = {
     location: { directory: "/workspace" },
-    theme: { text: { default: color, subdued: color } },
+    theme: {
+      text: {
+        default: color,
+        subdued: color,
+        action: { primary: { default: color, focused: color } },
+      },
+      background: { action: { primary: { default: RGBA.fromInts(0, 0, 0, 0), focused } } },
+    },
     keymap: {
       shortcuts: (id: string) =>
         id === "session.child.first" ? ["ctrl+j"] : id === "command.palette.show" ? ["ctrl+p"] : [],
+      dispatch: (id: string) => dispatched.push(id),
     },
     data: {
       session: {
@@ -39,6 +49,14 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     await app.renderOnce()
     expect(app.captureCharFrame()).toContain("ctrl+j 1 subagent · 1 shell · $1.00")
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
+
+    await app.mockMouse.moveTo(2, 0)
+    const live = app.renderer.root.getChildren()[0]?.getChildren()[0]
+    expect(live).toBeInstanceOf(BoxRenderable)
+    expect((live as BoxRenderable).backgroundColor.toInts()).toEqual(focused.toInts())
+
+    await app.mockMouse.click(2, 0)
+    expect(dispatched).toEqual(["session.child.first"])
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -1,23 +1,21 @@
 /** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
-import { BoxRenderable, RGBA } from "@opentui/core"
+import { RGBA, TextRenderable } from "@opentui/core"
 import { testRender } from "@opentui/solid"
 import type { Context } from "@opencode-ai/plugin/tui/context"
 import { PromptFooter } from "../../src/feature-plugins/prompt/footer"
 
 test("prompt footer separates simultaneous subagent, shell, and usage status", async () => {
   const color = RGBA.fromInts(200, 200, 200)
-  const focused = RGBA.fromInts(40, 40, 40)
+  const subdued = RGBA.fromInts(100, 100, 100)
   const dispatched: string[] = []
   const context = {
     location: { directory: "/workspace" },
     theme: {
       text: {
         default: color,
-        subdued: color,
-        action: { primary: { default: color, focused: color } },
+        subdued,
       },
-      background: { action: { primary: { default: RGBA.fromInts(0, 0, 0, 0), focused } } },
     },
     keymap: {
       shortcuts: (id: string) =>
@@ -51,9 +49,9 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
 
     await app.mockMouse.moveTo(2, 0)
-    const live = app.renderer.root.getChildren()[0]?.getChildren()[0]
-    expect(live).toBeInstanceOf(BoxRenderable)
-    expect((live as BoxRenderable).backgroundColor.toInts()).toEqual(focused.toInts())
+    const live = app.renderer.root.getChildren()[0]?.getChildren()[0]?.getChildren()[0]
+    expect(live).toBeInstanceOf(TextRenderable)
+    expect((live as TextRenderable).fg.toInts()).toEqual(color.toInts())
 
     await app.mockMouse.click(2, 0)
     expect(dispatched).toEqual(["session.child.first"])


### PR DESCRIPTION
## What

Make the live subagent/shell summary in the prompt footer behave like the action it advertises. The summary now gets brighter on hover and opens the existing Subagents bottom panel when clicked.

## Before / After

**Before:** The footer displayed the `session.child.first` shortcut next to running subagents, but the same text did not respond to hover or mouse clicks.

**After:** Hovering lifts the live-work label from subdued to default text color without adding a background. Clicking dispatches `session.child.first`, opening the same bottom panel as the keyboard shortcut.

## How

- `packages/tui/src/feature-plugins/prompt/footer.tsx` separates the interactive live-work summary from passive usage/cost text and routes clicks through the existing keymap command.
- `packages/tui/test/feature-plugins/prompt-footer.test.tsx` verifies the rendered text-color lift and mouse dispatch.

## Testing

- `bun run test test/feature-plugins/prompt-footer.test.tsx` from `packages/tui`
- `bun typecheck` from `packages/tui`
- Repository pre-push typecheck across 33 packages
- OpenCode Drive run with a simulated running subagent, exercising hover and click through to the real Subagents panel

## Demo

OpenCode Drive simulation. The captured hover frame is held for one second so the text-only state is visible before the click opens the panel.

https://github.com/user-attachments/assets/a768afcf-d1ce-46ae-a04b-d8c3bad2a318
