### PR TITLE
fix(core): identify user-initiated web fetches

### DIFF
--- a/packages/core/src/tool/plugin/webfetch.ts
+++ b/packages/core/src/tool/plugin/webfetch.ts
@@ -54,15 +54,10 @@ const headers = (format: Format, userAgent: string) => ({
   "User-Agent": userAgent,
   Accept: acceptHeader(format),
   "Accept-Language": "en-US,en;q=0.9",
-  "Sec-Fetch-Dest": "document",
-  "Sec-Fetch-Mode": "navigate",
-  "Sec-Fetch-Site": "none",
-  "Sec-Fetch-User": "?1",
-  "Upgrade-Insecure-Requests": "1",
 })
 
-const browserUserAgent =
-  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+const openCodeUserAgent =
+  "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OpenCode-User/1.0; +https://opencode.ai"
 
 const isCloudflareChallenge = (error: unknown) => {
   if (!error || typeof error !== "object" || !("reason" in error)) return false
@@ -79,14 +74,14 @@ const isCloudflareChallenge = (error: unknown) => {
   return response.status === 403 && response.headers["cf-mitigated"] === "challenge"
 }
 
-const request = (url: string, format: Format, userAgent = browserUserAgent) =>
+const request = (url: string, format: Format, userAgent = openCodeUserAgent) =>
   HttpClientRequest.get(url).pipe(HttpClientRequest.setHeaders(headers(format, userAgent)))
 
 const assertHttpUrl = (url: URL) => {
   if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("URL must use http:// or https://")
 }
 
-const execute = (http: HttpClient.HttpClient, url: string, format: Format, userAgent = browserUserAgent) =>
+const execute = (http: HttpClient.HttpClient, url: string, format: Format, userAgent = openCodeUserAgent) =>
   http.execute(request(url, format, userAgent)).pipe(Effect.flatMap(HttpClientResponse.filterStatusOk))
 
 const collectBody = (response: HttpClientResponse.HttpClientResponse) =>

--- a/packages/core/src/tool/plugin/webfetch.ts
+++ b/packages/core/src/tool/plugin/webfetch.ts
@@ -54,6 +54,11 @@ const headers = (format: Format, userAgent: string) => ({
   "User-Agent": userAgent,
   Accept: acceptHeader(format),
   "Accept-Language": "en-US,en;q=0.9",
+  "Sec-Fetch-Dest": "document",
+  "Sec-Fetch-Mode": "navigate",
+  "Sec-Fetch-Site": "none",
+  "Sec-Fetch-User": "?1",
+  "Upgrade-Insecure-Requests": "1",
 })
 
 const browserUserAgent =

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -23,6 +23,8 @@ const webFetchToolNode = makeLocationNode({
 })
 
 const sessionID = Session.ID.make("ses_webfetch_test")
+const webFetchUserAgent =
+  "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OpenCode-User/1.0; +https://opencode.ai"
 const requests: Array<{ readonly url: string; readonly headers: Record<string, string> }> = []
 const assertions: Permission.AssertInput[] = []
 let respond = (_request: HttpClientRequest.HttpClientRequest) =>
@@ -376,7 +378,17 @@ describe("WebFetchTool registration", () => {
       expect(assertions).toMatchObject([
         { sessionID, action: "webfetch", resources: [url], save: ["*"], metadata: { url, format: "text", timeout: 4 } },
       ])
-      expect(requests).toMatchObject([{ url, headers: { accept: expect.stringContaining("text/plain;q=1.0") } }])
+      expect(requests).toMatchObject([
+        {
+          url,
+          headers: {
+            accept: "text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1",
+            "accept-language": "en-US,en;q=0.9",
+            "user-agent": webFetchUserAgent,
+          },
+        },
+      ])
+      expect(requests[0]?.headers).not.toHaveProperty("sec-fetch-mode")
     }),
   )
 
@@ -397,15 +409,23 @@ describe("WebFetchTool registration", () => {
     }),
   )
 
-  live.effect("follows redirects while approving only the requested URL", () =>
-    Effect.acquireUseRelease(
+  live.effect("follows redirects while approving only the requested URL", () => {
+    const received: Array<Record<string, string | null>> = []
+    return Effect.acquireUseRelease(
       Effect.sync(() =>
         Bun.serve({
           port: 0,
-          fetch: (request) =>
-            new URL(request.url).pathname === "/redirect"
-              ? new Response("", { status: 302, headers: { location: "/target" } })
-              : new Response("redirected", { headers: { "content-type": "text/plain" } }),
+          fetch: (request) => {
+            received.push({
+              accept: request.headers.get("accept"),
+              "accept-language": request.headers.get("accept-language"),
+              "sec-fetch-mode": request.headers.get("sec-fetch-mode"),
+              "user-agent": request.headers.get("user-agent"),
+            })
+            if (new URL(request.url).pathname === "/redirect")
+              return new Response("", { status: 302, headers: { location: "/target" } })
+            return new Response("redirected", { headers: { "content-type": "text/plain" } })
+          },
         }),
       ),
       (server) =>
@@ -421,10 +441,18 @@ describe("WebFetchTool registration", () => {
           expect(assertions).toMatchObject([
             { sessionID, action: "webfetch", resources: [url], save: ["*"], metadata: { url, format: "text" } },
           ])
+          expect(received).toEqual(
+            Array.from({ length: 2 }, () => ({
+              accept: "text/plain;q=1.0, text/markdown;q=0.9, text/html;q=0.8, */*;q=0.1",
+              "accept-language": "en-US,en;q=0.9",
+              "sec-fetch-mode": null,
+              "user-agent": webFetchUserAgent,
+            })),
+          )
         }),
       (server) => Effect.promise(() => server.stop(true)),
-    ),
-  )
+    )
+  })
 
   it.effect("rejects non-HTTP schemes before permission or transport", () =>
     Effect.gen(function* () {
@@ -549,7 +577,7 @@ describe("WebFetchTool registration", () => {
         content: [{ type: "text", text: "ok" }],
       })
       expect(requests).toHaveLength(2)
-      expect(requests[0]?.headers["user-agent"]).toContain("Mozilla/5.0")
+      expect(requests[0]?.headers["user-agent"]).toBe(webFetchUserAgent)
       expect(requests[1]?.headers["user-agent"]).toBe("opencode")
     }),
   )


### PR DESCRIPTION
### Summary

`webfetch` identified itself as Chrome 143 while sending a non-browser request profile. Meta's Comet routes classify that combination as an invalid browser request, returning a generic `500`; Facebook similarly returns `400`.

Use a stable, transparent identity for user-initiated fetches instead:

```text
Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OpenCode-User/1.0; +https://opencode.ai
```

This follows the `ChatGPT-User` / `Claude-User` convention, avoids claiming to be ordinary Chrome, and preserves the format-specific `Accept` headers that let sites such as Cloudflare and Vercel serve Markdown directly.

### Verification

- Meta geographic-use policy: old profile `500` (1,542-byte error), new profile `200` (313 KB HTML)
- Facebook: old profile `400`, new profile `200`
- Three repeated comparisons against Amazon, Stack Overflow, Reddit, old Reddit, Medium, Bloomberg, npm, and Reuters showed no status regression versus the old UA
- Added assertions for the logical request profile and the actual headers received across both hops of a redirect
- `bun test test/tool-webfetch.test.ts`: 52 pass
- `bun typecheck` from `packages/core`: pass
- Commit hook full-repository typecheck: 33 tasks pass
