### PR TITLE
fix(plugin): surface unreadable plugin package.json in compat check

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -193,8 +193,11 @@ export async function resolvePathPluginTarget(spec: string) {
 
 export async function checkPluginCompatibility(target: string, opencodeVersion: string, pkg?: PluginPackage) {
   if (!semver.valid(opencodeVersion) || semver.major(opencodeVersion) === 0) return
-  const hit = pkg ?? (await readPluginPackage(target).catch(() => undefined))
-  if (!hit) return
+  // A compatibility gate that cannot read its input must not look like a pass.
+  const hit = pkg ?? (await readPluginPackage(target).catch((error) => {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(`Unable to read plugin package.json at ${target}: ${detail}`)
+  }))
   const engines = hit.json.engines
   if (!isRecord(engines)) return
   const range = engines.opencode

--- a/packages/opencode/test/plugin/shared.test.ts
+++ b/packages/opencode/test/plugin/shared.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test"
-import { parsePluginSpecifier } from "../../src/plugin/shared"
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { checkPluginCompatibility, parsePluginSpecifier } from "../../src/plugin/shared"
 
 describe("parsePluginSpecifier", () => {
   test("parses standard npm package without version", () => {
@@ -84,5 +87,45 @@ describe("parsePluginSpecifier", () => {
       pkg: "@opencode/acme",
       version: "latest",
     })
+  })
+})
+
+describe("checkPluginCompatibility", () => {
+  const dirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+  })
+
+  async function tmpPlugin(json?: string) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-plugin-"))
+    dirs.push(dir)
+    if (json !== undefined) await fs.writeFile(path.join(dir, "package.json"), json)
+    return dir
+  }
+
+  test("throws when package.json cannot be read", async () => {
+    const dir = await tmpPlugin()
+    await expect(checkPluginCompatibility(dir, "1.18.0")).rejects.toThrow(/Unable to read plugin package\.json/)
+  })
+
+  test("throws when package.json is malformed", async () => {
+    const dir = await tmpPlugin("{ not json")
+    await expect(checkPluginCompatibility(dir, "1.18.0")).rejects.toThrow(/Unable to read plugin package\.json/)
+  })
+
+  test("throws when engines.opencode is unsatisfied", async () => {
+    const dir = await tmpPlugin(JSON.stringify({ name: "acme", engines: { opencode: ">=99.0.0" } }))
+    await expect(checkPluginCompatibility(dir, "1.18.0")).rejects.toThrow(/Plugin requires opencode >=99\.0\.0/)
+  })
+
+  test("passes when engines.opencode is satisfied", async () => {
+    const dir = await tmpPlugin(JSON.stringify({ name: "acme", engines: { opencode: ">=1.0.0" } }))
+    await expect(checkPluginCompatibility(dir, "1.18.0")).resolves.toBeUndefined()
+  })
+
+  test("skips the gate for major version 0 builds", async () => {
+    const dir = await tmpPlugin()
+    await expect(checkPluginCompatibility(dir, "0.0.0-dev")).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #43094

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

checkPluginCompatibility used to swallow package.json read failures and return as if the gate passed. That meant an unreadable or malformed plugin manifest skipped the engines.opencode check with no error.

If the package cannot be read, throw a named error so the existing compatibility stage skips the plugin and surfaces the failure. Version mismatch and major-0 skip behavior are unchanged.

### How did you verify your code works?

From packages/opencode:

    bun test test/plugin/shared.test.ts

All passed, including cases for missing/malformed package.json, unsatisfied range, satisfied range, and major-0 skip.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
