### PR TITLE
fix(patch): honor the end-of-file anchor when applying patches

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -115,12 +115,16 @@ function parseUpdateFileChunks(lines: string[], startIdx: number): { chunks: Upd
       let isEndOfFile = false
 
       // Parse change lines
-      while (i < lines.length && !lines[i].startsWith("@@") && !lines[i].startsWith("***")) {
+      while (i < lines.length && !lines[i].startsWith("@@")) {
         const changeLine = lines[i]
 
         if (changeLine === "*** End of File") {
           isEndOfFile = true
           i++
+          break
+        }
+
+        if (changeLine.startsWith("***")) {
           break
         }
 

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -91,6 +91,31 @@ describe("Patch namespace", () => {
 
       expect(() => Patch.parsePatch(invalidPatch)).toThrow("Invalid patch format")
     })
+
+    test("should parse the end-of-file marker inside update chunks", () => {
+      const patchText = `*** Begin Patch
+*** Update File: update.txt
+@@
+-last
++end
+*** End of File
+*** End Patch`
+
+      const result = Patch.parsePatch(patchText)
+      expect(result.hunks).toHaveLength(1)
+      const hunk = result.hunks[0]
+      expect(hunk.type).toBe("update")
+      if (hunk.type === "update") {
+        expect(hunk.chunks).toEqual([
+          {
+            old_lines: ["last"],
+            new_lines: ["end"],
+            change_context: undefined,
+            is_end_of_file: true,
+          },
+        ])
+      }
+    })
   })
 
   describe("maybeParseApplyPatch", () => {
@@ -378,6 +403,29 @@ PATCH`
 
         const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
         expect(content).toBe("line 1\nLINE 2\nline 3\nLINE 4\n")
+      }),
+    )
+
+    it.live("should match the end-of-file anchor against the last occurrence", () =>
+      Effect.gen(function* () {
+        const filePath = path.join(tempDir, "eof-anchor.txt")
+        yield* Effect.promise(() => fs.writeFile(filePath, "marker\nend\nmiddle\nmarker\nend"))
+
+        const patchText = `*** Begin Patch
+*** Update File: ${filePath}
+@@
+-marker
+-end
++marker-changed
++end
+*** End of File
+*** End Patch`
+
+        const result = yield* Patch.applyPatch(patchText)
+        expect(result.modified).toHaveLength(1)
+
+        const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
+        expect(content).toBe("marker\nend\nmiddle\nmarker-changed\nend\n")
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #43331

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `*** End of File` anchor in update chunks never takes effect: `parseUpdateFileChunks` guards the change-line loop with `!lines[i].startsWith("***")`, so the `*** End of File` marker can never enter the loop body and `is_end_of_file` stays `undefined`. `tryMatch`'s EOF branch (match from end of file first) therefore never runs, and EOF-anchored patches edit the first occurrence of the pattern instead of the last.

The reference parser in `packages/core/src/patch.ts` handles the marker correctly: its inner loop only excludes `@@`, checks the EOF marker in the body, and breaks on other `***` lines. This PR makes the opencode parser match that behavior.

### How did you verify your code works?

- Added `should parse the end-of-file marker inside update chunks`: asserts `is_end_of_file: true` is parsed; fails before the fix, passes after.
- Added `should match the end-of-file anchor against the last occurrence`: end-to-end test where a repeated `marker`/`end` pair is edited at the end of file only when the anchor is honored.
- `bun test packages/opencode/test/patch/patch.test.ts`: 22 pass. Confirmed both new tests fail on the unfixed parser.
- `@opencode-ai/opencode` typecheck passes.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
