### PR TITLE
fix(tui): settle completed shell state

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -722,12 +722,16 @@ export function createData(config: CreateDataInput) {
         })
         return
       case "session.tool.success":
+        let completedShellID: string | undefined
+        const shellCompleted = event.data.metadata?.status === "completed"
         message.update(event.data.sessionID, (draft, index) => {
           const match = message.latestTool(
             message.assistant(draft, index, event.data.assistantMessageID),
             event.data.id,
           )
           if (match?.state.status !== "running") return
+          if (shellCompleted && typeof match.state.metadata.shellID === "string")
+            completedShellID = match.state.metadata.shellID
           match.state = {
             status: "completed",
             input: match.state.input,
@@ -738,6 +742,19 @@ export function createData(config: CreateDataInput) {
           match.providerResultState = event.data.resultState
           match.time.completed = event.created
         })
+        if (shellCompleted && event.location)
+          setStore(
+            "location",
+            locationKey(event.location),
+            "shell",
+            reconcile(
+              Object.fromEntries(
+                Object.entries(store.location[locationKey(event.location)]?.shell ?? {}).filter(
+                  ([id, shell]) => id !== completedShellID && shell.metadata.callID !== event.data.id,
+                ),
+              ),
+            ),
+          )
         return
       case "session.tool.failed":
         message.update(event.data.sessionID, (draft, index) => {
@@ -969,10 +986,16 @@ export function createData(config: CreateDataInput) {
         break
       case "shell.exited":
       case "shell.deleted":
-        setStore("location", locationKey(location), (data) => ({
-          ...data,
-          shell: Object.fromEntries(Object.entries(data?.shell ?? {}).filter(([id]) => id !== event.data.id)),
-        }))
+        setStore(
+          "location",
+          locationKey(location),
+          "shell",
+          reconcile(
+            Object.fromEntries(
+              Object.entries(store.location[locationKey(location)]?.shell ?? {}).filter(([id]) => id !== event.data.id),
+            ),
+          ),
+        )
         break
       case "reference.updated":
         result.location.reference.invalidate()

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -327,6 +327,7 @@ export const layer = (options?: ShellSelect.Options) =>
                   )
                 })
 
+              yield* bus.publish(Shell.Event.Created, { info })
               yield* session.timeout(invocation.timeout)
 
               runFork(
@@ -336,7 +337,6 @@ export const layer = (options?: ShellSelect.Options) =>
                 ),
               )
 
-              yield* bus.publish(Shell.Event.Created, { info })
               yield* Deferred.succeed(ready, session)
               // Hold the handle's scope open until the command terminates; closing it earlier would
               // release (kill) the process before its exit is observed.

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -291,16 +291,17 @@ export const layer = (options?: ShellSelect.Options) =>
                   })
                   yield* beforeWait
                   yield* Deferred.await(outputDone)
-                  // Resolve waiters with the terminal Info before any retention eviction, so an evicted
-                  // session still reports success rather than the removal NotFoundError. This runs before
-                  // the timeout-fiber interrupt below, which on the timeout path would otherwise cancel
-                  // this very fiber (finish is invoked by the timeout fiber) before waiters are resolved.
-                  yield* Deferred.succeed(session.done, session.info)
+                  // Publish terminal state before unblocking waiters. Once done resolves, the managing
+                  // scope may close and interrupt this exit watcher before clients receive shell.exited.
                   yield* bus.publish(Shell.Event.Exited, {
                     id,
                     ...(exit !== undefined ? { exit } : {}),
                     status,
                   })
+                  // Resolve waiters before retention eviction, so an evicted session still reports success
+                  // rather than the removal NotFoundError. This also runs before the timeout-fiber interrupt
+                  // below, which can otherwise cancel finish when invoked by that same timeout fiber.
+                  yield* Deferred.succeed(session.done, session.info)
                   exitOrder.push(id)
                   while (exitOrder.length > EXITED_LIMIT) {
                     const oldest = exitOrder[0]

--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -144,7 +144,7 @@ export const Plugin = {
                   command: input.command,
                   cwd: input.workdir,
                   timeout,
-                  metadata: { sessionID: context.sessionID },
+                  metadata: { sessionID: context.sessionID, callID: context.id },
                 },
                 (invocation) =>
                   Effect.gen(function* () {

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -745,6 +745,39 @@ describe("ShellTool", () => {
   )
 
   it.live(
+    "publishes shell exit before resolving waiters",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withSession(tmp.path, () =>
+            Effect.gen(function* () {
+              const bus = yield* Bus.Service
+              const shell = yield* Shell.Service
+              const publishing = yield* Deferred.make<void>()
+              const release = yield* Deferred.make<void>()
+              const unsubscribe = yield* bus.listen((event) => {
+                if (event.type !== ShellSchema.Event.Exited.type) return Effect.void
+                return Deferred.succeed(publishing, undefined).pipe(Effect.andThen(Deferred.await(release)))
+              })
+              yield* Effect.addFinalizer(() => unsubscribe)
+
+              const info = yield* shell.create({ command: "exit 0", timeout: 0 })
+              yield* Deferred.await(publishing)
+              expect((yield* shell.wait(info.id).pipe(Effect.timeoutOption(Duration.millis(20))))._tag).toBe("None")
+
+              yield* Deferred.succeed(release, undefined)
+              expect((yield* shell.wait(info.id)).status).toBe("exited")
+            }),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 15_000 },
+  )
+
+  it.live(
     "returns a useful timeout outcome",
     () =>
       Effect.acquireUseRelease(

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -708,6 +708,43 @@ describe("ShellTool", () => {
   )
 
   it.live(
+    "publishes shell creation before immediate exit",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withSession(tmp.path, () =>
+            Effect.gen(function* () {
+              const bus = yield* Bus.Service
+              const shell = yield* Shell.Service
+              const unsubscribe = yield* bus.listen((event) =>
+                event.type === ShellSchema.Event.Created.type ? Effect.sleep(Duration.millis(50)) : Effect.void,
+              )
+              yield* Effect.addFinalizer(() => unsubscribe)
+              const events = yield* bus.subscribe([ShellSchema.Event.Created, ShellSchema.Event.Exited]).pipe(
+                Stream.take(2),
+                Stream.map((event) => event.type),
+                Stream.runCollect,
+                Effect.forkScoped({ startImmediately: true }),
+              )
+
+              const info = yield* shell.create({ command: "exit 0", timeout: 0 })
+              yield* shell.wait(info.id)
+
+              expect(Array.from(yield* Fiber.join(events))).toEqual([
+                ShellSchema.Event.Created.type,
+                ShellSchema.Event.Exited.type,
+              ])
+            }),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 15_000 },
+  )
+
+  it.live(
     "returns a useful timeout outcome",
     () =>
       Effect.acquireUseRelease(

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -1,5 +1,5 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
-import { createMemo, Match, Show, Switch } from "solid-js"
+import { createMemo, createSignal, Match, onCleanup, Show, Switch } from "solid-js"
 import { contextUsage, formatContextUsage } from "../../util/session"
 import { useTerminalDimensions } from "@opentui/solid"
 
@@ -10,6 +10,11 @@ const money = new Intl.NumberFormat("en-US", {
 
 export function PromptFooter(props: { context: Plugin.Context; sessionID?: string; mode: "normal" | "shell" }) {
   const dimensions = useTerminalDimensions()
+  const [shellRevision, updateShellRevision] = createSignal(0)
+  const shellChanged = () => updateShellRevision((revision) => revision + 1)
+  onCleanup(props.context.data.on("shell.created", shellChanged))
+  onCleanup(props.context.data.on("shell.exited", shellChanged))
+  onCleanup(props.context.data.on("shell.deleted", shellChanged))
   const subagents = createMemo(() => {
     if (!props.sessionID) return 0
     const count = props.context.data.session
@@ -18,10 +23,26 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
     return count ? `${count} subagent${count === 1 ? "" : "s"}` : undefined
   })
   const shells = createMemo(() => {
+    shellRevision()
     if (!props.sessionID) return 0
+    const messages = props.context.data.session.message.list(props.sessionID)
     const count = props.context.data.shell
       .list(props.context.location)
-      .filter((shell) => shell.metadata.sessionID === props.sessionID).length
+      .filter((shell) => {
+        if (shell.metadata.sessionID !== props.sessionID) return false
+        if (typeof shell.metadata.callID !== "string") return false
+        return messages.some(
+          (message) =>
+            message.type === "assistant" &&
+            message.content.some(
+              (part) =>
+                part.type === "tool" &&
+                part.id === shell.metadata.callID &&
+                part.state.status === "completed" &&
+                part.state.metadata?.status === "running",
+            ),
+        )
+      }).length
     return count ? `${count} shell${count === 1 ? "" : "s"}` : undefined
   })
   const status = createMemo(() => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2953,7 +2953,17 @@ function Shell(props: ToolProps) {
     const id = shellID()
     return Boolean(background() && id && data.shell.get(id))
   })
-  const isRunning = createMemo(() => props.part.state.status === "running" || backgroundRunning())
+  const stepCompleted = createMemo(() =>
+    data.session.message.list(ctx.sessionID).some(
+      (message) =>
+        message.type === "assistant" &&
+        message.finish !== undefined &&
+        message.content.some((part) => part.type === "tool" && part.id === props.part.id),
+    ),
+  )
+  const isRunning = createMemo(() =>
+    background() ? backgroundRunning() : props.part.state.status === "running" && !stepCompleted(),
+  )
   const command = createMemo(() => stringValue(props.input.command))
   const workdir = createMemo(() => pathFormatter.format(stringValue(props.input.workdir)))
   const [expanded, setExpanded] = createSignal(false)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2938,10 +2938,20 @@ function Shell(props: ToolProps) {
   const permission = useToolPermission(() => props.part)
   const color = createMemo(() => (permission() ? theme.text.feedback.warning.default : theme.text.default))
   const shellID = createMemo(() => stringValue(props.metadata.shellID))
-  const background = createMemo(() => Boolean(shellID()) && props.part.state.status !== "running")
+  const [shellRevision, updateShellRevision] = createSignal(0)
+  const shellExited = (event: { data: { id: string } }) => {
+    if (event.data.id === shellID()) updateShellRevision((revision) => revision + 1)
+  }
+  onCleanup(data.on("shell.exited", shellExited))
+  onCleanup(data.on("shell.deleted", shellExited))
+  const background = createMemo(
+    () => Boolean(shellID()) && props.part.state.status === "completed" && props.metadata.status === "running",
+  )
   const backgroundRunning = createMemo(() => {
+    shellRevision()
+    data.session.status(ctx.sessionID)
     const id = shellID()
-    return Boolean(id && data.shell.get(id))
+    return Boolean(background() && id && data.shell.get(id))
   })
   const isRunning = createMemo(() => props.part.state.status === "running" || backgroundRunning())
   const command = createMemo(() => stringValue(props.input.command))

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -1997,9 +1997,13 @@ test("keeps shell state scoped to location", async () => {
     })
   }, events)
   let data!: ReturnType<typeof useData>
+  let otherShellCount = 0
 
   function Probe() {
     data = useData()
+    createEffect(() => {
+      otherShellCount = data.shell.list({ directory: other, workspaceID: workspace }).length
+    })
     return (
       <RouteProvider initialRoute={{ type: "session", sessionID: "ses_shared" }}>
         <Keymap.Provider>
@@ -2067,6 +2071,15 @@ test("keeps shell state scoped to location", async () => {
     expect(
       data.shell.listBySession("ses_shared").find((shell) => shell.id === "sh_live_other")?.location.directory,
     ).toBe(other)
+    await wait(() => otherShellCount === 2)
+    events.emit({
+      id: "evt_shell_exited",
+      created: 0,
+      type: "shell.exited",
+      location: { directory: other, workspaceID: workspace },
+      data: { id: "sh_live_other", exit: 0, status: "exited" },
+    })
+    await wait(() => otherShellCount === 1)
   } finally {
     app.renderer.destroy()
   }
@@ -2757,6 +2770,75 @@ test("settles pending tools when a live failure arrives", async () => {
       previous: { id: "model-1", providerID: "provider-1", variant: "medium" },
       model: { id: "model-1", providerID: "provider-1", variant: "high" },
     })
+
+    emitEvent(events, {
+      id: "evt_input_2",
+      created: 1,
+      type: "session.tool.input.started",
+      durable: durable("session-1", 7),
+      data: {
+        sessionID: "session-1",
+        assistantMessageID: "msg_explicit_assistant_9",
+        id: "call-2",
+        name: "shell",
+      },
+    })
+    emitEvent(events, {
+      id: "evt_called_2",
+      created: 1,
+      type: "session.tool.called",
+      durable: durable("session-1", 8),
+      data: {
+        sessionID: "session-1",
+        assistantMessageID: "msg_explicit_assistant_9",
+        id: "call-2",
+        input: { command: "exit 0" },
+        executed: false,
+      },
+    })
+    emitEvent(events, {
+      id: "evt_shell_created_2",
+      created: 1,
+      type: "shell.created",
+      data: {
+        info: {
+          id: "sh_completed",
+          status: "running",
+          command: "exit 0",
+          cwd: directory,
+          shell: "/bin/sh",
+          file: "/tmp/opencode-shell",
+          metadata: { sessionID: "session-1", callID: "call-2" },
+          time: { started: 1 },
+        },
+      },
+    })
+    emitEvent(events, {
+      id: "evt_progress_2",
+      created: 1,
+      type: "session.tool.progress",
+      data: {
+        sessionID: "session-1",
+        assistantMessageID: "msg_explicit_assistant_9",
+        id: "call-2",
+        metadata: { shellID: "sh_completed" },
+      },
+    })
+    emitEvent(events, {
+      id: "evt_success_2",
+      created: 2,
+      type: "session.tool.success",
+      durable: durable("session-1", 9, 2),
+      data: {
+        sessionID: "session-1",
+        assistantMessageID: "msg_explicit_assistant_9",
+        id: "call-2",
+        content: [{ type: "text", text: "(no output)" }],
+        metadata: { status: "completed", exit: 0 },
+        executed: false,
+      },
+    })
+    await wait(() => sync.shell.list().length === 0)
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -15,15 +15,29 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
         id === "session.child.first" ? ["ctrl+j"] : id === "command.palette.show" ? ["ctrl+p"] : [],
     },
     data: {
+      on: () => () => {},
       session: {
         family: () => ["session", "child"],
-        status: (id: string) => (id === "child" ? "running" : "idle"),
+        status: (id: string) => (id === "child" || id === "session" ? "running" : "idle"),
         get: () => ({ id: "session", location: { directory: "/workspace" } }),
         cost: () => 1,
-        message: { list: () => [] },
+        message: {
+          list: () => [
+            {
+              type: "assistant",
+              content: [
+                {
+                  type: "tool",
+                  id: "call-shell",
+                  state: { status: "completed", metadata: { status: "running" } },
+                },
+              ],
+            },
+          ],
+        },
       },
       shell: {
-        list: () => [{ metadata: { sessionID: "session" } }],
+        list: () => [{ metadata: { sessionID: "session", callID: "call-shell" } }],
       },
       location: {
         model: { list: () => [] },


### PR DESCRIPTION
### Issue for this PR

Closes #35816

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Completed foreground shell calls could keep a spinner and `1 shell` footer after the assistant finished. Shell lifecycle events now publish in order, shell entries carry their tool call ID, and the TUI only treats calls marked as background work as still running.

### How did you verify your code works?

- 25 shell tool tests pass in `packages/core`
- 42 data and footer tests pass in `packages/tui`
- core, client, TUI, and workspace typechecks pass
- reproduced with separate create, commit, and `git push` calls against a dummy repository; the final push row had no spinner and the footer had no shell count

### Screenshots / recordings

Before: the stale footer behavior is documented in #35816.

After: verified in the standalone TUI with commit `2ac9eb0` pushed to the dummy repository. The final `git push` row rendered as settled with no shell footer count.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR