### PR TITLE
feat(tui): make code concealment configurable via tui.json

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -72,6 +72,7 @@ export const Info = Schema.Struct({
   diff_style: Schema.optional(DiffStyle),
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  conceal: Schema.optional(Schema.Boolean).annotate({ description: "Default code concealment state" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -256,7 +256,7 @@ export function Session() {
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
   const [sidebarOpen, setSidebarOpen] = createSignal(false)
-  const [conceal, setConceal] = createSignal(true)
+  const [conceal, setConceal] = kv.signal("conceal", tuiConfig.conceal ?? true)
   const thinking = useThinkingMode()
   const thinkingMode = thinking.mode
   const showThinking = createMemo(() => true)


### PR DESCRIPTION
### Issue for this PR

Closes #35093

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- add a `conceal` option to `tui.json` to set the default code-concealment state
- initialize `conceal` from config using `kv.signal` (a manual toggle (eg using `<leader>h`) still wins)

### How did you verify your code works?

- verified with a project `tui.json` containing `"conceal": false`: code blocks render by default on launch.
- also toggled with `<leader>h` and restarted: the manual toggle wins.

### Screenshots / recordings

Technically not a UI change but I can add a screenshot if you want.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
