### PR TITLE
fix(desktop): add explicit return null in vite plugin resolveId hooks

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -59,6 +59,7 @@ const require = __cjs_mod__.createRequire(import.meta.url);
         enforce: "pre",
         resolveId(s) {
           if (s === "@lydell/node-pty") return nodePtyPkg
+          return null
         },
       },
       {
@@ -66,6 +67,7 @@ const require = __cjs_mod__.createRequire(import.meta.url);
         enforce: "pre",
         resolveId(id) {
           if (id === "virtual:opencode-server") return this.resolve(`${OPENCODE_SERVER_DIST}/node.js`)
+          return null
         },
       },
       {


### PR DESCRIPTION
### Summary
- In `packages/desktop/electron.vite.config.ts`, add explicit `return null` to plugin `resolveId` hooks when module identifiers do not match, satisfying TypeScript/oxlint `consistent-return` rules.