### PR TITLE
feat(ai): preserve streamed refusals as text

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import type { Content } from "@opencode-ai/schema/tool"
 import { HttpTransport } from "../route/transport/index.js"
 import { Protocol } from "../route/protocol.js"
@@ -62,6 +62,11 @@ type OutputContent = Schema.Schema.Type<typeof OutputContent>
 
 export const MessagePhase = Schema.Literals(["commentary", "final_answer"])
 type MessagePhase = Schema.Schema.Type<typeof MessagePhase>
+const ReplayTextMetadata = Schema.Struct({
+  refusal: Schema.optionalKey(Schema.Literal(true)),
+  phase: Schema.optionalKey(Schema.NullOr(MessagePhase)),
+})
+const decodeReplayTextMetadata = Schema.decodeUnknownOption(ReplayTextMetadata)
 
 const OpenResponsesReasoningSummaryText = Schema.Struct({
   type: Schema.tag("summary_text"),
@@ -491,8 +496,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         if (content.length === 0) return
         const groups = content.reduce<Array<{ phase: MessagePhase | null | undefined; parts: TextPart[] }>>(
           (groups, part) => {
-            const metadata = part.providerMetadata?.[providerMetadataKey]
-            const phase = ProviderShared.isRecord(metadata) ? messagePhase(metadata.phase, extension) : undefined
+            const phase = messagePhase(replayTextMetadata(part, providerMetadataKey)?.phase, extension)
             const group = groups.at(-1)
             if (group && group.phase === phase) group.parts.push(part)
             else groups.push({ phase, parts: [part] })
@@ -503,12 +507,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         input.push(
           ...groups.map((group) => ({
             role: "assistant" as const,
-            content: group.parts.map((part) => {
-              const metadata = part.providerMetadata?.[providerMetadataKey]
-              return ProviderShared.isRecord(metadata) && metadata.refusal === true
-                ? { type: "refusal" as const, refusal: part.text }
-                : { type: "output_text" as const, text: part.text }
-            }),
+            content: group.parts.map((part) => lowerAssistantContent(part, providerMetadataKey)),
             ...(group.phase === undefined ? {} : { phase: group.phase }),
           })),
         )
@@ -596,6 +595,14 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
       )
     : input
 })
+
+const replayTextMetadata = (part: TextPart, providerMetadataKey: string) =>
+  Option.getOrUndefined(decodeReplayTextMetadata(part.providerMetadata?.[providerMetadataKey]))
+
+const lowerAssistantContent = (part: TextPart, providerMetadataKey: string): OutputContent =>
+  replayTextMetadata(part, providerMetadataKey)?.refusal === true
+    ? { type: "refusal", refusal: part.text }
+    : { type: "output_text", text: part.text }
 
 const lowerOptions = (request: LLMRequest) => {
   const options = OpenResponsesOptions.resolve(request)

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -53,6 +53,12 @@ const OpenResponsesOutputText = Schema.Struct({
   type: Schema.tag("output_text"),
   text: Schema.String,
 })
+const OpenResponsesRefusal = Schema.Struct({
+  type: Schema.tag("refusal"),
+  refusal: Schema.String,
+})
+export const OutputContent = Schema.Union([OpenResponsesOutputText, OpenResponsesRefusal])
+type OutputContent = Schema.Schema.Type<typeof OutputContent>
 
 export const MessagePhase = Schema.Literals(["commentary", "final_answer"])
 type MessagePhase = Schema.Schema.Type<typeof MessagePhase>
@@ -94,7 +100,7 @@ export const InputItem = Schema.Union([
   Schema.Struct({ role: Schema.tag("user"), content: Schema.Array(OpenResponsesInputContent) }),
   Schema.Struct({
     role: Schema.tag("assistant"),
-    content: Schema.Array(OpenResponsesOutputText),
+    content: Schema.Array(OutputContent),
     phase: Schema.optionalKey(MessagePhase),
   }),
   OpenResponsesReasoningItem,
@@ -116,7 +122,7 @@ type LoweredInputItem =
   | OpenResponsesInputItem
   | {
       readonly role: "assistant"
-      readonly content: ReadonlyArray<{ readonly type: "output_text"; readonly text: string }>
+      readonly content: ReadonlyArray<OutputContent>
       readonly phase?: MessagePhase | null
     }
 
@@ -271,7 +277,10 @@ export const Event = Schema.StructWithRest(
     type: Schema.String,
     delta: Schema.optional(Schema.String),
     text: Schema.optional(Schema.String),
+    refusal: Schema.optional(Schema.String),
     item_id: Schema.optional(Schema.String),
+    output_index: Schema.optional(Schema.Number),
+    content_index: Schema.optional(Schema.Number),
     summary_index: Schema.optional(Schema.Number),
     item: Schema.optional(StreamItem),
     response: Schema.optional(
@@ -494,7 +503,12 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         input.push(
           ...groups.map((group) => ({
             role: "assistant" as const,
-            content: group.parts.map((part) => ({ type: "output_text" as const, text: part.text })),
+            content: group.parts.map((part) => {
+              const metadata = part.providerMetadata?.[providerMetadataKey]
+              return ProviderShared.isRecord(metadata) && metadata.refusal === true
+                ? { type: "refusal" as const, refusal: part.text }
+                : { type: "output_text" as const, text: part.text }
+            }),
             ...(group.phase === undefined ? {} : { phase: group.phase }),
           })),
         )
@@ -727,6 +741,36 @@ const onOutputTextDone = (state: ParserState, event: Event, id: string): StepRes
   return [{ ...state, lifecycle: Lifecycle.textEnd(state.lifecycle, events, id) }, events]
 }
 
+const refusalID = (event: Event) => `refusal:${event.item_id}:${event.content_index}`
+
+const refusalMetadata = (
+  state: ParserState,
+  itemID: string,
+  phase: MessagePhase | null | undefined = state.messagePhases[itemID],
+) =>
+  providerMetadata(state, { refusal: true, ...(phase === undefined ? {} : { phase }) })
+
+const onRefusalDelta = (state: ParserState, event: Event): StepResult => {
+  if (!event.item_id || !event.delta) return [state, NO_EVENTS]
+  const events: LLMEvent[] = []
+  const id = refusalID(event)
+  const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, refusalMetadata(state, event.item_id))
+  return [{ ...state, lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta) }, events]
+}
+
+const onRefusalDone = (state: ParserState, event: Event): StepResult => {
+  if (!event.item_id) return [state, NO_EVENTS]
+  const events: LLMEvent[] = []
+  const id = refusalID(event)
+  const metadata = refusalMetadata(state, event.item_id)
+  const started =
+    state.lifecycle.text.has(id) || event.refusal === undefined
+      ? state.lifecycle
+      : Lifecycle.textDelta(Lifecycle.textStart(state.lifecycle, events, id, metadata), events, id, event.refusal)
+  if (state.messageItems.has(event.item_id)) return [{ ...state, lifecycle: started }, events]
+  return [{ ...state, lifecycle: Lifecycle.textEnd(started, events, id, metadata) }, events]
+}
+
 export const onReasoningDelta = (state: ParserState, event: Event, itemID: string): StepResult => {
   if (!event.delta) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
@@ -929,21 +973,24 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   if (!item) return [state, NO_EVENTS] satisfies StepResult
 
   if (item.type === "message" && item.id) {
+    const itemID = item.id
     const itemPhase = state.messagePhase(item.phase)
-    const phase = itemPhase === undefined ? state.messagePhases[item.id] : itemPhase
+    const phase = itemPhase === undefined ? state.messagePhases[itemID] : itemPhase
     const events: LLMEvent[] = []
+    const metadata = phase === undefined ? undefined : providerMetadata(state, { phase })
+    const lifecycle = Array.from(state.lifecycle.text)
+      .filter((id) => id.startsWith(`refusal:${itemID}:`))
+      .reduce(
+        (lifecycle, id) => Lifecycle.textEnd(lifecycle, events, id, refusalMetadata(state, itemID, phase)),
+        Lifecycle.textEnd(state.lifecycle, events, itemID, metadata),
+      )
     const messageItems = new Set(state.messageItems)
-    messageItems.delete(item.id)
-    const { [item.id]: _phase, ...messagePhases } = state.messagePhases
+    messageItems.delete(itemID)
+    const { [itemID]: _phase, ...messagePhases } = state.messagePhases
     return [
       {
         ...state,
-        lifecycle: Lifecycle.textEnd(
-          state.lifecycle,
-          events,
-          item.id,
-          phase === undefined ? undefined : providerMetadata(state, { phase }),
-        ),
+        lifecycle,
         messageItems,
         messagePhases,
       },
@@ -1063,6 +1110,20 @@ export const step = (state: ParserState, event: Event) => {
       event.type === "response.output_text.delta"
         ? onOutputTextDelta(state, event, event.item_id)
         : onOutputTextDone(state, event, event.item_id),
+    )
+  }
+  if (event.type === "response.refusal.delta" || event.type === "response.refusal.done") {
+    if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
+    if (event.output_index === undefined)
+      return ProviderShared.eventError(state.id, `${event.type} is missing output_index`)
+    if (event.content_index === undefined)
+      return ProviderShared.eventError(state.id, `${event.type} is missing content_index`)
+    if (event.type === "response.refusal.delta" && event.delta === undefined)
+      return ProviderShared.eventError(state.id, `${event.type} is missing delta`)
+    if (event.type === "response.refusal.done" && event.refusal === undefined)
+      return ProviderShared.eventError(state.id, `${event.type} is missing refusal`)
+    return Effect.succeed(
+      event.type === "response.refusal.delta" ? onRefusalDelta(state, event) : onRefusalDone(state, event),
     )
   }
   if (event.type === "response.reasoning.delta" || event.type === "response.reasoning_summary_text.delta") {

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -271,10 +271,7 @@ export const Event = Schema.StructWithRest(
     type: Schema.String,
     delta: Schema.optional(Schema.String),
     text: Schema.optional(Schema.String),
-    refusal: Schema.optional(Schema.String),
     item_id: Schema.optional(Schema.String),
-    output_index: Schema.optional(Schema.Number),
-    content_index: Schema.optional(Schema.Number),
     summary_index: Schema.optional(Schema.Number),
     item: Schema.optional(StreamItem),
     response: Schema.optional(
@@ -300,6 +297,20 @@ export const Event = Schema.StructWithRest(
   [Schema.Record(Schema.String, Schema.Unknown)],
 )
 export type Event = Schema.Schema.Type<typeof Event>
+
+const RefusalEvent = Schema.Union([
+  Schema.Struct({
+    type: Schema.tag("response.refusal.delta"),
+    item_id: Schema.String,
+    delta: Schema.String,
+  }),
+  Schema.Struct({
+    type: Schema.tag("response.refusal.done"),
+    item_id: Schema.String,
+    refusal: Schema.String,
+  }),
+])
+const isRefusalEvent = Schema.is(RefusalEvent)
 
 export interface Extension {
   readonly id: string
@@ -730,35 +741,6 @@ const onOutputTextDone = (state: ParserState, event: Event, id: string): StepRes
   return [{ ...state, lifecycle: Lifecycle.textEnd(state.lifecycle, events, id) }, events]
 }
 
-const refusalID = (event: Event) => `refusal:${event.item_id}:${event.content_index}`
-
-const messageMetadata = (
-  state: ParserState,
-  itemID: string,
-  phase: MessagePhase | null | undefined = state.messagePhases[itemID],
-) => (phase === undefined ? undefined : providerMetadata(state, { phase }))
-
-const onRefusalDelta = (state: ParserState, event: Event): StepResult => {
-  if (!event.item_id || !event.delta) return [state, NO_EVENTS]
-  const events: LLMEvent[] = []
-  const id = refusalID(event)
-  const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, messageMetadata(state, event.item_id))
-  return [{ ...state, lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta) }, events]
-}
-
-const onRefusalDone = (state: ParserState, event: Event): StepResult => {
-  if (!event.item_id) return [state, NO_EVENTS]
-  const events: LLMEvent[] = []
-  const id = refusalID(event)
-  const metadata = messageMetadata(state, event.item_id)
-  const started =
-    state.lifecycle.text.has(id) || event.refusal === undefined
-      ? state.lifecycle
-      : Lifecycle.textDelta(Lifecycle.textStart(state.lifecycle, events, id, metadata), events, id, event.refusal)
-  if (state.messageItems.has(event.item_id)) return [{ ...state, lifecycle: started }, events]
-  return [{ ...state, lifecycle: Lifecycle.textEnd(started, events, id, metadata) }, events]
-}
-
 export const onReasoningDelta = (state: ParserState, event: Event, itemID: string): StepResult => {
   if (!event.delta) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
@@ -961,24 +943,21 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   if (!item) return [state, NO_EVENTS] satisfies StepResult
 
   if (item.type === "message" && item.id) {
-    const itemID = item.id
     const itemPhase = state.messagePhase(item.phase)
-    const phase = itemPhase === undefined ? state.messagePhases[itemID] : itemPhase
+    const phase = itemPhase === undefined ? state.messagePhases[item.id] : itemPhase
     const events: LLMEvent[] = []
-    const metadata = phase === undefined ? undefined : providerMetadata(state, { phase })
-    const lifecycle = Array.from(state.lifecycle.text)
-      .filter((id) => id.startsWith(`refusal:${itemID}:`))
-      .reduce(
-        (lifecycle, id) => Lifecycle.textEnd(lifecycle, events, id, messageMetadata(state, itemID, phase)),
-        Lifecycle.textEnd(state.lifecycle, events, itemID, metadata),
-      )
     const messageItems = new Set(state.messageItems)
-    messageItems.delete(itemID)
-    const { [itemID]: _phase, ...messagePhases } = state.messagePhases
+    messageItems.delete(item.id)
+    const { [item.id]: _phase, ...messagePhases } = state.messagePhases
     return [
       {
         ...state,
-        lifecycle,
+        lifecycle: Lifecycle.textEnd(
+          state.lifecycle,
+          events,
+          item.id,
+          phase === undefined ? undefined : providerMetadata(state, { phase }),
+        ),
         messageItems,
         messagePhases,
       },
@@ -1101,17 +1080,11 @@ export const step = (state: ParserState, event: Event) => {
     )
   }
   if (event.type === "response.refusal.delta" || event.type === "response.refusal.done") {
-    if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
-    if (event.output_index === undefined)
-      return ProviderShared.eventError(state.id, `${event.type} is missing output_index`)
-    if (event.content_index === undefined)
-      return ProviderShared.eventError(state.id, `${event.type} is missing content_index`)
-    if (event.type === "response.refusal.delta" && event.delta === undefined)
-      return ProviderShared.eventError(state.id, `${event.type} is missing delta`)
-    if (event.type === "response.refusal.done" && event.refusal === undefined)
-      return ProviderShared.eventError(state.id, `${event.type} is missing refusal`)
+    if (!isRefusalEvent(event)) return ProviderShared.eventError(state.id, `${event.type} is malformed`)
     return Effect.succeed(
-      event.type === "response.refusal.delta" ? onRefusalDelta(state, event) : onRefusalDone(state, event),
+      event.type === "response.refusal.delta"
+        ? onOutputTextDelta(state, event, event.item_id)
+        : onOutputTextDone(state, { ...event, text: event.refusal }, event.item_id),
     )
   }
   if (event.type === "response.reasoning.delta" || event.type === "response.reasoning_summary_text.delta") {

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1,4 +1,4 @@
-import { Effect, Option, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import type { Content } from "@opencode-ai/schema/tool"
 import { HttpTransport } from "../route/transport/index.js"
 import { Protocol } from "../route/protocol.js"
@@ -53,20 +53,9 @@ const OpenResponsesOutputText = Schema.Struct({
   type: Schema.tag("output_text"),
   text: Schema.String,
 })
-const OpenResponsesRefusal = Schema.Struct({
-  type: Schema.tag("refusal"),
-  refusal: Schema.String,
-})
-export const OutputContent = Schema.Union([OpenResponsesOutputText, OpenResponsesRefusal])
-type OutputContent = Schema.Schema.Type<typeof OutputContent>
 
 export const MessagePhase = Schema.Literals(["commentary", "final_answer"])
 type MessagePhase = Schema.Schema.Type<typeof MessagePhase>
-const ReplayTextMetadata = Schema.Struct({
-  refusal: Schema.optionalKey(Schema.Literal(true)),
-  phase: Schema.optionalKey(Schema.NullOr(MessagePhase)),
-})
-const decodeReplayTextMetadata = Schema.decodeUnknownOption(ReplayTextMetadata)
 
 const OpenResponsesReasoningSummaryText = Schema.Struct({
   type: Schema.tag("summary_text"),
@@ -105,7 +94,7 @@ export const InputItem = Schema.Union([
   Schema.Struct({ role: Schema.tag("user"), content: Schema.Array(OpenResponsesInputContent) }),
   Schema.Struct({
     role: Schema.tag("assistant"),
-    content: Schema.Array(OutputContent),
+    content: Schema.Array(OpenResponsesOutputText),
     phase: Schema.optionalKey(MessagePhase),
   }),
   OpenResponsesReasoningItem,
@@ -127,7 +116,7 @@ type LoweredInputItem =
   | OpenResponsesInputItem
   | {
       readonly role: "assistant"
-      readonly content: ReadonlyArray<OutputContent>
+      readonly content: ReadonlyArray<{ readonly type: "output_text"; readonly text: string }>
       readonly phase?: MessagePhase | null
     }
 
@@ -496,7 +485,8 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         if (content.length === 0) return
         const groups = content.reduce<Array<{ phase: MessagePhase | null | undefined; parts: TextPart[] }>>(
           (groups, part) => {
-            const phase = messagePhase(replayTextMetadata(part, providerMetadataKey)?.phase, extension)
+            const metadata = part.providerMetadata?.[providerMetadataKey]
+            const phase = ProviderShared.isRecord(metadata) ? messagePhase(metadata.phase, extension) : undefined
             const group = groups.at(-1)
             if (group && group.phase === phase) group.parts.push(part)
             else groups.push({ phase, parts: [part] })
@@ -507,7 +497,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         input.push(
           ...groups.map((group) => ({
             role: "assistant" as const,
-            content: group.parts.map((part) => lowerAssistantContent(part, providerMetadataKey)),
+            content: group.parts.map((part) => ({ type: "output_text" as const, text: part.text })),
             ...(group.phase === undefined ? {} : { phase: group.phase }),
           })),
         )
@@ -595,14 +585,6 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
       )
     : input
 })
-
-const replayTextMetadata = (part: TextPart, providerMetadataKey: string) =>
-  Option.getOrUndefined(decodeReplayTextMetadata(part.providerMetadata?.[providerMetadataKey]))
-
-const lowerAssistantContent = (part: TextPart, providerMetadataKey: string): OutputContent =>
-  replayTextMetadata(part, providerMetadataKey)?.refusal === true
-    ? { type: "refusal", refusal: part.text }
-    : { type: "output_text", text: part.text }
 
 const lowerOptions = (request: LLMRequest) => {
   const options = OpenResponsesOptions.resolve(request)
@@ -750,18 +732,17 @@ const onOutputTextDone = (state: ParserState, event: Event, id: string): StepRes
 
 const refusalID = (event: Event) => `refusal:${event.item_id}:${event.content_index}`
 
-const refusalMetadata = (
+const messageMetadata = (
   state: ParserState,
   itemID: string,
   phase: MessagePhase | null | undefined = state.messagePhases[itemID],
-) =>
-  providerMetadata(state, { refusal: true, ...(phase === undefined ? {} : { phase }) })
+) => (phase === undefined ? undefined : providerMetadata(state, { phase }))
 
 const onRefusalDelta = (state: ParserState, event: Event): StepResult => {
   if (!event.item_id || !event.delta) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
   const id = refusalID(event)
-  const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, refusalMetadata(state, event.item_id))
+  const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, messageMetadata(state, event.item_id))
   return [{ ...state, lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta) }, events]
 }
 
@@ -769,7 +750,7 @@ const onRefusalDone = (state: ParserState, event: Event): StepResult => {
   if (!event.item_id) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
   const id = refusalID(event)
-  const metadata = refusalMetadata(state, event.item_id)
+  const metadata = messageMetadata(state, event.item_id)
   const started =
     state.lifecycle.text.has(id) || event.refusal === undefined
       ? state.lifecycle
@@ -988,7 +969,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
     const lifecycle = Array.from(state.lifecycle.text)
       .filter((id) => id.startsWith(`refusal:${itemID}:`))
       .reduce(
-        (lifecycle, id) => Lifecycle.textEnd(lifecycle, events, id, refusalMetadata(state, itemID, phase)),
+        (lifecycle, id) => Lifecycle.textEnd(lifecycle, events, id, messageMetadata(state, itemID, phase)),
         Lifecycle.textEnd(state.lifecycle, events, itemID, metadata),
       )
     const messageItems = new Set(state.messageItems)

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -28,7 +28,7 @@ import { ToolSchemaProjection } from "./utils/tool-schema.js"
 import { ToolStream } from "./utils/tool-stream.js"
 
 const ADAPTER = "openai-chat"
-const RESERVED_REASONING_FIELDS = new Set(["role", "content", "tool_calls"])
+const RESERVED_REASONING_FIELDS = new Set(["role", "content", "refusal", "tool_calls"])
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1"
 export const PATH = "/chat/completions"
 
@@ -97,6 +97,7 @@ const OpenAIChatMessage = Schema.Union([
     Schema.Struct({
       role: Schema.Literal("assistant"),
       content: Schema.NullOr(Schema.String),
+      refusal: optionalNull(Schema.String),
       tool_calls: optionalArray(OpenAIChatAssistantToolCall),
       reasoning_content: Schema.optional(Schema.String),
       reasoning: Schema.optional(Schema.String),
@@ -194,6 +195,7 @@ type OpenAIChatToolCallDelta = Schema.Schema.Type<typeof OpenAIChatToolCallDelta
 const OpenAIChatDelta = Schema.StructWithRest(
   Schema.Struct({
     content: optionalNull(Schema.String),
+    refusal: optionalNull(Schema.String),
     reasoning_content: optionalNull(Schema.String),
     reasoning: optionalNull(Schema.String),
     reasoning_text: optionalNull(Schema.String),
@@ -241,6 +243,8 @@ export interface ParserState {
   readonly reasoningEmitted: boolean
   readonly latestToolIndex?: number
   readonly nextToolIndex: number
+  readonly activeText?: { readonly kind: "content" | "refusal"; readonly id: string }
+  readonly nextTextIndex: number
 }
 
 // =============================================================================
@@ -336,13 +340,15 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
   options: LoweringOptions = {},
 ) {
   const content: TextPart[] = []
+  const refusals: TextPart[] = []
   const reasoning: ReasoningPart[] = []
   const toolCalls: OpenAIChatAssistantToolCall[] = []
   for (const part of message.content) {
     if (!ProviderShared.supportsContent(part, ["text", "reasoning", "tool-call"]))
       return yield* ProviderShared.unsupportedContent("OpenAI Chat", "assistant", ["text", "reasoning", "tool-call"])
     if (part.type === "text") {
-      content.push(part)
+      if (part.providerMetadata?.openai?.refusal === true) refusals.push(part)
+      else content.push(part)
       continue
     }
     if (part.type === "reasoning") {
@@ -375,7 +381,13 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
   const cacheControl = options.cacheControl?.(cached && "cache" in cached ? cached.cache : undefined)
   const result = {
     role: "assistant" as const,
-    content: content.length > 0 ? content.map((part) => part.text).join("") : toolCalls.length > 0 ? null : "",
+    content:
+      content.length > 0
+        ? content.map((part) => part.text).join("")
+        : toolCalls.length > 0 || refusals.length > 0
+          ? null
+          : "",
+    ...(refusals.length > 0 ? { refusal: refusals.map((part) => part.text).join("") } : {}),
     ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
     ...(details !== undefined ? { reasoning_details: details } : {}),
     ...(cacheControl !== undefined ? { cache_control: cacheControl } : {}),
@@ -705,10 +717,13 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     let nextToolIndex = state.nextToolIndex
 
     let lifecycle = state.lifecycle
+    let activeText = state.activeText
+    let nextTextIndex = state.nextTextIndex
 
     const reasoning = reasoningDelta(delta, state.reasoningField)
     const hasLateContent =
       Boolean(delta?.content) ||
+      Boolean(delta?.refusal) ||
       reasoning !== undefined ||
       (Array.isArray(delta?.reasoning_details) && delta.reasoning_details.length > 0) ||
       toolDeltas.some((tool) => Boolean(tool.id) || Boolean(tool.function?.name) || Boolean(tool.function?.arguments))
@@ -740,7 +755,26 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         "reasoning-0",
         reasoningMetadata(reasoningField, reasoningDetailsObserved ? state.reasoningDetails : undefined),
       )
-      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+      if (activeText?.kind !== "content") {
+        if (activeText) lifecycle = Lifecycle.textEnd(lifecycle, events, activeText.id)
+        activeText = { kind: "content", id: `text-${nextTextIndex++}` }
+      }
+      lifecycle = Lifecycle.textDelta(lifecycle, events, activeText.id, delta.content)
+    }
+
+    if (delta?.refusal) {
+      lifecycle = Lifecycle.reasoningEnd(
+        lifecycle,
+        events,
+        "reasoning-0",
+        reasoningMetadata(reasoningField, reasoningDetailsObserved ? state.reasoningDetails : undefined),
+      )
+      if (activeText?.kind !== "refusal") {
+        if (activeText) lifecycle = Lifecycle.textEnd(lifecycle, events, activeText.id)
+        activeText = { kind: "refusal", id: `refusal-${nextTextIndex++}` }
+        lifecycle = Lifecycle.textStart(lifecycle, events, activeText.id, { openai: { refusal: true } })
+      }
+      lifecycle = Lifecycle.textDelta(lifecycle, events, activeText.id, delta.refusal)
     }
 
     // Compatible providers may omit indexes. Prefer durable identity, then use
@@ -806,6 +840,8 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningEmitted,
         latestToolIndex,
         nextToolIndex,
+        activeText,
+        nextTextIndex,
       },
       events,
     ] as const
@@ -867,6 +903,7 @@ export const protocol = Protocol.make({
       reasoningDetailsObserved: false,
       reasoningEmitted: false,
       nextToolIndex: 0,
+      nextTextIndex: 0,
     }),
     step,
     onHalt: finishEvents,

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -29,6 +29,8 @@ import { ToolStream } from "./utils/tool-stream.js"
 
 const ADAPTER = "openai-chat"
 const RESERVED_REASONING_FIELDS = new Set(["role", "content", "refusal", "tool_calls"])
+const RefusalMetadata = Schema.Struct({ refusal: Schema.Literal(true) })
+const isRefusalMetadata = Schema.is(RefusalMetadata)
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1"
 export const PATH = "/chat/completions"
 
@@ -230,6 +232,12 @@ interface PendingToolDelta {
   readonly input: string
 }
 
+type TextChannel = "content" | "refusal"
+interface ActiveText {
+  readonly kind: TextChannel
+  readonly id: string
+}
+
 export interface ParserState {
   readonly tools: ToolStream.State<number>
   readonly pendingTools: Partial<Record<number, PendingToolDelta>>
@@ -243,7 +251,7 @@ export interface ParserState {
   readonly reasoningEmitted: boolean
   readonly latestToolIndex?: number
   readonly nextToolIndex: number
-  readonly activeText?: { readonly kind: "content" | "refusal"; readonly id: string }
+  readonly activeText?: ActiveText
   readonly nextTextIndex: number
 }
 
@@ -347,7 +355,7 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
     if (!ProviderShared.supportsContent(part, ["text", "reasoning", "tool-call"]))
       return yield* ProviderShared.unsupportedContent("OpenAI Chat", "assistant", ["text", "reasoning", "tool-call"])
     if (part.type === "text") {
-      if (part.providerMetadata?.openai?.refusal === true) refusals.push(part)
+      if (isRefusalMetadata(part.providerMetadata?.openai)) refusals.push(part)
       else content.push(part)
       continue
     }
@@ -743,7 +751,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     else if (
       reasoningDetailsObserved &&
       !lifecycle.reasoning.has("reasoning-0") &&
-      (Boolean(delta?.content) || toolDeltas.length > 0)
+      (Boolean(delta?.content) || Boolean(delta?.refusal) || toolDeltas.length > 0)
     )
       lifecycle = Lifecycle.reasoningStart(lifecycle, events, "reasoning-0", deltaMetadata)
     const reasoningEmitted = state.reasoningEmitted || lifecycle.reasoning.has("reasoning-0")
@@ -756,6 +764,8 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningMetadata(reasoningField, reasoningDetailsObserved ? state.reasoningDetails : undefined),
       )
       if (activeText?.kind !== "content") {
+        // Chat exposes independent scalar channels without part IDs. Segment field
+        // switches so provider-neutral consumers receive balanced, unique blocks.
         if (activeText) lifecycle = Lifecycle.textEnd(lifecycle, events, activeText.id)
         activeText = { kind: "content", id: `text-${nextTextIndex++}` }
       }

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -29,8 +29,6 @@ import { ToolStream } from "./utils/tool-stream.js"
 
 const ADAPTER = "openai-chat"
 const RESERVED_REASONING_FIELDS = new Set(["role", "content", "refusal", "tool_calls"])
-const RefusalMetadata = Schema.Struct({ refusal: Schema.Literal(true) })
-const isRefusalMetadata = Schema.is(RefusalMetadata)
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1"
 export const PATH = "/chat/completions"
 
@@ -99,7 +97,6 @@ const OpenAIChatMessage = Schema.Union([
     Schema.Struct({
       role: Schema.Literal("assistant"),
       content: Schema.NullOr(Schema.String),
-      refusal: optionalNull(Schema.String),
       tool_calls: optionalArray(OpenAIChatAssistantToolCall),
       reasoning_content: Schema.optional(Schema.String),
       reasoning: Schema.optional(Schema.String),
@@ -232,12 +229,6 @@ interface PendingToolDelta {
   readonly input: string
 }
 
-type TextChannel = "content" | "refusal"
-interface ActiveText {
-  readonly kind: TextChannel
-  readonly id: string
-}
-
 export interface ParserState {
   readonly tools: ToolStream.State<number>
   readonly pendingTools: Partial<Record<number, PendingToolDelta>>
@@ -251,8 +242,6 @@ export interface ParserState {
   readonly reasoningEmitted: boolean
   readonly latestToolIndex?: number
   readonly nextToolIndex: number
-  readonly activeText?: ActiveText
-  readonly nextTextIndex: number
 }
 
 // =============================================================================
@@ -348,15 +337,13 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
   options: LoweringOptions = {},
 ) {
   const content: TextPart[] = []
-  const refusals: TextPart[] = []
   const reasoning: ReasoningPart[] = []
   const toolCalls: OpenAIChatAssistantToolCall[] = []
   for (const part of message.content) {
     if (!ProviderShared.supportsContent(part, ["text", "reasoning", "tool-call"]))
       return yield* ProviderShared.unsupportedContent("OpenAI Chat", "assistant", ["text", "reasoning", "tool-call"])
     if (part.type === "text") {
-      if (isRefusalMetadata(part.providerMetadata?.openai)) refusals.push(part)
-      else content.push(part)
+      content.push(part)
       continue
     }
     if (part.type === "reasoning") {
@@ -389,13 +376,7 @@ const lowerAssistantMessage = Effect.fn("OpenAIChat.lowerAssistantMessage")(func
   const cacheControl = options.cacheControl?.(cached && "cache" in cached ? cached.cache : undefined)
   const result = {
     role: "assistant" as const,
-    content:
-      content.length > 0
-        ? content.map((part) => part.text).join("")
-        : toolCalls.length > 0 || refusals.length > 0
-          ? null
-          : "",
-    ...(refusals.length > 0 ? { refusal: refusals.map((part) => part.text).join("") } : {}),
+    content: content.length > 0 ? content.map((part) => part.text).join("") : toolCalls.length > 0 ? null : "",
     ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
     ...(details !== undefined ? { reasoning_details: details } : {}),
     ...(cacheControl !== undefined ? { cache_control: cacheControl } : {}),
@@ -725,8 +706,6 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     let nextToolIndex = state.nextToolIndex
 
     let lifecycle = state.lifecycle
-    let activeText = state.activeText
-    let nextTextIndex = state.nextTextIndex
 
     const reasoning = reasoningDelta(delta, state.reasoningField)
     const hasLateContent =
@@ -763,13 +742,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         "reasoning-0",
         reasoningMetadata(reasoningField, reasoningDetailsObserved ? state.reasoningDetails : undefined),
       )
-      if (activeText?.kind !== "content") {
-        // Chat exposes independent scalar channels without part IDs. Segment field
-        // switches so provider-neutral consumers receive balanced, unique blocks.
-        if (activeText) lifecycle = Lifecycle.textEnd(lifecycle, events, activeText.id)
-        activeText = { kind: "content", id: `text-${nextTextIndex++}` }
-      }
-      lifecycle = Lifecycle.textDelta(lifecycle, events, activeText.id, delta.content)
+      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
     }
 
     if (delta?.refusal) {
@@ -779,12 +752,7 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         "reasoning-0",
         reasoningMetadata(reasoningField, reasoningDetailsObserved ? state.reasoningDetails : undefined),
       )
-      if (activeText?.kind !== "refusal") {
-        if (activeText) lifecycle = Lifecycle.textEnd(lifecycle, events, activeText.id)
-        activeText = { kind: "refusal", id: `refusal-${nextTextIndex++}` }
-        lifecycle = Lifecycle.textStart(lifecycle, events, activeText.id, { openai: { refusal: true } })
-      }
-      lifecycle = Lifecycle.textDelta(lifecycle, events, activeText.id, delta.refusal)
+      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.refusal)
     }
 
     // Compatible providers may omit indexes. Prefer durable identity, then use
@@ -850,8 +818,6 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         reasoningEmitted,
         latestToolIndex,
         nextToolIndex,
-        activeText,
-        nextTextIndex,
       },
       events,
     ] as const
@@ -913,7 +879,6 @@ export const protocol = Protocol.make({
       reasoningDetailsObserved: false,
       reasoningEmitted: false,
       nextToolIndex: 0,
-      nextTextIndex: 0,
     }),
     step,
     onHalt: finishEvents,

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -43,7 +43,7 @@ const OpenAIResponsesToolChoice = Schema.Union([
 const OpenAIResponsesInputItem = Schema.Union([
   Schema.Struct({
     role: Schema.tag("assistant"),
-    content: Schema.Array(Schema.Struct({ type: Schema.tag("output_text"), text: Schema.String })),
+    content: Schema.Array(OpenResponses.OutputContent),
     phase: Schema.optionalKey(Schema.NullOr(OpenResponses.MessagePhase)),
   }),
   OpenResponses.InputItem,

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -43,7 +43,7 @@ const OpenAIResponsesToolChoice = Schema.Union([
 const OpenAIResponsesInputItem = Schema.Union([
   Schema.Struct({
     role: Schema.tag("assistant"),
-    content: Schema.Array(OpenResponses.OutputContent),
+    content: Schema.Array(Schema.Struct({ type: Schema.tag("output_text"), text: Schema.String })),
     phase: Schema.optionalKey(Schema.NullOr(OpenResponses.MessagePhase)),
   }),
   OpenResponses.InputItem,

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -664,7 +664,7 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
-  it.effect("preserves and replays streamed refusals", () =>
+  it.effect("preserves streamed refusals as ordinary assistant text", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -680,32 +680,10 @@ describe("OpenAI Chat route", () => {
 
       expect(response.text).toBe("I can't help with that.")
       expect(response.finishReason).toEqual({ normalized: "stop", raw: "stop" })
-      expect(response.message.content).toEqual([
-        {
-          type: "text",
-          text: "I can't help with that.",
-          providerMetadata: { openai: { refusal: true } },
-        },
-      ])
+      expect(response.message.content).toEqual([{ type: "text", text: "I can't help with that." }])
 
       const replay = yield* compileRequest(LLM.request({ model, messages: [response.message] }))
-      expect(replay.body.messages).toEqual([
-        { role: "assistant", content: null, refusal: "I can't help with that." },
-      ])
-
-      const malformed = yield* compileRequest(
-        LLM.request({
-          model,
-          messages: [
-            Message.assistant({
-              type: "text",
-              text: "Keep this visible.",
-              providerMetadata: { openai: { refusal: "invalid" } },
-            }),
-          ],
-        }),
-      )
-      expect(malformed.body.messages).toEqual([{ role: "assistant", content: "Keep this visible." }])
+      expect(replay.body.messages).toEqual([{ role: "assistant", content: "I can't help with that." }])
     }),
   )
 
@@ -728,13 +706,12 @@ describe("OpenAI Chat route", () => {
         {
           type: "text",
           text: "I can't help with that.",
-          providerMetadata: { openai: { refusal: true } },
         },
       ])
     }),
   )
 
-  it.effect("uses fresh block ids when content and refusal deltas alternate", () =>
+  it.effect("joins content and refusal deltas into ordinary assistant text", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -749,16 +726,9 @@ describe("OpenAI Chat route", () => {
         ),
       )
 
-      expect(response.events.filter(LLMEvent.is.textStart).map((event) => event.id)).toEqual([
-        "refusal-0",
-        "text-1",
-        "refusal-2",
-      ])
-      expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.id)).toEqual([
-        "refusal-0",
-        "text-1",
-        "refusal-2",
-      ])
+      expect(response.text).toBe("No. Alternative. Still no.")
+      expect(response.events.filter(LLMEvent.is.textStart).map((event) => event.id)).toEqual(["text-0"])
+      expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.id)).toEqual(["text-0"])
     }),
   )
 

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -664,6 +664,65 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("preserves and replays streamed refusals", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({ role: "assistant", refusal: "I can't" }),
+              deltaChunk({ refusal: " help with that." }),
+              deltaChunk({}, "stop"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.text).toBe("I can't help with that.")
+      expect(response.finishReason).toEqual({ normalized: "stop", raw: "stop" })
+      expect(response.message.content).toEqual([
+        {
+          type: "text",
+          text: "I can't help with that.",
+          providerMetadata: { openai: { refusal: true } },
+        },
+      ])
+
+      const replay = yield* compileRequest(LLM.request({ model, messages: [response.message] }))
+      expect(replay.body.messages).toEqual([
+        { role: "assistant", content: null, refusal: "I can't help with that." },
+      ])
+    }),
+  )
+
+  it.effect("uses fresh block ids when content and refusal deltas alternate", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              deltaChunk({ refusal: "No." }),
+              deltaChunk({ content: " Alternative." }),
+              deltaChunk({ refusal: " Still no." }),
+              deltaChunk({}, "stop"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.events.filter(LLMEvent.is.textStart).map((event) => event.id)).toEqual([
+        "refusal-0",
+        "text-1",
+        "refusal-2",
+      ])
+      expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.id)).toEqual([
+        "refusal-0",
+        "text-1",
+        "refusal-2",
+      ])
+    }),
+  )
+
   it.effect("parses and replays OpenAI-compatible reasoning fields", () =>
     Effect.gen(function* () {
       const fields = ["reasoning_content", "reasoning", "reasoning_text"] as const

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -692,6 +692,45 @@ describe("OpenAI Chat route", () => {
       expect(replay.body.messages).toEqual([
         { role: "assistant", content: null, refusal: "I can't help with that." },
       ])
+
+      const malformed = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant({
+              type: "text",
+              text: "Keep this visible.",
+              providerMetadata: { openai: { refusal: "invalid" } },
+            }),
+          ],
+        }),
+      )
+      expect(malformed.body.messages).toEqual([{ role: "assistant", content: "Keep this visible." }])
+    }),
+  )
+
+  it.effect("orders metadata-only reasoning before refusal output", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { choices: [{ delta: { reasoning_details: [] } }] },
+              deltaChunk({ refusal: "I can't help with that." }),
+              deltaChunk({}, "stop"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.message.content).toEqual([
+        { type: "reasoning", text: "", providerMetadata: { openai: { reasoningDetails: [] } } },
+        {
+          type: "text",
+          text: "I can't help with that.",
+          providerMetadata: { openai: { refusal: true } },
+        },
+      ])
     }),
   )
 

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -171,6 +171,32 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  it.effect("falls back to output text for malformed refusal replay metadata", () =>
+    Effect.gen(function* () {
+      const model = configure({
+        apiKey: "test-key",
+        baseURL: "https://responses.example.test/v1",
+        provider: "example",
+      }).model("example-model")
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant({
+              type: "text",
+              text: "Keep this visible.",
+              providerMetadata: { openresponses: { refusal: true, phase: "not-a-phase" } },
+            }),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        { role: "assistant", content: [{ type: "output_text", text: "Keep this visible." }] },
+      ])
+    }),
+  )
+
   it.effect("reads standard Open Responses options", () =>
     Effect.gen(function* () {
       const model = configure({

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -118,6 +118,59 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  it.effect("preserves standard refusal content in the Open Responses namespace", () =>
+    Effect.gen(function* () {
+      const model = configure({
+        apiKey: "test-key",
+        baseURL: "https://responses.example.test/v1",
+        provider: "example",
+      }).model("example-model")
+      const response = yield* LLMClient.generate(LLM.request({ model, prompt: "Unsafe request" })).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { type: "message", id: "msg_refusal", content: [] },
+              },
+              {
+                type: "response.refusal.done",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                refusal: "I can't help with that.",
+              },
+              {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: {
+                  type: "message",
+                  id: "msg_refusal",
+                  content: [{ type: "refusal", refusal: "I can't help with that." }],
+                },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.message.content).toEqual([
+        {
+          type: "text",
+          text: "I can't help with that.",
+          providerMetadata: { openresponses: { refusal: true } },
+        },
+      ])
+
+      const prepared = yield* compileRequest(LLM.request({ model, messages: [response.message] }))
+      expect(prepared.body.input).toEqual([
+        { role: "assistant", content: [{ type: "refusal", refusal: "I can't help with that." }] },
+      ])
+    }),
+  )
+
   it.effect("reads standard Open Responses options", () =>
     Effect.gen(function* () {
       const model = configure({

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -118,7 +118,7 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
-  it.effect("preserves standard refusal content in the Open Responses namespace", () =>
+  it.effect("preserves standard refusal content as ordinary assistant text", () =>
     Effect.gen(function* () {
       const model = configure({
         apiKey: "test-key",
@@ -156,43 +156,11 @@ describe("Open Responses-compatible route", () => {
         ),
       )
 
-      expect(response.message.content).toEqual([
-        {
-          type: "text",
-          text: "I can't help with that.",
-          providerMetadata: { openresponses: { refusal: true } },
-        },
-      ])
+      expect(response.message.content).toEqual([{ type: "text", text: "I can't help with that." }])
 
       const prepared = yield* compileRequest(LLM.request({ model, messages: [response.message] }))
       expect(prepared.body.input).toEqual([
-        { role: "assistant", content: [{ type: "refusal", refusal: "I can't help with that." }] },
-      ])
-    }),
-  )
-
-  it.effect("falls back to output text for malformed refusal replay metadata", () =>
-    Effect.gen(function* () {
-      const model = configure({
-        apiKey: "test-key",
-        baseURL: "https://responses.example.test/v1",
-        provider: "example",
-      }).model("example-model")
-      const prepared = yield* compileRequest(
-        LLM.request({
-          model,
-          messages: [
-            Message.assistant({
-              type: "text",
-              text: "Keep this visible.",
-              providerMetadata: { openresponses: { refusal: true, phase: "not-a-phase" } },
-            }),
-          ],
-        }),
-      )
-
-      expect(prepared.body.input).toEqual([
-        { role: "assistant", content: [{ type: "output_text", text: "Keep this visible." }] },
+        { role: "assistant", content: [{ type: "output_text", text: "I can't help with that." }] },
       ])
     }),
   )

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -137,8 +137,6 @@ describe("Open Responses-compatible route", () => {
               {
                 type: "response.refusal.done",
                 item_id: "msg_refusal",
-                output_index: 0,
-                content_index: 0,
                 refusal: "I can't help with that.",
               },
               {

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -485,52 +485,6 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("continues after a completed refusal without replaying it", () =>
-    Effect.gen(function* () {
-      const firstInput = [{ role: "user", content: [{ type: "input_text", text: "Unsafe request" }] }]
-      const first = continuationDriver({ type: "response.create", model: "gpt-5.2", store: false, input: firstInput })
-      const create = yield* first.create(undefined)
-      yield* first.observe(
-        create,
-        ProviderShared.encodeJson({
-          type: "response.output_item.done",
-          item: {
-            type: "message",
-            id: "msg_refusal",
-            status: "completed",
-            role: "assistant",
-            content: [{ type: "refusal", refusal: "I can't help with that." }],
-          },
-        }),
-      )
-      const saved = checkpoint(
-        yield* first.observe(
-          create,
-          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
-        ),
-      )
-      const followUp = { role: "user", content: [{ type: "input_text", text: "Try something safe" }] }
-      const next = continuationDriver({
-        type: "response.create",
-        model: "gpt-5.2",
-        store: false,
-        input: [
-          ...firstInput,
-          { role: "assistant", content: [{ type: "refusal", refusal: "I can't help with that." }] },
-          followUp,
-        ],
-      })
-
-      const continued = yield* next.create(saved)
-
-      expect(continued.mode).toBe("incremental")
-      expect(ProviderShared.decodeJson(continued.message)).toMatchObject({
-        previous_response_id: "resp_1",
-        input: [followUp],
-      })
-    }),
-  )
-
   it.effect("continues store-false reasoning without replaying the output-only item ID", () =>
     Effect.gen(function* () {
       const firstInput = [{ role: "user", content: [{ type: "input_text", text: "Think" }] }]
@@ -1551,7 +1505,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("preserves and replays standard refusal content", () =>
+  it.effect("preserves standard refusal content as ordinary assistant text", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -1619,7 +1573,7 @@ describe("OpenAI Responses route", () => {
         {
           type: "text",
           text: "I can't help with that.",
-          providerMetadata: { openai: { refusal: true, phase: "final_answer" } },
+          providerMetadata: { openai: { phase: "final_answer" } },
         },
       ])
 
@@ -1627,7 +1581,7 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body.input).toEqual([
         {
           role: "assistant",
-          content: [{ type: "refusal", refusal: "I can't help with that." }],
+          content: [{ type: "output_text", text: "I can't help with that." }],
           phase: "final_answer",
         },
       ])

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -485,6 +485,52 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("continues after a completed refusal without replaying it", () =>
+    Effect.gen(function* () {
+      const firstInput = [{ role: "user", content: [{ type: "input_text", text: "Unsafe request" }] }]
+      const first = continuationDriver({ type: "response.create", model: "gpt-5.2", store: false, input: firstInput })
+      const create = yield* first.create(undefined)
+      yield* first.observe(
+        create,
+        ProviderShared.encodeJson({
+          type: "response.output_item.done",
+          item: {
+            type: "message",
+            id: "msg_refusal",
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "refusal", refusal: "I can't help with that." }],
+          },
+        }),
+      )
+      const saved = checkpoint(
+        yield* first.observe(
+          create,
+          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
+        ),
+      )
+      const followUp = { role: "user", content: [{ type: "input_text", text: "Try something safe" }] }
+      const next = continuationDriver({
+        type: "response.create",
+        model: "gpt-5.2",
+        store: false,
+        input: [
+          ...firstInput,
+          { role: "assistant", content: [{ type: "refusal", refusal: "I can't help with that." }] },
+          followUp,
+        ],
+      })
+
+      const continued = yield* next.create(saved)
+
+      expect(continued.mode).toBe("incremental")
+      expect(ProviderShared.decodeJson(continued.message)).toMatchObject({
+        previous_response_id: "resp_1",
+        input: [followUp],
+      })
+    }),
+  )
+
   it.effect("continues store-false reasoning without replaying the output-only item ID", () =>
     Effect.gen(function* () {
       const firstInput = [{ role: "user", content: [{ type: "input_text", text: "Think" }] }]
@@ -1502,6 +1548,108 @@ describe("OpenAI Responses route", () => {
           usage,
         },
       ])
+    }),
+  )
+
+  it.effect("preserves and replays standard refusal content", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { type: "message", id: "msg_refusal", content: [] },
+              },
+              {
+                type: "response.content_part.added",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                part: { type: "refusal", refusal: "" },
+              },
+              {
+                type: "response.refusal.delta",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                delta: "I can't",
+              },
+              {
+                type: "response.refusal.delta",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                delta: " help with that.",
+              },
+              {
+                type: "response.refusal.done",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                refusal: "I can't help with that.",
+              },
+              {
+                type: "response.content_part.done",
+                item_id: "msg_refusal",
+                output_index: 0,
+                content_index: 0,
+                part: { type: "refusal", refusal: "I can't help with that." },
+              },
+              {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: {
+                  type: "message",
+                  id: "msg_refusal",
+                  phase: "final_answer",
+                  content: [{ type: "refusal", refusal: "I can't help with that." }],
+                },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.text).toBe("I can't help with that.")
+      expect(response.finishReason).toEqual({ normalized: "stop", raw: undefined })
+      expect(response.message.content).toEqual([
+        {
+          type: "text",
+          text: "I can't help with that.",
+          providerMetadata: { openai: { refusal: true, phase: "final_answer" } },
+        },
+      ])
+
+      const prepared = yield* compileRequest(LLM.request({ model, messages: [response.message] }))
+      expect(prepared.body.input).toEqual([
+        {
+          role: "assistant",
+          content: [{ type: "refusal", refusal: "I can't help with that." }],
+          phase: "final_answer",
+        },
+      ])
+    }),
+  )
+
+  it.effect("rejects refusal events without standard content coordinates", () =>
+    Effect.gen(function* () {
+      const events = [
+        { type: "response.refusal.delta", output_index: 0, content_index: 0, delta: "missing item" },
+        { type: "response.refusal.delta", item_id: "msg_1", content_index: 0, delta: "missing output" },
+        { type: "response.refusal.delta", item_id: "msg_1", output_index: 0, delta: "missing content" },
+        { type: "response.refusal.delta", item_id: "msg_1", output_index: 0, content_index: 0 },
+        { type: "response.refusal.done", item_id: "msg_1", output_index: 0, content_index: 0 },
+      ]
+      for (const event of events) {
+        const error = yield* LLMClient.generate(request).pipe(
+          Effect.provide(fixedResponse(sseEvents(event))),
+          Effect.flip,
+        )
+        expect(error.reason._tag).toBe("InvalidProviderOutput")
+      }
     }),
   )
 

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -1588,12 +1588,10 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("rejects refusal events without standard content coordinates", () =>
+  it.effect("rejects malformed refusal events", () =>
     Effect.gen(function* () {
       const events = [
         { type: "response.refusal.delta", output_index: 0, content_index: 0, delta: "missing item" },
-        { type: "response.refusal.delta", item_id: "msg_1", content_index: 0, delta: "missing output" },
-        { type: "response.refusal.delta", item_id: "msg_1", output_index: 0, delta: "missing content" },
         { type: "response.refusal.delta", item_id: "msg_1", output_index: 0, content_index: 0 },
         { type: "response.refusal.done", item_id: "msg_1", output_index: 0, content_index: 0 },
       ]


### PR DESCRIPTION
## Summary

- preserve OpenAI Chat `delta.refusal` as visible ordinary assistant text
- preserve Open Responses and OpenAI Responses `response.refusal.delta` / `response.refusal.done` as visible ordinary assistant text
- use typed refusal event variants while accepting compatible providers that omit unused standard coordinates
- retain Responses message phase metadata through the existing message text lifecycle
- keep provider terminal semantics unchanged: a refusal ending with `stop` remains a successful assistant answer
- replay persisted refusal text as ordinary Chat `content` or Responses `output_text`, never as native refusal state

Follow-up to #43332. Part of #41932.

## Testing

- focused Chat refusal, reasoning-order, and mixed-delta tests
- full OpenAI Responses and Open Responses-compatible provider test files
- `bun typecheck` and `bun run build` in `packages/ai`

The complete AI suite previously had unrelated failures on `v2`: an Azure Chat URL expectation, stale OpenRouter recorded requests, and existing OpenRouter reasoning-lowering expectations.