### PR TITLE
fix(patch): honor `*** End of File` anchor in apply_patch updates

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -115,12 +115,16 @@ function parseUpdateFileChunks(lines: string[], startIdx: number): { chunks: Upd
       let isEndOfFile = false
 
       // Parse change lines
-      while (i < lines.length && !lines[i].startsWith("@@") && !lines[i].startsWith("***")) {
+      while (i < lines.length && !lines[i].startsWith("@@")) {
         const changeLine = lines[i]
 
         if (changeLine === "*** End of File") {
           isEndOfFile = true
           i++
+          break
+        }
+
+        if (changeLine.startsWith("***")) {
           break
         }
 

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -91,6 +91,24 @@ describe("Patch namespace", () => {
 
       expect(() => Patch.parsePatch(invalidPatch)).toThrow("Invalid patch format")
     })
+
+    test("should parse End of File anchor", () => {
+      const patchText = `*** Begin Patch
+*** Update File: test.txt
+@@
+-old line
++new line
+*** End of File
+*** End Patch`
+
+      const result = Patch.parsePatch(patchText)
+      expect(result.hunks).toHaveLength(1)
+      const hunk = result.hunks[0]
+      expect(hunk.type).toBe("update")
+      if (hunk.type === "update") {
+        expect(hunk.chunks[0].is_end_of_file).toBe(true)
+      }
+    })
   })
 
   describe("maybeParseApplyPatch", () => {
@@ -378,6 +396,29 @@ PATCH`
 
         const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
         expect(content).toBe("line 1\nLINE 2\nline 3\nLINE 4\n")
+      }),
+    )
+
+    it.live("should apply End of File anchored updates to the last occurrence", () =>
+      Effect.gen(function* () {
+        const filePath = path.join(tempDir, "eof-anchor.txt")
+        yield* Effect.promise(() => fs.writeFile(filePath, "marker\nend\nmiddle\nmarker\nend"))
+
+        const patchText = `*** Begin Patch
+*** Update File: ${filePath}
+@@
+-marker
+-end
++marker-changed
++end
+*** End of File
+*** End Patch`
+
+        const result = yield* Patch.applyPatch(patchText)
+        expect(result.modified).toHaveLength(1)
+
+        const content = yield* Effect.promise(() => fs.readFile(filePath, "utf-8"))
+        expect(content).toBe("marker\nend\nmiddle\nmarker-changed\nend\n")
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #43331

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`parseUpdateFileChunks` in `packages/opencode/src/patch/index.ts` guarded the change-line loop with `!lines[i].startsWith("***")`, so the `*** End of File` marker could never enter the loop body and the `isEndOfFile` flag stayed `undefined` forever. The `tryMatch` EOF branch (match from end of file first) therefore never ran, and EOF-anchored patches silently fell back to plain forward matching — editing the *first* occurrence of the pattern instead of the last.

The reference parser in `packages/core/src/patch.ts` implements the same marker correctly: the loop guard only excludes `@@`, the EOF marker is checked inside the body, and other `***` lines break the loop. This PR makes the `parseUpdateFileChunks` inner loop match that reference implementation exactly.

Also added two regression tests:
- `parsePatch` unit test asserting `is_end_of_file` is set on the chunk.
- `applyPatch` integration test where the pattern occurs twice in the file, proving the last occurrence is edited (this is the case the pre-existing "EOF anchor matches from end of file first" test in `apply_patch.test.ts` could not distinguish, which is why the dead code went unnoticed).

### How did you verify your code works?

- Reproduced the reported symptom with a real harness against `packages/opencode` (parse + `deriveNewContentsFromChunks` on `marker\nend\nmiddle\nmarker\nend`):
  - **Before**: chunk has no `is_end_of_file`; result edits the *first* occurrence → `marker-changed\nend\nmiddle\nmarker\nend`.
  - **After**: chunk has `is_end_of_file: true`; result edits the *last* occurrence → `marker\nend\nmiddle\nmarker-changed\nend`.
- Control: the reference parser `packages/core/src/patch.ts` (`derive`) already produced the correct EOF-anchored result, confirming the two parsers are now aligned.
- `bun test test/patch test/tool` → 360 pass, 0 fail (includes the 2 new tests).
- `tsgo --noEmit` (package typecheck) clean; `oxlint` 0 errors, no new warnings (5 pre-existing warnings unrelated to this diff).
- v2 branch check: `packages/util/src/patch.ts` already handles `*** End of File` correctly, so this bug is dev-branch-only.

### Screenshots / recordings

N/A (logic change, no UI).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR