### PR TITLE
fix(tool): resolve symlinks before external_directory boundary check

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -1,5 +1,5 @@
 import { NodeFileSystem } from "@effect/platform-node"
-import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
+import { basename, dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
 import { lookup } from "mime-types"
@@ -251,6 +251,30 @@ export namespace FSUtil {
     } catch (e: any) {
       if (e?.code === "ENOENT") return normalizePath(resolved)
       throw e
+    }
+  }
+
+  /**
+   * Resolve a path to its real (symlink-resolved) form even when the final
+   * component does not exist yet. `realpathSync` throws ENOENT as soon as any
+   * component is missing, so for a not-yet-created file we resolve the deepest
+   * existing ancestor and re-append the remaining suffix. Without this, a path
+   * whose parent is a symlink (e.g. an in-workspace symlink pointing outside the
+   * project) would be compared lexically and could escape the boundary.
+   */
+  export function resolveExisting(p: string): string {
+    let existing = pathResolve(windowsPath(p))
+    const suffix: string[] = []
+    for (;;) {
+      try {
+        return normalizePath(pathResolve(realpathSync(existing), ...suffix))
+      } catch (e: any) {
+        if (e?.code !== "ENOENT") throw e
+        const parent = dirname(existing)
+        if (parent === existing) return normalizePath(pathResolve(windowsPath(p)))
+        suffix.unshift(basename(existing))
+        existing = parent
+      }
     }
   }
 

--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -22,11 +22,15 @@ export const assertExternalDirectoryEffect = Effect.fn("Tool.assertExternalDirec
   if (options?.bypass) return false
 
   const ins = yield* InstanceState.context
-  const full = process.platform === "win32" ? FSUtil.normalizePath(target) : target
+  const full = FSUtil.resolveExisting(target)
   if (containsPath(full, ins)) return false
 
+  // The permission glob keeps the caller's lexical target so user-configured
+  // external_directory allow rules (which are written against the paths an
+  // agent refers to, e.g. a symlinked alias) keep matching. The boundary check
+  // above already used the resolved real path to detect symlink escapes.
   const kind = options?.kind ?? "file"
-  const dir = kind === "directory" ? full : path.dirname(full)
+  const dir = kind === "directory" ? target : path.dirname(target)
   const glob =
     process.platform === "win32"
       ? FSUtil.normalizePathPattern(path.join(dir, "*"))

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -105,6 +105,47 @@ describe("tool.assertExternalDirectory", () => {
     }),
   )
 
+  if (process.platform !== "win32") {
+    it.instance(
+      "prompts when an in-workspace symlink points outside and the leaf exists",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const outside = yield* tmpdirScoped()
+          const linkDir = path.join(test.directory, "outbox")
+          yield* Effect.promise(() => Bun.$`ln -s ${outside} ${linkDir}`.quiet())
+          const target = path.join(linkDir, "escaped.txt")
+          yield* Effect.promise(() => Bun.write(target, "ESCAPED"))
+
+          const { requests, ctx } = makeCtx()
+          yield* assertExternalDirectoryEffect(ctx, target)
+
+          const req = requests.find((r) => r.permission === "external_directory")
+          expect(req).toBeDefined()
+        }),
+      { git: true },
+    )
+
+    it.instance(
+      "prompts when an in-workspace symlink points outside and the leaf does not exist yet",
+      () =>
+        Effect.gen(function* () {
+          const test = yield* TestInstance
+          const outside = yield* tmpdirScoped()
+          const linkDir = path.join(test.directory, "outbox2")
+          yield* Effect.promise(() => Bun.$`ln -s ${outside} ${linkDir}`.quiet())
+          const target = path.join(linkDir, "newfile.txt")
+
+          const { requests, ctx } = makeCtx()
+          yield* assertExternalDirectoryEffect(ctx, target)
+
+          const req = requests.find((r) => r.permission === "external_directory")
+          expect(req).toBeDefined()
+        }),
+      { git: true },
+    )
+  }
+
   if (process.platform === "win32") {
     it.instance(
       "normalizes Windows path variants to one glob",


### PR DESCRIPTION
## Summary

Resolve in-workspace symlinks before checking the `external_directory` boundary so a symlink pointing outside the workspace can no longer silently escape the sandbox (POSIX). Windows already resolves with `realpathSync.native`; this aligns POSIX.

- Adds `FSUtil.resolveExisting` in `packages/core/src/fs-util.ts` (walks to the deepest existing ancestor, realpath, re-appends the suffix) so writes to not-yet-existing leaves are still resolved.
- `external-directory.ts` uses the resolved path for the boundary check while keeping the lexical target for permission globs, so `external_directory:{alias/*:allow}` rules keep matching.
- 2 regression tests (symlink escape + non-existent leaf, POSIX).

**Status: closed as withdrawn.** The maintainer closed the linked issue #43346 as `not_planned` with "this is intentional", and the identical finding #43336 has the same status — the symlink boundary behavior is a deliberate design decision. See close note.