### PR TITLE
fix(app): wait for local server readiness before bootstrap fan-out

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -110,7 +110,7 @@ export const loadGlobalConfigQuery = (scope: ServerScope, sdk: OpencodeClient, p
     queryKey: [scope, "config"],
     queryFn: async () => {
       if ((await protocol) !== "v1") return {}
-      return retry(() => sdk.global.config.get().then((x) => x.data!))
+      return retry(() => sdk.global.config.get().then((x) => x.data!), { retryOnTypeError: true })
     },
   })
 
@@ -128,15 +128,17 @@ export const loadProjectsQuery = (scope: ServerScope, api: ProjectApi) =>
   queryOptions({
     queryKey: [scope, "project"],
     queryFn: () =>
-      retry(() =>
-        api.list().then((projects) => {
-          return projects
-            .filter((p) => !!p?.id)
-            .filter((p) => !!p.worktree && !p.worktree.includes("opencode-test"))
-            .map(normalizeProjectInfo)
-            .slice()
-            .sort((a, b) => cmp(a.id, b.id))
-        }),
+      retry(
+        () =>
+          api.list().then((projects) => {
+            return projects
+              .filter((p) => !!p?.id)
+              .filter((p) => !!p.worktree && !p.worktree.includes("opencode-test"))
+              .map(normalizeProjectInfo)
+              .slice()
+              .sort((a, b) => cmp(a.id, b.id))
+          }),
+        { retryOnTypeError: true },
       ),
   })
 
@@ -211,7 +213,7 @@ function warmSessions(input: {
   if (ids.length === 0) return Promise.resolve()
   return Promise.all(
     ids.map((sessionID) =>
-      retry(() => input.api.get({ sessionID })).then((session) =>
+      retry(() => input.api.get({ sessionID }), { retryOnTypeError: true }).then((session) =>
         mergeSession(input.setStore, normalizeSessionInfo(session)),
       ),
     ),
@@ -228,19 +230,22 @@ export const loadProvidersQuery = (
   queryOptions({
     queryKey: [scope, directory, "providers"],
     queryFn: () =>
-      retry(async () => {
-        if ((await protocol) === "v1" && legacy) {
-          const result = await legacy.provider.list()
-          return normalizeProviderList(result.data!)
-        }
-        const location = directory ? { location: { directory } } : undefined
-        const [providers, models, defaultModel] = await Promise.all([
-          sdk.provider.list(location),
-          sdk.model.list(location),
-          sdk.model.default(location),
-        ])
-        return normalizeProviderList(providers.data, models.data, defaultModel.data)
-      }),
+      retry(
+        async () => {
+          if ((await protocol) === "v1" && legacy) {
+            const result = await legacy.provider.list()
+            return normalizeProviderList(result.data!)
+          }
+          const location = directory ? { location: { directory } } : undefined
+          const [providers, models, defaultModel] = await Promise.all([
+            sdk.provider.list(location),
+            sdk.model.list(location),
+            sdk.model.default(location),
+          ])
+          return normalizeProviderList(providers.data, models.data, defaultModel.data)
+        },
+        { retryOnTypeError: true },
+      ),
   })
 
 type AgentListApi = {
@@ -265,10 +270,13 @@ export const loadAgentsQuery = (
   queryOptions({
     queryKey: [scope, directory, "agents"],
     queryFn: () =>
-      retry(async () => {
-        if ((await protocol) === "v1" && legacy) return normalizeAgentList((await legacy.app.agents()).data ?? [])
-        return sdk.list({ location: { directory } }).then((result) => normalizeAgentList(result.data))
-      }),
+      retry(
+        async () => {
+          if ((await protocol) === "v1" && legacy) return normalizeAgentList((await legacy.app.agents()).data ?? [])
+          return sdk.list({ location: { directory } }).then((result) => normalizeAgentList(result.data))
+        },
+        { retryOnTypeError: true },
+      ),
   })
 
 export const loadCommands = (
@@ -277,23 +285,26 @@ export const loadCommands = (
   legacy?: OpencodeClient,
   protocol?: Promise<ServerProtocol>,
 ): Promise<CommandInfo[]> =>
-  retry(async () => {
-    if ((await protocol) === "v1" && legacy) {
-      return ((await legacy.command.list()).data ?? []).map((command) => {
-        const [providerID, id] = command.model?.split("/") ?? []
-        return {
-          name: command.name,
-          template: command.template,
-          description: command.description,
-          agent: command.agent,
-          model: providerID && id ? { providerID, id } : undefined,
-          subtask: command.subtask,
-          // source: command.source === "skill" ? undefined : command.source,
-        }
-      })
-    }
-    return api.list({ location: { directory } }).then((result) => result.data)
-  })
+  retry(
+    async () => {
+      if ((await protocol) === "v1" && legacy) {
+        return ((await legacy.command.list()).data ?? []).map((command) => {
+          const [providerID, id] = command.model?.split("/") ?? []
+          return {
+            name: command.name,
+            template: command.template,
+            description: command.description,
+            agent: command.agent,
+            model: providerID && id ? { providerID, id } : undefined,
+            subtask: command.subtask,
+            // source: command.source === "skill" ? undefined : command.source,
+          }
+        })
+      }
+      return api.list({ location: { directory } }).then((result) => result.data)
+    },
+    { retryOnTypeError: true },
+  )
 
 export const loadPathQuery = (
   scope: ServerScope,
@@ -306,7 +317,9 @@ export const loadPathQuery = (
     queryFn: async () => {
       if ((await protocol) !== "v1")
         return { state: "", config: "", worktree: "", directory: directory ?? "", home: "" }
-      return retry(() => sdk.path.get({ directory: directory ?? undefined }).then((result) => result.data!))
+      return retry(() => sdk.path.get({ directory: directory ?? undefined }).then((result) => result.data!), {
+        retryOnTypeError: true,
+      })
     },
   })
 
@@ -320,10 +333,13 @@ export const loadReferencesQuery = (
   queryOptions<ReferenceInfo[]>({
     queryKey: [scope, directory, "references"] as const,
     queryFn: () =>
-      retry(async () => {
-        if ((await protocol) === "v1" && legacy) return (await legacy.v2.reference.list()).data?.data ?? []
-        return api.list({ location: { directory } }).then((result) => result.data)
-      }).catch(() => []),
+      retry(
+        async () => {
+          if ((await protocol) === "v1" && legacy) return (await legacy.v2.reference.list()).data?.data ?? []
+          return api.list({ location: { directory } }).then((result) => result.data)
+        },
+        { retryOnTypeError: true },
+      ).catch(() => []),
     placeholderData: [],
   })
 
@@ -379,42 +395,47 @@ export async function bootstrapDirectory(input: {
           .ensureQueryData(loadAgentsQuery(input.scope, input.directory, input.api.agent, input.sdk, input.protocol))
           .then((data) => input.setStore("agent", data)),
       () =>
-        retry(async () => {
-          if ((await input.protocol) !== "v1") return
-          return input.sdk.config.get().then((x) => input.setStore("config", reconcile(x.data!, { merge: false })))
-        }),
-      () =>
-        retry(() =>
-          (async () => {
+        retry(
+          async () => {
             if ((await input.protocol) !== "v1") return
-            const x = await input.sdk.session.status()
-            if (!input.session) {
-              input.setStore("session_status", x.data!)
-              return
-            }
-            const statuses = x.data ?? {}
-            input.session.set(
-              "session_status",
-              produce((draft) => {
-                for (const sessionID of Object.keys(draft)) {
-                  if (statuses[sessionID]) continue
-                  if (input.session?.get(sessionID)?.directory === input.directory) delete draft[sessionID]
-                }
-              }),
-            )
-            for (const [sessionID, status] of Object.entries(statuses)) {
-              input.session.set("session_status", sessionID, reconcile(status))
-            }
-            await Promise.all(
-              Object.keys(statuses).map((sessionID) => input.session!.resolve(sessionID).catch(() => undefined)),
-            )
-          })(),
+            return input.sdk.config.get().then((x) => input.setStore("config", reconcile(x.data!, { merge: false })))
+          },
+          { retryOnTypeError: true },
+        ),
+      () =>
+        retry(
+          () =>
+            (async () => {
+              if ((await input.protocol) !== "v1") return
+              const x = await input.sdk.session.status()
+              if (!input.session) {
+                input.setStore("session_status", x.data!)
+                return
+              }
+              const statuses = x.data ?? {}
+              input.session.set(
+                "session_status",
+                produce((draft) => {
+                  for (const sessionID of Object.keys(draft)) {
+                    if (statuses[sessionID]) continue
+                    if (input.session?.get(sessionID)?.directory === input.directory) delete draft[sessionID]
+                  }
+                }),
+              )
+              for (const [sessionID, status] of Object.entries(statuses)) {
+                input.session.set("session_status", sessionID, reconcile(status))
+              }
+              await Promise.all(
+                Object.keys(statuses).map((sessionID) => input.session!.resolve(sessionID).catch(() => undefined)),
+              )
+            })(),
+          { retryOnTypeError: true },
         ),
       !seededProject &&
         (() =>
-          retry(() => input.api.project.current({ location: { directory: input.directory } })).then((project) =>
-            input.setStore("project", project.id),
-          )),
+          retry(() => input.api.project.current({ location: { directory: input.directory } }), {
+            retryOnTypeError: true,
+          }).then((project) => input.setStore("project", project.id))),
       !seededPath &&
         (() =>
           input.queryClient
@@ -424,14 +445,17 @@ export async function bootstrapDirectory(input: {
               if (next) input.setStore("project", next)
             })),
       () =>
-        retry(async () => {
-          if ((await input.protocol) !== "v1") return
-          return input.sdk.vcs.get().then((result) => {
-            const next = { branch: result.data?.branch, default_branch: result.data?.default_branch }
-            input.setStore("vcs", next)
-            if (next) input.vcsCache.setStore("value", next)
-          })
-        }),
+        retry(
+          async () => {
+            if ((await input.protocol) !== "v1") return
+            return input.sdk.vcs.get().then((result) => {
+              const next = { branch: result.data?.branch, default_branch: result.data?.default_branch }
+              input.setStore("vcs", next)
+              if (next) input.vcsCache.setStore("value", next)
+            })
+          },
+          { retryOnTypeError: true },
+        ),
       input.mcp &&
         (() =>
           loadCommands(input.directory, input.api.command, input.sdk, input.protocol).then((commands) =>
@@ -442,76 +466,80 @@ export async function bootstrapDirectory(input: {
           loadReferencesQuery(input.scope, input.directory, input.api.reference, input.sdk, input.protocol),
         ),
       () =>
-        retry(() =>
-          (async () => {
-            if ((await input.protocol) === "v1") return (await input.sdk.permission.list()).data ?? []
-            return input.api.permission.request
-              .list({ location: { directory: input.directory } })
-              .then((result) => result.data.map(normalizePermissionRequest))
-          })().then((permissions) => {
-            const ids = permissions.map((permission) => permission.sessionID)
-            const grouped = groupBySession(
-              permissions.filter((permission) => !!permission.id && !!permission.sessionID),
-            )
-            const warm = input.session
-              ? Promise.all(ids.map((sessionID) => input.session!.resolve(sessionID))).then(() => undefined)
-              : warmSessions({ ids, store: input.store, setStore: input.setStore, api: input.api.session })
-            return warm.then(() =>
-              batch(() => {
-                const current = input.session?.data.permission ?? input.store.permission
-                for (const sessionID of Object.keys(current)) {
-                  if (grouped[sessionID]) continue
-                  if (input.session?.get(sessionID)?.directory !== input.directory) continue
-                  if (input.session) input.session.set("permission", sessionID, [])
-                  if (!input.session) input.setStore("permission", sessionID, [])
-                }
-                for (const [sessionID, permissions] of Object.entries(grouped)) {
-                  const value = reconcile(
-                    permissions.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id)),
-                    { key: "id" },
-                  )
-                  if (input.session) input.session.set("permission", sessionID, value)
-                  if (!input.session) input.setStore("permission", sessionID, value)
-                }
-              }),
-            )
-          }),
+        retry(
+          () =>
+            (async () => {
+              if ((await input.protocol) === "v1") return (await input.sdk.permission.list()).data ?? []
+              return input.api.permission.request
+                .list({ location: { directory: input.directory } })
+                .then((result) => result.data.map(normalizePermissionRequest))
+            })().then((permissions) => {
+              const ids = permissions.map((permission) => permission.sessionID)
+              const grouped = groupBySession(
+                permissions.filter((permission) => !!permission.id && !!permission.sessionID),
+              )
+              const warm = input.session
+                ? Promise.all(ids.map((sessionID) => input.session!.resolve(sessionID))).then(() => undefined)
+                : warmSessions({ ids, store: input.store, setStore: input.setStore, api: input.api.session })
+              return warm.then(() =>
+                batch(() => {
+                  const current = input.session?.data.permission ?? input.store.permission
+                  for (const sessionID of Object.keys(current)) {
+                    if (grouped[sessionID]) continue
+                    if (input.session?.get(sessionID)?.directory !== input.directory) continue
+                    if (input.session) input.session.set("permission", sessionID, [])
+                    if (!input.session) input.setStore("permission", sessionID, [])
+                  }
+                  for (const [sessionID, permissions] of Object.entries(grouped)) {
+                    const value = reconcile(
+                      permissions.filter((p) => !!p?.id).sort((a, b) => cmp(a.id, b.id)),
+                      { key: "id" },
+                    )
+                    if (input.session) input.session.set("permission", sessionID, value)
+                    if (!input.session) input.setStore("permission", sessionID, value)
+                  }
+                }),
+              )
+            }),
+          { retryOnTypeError: true },
         ),
       () =>
-        retry(() =>
-          (async () => {
-            if ((await input.protocol) === "v1") return (await input.sdk.question.list()).data ?? []
-            return input.api.question.request
-              .list({ location: { directory: input.directory } })
-              .then((result) => result.data)
-          })().then((questions) => {
-            const ids = questions.map((question) => question.sessionID)
-            const grouped = groupBySession(
-              questions.filter((question) => !!question.id && !!question.sessionID) as QuestionRequest[],
-            )
-            const warm = input.session
-              ? Promise.all(ids.map((sessionID) => input.session!.resolve(sessionID))).then(() => undefined)
-              : warmSessions({ ids, store: input.store, setStore: input.setStore, api: input.api.session })
-            return warm.then(() =>
-              batch(() => {
-                const current = input.session?.data.question ?? input.store.question
-                for (const sessionID of Object.keys(current)) {
-                  if (grouped[sessionID]) continue
-                  if (input.session?.get(sessionID)?.directory !== input.directory) continue
-                  if (input.session) input.session.set("question", sessionID, [])
-                  if (!input.session) input.setStore("question", sessionID, [])
-                }
-                for (const [sessionID, questions] of Object.entries(grouped)) {
-                  const value = reconcile(
-                    questions.filter((q) => !!q?.id).sort((a, b) => cmp(a.id, b.id)),
-                    { key: "id" },
-                  )
-                  if (input.session) input.session.set("question", sessionID, value)
-                  if (!input.session) input.setStore("question", sessionID, value)
-                }
-              }),
-            )
-          }),
+        retry(
+          () =>
+            (async () => {
+              if ((await input.protocol) === "v1") return (await input.sdk.question.list()).data ?? []
+              return input.api.question.request
+                .list({ location: { directory: input.directory } })
+                .then((result) => result.data)
+            })().then((questions) => {
+              const ids = questions.map((question) => question.sessionID)
+              const grouped = groupBySession(
+                questions.filter((question) => !!question.id && !!question.sessionID) as QuestionRequest[],
+              )
+              const warm = input.session
+                ? Promise.all(ids.map((sessionID) => input.session!.resolve(sessionID))).then(() => undefined)
+                : warmSessions({ ids, store: input.store, setStore: input.setStore, api: input.api.session })
+              return warm.then(() =>
+                batch(() => {
+                  const current = input.session?.data.question ?? input.store.question
+                  for (const sessionID of Object.keys(current)) {
+                    if (grouped[sessionID]) continue
+                    if (input.session?.get(sessionID)?.directory !== input.directory) continue
+                    if (input.session) input.session.set("question", sessionID, [])
+                    if (!input.session) input.setStore("question", sessionID, [])
+                  }
+                  for (const [sessionID, questions] of Object.entries(grouped)) {
+                    const value = reconcile(
+                      questions.filter((q) => !!q?.id).sort((a, b) => cmp(a.id, b.id)),
+                      { key: "id" },
+                    )
+                    if (input.session) input.session.set("question", sessionID, value)
+                    if (!input.session) input.setStore("question", sessionID, value)
+                  }
+                }),
+              )
+            }),
+          { retryOnTypeError: true },
         ),
       () => Promise.resolve(input.loadSessions(input.directory)),
       input.mcp &&

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -537,10 +537,13 @@ export function createServerSession(
   const fetchMessages = async (sessionID: string, limit: number, before?: string, onAttempt?: () => void) => {
     if (messageApi && (await options?.protocol) !== "v1") {
       const request = (cursor?: string) =>
-        (options?.retry ?? retry)(() => {
-          onAttempt?.()
-          return messageApi.list(cursor ? { sessionID, limit, cursor } : { sessionID, limit, order: "desc" })
-        })
+        (options?.retry ?? retry)(
+          () => {
+            onAttempt?.()
+            return messageApi.list(cursor ? { sessionID, limit, cursor } : { sessionID, limit, order: "desc" })
+          },
+          { retryOnTypeError: true },
+        )
       const first = await request(before)
       const pages = [first]
       while (pages.at(-1)?.cursor.next && needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) {
@@ -563,10 +566,13 @@ export function createServerSession(
         complete: response.data.length === 0,
       }
     }
-    const response = await (options?.retry ?? retry)(() => {
-      onAttempt?.()
-      return client.session.messages({ sessionID, limit, before })
-    })
+    const response = await (options?.retry ?? retry)(
+      () => {
+        onAttempt?.()
+        return client.session.messages({ sessionID, limit, before })
+      },
+      { retryOnTypeError: true },
+    )
     const items = (response.data ?? []).filter((item) => !!item?.info?.id)
     return {
       session: items.map((item) => cleanMessage(item.info)).sort(compareMessages),
@@ -583,19 +589,25 @@ export function createServerSession(
 
   const fetchMessage = async (sessionID: string, messageID: string, onAttempt?: () => void) => {
     if (sessionApi && (await options?.protocol) !== "v1") {
-      const response = await (options?.retry ?? retry)(() => {
-        onAttempt?.()
-        return sessionApi.message({ sessionID, messageID })
-      })
+      const response = await (options?.retry ?? retry)(
+        () => {
+          onAttempt?.()
+          return sessionApi.message({ sessionID, messageID })
+        },
+        { retryOnTypeError: true },
+      )
       const normalized = normalizeSessionMessages(sessionID, [response])
       const message = normalized.messages[0]
       if (!message) throw new Error(`Message not found: ${messageID}`)
       return { message, parts: normalized.parts.get(messageID) ?? [] }
     }
-    const response = await (options?.retry ?? retry)(() => {
-      onAttempt?.()
-      return client.session.message({ sessionID, messageID })
-    })
+    const response = await (options?.retry ?? retry)(
+      () => {
+        onAttempt?.()
+        return client.session.message({ sessionID, messageID })
+      },
+      { retryOnTypeError: true },
+    )
     if (!response.data?.info?.id) throw new Error(`Message not found: ${messageID}`)
     return {
       message: cleanMessage(response.data.info),
@@ -1386,10 +1398,12 @@ export function createServerSession(
       }
       return runInflight(inflightTodo, sessionID, () => {
         const active = generation(sessionID)
-        return (options?.retry ?? retry)(() => client.session.todo({ sessionID })).then((result) => {
-          if (generations.get(sessionID) !== active) return
-          setData("todo", sessionID, reconcile(result.data ?? [], { key: "id" }))
-        })
+        return (options?.retry ?? retry)(() => client.session.todo({ sessionID }), { retryOnTypeError: true }).then(
+          (result) => {
+            if (generations.get(sessionID) !== active) return
+            setData("todo", sessionID, reconcile(result.data ?? [], { key: "id" }))
+          },
+        )
       })
     },
     history: {

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -32,6 +32,7 @@ import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
 import { SESSION_RECENT_LIMIT } from "./global-sync/types"
 import { formatServerError } from "@/utils/server-errors"
+import { waitForServerReady } from "@/utils/server-health"
 import { queryOptions, useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/solid-query"
 import type { SolidQueryOptions } from "@tanstack/solid-query"
 import { createRefreshQueue } from "./global-sync/queue"
@@ -320,6 +321,12 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
   const bootstrap = useQuery(() => ({
     queryKey: [serverSDK.scope, "bootstrap"],
     queryFn: async () => {
+      // Wait for the local sidecar to be reachable before firing the bootstrap
+      // fan-out, otherwise the first batch of `get`/`list` requests races the
+      // server's cold start and throws `TypeError: Failed to fetch`.
+      if (ServerConnection.local(serverSDK.server)) {
+        await waitForServerReady(serverSDK.server.http, globalThis.fetch)
+      }
       await bootstrapGlobal({
         serverSDK: serverSDK.client,
         serverAPI: serverSDK.api,
@@ -476,6 +483,11 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
 
     children.pin(key)
     const promise = Promise.resolve().then(async () => {
+      // Same readiness gate as the global bootstrap: a directory may be opened
+      // after a server restart, so re-check before its data fan-out.
+      if (ServerConnection.local(serverSDK.server)) {
+        await waitForServerReady(serverSDK.server.http, globalThis.fetch)
+      }
       const child = children.ensureChild(directory)
       const cache = children.vcsCache.get(key)
       if (!cache) return

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -318,15 +318,21 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     return (setGlobalStore as (...args: unknown[]) => unknown)(...input)
   }) as typeof setGlobalStore
 
+  // Wait for the local sidecar to be reachable before firing a data fan-out,
+  // otherwise the batch of `get`/`list` requests races the server's cold start
+  // and throws `TypeError: Failed to fetch`. When the server never becomes
+  // reachable, fail fast with a readable error instead of silently fanning out
+  // into a dead server.
+  const ensureServerReady = async () => {
+    if (!ServerConnection.local(serverSDK.server)) return
+    const ready = await waitForServerReady(serverSDK.server.http, globalThis.fetch)
+    if (!ready) throw new Error(language.t("app.server.unreachable", { server: serverSDK.url }))
+  }
+
   const bootstrap = useQuery(() => ({
     queryKey: [serverSDK.scope, "bootstrap"],
     queryFn: async () => {
-      // Wait for the local sidecar to be reachable before firing the bootstrap
-      // fan-out, otherwise the first batch of `get`/`list` requests races the
-      // server's cold start and throws `TypeError: Failed to fetch`.
-      if (ServerConnection.local(serverSDK.server)) {
-        await waitForServerReady(serverSDK.server.http, globalThis.fetch)
-      }
+      await ensureServerReady()
       await bootstrapGlobal({
         serverSDK: serverSDK.client,
         serverAPI: serverSDK.api,
@@ -485,9 +491,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     const promise = Promise.resolve().then(async () => {
       // Same readiness gate as the global bootstrap: a directory may be opened
       // after a server restart, so re-check before its data fan-out.
-      if (ServerConnection.local(serverSDK.server)) {
-        await waitForServerReady(serverSDK.server.http, globalThis.fetch)
-      }
+      await ensureServerReady()
       const child = children.ensureChild(directory)
       const cache = children.vcsCache.get(key)
       if (!cache) return
@@ -515,12 +519,23 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
       })
     })
 
-    booting.set(key, promise)
-    void promise.finally(() => {
+    // Surface the negative result to the caller (and the user) instead of
+    // leaving an unhandled rejection: a failed readiness gate or fan-out shows
+    // the same toast as other per-directory load failures.
+    const tracked = promise.catch((err) => {
+      showToast({
+        variant: "error",
+        title: language.t("toast.project.reloadFailed.title", { project: getFilename(directory) }),
+        description: formatServerError(err, language.t),
+      })
+    })
+
+    booting.set(key, tracked)
+    void tracked.finally(() => {
       booting.delete(key)
       children.unpin(key)
     })
-    return promise
+    return tracked
   }
 
   const indexSession = (info: Parameters<typeof session.remember>[0]) => {

--- a/packages/app/src/utils/server-health.test.ts
+++ b/packages/app/src/utils/server-health.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { ServerConnection } from "@/context/server"
-import { checkServerHealth } from "./server-health"
+import { checkServerHealth, waitForServerReady } from "./server-health"
 
 const server: ServerConnection.HttpBase = {
   url: "http://localhost:4096",
@@ -174,5 +174,58 @@ describe("checkServerHealth", () => {
 
     expect(count).toBe(6)
     expect(result).toEqual({ healthy: false })
+  })
+})
+
+describe("waitForServerReady", () => {
+  test("resolves immediately when the server is already healthy", async () => {
+    const fetch = (async () =>
+      new Response(JSON.stringify({ healthy: true, version: "1.2.3" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof globalThis.fetch
+
+    const ready = await waitForServerReady(server, fetch, { timeoutMs: 1000, pollMs: 50 })
+
+    expect(ready).toBe(true)
+  })
+
+  test("waits and resolves once the server becomes reachable", async () => {
+    let count = 0
+    const fetch = (async () => {
+      count += 1
+      if (count < 3) throw new TypeError("Failed to fetch")
+      return new Response(JSON.stringify({ healthy: true, version: "1.2.3" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }) as unknown as typeof globalThis.fetch
+
+    const ready = await waitForServerReady(server, fetch, { timeoutMs: 5000, pollMs: 20 })
+
+    expect(ready).toBe(true)
+    expect(count).toBeGreaterThanOrEqual(3)
+  })
+
+  test("returns false when the server never becomes reachable", async () => {
+    const fetch = (async () => {
+      throw new TypeError("Failed to fetch")
+    }) as unknown as typeof globalThis.fetch
+
+    const ready = await waitForServerReady(server, fetch, { timeoutMs: 200, pollMs: 20 })
+
+    expect(ready).toBe(false)
+  })
+
+  test("aborts early when the signal fires", async () => {
+    const fetch = (async () => {
+      throw new TypeError("Failed to fetch")
+    }) as unknown as typeof globalThis.fetch
+    const abort = new AbortController()
+    abort.abort()
+
+    const ready = await waitForServerReady(server, fetch, { timeoutMs: 5000, pollMs: 20, signal: abort.signal })
+
+    expect(ready).toBe(false)
   })
 })

--- a/packages/app/src/utils/server-health.test.ts
+++ b/packages/app/src/utils/server-health.test.ts
@@ -122,22 +122,26 @@ describe("checkServerHealth", () => {
     expect(result).toEqual({ healthy: false })
   })
 
-  test("uses provided abort signal", async () => {
+  test("aborts the in-flight request when the provided signal fires", async () => {
     let signal: AbortSignal | undefined
+    // Hangs until its signal fires, like a request against a dead server.
     const fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       signal = abortFromInput(input, init)
-      return new Response(JSON.stringify({ healthy: true, version: "1.2.3" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true })
       })
     }) as unknown as typeof globalThis.fetch
 
     const abort = new AbortController()
+    setTimeout(() => abort.abort(), 20)
     await checkServerHealth(server, fetch, {
       signal: abort.signal,
+      retryCount: 0,
     })
 
-    expect(signal).toBe(abort.signal)
+    // The request sees a derived signal that also covers the per-attempt
+    // timeout; firing the caller's signal must still abort the request.
+    expect(signal?.aborted).toBe(true)
   })
 
   test("retries transient failures and eventually succeeds", async () => {
@@ -227,5 +231,71 @@ describe("waitForServerReady", () => {
     const ready = await waitForServerReady(server, fetch, { timeoutMs: 5000, pollMs: 20, signal: abort.signal })
 
     expect(ready).toBe(false)
+  })
+
+  test("aborts the in-flight health request when the caller signal fires mid-poll", async () => {
+    let requestAborted = false
+    // A fetch that hangs until its abort signal fires, like the platform fetch.
+    const fetch = ((_url: unknown, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => {
+            requestAborted = true
+            reject(new DOMException("Aborted", "AbortError"))
+          },
+          { once: true },
+        )
+      })) as unknown as typeof globalThis.fetch
+    const controller = new AbortController()
+
+    const pending = waitForServerReady(server, fetch, { timeoutMs: 10_000, pollMs: 20, signal: controller.signal })
+    setTimeout(() => controller.abort(), 50)
+
+    const started = Date.now()
+    const ready = await pending
+
+    expect(ready).toBe(false)
+    expect(requestAborted).toBe(true)
+    // The in-flight attempt is cut off instead of waiting for its own timeout.
+    expect(Date.now() - started).toBeLessThan(5000)
+  })
+
+  test("cuts off a hung attempt so the total wall clock stays near timeoutMs", async () => {
+    const started = Date.now()
+    // A request that never settles must be abandoned by the per-attempt
+    // timeout, and each attempt is bounded by the time left before the overall
+    // deadline — otherwise the poll overshoots `timeoutMs` by up to a poll
+    // budget per iteration.
+    const fetch = ((_url: unknown, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true })
+      })) as unknown as typeof globalThis.fetch
+
+    const ready = await waitForServerReady(server, fetch, { timeoutMs: 200, pollMs: 150 })
+
+    const elapsed = Date.now() - started
+    expect(ready).toBe(false)
+    // Without the remaining-time clamp this poll overshoots to ~timeoutMs +
+    // (pollMs * 4) + pollMs.
+    expect(elapsed).toBeLessThan(600)
+  })
+
+  test("readiness gate blocks the fan-out and fails fast when the server never becomes ready", async () => {
+    // Pins the wiring contract used by both gates in server-sync.tsx (global
+    // bootstrap + per-directory fan-out): when readiness fails, no data
+    // requests are fired into the dead server and the caller gets an error.
+    const fetch = (async () => {
+      throw new TypeError("Failed to fetch")
+    }) as unknown as typeof globalThis.fetch
+    let fanOutCalls = 0
+    const gatedFanOut = async () => {
+      const ready = await waitForServerReady(server, fetch, { timeoutMs: 200, pollMs: 20 })
+      if (!ready) throw new Error("Could not reach http://localhost:4096")
+      fanOutCalls += 1
+    }
+
+    await expect(gatedFanOut()).rejects.toThrow("Could not reach")
+    expect(fanOutCalls).toBe(0)
   })
 })

--- a/packages/app/src/utils/server-health.ts
+++ b/packages/app/src/utils/server-health.ts
@@ -134,6 +134,39 @@ export function useCheckServerHealth() {
   }
 }
 
+export interface WaitForServerReadyOptions {
+  timeoutMs?: number
+  pollMs?: number
+  signal?: AbortSignal
+}
+
+/**
+ * Bounded startup precheck: poll the server health endpoint until it reports
+ * healthy or the timeout elapses. This prevents the bootstrap fan-out of
+ * `get`/`list` requests from racing a not-yet-listening local sidecar server,
+ * which would otherwise throw an unhandled `TypeError: Failed to fetch` in the
+ * render process. Resolves immediately when the server is already reachable.
+ */
+export async function waitForServerReady(
+  server: ServerConnection.HttpBase,
+  fetch: typeof globalThis.fetch,
+  opts?: WaitForServerReadyOptions,
+): Promise<boolean> {
+  const timeoutMs = opts?.timeoutMs ?? 10_000
+  const pollMs = opts?.pollMs ?? 250
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (opts?.signal?.aborted) return false
+    const healthy = await checkServerHealth(server, fetch, {
+      timeoutMs: Math.min(pollMs * 4, 1_000),
+      retryCount: 0,
+    }).catch(() => ({ healthy: false }) as ServerHealth)
+    if (healthy.healthy) return true
+    await wait(pollMs, opts?.signal).catch(() => undefined)
+  }
+  return false
+}
+
 export const useServerHealth = (servers: Accessor<ServerConnection.Any[]>, enabled: Accessor<boolean>) => {
   const checkServerHealth = useCheckServerHealth()
   const [status, setStatus] = createStore({} as Record<ServerConnection.Key, ServerHealth | undefined>)

--- a/packages/app/src/utils/server-health.ts
+++ b/packages/app/src/utils/server-health.ts
@@ -42,6 +42,24 @@ function timeoutSignal(timeoutMs: number) {
   return { signal: controller.signal, clear: () => clearTimeout(timer) }
 }
 
+function linkSignals(signals: (AbortSignal | undefined)[]): AbortSignal | undefined {
+  const defined = signals.filter((s): s is AbortSignal => !!s)
+  if (defined.length === 0) return undefined
+  if (defined.length === 1) return defined[0]
+  const any = (AbortSignal as unknown as { any?: (list: AbortSignal[]) => AbortSignal }).any
+  if (any) return any.call(AbortSignal, defined)
+  const controller = new AbortController()
+  const onAbort = () => controller.abort()
+  for (const signal of defined) {
+    if (signal.aborted) {
+      controller.abort()
+      return controller.signal
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  }
+  return controller.signal
+}
+
 function wait(ms: number, signal?: AbortSignal) {
   return new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {
@@ -74,8 +92,11 @@ export async function checkServerHealth(
   fetch: typeof globalThis.fetch,
   opts?: CheckServerHealthOptions,
 ): Promise<ServerHealth> {
-  const timeout = opts?.signal ? undefined : timeoutSignal(opts?.timeoutMs ?? defaultTimeoutMs)
-  const signal = opts?.signal ?? timeout?.signal
+  // Combine (not choose between) the caller's signal and the per-attempt
+  // timeout so an aborted caller also cuts off an in-flight request, and a
+  // hung request still respects `timeoutMs`.
+  const timeout = timeoutSignal(opts?.timeoutMs ?? defaultTimeoutMs)
+  const signal = linkSignals([opts?.signal, timeout.signal])
   const retryCount = opts?.retryCount ?? defaultRetryCount
   const retryDelayMs = opts?.retryDelayMs ?? defaultRetryDelayMs
   const next = (count: number, error: unknown) => {
@@ -146,6 +167,11 @@ export interface WaitForServerReadyOptions {
  * `get`/`list` requests from racing a not-yet-listening local sidecar server,
  * which would otherwise throw an unhandled `TypeError: Failed to fetch` in the
  * render process. Resolves immediately when the server is already reachable.
+ *
+ * Each attempt is bounded by both the poll budget and the time left before the
+ * overall deadline, so a hung request cannot push the total wall clock past
+ * `timeoutMs`. When `opts.signal` fires, the in-flight request is aborted and
+ * the poll loop returns promptly.
  */
 export async function waitForServerReady(
   server: ServerConnection.HttpBase,
@@ -157,9 +183,11 @@ export async function waitForServerReady(
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if (opts?.signal?.aborted) return false
+    const remaining = Math.max(deadline - Date.now(), 1)
     const healthy = await checkServerHealth(server, fetch, {
-      timeoutMs: Math.min(pollMs * 4, 1_000),
+      timeoutMs: Math.min(pollMs * 4, 1_000, remaining),
       retryCount: 0,
+      signal: opts?.signal,
     }).catch(() => ({ healthy: false }) as ServerHealth)
     if (healthy.healthy) return true
     await wait(pollMs, opts?.signal).catch(() => undefined)

--- a/packages/core/src/util/retry.test.ts
+++ b/packages/core/src/util/retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { retry } from "./retry"
+
+describe("retry", () => {
+  test("retries on network TypeError and eventually succeeds", async () => {
+    let count = 0
+    const result = await retry(
+      async () => {
+        count += 1
+        if (count < 3) throw new TypeError("Failed to fetch")
+        return "ok"
+      },
+      { attempts: 3, delay: 1, factor: 1 },
+    )
+    expect(result).toBe("ok")
+    expect(count).toBe(3)
+  })
+
+  test("retries on a localized/unknown TypeError message", async () => {
+    let count = 0
+    const result = await retry(
+      async () => {
+        count += 1
+        if (count < 2) throw new TypeError("ネットワークエラー")
+        return "ok"
+      },
+      { attempts: 3, delay: 1, factor: 1 },
+    )
+    expect(result).toBe("ok")
+    expect(count).toBe(2)
+  })
+
+  test("gives up after exhausting attempts", async () => {
+    let count = 0
+    const error = await retry(
+      async () => {
+        count += 1
+        throw new TypeError("NetworkError")
+      },
+      { attempts: 2, delay: 1, factor: 1 },
+    ).catch((e) => e)
+    expect(count).toBe(2)
+    expect(error).toBeInstanceOf(TypeError)
+  })
+})

--- a/packages/core/src/util/retry.test.ts
+++ b/packages/core/src/util/retry.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { retry } from "./retry"
 
 describe("retry", () => {
-  test("retries on network TypeError and eventually succeeds", async () => {
+  test("retries on network TypeError when opted in and eventually succeeds", async () => {
     let count = 0
     const result = await retry(
       async () => {
@@ -10,13 +10,13 @@ describe("retry", () => {
         if (count < 3) throw new TypeError("Failed to fetch")
         return "ok"
       },
-      { attempts: 3, delay: 1, factor: 1 },
+      { attempts: 3, delay: 1, factor: 1, retryOnTypeError: true },
     )
     expect(result).toBe("ok")
     expect(count).toBe(3)
   })
 
-  test("retries on a localized/unknown TypeError message", async () => {
+  test("retries on a localized/unknown TypeError message when opted in", async () => {
     let count = 0
     const result = await retry(
       async () => {
@@ -24,10 +24,39 @@ describe("retry", () => {
         if (count < 2) throw new TypeError("ネットワークエラー")
         return "ok"
       },
-      { attempts: 3, delay: 1, factor: 1 },
+      { attempts: 3, delay: 1, factor: 1, retryOnTypeError: true },
     )
     expect(result).toBe("ok")
     expect(count).toBe(2)
+  })
+
+  test("does not retry a programming TypeError by default", async () => {
+    // A bare `TypeError` is only treated as transient for callers that opted in;
+    // by default it fails fast so a bug in the callback surfaces immediately.
+    let count = 0
+    const error = await retry(
+      async () => {
+        count += 1
+        throw new TypeError("x.foo is not a function")
+      },
+      { attempts: 3, delay: 1, factor: 1 },
+    ).catch((e) => e)
+    expect(count).toBe(1)
+    expect(error).toBeInstanceOf(TypeError)
+  })
+
+  test("still retries message-matched transient errors without opting in", async () => {
+    let count = 0
+    const result = await retry(
+      async () => {
+        count += 1
+        if (count < 3) throw new Error("connect ECONNREFUSED 127.0.0.1:4096")
+        return "ok"
+      },
+      { attempts: 3, delay: 1, factor: 1 },
+    )
+    expect(result).toBe("ok")
+    expect(count).toBe(3)
   })
 
   test("gives up after exhausting attempts", async () => {
@@ -37,9 +66,23 @@ describe("retry", () => {
         count += 1
         throw new TypeError("NetworkError")
       },
-      { attempts: 2, delay: 1, factor: 1 },
+      { attempts: 2, delay: 1, factor: 1, retryOnTypeError: true },
     ).catch((e) => e)
     expect(count).toBe(2)
     expect(error).toBeInstanceOf(TypeError)
+  })
+
+  test("honors a custom retryIf over the default rules", async () => {
+    let count = 0
+    const result = await retry(
+      async () => {
+        count += 1
+        if (count < 2) throw new TypeError("anything")
+        return "ok"
+      },
+      { attempts: 3, delay: 1, factor: 1, retryIf: () => true },
+    )
+    expect(result).toBe("ok")
+    expect(count).toBe(2)
   })
 })

--- a/packages/core/src/util/retry.ts
+++ b/packages/core/src/util/retry.ts
@@ -19,6 +19,12 @@ const TRANSIENT_MESSAGES = [
 
 function isTransientError(error: unknown): boolean {
   if (!error) return false
+  // A `TypeError` thrown by `fetch` (e.g. "Failed to fetch", "NetworkError",
+  // localized messages) is the network-layer signal that the server is not
+  // reachable yet. These must be retried regardless of the (locale-dependent)
+  // message text, otherwise a cold-starting local server surfaces an unhandled
+  // `TypeError` instead of recovering on the next attempt.
+  if (error instanceof TypeError) return true
   // oxlint-disable-next-line no-base-to-string -- error is unknown, intentional coercion for message matching
   const message = String(error instanceof Error ? error.message : error).toLowerCase()
   return TRANSIENT_MESSAGES.some((m) => message.includes(m))

--- a/packages/core/src/util/retry.ts
+++ b/packages/core/src/util/retry.ts
@@ -4,6 +4,15 @@ export interface RetryOptions {
   factor?: number
   maxDelay?: number
   retryIf?: (error: unknown) => boolean
+  /**
+   * Treat a thrown `TypeError` as transient. `fetch` rejects with a bare
+   * `TypeError` when the target server is unreachable and its message is
+   * locale-dependent ("Failed to fetch", "ネットワークエラー", ...), so it cannot
+   * be matched by text. Opt in only from callbacks whose failures are
+   * exclusively network requests — otherwise a programming error inside the
+   * callback would be silently re-run instead of failing fast.
+   */
+  retryOnTypeError?: boolean
 }
 
 const TRANSIENT_MESSAGES = [
@@ -17,21 +26,17 @@ const TRANSIENT_MESSAGES = [
   "socket hang up",
 ]
 
-function isTransientError(error: unknown): boolean {
+function isTransientError(error: unknown, retryOnTypeError: boolean): boolean {
   if (!error) return false
-  // A `TypeError` thrown by `fetch` (e.g. "Failed to fetch", "NetworkError",
-  // localized messages) is the network-layer signal that the server is not
-  // reachable yet. These must be retried regardless of the (locale-dependent)
-  // message text, otherwise a cold-starting local server surfaces an unhandled
-  // `TypeError` instead of recovering on the next attempt.
-  if (error instanceof TypeError) return true
+  if (retryOnTypeError && error instanceof TypeError) return true
   // oxlint-disable-next-line no-base-to-string -- error is unknown, intentional coercion for message matching
   const message = String(error instanceof Error ? error.message : error).toLowerCase()
   return TRANSIENT_MESSAGES.some((m) => message.includes(m))
 }
 
 export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { attempts = 3, delay = 500, factor = 2, maxDelay = 10000, retryIf = isTransientError } = options
+  const { attempts = 3, delay = 500, factor = 2, maxDelay = 10000, retryIf } = options
+  const shouldRetry = retryIf ?? ((error: unknown) => isTransientError(error, options.retryOnTypeError === true))
 
   let lastError: unknown
   for (let attempt = 0; attempt < attempts; attempt++) {
@@ -39,7 +44,7 @@ export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {})
       return await fn()
     } catch (error) {
       lastError = error
-      if (attempt === attempts - 1 || !retryIf(error)) throw error
+      if (attempt === attempts - 1 || !shouldRetry(error)) throw error
       const wait = Math.min(delay * Math.pow(factor, attempt), maxDelay)
       await new Promise((resolve) => setTimeout(resolve, wait))
     }


### PR DESCRIPTION
### Issue for this PR

Closes #32379

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On desktop startup the render process fires a fan-out of `get`/`list` requests through the v2 client (`throwOnError: true`) as soon as the bootstrap query mounts. The local sidecar server is started in parallel, so the first requests can hit a socket that is not listening yet, and the bootstrap query dies with an unhandled `TypeError: Failed to fetch` (call stack: render `main-*.js` `fetch → request → Object.get`).

Two source defects contribute:

1. `isTransientError` in `packages/core/src/util/retry.ts` classifies transient errors purely by message text (`TRANSIENT_MESSAGES` contains `"failed to fetch"`). That message is locale-dependent — on non-English systems the browser localizes it (e.g. `ネットワークエラー`), so the error is treated as non-transient and never retried. The cold-start race then surfaces as an unhandled exception instead of recovering on the next attempt.
2. There is no readiness gate before the bootstrap fan-out: nothing waits for the local server to actually start listening.

Changes:

- `packages/core/src/util/retry.ts` — add an explicit `retryOnTypeError` option (default off). `fetch` rejects with a bare `TypeError` when the target is unreachable and its message is locale-dependent, so it cannot be matched by text; callbacks whose failures are exclusively network requests opt in, while any other `TypeError` (a programming bug inside the callback) keeps failing fast after one attempt instead of being silently re-run.
- `packages/app/src/context/global-sync/bootstrap.ts`, `packages/app/src/context/server-session.ts` — every retried network call site opts in with `{ retryOnTypeError: true }`.
- `packages/app/src/utils/server-health.ts` — new `waitForServerReady()`: bounded polling of the existing health check (defaults: 10s deadline / 250ms interval), reusing `checkServerHealth`; resolves `false` on timeout or abort instead of throwing. Each attempt is bounded by both its own budget and the time left before the overall deadline (`min(pollMs*4, 1s, deadline - now)`), so total wall clock stays within `timeoutMs`; and `checkServerHealth` now combines the caller's abort signal with its per-attempt timeout signal instead of choosing one or the other, so an aborted caller cuts off the in-flight request.
- `packages/app/src/context/server-sync.tsx` — gate the global `bootstrap` queryFn and the per-directory fan-out (`bootstrapInstance`) on `waitForServerReady()` via a shared `ensureServerReady()` helper, guarded by `ServerConnection.local(serverSDK.server)` so remote server connections get no extra startup delay. When readiness fails, both gates now **fail fast** with a localized `Could not reach <url>` error (reuses the existing `app.server.unreachable` key, rendered via `formatServerError`) instead of silently firing the fan-out into a dead server; directory-bootstrap failures surface through the same toast used by sibling per-directory load failures.

Relation to earlier attempts: #41650 / #32468 retried MCP queries only, #28792 / #28707 are older and closed. This PR fixes the retry classification itself and adds the startup gate, in different files — not a duplicate of those.

### How did you verify your code works?

- `packages/core/src/util/retry.test.ts`: 6 cases — TypeError retried when opted in; localized TypeError message retried when opted in; programming TypeError **fails after one attempt by default**; message-matched transient errors still retried without opting in; attempts exhausted rethrows; custom `retryIf` takes precedence. Ran locally: `bun test src/util/retry.test.ts` (in `packages/core`) → 6 pass, 0 fail.
- `packages/app/src/utils/server-health.test.ts`: 16 pass, 0 fail (`bun test --conditions=solid --preload ./happydom.ts ./src/utils/server-health.test.ts`). Includes the original 4 `waitForServerReady` cases plus 3 new ones: never-ready gating pins the wiring contract used by both gates (readiness failure ⇒ no data requests fired into the dead server and the caller gets an error); a hung fetch cannot push total wall clock past `timeoutMs` (old behavior overshot to ~`timeoutMs + pollMs*4 + pollMs`); a mid-poll caller abort cuts off the in-flight health request. One pre-existing `checkServerHealth` case was updated from asserting signal identity to asserting abort propagation, because the request now correctly receives a derived signal combining the caller's signal with the per-attempt timeout.
- Full app suite: `bun test --conditions=solid --preload ./happydom.ts` → 729 pass, 0 fail.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
