### PR TITLE
fix(openai): harden Codex cache control handling

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -243,6 +243,26 @@ function stopOAuthServer() {
   }
 }
 
+function sanitizeCodexRequestBody(body: RequestInit["body"]) {
+  if (typeof body !== "string") return body
+  try {
+    const payload = JSON.parse(body)
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return body
+    if (typeof payload.model !== "string") return body
+    const match = payload.model.match(/^gpt-(\d+)\.(\d+)/)
+    if (!match) return body
+    const major = Number(match[1])
+    const minor = Number(match[2])
+    if (major < 5 || (major === 5 && minor < 6)) return body
+    // The ChatGPT Codex endpoint currently rejects both the legacy retention field and GPT-5.6's public API TTL field.
+    delete payload.prompt_cache_retention
+    delete payload.prompt_cache_options
+    return JSON.stringify(payload)
+  } catch {
+    return body
+  }
+}
+
 function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResponse> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(
@@ -425,7 +445,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
 
             const requestInit = {
               ...init,
-              body: init?.body,
+              body: rewrite ? sanitizeCodexRequestBody(init?.body) : init?.body,
               headers,
             }
             if (websocketFetch && parsed.pathname.endsWith("/responses")) return websocketFetch(url, requestInit)

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -326,6 +326,64 @@ describe("plugin.codex", () => {
     )
   })
 
+  test("removes unsupported prompt cache controls from GPT-5.6+ Codex requests", async () => {
+    const requests: Record<string, unknown>[] = []
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        requests.push((await request.json()) as Record<string, unknown>)
+        return new Response("{}", { status: 200 })
+      },
+    })
+    const hooks = await CodexAuthPlugin({} as never, {
+      codexApiEndpoint: new URL("/backend-api/codex/responses", server.url).toString(),
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh",
+          access: createTestJwt({ chatgpt_account_id: "acc-123" }),
+          expires: Date.now() + 60_000,
+        }) as never,
+      {} as never,
+    )
+
+    await loaded.fetch!("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.6-sol", prompt_cache_retention: "24h", input: "hello" }),
+    })
+    await loaded.fetch!("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.6-sol-fast", prompt_cache_retention: "24h", input: "hello" }),
+    })
+    await loaded.fetch!("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.6-terra", prompt_cache_retention: "in_memory", input: "hello" }),
+    })
+    await loaded.fetch!("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "gpt-5.6-luna",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: { mode: "explicit", ttl: "30m" },
+        input: "hello",
+      }),
+    })
+    await loaded.fetch!("https://api.openai.com/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.5", prompt_cache_retention: "24h", input: "hello" }),
+    })
+
+    expect(requests).toEqual([
+      { model: "gpt-5.6-sol", input: "hello" },
+      { model: "gpt-5.6-sol-fast", input: "hello" },
+      { model: "gpt-5.6-terra", input: "hello" },
+      { model: "gpt-5.6-luna", input: "hello" },
+      { model: "gpt-5.5", prompt_cache_retention: "24h", input: "hello" },
+    ])
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     const refreshedAccess = createTestJwt({
       "https://api.openai.com/auth": { chatgpt_compute_residency: "eu" },


### PR DESCRIPTION
### Issue for this PR

Defensive hardening only. Related investigation: #43367.

The incident reported in #43367 was independently confirmed by OpenAI as a server-side configuration issue; this PR addresses a separate defensive boundary.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If caller configuration or a plugin explicitly adds `prompt_cache_retention` or `prompt_cache_options`, the ChatGPT Codex OAuth endpoint can reject those fields for GPT-5.6 models.

This change defensively removes those two fields only when rewriting GPT-5.6 or newer requests to the Codex endpoint. It keeps `prompt_cache_key`, GPT-5.5 behavior, and non-Codex requests unchanged.

The default OpenCode request path and the model catalog do not currently add either field. This is transport-boundary hardening, not a remedy for the server-side incident reported in #43367.

### How did you verify your code works?

- `bun test test/plugin/codex.test.ts` (25 passed)
- `bun typecheck` in `packages/opencode`
- pre-push `bun turbo typecheck` (30 tasks passed)
- live Codex OAuth checks for `gpt-5.6-sol` and `gpt-5.6-sol-fast` with both rejected fields deliberately injected
- isolated control run with neither field injected, confirming the pre-patch binary succeeds on the default request path

### Screenshots / recordings

Not applicable; this is a non-UI provider hardening change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR