### PR TITLE
docs: add Eden AI to the providers list

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -843,6 +843,52 @@ Selecting a router model is a drop-in replacement for any other model — OpenCo
 
 ---
 
+### Eden AI
+
+[Eden AI](https://www.edenai.co/) is an EU-based gateway that serves models from many vendors over a single OpenAI-compatible API, with a separate EU endpoint for teams that need inference to stay in the EU.
+
+1. Head over to the [Eden AI platform](https://app.edenai.run/user/register) to create an account and generate an API key.
+
+2. Run the `/connect` command and search for **Eden AI**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Eden AI API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _Mistral Large 3_ or _Claude Sonnet 5_.
+
+   ```txt
+   /models
+   ```
+
+   Eden AI model ids are themselves in `vendor/model` form, so a full reference has three segments, for example `edenai/anthropic/claude-sonnet-5`.
+
+5. To keep requests on Eden AI's EU gateway, set its base URL.
+
+   ```json title="opencode.json"
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "edenai": {
+         "options": {
+           "baseURL": "https://api.eu.edenai.run/v3"
+         }
+       }
+     }
+   }
+   ```
+
+---
+
 ### FrogBot
 
 1. Head over to the [FrogBot dashboard](https://app.frogbot.ai/signup), create an account, and generate an API key.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -887,6 +887,8 @@ Selecting a router model is a drop-in replacement for any other model — OpenCo
    }
    ```
 
+   The default is `https://api.edenai.run/v3`, so this swaps the global endpoint for the EU one. The EU endpoint serves the subset of the catalog that is available in the EU, so a model chosen in step 4 may not be reachable through it.
+
 ---
 
 ### FrogBot


### PR DESCRIPTION
### Issue for this PR

Closes # N/A — docs-only. Provider registration was anomalyco/models.dev#4506 (merged 2026-08-12).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds an **Eden AI** section to `docs/providers`, between DigitalOcean and FrogBot.

Eden AI has been in models.dev since #4506 merged, and the catalog is kept current by
the sync workflow there, so it already shows up in `/connect` and `/models`. The
providers page is maintained by hand, so it was missing there. Same four steps as the
neighbouring sections.

Two notes I did add, because they are the two things people get wrong with this one:
Eden AI model ids already contain a vendor segment, so a full reference has three
segments (`edenai/anthropic/claude-sonnet-5`), and the EU endpoint is a different host
rather than a flag, so I showed it with the `baseURL` option from the Base URL section
at the top of the page.

English only. I left the 17 translated copies of `providers.mdx` alone since
`docs-locale-sync.yml` looks like it handles those separately, and they are already
behind. Happy to include them if you would rather.

For context, there was an earlier docs PR for this provider, #19089, which was declined
because at the time it documented a provider that was not in models.dev yet. That part
is now done, which is why I am back with docs only and no code. Per CONTRIBUTING, a
provider like this one needs no changes in `provider.ts`.

### How did you verify your code works?

- Diff is `+46 −0` in one file, purely additive, no other section touched.
- Confirmed Eden AI actually resolves before documenting it: `edenai` is in
  `models.opencode.ai/api.json` with 234 models, `api` and `npm` populated. That is the
  default `source` in `packages/core/src/models-dev.ts`, so it is what a client fetches.
- The two models named in step 4 both respond on the live API, and both are in the
  catalog above under those display names (_Mistral Large 3_, _Claude Sonnet 5_).
- The `baseURL` in step 5 was exercised: same request against
  `https://api.eu.edenai.run/v3` returns 200.
- All four links in the section return 200.
- Compiled the edited file with `@mdx-js/mdx` v3, parses clean.

I did not run a full Astro build; the addition is markdown plus one fenced JSON block,
structurally identical to the OpenRouter section.

### Screenshots / recordings

N/A — text-only docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

_I work at Eden AI._
