### PR TITLE
fix(opencode): sort slash commands alphabetically

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -165,7 +165,7 @@ const layer = Layer.effect(
 
     const list = Effect.fn("Command.list")(function* () {
       const s = yield* InstanceState.get(state)
-      return Object.values(s.commands)
+      return Object.values(s.commands).toSorted((a, b) => a.name.localeCompare(b.name))
     })
 
     return Service.of({ get, list })


### PR DESCRIPTION
### Issue for this PR

Closes #43397

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The slash command picker (desktop app and TUI) lists skills in random order. Skill files are parsed concurrently during discovery, so the insertion order into the commands map is nondeterministic, and `command.list()` returned it as-is.

`list()` now sorts commands by name with `localeCompare`. This makes the picker order deterministic and consistent with the model-facing skill list, which already sorts the same way.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode` — passes
- Change is a one-line sort; no behavioral change to command lookup or execution

### Screenshots / recordings

_Not applicable — no visual changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR