### PR TITLE
docs(ecosystem): add opencode-widget to Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [opencode-widget](https://gitee.com/fushoujiang/opencode-widget)                           | macOS floating widget that shows OpenCode's live status          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs-only addition to the Ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-widget](https://gitee.com/fushoujiang/opencode-widget) to the Projects list in the Ecosystem doc. It's a small macOS floating widget (avatar + status ring) that shows OpenCode's live session status by watching the local SQLite DB read-only.

### How did you verify your code works?

Docs-only change: one table row added, matching the column alignment of existing rows. Repo link verified.

### Screenshots / recordings

N/A (docs change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
