### PR TITLE
refactor(core): move snapshot config into state

### DIFF
--- a/packages/core/src/config/plugin/snapshot.ts
+++ b/packages/core/src/config/plugin/snapshot.ts
@@ -1,0 +1,30 @@
+export * as ConfigSnapshotPlugin from "./snapshot.js"
+
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Effect, Stream } from "effect"
+import { Config } from "../../config.js"
+import { Snapshot } from "../../snapshot.js"
+
+export const Plugin = define({
+  id: "opencode.config.snapshot",
+  effect: Effect.fn(function* (ctx) {
+    const config = yield* Config.Service
+    const snapshot = yield* Snapshot.Service
+    const loaded = { entries: yield* config.entries() }
+    const reload = config.entries().pipe(
+      Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),
+      Effect.andThen(snapshot.reload()),
+    )
+    yield* ctx.event.subscribe().pipe(
+      Stream.filter((event) => event.type === "config.updated"),
+      Stream.runForEach(() => reload),
+      Effect.forkScoped({ startImmediately: true }),
+    )
+    loaded.entries = yield* config.entries()
+    yield* snapshot.transform((draft) => {
+      const configured = Config.latest(loaded.entries, "snapshots")
+      if (configured === undefined) return
+      draft.configure(configured)
+    })
+  }),
+})

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -20,6 +20,7 @@ import { ConfigMCPPlugin } from "../config/plugin/mcp.js"
 import { ConfigProviderPlugin } from "../config/plugin/provider.js"
 import { ConfigPolicyPlugin } from "../config/plugin/policy.js"
 import { ConfigReferencePlugin } from "../config/plugin/reference.js"
+import { ConfigSnapshotPlugin } from "../config/plugin/snapshot.js"
 import { ConfigSkillPlugin } from "../config/plugin/skill.js"
 import { ConfigPluginSource } from "../config/plugin/source.js"
 import { ConfigWebSearchPlugin } from "../config/plugin/websearch.js"
@@ -46,6 +47,7 @@ import { WebSearch } from "../websearch.js"
 import { Ripgrep } from "../ripgrep.js"
 import { SessionInstructions } from "../session/instructions.js"
 import { Shell } from "../shell.js"
+import { Snapshot } from "../snapshot.js"
 import { Skill } from "../skill.js"
 import { SkillDiscovery } from "../skill/discovery.js"
 import { Watcher } from "../filesystem/watcher.js"
@@ -112,6 +114,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const ripgrep = yield* Ripgrep.Service
   const instructions = yield* SessionInstructions.Service
   const shell = yield* Shell.Service
+  const snapshot = yield* Snapshot.Service
   const skill = yield* Skill.Service
   const skillDiscovery = yield* SkillDiscovery.Service
   const tools = yield* Tool.Service
@@ -151,6 +154,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Ripgrep.Service, ripgrep),
     Context.make(SessionInstructions.Service, instructions),
     Context.make(Shell.Service, shell),
+    Context.make(Snapshot.Service, snapshot),
     Context.make(Skill.Service, skill),
     Context.make(SkillDiscovery.Service, skillDiscovery),
     Context.make(Tool.Service, tools),
@@ -197,6 +201,7 @@ export const requirements = LayerNode.group([
   Ripgrep.node,
   SessionInstructions.node,
   Shell.node,
+  Snapshot.node,
   Skill.node,
   SkillDiscovery.node,
   Tool.node,
@@ -240,6 +245,7 @@ const post = [
   ConfigCommandPlugin.Plugin,
   ConfigFormatterPlugin.Plugin,
   ConfigImagePlugin.Plugin,
+  ConfigSnapshotPlugin.Plugin,
   ConfigSkillPlugin.Plugin,
   ConfigProviderPlugin.Plugin,
   ConfigWebSearchPlugin.Plugin,

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -3,7 +3,6 @@ export * as Snapshot from "./snapshot.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
 import { Context, Effect, Fiber, Layer, Schema, Scope } from "effect"
-import { Config } from "./config.js"
 import { File } from "./file.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "./git.js"
@@ -12,6 +11,7 @@ import { Location } from "./location.js"
 import { AbsolutePath, RelativePath } from "./schema.js"
 import { ID } from "@opencode-ai/schema/snapshot"
 import { Hash } from "@opencode-ai/util/hash"
+import { State } from "./state.js"
 
 export { ID }
 
@@ -36,7 +36,11 @@ export interface RestoreInput {
   readonly files: ReadonlyMap<RelativePath, ID>
 }
 
-export interface Interface {
+export type Draft = {
+  configure: (enabled: boolean) => void
+}
+
+export interface Interface extends State.Transformable<Draft> {
   /**
    * Capture the current Location-scoped filesystem state as a content-addressed
    * tree. Returns `undefined` when snapshots are disabled, unsupported, or the
@@ -68,12 +72,20 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Sn
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const config = yield* Config.Service
     const fs = yield* FSUtil.Service
     const git = yield* Git.Service
     const global = yield* Global.Service
     const location = yield* Location.Service
     const lifetime = yield* Scope.Scope
+    const state = State.create<{ enabled: boolean }, Draft>({
+      name: "snapshot",
+      initial: () => ({ enabled: true }),
+      draft: (draft) => ({
+        configure: (enabled) => {
+          draft.enabled = enabled
+        },
+      }),
+    })
     // Cache a scope-owned fiber so caller cancellation stops waiting without poisoning shared initialization.
     const repositoryFiber = yield* Effect.cached(
       Effect.gen(function* () {
@@ -100,13 +112,10 @@ const layer = Layer.effect(
       return RelativePath.make(relative.replaceAll("\\", "/") || ".")
     })
 
-    const enabled = Effect.fnUntraced(function* () {
-      if (location.vcs?.type !== "git") return false
-      return Config.latest(yield* config.entries(), "snapshots") !== false
-    })
+    const enabled = () => location.vcs?.type === "git" && state.get().enabled
 
     const capture = Effect.fn("Snapshot.capture")(function* () {
-      if (!(yield* enabled())) return undefined
+      if (!enabled()) return undefined
       return yield* Effect.gen(function* () {
         const repo = yield* repository
         return ID.make(
@@ -170,26 +179,28 @@ const layer = Layer.effect(
     })
 
     const restore = Effect.fn("Snapshot.restore")(function* (input: RestoreInput) {
-      if (!(yield* enabled())) return yield* new Error({ operation: "restore", message: "Snapshots are disabled" })
+      if (!enabled()) return yield* new Error({ operation: "restore", message: "Snapshots are disabled" })
       const repo = yield* repository.pipe(Effect.mapError((cause) => failure("restore", cause)))
       yield* git.tree
         .restore({ repository: repo.snapshotRepository, files: yield* plan(repo.worktree, input) })
         .pipe(Effect.mapError((cause) => failure("restore", cause)))
     })
 
-    return Service.of({ capture, files, diff, restore })
+    return Service.of({ transform: state.transform, reload: state.reload, capture, files, diff, restore })
   }).pipe(Effect.withSpan("Snapshot.boot")),
 )
 
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Config.node, FSUtil.node, Git.node, Global.node, Location.node],
+  deps: [FSUtil.node, Git.node, Global.node, Location.node],
 })
 
 export const noopLayer = Layer.succeed(
   Service,
   Service.of({
+    transform: () => Effect.succeed({ dispose: Effect.void }),
+    reload: () => Effect.void,
     capture: () => Effect.succeed(undefined),
     files: () => Effect.succeed([]),
     diff: () => Effect.succeed([]),

--- a/packages/core/test/config/snapshot.test.ts
+++ b/packages/core/test/config/snapshot.test.ts
@@ -41,9 +41,13 @@ describe("ConfigSnapshotPlugin.Plugin", () => {
 
             expect(yield* snapshot.capture()).toBeUndefined()
 
-            yield* config.setEntries([document(true)])
+            yield* config.setEntries([new Document({ type: "document", info: new Info({ snapshots: true }) })])
             yield* bus.publish(Event.Updated, {})
-            yield* waitUntil(snapshot.capture().pipe(Effect.map((value) => value !== undefined)))
+            for (let attempt = 0; attempt < 200; attempt++) {
+              if ((yield* snapshot.capture()) !== undefined) return
+              yield* Effect.sleep("10 millis")
+            }
+            yield* Effect.die(new Error("Timed out waiting for snapshot config reload"))
           }).pipe(
             Effect.provide(
               AppNodeBuilder.build(Snapshot.node, [
@@ -54,18 +58,9 @@ describe("ConfigSnapshotPlugin.Plugin", () => {
           )
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ).pipe(Effect.provide(PluginTestLayer), Effect.provide(Config.testLayer([document(false)]))),
+    ).pipe(
+      Effect.provide(PluginTestLayer),
+      Effect.provide(Config.testLayer([new Document({ type: "document", info: new Info({ snapshots: false }) })])),
+    ),
   )
-})
-
-function document(snapshots: boolean) {
-  return new Document({ type: "document", info: new Info({ snapshots }) })
-}
-
-const waitUntil = Effect.fnUntraced(function* (condition: Effect.Effect<boolean>) {
-  for (let attempt = 0; attempt < 200; attempt++) {
-    if (yield* condition) return
-    yield* Effect.sleep("10 millis")
-  }
-  yield* Effect.die(new Error("Timed out waiting for snapshot config reload"))
 })

--- a/packages/core/test/config/snapshot.test.ts
+++ b/packages/core/test/config/snapshot.test.ts
@@ -1,0 +1,71 @@
+import { $ } from "bun"
+import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Bus } from "@opencode-ai/core/bus"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigSnapshotPlugin } from "@opencode-ai/core/config/plugin/snapshot"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Location } from "@opencode-ai/core/location"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Snapshot } from "@opencode-ai/core/snapshot"
+import { Document, Event, Info } from "@opencode-ai/schema/config"
+import { Global } from "@opencode-ai/util/global"
+import { Effect } from "effect"
+import { tmpdir } from "../fixture/tmpdir"
+import { it } from "../lib/effect"
+import { PluginTestLayer } from "../plugin/fixture"
+
+describe("ConfigSnapshotPlugin.Plugin", () => {
+  it.live("applies availability and reloads changed config", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await $`git init`.cwd(project).quiet()
+            await $`git -c core.fsmonitor=false add .`.cwd(project).quiet()
+          })
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            const bus = yield* Bus.Service
+            const config = yield* Config.Test
+            const plugins = yield* Plugin.Service
+            yield* ConfigSnapshotPlugin.Plugin.effect(yield* PluginHost.make(plugins))
+
+            expect(yield* snapshot.capture()).toBeUndefined()
+
+            yield* config.setEntries([document(true)])
+            yield* bus.publish(Event.Updated, {})
+            yield* waitUntil(snapshot.capture().pipe(Effect.map((value) => value !== undefined)))
+          }).pipe(
+            Effect.provide(
+              AppNodeBuilder.build(Snapshot.node, [
+                [Location.node, Location.boundNode(Location.Ref.make({ directory: AbsolutePath.make(project) }))],
+                [Global.node, Global.layerWith({ data: tmp.path, config: path.join(tmp.path, "config") })],
+              ]),
+            ),
+          )
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(Effect.provide(PluginTestLayer), Effect.provide(Config.testLayer([document(false)]))),
+  )
+})
+
+function document(snapshots: boolean) {
+  return new Document({ type: "document", info: new Info({ snapshots }) })
+}
+
+const waitUntil = Effect.fnUntraced(function* (condition: Effect.Effect<boolean>) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (yield* condition) return
+    yield* Effect.sleep("10 millis")
+  }
+  yield* Effect.die(new Error("Timed out waiting for snapshot config reload"))
+})

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -127,6 +127,31 @@ describe("Snapshot", () => {
     ),
   )
 
+  testEffect(Layer.empty).live("applies availability transforms", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await initGit(project)
+          })
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            const registration = yield* snapshot.transform((draft) => draft.configure(false))
+            expect(yield* snapshot.capture()).toBeUndefined()
+
+            yield* registration.dispose
+            expect(yield* snapshot.capture()).toBeDefined()
+          }).pipe(Effect.provide(snapshotLayer(tmp.path, project)))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   testEffect(Layer.empty).live("treats capture outside Git as unavailable", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
## summary
- move snapshot availability into reloadable service state
- project config through an internal config plugin
- preserve lazy repository discovery and the explicit no-op layer

## testing
- bun typecheck from packages/core
- bun test test/snapshot.test.ts test/config/snapshot.test.ts
- bun test test/session-runner.test.ts test/session-runner-recorded.test.ts
- bun test test/location-layer.test.ts
- pre-push monorepo typecheck