### PR TITLE
refactor(core): move shell config into state

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -51,7 +51,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Command") {}
 
-export const layer = () =>
+const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -254,12 +254,8 @@ const placeholderRegex = /\$(\d+)/g
 const quoteTrimRegex = /^["']|["']$/g
 const shellRegex = /!`([^`]+)`/g
 
-export function configured() {
-  return makeLocationNode({
-    service: Service,
-    layer: layer(),
-    deps: [MCP.node, Bus.node, AppProcess.node, Location.node, ShellSelect.node],
-  })
-}
-
-export const node = configured()
+export const node = makeLocationNode({
+  service: Service,
+  layer: layer(),
+  deps: [MCP.node, Bus.node, AppProcess.node, Location.node, ShellSelect.node],
+})

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -8,10 +8,8 @@ import { MCP } from "./mcp/index.js"
 import { Bus } from "./bus.js"
 import { AppProcess } from "@opencode-ai/util/process"
 import { ChildProcess } from "effect/unstable/process"
-import { Config } from "./config.js"
 import { Location } from "./location.js"
 import { ShellSelect } from "./shell/select.js"
-import { Global } from "@opencode-ai/util/global"
 
 export const Info = Command.Info
 export type Info = Command.Info
@@ -53,16 +51,15 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Command") {}
 
-export const layer = (options?: ShellSelect.Options) =>
+export const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
       const mcp = yield* MCP.Service
       const bus = yield* Bus.Service
       const processes = yield* AppProcess.Service
-      const config = yield* Config.Service
       const location = yield* Location.Service
-      const global = yield* Global.Service
+      const shell = yield* ShellSelect.Service
       const state = State.create<Data, Draft>({
         name: "command",
         initial: () => ({ commands: new Map() }),
@@ -109,11 +106,9 @@ export const layer = (options?: ShellSelect.Options) =>
           const command = staticCommand(input.name)
           if (command)
             return yield* evaluateTemplate(input.name, command.template, input.arguments ?? "", {
-              config,
               location,
               processes,
-              shell: options,
-              bin: global.bin,
+              shell,
             })
 
           const prompt = (yield* mcp.prompts()).find(
@@ -163,11 +158,9 @@ function evaluateTemplate(
   template: string,
   input: string,
   services: {
-    readonly config: Config.Interface
     readonly location: Location.Info
     readonly processes: AppProcess.Interface
-    readonly shell?: ShellSelect.Options
-    readonly bin: string
+    readonly shell: ShellSelect.Interface
   },
 ) {
   return Effect.gen(function* () {
@@ -197,20 +190,14 @@ const evaluateShell = Effect.fnUntraced(function* (
   command: string,
   text: string,
   services: {
-    readonly config: Config.Interface
     readonly location: Location.Info
     readonly processes: AppProcess.Interface
-    readonly shell?: ShellSelect.Options
-    readonly bin: string
+    readonly shell: ShellSelect.Interface
   },
 ) {
   const matches = Array.from(text.matchAll(shellRegex))
   if (matches.length === 0) return text
-  const shell = ShellSelect.preferred(
-    Config.latest(yield* services.config.entries(), "shell"),
-    services.shell,
-    services.bin,
-  )
+  const shell = yield* services.shell.preferred()
   const outputs = yield* Effect.forEach(
     matches,
     (match) => {
@@ -267,11 +254,11 @@ const placeholderRegex = /\$(\d+)/g
 const quoteTrimRegex = /^["']|["']$/g
 const shellRegex = /!`([^`]+)`/g
 
-export function configured(options?: ShellSelect.Options) {
+export function configured() {
   return makeLocationNode({
     service: Service,
-    layer: layer(options),
-    deps: [MCP.node, Bus.node, AppProcess.node, Config.node, Location.node, Global.node],
+    layer: layer(),
+    deps: [MCP.node, Bus.node, AppProcess.node, Location.node, ShellSelect.node],
   })
 }
 

--- a/packages/core/src/config/plugin/shell.ts
+++ b/packages/core/src/config/plugin/shell.ts
@@ -1,0 +1,29 @@
+export * as ConfigShellPlugin from "./shell.js"
+
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Effect, Stream } from "effect"
+import { Config } from "../../config.js"
+import { ShellSelect } from "../../shell/select.js"
+
+export const Plugin = define({
+  id: "opencode.config.shell",
+  effect: Effect.fn(function* (ctx) {
+    const config = yield* Config.Service
+    const shell = yield* ShellSelect.Service
+    const loaded = { entries: yield* config.entries() }
+    const reload = config.entries().pipe(
+      Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),
+      Effect.andThen(shell.reload()),
+    )
+    yield* ctx.event.subscribe().pipe(
+      Stream.filter((event) => event.type === "config.updated"),
+      Stream.runForEach(() => reload),
+      Effect.forkScoped({ startImmediately: true }),
+    )
+    loaded.entries = yield* config.entries()
+    yield* shell.transform((draft) => {
+      const configured = Config.latest(loaded.entries, "shell")
+      if (configured) draft.configure(configured)
+    })
+  }),
+})

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -29,6 +29,7 @@ import { PluginSupervisor } from "./plugin/supervisor.js"
 import { Worktree } from "./worktree.js"
 import { Pty } from "./pty.js"
 import { Shell } from "./shell.js"
+import { ShellSelect } from "./shell/select.js"
 import { Reference } from "./reference.js"
 import { WebSearch } from "./websearch.js"
 import { ReferenceInstructions } from "./reference/instructions.js"
@@ -71,6 +72,7 @@ const locationServiceNodes = [
   Worktree.refreshNode,
   FileSystemSearch.node,
   FileSystem.node,
+  ShellSelect.node,
   Pty.node,
   Shell.node,
   Skill.node,

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -20,6 +20,7 @@ import { ConfigMCPPlugin } from "../config/plugin/mcp.js"
 import { ConfigProviderPlugin } from "../config/plugin/provider.js"
 import { ConfigPolicyPlugin } from "../config/plugin/policy.js"
 import { ConfigReferencePlugin } from "../config/plugin/reference.js"
+import { ConfigShellPlugin } from "../config/plugin/shell.js"
 import { ConfigSnapshotPlugin } from "../config/plugin/snapshot.js"
 import { ConfigSkillPlugin } from "../config/plugin/skill.js"
 import { ConfigToolOutputPlugin } from "../config/plugin/tool-output.js"
@@ -48,6 +49,7 @@ import { WebSearch } from "../websearch.js"
 import { Ripgrep } from "../ripgrep.js"
 import { SessionInstructions } from "../session/instructions.js"
 import { Shell } from "../shell.js"
+import { ShellSelect } from "../shell/select.js"
 import { Snapshot } from "../snapshot.js"
 import { Skill } from "../skill.js"
 import { SkillDiscovery } from "../skill/discovery.js"
@@ -116,6 +118,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const ripgrep = yield* Ripgrep.Service
   const instructions = yield* SessionInstructions.Service
   const shell = yield* Shell.Service
+  const shellSelect = yield* ShellSelect.Service
   const snapshot = yield* Snapshot.Service
   const skill = yield* Skill.Service
   const skillDiscovery = yield* SkillDiscovery.Service
@@ -157,6 +160,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Ripgrep.Service, ripgrep),
     Context.make(SessionInstructions.Service, instructions),
     Context.make(Shell.Service, shell),
+    Context.make(ShellSelect.Service, shellSelect),
     Context.make(Snapshot.Service, snapshot),
     Context.make(Skill.Service, skill),
     Context.make(SkillDiscovery.Service, skillDiscovery),
@@ -205,6 +209,7 @@ export const requirements = LayerNode.group([
   Ripgrep.node,
   SessionInstructions.node,
   Shell.node,
+  ShellSelect.node,
   Snapshot.node,
   Skill.node,
   SkillDiscovery.node,
@@ -250,6 +255,7 @@ const post = [
   ConfigCommandPlugin.Plugin,
   ConfigFormatterPlugin.Plugin,
   ConfigImagePlugin.Plugin,
+  ConfigShellPlugin.Plugin,
   ConfigSnapshotPlugin.Plugin,
   ConfigToolOutputPlugin.Plugin,
   ConfigSkillPlugin.Plugin,

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -88,7 +88,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Pty") {}
 
-export const layer = () =>
+const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -313,12 +313,8 @@ export const layer = () =>
     }),
   )
 
-export function configured() {
-  return makeLocationNode({
-    service: Service,
-    layer: layer(),
-    deps: [Bus.node, Location.node, ShellSelect.node],
-  })
-}
-
-export const node = configured()
+export const node = makeLocationNode({
+  service: Service,
+  layer: layer(),
+  deps: [Bus.node, Location.node, ShellSelect.node],
+})

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -4,12 +4,10 @@ import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import type { Disp, Proc } from "#pty"
 import { Context, Effect, Layer, Schema, Types } from "effect"
 import { Pty } from "@opencode-ai/schema/pty"
-import { Config } from "./config.js"
 import { Bus } from "./bus.js"
 import { Location } from "./location.js"
 import { PtyID } from "./pty/schema.js"
 import { ShellSelect } from "./shell/select.js"
-import { Global } from "@opencode-ai/util/global"
 import { lazy } from "./util/lazy.js"
 
 const BUFFER_LIMIT = 1024 * 1024 * 2
@@ -90,14 +88,13 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Pty") {}
 
-export const layer = (options?: ShellSelect.Options) =>
+export const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
       const location = yield* Location.Service
-      const config = yield* Config.Service
-      const global = yield* Global.Service
+      const shell = yield* ShellSelect.Service
       const context = yield* Effect.context()
       const runFork = Effect.runForkWith(context)
       const sessions = new Map<PtyID, Active>()
@@ -167,8 +164,7 @@ export const layer = (options?: ShellSelect.Options) =>
 
       const create = Effect.fn("Pty.create")(function* (input: CreateInput) {
         const id = PtyID.ascending()
-        const command =
-          input.command || ShellSelect.preferred(Config.latest(yield* config.entries(), "shell"), options, global.bin)
+        const command = input.command || (yield* shell.preferred())
         const args = ShellSelect.login(command) ? [...(input.args ?? []), "-l"] : [...(input.args ?? [])]
         const cwd = input.cwd || location.directory
         const env = {
@@ -317,11 +313,11 @@ export const layer = (options?: ShellSelect.Options) =>
     }),
   )
 
-export function configured(options?: ShellSelect.Options) {
+export function configured() {
   return makeLocationNode({
     service: Service,
-    layer: layer(options),
-    deps: [Bus.node, Location.node, Config.node, Global.node],
+    layer: layer(),
+    deps: [Bus.node, Location.node, ShellSelect.node],
   })
 }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -628,7 +628,11 @@ const layer = Layer.effect(
       }),
       command: Effect.fn("Session.command")(function* (input) {
         const session = yield* result.get(input.sessionID)
-        const commands = yield* Command.Service.pipe(Effect.provide(locations.get(session.location)))
+        const commands = yield* Effect.gen(function* () {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
+          return yield* Command.Service
+        }).pipe(Effect.provide(locations.get(session.location)))
         const command = yield* commands.get(input.command)
         if (!command)
           return yield* new Command.NotFoundError({
@@ -667,6 +671,8 @@ const layer = Layer.effect(
             activeShells.add(input.sessionID)
             yield* execution.awaitIdle(input.sessionID)
             const started = yield* Effect.gen(function* () {
+              const plugins = yield* PluginSupervisor.Service
+              yield* plugins.flush
               const shell = yield* Shell.Service
               return yield* shell
                 .create({

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -67,7 +67,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Shell") {}
 
-export const layer = () =>
+const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
@@ -347,20 +347,16 @@ export const layer = () =>
     }),
   )
 
-export function configured() {
-  return makeLocationNode({
-    service: Service,
-    layer: layer(),
-    deps: [
-      Bus.node,
-      Location.node,
-      Global.node,
-      ShellSelect.node,
-      Environment.node,
-      PluginHooks.node,
-      SessionEnvironment.node,
-    ],
-  })
-}
-
-export const node = configured()
+export const node = makeLocationNode({
+  service: Service,
+  layer: layer(),
+  deps: [
+    Bus.node,
+    Location.node,
+    Global.node,
+    ShellSelect.node,
+    Environment.node,
+    PluginHooks.node,
+    SessionEnvironment.node,
+  ],
+})

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -7,7 +7,6 @@ import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
 import { AppProcess } from "@opencode-ai/util/process"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Config } from "./config.js"
 import { Bus } from "./bus.js"
 import { Environment } from "./environment/index.js"
 import { Location } from "./location.js"
@@ -68,14 +67,14 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Shell") {}
 
-export const layer = (options?: ShellSelect.Options) =>
+export const layer = () =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
       const bus = yield* Bus.Service
       const location = yield* Location.Service
-      const config = yield* Config.Service
       const global = yield* Global.Service
+      const shell = yield* ShellSelect.Service
       const environment = yield* Environment.Service
       const hooks = yield* PluginHooks.Service
       const environments = yield* SessionEnvironment.Service
@@ -146,12 +145,7 @@ export const layer = (options?: ShellSelect.Options) =>
         return session.info
       })
 
-      const resolve = () =>
-        config
-          .entries()
-          .pipe(Effect.map((entries) => ShellSelect.preferred(Config.latest(entries, "shell"), options, global.bin)))
-
-      const name = () => resolve().pipe(Effect.map(ShellSelect.name))
+      const name = () => shell.preferred().pipe(Effect.map(ShellSelect.name))
 
       const output = Effect.fnUntraced(function* (id: Shell.ID, input?: Shell.OutputInput) {
         const session = yield* require(id)
@@ -196,7 +190,7 @@ export const layer = (options?: ShellSelect.Options) =>
           command: input.command,
           cwd: input.cwd ?? location.directory,
           timeout: input.timeout,
-          shell: yield* resolve(),
+          shell: yield* shell.preferred(),
           env: {
             ...(sessionEnvironment ?? process.env),
             TERM: "xterm-256color",
@@ -353,15 +347,15 @@ export const layer = (options?: ShellSelect.Options) =>
     }),
   )
 
-export function configured(options?: ShellSelect.Options) {
+export function configured() {
   return makeLocationNode({
     service: Service,
-    layer: layer(options),
+    layer: layer(),
     deps: [
       Bus.node,
       Location.node,
-      Config.node,
       Global.node,
+      ShellSelect.node,
       Environment.node,
       PluginHooks.node,
       SessionEnvironment.node,

--- a/packages/core/src/shell/select.ts
+++ b/packages/core/src/shell/select.ts
@@ -3,8 +3,11 @@ export * as ShellSelect from "./select.js"
 import path from "path"
 import { readFile } from "fs/promises"
 import { statSync } from "fs"
-import { Schema } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Global } from "@opencode-ai/util/global"
+import { State } from "../state.js"
 import { which } from "../util/which.js"
 
 const META: Record<string, { deny?: boolean; login?: boolean; ps?: boolean }> = {
@@ -29,6 +32,20 @@ export const Options = Schema.Struct({
   gitbash: Schema.optional(Schema.String),
 })
 export type Options = typeof Options.Type
+
+type Data = {
+  shell?: string
+}
+
+export type Draft = {
+  configure: (shell: string) => void
+}
+
+export interface Interface extends State.Transformable<Draft> {
+  readonly preferred: () => Effect.Effect<string>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ShellSelect") {}
 
 function stat(file: string) {
   return statSync(file, { throwIfNoEntry: false }) ?? undefined
@@ -181,3 +198,31 @@ export async function list(options?: Options, bin?: string): Promise<Item[]> {
   const shells = process.platform === "win32" ? win(options, bin) : await unix()
   return shells.filter((shell) => resolve(shell, options, bin)).map((shell) => info(shell, options, bin))
 }
+
+const layer = (options?: Options) =>
+  Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const global = yield* Global.Service
+      const state = State.create<Data, Draft>({
+        name: "shell-select",
+        initial: () => ({}),
+        draft: (draft) => ({
+          configure: (shell) => {
+            draft.shell = shell
+          },
+        }),
+      })
+      return Service.of({
+        transform: state.transform,
+        reload: state.reload,
+        preferred: () => Effect.sync(() => preferred(state.get().shell, options, global.bin)),
+      })
+    }),
+  )
+
+export function configured(options?: Options) {
+  return makeLocationNode({ service: Service, layer: layer(options), deps: [Global.node] })
+}
+
+export const node = configured()

--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -1,19 +1,17 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { Command } from "@opencode-ai/core/command"
-import { Config } from "@opencode-ai/core/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
-import { emptyConfigLayer, emptyMcpLayer, testLocationLayer } from "./fixture/mcp"
+import { emptyMcpLayer, testLocationLayer } from "./fixture/mcp"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(
   AppNodeBuilder.build(Command.node, [
     [MCP.node, emptyMcpLayer],
-    [Config.node, emptyConfigLayer],
     [Location.node, testLocationLayer],
   ]),
 )

--- a/packages/core/test/config/shell.test.ts
+++ b/packages/core/test/config/shell.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect } from "bun:test"
+import { Bus } from "@opencode-ai/core/bus"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigShellPlugin } from "@opencode-ai/core/config/plugin/shell"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { ShellSelect } from "@opencode-ai/core/shell/select"
+import { Document, Event, Info } from "@opencode-ai/schema/config"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Effect, Layer } from "effect"
+import { testEffect } from "../lib/effect"
+import { PluginTestLayer } from "../plugin/fixture"
+
+const it = testEffect(Layer.merge(PluginTestLayer, AppNodeBuilder.build(ShellSelect.node)))
+
+describe("ConfigShellPlugin.Plugin", () => {
+  it.live("applies the preferred shell and reloads changed config", () =>
+    Effect.gen(function* () {
+      const shell = yield* ShellSelect.Service
+      const bus = yield* Bus.Service
+      const config = yield* Config.Test
+      const plugins = yield* Plugin.Service
+      yield* ConfigShellPlugin.Plugin.effect(yield* PluginHost.make(plugins))
+
+      const configured = process.platform === "win32" ? FSUtil.windowsPath(process.execPath) : process.execPath
+      expect(yield* shell.preferred()).toBe(configured)
+
+      yield* config.setEntries([])
+      yield* bus.publish(Event.Updated, {})
+      for (let attempt = 0; attempt < 200; attempt++) {
+        if ((yield* shell.preferred()) !== configured) return
+        yield* Effect.sleep("10 millis")
+      }
+      yield* Effect.die(new Error("Timed out waiting for shell config reload"))
+    }).pipe(
+      Effect.provide(
+        Config.testLayer([new Document({ type: "document", info: new Info({ shell: process.execPath }) })]),
+      ),
+    ),
+  )
+})

--- a/packages/core/test/pty/pty-session.test.ts
+++ b/packages/core/test/pty/pty-session.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect } from "bun:test"
 import { Cause, Deferred, Effect, Exit, Layer, Queue } from "effect"
-import { Config } from "@opencode-ai/core/config"
-import { Document, Info } from "@opencode-ai/schema/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
@@ -9,6 +7,7 @@ import { Location } from "@opencode-ai/core/location"
 import { Pty } from "@opencode-ai/core/pty"
 import type { PtyID } from "@opencode-ai/core/pty/schema"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { location } from "../fixture/location"
 import { testEffect } from "../lib/effect"
 
@@ -18,13 +17,7 @@ const locationLayer = Layer.succeed(
   Location.Service,
   Location.Service.of(location({ directory: AbsolutePath.make("/tmp") })),
 )
-const configLayer = Layer.mock(Config.Service)({ entries: () => Effect.succeed([]) })
-const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Pty.node, Bus.node]), [
-    [Config.node, configLayer],
-    [Location.node, locationLayer],
-  ]),
-)
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Pty.node, Bus.node]), [[Location.node, locationLayer]]))
 const ptyTest = process.platform === "win32" ? it.live.skip : it.live
 
 const subscribePtyEvents = Effect.fn("PtySessionTest.subscribePtyEvents")(function* () {
@@ -207,26 +200,17 @@ describe("pty", () => {
 
 const configuredShell = process.platform === "win32" ? undefined : Bun.which("bash")
 const configuredIt = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Pty.node, Bus.node]), [
-    [
-      Config.node,
-      Layer.mock(Config.Service)({
-        entries: () =>
-          Effect.succeed(
-            configuredShell ? [new Document({ type: "document", info: new Info({ shell: configuredShell }) })] : [],
-          ),
-      }),
-    ],
-    [Location.node, locationLayer],
-  ]),
+  AppNodeBuilder.build(LayerNode.group([Pty.node, Bus.node, ShellSelect.node]), [[Location.node, locationLayer]]),
 )
 const configuredTest = process.platform === "win32" ? configuredIt.live.skip : configuredIt.live
 
 describe("pty create defaults", () => {
-  configuredTest("defaults command, login args, and cwd from config and location", () =>
+  configuredTest("defaults command, login args, and cwd from shell selection and location", () =>
     Effect.gen(function* () {
       if (!configuredShell) return
       const pty = yield* Pty.Service
+      const shell = yield* ShellSelect.Service
+      yield* shell.transform((draft) => draft.configure(configuredShell))
       const info = yield* Effect.acquireRelease(pty.create({ title: "configured" }), (created) =>
         pty.remove(created.id).pipe(Effect.ignore),
       )

--- a/packages/server/src/handlers/pty.ts
+++ b/packages/server/src/handlers/pty.ts
@@ -1,6 +1,7 @@
 import { Pty } from "@opencode-ai/core/pty"
 import { PtyProtocol } from "@opencode-ai/core/pty/protocol"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor-service"
 import { Location } from "@opencode-ai/core/location"
 import { Effect, Queue } from "effect"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
@@ -39,6 +40,8 @@ export const PtyHandler = HttpApiBuilder.group(Api, "server.pty", (handlers) =>
       .handle(
         "pty.create",
         Effect.fn(function* (ctx) {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
           const pty = yield* Pty.Service
           const location = yield* Location.Service
           const cwd = ctx.payload.cwd || location.directory

--- a/packages/server/src/handlers/shell.ts
+++ b/packages/server/src/handlers/shell.ts
@@ -1,5 +1,6 @@
 import { Shell } from "@opencode-ai/core/shell"
 import { Location } from "@opencode-ai/core/location"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor-service"
 import { Effect } from "effect"
 import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { ShellNotFoundError } from "@opencode-ai/protocol/errors"
@@ -19,6 +20,8 @@ export const ShellHandler = HttpApiBuilder.group(Api, "server.shell", (handlers)
       .handle(
         "shell.create",
         Effect.fn(function* (ctx) {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
           const shell = yield* Shell.Service
           const location = yield* Location.Service
           return yield* response(

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -9,14 +9,12 @@ import { EventLogger } from "@opencode-ai/core/event-logger"
 import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
 import { Credential } from "@opencode-ai/core/credential"
 import { Config } from "@opencode-ai/core/config"
-import { Command } from "@opencode-ai/core/command"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
-import { Pty } from "@opencode-ai/core/pty"
 import { Project } from "@opencode-ai/core/project"
 import { Session } from "@opencode-ai/core/session"
 import { SessionTransfer } from "@opencode-ai/core/session/transfer"
-import { Shell } from "@opencode-ai/core/shell"
+import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { Job } from "@opencode-ai/core/job"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { Global } from "@opencode-ai/util/global"
@@ -115,9 +113,7 @@ function makeRoutes<AuthError, AuthServices>(
       }),
     ],
     [InstructionDiscovery.node, InstructionDiscovery.configured({ project: options.config?.project })],
-    [Command.node, Command.configured({ gitbash: options.windows?.gitbash })],
-    [Pty.node, Pty.configured({ gitbash: options.windows?.gitbash })],
-    [Shell.node, Shell.configured({ gitbash: options.windows?.gitbash })],
+    [ShellSelect.node, ShellSelect.configured({ gitbash: options.windows?.gitbash })],
     [
       MCP.node,
       MCP.configured({


### PR DESCRIPTION
## summary
- make ShellSelect the shared state-backed owner of configured shell selection
- project shell config through an internal config plugin
- remove direct Config dependencies from Command, Pty, and Shell
- route the Windows Git Bash override through one shared node replacement
- await location plugin readiness before direct Command, Shell, and PTY operations

## testing
- bun typecheck from packages/core
- bun typecheck from packages/server
- bun test test/session-create.test.ts test/config/shell.test.ts test/command.test.ts test/pty/pty-session.test.ts test/shell.test.ts test/tool-shell.test.ts test/location-layer.test.ts
- bun test test/config/command.test.ts test/plugin/command.test.ts
- bun test test/options.test.ts test/workerd.test.ts test/process.test.ts from packages/server
- pre-push monorepo typecheck