### PR TITLE
fix(core): route Vertex Gemini through native provider

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -51,6 +51,19 @@ export function map(input: MapInput): Mapping | undefined {
           ...mapGoogleOptions(input.settings),
         },
       }
+    case "@ai-sdk/google-vertex":
+      return {
+        package: "@opencode-ai/ai/providers/google-vertex",
+        settings: {
+          ...baseSettings,
+          ...(typeof input.settings.accessToken === "string" ? { accessToken: input.settings.accessToken } : {}),
+          ...mapAPIKey(input.settings),
+          ...(typeof input.settings.location === "string" ? { location: input.settings.location } : {}),
+          ...(typeof input.settings.project === "string" ? { project: input.settings.project } : {}),
+          ...mapGoogleOptions(input.settings),
+        },
+        ...(isStringRecord(input.settings.headers) ? { headers: input.settings.headers } : {}),
+      }
     case "@ai-sdk/google-vertex/anthropic":
       return {
         package: "@opencode-ai/ai/providers/google-vertex/messages",

--- a/packages/core/test/aisdk-native.test.ts
+++ b/packages/core/test/aisdk-native.test.ts
@@ -273,6 +273,29 @@ describe("AISDKNative", () => {
     })
   })
 
+  test("maps Vertex Gemini settings to the native Gemini route", () => {
+    expect(
+      map("@ai-sdk/google-vertex", {
+        accessToken: "vertex-token",
+        baseURL: "https://vertex.example/v1",
+        headers: { "x-test": "value" },
+        location: "eu",
+        project: "vertex-project",
+        thinkingConfig: { thinkingLevel: "high" },
+      }),
+    ).toEqual({
+      package: "@opencode-ai/ai/providers/google-vertex",
+      settings: {
+        accessToken: "vertex-token",
+        baseURL: "https://vertex.example/v1",
+        location: "eu",
+        project: "vertex-project",
+        providerOptions: { gemini: { thinkingConfig: { thinkingLevel: "high" } } },
+      },
+      headers: { "x-test": "value" },
+    })
+  })
+
   test("maps Vertex Anthropic settings to native Messages", () => {
     expect(
       map("@ai-sdk/google-vertex/anthropic", {


### PR DESCRIPTION
### Issue for this PR

Closes #43431

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Vertex Gemini models configured through `@ai-sdk/google-vertex` were falling through the generic AI SDK adapter.

When session instructions changed, the adapter emitted a system message after conversation history had started, which Vertex rejected.

This maps Vertex Gemini to OpenCode's native provider, which preserves the Vertex settings and safely lowers chronological instruction updates.

### How did you verify your code works?

- `cd packages/core && bun test test/aisdk-native.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/ai && bun test test/provider/google-vertex.test.ts`
- `git diff --check`

### Screenshots / recordings

Not applicable because this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
