### PR TITLE
fix: fall back to native tsc --lsp for typescript@7+

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -143,7 +143,8 @@ export const Typescript: Info = {
     // typescript@7+ (native Go port) dropped tsserver.js in favor of its own
     // `tsc --lsp` mode, so typescript-language-server can no longer attach.
     // Fall back to the native LSP directly.
-    const localTsc = path.join(root, "node_modules", ".bin", "tsc")
+    const tscExt = process.platform === "win32" ? ".cmd" : ""
+    const localTsc = path.join(root, "node_modules", ".bin", "tsc" + tscExt)
     const bin = (await Filesystem.exists(localTsc)) ? localTsc : which("tsc")
     if (!bin) return
     const proc = spawn(bin, ["--lsp", "-stdio"], {

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -121,10 +121,32 @@ export const Typescript: Info = {
   extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
   async spawn(root, ctx) {
     const tsserver = Module.resolve("typescript/lib/tsserver.js", ctx.directory)
-    if (!tsserver) return
-    const bin = await Npm.which("typescript-language-server")
+    if (tsserver) {
+      const bin = await Npm.which("typescript-language-server")
+      if (!bin) return
+      const proc = spawn(bin, ["--stdio"], {
+        cwd: root,
+        env: {
+          ...process.env,
+        },
+      })
+      return {
+        process: proc,
+        initialization: {
+          tsserver: {
+            path: tsserver,
+          },
+        },
+      }
+    }
+
+    // typescript@7+ (native Go port) dropped tsserver.js in favor of its own
+    // `tsc --lsp` mode, so typescript-language-server can no longer attach.
+    // Fall back to the native LSP directly.
+    const localTsc = path.join(root, "node_modules", ".bin", "tsc")
+    const bin = (await Filesystem.exists(localTsc)) ? localTsc : which("tsc")
     if (!bin) return
-    const proc = spawn(bin, ["--stdio"], {
+    const proc = spawn(bin, ["--lsp", "-stdio"], {
       cwd: root,
       env: {
         ...process.env,
@@ -132,11 +154,6 @@ export const Typescript: Info = {
     })
     return {
       process: proc,
-      initialization: {
-        tsserver: {
-          path: tsserver,
-        },
-      },
     }
   },
 }

--- a/packages/opencode/test/lsp/typescript-native-fallback.test.ts
+++ b/packages/opencode/test/lsp/typescript-native-fallback.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, spyOn } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { Effect } from "effect"
+import * as LSPServer from "@/lsp/server"
+import { Module } from "@opencode-ai/core/util/module"
+import * as WhichModule from "@opencode-ai/core/util/which"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { tmpdir } from "../fixture/fixture"
+import type { InstanceContext } from "@/project/instance-context"
+
+function makeCtx(directory: string): InstanceContext {
+  return { directory, worktree: "/", project: {} as any }
+}
+
+async function defaultFlags(): Promise<RuntimeFlags.Info> {
+  return Effect.runPromise(Effect.gen(function* () { return yield* RuntimeFlags.Service }).pipe(Effect.provide(RuntimeFlags.layer())))
+}
+
+// typescript@7+ locked down its package.json `exports` map, so
+// `require.resolve("typescript/lib/tsserver.js", ...)` throws
+// ERR_PACKAGE_PATH_NOT_EXPORTED and Module.resolve returns undefined for it
+// even when typescript is installed. Simulate that by forcing Module.resolve
+// to return undefined, regardless of what's actually on disk.
+describe("Typescript.spawn native fallback", () => {
+  test("spawns local node_modules/.bin/tsc with --lsp -stdio when tsserver.js is unresolvable", async () => {
+    await using tmp = await tmpdir()
+    const root = tmp.path
+
+    const binDir = path.join(root, "node_modules", ".bin")
+    await fs.mkdir(binDir, { recursive: true })
+
+    const ext = process.platform === "win32" ? ".cmd" : ""
+    const tscPath = path.join(binDir, "tsc" + ext)
+    const recordPath = path.join(root, "record.json")
+
+    if (process.platform === "win32") {
+      const implPath = path.join(binDir, "tsc-impl.js")
+      await Bun.write(
+        implPath,
+        `const fs = require("fs")\nfs.writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({ argv: process.argv.slice(2), cwd: process.cwd() }))\n`,
+      )
+      await Bun.write(tscPath, `@echo off\r\nnode "${implPath}" %*\r\n`)
+    } else {
+      await Bun.write(
+        tscPath,
+        `#!/usr/bin/env node\nconst fs = require("fs")\nfs.writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({ argv: process.argv.slice(2), cwd: process.cwd() }))\n`,
+      )
+      await fs.chmod(tscPath, 0o755)
+    }
+
+    const spy = spyOn(Module, "resolve").mockReturnValue(undefined)
+    try {
+      const flags = await defaultFlags()
+      const handle = await LSPServer.Typescript.spawn(root, makeCtx(root), flags)
+      expect(handle).toBeDefined()
+      if (!handle) return
+
+      await new Promise<void>((resolve) => handle.process.once("exit", () => resolve()))
+      expect(handle.initialization).toBeUndefined()
+
+      const recorded = JSON.parse(await fs.readFile(recordPath, "utf-8"))
+      expect(recorded.argv).toEqual(["--lsp", "-stdio"])
+      expect(recorded.cwd).toBe(await fs.realpath(root))
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  test("returns undefined when neither tsserver.js nor a tsc binary can be found", async () => {
+    await using tmp = await tmpdir()
+    const root = tmp.path
+
+    const resolveSpy = spyOn(Module, "resolve").mockReturnValue(undefined)
+    // No local node_modules/.bin/tsc, and stub out PATH lookup so this
+    // assertion doesn't depend on whether the host machine happens to have
+    // a global `tsc` installed.
+    const whichSpy = spyOn(WhichModule, "which").mockReturnValue(null)
+    try {
+      const flags = await defaultFlags()
+      const handle = await LSPServer.Typescript.spawn(root, makeCtx(root), flags)
+      expect(handle).toBeUndefined()
+    } finally {
+      resolveSpy.mockRestore()
+      whichSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #39928

### Type of change

- [x] Bug fix

### What does this PR do?

typescript@7 (native Go port) dropped `lib/tsserver.js` and `bin/tsserver` in favor of its own `tsc --lsp` mode, and locked down its package `exports` map so those paths are no longer resolvable at all (`ERR_PACKAGE_PATH_NOT_EXPORTED`) even via `require.resolve`. `typescript-language-server` depends on `tsserver`, so it silently fails to attach for any project pinned to typescript@7+, leaving TS/JS files with no diagnostics (#39928).

This falls back to spawning the project's local `tsc --lsp -stdio` directly when `tsserver.js` can't be resolved (i.e. typescript@7+), resolving the binary from `node_modules/.bin/tsc` first, then PATH — matching the existing local-then-global fallback pattern already used by `Biome`/`Oxlint`/`Vue` in the same file.

### How did you verify your code works?

- `bun run typecheck` (via `turbo`, all 30 packages) passes.
- Manually confirmed `typescript@7.0.2`'s `package.json` exports map excludes `./bin/tsc` and `./lib/tsc.js`, and that `tsc --lsp -stdio` speaks plain LSP over stdio (confirmed via `tsc --lsp --help`).
- Repro'd the original issue locally: `bun install -d typescript@7` in a scratch project — before this change, no diagnostics; after, diagnostics come through via the native `tsc --lsp` server.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR