### PR TITLE
fix(core): decode plugin tool input with the schema's own instance

### DIFF
--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -74,7 +74,34 @@ const validateInput = (
   return Effect.gen(function* () {
     const codec = Schema.isSchema(schema) ? schema : yield* Cache.get(jsonSchemas, schema)
     if (codec === undefined) return { value }
-    return yield* Schema.decodeUnknownEffect(codec)(value, { errors: "all" }).pipe(
+    const decode = Schema.decodeUnknownEffect(codec)(value, { errors: "all" })
+    // Effect schemas are version-coupled to the effect instance that created them. A config
+    // plugin bundling a different effect version than the server still passes the host
+    // `isSchema` check (the `~effect/Schema/Schema` TypeId string is stable across versions),
+    // but the host decoder cannot interpret the foreign AST and rejects even valid inputs.
+    // The schema's own constructor (`makeEffect`) validates with the schema's own instance,
+    // so fall back to it when the host decode fails. This is only safe when the schema has
+    // no transformations or decoding defaults (make view === decoded view); for transformed
+    // schemas the make view is the type side, so the fallback could silently accept input
+    // that decode would reject.
+    if (Schema.isSchema(schema) && !hasTransformations(schema)) {
+      return yield* decode.pipe(
+        Effect.matchEffect({
+          onFailure: (error) =>
+            schema.makeEffect(value).pipe(
+              Effect.matchEffect({
+                // The fallback only helps when the schema's own instance accepts the input
+                // (foreign-effect-version schemas whose AST the host cannot interpret). When
+                // it also rejects, keep the host decode's normalized error format.
+                onFailure: () => Effect.succeed(formatEffectIssues(error.issue)),
+                onSuccess: (decoded) => Effect.succeed({ value: decoded }),
+              }),
+            ),
+          onSuccess: (value) => Effect.succeed({ value }),
+        }),
+      )
+    }
+    return yield* decode.pipe(
       Effect.match({
         onFailure: (error) => formatEffectIssues(error.issue),
         onSuccess: (value) => ({ value }),
@@ -103,6 +130,43 @@ const jsonSchema = (schema: JsonSchema.JsonSchema) => {
       ? JsonSchema.fromSchemaDraft07(schema)
       : JsonSchema.fromSchemaDraft2020_12(schema)
   return Schema.make<Schema.Codec<unknown>>(SchemaRepresentation.fromJsonSchemaDocument(draft).ast)
+}
+
+const hasTransformations = (schema: Tool.ValueSchema<any>) => {
+  // A schema AST carries an `encoding` node only when it transforms or defaults a value
+  // between its encoded and type views. Transformations can be nested inside containers
+  // (struct fields, array elements, unions, tuples, records), so walk the AST. Recursive
+  // schemas reuse node objects, so track visited nodes to terminate. Inspecting the AST can
+  // itself throw for schemas with decoding defaults, so treat any inspection failure as
+  // "has transformations" and keep the plain host decode (never use the fallback) there.
+  try {
+    const ast = (schema as { ast?: unknown }).ast
+    if (typeof ast !== "object" || ast === null) return true
+    const visited = new Set<unknown>()
+    const walk = (node: unknown): boolean => {
+      if (typeof node !== "object" || node === null || visited.has(node)) return false
+      visited.add(node)
+      const record = node as Record<string, unknown>
+      if (record.encoding !== undefined) return true
+      const signatures = record.propertySignatures
+      if (Array.isArray(signatures))
+        for (const signature of signatures)
+          if (walk((signature as { type?: unknown }).type)) return true
+      const indexSignatures = record.indexSignatures
+      if (Array.isArray(indexSignatures))
+        for (const signature of indexSignatures)
+          if (walk((signature as { type?: unknown }).type)) return true
+      if (Array.isArray(record.types)) for (const type of record.types) if (walk(type)) return true
+      if (Array.isArray(record.elements)) for (const element of record.elements) if (walk(element)) return true
+      if (record.type !== undefined && walk(record.type)) return true
+      if (record.key !== undefined && walk(record.key)) return true
+      if (record.value !== undefined && walk(record.value)) return true
+      return false
+    }
+    return walk(ast)
+  } catch {
+    return true
+  }
 }
 
 const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -400,3 +400,50 @@ test("missing external input schemas fall back to an empty schema", () => {
     inputSchema: {},
   })
 })
+
+test("decodes tool input through the schema's own instance when the host decoder cannot interpret it", async () => {
+  const schema = Schema.Struct({ value: Schema.String })
+  // Simulate an effect-version drift: a plugin bundles a different effect version than the
+  // server. The host `isSchema` check still passes (the `~effect/Schema/Schema` TypeId string
+  // is stable across versions) but the host decoder cannot interpret the foreign AST and
+  // rejects even valid inputs with a generic error. The schema's own constructor stays
+  // consistent with the schema, so the runtime falls back to it.
+  const drifted = Object.assign(Object.create(Object.getPrototypeOf(schema)) as typeof schema, {
+    ...schema,
+    ast: Schema.String.ast,
+  })
+  const tool: Info = {
+    name: "drifted",
+    description: "Drifted",
+    input: drifted,
+    execute: (input) => Effect.succeed({ content: JSON.stringify(input) }),
+  }
+
+  // Valid input: the host decode fails on the drifted AST, the schema's own instance accepts.
+  const settled = await Effect.runPromiseExit(execute(tool, { value: "ok" }, {} as Tool.Context))
+  expect(settled._tag).toBe("Success")
+  if (settled._tag === "Success") {
+    expect(settled.value.content).toEqual([{ type: "text", text: '{"value":"ok"}' }])
+  }
+
+  // Invalid input: the fallback also rejects, surfacing a Tool.Error instead of accepting.
+  const rejected = await Effect.runPromiseExit(execute(tool, { value: 123 }, {} as Tool.Context))
+  expect(rejected._tag).toBe("Failure")
+  if (rejected._tag === "Failure") {
+    expect(rejected.cause.toString()).toContain("Invalid arguments for tool")
+  }
+
+  // The same-host schema keeps its prior behavior: valid input decodes, invalid input fails.
+  const normal: Info = {
+    name: "normal",
+    description: "Normal",
+    input: schema,
+    execute: (input) => Effect.succeed({ content: JSON.stringify(input) }),
+  }
+  expect(await Effect.runPromise(execute(normal, { value: "ok" }, {} as Tool.Context))).toEqual({
+    output: undefined,
+    content: [{ type: "text", text: '{"value":"ok"}' }],
+  })
+  const normalRejected = await Effect.runPromiseExit(execute(normal, { value: 123 }, {} as Tool.Context))
+  expect(normalRejected._tag).toBe("Failure")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #43322

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a config plugin bundles a different `effect` version than the server, every tool input decode failed with `Invalid tool input: Expected object` — input-independent, for every tool, until the plugin's `effect` was manually realigned. Root cause: the plugin's schema still passes the host `Schema.isSchema` check (the `~effect/Schema/Schema` TypeId string is stable across versions), so `decodeInput` ran the **host's** `Schema.decodeUnknownEffect` on the **foreign** AST, which the host decoder cannot interpret.

This PR makes `decodeInput` in `packages/core/src/tool/runtime.ts` fall back to the schema's **own constructor** (`schema.makeEffect`), which validates with the schema's own instance and is therefore version-agnostic:

- The host decode runs first, preserving existing behavior and error text for the server's own schemas.
- On host-decode failure, the schema's own constructor validates the value: it only succeeds when the failure was schema drift rather than an invalid input, so genuine invalid inputs are still rejected with a `Tool.Error`.
- The fallback is gated by a new `hasTransformations` helper that walks the schema AST for `encoding` nodes (struct fields, arrays, unions, tuples, records). Schemas with transformations or decoding defaults keep the plain host decode, because their `make` view (type side) differs from their decoded view — a naive fallback there could silently accept input the decoder would reject. Inspection failures (e.g. decoding-default schemas whose AST accessor throws) also keep the plain path.

Reproduced and verified end-to-end against a real foreign schema built with `effect@4.0.0-beta.101` loaded into the `beta.107` server: valid input now decodes successfully (previously `Expected object`), and invalid input is rejected with `Invalid tool input: Expected number, got "no" at ["bar"]`.

The `encodeOutput` path has the same theoretical drift exposure for plugin tools that declare output schemas, but effect schemas expose no version-agnostic encode primitive on the instance, so that is left as a follow-up.

### How did you verify your code works?

- `bun test ./test/tool-schema.test.ts` from `packages/core`: 10 passed, including a new regression test that simulates a drifted schema (mutated AST the host decoder rejects while the schema's own constructor still validates) and asserts valid input decodes, invalid input is rejected, and same-host schemas behave unchanged.
- Existing transformed-codec test (`session-runner-tool-registry.test.ts`) passes unchanged — it guards the no-fallback-for-transforms gate.
- `bun test` from `packages/core`: 1891 passed, 16 skipped, 0 failed.
- `bun typecheck` from `packages/core` and repo-wide `bun typecheck` (33 tasks): passed.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
