### PR TITLE
fix(cli): bound managed service shutdown

### DIFF
--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -41,11 +41,21 @@ export const run = Effect.fnUntraced(function* (options: Options) {
 
 const processEffect = Effect.fnUntraced(function* (options: Options) {
   const global = yield* Global.Service
+  const shutdownWatchdogs = new Set<ReturnType<typeof setTimeout>>()
   if (options.mode === "service") yield* Effect.sync(() => process.chdir(global.home))
   return yield* Effect.scoped(
     Effect.gen(function* () {
       const foreground = options.mode === "default"
       const serviceOptions = options.mode === "service" ? yield* ServiceConfig.options() : undefined
+      // A native timer can still fire when an Effect finalizer never completes.
+      if (serviceOptions !== undefined)
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            const watchdog = setTimeout(() => process.exit(1), 10_000)
+            watchdog.unref()
+            shutdownWatchdogs.add(watchdog)
+          }),
+        )
       const config = options.mode === "service" ? yield* ServiceConfig.read() : {}
       const hostname = options.hostname ?? config.hostname ?? "127.0.0.1"
       const port = options.port ?? config.port ?? (options.mode === "service" ? ServiceConfig.defaultPort() : undefined)
@@ -154,7 +164,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           ? waitForStdinClose()
           : Effect.never
     }).pipe(Effect.annotateLogs({ role: "server" })),
-  )
+  ).pipe(Effect.ensuring(Effect.sync(() => shutdownWatchdogs.forEach(clearTimeout))))
 })
 
 const infoJson = Schema.fromJsonString(Service.Info)


### PR DESCRIPTION
## Summary

- arm a native 10-second watchdog when a managed service begins shutdown
- force the daemon to exit if an Effect finalizer remains stuck
- clear the watchdog after successful shutdown so embedded callers are unaffected

## Testing

- `bun typecheck` in `packages/cli`
- repository pre-push typecheck: 33 packages passed
- `bun test test/service.test.ts -t "clean managed service shutdown removes its registration"`
- `bun test test/service.test.ts -t "deleting a managed service registration stops its owner"`