### PR TITLE
refactor(core): move location watcher config into state

### DIFF
--- a/packages/core/src/config/plugin/location-watcher.ts
+++ b/packages/core/src/config/plugin/location-watcher.ts
@@ -1,0 +1,31 @@
+export * as ConfigLocationWatcherPlugin from "./location-watcher.js"
+
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Effect, Stream } from "effect"
+import { Config } from "../../config.js"
+import { LocationWatcherPolicy } from "../../filesystem/location-watcher-policy.js"
+
+export const Plugin = define({
+  id: "opencode.config.location-watcher",
+  effect: Effect.fn(function* (ctx) {
+    const config = yield* Config.Service
+    const policy = yield* LocationWatcherPolicy.Service
+    const loaded = { entries: yield* config.entries() }
+    const reload = config.entries().pipe(
+      Effect.tap((entries) => Effect.sync(() => (loaded.entries = entries))),
+      Effect.andThen(policy.reload()),
+    )
+    yield* ctx.event.subscribe().pipe(
+      Stream.filter((event) => event.type === "config.updated"),
+      Stream.runForEach(() => reload),
+      Effect.forkScoped({ startImmediately: true }),
+    )
+    loaded.entries = yield* config.entries()
+    yield* policy.transform((draft) => {
+      for (const entry of loaded.entries) {
+        if (entry.type !== "document" || !entry.info.watcher?.ignore) continue
+        draft.add(entry.info.watcher.ignore)
+      }
+    })
+  }),
+})

--- a/packages/core/src/filesystem/location-watcher-policy.ts
+++ b/packages/core/src/filesystem/location-watcher-policy.ts
@@ -1,0 +1,65 @@
+export * as LocationWatcherPolicy from "./location-watcher-policy.js"
+
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Context, Effect, Layer, Scope } from "effect"
+import { State } from "../state.js"
+
+type Data = {
+  ignore: string[]
+}
+
+export type Draft = {
+  add: (ignore: readonly string[]) => void
+  list: () => readonly string[]
+}
+
+export interface Interface extends State.Transformable<Draft> {
+  readonly current: () => readonly string[]
+  readonly observe: (
+    listener: (ignore: readonly string[]) => Effect.Effect<void>,
+  ) => Effect.Effect<State.Registration, never, Scope.Scope>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/LocationWatcherPolicy") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    let current: readonly string[] = []
+    const listeners = new Set<(ignore: readonly string[]) => Effect.Effect<void>>()
+    const state = State.create<Data, Draft>({
+      name: "location-watcher-policy",
+      initial: () => ({ ignore: [] }),
+      draft: (draft) => ({
+        add: (ignore) => draft.ignore.push(...ignore),
+        list: () => draft.ignore,
+      }),
+      finalize: (draft) =>
+        Effect.sync(() => {
+          current = [...draft.list()]
+        }).pipe(Effect.andThen(Effect.forEach(listeners, (listener) => listener(current), { discard: true }))),
+    })
+    const observe = Effect.fn("LocationWatcherPolicy.observe")(function* (
+      listener: (ignore: readonly string[]) => Effect.Effect<void>,
+    ) {
+      const scope = yield* Scope.Scope
+      let active = true
+      const dispose = Effect.sync(() => {
+        if (!active) return
+        active = false
+        listeners.delete(listener)
+      })
+      listeners.add(listener)
+      yield* Scope.addFinalizer(scope, dispose)
+      return { dispose }
+    })
+    return Service.of({
+      transform: state.transform,
+      reload: state.reload,
+      current: () => current,
+      observe,
+    })
+  }),
+)
+
+export const node = makeLocationNode({ service: Service, layer, deps: [] })

--- a/packages/core/src/filesystem/location-watcher.ts
+++ b/packages/core/src/filesystem/location-watcher.ts
@@ -1,15 +1,15 @@
 export * as LocationWatcher from "./location-watcher.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Effect, Layer, Stream } from "effect"
+import { Cause, Context, Effect, Exit, Layer, Scope, Semaphore, Stream } from "effect"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
-import { Document } from "@opencode-ai/schema/config"
 import path from "path"
-import { Config } from "../config.js"
 import { Bus } from "../bus.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "../git.js"
 import { Location } from "../location.js"
+import { PluginSupervisor } from "../plugin/supervisor.js"
+import { LocationWatcherPolicy } from "./location-watcher-policy.js"
 import { Watcher } from "./watcher.js"
 
 export interface Interface {}
@@ -24,42 +24,86 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const git = yield* Git.Service
-    const configService = yield* Config.Service
+    const plugins = yield* PluginSupervisor.Service
+    const policy = yield* LocationWatcherPolicy.Service
     const publish = (update: { type: "create" | "update" | "delete"; path: string }) =>
       bus.publish(FileSystem.Event.Changed, {
         file: update.path,
         event: update.type === "create" ? "add" : update.type === "update" ? "change" : "unlink",
       })
-
-    yield* Effect.gen(function* () {
-      const config = (yield* configService.entries())
-        .filter((entry): entry is Document => entry.type === "document")
-        .flatMap((item) => item.info.watcher?.ignore ?? [])
-
-      if (location.vcs?.type === "git") {
-        const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory
-        const vcs = resolved
-          ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
-          : undefined
-        if (vcs && !config.includes(".git") && !config.includes(vcs) && (!resolved || !config.includes(resolved))) {
-          const updates = yield* watcher.subscribe({ path: path.join(vcs, "HEAD"), type: "file" })
-          yield* updates.pipe(Stream.runForEach(publish), Effect.forkScoped)
+    const target = yield* Effect.cached(
+      Effect.gen(function* () {
+        if (location.vcs?.type === "git") {
+          const resolved = (yield* git.repo.discover(location.directory))?.gitDirectory
+          const vcs = resolved
+            ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
+            : undefined
+          if (vcs) return { path: path.join(vcs, "HEAD"), aliases: [".git", vcs, ...(resolved ? [resolved] : [])] }
         }
-      }
-      if (location.vcs?.type === "hg") {
-        const store = location.vcs.store
-        const vcs = yield* fs.realPath(store).pipe(Effect.catch(() => Effect.succeed(store)))
-        if (!config.includes(".hg") && !config.includes(vcs)) {
-          const updates = yield* watcher.subscribe({ path: path.join(vcs, "branch"), type: "file" })
-          yield* updates.pipe(Stream.runForEach(publish), Effect.forkScoped)
+        if (location.vcs?.type === "hg") {
+          const store = location.vcs.store
+          const vcs = yield* fs.realPath(store).pipe(Effect.catch(() => Effect.succeed(store)))
+          return { path: path.join(vcs, "branch"), aliases: [".hg", vcs] }
         }
-      }
-    }).pipe(
-      Effect.withSpan("LocationWatcher.start", { attributes: { directory: location.directory } }),
-      Effect.catchCause((cause) => Effect.logError("failed to init location watcher service", { cause })),
-      Effect.forkScoped,
+      }).pipe(
+        Effect.withSpan("LocationWatcher.target", { attributes: { directory: location.directory } }),
+        Effect.catchCause((cause) =>
+          Effect.logError("failed to resolve location watcher target", { cause }).pipe(Effect.as(undefined)),
+        ),
+      ),
     )
-
+    const lock = Semaphore.makeUnsafe(1)
+    let requested = 0
+    let stopped = false
+    let active: { path: string; scope: Scope.Closeable } | undefined
+    const reconcile = (ignore: readonly string[]) => {
+      const request = ++requested
+      return lock.withPermit(
+        Effect.gen(function* () {
+          if (stopped || request !== requested) return
+          const resolved = yield* target
+          if (stopped || request !== requested) return
+          const next = resolved && !resolved.aliases.some((alias) => ignore.includes(alias)) ? resolved.path : undefined
+          if (active?.path === next) return
+          if (active) yield* Scope.close(active.scope, Exit.void)
+          active = undefined
+          if (!next) return
+          const scope = yield* Scope.make()
+          active = { path: next, scope }
+          yield* Effect.gen(function* () {
+            const updates = yield* watcher.subscribe({ path: next, type: "file" })
+            yield* Stream.runForEach(updates, publish)
+          }).pipe(
+            Effect.catchCauseIf(
+              (cause) => !Cause.hasInterrupts(cause),
+              (cause) => Effect.logError("location watcher subscription failed", { path: next, cause }),
+            ),
+            Effect.forkIn(scope, { startImmediately: true }),
+          )
+        }).pipe(Effect.withSpan("LocationWatcher.reconcile", { attributes: { directory: location.directory } })),
+      )
+    }
+    yield* Effect.addFinalizer(() =>
+      lock.withPermit(
+        Effect.gen(function* () {
+          stopped = true
+          requested++
+          if (active) yield* Scope.close(active.scope, Exit.void)
+          active = undefined
+        }),
+      ),
+    )
+    yield* policy.observe(reconcile)
+    yield* Effect.gen(function* () {
+      yield* plugins.flush
+      yield* reconcile(policy.current())
+    }).pipe(
+      Effect.catchCauseIf(
+        (cause) => !Cause.hasInterrupts(cause),
+        (cause) => Effect.logError("failed to start location watcher", { cause }),
+      ),
+      Effect.forkScoped({ startImmediately: true }),
+    )
     return Service.of({})
   }),
 )
@@ -67,5 +111,13 @@ const layer = Layer.effect(
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Watcher.node, FSUtil.node, Location.node, Config.node, Git.node, Bus.node],
+  deps: [
+    Watcher.node,
+    FSUtil.node,
+    Location.node,
+    Git.node,
+    Bus.node,
+    PluginSupervisor.node,
+    LocationWatcherPolicy.node,
+  ],
 })

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -17,6 +17,7 @@ import { ConfigCompactionPlugin } from "../config/plugin/compaction.js"
 import { ConfigFormatterPlugin } from "../config/plugin/formatter.js"
 import { ConfigImagePlugin } from "../config/plugin/image.js"
 import { ConfigInstructionPlugin } from "../config/plugin/instruction.js"
+import { ConfigLocationWatcherPlugin } from "../config/plugin/location-watcher.js"
 import { ConfigMCPPlugin } from "../config/plugin/mcp.js"
 import { ConfigProviderPlugin } from "../config/plugin/provider.js"
 import { ConfigPolicyPlugin } from "../config/plugin/policy.js"
@@ -33,6 +34,7 @@ import { FileMutation } from "../file-mutation.js"
 import { Formatter } from "../formatter.js"
 import { Form } from "../form.js"
 import { FileSystem } from "../filesystem.js"
+import { LocationWatcherPolicy } from "../filesystem/location-watcher-policy.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { Image } from "../image.js"
@@ -98,6 +100,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const environment = yield* Environment.Service
   const mutation = yield* FileMutation.Service
   const formatter = yield* Formatter.Service
+  const locationWatcherPolicy = yield* LocationWatcherPolicy.Service
   const filesystem = yield* FileSystem.Service
   const fs = yield* FSUtil.Service
   const global = yield* Global.Service
@@ -141,6 +144,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Environment.Service, environment),
     Context.make(FileMutation.Service, mutation),
     Context.make(Formatter.Service, formatter),
+    Context.make(LocationWatcherPolicy.Service, locationWatcherPolicy),
     Context.make(FileSystem.Service, filesystem),
     Context.make(FSUtil.Service, fs),
     Context.make(Global.Service, global),
@@ -191,6 +195,7 @@ export const requirements = LayerNode.group([
   Environment.node,
   FileMutation.node,
   Formatter.node,
+  LocationWatcherPolicy.node,
   FileSystem.node,
   FSUtil.node,
   Global.node,
@@ -261,6 +266,7 @@ const post = [
   ConfigCompactionPlugin.Plugin,
   ConfigFormatterPlugin.Plugin,
   ConfigImagePlugin.Plugin,
+  ConfigLocationWatcherPlugin.Plugin,
   ConfigShellPlugin.Plugin,
   ConfigSnapshotPlugin.Plugin,
   ConfigToolOutputPlugin.Plugin,

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -4,18 +4,24 @@ import fs from "fs/promises"
 import path from "path"
 import { Deferred, Duration, Effect, Fiber, Layer, Option, Schedule, Stream } from "effect"
 import { Config } from "@opencode-ai/core/config"
+import { ConfigLocationWatcherPlugin } from "@opencode-ai/core/config/plugin/location-watcher"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { makeLocationNode, type LocationNode } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { LocationWatcher } from "@opencode-ai/core/filesystem/location-watcher"
+import { LocationWatcherPolicy } from "@opencode-ai/core/filesystem/location-watcher-policy"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
+import { Document, Event, Info, type Entry } from "@opencode-ai/schema/config"
 import { Location } from "@opencode-ai/core/location"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
+import { host } from "../plugin/host"
 
 type WatcherEvent = { file: string; event: "add" | "change" | "unlink" }
 const describeNative = process.env.CI ? describe.skip : describe
@@ -23,6 +29,11 @@ const describeNative = process.env.CI ? describe.skip : describe
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([FSUtil.node, Bus.node])))
 
 const configLayer = Config.testLayer()
+const pluginNode = makeLocationNode({
+  service: PluginSupervisor.Service,
+  layer: Layer.succeed(PluginSupervisor.Service, PluginSupervisor.Service.of({ flush: Effect.void })),
+  deps: [],
+})
 
 describe("Watcher.testLayer", () => {
   it.effect("records subscriptions and broadcasts emitted updates through the service", () =>
@@ -135,16 +146,26 @@ describe("Watcher lifecycle", () => {
   })
 })
 
-function provide(directory: string, vcs?: Location.Interface["vcs"], watcher?: Layer.Layer<Watcher.Service>) {
+function provide(
+  directory: string,
+  vcs?: Location.Interface["vcs"],
+  watcher?: Layer.Layer<Watcher.Service>,
+  config: Layer.Layer<Config.Service> = configLayer,
+  plugins: LocationNode<PluginSupervisor.Service> = pluginNode,
+) {
   const locationLayer = Layer.succeed(
     Location.Service,
     Location.Service.of(location({ directory: AbsolutePath.make(directory) }, { vcs })),
   )
-  const built = AppNodeBuilder.build(LocationWatcher.node, [
-    [Config.node, configLayer],
-    [Location.node, locationLayer],
-    ...(watcher ? ([[Watcher.node, watcher]] as const) : []),
-  ])
+  const built = AppNodeBuilder.build(
+    LayerNode.group([LocationWatcher.node, LocationWatcherPolicy.node, Bus.node, Config.node]),
+    [
+      [Config.node, config],
+      [Location.node, locationLayer],
+      [PluginSupervisor.node, plugins],
+      ...(watcher ? ([[Watcher.node, watcher]] as const) : []),
+    ],
+  )
   return Effect.provide(built)
 }
 
@@ -154,6 +175,8 @@ function withTmp<A, E, R>(
     vcs?: "git" | "hg"
     init?: (directory: string) => Promise<void>
     watcher?: Layer.Layer<Watcher.Service>
+    config?: Layer.Layer<Config.Service>
+    plugins?: LocationNode<PluginSupervisor.Service>
   },
 ) {
   return Effect.acquireRelease(
@@ -174,7 +197,11 @@ function withTmp<A, E, R>(
       return { tmp, vcs: { type: "git" as const, store: AbsolutePath.make(path.join(tmp.path, ".git")) } }
     }),
     ({ tmp }) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ).pipe(Effect.flatMap(({ tmp, vcs }) => f(tmp.path, vcs).pipe(provide(tmp.path, vcs, options?.watcher))))
+  ).pipe(
+    Effect.flatMap(({ tmp, vcs }) =>
+      f(tmp.path, vcs).pipe(provide(tmp.path, vcs, options?.watcher, options?.config ?? configLayer, options?.plugins)),
+    ),
+  )
 }
 
 describe("LocationWatcher subscriptions", () => {
@@ -221,6 +248,107 @@ describe("LocationWatcher subscriptions", () => {
           expect(subscriptions).toEqual([{ path: path.join(directory, ".hg", "branch"), type: "file" }])
         }),
       { vcs: "hg", watcher },
+    )
+  })
+
+  it.live("reconciles config without duplicate subscriptions", () => {
+    const entries = { current: [] as Entry[] }
+    const subscriptions: Watcher.WatchInput[] = []
+    const counts = { active: 0, released: 0 }
+    const watcher = Layer.succeed(
+      Watcher.Service,
+      Watcher.Service.of({
+        subscribe: (input) =>
+          Effect.sync(() => {
+            subscriptions.push(input)
+            counts.active++
+            return Stream.never.pipe(
+              Stream.ensuring(
+                Effect.sync(() => {
+                  counts.active--
+                  counts.released++
+                }),
+              ),
+            )
+          }),
+      }),
+    )
+    const config = Layer.succeed(
+      Config.Service,
+      Config.Service.of({
+        entries: () => Effect.sync(() => entries.current),
+        update: () => Effect.die("unused config.update"),
+        changes: () => Stream.never,
+      }),
+    )
+    return Effect.gen(function* () {
+      yield* withTmp(
+        () =>
+          Effect.gen(function* () {
+            const policy = yield* LocationWatcherPolicy.Service
+            const bus = yield* Bus.Service
+            yield* Effect.sync(() => subscriptions.length).pipe(
+              Effect.filterOrFail((count) => count === 1),
+              Effect.retry(Schedule.spaced("10 millis")),
+            )
+            expect(counts.active).toBe(1)
+
+            entries.current = [new Document({ type: "document", info: new Info({ watcher: { ignore: [".git"] } }) })]
+            yield* ConfigLocationWatcherPlugin.Plugin.effect(
+              host({ event: { subscribe: () => bus.subscribe(Event.Updated) } }),
+            )
+            yield* Effect.sync(() => counts.active).pipe(
+              Effect.filterOrFail((count) => count === 0),
+              Effect.retry(Schedule.spaced("10 millis")),
+            )
+            expect(counts.released).toBe(1)
+
+            entries.current = []
+            yield* bus.publish(Event.Updated, {})
+            yield* Effect.sync(() => subscriptions.length).pipe(
+              Effect.filterOrFail((count) => count === 2),
+              Effect.retry(Schedule.spaced("10 millis")),
+            )
+            expect(counts.active).toBe(1)
+
+            yield* policy.reload()
+            expect(subscriptions).toHaveLength(2)
+          }),
+        { vcs: "git", watcher, config },
+      )
+      expect(counts.active).toBe(0)
+      expect(counts.released).toBe(2)
+    })
+  })
+
+  it.live("does not start before configured policy is ready", () => {
+    const subscriptions: Watcher.WatchInput[] = []
+    const watcher = Layer.succeed(
+      Watcher.Service,
+      Watcher.Service.of({
+        subscribe: (input) => Effect.sync(() => subscriptions.push(input)).pipe(Effect.as(Stream.never)),
+      }),
+    )
+    const plugins = makeLocationNode({
+      service: PluginSupervisor.Service,
+      layer: Layer.effect(
+        PluginSupervisor.Service,
+        Effect.gen(function* () {
+          const policy = yield* LocationWatcherPolicy.Service
+          yield* policy.transform((draft) => draft.add([".git"]))
+          return PluginSupervisor.Service.of({ flush: Effect.void })
+        }),
+      ),
+      deps: [LocationWatcherPolicy.node],
+    })
+    return withTmp(
+      () =>
+        Effect.gen(function* () {
+          yield* LocationWatcher.Service
+          yield* Effect.sleep("50 millis")
+          expect(subscriptions).toEqual([])
+        }),
+      { vcs: "git", watcher, plugins },
     )
   })
 })


### PR DESCRIPTION
## summary
- move watcher ignore projection into passive reloadable policy state
- keep the side-effecting location watcher boot-last and non-blocking
- reconcile one scoped Git or Hg metadata subscription without duplicates or leaks
- remove the LocationWatcher dependency on Config

## testing
- bun typecheck from packages/core
- bun test test/filesystem/watcher.test.ts
- bun test test/filesystem/watcher.test.ts --test-name-pattern "LocationWatcher subscriptions" --rerun-each 10
- bun test test/location-layer.test.ts
- bun test test/workerd.test.ts from packages/server
- pre-push monorepo typecheck