### PR TITLE
feat(ci): enable nix-hashes ci in v2 branch

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [dev, beta]
+    branches: [dev, beta, v2]
     paths:
       - "bun.lock"
       - "package.json"


### PR DESCRIPTION
### Issue for this PR

Closes #36328

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Without this, using flake on the v2 branch will be impossible.  The current hash is simply recalculated

### How did you verify your code works?

Just run ci

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
