### PR TITLE
fix(provider): strip trailing slash from model name strings

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -31,7 +31,7 @@ export type MutableInfo = Omit<Types.DeepMutable<Info>, "api"> & {
 }
 
 export function parse(input: string): { providerID: ProviderV2.ID; modelID: ID } {
-  const [providerID, ...modelID] = input.split("/")
+  const [providerID, ...modelID] = input.replace(/\/+$/, "").split("/")
   return {
     providerID: ProviderV2.ID.make(providerID),
     modelID: ID.make(modelID.join("/")),

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -21,3 +21,17 @@ describe("ModelV2.Ref", () => {
     })
   })
 })
+
+describe("ModelV2.parse", () => {
+  test("parses provider/model string", () => {
+    const result = ModelV2.parse("anthropic/claude-sonnet-4")
+    expect(String(result.providerID)).toBe("anthropic")
+    expect(String(result.modelID)).toBe("claude-sonnet-4")
+  })
+
+  test("strips trailing slash", () => {
+    const result = ModelV2.parse("anthropic/claude-sonnet-4/")
+    expect(String(result.providerID)).toBe("anthropic")
+    expect(String(result.modelID)).toBe("claude-sonnet-4")
+  })
+})

--- a/packages/opencode/src/acp/config-option.ts
+++ b/packages/opencode/src/acp/config-option.ts
@@ -113,9 +113,10 @@ export function buildConfigOptions(input: {
 }
 
 export function parseModelSelection(modelId: string, providers: readonly ConfigOptionProvider[]): ModelSelection {
-  const provider = providers.find((item) => modelId.startsWith(`${item.id}/`))
+  const trimmed = modelId.replace(/\/+$/, "")
+  const provider = providers.find((item) => trimmed.startsWith(`${item.id}/`))
   if (provider) {
-    const modelID = modelId.slice(provider.id.length + 1)
+    const modelID = trimmed.slice(provider.id.length + 1)
     if (provider.models[modelID]) {
       return { model: { providerID: provider.id, modelID } }
     }
@@ -132,15 +133,15 @@ export function parseModelSelection(modelId: string, providers: readonly ConfigO
     return { model: { providerID: provider.id, modelID } }
   }
 
-  const separator = modelId.indexOf("/")
+  const separator = trimmed.indexOf("/")
   if (separator === -1) {
-    return { model: { providerID: modelId, modelID: "" } }
+    return { model: { providerID: trimmed, modelID: "" } }
   }
 
   return {
     model: {
-      providerID: modelId.slice(0, separator),
-      modelID: modelId.slice(separator + 1),
+      providerID: trimmed.slice(0, separator),
+      modelID: trimmed.slice(separator + 1),
     },
   }
 }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -30,7 +30,7 @@ type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
 
 function pick(value: string | undefined): ModelInput | undefined {
   if (!value) return undefined
-  const [providerID, ...rest] = value.split("/")
+  const [providerID, ...rest] = value.replace(/\/+$/, "").split("/")
   return {
     providerID,
     modelID: rest.join("/"),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -2026,7 +2026,7 @@ export function sort<T extends { id: string }>(models: T[]) {
 }
 
 export function parseModel(model: string) {
-  const [providerID, ...rest] = model.split("/")
+  const [providerID, ...rest] = model.replace(/\/+$/, "").split("/")
   return {
     providerID: ProviderV2.ID.make(providerID),
     modelID: ModelV2.ID.make(rest.join("/")),

--- a/packages/opencode/test/acp/config-option.test.ts
+++ b/packages/opencode/test/acp/config-option.test.ts
@@ -194,6 +194,12 @@ describe("acp config options", () => {
     })
   })
 
+  test("strips trailing slash from model selection", () => {
+    expect(parseModelSelection("openai/gpt-5/", providers)).toEqual({
+      model: { providerID: "openai", modelID: "gpt-5" },
+    })
+  })
+
   test("formats current model ids with and without selected variants", () => {
     expect(
       formatCurrentModelId({

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -347,6 +347,24 @@ test("parseModel handles model IDs with slashes", () => {
   expect(String(result.modelID)).toBe("anthropic/claude-3-opus")
 })
 
+test("parseModel strips trailing slash from model string", () => {
+  const result = Provider.parseModel("lmstudio/qwen3-4b/")
+  expect(String(result.providerID)).toBe("lmstudio")
+  expect(String(result.modelID)).toBe("qwen3-4b")
+})
+
+test("parseModel strips trailing slash from provider/model string", () => {
+  const result = Provider.parseModel("anthropic/claude-sonnet-4/")
+  expect(String(result.providerID)).toBe("anthropic")
+  expect(String(result.modelID)).toBe("claude-sonnet-4")
+})
+
+test("parseModel strips multiple trailing slashes", () => {
+  const result = Provider.parseModel("anthropic/claude-sonnet-4//")
+  expect(String(result.providerID)).toBe("anthropic")
+  expect(String(result.modelID)).toBe("claude-sonnet-4")
+})
+
 it.instance("defaultModel returns first available model when no config set", () =>
   Effect.gen(function* () {
     yield* setProcessEnv("ANTHROPIC_API_KEY", "test-api-key")

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -1,7 +1,7 @@
 import type { Provider } from "@opencode-ai/sdk/v2"
 
 export function parse(value: string) {
-  const [providerID, ...modelID] = value.split("/")
+  const [providerID, ...modelID] = value.replace(/\/+$/, "").split("/")
   return { providerID, modelID: modelID.join("/") }
 }
 

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -6,4 +6,8 @@ describe("util.model", () => {
     expect(parse("provider/org/model")).toEqual({ providerID: "provider", modelID: "org/model" })
     expect(parse("invalid")).toEqual({ providerID: "invalid", modelID: "" })
   })
+
+  test("strips trailing slash", () => {
+    expect(parse("provider/org/model/")).toEqual({ providerID: "provider", modelID: "org/model" })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #43473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Model names with trailing slashes (e.g. `qwen3-4b/`) caused lookup failures. When `parseModel("qwen3-4b/")` was called, `split("/")` produced an empty `modelID` (or a slash-bearing one for `provider/model/`), which never matched the keys in `provider.models`. This resulted in a `ModelNotFoundError` even though the model was correctly loaded and listed.

The fix strips trailing slashes with `.replace(/\/+$/, "")` before `.split("/")` in all model-string parse functions:

- `packages/opencode/src/provider/provider.ts` — `parseModel()`
- `packages/core/src/model.ts` — `parse()`
- `packages/tui/src/util/model.ts` — `parse()`
- `packages/opencode/src/cli/cmd/run.ts` — `pick()`
- `packages/opencode/src/acp/config-option.ts` — `parseModelSelection()` (trimmed once at top, used in all branches)

### How did you verify your code works?

Added tests for trailing-slash handling in all affected packages:

- `packages/opencode/test/provider/provider.test.ts` — 3 tests: trailing slash on model, trailing slash on provider/model, multiple trailing slashes
- `packages/core/test/model.test.ts` — 2 tests: basic parse, strips trailing slash
- `packages/tui/test/util/model.test.ts` — 1 test: strips trailing slash
- `packages/opencode/test/acp/config-option.test.ts` — 1 test: strips trailing slash from model selection

All tests pass.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR