### PR TITLE
feat(plugin): add HTTP routes support for webhook endpoints

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -1,6 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import type {
   Hooks,
+  HttpRoute,
   PluginInput,
   Plugin as PluginInstance,
   PluginModule,
@@ -35,6 +36,7 @@ import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
 type State = {
   hooks: Hooks[]
+  httpRoutes: HttpRoute[]
 }
 
 // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -54,6 +56,7 @@ export interface Interface {
   ) => Effect.Effect<Output>
   readonly list: () => Effect.Effect<Hooks[]>
   readonly init: () => Effect.Effect<void>
+  readonly getRoutes: () => Effect.Effect<HttpRoute[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Plugin") {}
@@ -109,16 +112,24 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
   return result
 }
 
-async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
+async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[], httpRoutes: HttpRoute[]) {
   const plugin = readV1Plugin(load.mod, load.spec, "server", "detect")
   if (plugin) {
     await resolvePluginId(load.source, load.spec, load.target, readPluginId(plugin.id, load.spec), load.pkg)
-    hooks.push(await (plugin as PluginModule).server(input, load.options))
+    const hook = await (plugin as PluginModule).server(input, load.options)
+    hooks.push(hook)
+    if (hook.http?.routes) {
+      httpRoutes.push(...hook.http.routes)
+    }
     return
   }
 
   for (const server of getLegacyPlugins(load.mod)) {
-    hooks.push(await server(input, load.options))
+    const hook = await server(input, load.options)
+    hooks.push(hook)
+    if (hook.http?.routes) {
+      httpRoutes.push(...hook.http.routes)
+    }
   }
 }
 
@@ -132,6 +143,7 @@ const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("Plugin.state")(function* (ctx) {
         const hooks: Hooks[] = []
+        const httpRoutes: HttpRoute[] = []
         const bridge = yield* EffectBridge.make()
 
         function publishPluginError(message: string) {
@@ -173,7 +185,12 @@ const layer = Layer.effect(
             Effect.tapError((error) => Effect.logError("failed to load internal plugin", { name: plugin.name, error })),
             Effect.option,
           )
-          if (init._tag === "Some") hooks.push(init.value)
+          if (init._tag === "Some") {
+            hooks.push(init.value)
+            if (init.value.http?.routes) {
+              httpRoutes.push(...init.value.http.routes)
+            }
+          }
         }
 
         const plugins = flags.pure ? [] : (cfg.plugin_origins ?? [])
@@ -220,7 +237,7 @@ const layer = Layer.effect(
           // Keep plugin execution sequential so hook registration and execution
           // order remains deterministic across plugin runs.
           yield* Effect.tryPromise({
-            try: () => applyPlugin(load, input, hooks),
+            try: () => applyPlugin(load, input, hooks, httpRoutes),
             catch: (err) => {
               const message = errorMessage(err)
               return message
@@ -275,7 +292,7 @@ const layer = Layer.effect(
           ),
         )
 
-        return { hooks }
+        return { hooks, httpRoutes }
       }),
     )
 
@@ -299,11 +316,16 @@ const layer = Layer.effect(
       return s.hooks
     })
 
+    const getRoutes = Effect.fn("Plugin.getRoutes")(function* () {
+      const s = yield* InstanceState.get(state)
+      return s.httpRoutes
+    })
+
     const init = Effect.fn("Plugin.init")(function* () {
       yield* InstanceState.get(state)
     })
 
-    return Service.of({ trigger, list, init })
+    return Service.of({ trigger, list, init, getRoutes })
   }),
 )
 

--- a/packages/opencode/src/server/plugin-routes.ts
+++ b/packages/opencode/src/server/plugin-routes.ts
@@ -1,0 +1,94 @@
+import type { HttpRoute } from "@opencode-ai/plugin"
+import { Effect } from "effect"
+import { HttpMiddleware, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import { Plugin } from "@/plugin"
+import { disposeMiddleware } from "./routes/instance/httpapi/lifecycle"
+
+/**
+ * Matches a route pattern against a pathname.
+ * Supports simple exact matching and path parameters (e.g., /webhook/:provider).
+ */
+function matchPath(pattern: string, pathname: string): { matched: boolean; params: Record<string, string> } {
+  const patternParts = pattern.split("/").filter(Boolean)
+  const pathParts = pathname.split("/").filter(Boolean)
+
+  if (patternParts.length !== pathParts.length) {
+    return { matched: false, params: {} }
+  }
+
+  const params: Record<string, string> = {}
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const patternPart = patternParts[i]!
+    const pathPart = pathParts[i]!
+
+    if (patternPart.startsWith(":")) {
+      // Path parameter
+      params[patternPart.slice(1)] = pathPart
+    } else if (patternPart !== pathPart) {
+      // Exact match failed
+      return { matched: false, params: {} }
+    }
+  }
+
+  return { matched: true, params }
+}
+
+/**
+ * Effect-based middleware that routes requests to plugin-defined HTTP handlers.
+ * If a matching route is found, the plugin handler is called and the response is returned.
+ * Otherwise, the request is passed to the next handler in the chain.
+ */
+export const pluginRoutesMiddleware: HttpMiddleware.HttpMiddleware = (effect) =>
+  Effect.gen(function* () {
+    const plugin = yield* Plugin.Service
+    const routes = yield* plugin.getRoutes()
+    const request = yield* HttpServerRequest.HttpServerRequest
+
+    const url = new URL(request.url)
+    const method = request.method.toUpperCase()
+
+    // Find matching route
+    for (const route of routes) {
+      if (route.method === method) {
+        const { matched, params } = matchPath(route.path, url.pathname)
+        if (matched) {
+          try {
+            // Convert HttpServerRequest to web Request and attach params
+            const webRequest = yield* HttpServerRequest.toWeb(request)
+            const requestWithParams = new Request(webRequest.url, {
+              method: webRequest.method,
+              headers: webRequest.headers,
+              body: webRequest.body,
+              // @ts-expect-error - Custom property for params
+              routeParams: params,
+            })
+            const response = yield* Effect.promise(() => Promise.resolve(route.handler(requestWithParams)))
+            return HttpServerResponse.fromWeb(response)
+          } catch (error) {
+            console.error(`Plugin route handler error: ${route.method} ${route.path}`, error)
+            return HttpServerResponse.jsonUnsafe({ error: "Internal server error" }, { status: 500 })
+          }
+        }
+      }
+    }
+
+    // No matching plugin route, pass to next handler
+    return yield* effect
+  })
+
+/**
+ * Helper to extract route params from a request.
+ * Use this in plugin handlers to access path parameters.
+ */
+export function getRouteParams(request: Request): Record<string, string> {
+  // @ts-expect-error - Custom property for params
+  return request.routeParams ?? {}
+}
+
+/**
+ * Composed middleware that first checks plugin routes, then applies disposal middleware.
+ * Use this as the middleware parameter for HttpRouter.toWebHandler or HttpRouter.serve.
+ */
+export const composedMiddleware: HttpMiddleware.HttpMiddleware = (effect) =>
+  pluginRoutesMiddleware(disposeMiddleware(effect))

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -109,6 +109,7 @@ import { workspaceHandlers } from "./handlers/workspace"
 import { instanceContextLayer } from "./middleware/instance-context"
 import { workspaceRoutingLayer } from "./middleware/workspace-routing"
 import { disposeMiddleware } from "./lifecycle"
+import { composedMiddleware } from "@/server/plugin-routes"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { compressionLayer } from "./middleware/compression"
 import { corsVaryFix } from "./middleware/cors-vary"
@@ -318,7 +319,7 @@ export const webHandler = lazy(() =>
   HttpRouter.toWebHandler(routes, {
     disableLogger: true,
     memoMap,
-    middleware: disposeMiddleware,
+    middleware: composedMiddleware,
   }),
 )
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -47,6 +47,7 @@ const brokenPluginLayer = Layer.succeed(
           },
         },
       ]),
+    getRoutes: () => Effect.succeed([]),
   }),
 )
 

--- a/packages/plugin/docs/http-routes.md
+++ b/packages/plugin/docs/http-routes.md
@@ -1,0 +1,155 @@
+# Plugin HTTP Routes
+
+This feature allows plugins to register custom HTTP endpoints on the main OpenCode server port.
+
+## Overview
+
+Plugins can now expose HTTP endpoints by defining routes in their `Hooks` object. These routes are registered on the same port as the main OpenCode API server, allowing plugins to receive webhooks and provide custom API endpoints without requiring additional ports or infrastructure.
+
+## Usage
+
+To register HTTP routes, add an `http` property to your plugin's `Hooks` object:
+
+```typescript
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+export default async function myPlugin(input: PluginInput): Promise<Hooks> {
+  return {
+    http: {
+      routes: [
+        {
+          method: "POST",
+          path: "/webhook/github",
+          handler: async (request: Request) => {
+            const payload = await request.json()
+            console.log("GitHub webhook received:", payload)
+            return new Response(JSON.stringify({ received: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" }
+            })
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Route Configuration
+
+Each route has the following properties:
+
+- `method`: HTTP method (`"GET"`, `"POST"`, `"PUT"`, `"DELETE"`, `"PATCH"`)
+- `path`: URL path (supports path parameters)
+- `handler`: Async function that receives a `Request` and returns a `Response`
+
+## Path Parameters
+
+Routes support path parameters using the `:paramName` syntax:
+
+```typescript
+{
+  method: "GET",
+  path: "/api/users/:id",
+  handler: async (request: Request) => {
+    const url = new URL(request.url)
+    const id = url.pathname.split("/")[3]
+    return new Response(JSON.stringify({ userId: id }))
+  }
+}
+```
+
+## Accessing the OpenCode Client
+
+Your plugin has access to the OpenCode SDK client through the `input` parameter:
+
+```typescript
+export default async function myPlugin(input: PluginInput): Promise<Hooks> {
+  const { client } = input
+  
+  return {
+    http: {
+      routes: [
+        {
+          method: "POST",
+          path: "/create-session",
+          handler: async (request: Request) => {
+            const session = await client.session.create()
+            return new Response(JSON.stringify(session), {
+              status: 201,
+              headers: { "Content-Type": "application/json" }
+            })
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Example: GitHub Webhook Integration
+
+Here's a complete example of a plugin that receives GitHub webhooks and creates OpenCode sessions:
+
+```typescript
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+export default async function githubWebhookPlugin(input: PluginInput): Promise<Hooks> {
+  const { client } = input
+  
+  return {
+    http: {
+      routes: [
+        {
+          method: "POST",
+          path: "/webhook/github",
+          handler: async (request: Request) => {
+            // Verify GitHub webhook signature
+            const signature = request.headers.get("x-hub-signature-256")
+            const body = await request.text()
+            
+            // TODO: Verify signature using crypto
+            
+            // Parse webhook payload
+            const payload = JSON.parse(body)
+            
+            // Handle different event types
+            const eventType = request.headers.get("x-github-event")
+            
+            if (eventType === "issues" && payload.action === "opened") {
+              // Create a new session for the issue
+              const session = await client.session.create()
+              
+              // Send a message to the session
+              await client.session.chat({
+                sessionId: session.id,
+                message: `Please help with GitHub issue #${payload.issue.number}: ${payload.issue.title}\n\n${payload.issue.body}`
+              })
+            }
+            
+            return new Response(JSON.stringify({ received: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" }
+            })
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Security Considerations
+
+When implementing webhook endpoints, consider the following security measures:
+
+1. **Verify signatures**: Always verify webhook signatures from services like GitHub, Stripe, etc.
+2. **Rate limiting**: Implement rate limiting to prevent abuse
+3. **Authentication**: Consider adding API key authentication for sensitive endpoints
+4. **Input validation**: Validate all incoming data before processing
+
+## Limitations
+
+- Routes are registered on the main server port and share the same authentication as the OpenCode API
+- Plugin routes are checked before the main API, so avoid paths that conflict with OpenCode's built-in routes
+- Each request to a plugin route is processed sequentially, so heavy operations should be offloaded to background tasks

--- a/packages/plugin/examples/webhook-plugin.ts
+++ b/packages/plugin/examples/webhook-plugin.ts
@@ -1,0 +1,158 @@
+// Example plugin demonstrating HTTP route registration for webhook endpoints
+// This plugin registers endpoints to receive webhooks from GitHub and GitLab
+
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+
+export default async function webhookPlugin(input: PluginInput): Promise<Hooks> {
+  const { client } = input
+
+  return {
+    http: {
+      routes: [
+        // GitHub webhook endpoint
+        {
+          method: "POST",
+          path: "/webhook/github",
+          handler: async (request: Request) => {
+            const signature = request.headers.get("x-hub-signature-256")
+            const eventType = request.headers.get("x-github-event")
+            const body = await request.text()
+
+            console.log(`[Webhook Plugin] GitHub ${eventType} event received`)
+
+            // TODO: Verify signature using crypto
+            // const secret = process.env.GITHUB_WEBHOOK_SECRET
+            // const expectedSignature = `sha256=${crypto.createHmac('sha256', secret).update(body).digest('hex')}`
+            // if (signature !== expectedSignature) {
+            //   return new Response("Invalid signature", { status: 401 })
+            // }
+
+            try {
+              const payload = JSON.parse(body)
+
+              // Handle different GitHub event types
+              if (eventType === "issues" && payload.action === "opened") {
+                const session = await client.session.create()
+                await client.session.chat({
+                  sessionId: session.id,
+                  message: `GitHub issue #${payload.issue.number} opened: ${payload.issue.title}\n\n${payload.issue.body}`,
+                })
+                console.log(`[Webhook Plugin] Created session ${session.id} for GitHub issue #${payload.issue.number}`)
+              } else if (eventType === "pull_request" && payload.action === "opened") {
+                const session = await client.session.create()
+                await client.session.chat({
+                  sessionId: session.id,
+                  message: `GitHub PR #${payload.pull_request.number} opened: ${payload.pull_request.title}\n\n${payload.pull_request.body}`,
+                })
+                console.log(`[Webhook Plugin] Created session ${session.id} for GitHub PR #${payload.pull_request.number}`)
+              }
+
+              return new Response(JSON.stringify({ received: true }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              })
+            } catch (error) {
+              console.error("[Webhook Plugin] Error processing GitHub webhook:", error)
+              return new Response("Internal server error", { status: 500 })
+            }
+          },
+        },
+
+        // GitLab webhook endpoint
+        {
+          method: "POST",
+          path: "/webhook/gitlab",
+          handler: async (request: Request) => {
+            const token = request.headers.get("x-gitlab-token")
+            const eventType = request.headers.get("x-gitlab-event")
+            const body = await request.text()
+
+            console.log(`[Webhook Plugin] GitLab ${eventType} event received`)
+
+            // TODO: Verify token
+            // const expectedToken = process.env.GITLAB_WEBHOOK_TOKEN
+            // if (token !== expectedToken) {
+            //   return new Response("Invalid token", { status: 401 })
+            // }
+
+            try {
+              const payload = JSON.parse(body)
+
+              // Handle different GitLab event types
+              if (eventType === "Issue Hook" && payload.object_attributes?.action === "open") {
+                const session = await client.session.create()
+                await client.session.chat({
+                  sessionId: session.id,
+                  message: `GitLab issue #${payload.object_attributes.iid} opened: ${payload.object_attributes.title}\n\n${payload.object_attributes.description}`,
+                })
+                console.log(`[Webhook Plugin] Created session ${session.id} for GitLab issue #${payload.object_attributes.iid}`)
+              } else if (eventType === "Merge Request Hook" && payload.object_attributes?.action === "open") {
+                const session = await client.session.create()
+                await client.session.chat({
+                  sessionId: session.id,
+                  message: `GitLab MR !${payload.object_attributes.iid} opened: ${payload.object_attributes.title}\n\n${payload.object_attributes.description}`,
+                })
+                console.log(`[Webhook Plugin] Created session ${session.id} for GitLab MR !${payload.object_attributes.iid}`)
+              }
+
+              return new Response(JSON.stringify({ received: true }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              })
+            } catch (error) {
+              console.error("[Webhook Plugin] Error processing GitLab webhook:", error)
+              return new Response("Internal server error", { status: 500 })
+            }
+          },
+        },
+
+        // Generic webhook endpoint with path parameter
+        {
+          method: "POST",
+          path: "/webhook/:provider",
+          handler: async (request: Request) => {
+            const url = new URL(request.url)
+            const provider = url.pathname.split("/").pop()
+            const body = await request.text()
+
+            console.log(`[Webhook Plugin] Generic webhook from ${provider} received`)
+
+            try {
+              const payload = JSON.parse(body)
+              console.log(`[Webhook Plugin] Payload:`, payload)
+
+              return new Response(JSON.stringify({ received: true, provider }), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              })
+            } catch (error) {
+              console.error(`[Webhook Plugin] Error processing ${provider} webhook:`, error)
+              return new Response("Internal server error", { status: 500 })
+            }
+          },
+        },
+
+        // Health check endpoint
+        {
+          method: "GET",
+          path: "/webhook/health",
+          handler: async () => {
+            return new Response(JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            })
+          },
+        },
+      ],
+    },
+
+    // Also listen to OpenCode events
+    async event(input) {
+      console.log(`[Webhook Plugin] OpenCode event: ${input.event.type}`)
+    },
+
+    async dispose() {
+      console.log("[Webhook Plugin] Disposed")
+    },
+  }
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -216,6 +216,14 @@ export type ProviderHook = {
   models?: (provider: ProviderV2, ctx: ProviderHookContext) => Promise<Record<string, ModelV2>>
 }
 
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH"
+
+export type HttpRoute = {
+  method: HttpMethod
+  path: string
+  handler: (request: Request) => Response | Promise<Response>
+}
+
 /** @deprecated Use AuthOAuthResult instead. */
 export type AuthOuathResult = AuthOAuthResult
 
@@ -228,6 +236,9 @@ export interface Hooks {
   }
   auth?: AuthHook
   provider?: ProviderHook
+  http?: {
+    routes?: HttpRoute[]
+  }
   /**
    * Called when a new message is received
    */


### PR DESCRIPTION
# PR Description for Plugin HTTP Routes Feature

## Issue for this PR

Closes #41362

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

Adds HTTP routes support to OpenCode server plugins. This allows plugins to register custom HTTP endpoints on the main server port, enabling webhook integrations without the need to run separate servers or use reverse proxies.

### Motivation

Issue #41362 requested functionality for controlling OpenCode from external services via webhooks (Telegram, Slack, GitHub, GitLab, etc.). The current plugin architecture supports event hooks and custom tools, but provides no mechanism for receiving incoming HTTP requests.

### Implementation

**Plugin system changes:**
- Added `HttpMethod` and `HttpRoute` types in `packages/plugin/src/index.ts`
- Extended the `Hooks` interface with an optional `http.routes` field for endpoint declarations
- Implemented route collection from all loaded plugins in `packages/opencode/src/plugin/index.ts`

**Routing middleware:**
- Created new file `packages/opencode/src/server/plugin-routes.ts` with middleware
- Middleware intercepts requests, checks for matches against plugin routes, and calls the corresponding handler
- Supports path parameters (e.g., `/webhook/:provider`)
- Integrated into the main HTTP server via `composedMiddleware`

**Documentation and examples:**
- Added documentation in `packages/plugin/docs/http-routes.md` with usage examples
- Created example plugin `packages/plugin/examples/webhook-plugin.ts` for GitHub/GitLab webhooks

### Why this works

The middleware is inserted into the request processing chain before the main API routes. When a request is received:
1. All registered plugin routes are retrieved via `Plugin.Service.getRoutes()`
2. Method + path matching is checked (with parameter support)
3. If a match is found, the plugin handler is called with the `Request` object
4. If no match is found, the request is passed down the chain to the main API

This is a minimally invasive change - plugins that don't use `http.routes` continue to work as before.

## How did you verify your code works?

Currently:
- Code written following existing patterns in the codebase (studied lifecycle.ts, server.ts)
- Created example plugin with real webhook endpoints
- Middleware follows the same style as `disposeMiddleware` from lifecycle.ts

**Planned:**
- Write unit tests for `matchPath` function and middleware logic
- Write integration test with mock plugin registering routes
- Test with real webhook payloads from GitHub/GitLab

## Screenshots / recordings

_N/A - this is a backend feature, UI is not affected_

## Checklist

- [ ] I have tested my changes locally _(pending - need bun installed)_
- [x] I have not included unrelated changes in this PR

---

## Plugin usage example

```typescript
import type { Hooks, PluginInput } from "@opencode-ai/plugin"

export default async function myPlugin(input: PluginInput): Promise<Hooks> {
  return {
    http: {
      routes: [
        {
          method: "POST",
          path: "/webhook/github",
          handler: async (request: Request) => {
            const payload = await request.json()
            // Handle GitHub webhook
            return new Response(JSON.stringify({ received: true }))
          }
        }
      ]
    }
  }
}
```

## Technical details

**Modified files:**
- `packages/plugin/src/index.ts` - added types and extended Hooks interface
- `packages/opencode/src/plugin/index.ts` - route collection and `getRoutes()` method
- `packages/opencode/src/server/plugin-routes.ts` - new middleware
- `packages/opencode/src/server/routes/instance/httpapi/server.ts` - middleware integration
- `packages/plugin/docs/http-routes.md` - documentation
- `packages/plugin/examples/webhook-plugin.ts` - example plugin

**Scope of changes:** ~150 lines of core code + documentation + example
