### PR TITLE
fix(ai): avoid azure chat v1 url duplication

### DIFF
--- a/packages/ai/src/providers/azure.ts
+++ b/packages/ai/src/providers/azure.ts
@@ -90,7 +90,8 @@ function endpoint(input: Config, modelID: string | ModelID) {
   if (input.baseURL !== undefined && !new URL(input.baseURL).hostname.endsWith(".openai.azure.com")) {
     return { baseURL, query: input.queryParams }
   }
-  return { baseURL: `${baseURL}/v1`, query }
+  // Azure's v1 API serves from /openai/v1; callers may pass the base URL with or without the version segment.
+  return { baseURL: baseURL.endsWith("/v1") ? baseURL : `${baseURL}/v1`, query }
 }
 
 export const configure = (input: Config) => {

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -255,7 +255,7 @@ describe("OpenAI Chat route", () => {
     LLMClient.generate(
       LLMRequest.update(request, {
         model: Azure.configure({
-          baseURL: "https://opencode-test.openai.azure.com/openai/v1/",
+          baseURL: "https://opencode-test.openai.azure.com/openai/",
           apiKey: "azure-key",
           headers: { authorization: "Bearer stale" },
         }).chat("gpt-4o-mini"),
@@ -268,6 +268,29 @@ describe("OpenAI Chat route", () => {
             expect(web.url).toBe("https://opencode-test.openai.azure.com/openai/v1/chat/completions?api-version=v1")
             expect(web.headers.get("api-key")).toBe("azure-key")
             expect(web.headers.get("authorization")).toBeNull()
+            return input.respond(sseEvents(deltaChunk({}, "stop")), {
+              headers: { "content-type": "text/event-stream" },
+            })
+          }),
+        ),
+      ),
+    ),
+  )
+
+  it.effect("does not duplicate /v1 for already-versioned Azure Chat base URLs", () =>
+    LLMClient.generate(
+      LLMRequest.update(request, {
+        model: Azure.configure({
+          baseURL: "https://opencode-test.openai.azure.com/openai/v1/",
+          apiKey: "azure-key",
+        }).chat("gpt-4o-mini"),
+      }),
+    ).pipe(
+      Effect.provide(
+        dynamicResponse((input) =>
+          Effect.gen(function* () {
+            const web = yield* HttpClientRequest.toWeb(input.request).pipe(Effect.orDie)
+            expect(web.url).toBe("https://opencode-test.openai.azure.com/openai/v1/chat/completions?api-version=v1")
             return input.respond(sseEvents(deltaChunk({}, "stop")), {
               headers: { "content-type": "text/event-stream" },
             })


### PR DESCRIPTION
## Summary

`packages/ai/test/provider/openai-chat.test.ts` failed on `OpenAI Chat route > uses Azure api-key header for static OpenAI Chat keys`:

```
Expected: "https://opencode-test.openai.azure.com/openai/v1/chat/completions?api-version=v1"
Received: "https://opencode-test.openai.azure.com/openai/v1/v1/chat/completions?api-version=v1"
```

## Cause

Regression from `ae494ffce5` / #40487 (`fix(core): retire legacy provider aliases`). That commit changed `resourceBaseURL` in `packages/ai/src/providers/azure.ts` from `https://${resource}.openai.azure.com/openai/v1` to `https://${resource}.openai.azure.com/openai` and made `endpoint()` always append `/v1` for `*.openai.azure.com` hosts. The Chat test still passed a base URL that already included `/v1` (`.../openai/v1/`), so Azure appended a second `/v1`, producing `/openai/v1/v1/chat/completions`. The matching Responses test had already been updated to pass `.../openai/` and let Azure add `/v1`; the Chat test was left behind — an `/openai/v1` vs `/openai/` mismatch.

## Fix

`endpoint()` in `packages/ai/src/providers/azure.ts` now skips appending `/v1` when the resolved base URL already ends with `/v1`:

- `baseURL: ".../openai/"` → `.../openai/v1/...` (unchanged)
- `baseURL: ".../openai/v1/"` → unchanged, no `/v1/v1` (new)
- `resourceName` → `https://<resource>.openai.azure.com/openai/v1` (unchanged)
- Non-Azure gateway `baseURL`s stay untouched (unchanged)
- `useDeploymentBasedUrls` → `.../openai/deployments/<id>` (unchanged)

Aligned the Chat test with the Responses test (caller-facing base URL `.../openai/`) and added coverage that an already-versioned `.../openai/v1/` base URL does not become `/v1/v1`.

## Testing

From `packages/ai`:

```sh
bun test test/provider/openai-chat.test.ts test/provider/openai-responses.test.ts test/provider-package.test.ts --timeout 30000
```

All pass (149 tests). The previously failing Chat test now passes; the Responses Azure test and provider-package Azure URL tests are unaffected. The remaining OpenRouter test failures in the package are pre-existing on the base branch and unrelated.