### PR TITLE
fix(tui): utilize TUI cursor style config in `opencode2 mini`

### DIFF
--- a/packages/tui/src/mini/footer.prompt.tsx
+++ b/packages/tui/src/mini/footer.prompt.tsx
@@ -42,6 +42,7 @@ import type {
   RunPrompt,
   RunPromptPart,
   RunReference,
+  RunTuiConfig,
 } from "./types"
 
 const AUTOCOMPLETE_ROWS = FOOTER_MENU_ROWS
@@ -176,6 +177,7 @@ export function selectedCommand(text: string, command: RunPrompt["command"]) {
 export function RunPromptBody(props: {
   theme: () => RunFooterTheme
   background: () => ColorInput
+  cursorStyle: RunTuiConfig["cursor"]
   placeholder: () => StyledText | string
   onSubmit: () => void
   onKeyDown: (event: KeyEvent) => void
@@ -239,6 +241,7 @@ export function RunPromptBody(props: {
           backgroundColor={props.background()}
           focusedBackgroundColor={props.background()}
           cursorColor={props.theme().text}
+          cursorStyle={props.cursorStyle}
           onSubmit={props.onSubmit}
           onKeyDown={props.onKeyDown}
           onPaste={() => {

--- a/packages/tui/src/mini/footer.ts
+++ b/packages/tui/src/mini/footer.ts
@@ -335,6 +335,7 @@ export class RunFooter implements FooterApi {
               variants: footer.variants,
               currentVariant: footer.currentVariant,
               theme: footer.theme,
+              tuiConfig: options.tuiConfig,
               mono: options.mono,
               miniSettings: footer.miniSettings,
               history: footer.history,

--- a/packages/tui/src/mini/footer.view.tsx
+++ b/packages/tui/src/mini/footer.view.tsx
@@ -55,6 +55,7 @@ import type {
   RunPrompt,
   RunProvider,
   RunReference,
+  RunTuiConfig,
 } from "./types"
 import type { RunTheme } from "./theme"
 
@@ -92,6 +93,7 @@ type RunFooterViewProps = {
   subagent?: () => FooterSubagentState
   queuedPrompts?: () => FooterQueuedPrompt[]
   theme: () => RunTheme
+  tuiConfig: RunTuiConfig
   mono: boolean
   miniSettings: () => MiniSettings
   history?: () => RunPrompt[]
@@ -733,6 +735,7 @@ export function RunFooterView(props: RunFooterViewProps) {
                         <Match when={active().type === "prompt" && route().type === "composer"}>
                           <RunPromptBody
                             theme={theme}
+                            cursorStyle={props.tuiConfig.cursor}
                             background={() => runTheme().background}
                             placeholder={composer.placeholder}
                             onSubmit={composer.onSubmit}

--- a/packages/tui/src/mini/types.ts
+++ b/packages/tui/src/mini/types.ts
@@ -392,7 +392,7 @@ export type FormCancel = {
   location?: LocationRef
 }
 
-export type RunTuiConfig = Pick<Config.Resolved, "keybinds" | "leader" | "theme" | "mini" | "session">
+export type RunTuiConfig = Pick<Config.Resolved, "keybinds" | "leader" | "theme" | "mini" | "session" | "cursor">
 
 export type MiniSettings = {
   thinking: "show" | "hide"

--- a/packages/tui/test/mini/footer-keymap.test.tsx
+++ b/packages/tui/test/mini/footer-keymap.test.tsx
@@ -65,6 +65,7 @@ async function renderSubagent(interrupt: "ctrl+i" | "none") {
           view={view}
           subagent={subagents}
           theme={() => RUN_THEME_FALLBACK}
+          tuiConfig={config}
           miniSettings={() => ({
             thinking: "hide",
             shell_output: "hide",

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -169,6 +169,7 @@ async function renderFooter(
           subagent={subagents}
           queuedPrompts={() => input.queuedPrompts ?? []}
           theme={input.theme ?? (() => RUN_THEME_FALLBACK)}
+          tuiConfig={config}
           mono={input.mono ?? false}
           miniSettings={miniSettings}
           onSubmit={input.onSubmit ?? (() => true)}
@@ -1454,6 +1455,7 @@ test("direct footer shows authoritative queued work while running", async () => 
             },
           ]}
           theme={() => RUN_THEME_FALLBACK}
+          tuiConfig={tuiConfig}
           miniSettings={() => ({
             thinking: "hide",
             shell_output: "hide",

--- a/packages/tui/test/mini/runtime.boot.test.ts
+++ b/packages/tui/test/mini/runtime.boot.test.ts
@@ -30,11 +30,13 @@ describe("run runtime boot", () => {
       createTuiResolvedConfig({
         theme: { mode: "light" },
         leader: { timeout: 450 },
+        cursor: { style: "underline", blinking: false },
       }),
     )
 
     expect(result.theme).toEqual({ mode: "light" })
     expect(result.leader.timeout).toBe(450)
+    expect(result.cursor).toEqual({ style: "underline", blinking: false })
     expect(resolveMiniSettings(result)).toEqual({
       thinking: "hide",
       shell_output: "hide",


### PR DESCRIPTION
### Issue for this PR

Closes #43521

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds proper utilization of cursor style option in opencode mini mode. That setting is not forwarded to mini TUI config.

### How did you verify your code works?

By manual testing on local setup.

### Screenshots / recordings

[Screencast_20260820_004749.webm](https://github.com/user-attachments/assets/ede6b15a-51f6-4209-b091-d6af0fa16226)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
