### PR TITLE
fix(app): show header for untitled sessions

### DIFF
--- a/packages/app/e2e/regression/session-timeline-header.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-header.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { fixture } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+const sessionID = "ses_untitled_header_regression"
+
+test("keeps the header visible for a persisted untitled session", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    sessions: [{ ...fixture.sessions[0], id: sessionID, title: "" }],
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+
+  await page.goto(`/${base64Encode(fixture.directory)}/session/${sessionID}`)
+  await expectAppVisible(page.getByRole("textbox", { name: "Prompt" }))
+  const header = page.locator("[data-session-title]")
+  await expect(header).toBeVisible()
+  await expect(header.getByRole("button", { name: "More options" })).toBeVisible()
+
+  await page.goto(`/${base64Encode(fixture.directory)}/session`)
+  await expectAppVisible(page.getByRole("textbox", { name: "Prompt" }))
+  await expect(page.locator("[data-session-title]")).toHaveCount(0)
+})

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -329,7 +329,7 @@ export function MessageTimeline(props: {
     if (value) return value
     return language.t("command.session.new")
   })
-  const showHeader = createMemo(() => !!(titleValue() || parentID()))
+  const showHeader = createMemo(() => !!sessionID())
   const projection = createTimelineProjection({
     messages: sessionMessages,
     userMessages: () => props.userMessages,


### PR DESCRIPTION
### Issue for this PR

Closes #42821

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The timeline header was gated on the session title or parent ID, so a newly persisted root session had no header until title generation completed.

This change gates the header on the session ID instead. Persisted untitled sessions now keep their header actions available, while drafts without an ID remain unchanged.

### How did you verify your code works?

- Added a Playwright regression test covering both persisted untitled sessions and drafts
- Ran app and E2E typechecks
- Ran the first-navigation performance benchmark

### Screenshots / recordings

Not included — this preserves the existing header while title generation is pending rather than adding a new visual state.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR