### PR TITLE
fix(tui): honest reconnect overlay copy without a managed service

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1376,7 +1376,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         <StartupLoading ready={plugins.ready} />
       </Show>
       <Show when={showReconnecting()}>
-        <Reconnecting />
+        <Reconnecting managed={client.restart !== undefined} />
       </Show>
       <MigrationOverlay />
       <Toast />

--- a/packages/tui/src/component/reconnecting.tsx
+++ b/packages/tui/src/component/reconnecting.tsx
@@ -2,7 +2,7 @@ import { RGBA } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { Spinner } from "./spinner"
 
-export function Reconnecting() {
+export function Reconnecting(props: { managed?: boolean }) {
   const theme = useTheme("elevated")
 
   return (
@@ -28,8 +28,12 @@ export function Reconnecting() {
         paddingRight={2}
         gap={1}
       >
-        <Spinner color={theme.text.default}>Restarting service...</Spinner>
-        <text fg={theme.text.subdued}>Your session will resume automatically.</text>
+        <Spinner color={theme.text.default}>{props.managed ? "Restarting service..." : "Connection lost..."}</Spinner>
+        <text fg={theme.text.subdued}>
+          {props.managed
+            ? "Your session will resume automatically."
+            : "Reconnecting to the server automatically."}
+        </text>
       </box>
     </box>
   )


### PR DESCRIPTION
## What

The full-screen reconnect overlay always says **"Restarting service... / Your session will resume automatically."** When the TUI is attached to a managed service that copy is truthful, but when it is pinned to an explicit server with `--server` there is no managed service to restart: the connection is simply down, nothing is restarting, and the TUI cannot restart anything. The overlay now tells the truth in both modes.

## Before / After

**Before**: kill the TUI's connections to a healthy server it was launched against with `--server` (network fault, server unreachable). After the grace period the overlay claims a service is restarting:

![before](https://github.com/user-attachments/assets/00e94132-928b-4dcd-b438-9cd271590353)

**After**: the same fault shows connection-state copy instead:

![after](https://github.com/user-attachments/assets/0e4e4725-3e67-4bcc-bbf2-730730fa1672)

Managed-service mode keeps the existing "Restarting service..." wording, since the reconnect loop there really does re-elect/restart the service.

## How

- `packages/tui/src/component/reconnecting.tsx`: takes a `managed` prop and branches spinner + subtext copy.
- `packages/tui/src/app.tsx`: passes `managed={client.restart !== undefined}` — `client.restart` is only defined when a managed service was provided to the TUI (`packages/tui/src/context/client.tsx`).

## Scope

Copy-only. The overlay's trigger conditions, grace periods, and the submit path underneath it (which already rejects fast with a toast and preserves composer text) are unchanged.

## Testing

- `bun run --cwd packages/tui typecheck`
- End-to-end with opencode-drive's network-chaos proxy: launched the TUI `--server`-pinned through the proxy, established a session, then `refuseNew` + killed all connections. Screenshots above are from those runs (before: v2 baseline, after: this branch).