### PR TITLE
fix(tui): stop registering one resize listener per transcript row

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -121,6 +121,7 @@ const TRANSCRIPT_BACKFILL_CHUNK = 60
 type PendingAction = "steer" | "queue" | "cancel"
 
 const context = createContext<{
+  /** Content width: terminal width minus vertical tabs, sidebar, and padding. */
   width: number
   /**
    * Shared reactive terminal size. Transcript-row components must read this
@@ -1130,6 +1131,11 @@ export function Session(props: { verticalTabsWidth: number }) {
     ),
   )
 
+  // Memoized per axis so width readers do not re-run on height-only resizes
+  // (dimensions() is one object signal with identity equality) and vice versa.
+  const terminalWidth = createMemo(() => dimensions().width)
+  const terminalHeight = createMemo(() => dimensions().height)
+
   return (
     <context.Provider
       value={{
@@ -1138,10 +1144,10 @@ export function Session(props: { verticalTabsWidth: number }) {
         },
         terminal: {
           get width() {
-            return dimensions().width
+            return terminalWidth()
           },
           get height() {
-            return dimensions().height
+            return terminalHeight()
           },
         },
         sessionID: route.sessionID,

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -122,6 +122,12 @@ type PendingAction = "steer" | "queue" | "cancel"
 
 const context = createContext<{
   width: number
+  /**
+   * Shared reactive terminal size. Transcript-row components must read this
+   * instead of calling useTerminalDimensions(), which registers one renderer
+   * resize listener per mounted component and grows with transcript length.
+   */
+  terminal: { width: number; height: number }
   sessionID: string
   thinkingMode: () => ThinkingMode
   showThinking: () => boolean
@@ -1130,6 +1136,14 @@ export function Session(props: { verticalTabsWidth: number }) {
         get width() {
           return contentWidth()
         },
+        terminal: {
+          get width() {
+            return dimensions().width
+          },
+          get height() {
+            return dimensions().height
+          },
+        },
         sessionID: route.sessionID,
         thinkingMode,
         showThinking,
@@ -1805,7 +1819,6 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
   const ctx = use()
   const data = useData()
   const local = useLocal()
-  const dimensions = useTerminalDimensions()
   const theme = useTheme("elevated")
   const model = createMemo(
     () =>
@@ -1829,10 +1842,10 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
           <span style={{ fg: props.message.error ? theme.text.subdued : local.agent.color(props.message.agent) }}>
             {Locale.titlecase(props.message.agent)}
           </span>
-          <Show when={dimensions().width >= 28}>
+          <Show when={ctx.terminal.width >= 28}>
             <span style={{ fg: theme.text.subdued }}> · {model()}</span>
           </Show>
-          <Show when={duration() && (dimensions().width < 28 || dimensions().width >= 36)}>
+          <Show when={duration() && (ctx.terminal.width < 28 || ctx.terminal.width >= 36)}>
             <span style={{ fg: theme.text.subdued }}> · {Locale.duration(duration())}</span>
           </Show>
           <Show when={interrupted()}>
@@ -2521,9 +2534,8 @@ function ToolImages(props: { parts: readonly SessionMessageAssistantTool[] }) {
 function SessionImages(props: { images: readonly { uri: string }[]; paddingLeft?: number }) {
   const ctx = use()
   const dialog = useDialog()
-  const dimensions = useTerminalDimensions()
   const images = createMemo(() => (ctx.config.session?.image_preview ? props.images : []))
-  const height = createMemo(() => Math.max(4, Math.min(8, Math.floor(dimensions().height / 4))))
+  const height = createMemo(() => Math.max(4, Math.min(8, Math.floor(ctx.terminal.height / 4))))
   const visible = createMemo(() => images().slice(0, 3))
 
   return (


### PR DESCRIPTION
## What

Listener count on the renderer grew linearly with transcript length, tripping Bun's EventTarget warning (`"11 resize listeners added to [CliRenderer]. MaxListeners is undefined..."`) within about four prompts of a live session and climbing into the dozens over a long one.

## Before / After

**Before**: every `AssistantFooter` (one per assistant message) and every `SessionImages` (one per user message, per tool part, and per grouped tool section — even when it renders nothing, since the hook ran before the empty-images guard) called `useTerminalDimensions()`, which registers a renderer `resize` listener for the lifetime of the mounted row. Transcript rows stay mounted for the life of the session view, so a 10-prompt drive session logged the leak warning with zero actual resizes.

**After**: the session route's single existing `useTerminalDimensions()` subscription is exposed as a reactive `terminal` size on the session context, and the row components read that instead. The same 10-prompt session registers no extra listeners and logs no warning.

## How

`packages/tui/src/routes/session/index.tsx`:
- session context gains `terminal: { width, height }` backed by reactive getters over the route-level `dimensions()` memo, with a doc comment steering row components away from the hook.
- `AssistantFooter` reads `ctx.terminal.width`; `SessionImages` reads `ctx.terminal.height`. Reactivity is preserved — the getters track the same signal the hook wrapped.

## Scope

Only the two per-row subscribers. App-chrome `useTerminalDimensions()` call sites (prompt, tabs, dialogs, toasts) are bounded and untouched. No `setMaxListeners` suppression — the growth is fixed rather than silenced.

## Testing

- `bun run --cwd packages/tui typecheck`
- End-to-end with opencode-drive: a scripted 10-prompt session (5 streams + 5 mid-stream steers) against this branch produced zero `resize listeners` warnings in TUI stderr; the same script against the v2 baseline warns at 11 listeners. Footer model/duration hiding still responds to width (getters remain reactive).