### PR TITLE
refactor(core): use Latch for plugin supervisor ready gate

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -3,7 +3,7 @@ export { Service, type Interface } from "./supervisor-service.js"
 
 import type { Plugin as PluginDefinition } from "@opencode-ai/plugin/effect/plugin"
 import { Event } from "@opencode-ai/schema/config"
-import { Cause, Deferred, Effect, Layer, Schema, Stream } from "effect"
+import { Cause, Effect, Latch, Layer, Schema, Stream } from "effect"
 import path from "path"
 import { pathToFileURL } from "url"
 import { ConfigPluginSource } from "../config/plugin/source.js"
@@ -137,7 +137,7 @@ export const layer = Layer.effect(
     const sdk = yield* SdkPlugins.Service
     const sources = yield* ConfigPluginSource.Service
     const bus = yield* Bus.Service
-    const ready = { current: yield* Deferred.make<void>() }
+    const ready = yield* Latch.make()
     let observed = 0
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* () {
@@ -164,7 +164,7 @@ export const layer = Layer.effect(
       Stream.mapEffect(() =>
         Effect.gen(function* () {
           observed++
-          if (yield* Deferred.isDone(ready.current)) ready.current = yield* Deferred.make<void>()
+          yield* ready.close
           return observed
         }),
       ),
@@ -176,12 +176,12 @@ export const layer = Layer.effect(
       Stream.runForEach((target) =>
         Effect.gen(function* () {
           yield* activate()
-          if (observed === target) yield* Deferred.succeed(ready.current, undefined)
+          if (observed === target) yield* ready.open
         }).pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }))),
       ),
       Effect.forkScoped({ startImmediately: true }),
     )
-    return Service.of({ flush: Effect.suspend(() => Deferred.await(ready.current)) })
+    return Service.of({ flush: ready.await })
   }),
 )
 


### PR DESCRIPTION
## What

The plugin supervisor's `flush` readiness signal is a hand-rolled reusable gate: a `Deferred<void>` in a mutable `ready.current` box, recreated via an `isDone` check on every update and re-awaited through `Effect.suspend`. Effect's `Latch` is exactly this primitive — a valueless, never-failing gate that can close and reopen — so this replaces the machinery with one `Latch`.

## How

`packages/core/src/plugin/supervisor.ts`:

- `ready` is now `yield* Latch.make()` (starts closed, like the fresh deferred).
- Each observed update runs `ready.close` (idempotent) instead of `isDone` + recreate; the mutable box disappears.
- Activation catching up to the latest generation runs `ready.open` instead of `Deferred.succeed`.
- `flush` is `ready.await` directly — no `Effect.suspend` needed since there is no longer a swapped reference to re-read.

Behavior is unchanged: updates close the gate before the burst coalesces (same "make accepted work visible to flush" point in the stream), and only an activation that has caught up to the last observed generation opens it.

Found by a repo-wide audit of `Deferred<void>`-as-gate patterns; sibling PRs convert the other pure-gate sites.

## Testing

- `packages/core`: `bun typecheck`, `bun test test/plugin.test.ts test/plugin-hooks.test.ts test/session-runner.test.ts` (172 pass), and the full `bun run test` suite (1892 pass / 0 fail).
