### PR TITLE
refactor(core): use Latch for shell output gate

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,7 +1,7 @@
 export * as Shell from "./shell.js"
 
 import path from "path"
-import { Context, Deferred, Duration, Effect, Fiber, Layer, Schema, Schedule, Stream } from "effect"
+import { Context, Deferred, Duration, Effect, Fiber, Latch, Layer, Schema, Schedule, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
@@ -286,7 +286,7 @@ const layer = () =>
               sessions.set(id, session)
 
               const stream = createWriteStream(file)
-              const outputDone = Deferred.makeUnsafe<void>()
+              const outputDone = Latch.makeUnsafe()
               const pump = handle.all.pipe(
                 Stream.runForEach((chunk: Uint8Array) =>
                   Effect.sync(() => {
@@ -304,8 +304,8 @@ const layer = () =>
                         stream.end(() => resolve())
                       }),
                   )
-                  yield* Deferred.succeed(outputDone, undefined)
-                }).pipe(Effect.catch(() => Deferred.succeed(outputDone, undefined))),
+                  yield* outputDone.open
+                }).pipe(Effect.catch(() => outputDone.open)),
               )
               yield* Effect.promise(
                 () =>
@@ -324,7 +324,7 @@ const layer = () =>
                     draft.time.completed = Date.now()
                   })
                   yield* beforeWait
-                  yield* Deferred.await(outputDone)
+                  yield* outputDone.await
                   // Resolve waiters with the terminal Info before any retention eviction, so an evicted
                   // session still reports success rather than the removal NotFoundError. This runs before
                   // the timeout-fiber interrupt below, which on the timeout path would otherwise cancel


### PR DESCRIPTION
## What

The shell session's `outputDone` signal is a pure "output pump drained" gate — a `Deferred<void>` succeeded on both the success and catch paths of the pump fiber and awaited once in `finish`. `Latch` expresses that open-once, never-failing intent directly.

## How

`packages/core/src/shell.ts`:

- `outputDone` is now `Latch.makeUnsafe()` (starts closed).
- Both completion sites (normal drain and the catch fallback) use `outputDone.open`.
- `finish` waits with `outputDone.await`.

The value/error-carrying deferreds in the same file (`ready`, waiter `Info` resolution) are correct as `Deferred` and unchanged. No behavior change. Found by a repo-wide audit of `Deferred<void>`-as-gate patterns; sibling PRs convert the other pure-gate sites.

## Testing

- `packages/core`: `bun typecheck`; `bun test test/shell.test.ts test/shell-cleanup.test.ts test/tool-shell.test.ts` (29 pass); full `bun run test` (1908 tests, 0 fail).
