### PR TITLE
fix(ai): settle pending Responses tool calls

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1006,11 +1006,19 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   return [state, NO_EVENTS] satisfies StepResult
 })
 
-const onResponseFinish = (state: ParserState, event: Event): StepResult => {
-  const events: LLMEvent[] = []
+const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (state: ParserState, event: Event) {
+  // Some compatible providers omit output_item.done even after completing the response.
+  const pending =
+    event.type === "response.completed"
+      ? yield* ToolStream.finishAll(state.id, state.tools)
+      : { tools: state.tools, events: NO_EVENTS }
+  const events: LLMEvent[] = [...pending.events]
+  const hasFunctionCall =
+    pending.events.some((event) => LLMEvent.is.toolCall(event) || LLMEvent.is.toolInputError(event)) ||
+    state.hasFunctionCall
   const lifecycle = Lifecycle.finish(state.lifecycle, events, {
     reason: {
-      normalized: mapFinishReason(event, state.hasFunctionCall),
+      normalized: mapFinishReason(event, hasFunctionCall),
       raw: event.response?.incomplete_details?.reason,
     },
     usage: mapUsage(event.response?.usage, state.providerMetadataKey),
@@ -1022,8 +1030,8 @@ const onResponseFinish = (state: ParserState, event: Event): StepResult => {
           })
         : undefined,
   })
-  return [{ ...state, lifecycle }, events]
-}
+  return [{ ...state, lifecycle, hasFunctionCall, tools: pending.tools }, events] satisfies StepResult
+})
 
 // Build a single human-readable message from whatever the provider supplied.
 // When both code and message are present, prefix the code so consumers see
@@ -1092,8 +1100,7 @@ export const step = (state: ParserState, event: Event) => {
       return ProviderShared.eventError(state.id, `${event.type} message is missing id`)
     return onOutputItemDone(state, event)
   }
-  if (event.type === "response.completed" || event.type === "response.incomplete")
-    return Effect.succeed(onResponseFinish(state, event))
+  if (event.type === "response.completed" || event.type === "response.incomplete") return onResponseFinish(state, event)
   if (event.type === "response.failed") return providerError(state, event, `${state.name} response failed`)
   if (event.type === "error")
     return decodeKnownErrorEvent(event).pipe(

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2185,6 +2185,39 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("finalizes a pending function call at response completion", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        {
+          type: "response.output_item.added",
+          item: { type: "function_call", id: "item_1", call_id: "call_1", name: "lookup", arguments: "" },
+        },
+        { type: "response.completed", response: { usage: { input_tokens: 5, output_tokens: 1 } } },
+      )
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.events.filter((event) => LLMEvent.is.toolInputEnd(event) || LLMEvent.is.toolCall(event))).toEqual(
+        [
+          {
+            type: "tool-input-end",
+            id: "call_1",
+            name: "lookup",
+            providerMetadata: { openai: { itemId: "item_1" } },
+          },
+          {
+            type: "tool-call",
+            id: "call_1",
+            name: "lookup",
+            input: {},
+            providerExecuted: undefined,
+            providerMetadata: { openai: { itemId: "item_1" } },
+          },
+        ],
+      )
+      expect(response.finishReason.normalized).toBe("tool-calls")
+    }),
+  )
+
   it.effect("emits malformed final function arguments as an unexecuted tool error", () =>
     Effect.gen(function* () {
       const body = sseEvents(


### PR DESCRIPTION
## Summary

- finalize pending function calls when a Responses stream reaches successful completion without `response.output_item.done`
- parse accumulated arguments through the existing canonical tool-input path
- finish the step as `tool-calls` so Session execution can validate or execute the call instead of persisting a streaming tool

Malformed accumulated JSON remains non-executable and produces `tool-input-error`. Normal `response.output_item.done` arguments remain authoritative.

Closes #37159

## Testing

- `bun test test/provider/openai-responses.test.ts test/provider/openai-compatible-responses.test.ts test/tool-stream.test.ts`
- `bun typecheck`
- `bun run build`
- Prettier check
- `git diff --check`