### PR TITLE
fix(core): settle foreign typed tool failures instead of dropping them

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -89,7 +89,15 @@ const classifyToolExits = (
     .flatMap((cause) => {
       if (Cause.hasInterrupts(cause)) return []
       const reasons = cause.reasons.flatMap(
-        (reason): Array<Cause.Reason<never>> => (Cause.isFailReason(reason) ? [] : [reason]),
+        (reason): Array<Cause.Reason<never>> =>
+          Cause.isFailReason(reason)
+            ? isDecline(reason.error)
+              ? []
+              : // A typed failure here broke the ExecuteError contract (the per-fiber
+                // `catchTag("Tool.Error")` consumes honest ones). Surfacing it as a defect
+                // keeps it from being dropped, which would leave its call unsettled forever.
+                [Cause.makeDieReason(reason.error)]
+            : [reason],
       )
       return reasons.length > 0 ? [Cause.fromReasons(reasons)] : []
     })

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -13,7 +13,20 @@ export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
 export const execute = (tool: Tool.Info<any, any>, input: unknown, context: Tool.Context) =>
   Effect.gen(function* () {
     const decoded = yield* decodeInput(tool.input, input)
-    const result = yield* tool.execute(decoded, context)
+    // Tool implementations declare `Tool.Error` but plugins can fail with anything at
+    // runtime. A foreign typed failure would slip past every `catchTag("Tool.Error")`
+    // downstream and leave its call permanently unsettled, so the declared contract is
+    // enforced here at the untrusted boundary. Declines tunnel through as defects and
+    // interrupts are not errors; neither is touched.
+    const result = yield* tool.execute(decoded, context).pipe(
+      Effect.mapError((error: unknown) =>
+        error instanceof Tool.Error
+          ? error
+          : new Tool.Error({
+              message: error instanceof globalThis.Error ? error.message : String(error),
+            }),
+      ),
+    )
     if (tool.output === undefined) {
       if ("output" in result) return yield* Effect.die("Tool result declared output without an output schema")
       return {

--- a/packages/core/test/tool-execute.test.ts
+++ b/packages/core/test/tool-execute.test.ts
@@ -94,6 +94,24 @@ test("declared outputs cannot bypass validation and raw outputs stay JSON-compat
   )
 })
 
+test("foreign typed failures settle as Tool.Error at the untrusted boundary", async () => {
+  class ForeignFailure extends Schema.TaggedError<ForeignFailure>()("Plugin.ForeignFailure", {
+    message: Schema.String,
+  }) {}
+  const lying: Info = {
+    name: "lying",
+    description: "Fails with a non-Tool.Error typed failure",
+    input: Schema.Struct({}),
+    execute: () => new ForeignFailure({ message: "transport died" }) as never,
+  }
+
+  const exit = await Effect.runPromiseExit(execute(lying, {}, context))
+  expect(exit._tag).toBe("Failure")
+  const error = exit._tag === "Failure" ? exit.cause.reasons.find((reason) => "error" in reason)?.error : undefined
+  expect(error).toBeInstanceOf(Tool.Error)
+  expect((error as Tool.Error).message).toBe("transport died")
+})
+
 test("execute supports callable namespace tools", async () => {
   const callable: Info = {
     name: "admin",


### PR DESCRIPTION
## What

A plugin tool that fails with a **foreign typed error** (anything that isn't `Tool.Error`) leaves its tool call permanently unsettled: the part stays `running` with a live spinner forever, while the step continues anyway and the execution reports success. Found by a drive gauntlet probe whose tool transport died mid-execution.

`Tool.Info.execute` declares `Effect<Result, Tool.Error>`, but a plugin can fail with anything at runtime. Nothing enforced the declaration, and every downstream handler assumes it:

- the runner fiber's `catchTag("Tool.Error", failTool)` misses it (llm.ts)
- `classifyToolExits` drops Fail reasons wholesale, assuming any typed failure surviving the fiber's `catchTag` is a decline (llm.ts:91)
- the clean-stream sweep only settles **hosted** calls (llm.ts:543)

So the failure threads every needle: no `tool.failed` event is ever published, `needsContinuation` still fires off `call.called`, and the part is only healed if some later drain's `settleStaleToolCalls` sweep happens to run.

## Before

1. Plugin tool starts; part shows `running`, spinner animates.
2. The tool's transport dies; the plugin fails with its own tagged error.
3. The failure is silently dropped. No `session.tool.*` terminal event is published.
4. The step continues, the model replies, the turn ends — `session.execution.succeeded`.
5. The spinner keeps animating indefinitely; the server projection still says `running`. If the user never sends another message, it never settles.

Event stream from the repro (note: no tool terminal event between `tool.called` and `execution.succeeded`):

```
seq=8  session.tool.called
seq=11 session.step.ended
seq=12 session.step.started      ← continuation
seq=15 session.step.ended
seq=16 session.execution.succeeded   ← tool part still "running"
```

## After

1. Same trigger: the plugin fails with a foreign typed error.
2. The tool runtime maps it to `Tool.Error` at the untrusted boundary; the fiber's existing `failTool` path publishes the durable failure immediately.
3. The part settles as `error` with the real message, the model reads the failure, the continuation proceeds, the UI is quiescent right after the turn.

## How

- `packages/core/src/tool/runtime.ts` — enforce the declared contract where untrusted tool implementations enter typed code: any typed failure that isn't `Tool.Error` becomes one, preserving its message. Decline tunneling (defects) and interrupts are untouched.
- `packages/core/src/session/runner/llm.ts` — defense in depth in `classifyToolExits`: a non-decline Fail reason is surfaced as a defect (failing the unsettled calls) instead of being silently dropped.
- `packages/core/test/tool-execute.test.ts` — regression test: a tool failing with a foreign tagged error settles as `Tool.Error`.

## Scope

- Does not change decline semantics, interrupt semantics, or the stale-call sweep.
- The drive-side transport bug that exposed this (tool controller idle timeout) is fixed separately in opencode-drive.

## Testing

- `bun run typecheck` (packages/core) clean.
- `bun run test -- test/tool-execute.test.ts test/session-runner.test.ts test/session-runner-tool-events.test.ts test/session-runner-tool-registry.test.ts` — 198 pass, plus the new regression test.
- End-to-end via opencode-drive: a probe holds a plugin shell open, kills its transport mid-execution, and asserts the part reaches a terminal state and the UI settles with no further prompts. Fails on `v2`, passes on this branch.

## Demo

Before — turn is over (`T0X_CONTINUED`, 9.0s footer), but the shell row is still spinning; the server projection reports the part as `running` indefinitely:

![before: stuck spinner after the turn ended](https://github.com/user-attachments/assets/2423dbf6-9ea2-42c0-82b5-c326ac9e0c78)

After — identical scenario: the part settles immediately as an error with the real transport message, then the continuation completes and the UI is quiescent:

![after: part settled as error, UI quiescent](https://github.com/user-attachments/assets/8b422400-39de-48fc-ba68-6556dda69fc9)

## Flow

```mermaid
sequenceDiagram
    participant P as Plugin tool
    participant R as Tool runtime (runtime.ts)
    participant F as Runner tool fiber (llm.ts)
    participant S as Settlement

    P->>R: fail with foreign tagged error
    rect rgb(60,30,30)
    note over R,S: before: error escapes catchTag("Tool.Error"),<br/>classifyToolExits drops the Fail reason,<br/>part never settles, step continues
    end
    rect rgb(30,60,30)
    note over R: after: mapError enforces the declared contract
    R->>F: Tool.Error
    F->>S: failTool → durable tool.failed, part settles
    end
```
