### PR TITLE
refactor(ai): remove model limits

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -309,7 +309,7 @@ Included providers: OpenAI, Anthropic, Google (Gemini), Google Vertex Gemini and
 
 ### Package-like entrypoints
 
-Native catalog integrations load provider behavior through package-like entrypoints. These are export paths from the same `@opencode-ai/ai` npm package, not independently published packages. Each entrypoint exports the same `model(modelID, settings)` contract, and `settings` contains serializable provider configuration plus common `headers`, `body`, and `limits` overlays.
+Native catalog integrations load provider behavior through package-like entrypoints. These are export paths from the same `@opencode-ai/ai` npm package, not independently published packages. Each entrypoint exports the same `model(modelID, settings)` contract, and `settings` contains serializable provider configuration plus common `headers` and `body` overlays.
 
 ```ts
 import { model } from "@opencode-ai/ai/providers/openai/responses"
@@ -317,7 +317,6 @@ import { model } from "@opencode-ai/ai/providers/openai/responses"
 const selected = model("gpt-5", {
   apiKey: process.env.OPENAI_API_KEY,
   headers: { "x-application": "opencode" },
-  limits: { context: 200_000, output: 64_000 },
 })
 ```
 

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -31,6 +31,7 @@ import { ToolStream } from "./utils/tool-stream.js"
 const ADAPTER = "anthropic-messages"
 export const DEFAULT_BASE_URL = "https://api.anthropic.com/v1"
 export const PATH = "/messages"
+export const DEFAULT_MAX_TOKENS = 32_000
 
 export type ThinkingInput =
   | {
@@ -624,7 +625,6 @@ const resolveThinking = Effect.fn("AnthropicMessages.resolveThinking")(function*
 const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (request: LLMRequest) {
   const generation = request.generation
   const toolSchemaCompatibility = request.model.compatibility?.toolSchema
-  const outputLimit = request.model.defaults?.limits?.output ?? request.model.route.defaults.limits?.output ?? 4096
   // Allocate the 4-breakpoint budget in invalidation order: tools → system →
   // messages. Tools live highest in the cache hierarchy, so when callers
   // over-mark we keep their tool hints and shed the message-tail ones first.
@@ -663,7 +663,7 @@ const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (reques
     tools,
     tool_choice: toolChoice,
     stream: true as const,
-    max_tokens: generation?.maxTokens ?? outputLimit,
+    max_tokens: generation?.maxTokens ?? DEFAULT_MAX_TOKENS,
     temperature: generation?.temperature,
     top_p: generation?.topP,
     top_k: generation?.topK,

--- a/packages/ai/src/provider-package.ts
+++ b/packages/ai/src/provider-package.ts
@@ -4,11 +4,6 @@ export interface Settings extends Readonly<Record<string, unknown>> {
   readonly baseURL?: string
   readonly headers?: Readonly<Record<string, string>>
   readonly body?: Readonly<Record<string, unknown>>
-  readonly limits?: {
-    readonly context: number
-    readonly input?: number
-    readonly output: number
-  }
 }
 
 export interface Definition<

--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -90,7 +90,6 @@ const config = (settings: Settings): Config => {
     credentials: settings.credentials,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
     region: settings.region,
   }

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -62,7 +62,6 @@ export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, se
     generation: settings.topP === undefined ? undefined : { topP: settings.topP },
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     region: settings.region,
   }).model(modelID)
 }

--- a/packages/ai/src/providers/anthropic-compatible.ts
+++ b/packages/ai/src/providers/anthropic-compatible.ts
@@ -68,7 +68,6 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     provider: settings.provider,
     providerOptions: settings.providerOptions,
   }).model(modelID)

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -63,7 +63,6 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
   }).model(modelID)
 }

--- a/packages/ai/src/providers/azure.ts
+++ b/packages/ai/src/providers/azure.ts
@@ -126,7 +126,6 @@ const config = (settings: Settings): Config => {
     apiVersion: settings.apiVersion,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
     queryParams: settings.queryParams === undefined ? undefined : { ...settings.queryParams },
     useDeploymentBasedUrls: settings.useDeploymentBasedUrls,

--- a/packages/ai/src/providers/google-vertex-chat.ts
+++ b/packages/ai/src/providers/google-vertex-chat.ts
@@ -75,7 +75,6 @@ export const model: ProviderPackage.Definition<Settings, OpenAIProviderOptionsIn
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     location: settings.location,
     project: settings.project,
     providerOptions: settings.providerOptions,

--- a/packages/ai/src/providers/google-vertex-messages.ts
+++ b/packages/ai/src/providers/google-vertex-messages.ts
@@ -110,7 +110,6 @@ export const model: ProviderPackage.Definition<Settings, AnthropicMessages.Provi
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     location: settings.location,
     project: settings.project,
     providerOptions: settings.providerOptions,

--- a/packages/ai/src/providers/google-vertex-responses.ts
+++ b/packages/ai/src/providers/google-vertex-responses.ts
@@ -80,7 +80,6 @@ export const model: ProviderPackage.Definition<Settings, OpenResponsesProviderOp
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     location: settings.location,
     project: settings.project,
     providerOptions: settings.providerOptions,

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -119,7 +119,6 @@ export const model: ProviderPackage.Definition<Settings, GeminiProviderOptionsIn
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     location: settings.location,
     project: settings.project,
     providerOptions: settings.providerOptions,

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -63,7 +63,6 @@ export const model: ProviderPackage.Definition<Settings, Gemini.ProviderOptionsI
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
   }).model(modelID)
 

--- a/packages/ai/src/providers/openai-compatible-responses.ts
+++ b/packages/ai/src/providers/openai-compatible-responses.ts
@@ -55,7 +55,6 @@ export const model: ProviderPackage.Definition<Settings, OpenResponsesProviderOp
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     provider: settings.provider,
     providerOptions: settings.providerOptions,
   }).model(modelID)

--- a/packages/ai/src/providers/openai-compatible.ts
+++ b/packages/ai/src/providers/openai-compatible.ts
@@ -74,7 +74,6 @@ export const model: ProviderPackage.Definition<Settings, OpenAIProviderOptionsIn
     baseURL: settings.baseURL,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     provider: settings.provider,
     providerOptions: settings.providerOptions,
   }).model(modelID)

--- a/packages/ai/src/providers/openai.ts
+++ b/packages/ai/src/providers/openai.ts
@@ -124,7 +124,6 @@ const config = (settings: Settings): Config => {
     baseURL: settings.baseURL,
     headers: Object.keys(headers).length === 0 ? undefined : headers,
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
     queryParams: settings.queryParams === undefined ? undefined : { ...settings.queryParams },
   }

--- a/packages/ai/src/providers/openrouter.ts
+++ b/packages/ai/src/providers/openrouter.ts
@@ -200,6 +200,5 @@ export const model: ProviderPackage.Definition<Settings, OpenRouterProviderOptio
     baseURL: settings.baseURL,
     headers: settings.headers,
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
   }).model(modelID)

--- a/packages/ai/src/providers/xai.ts
+++ b/packages/ai/src/providers/xai.ts
@@ -101,7 +101,6 @@ export const model: ProviderPackage.Definition<Settings, XAIProviderOptionsInput
     baseURL: settings.baseURL,
     headers: settings.headers,
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    limits: settings.limits,
     providerOptions: settings.providerOptions,
   }).model(modelID)
 export const responses = provider.responses

--- a/packages/ai/src/route/client.ts
+++ b/packages/ai/src/route/client.ts
@@ -16,7 +16,6 @@ import {
   LLMRequest,
   LLMResponse,
   LanguageModel,
-  LanguageModelLimits,
   LLMEvent,
   InvalidProviderOutputReason,
   ProviderID,
@@ -74,7 +73,6 @@ export type RouteRoutedLanguageModelInput = Omit<LanguageModel.Input, "route">
 
 export interface RouteDefaults {
   readonly headers?: Record<string, string>
-  readonly limits?: LanguageModelLimits
   readonly generation?: GenerationOptions
   readonly providerOptions?: ProviderOptions
   readonly http?: HttpOptions
@@ -82,7 +80,6 @@ export interface RouteDefaults {
 
 export interface RouteDefaultsInput {
   readonly headers?: Record<string, string>
-  readonly limits?: LanguageModelLimits.Input
   readonly generation?: GenerationOptions.Input
   readonly providerOptions?: ProviderOptions
   readonly http?: HttpOptions.Input
@@ -119,7 +116,6 @@ const mergeRouteDefaults = (base: RouteDefaults | undefined, patch: RouteDefault
     ...base,
     ...patch,
     headers,
-    limits: patch.limits === undefined ? base?.limits : LanguageModelLimits.make(patch.limits),
     generation: mergeGenerationOptions(generationOptions(base?.generation), generationOptions(patch.generation)),
     providerOptions: mergeProviderOptions(base?.providerOptions, patch.providerOptions),
     http: mergeHttpOptions(

--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -114,22 +114,7 @@ export const mergeGenerationOptions = (...items: ReadonlyArray<GenerationOptions
   return Object.values(result).some((value) => value !== undefined) ? result : undefined
 }
 
-export class LanguageModelLimits extends Schema.Class<LanguageModelLimits>("LLM.LanguageModelLimits")({
-  context: Schema.optional(Schema.Number),
-  input: Schema.optional(Schema.Number),
-  output: Schema.optional(Schema.Number),
-}) {}
-
-export namespace LanguageModelLimits {
-  export type Input = LanguageModelLimits | ConstructorParameters<typeof LanguageModelLimits>[0]
-
-  /** Normalize model limit input into the canonical `LanguageModelLimits` class. */
-  export const make = (input: Input | undefined) =>
-    input instanceof LanguageModelLimits ? input : new LanguageModelLimits(input ?? {})
-}
-
 export class LanguageModelDefaults extends Schema.Class<LanguageModelDefaults>("LLM.LanguageModelDefaults")({
-  limits: Schema.optional(LanguageModelLimits),
   generation: Schema.optional(GenerationOptions),
   providerOptions: Schema.optional(ProviderOptions),
   http: Schema.optional(HttpOptions),
@@ -139,7 +124,6 @@ export namespace LanguageModelDefaults {
   export type Input =
     | LanguageModelDefaults
     | {
-        readonly limits?: LanguageModelLimits.Input
         readonly generation?: GenerationOptions.Input
         readonly providerOptions?: ProviderOptions
         readonly http?: HttpOptions.Input
@@ -149,7 +133,6 @@ export namespace LanguageModelDefaults {
   export const make = (input: Input) => {
     if (input instanceof LanguageModelDefaults) return input
     return new LanguageModelDefaults({
-      limits: input.limits === undefined ? undefined : LanguageModelLimits.make(input.limits),
       generation: input.generation === undefined ? undefined : GenerationOptions.make(input.generation),
       providerOptions: input.providerOptions,
       http: input.http === undefined ? undefined : HttpOptions.make(input.http),

--- a/packages/ai/test/compile.test.ts
+++ b/packages/ai/test/compile.test.ts
@@ -270,21 +270,20 @@ describe("request option precedence", () => {
     ),
   )
 
-  it.effect("uses model output limits after route limits and before call maxTokens", () =>
+  it.effect("uses the Anthropic default before call maxTokens", () =>
     Effect.gen(function* () {
       const route = AnthropicMessages.route.with({
         endpoint: { baseURL: "https://api.anthropic.test/v1/" },
         auth: Auth.header("x-api-key", "test"),
-        limits: { output: 128 },
       })
-      const model = route.model({ id: "claude-sonnet-4-5", defaults: { limits: { output: 64 } } })
+      const model = route.model({ id: "claude-sonnet-4-5" })
       const withoutMaxTokens = yield* compileRequest(LLM.request({ model, prompt: "Say hello.", cache: "none" }))
       const withMaxTokens = yield* compileRequest(
-        LLM.request({ model, prompt: "Say hello.", cache: "none", generation: { maxTokens: 32 } }),
+        LLM.request({ model, prompt: "Say hello.", cache: "none", generation: { maxTokens: 8_000 } }),
       )
 
-      expect(withoutMaxTokens.body.max_tokens).toBe(64)
-      expect(withMaxTokens.body.max_tokens).toBe(32)
+      expect(withoutMaxTokens.body.max_tokens).toBe(32_000)
+      expect(withMaxTokens.body.max_tokens).toBe(8_000)
     }),
   )
 })

--- a/packages/ai/test/llm.test.ts
+++ b/packages/ai/test/llm.test.ts
@@ -121,7 +121,6 @@ describe("llm constructors", () => {
     const model = chatRoute.model({
       id: "kimi-k2",
       defaults: {
-        limits: { context: 128_000, output: 8_192 },
         generation: { maxTokens: 1_024, stop: ["END"] },
         providerOptions: { parallelToolCalls: false },
         http: { body: { extra_body: true } },
@@ -130,7 +129,6 @@ describe("llm constructors", () => {
     })
     const request = LLM.request({ model, prompt: "Say hello." })
 
-    expect(request.model.defaults?.limits).toEqual({ context: 128_000, output: 8_192 })
     expect(request.model.defaults?.generation).toEqual({ maxTokens: 1_024, stop: ["END"] })
     expect(request.model.defaults?.providerOptions).toEqual({ parallelToolCalls: false })
     expect(request.model.defaults?.http).toEqual({ body: { extra_body: true } })

--- a/packages/ai/test/provider-package.test.ts
+++ b/packages/ai/test/provider-package.test.ts
@@ -43,7 +43,6 @@ describe("provider package entrypoints", () => {
       baseURL: "https://provider.example.test/v1",
       headers: { "x-application": "opencode" },
       body: { service_tier: "priority" },
-      limits: { context: 200_000, output: 64_000 },
     }
     const openrouter = OpenRouter.model("anthropic/claude-sonnet-4", {
       ...settings,
@@ -58,7 +57,6 @@ describe("provider package entrypoints", () => {
       expect(selected.route.endpoint.baseURL).toBe(settings.baseURL)
       expect(selected.route.defaults.headers).toEqual(settings.headers)
       expect(selected.route.defaults.http?.body).toEqual(settings.body)
-      expect(selected.route.defaults.limits).toEqual(settings.limits)
     }
     expect(openrouter.route.defaults.providerOptions).toEqual({ usage: true })
     expect(xai.route.defaults.providerOptions).toMatchObject({ reasoningEffort: "high", store: false })
@@ -70,14 +68,12 @@ describe("provider package entrypoints", () => {
       baseURL: "https://api.openai.test/v1",
       headers: { "x-application": "opencode" },
       body: { service_tier: "priority" },
-      limits: { context: 200_000, output: 64_000 },
       unrelatedInheritedSetting: true,
     })
 
     expect(selected.route.id).toBe("openai-responses")
     expect(selected.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(selected.route.defaults.http?.body).toEqual({ service_tier: "priority" })
-    expect(selected.route.defaults.limits).toEqual({ context: 200_000, output: 64_000 })
   })
 
   test("maps OpenAI-compatible Responses settings onto the executable model", async () => {
@@ -88,7 +84,6 @@ describe("provider package entrypoints", () => {
       provider: "example",
       headers: { "x-application": "opencode" },
       body: { service_tier: "priority" },
-      limits: { context: 200_000, output: 64_000 },
       providerOptions: { reasoningEffort: "low", store: true },
     })
 
@@ -100,7 +95,6 @@ describe("provider package entrypoints", () => {
     })
     expect(selected.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(selected.route.defaults.http?.body).toEqual({ service_tier: "priority" })
-    expect(selected.route.defaults.limits).toEqual({ context: 200_000, output: 64_000 })
     expect(selected.route.defaults.providerOptions).toEqual({ reasoningEffort: "low", store: true })
   })
 
@@ -112,7 +106,6 @@ describe("provider package entrypoints", () => {
       provider: "example",
       headers: { "x-application": "opencode" },
       body: { metadata: { user_id: "user_1" } },
-      limits: { context: 200_000, output: 64_000 },
       providerOptions: { effort: "low" },
     })
 
@@ -124,7 +117,6 @@ describe("provider package entrypoints", () => {
     })
     expect(selected.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(selected.route.defaults.http?.body).toEqual({ metadata: { user_id: "user_1" } })
-    expect(selected.route.defaults.limits).toEqual({ context: 200_000, output: 64_000 })
     expect(selected.route.defaults.providerOptions).toEqual({ effort: "low" })
   })
 
@@ -185,7 +177,6 @@ describe("provider package entrypoints", () => {
       resourceName: "opencode-test",
       headers: { "x-application": "opencode" },
       body: { service_tier: "priority" },
-      limits: { context: 200_000, output: 64_000 },
     }
 
     const responses = AzureResponses.model("deployment", settings)
@@ -196,7 +187,6 @@ describe("provider package entrypoints", () => {
     expect(responses.route.endpoint.baseURL).toBe("https://opencode-test.openai.azure.com/openai/v1")
     expect(responses.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(responses.route.defaults.http?.body).toEqual({ service_tier: "priority" })
-    expect(responses.route.defaults.limits).toEqual({ context: 200_000, output: 64_000 })
     expect(chat.route.id).toBe("azure-openai-chat")
   })
 
@@ -228,7 +218,6 @@ describe("provider package entrypoints", () => {
       baseURL: "https://generativelanguage.test/v1beta",
       headers: { "x-application": "opencode" },
       body: { safetySettings: [] },
-      limits: { context: 1_000_000, output: 65_536 },
       providerOptions: { thinkingConfig: { thinkingBudget: 1_024 } },
     })
 
@@ -236,7 +225,6 @@ describe("provider package entrypoints", () => {
     expect(selected.route.endpoint.baseURL).toBe("https://generativelanguage.test/v1beta")
     expect(selected.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(selected.route.defaults.http?.body).toEqual({ safetySettings: [] })
-    expect(selected.route.defaults.limits).toEqual({ context: 1_000_000, output: 65_536 })
     expect(selected.route.defaults.providerOptions).toEqual({ thinkingConfig: { thinkingBudget: 1_024 } })
   })
 
@@ -250,7 +238,6 @@ describe("provider package entrypoints", () => {
       apiKey: "fixture",
       headers: { "x-application": "opencode" },
       body: { safetySettings: [] },
-      limits: { context: 1_000_000, output: 65_536 },
     })
     const messages = GoogleVertexMessages.model("claude-sonnet-4-6", {
       accessToken: "fixture",
@@ -274,7 +261,6 @@ describe("provider package entrypoints", () => {
     expect(gemini.route.endpoint.baseURL).toBe("https://aiplatform.googleapis.com/v1/publishers/google")
     expect(gemini.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(gemini.route.defaults.http?.body).toEqual({ safetySettings: [] })
-    expect(gemini.route.defaults.limits).toEqual({ context: 1_000_000, output: 65_536 })
     expect(
       GoogleVertex.model("gemini-3.5-flash", {
         accessToken: "fixture",

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -322,7 +322,7 @@ describe("Anthropic Messages route", () => {
           { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: '{"forecast":"sunny"}' }] },
         ],
         stream: true,
-        max_tokens: 4096,
+        max_tokens: 32_000,
       })
     }),
   )

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -328,7 +328,6 @@ function modelFromLanguage(info: Info, language: LanguageModelV3) {
               body: projected.body === undefined ? undefined : { ...projected.body },
               headers: info.headers,
             },
-      limits: { context: info.limit.context, input: info.limit.input, output: info.limit.output },
       providerOptions: projected.settings,
     },
     body: {

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -164,7 +164,6 @@ const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(funct
     ...nativeCredentialSettings(specifier, credential),
     headers: Provider.mergeHeaders(mapping?.headers, resolved.headers),
     body: Provider.mergeOverlay(mapping?.body, resolved.body),
-    limits: { context: resolved.limit.context, input: resolved.limit.input, output: resolved.limit.output },
   }
   return yield* Effect.try({
     try: () => {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -236,7 +236,6 @@ describe("ModelResolver", () => {
         endpoint: { baseURL: "https://openai.example/v1" },
         defaults: {
           headers: { "x-test": "header" },
-          limits: { context: 100, input: 80, output: 20 },
           http: { body: { custom_extension: { enabled: true } } },
         },
       })
@@ -785,7 +784,6 @@ describe("ModelResolver", () => {
                   region: "test",
                   headers: { "x-package": "header" },
                   body: { custom: true },
-                  limits: { context: 100, output: 20 },
                 })
                 return LanguageModel.make({ id: modelID, provider: "package-provider", route: native.route })
               },
@@ -913,7 +911,6 @@ describe("ModelResolver", () => {
                     baseURL: "https://provider.example/v1",
                     headers: { "x-provider": "header" },
                     body: { custom: true },
-                    limits: { context: 100, output: 20 },
                     providerOptions,
                   })
                   return LanguageModel.make({ id: modelID, provider: "native-provider", route: native.route })

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -28,7 +28,7 @@ const location = Location.Ref.make({ directory: AbsolutePath.make("/project") })
 const model = LanguageModel.make({
   id: "summary-model",
   provider: "test",
-  route: OpenAIChat.route.with({ limits: { context: 10_000, output: 1_000 } }),
+  route: OpenAIChat.route,
 })
 let requests: LLMRequest[] = []
 const client = Layer.mock(LLMClient.Service)({

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -30,7 +30,7 @@ let requests: LLMRequest[] = []
 const model = LanguageModel.make({
   id: "summary-model",
   provider: "test",
-  route: OpenAIChat.route.with({ limits: { context: 10_000, output: 1_000 } }),
+  route: OpenAIChat.route,
 })
 const cost = [
   {

--- a/packages/core/test/session-title.test.ts
+++ b/packages/core/test/session-title.test.ts
@@ -27,7 +27,7 @@ let requests: LLMRequest[] = []
 const model = LanguageModel.make({
   id: "title-model",
   provider: "test",
-  route: OpenAIChat.route.with({ limits: { context: 10_000, output: 1_000 } }),
+  route: OpenAIChat.route,
 })
 const cost = [
   {


### PR DESCRIPTION
## Summary
- remove model capability limits from AI model, route, and provider-package defaults
- stop projecting Core catalog limits into AI provider settings
- default Anthropic Messages `max_tokens` to 32K while preserving explicit `generation.maxTokens`

## Testing
- `bun typecheck` in `packages/ai`
- `bun typecheck` in `packages/core`
- focused AI protocol, provider-package, and request compilation tests
- focused Core model resolver, AI SDK, compaction, and title tests