### PR TITLE
fix(tui): remove encrypted label from thought header

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1663,7 +1663,7 @@ function ReasoningHeader(props: {
       ? RGBA.fromValues(theme.warning.r, theme.warning.g, theme.warning.b, theme.thinkingOpacity)
       : theme.warning
   const completed = () => {
-    if (props.encrypted) return `Thought (encrypted)${props.duration ? ` · ${props.duration}` : ""}`
+    if (props.encrypted) return `Thought${props.duration ? ` · ${props.duration}` : ""}`
     const detail = [props.title, props.duration].filter(Boolean).join(" · ")
     return `${props.toggleable ? (props.open ? "- " : "+ ") : ""}Thought${detail ? `: ${detail}` : ""}`
   }


### PR DESCRIPTION
Removes `(encrypted)` from encrypted reasoning header.

Previously `Thought (encrypted) · 3ms` (from #43578), now just `Thought · 3ms` to reduce noise when many reasoning blocks are encrypted (common with GPT-5* + store:false needing `reasoning.encrypted_content`).

Change: `packages/tui/src/routes/session/index.tsx:1666`