### PR TITLE
fix(keybinds): remove ctrl+c from default app_exit to prevent accidental exits

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -45,7 +45,7 @@ const keybind = (value: Definition["default"], description: string): Definition 
 export const Definitions = {
   leader: keybind(LeaderDefault, "Leader key for keybind combinations"),
 
-  app_exit: keybind("ctrl+c,ctrl+d,<leader>q", "Exit the application"),
+  app_exit: keybind("ctrl+d,<leader>q", "Exit the application"),
   app_debug: keybind("none", "Toggle debug panel"),
   app_console: keybind("none", "Toggle console"),
   app_heap_snapshot: keybind("none", "Write heap snapshot"),

--- a/packages/web/src/content/docs/ar/keybinds.mdx
+++ b/packages/web/src/content/docs/ar/keybinds.mdx
@@ -10,7 +10,7 @@ description: خصّص اختصارات لوحة المفاتيح.
   "$schema": "https://opencode.ai/config.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/bs/keybinds.mdx
+++ b/packages/web/src/content/docs/bs/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode ima listu veza tipki koje možete prilagoditi putem `tui.json`.
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/da/keybinds.mdx
+++ b/packages/web/src/content/docs/da/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode har en liste over nøglebindinger, som du kan tilpasse gennem `tui.json
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/de/keybinds.mdx
+++ b/packages/web/src/content/docs/de/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode verfügt über eine Liste von Tastenkombinationen, die Sie über `tui.j
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/es/keybinds.mdx
+++ b/packages/web/src/content/docs/es/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode tiene una lista de combinaciones de teclas que puede personalizar a tra
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/fr/keybinds.mdx
+++ b/packages/web/src/content/docs/fr/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode a une liste de raccourcis clavier que vous pouvez personnaliser via la 
   "$schema": "https://opencode.ai/config.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/it/keybinds.mdx
+++ b/packages/web/src/content/docs/it/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode ha una lista di scorciatoie che puoi personalizzare tramite `tui.json`.
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/ja/keybinds.mdx
+++ b/packages/web/src/content/docs/ja/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode には、`tui.json` を通じてカスタマイズできるキーバイ
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -11,7 +11,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
   "leader_timeout": 2000,
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "app_debug": "none",
     "app_console": "none",
     "app_heap_snapshot": "none",

--- a/packages/web/src/content/docs/ko/keybinds.mdx
+++ b/packages/web/src/content/docs/ko/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode에는 `tui.json`을 통해 커스터마이즈할 수 있는 키바인�
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/nb/keybinds.mdx
+++ b/packages/web/src/content/docs/nb/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode har en liste over tastebindinger som du kan tilpasse gjennom `tui.json`
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/pl/keybinds.mdx
+++ b/packages/web/src/content/docs/pl/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode zawiera listę skrótów klawiszowych, które można dostosować za pom
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/pt-br/keybinds.mdx
+++ b/packages/web/src/content/docs/pt-br/keybinds.mdx
@@ -10,7 +10,7 @@ O opencode tem uma lista de atalhos de teclado que você pode personalizar atrav
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/ru/keybinds.mdx
+++ b/packages/web/src/content/docs/ru/keybinds.mdx
@@ -10,7 +10,7 @@ opencode имеет список сочетаний клавиш, которые
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/th/keybinds.mdx
+++ b/packages/web/src/content/docs/th/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode มีรายการปุ่มลัดที่คุณปร�
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/tr/keybinds.mdx
+++ b/packages/web/src/content/docs/tr/keybinds.mdx
@@ -10,7 +10,7 @@ opencode, `tui.json` aracılığıyla özelleştirebileceğiniz bir tuş bağlan
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/zh-cn/keybinds.mdx
+++ b/packages/web/src/content/docs/zh-cn/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode 提供了一系列快捷键，您可以通过 `tui.json` 进行自定�
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",

--- a/packages/web/src/content/docs/zh-tw/keybinds.mdx
+++ b/packages/web/src/content/docs/zh-tw/keybinds.mdx
@@ -10,7 +10,7 @@ OpenCode 提供了一系列快捷鍵，您可以透過 `tui.json` 進行自訂�
   "$schema": "https://opencode.ai/tui.json",
   "keybinds": {
     "leader": "ctrl+x",
-    "app_exit": "ctrl+c,ctrl+d,<leader>q",
+    "app_exit": "ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "sidebar_toggle": "<leader>b",


### PR DESCRIPTION
### Issue for this PR

Closes #7957

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ctrl+c` is bound to `app_exit` by default in the TUI, so pressing it with an empty prompt or during generation quits the whole app. That conflicts with the universal copy shortcut and has been reported in #7957 (and earlier in #2999); previous fix PRs (#11291, #9050) were auto-closed before landing.

This PR removes `ctrl+c` from the `app_exit` default in `packages/tui/src/config/keybind.ts`: `"ctrl+c,ctrl+d,<leader>q"` → `"ctrl+d,<leader>q"`. Ctrl+D and `<leader>q` still exit the app. Docs (18 locales) are synced.

No tests assert the old default, so no test changes are needed.

### How did you verify your code works?

- Reproduced the issue before the change: in tmux, Ctrl+C exits on both the idle home screen and mid-generation.
- With the new default, Ctrl+C no longer exits the app; Ctrl+D and `<leader>q` still exit.
- No unit tests cover the keybind defaults, so nothing else needed updating.

### Screenshots / recordings

_Keybinding default change in the TUI; no visible UI diff. Can add a terminal recording if helpful._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
