### PR TITLE
fix(provider): ignore SSE comment heartbeats for chunk timeout

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -40,15 +40,28 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
 
   const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  let deadline: number | undefined
+
+  function observedDataEvent(value: Uint8Array) {
+    buffer += decoder.decode(value, { stream: true })
+    const events = buffer.split(/\r?\n\r?\n/)
+    buffer = events.pop() ?? ""
+    return events.some((event) => /^data\s*:/m.test(event))
+  }
+
   const body = new ReadableStream<Uint8Array>({
     async pull(ctrl) {
+      if (deadline === undefined) deadline = Date.now() + ms
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
+        const remaining = Math.max(0, deadline - Date.now())
         const id = setTimeout(() => {
           const err = new ProviderError.ResponseStreamError("SSE read timed out")
           ctl.abort(err)
           void reader.cancel(err)
           reject(err)
-        }, ms)
+        }, remaining)
 
         reader.read().then(
           (part) => {
@@ -67,6 +80,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
         return
       }
 
+      if (observedDataEvent(part.value)) deadline = Date.now() + ms
       ctrl.enqueue(part.value)
     },
     async cancel(reason) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -53,9 +53,10 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
 
   const body = new ReadableStream<Uint8Array>({
     async pull(ctrl) {
-      if (deadline === undefined) deadline = Date.now() + ms
+      const current = deadline ?? Date.now() + ms
+      deadline = current
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-        const remaining = Math.max(0, deadline - Date.now())
+        const remaining = Math.max(0, current - Date.now())
         const id = setTimeout(() => {
           const err = new ProviderError.ResponseStreamError("SSE read timed out")
           ctl.abort(err)

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -80,6 +80,36 @@ it.live("chunkTimeout raises a response stream error when SSE body stalls", () =
   }),
 )
 
+it.live("chunkTimeout ignores SSE comment heartbeats", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => keepaliveBodyServer(20)),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const result = streamText({
+            model: yield* provider.getLanguage(model),
+            onError() {},
+            messages: [{ role: "user", content: "hello" }],
+          })
+
+          const error = yield* Effect.promise(async () => {
+            for await (const part of result.fullStream) {
+              if (part.type === "error") return part.error
+            }
+          })
+          expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)
+        }),
+      { config: providerConfig(server.url, { chunkTimeout: 50 }) },
+    )
+  }),
+)
+
 it.live("headerTimeout aborts when response headers do not arrive", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
@@ -204,6 +234,19 @@ async function delayedBodyServer(delay: number): Promise<{ server: Server; url: 
     setTimeout(() => {
       res.end('data: {"choices":[{"delta":{"content":"late"}}]}\n\ndata: [DONE]\n\n')
     }, delay)
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("server did not bind to a TCP port")
+  return { server, url: `http://127.0.0.1:${address.port}` }
+}
+
+async function keepaliveBodyServer(interval: number): Promise<{ server: Server; url: string }> {
+  const server = createServer((_, res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" })
+    res.write('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n')
+    const keepalive = setInterval(() => res.write(": keepalive\n\n"), interval)
+    res.on("close", () => clearInterval(keepalive))
   })
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
   const address = server.address()

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -99,8 +99,12 @@ it.live("chunkTimeout ignores SSE comment heartbeats", () =>
           })
 
           const error = yield* Effect.promise(async () => {
-            for await (const part of result.fullStream) {
-              if (part.type === "error") return part.error
+            try {
+              for await (const part of result.fullStream) {
+                if (part.type === "error") return part.error
+              }
+            } catch (error) {
+              return error
             }
           })
           expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -106,6 +106,7 @@ it.live("chunkTimeout ignores SSE comment heartbeats", () =>
             } catch (error) {
               return error
             }
+            return undefined
           })
           expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)
         }),


### PR DESCRIPTION
### Issue for this PR

Closes #43519

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`chunkTimeout` currently restarts for every response body read. SSE comment frames such as `: keepalive` therefore prevent an otherwise stalled model stream from timing out. This keeps one deadline across reads and resets it only after a complete SSE event containing `data:`. Header timeouts and non-SSE responses are unchanged.

The regression uses the existing loopback OpenAI-compatible server: it sends one data event, then comment heartbeats every 20 ms. With a 50 ms timeout, the stream must produce the existing typed response-stream error.

### How did you verify your code works?

- PR base: `3a31c4ea801915c0b050df4b3842997ea62b6e93`
- Current head: `8de252f7aed6b8fc4d93a650be397fd385c7c433`
- Provider timeout tests: 7 passed
- Package typecheck: passed
- Repository pre-push typecheck: 30/30 tasks passed
- Standards and compliance checks: passed

The upstream `test`, `typecheck`, and `nix-eval` workflows require maintainer approval for this fork head.

### Screenshots / recordings

Not applicable; this is a provider timeout fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
