### PR TITLE
fix(config): write config updates to a file config discovery reads

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -146,6 +146,22 @@ function globalConfigFile() {
   return candidates[0]
 }
 
+// Config discovery only reads opencode.json/opencode.jsonc, so an update has to
+// land in one of those. Prefer a file the project already has, otherwise create
+// opencode.json next to it.
+function projectConfigFile(dir: string) {
+  const candidates = [
+    path.join(dir, "opencode.jsonc"),
+    path.join(dir, "opencode.json"),
+    path.join(dir, ".opencode", "opencode.jsonc"),
+    path.join(dir, ".opencode", "opencode.json"),
+  ]
+  for (const file of candidates) {
+    if (existsSync(file)) return file
+  }
+  return path.join(dir, "opencode.json")
+}
+
 function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
   if (!isRecord(patch)) {
     const edits = modify(input, path, patch, {
@@ -623,7 +639,12 @@ const layer = Layer.effect(
 
     const update = Effect.fn("Config.update")(function* (config: Info) {
       const dir = yield* InstanceState.directory
-      const file = path.join(dir, "config.json")
+      const file = projectConfigFile(dir)
+      if (file.endsWith(".jsonc")) {
+        const before = (yield* readConfigFile(file)) ?? "{}"
+        yield* fs.writeFileString(file, patchJsonc(before, writable(config))).pipe(Effect.orDie)
+        return
+      }
       const existing = yield* loadFile(file)
       yield* fs
         .writeFileString(file, JSON.stringify(mergeDeep(writable(existing), writable(config)), null, 2))

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -358,15 +358,11 @@ it.instance(
 it.instance("updates config and preserves empty shell sentinel", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance
-    yield* writeConfigEffect(
-      test.directory,
-      { $schema: "https://opencode.ai/config.json", shell: "bash" },
-      "config.json",
-    )
+    yield* writeConfigEffect(test.directory, { $schema: "https://opencode.ai/config.json", shell: "bash" })
 
     yield* Config.Service.use((svc) => svc.update(ConfigParse.schema(ConfigV1.Info, { shell: "" }, "test:config")))
 
-    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "config.json"))
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
     expect(writtenConfig).toMatchObject({ shell: "" })
   }),
 )
@@ -890,15 +886,48 @@ Nested command template`,
   }),
 )
 
-it.instance("updates config and writes to file", () =>
+it.instance("updates config into opencode.json when the project has no config file", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance
     yield* Config.Service.use((svc) =>
       svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
     )
 
-    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "config.json"))
+    const writtenConfig = yield* FSUtil.use.readJson(path.join(test.directory, "opencode.json"))
     expect(writtenConfig).toMatchObject({ model: "updated/model" })
+    expect(yield* FSUtil.use.existsSafe(path.join(test.directory, "config.json"))).toBe(false)
+  }),
+)
+
+it.instance("updates the config file the project already has", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, ".opencode", "opencode.json")
+    yield* writeConfigEffect(path.join(test.directory, ".opencode"), { model: "old/model" })
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    expect(yield* FSUtil.use.readJson(file)).toMatchObject({ model: "updated/model" })
+    expect(yield* FSUtil.use.existsSafe(path.join(test.directory, "opencode.json"))).toBe(false)
+  }),
+)
+
+it.instance("updates opencode.jsonc in place and keeps its comments", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "opencode.jsonc")
+    yield* FSUtil.use.writeWithDirs(file, '{\n  // keep me\n  "model": "old/model"\n}\n')
+
+    yield* Config.Service.use((svc) =>
+      svc.update(ConfigParse.schema(ConfigV1.Info, { model: "updated/model" }, "test:config")),
+    )
+
+    const written = (yield* FSUtil.use.readFileStringSafe(file)) ?? ""
+    expect(written).toContain("// keep me")
+    expect(written).toContain('"model": "updated/model"')
+    expect(yield* FSUtil.use.existsSafe(path.join(test.directory, "opencode.json"))).toBe(false)
   }),
 )
 

--- a/packages/opencode/test/server/httpapi-config.test.ts
+++ b/packages/opencode/test/server/httpapi-config.test.ts
@@ -56,7 +56,7 @@ describe("config HttpApi", () => {
         lsp: false,
       })
       yield* Fiber.join(disposed)
-      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "config.json")).json())).toMatchObject({
+      expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "opencode.json")).json())).toMatchObject({
         username: "patched-user",
         formatter: false,
         lsp: false,


### PR DESCRIPTION
### Issue for this PR

Closes #43613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Config.update` (behind `PATCH /config`) wrote `<project>/config.json`. Project config discovery only reads `opencode.json` / `opencode.jsonc` — `ConfigPaths.files("opencode", ...)` walks up with those two targets — so the file it wrote was never loaded again: the request returned the new config, but nothing changed on the next start, and a stray `config.json` was left in the project.

The fix picks the config file the project already has (`opencode.jsonc`, `opencode.json`, then the same two under `.opencode/`) and falls back to creating `opencode.json`, mirroring what `globalConfigFile()` already does for the global config. Writing to whichever file exists is what #4194 asked for, and it matters for precedence: within a directory `opencode.jsonc` is merged after `opencode.json`, so always writing `opencode.json` would still leave a `.jsonc` user's update shadowed.

When the target is a `.jsonc`, it is patched with the existing `patchJsonc` helper (the one `updateGlobal` uses) instead of being re-serialized, so comments and formatting survive.

### How did you verify your code works?

Manually, against a scratch project with `"model": "anthropic/claude-sonnet-4-5"` in `opencode.json`:

```
curl -X PATCH http://127.0.0.1:4199/config -H 'content-type: application/json' \
  -H "x-opencode-directory: $PROJECT" -d '{"model":"anthropic/claude-opus-4-5"}'
```

Before: `config.json` created with the new model, `opencode.json` untouched, restart keeps the old model.
After: `opencode.json` updated in place (`$schema` preserved), no `config.json`.

Tests — `bun test test/config/config.test.ts test/server/httpapi-config.test.ts` (98 + 4 pass). Existing update tests now assert the write lands somewhere discovery reads, plus new cases for: no config file (creates `opencode.json`, no `config.json`), an existing `.opencode/opencode.json`, and an `opencode.jsonc` whose comments must survive.

`bun run typecheck` passes in `packages/opencode`. The 12 failures in `test/server/httpapi-sdk.test.ts` reproduce identically on unmodified `dev`.

### Screenshots / recordings

n/a — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
