### PR TITLE
fix(core): revert SSE heartbeat handling

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -34,7 +34,6 @@ import {
 import { Auth, Endpoint, RequestExecutor, type AnyRoute } from "@opencode-ai/ai/route"
 import { ProviderShared } from "@opencode-ai/ai/protocols/shared"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
-import { makeParser } from "effect/unstable/encoding/Sse"
 import type { ID, Info } from "./model.js"
 import { Provider } from "./provider.js"
 import { State } from "./state.js"
@@ -66,23 +65,15 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
 
   const reader = res.body.getReader()
-  const decoder = new TextDecoder()
-  let deadline: number | undefined
-  const parser = makeParser((event) => {
-    if (event._tag === "Event") deadline = Date.now() + ms
-  })
   const body = new ReadableStream<Uint8Array>({
     async pull(ctrl) {
-      const expires = deadline ?? Date.now() + ms
-      deadline = expires
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-        const remaining = Math.max(0, expires - Date.now())
         const id = setTimeout(() => {
           const err = new Error("SSE read timed out")
           ctl.abort(err)
           void reader.cancel(err)
           reject(err)
-        }, remaining)
+        }, ms)
 
         reader.read().then(
           (part) => {
@@ -101,7 +92,6 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
         return
       }
 
-      parser.feed(decoder.decode(part.value, { stream: true }))
       ctrl.enqueue(part.value)
     },
     async cancel(reason) {

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -1,7 +1,6 @@
 import { APICallError } from "@ai-sdk/provider"
 import type { LanguageModelV3, LanguageModelV3StreamPart } from "@ai-sdk/provider"
 import { createMistral } from "@ai-sdk/mistral"
-import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { SessionRunnerRetry } from "@opencode-ai/core/session/runner/retry"
 import { toSessionError } from "@opencode-ai/core/session/to-session-error"
@@ -410,63 +409,6 @@ it.effect("moves a tool image through the real Mistral provider as a user messag
         ],
       },
     ])
-  }),
-)
-
-it.effect("does not treat SSE comment heartbeats as model progress", () =>
-  Effect.gen(function* () {
-    const aisdk = yield* AISDK.Service
-    const encoder = new TextEncoder()
-    let heartbeat: ReturnType<typeof setInterval> | undefined
-    const customFetch = Object.assign(
-      async () =>
-        new Response(
-          new ReadableStream({
-            start(controller) {
-              controller.enqueue(
-                encoder.encode(
-                  'data: {"id":"response-1","object":"chat.completion.chunk","created":0,"model":"api-model","choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}]}\n\n',
-                ),
-              )
-              heartbeat = setInterval(() => controller.enqueue(encoder.encode(": keepalive\n\n")), 5)
-            },
-            cancel() {
-              if (heartbeat) clearInterval(heartbeat)
-            },
-          }),
-          { headers: { "content-type": "text/event-stream" } },
-        ),
-      { preconnect: fetch.preconnect },
-    )
-    yield* aisdk.hook.sdk((event) => {
-      event.sdk = createOpenAICompatible({
-        ...event.options,
-        name: String(event.options.name),
-        baseURL: String(event.options.baseURL),
-      })
-    })
-    const resolved = yield* aisdk.model(
-      model("@ai-sdk/openai-compatible", {
-        apiKey: "test",
-        baseURL: "https://example.test/v1",
-        chunkTimeout: 25,
-        fetch: customFetch,
-      }),
-    )
-    const result = yield* LLMClient.generate(LLM.request({ model: resolved, prompt: "Hello" })).pipe(
-      Effect.provide(client),
-      Effect.result,
-      Effect.ensuring(
-        Effect.sync(() => {
-          if (heartbeat) clearInterval(heartbeat)
-        }),
-      ),
-    )
-
-    expect(result).toMatchObject({
-      _tag: "Failure",
-      failure: { reason: { message: expect.stringContaining("SSE read timed out") } },
-    })
   }),
 )
 


### PR DESCRIPTION
## Summary
- revert SSE comment heartbeat filtering from #43618
- restore the previous SSE parsing behavior and tests

## Testing
- `bun turbo typecheck --concurrency=3`