### PR TITLE
fix(ai): lower Gemini cached content resource names

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -385,6 +385,15 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
   return contents
 })
 
+// Gemini and Vertex AI support explicit `cachedContent` resource names (e.g.,
+// "cachedContents/{id}" or "projects/{project}/locations/{location}/cachedContents/{id}").
+// See:
+//   - https://ai.google.dev/gemini-api/docs/caching
+//   - https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
+const isCachedContentResourceName = (value: string) =>
+  /^cachedContents\/[^/]+$/.test(value) ||
+  /^projects\/[^/]+\/locations\/[^/]+\/cachedContents\/[^/]+$/.test(value)
+
 const resolveOptions = (request: LLMRequest) => {
   const input = request.providerOptions
   const value = input?.thinkingConfig
@@ -400,8 +409,14 @@ const resolveOptions = (request: LLMRequest) => {
     thinkingLevel:
       ProviderShared.isRecord(value) && typeof value.thinkingLevel === "string" ? value.thinkingLevel : undefined,
   }
+  const cachedContent =
+    typeof input?.cachedContent === "string"
+      ? input.cachedContent
+      : typeof request.promptCacheKey === "string" && isCachedContentResourceName(request.promptCacheKey)
+        ? request.promptCacheKey
+        : undefined
   return {
-    cachedContent: typeof input?.cachedContent === "string" ? input.cachedContent : undefined,
+    cachedContent,
     safetySettings: mapSafetySettings(input?.safetySettings),
     serviceTier: typeof input?.serviceTier === "string" ? input.serviceTier : undefined,
     thinkingConfig: Object.values(thinkingConfig).some((item) => item !== undefined) ? thinkingConfig : undefined,

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -70,6 +70,46 @@ describe("Gemini route", () => {
           providerOptions: { safetySettings: [] },
         }),
       )
+      const cachedKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "cachedContents/from-key",
+        }),
+      )
+      const vertexCachedKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "projects/my-project/locations/us-central1/cachedContents/from-vertex-key",
+        }),
+      )
+      const genericCacheKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "session_12345",
+        }),
+      )
+      const emptyStudioKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "cachedContents/",
+        }),
+      )
+      const trailingStudioKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "cachedContents/id/extra",
+        }),
+      )
+      const emptyVertexKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "projects/p/locations/l/cachedContents/",
+        }),
+      )
+      const trailingVertexKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "projects/p/locations/l/cachedContents/id/extra",
+        }),
+      )
+      const invalidProjectsKey = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "projects/my-project/other-resource",
+        }),
+      )
 
       expect(prepared.body.generationConfig?.thinkingConfig).toEqual({
         thinkingBudget: 0,
@@ -77,6 +117,16 @@ describe("Gemini route", () => {
         thinkingLevel: "high",
       })
       expect(prepared.body.cachedContent).toBe("cachedContents/example")
+      expect(cachedKey.body.cachedContent).toBe("cachedContents/from-key")
+      expect(vertexCachedKey.body.cachedContent).toBe(
+        "projects/my-project/locations/us-central1/cachedContents/from-vertex-key",
+      )
+      expect(genericCacheKey.body.cachedContent).toBeUndefined()
+      expect(emptyStudioKey.body.cachedContent).toBeUndefined()
+      expect(trailingStudioKey.body.cachedContent).toBeUndefined()
+      expect(emptyVertexKey.body.cachedContent).toBeUndefined()
+      expect(trailingVertexKey.body.cachedContent).toBeUndefined()
+      expect(invalidProjectsKey.body.cachedContent).toBeUndefined()
       expect(prepared.body.safetySettings).toEqual([
         { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
       ])

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -55,6 +55,12 @@ describe("Gemini route", () => {
           },
         }),
       )
+      const explicitCachedContent = yield* compileRequest(
+        LLMRequest.update(request, {
+          promptCacheKey: "cachedContents/from-key",
+          providerOptions: { cachedContent: "cachedContents/explicit" },
+        }),
+      )
       const filtered = yield* compileRequest(
         LLMRequest.update(request, {
           providerOptions: { thinkingConfig: { thinkingBudget: "invalid", includeThoughts: false } },
@@ -117,6 +123,7 @@ describe("Gemini route", () => {
         thinkingLevel: "high",
       })
       expect(prepared.body.cachedContent).toBe("cachedContents/example")
+      expect(explicitCachedContent.body.cachedContent).toBe("cachedContents/explicit")
       expect(cachedKey.body.cachedContent).toBe("cachedContents/from-key")
       expect(vertexCachedKey.body.cachedContent).toBe(
         "projects/my-project/locations/us-central1/cachedContents/from-vertex-key",


### PR DESCRIPTION
### Issue for this PR

Closes #43628

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gemini and Vertex explicit context caches use resource names such as `cachedContents/{id}` and `projects/{project}/locations/{location}/cachedContents/{id}`.
This change lets an exact resource-shaped `LLMRequest.promptCacheKey` populate Gemini's `cachedContent` request field while preserving explicit `providerOptions.cachedContent` precedence.
Ordinary prompt-cache affinity keys and malformed resource names remain ignored.

### How did you verify your code works?

- `cd packages/ai && bun test test/provider/gemini.test.ts`
- `cd packages/ai && bun typecheck`
- `bun turbo typecheck --concurrency=3` via the push hook

### Screenshots / recordings

N/A (backend / protocol fix)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
