### PR TITLE
fix(core): shorten session warming interval

### DIFF
--- a/packages/core/src/plugin/warming.ts
+++ b/packages/core/src/plugin/warming.ts
@@ -10,8 +10,8 @@ import { SessionSchema } from "../session/schema.js"
 // See:
 //   - https://ai.google.dev/gemini-api/docs/caching
 //   - https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
-// A 2.5-minute (150s) default interval refreshes ephemeral cache prefixes during idle pauses
-// when warming is enabled.
+// A 2.5-minute (150s) default interval can increase the chance that ephemeral cache prefixes
+// remain available during idle pauses when warming is enabled.
 const defaults = {
   prompt: "This is a keep-alive request. Do not perform any work or use tools. Reply with exactly: OK",
   interval: Duration.seconds(150),

--- a/packages/core/src/plugin/warming.ts
+++ b/packages/core/src/plugin/warming.ts
@@ -5,9 +5,16 @@ import { Clock, Duration, Effect, Scope } from "effect"
 import { Config } from "../config.js"
 import { SessionSchema } from "../session/schema.js"
 
+// Providers that offer ephemeral implicit prompt caching benefit from keep-alive requests
+// sent within a short idle window.
+// See:
+//   - https://ai.google.dev/gemini-api/docs/caching
+//   - https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview
+// A 2.5-minute (150s) default interval refreshes ephemeral cache prefixes during idle pauses
+// when warming is enabled.
 const defaults = {
   prompt: "This is a keep-alive request. Do not perform any work or use tools. Reply with exactly: OK",
-  interval: Duration.minutes(4),
+  interval: Duration.seconds(150),
   duration: Duration.minutes(30),
 }
 

--- a/packages/core/test/config/warming.test.ts
+++ b/packages/core/test/config/warming.test.ts
@@ -13,12 +13,12 @@ describe("config warming", () => {
 
   test("decodes custom durations", () => {
     const warming = decode({
-      warming: { prompt: "Reply pong", interval: "2 minutes", duration: "1 hour" },
+      warming: { prompt: "Reply pong", interval: "2.5 minutes", duration: "1 hour" },
     }).warming
     expect(typeof warming).toBe("object")
     if (typeof warming !== "object") return
     expect(warming.prompt).toBe("Reply pong")
-    expect(warming.interval).toEqual(Duration.minutes(2))
+    expect(warming.interval).toEqual(Duration.seconds(150))
     expect(warming.duration).toEqual(Duration.hours(1))
   })
 })

--- a/packages/core/test/plugin/warming.test.ts
+++ b/packages/core/test/plugin/warming.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect } from "bun:test"
+import { Message } from "@opencode-ai/ai"
+import { Agent } from "@opencode-ai/core/agent"
+import { Config } from "@opencode-ai/core/config"
+import { Model } from "@opencode-ai/core/model"
+import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
+import { Provider } from "@opencode-ai/core/provider"
+import { Session } from "@opencode-ai/core/session"
+import { Effect, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { Config as ConfigSchema } from "@opencode-ai/schema/config"
+import { WarmingPlugin } from "../../src/plugin/warming"
+import { testEffect } from "../lib/effect"
+import { PluginTestLayer } from "./fixture"
+import { host } from "./host"
+
+const it = testEffect(PluginTestLayer)
+
+describe("warming plugin", () => {
+  it.effect("uses the 150-second default interval", () =>
+    Effect.gen(function* () {
+      const hooks = yield* PluginHooks.Service
+      const generated: string[] = []
+      const sessionID = Session.ID.make("ses_warming_default")
+      const config = Config.Service.of({
+        entries: () =>
+          Effect.succeed([
+            new ConfigSchema.Document({
+              type: "document",
+              info: new ConfigSchema.Info({ warming: true }),
+            }),
+          ]),
+        update: () => Effect.die("unused config.update"),
+        changes: () => Stream.empty,
+      })
+
+      yield* WarmingPlugin.Plugin.effect(
+        host({
+          session: {
+            hook: (name, callback, options) => hooks.register("session", name, callback, options),
+            generate: (input) => Effect.sync(() => generated.push(input.prompt)).pipe(Effect.as({ text: "OK" })),
+          },
+        }),
+      ).pipe(Effect.provideService(Config.Service, config))
+      yield* hooks.trigger("session", "context", {
+        sessionID,
+        agent: Agent.ID.make("build"),
+        model: Model.Ref.make({ providerID: Provider.ID.make("test"), id: Model.ID.make("model") }),
+        system: [],
+        messages: [Message.user("Hello")],
+        tools: {},
+      })
+
+      yield* TestClock.adjust("149 seconds")
+      expect(generated).toEqual([])
+      yield* TestClock.adjust("1 second")
+      expect(generated).toEqual([
+        "This is a keep-alive request. Do not perform any work or use tools. Reply with exactly: OK",
+      ])
+    }),
+  )
+})

--- a/packages/schema/src/config/warming.ts
+++ b/packages/schema/src/config/warming.ts
@@ -8,7 +8,7 @@ export class Info extends Schema.Class<Info>("Config.Warming")({
     description: "Prompt sent for keep-alive requests",
   }),
   interval: Schema.DurationFromString.pipe(optional).annotate({
-    description: 'Idle time between keep-alive requests (default: "4 minutes")',
+    description: 'Idle time between keep-alive requests (default: "2.5 minutes")',
   }),
   duration: Schema.DurationFromString.pipe(optional).annotate({
     description: 'Time after the last active request to keep a session warm (default: "30 minutes")',

--- a/packages/www/content/docs/(Configure)/warming.mdx
+++ b/packages/www/content/docs/(Configure)/warming.mdx
@@ -6,7 +6,7 @@ Session warming sends periodic model requests for recently active sessions.
 This can preserve provider-side prompt caches or other short-lived session state while you pause between prompts.
 
 Providers such as [Gemini API](https://ai.google.dev/gemini-api/docs/caching) and [Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview) offer automatic implicit prefix caching for frequent requests sent within a short idle window, as well as explicit cached content with longer configurable lifetimes.
-When session warming is enabled, OpenCode sends keep-alive requests during idle pauses to keep ephemeral cache prefixes active.
+When session warming is enabled, OpenCode sends keep-alive requests during idle pauses that can increase the chance that ephemeral cache prefixes remain available.
 
 Warming is disabled by default.
 Enable it with the default settings in any [OpenCode configuration file](/config):

--- a/packages/www/content/docs/(Configure)/warming.mdx
+++ b/packages/www/content/docs/(Configure)/warming.mdx
@@ -3,11 +3,13 @@ title: "Session warming"
 ---
 
 Session warming sends periodic model requests for recently active sessions.
-This can preserve provider-side prompt caches or other short-lived session
-state while you pause between prompts.
+This can preserve provider-side prompt caches or other short-lived session state while you pause between prompts.
 
-Warming is disabled by default. Enable it with the default settings in any
-[OpenCode configuration file](/config):
+Providers such as [Gemini API](https://ai.google.dev/gemini-api/docs/caching) and [Google Cloud Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview) offer automatic implicit prefix caching for frequent requests sent within a short idle window, as well as explicit cached content with longer configurable lifetimes.
+When session warming is enabled, OpenCode sends keep-alive requests during idle pauses to keep ephemeral cache prefixes active.
+
+Warming is disabled by default.
+Enable it with the default settings in any [OpenCode configuration file](/config):
 
 ```jsonc title="opencode.jsonc"
 {
@@ -16,10 +18,9 @@ Warming is disabled by default. Enable it with the default settings in any
 }
 ```
 
-With the defaults, OpenCode sends a warming request after a session has made no
-model request for four minutes. It repeats this while the session remains idle,
-but stops 30 minutes after the last non-warming request. New model activity
-starts a new 30-minute window.
+With the defaults, OpenCode sends a warming request after a session has made no model request for 2.5 minutes.
+It repeats this while the session remains idle, but stops 30 minutes after the last non-warming request.
+New model activity starts a new 30-minute window.
 
 ## Configuration
 
@@ -30,7 +31,7 @@ Use the object form to customize the prompt, idle interval, or active duration:
   "$schema": "https://opencode.ai/config.json",
   "warming": {
     "prompt": "Do not perform any work. Reply with exactly: OK",
-    "interval": "4 minutes",
+    "interval": "2.5 minutes",
     "duration": "30 minutes",
   },
 }
@@ -39,11 +40,11 @@ Use the object form to customize the prompt, idle interval, or active duration:
 | Field      | Default                | Description                                                                                             |
 | ---------- | ---------------------- | ------------------------------------------------------------------------------------------------------- |
 | `prompt`   | Keep-alive instruction | Prompt sent in each warming request. The default instructs the model to do no work and reply with `OK`. |
-| `interval` | `"4 minutes"`          | Idle time between warming requests.                                                                     |
+| `interval` | `"2.5 minutes"`        | Idle time between warming requests.                                                                     |
 | `duration` | `"30 minutes"`         | Maximum warming window after the latest non-warming model request.                                      |
 
-`interval` and `duration` accept duration strings such as `"30 seconds"`,
-`"4 minutes"`, or `"1 hour"`. Both must be finite and greater than zero.
+`interval` and `duration` accept duration strings such as `"30 seconds"`, `"2.5 minutes"`, `"4 minutes"`, or `"1 hour"`.
+Both must be finite and greater than zero.
 
 To disable warming explicitly:
 

--- a/packages/www/content/docs/config.mdx
+++ b/packages/www/content/docs/config.mdx
@@ -335,14 +335,13 @@ See the [compaction guide](/compaction) for automatic context management.
 ### Session warming
 
 Keep recently active model sessions warm with periodic transient requests.
-Warming is disabled by default; set it to `true` to use the four-minute idle
-interval and 30-minute active window.
+Warming is disabled by default; set `"warming": true` to use the 2.5-minute idle interval and 30-minute active window.
 
 ```jsonc
 {
   "warming": {
     "prompt": "Do not perform any work. Reply with exactly: OK",
-    "interval": "4 minutes",
+    "interval": "2.5 minutes",
     "duration": "30 minutes",
   },
 }


### PR DESCRIPTION
### Issue for this PR

Closes #43628

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This changes the default interval for explicitly enabled session warming from 4 minutes to 150 seconds.
Warming remains disabled unless configured with `"warming": true` or an object, and custom intervals and durations are unchanged.
The documentation distinguishes short-lived implicit prefix caching from explicit cached-content resources and documents the request-cost implications without guaranteeing cache retention.

### How did you verify your code works?

- `cd packages/core && bun test test/config/warming.test.ts test/config/normalization.test.ts test/session-generate.test.ts test/plugin/warming.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/schema && bun typecheck`
- `cd packages/www && bun validate`
- `cd packages/www && bun run build`
- `bun turbo typecheck --concurrency=3` via the push hook

### Screenshots / recordings

N/A (backend and documentation change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
