### PR TITLE
fix(ui): correct AnimatedNumber digit order in RTL locales

### DIFF
--- a/packages/ui/src/components/animated-number.css
+++ b/packages/ui/src/components/animated-number.css
@@ -8,6 +8,7 @@
   [data-slot="animated-number-value"] {
     display: inline-flex;
     flex-direction: row-reverse;
+    direction: ltr;
     align-items: baseline;
     justify-content: flex-end;
     line-height: inherit;


### PR DESCRIPTION
### Issue for this PR

Closes #43643

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`AnimatedNumber` renders digits by reversing the digit array in DOM order and
relying on `flex-direction: row-reverse` to restore the visual order. But
`row-reverse` resolves against the inherited document direction, so when the UI
language is RTL (e.g. Arabic sets `document.documentElement.dir = "rtl"`), the
rule resolves to left-to-right and multi-digit numbers render reversed — `16`
displays as `61` (visible in tool-count labels like "16 قراءة" and in the todo
progress numbers).

The fix adds `direction: ltr` to the `[data-slot="animated-number-value"]` rule
in `animated-number.css`, pinning the container's direction context so
`row-reverse` always resolves the same way regardless of document direction.
No component or callsite changes are needed; both consumers
(`@opencode-ai/ui/animated-number` in session-ui and the app) inherit the fix.
Accessibility is unaffected — the root span still carries an `aria-label` with
the full number.

### How did you verify your code works?

- Rendered the exact DOM structure the component generates (reversed digits
  for `16`) against the real stylesheet in a browser:
  - original CSS: LTR → `16`, RTL → `61` (bug reproduced)
  - fixed CSS: LTR → `16`, RTL → `16` (correct in both directions)
- `bun typecheck` passes in `packages/ui`, `packages/session-ui`, and
  `packages/app`.

### Screenshots / recordings

_The change is a one-line CSS direction pin; digit order is now identical in
LTR and RTL documents._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR