### PR TITLE
fix(core): roll up subagent cost into parent session and fix fork double-counting

### DIFF
--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -86,35 +86,51 @@ const Endpoint3_3 = (raw: RawClient["server.session"]) => (input: Endpoint3_3Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
-type Endpoint3_4Input = {
-  readonly sessionID: Endpoint3_4Request["params"]["sessionID"]
-  readonly agent: Endpoint3_4Request["payload"]["agent"]
-}
+type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.children"]>[0]
+type Endpoint3_4Input = { readonly sessionID: Endpoint3_4Request["params"]["sessionID"] }
 const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
+  raw["session.children"]({ params: { sessionID: input["sessionID"] } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.cost"]>[0]
+type Endpoint3_5Input = { readonly sessionID: Endpoint3_5Request["params"]["sessionID"] }
+const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
+  raw["session.cost"]({ params: { sessionID: input["sessionID"] } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
+type Endpoint3_6Input = {
+  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
+  readonly agent: Endpoint3_6Request["payload"]["agent"]
+}
+const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
   raw["session.switchAgent"]({ params: { sessionID: input["sessionID"] }, payload: { agent: input["agent"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
-type Endpoint3_5Input = {
-  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
-  readonly model: Endpoint3_5Request["payload"]["model"]
+type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
+type Endpoint3_7Input = {
+  readonly sessionID: Endpoint3_7Request["params"]["sessionID"]
+  readonly model: Endpoint3_7Request["payload"]["model"]
 }
-const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
+const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
   raw["session.switchModel"]({ params: { sessionID: input["sessionID"] }, payload: { model: input["model"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
-type Endpoint3_6Input = {
-  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
-  readonly id?: Endpoint3_6Request["payload"]["id"]
-  readonly prompt: Endpoint3_6Request["payload"]["prompt"]
-  readonly delivery?: Endpoint3_6Request["payload"]["delivery"]
-  readonly resume?: Endpoint3_6Request["payload"]["resume"]
+type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint3_8Input = {
+  readonly sessionID: Endpoint3_8Request["params"]["sessionID"]
+  readonly id?: Endpoint3_8Request["payload"]["id"]
+  readonly prompt: Endpoint3_8Request["payload"]["prompt"]
+  readonly delivery?: Endpoint3_8Request["payload"]["delivery"]
+  readonly resume?: Endpoint3_8Request["payload"]["resume"]
 }
-const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
+const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
@@ -123,23 +139,23 @@ const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint3_7Input = { readonly sessionID: Endpoint3_7Request["params"]["sessionID"] }
-const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
+type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint3_9Input = { readonly sessionID: Endpoint3_9Request["params"]["sessionID"] }
+const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
   raw["session.compact"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-type Endpoint3_8Input = { readonly sessionID: Endpoint3_8Request["params"]["sessionID"] }
-const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
+type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint3_10Input = { readonly sessionID: Endpoint3_10Request["params"]["sessionID"] }
+const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
   raw["session.wait"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint3_9Input = {
-  readonly sessionID: Endpoint3_9Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_9Request["payload"]["messageID"]
-  readonly files?: Endpoint3_9Request["payload"]["files"]
+type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint3_11Input = {
+  readonly sessionID: Endpoint3_11Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_11Request["payload"]["messageID"]
+  readonly files?: Endpoint3_11Request["payload"]["files"]
 }
-const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
+const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input["sessionID"] },
     payload: { messageID: input["messageID"], files: input["files"] },
@@ -148,42 +164,42 @@ const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint3_10Input = { readonly sessionID: Endpoint3_10Request["params"]["sessionID"] }
-const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
-  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
-type Endpoint3_11Input = { readonly sessionID: Endpoint3_11Request["params"]["sessionID"] }
-const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
-  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 type Endpoint3_12Input = { readonly sessionID: Endpoint3_12Request["params"]["sessionID"] }
 const Endpoint3_12 = (raw: RawClient["server.session"]) => (input: Endpoint3_12Input) =>
+  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint3_13Input = { readonly sessionID: Endpoint3_13Request["params"]["sessionID"] }
+const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
+  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_14Input = { readonly sessionID: Endpoint3_14Request["params"]["sessionID"] }
+const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
   raw["session.context"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.history"]>[0]
-type Endpoint3_13Input = {
-  readonly sessionID: Endpoint3_13Request["params"]["sessionID"]
-  readonly limit?: Endpoint3_13Request["query"]["limit"]
-  readonly after?: Endpoint3_13Request["query"]["after"]
+type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.history"]>[0]
+type Endpoint3_15Input = {
+  readonly sessionID: Endpoint3_15Request["params"]["sessionID"]
+  readonly limit?: Endpoint3_15Request["query"]["limit"]
+  readonly after?: Endpoint3_15Request["query"]["after"]
 }
-const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
+const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
   raw["session.history"]({
     params: { sessionID: input["sessionID"] },
     query: { limit: input["limit"], after: input["after"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.events"]>[0]
-type Endpoint3_14Input = {
-  readonly sessionID: Endpoint3_14Request["params"]["sessionID"]
-  readonly after?: Endpoint3_14Request["query"]["after"]
+type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.events"]>[0]
+type Endpoint3_16Input = {
+  readonly sessionID: Endpoint3_16Request["params"]["sessionID"]
+  readonly after?: Endpoint3_16Request["query"]["after"]
 }
-const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
+const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
   Stream.unwrap(
     raw["session.events"]({ params: { sessionID: input["sessionID"] }, query: { after: input["after"] } }).pipe(
       Effect.mapError(mapClientError),
@@ -191,17 +207,17 @@ const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14I
     ),
   )
 
-type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint3_15Input = { readonly sessionID: Endpoint3_15Request["params"]["sessionID"] }
-const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
+type Endpoint3_17Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
+type Endpoint3_17Input = { readonly sessionID: Endpoint3_17Request["params"]["sessionID"] }
+const Endpoint3_17 = (raw: RawClient["server.session"]) => (input: Endpoint3_17Input) =>
   raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint3_16Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint3_16Input = {
-  readonly sessionID: Endpoint3_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint3_16Request["params"]["messageID"]
+type Endpoint3_18Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint3_18Input = {
+  readonly sessionID: Endpoint3_18Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_18Request["params"]["messageID"]
 }
-const Endpoint3_16 = (raw: RawClient["server.session"]) => (input: Endpoint3_16Input) =>
+const Endpoint3_18 = (raw: RawClient["server.session"]) => (input: Endpoint3_18Input) =>
   raw["session.message"]({ params: { sessionID: input["sessionID"], messageID: input["messageID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
@@ -212,19 +228,21 @@ const adaptGroup3 = (raw: RawClient["server.session"]) => ({
   create: Endpoint3_1(raw),
   active: Endpoint3_2(raw),
   get: Endpoint3_3(raw),
-  switchAgent: Endpoint3_4(raw),
-  switchModel: Endpoint3_5(raw),
-  prompt: Endpoint3_6(raw),
-  compact: Endpoint3_7(raw),
-  wait: Endpoint3_8(raw),
-  stage: Endpoint3_9(raw),
-  clear: Endpoint3_10(raw),
-  commit: Endpoint3_11(raw),
-  context: Endpoint3_12(raw),
-  history: Endpoint3_13(raw),
-  events: Endpoint3_14(raw),
-  interrupt: Endpoint3_15(raw),
-  message: Endpoint3_16(raw),
+  children: Endpoint3_4(raw),
+  cost: Endpoint3_5(raw),
+  switchAgent: Endpoint3_6(raw),
+  switchModel: Endpoint3_7(raw),
+  prompt: Endpoint3_8(raw),
+  compact: Endpoint3_9(raw),
+  wait: Endpoint3_10(raw),
+  stage: Endpoint3_11(raw),
+  clear: Endpoint3_12(raw),
+  commit: Endpoint3_13(raw),
+  context: Endpoint3_14(raw),
+  history: Endpoint3_15(raw),
+  events: Endpoint3_16(raw),
+  interrupt: Endpoint3_17(raw),
+  message: Endpoint3_18(raw),
 })
 
 type Endpoint4_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -11,6 +11,10 @@ import type {
   SessionsActiveOutput,
   SessionsGetInput,
   SessionsGetOutput,
+  SessionsChildrenInput,
+  SessionsChildrenOutput,
+  SessionsCostInput,
+  SessionsCostOutput,
   SessionsSwitchAgentInput,
   SessionsSwitchAgentOutput,
   SessionsSwitchModelInput,
@@ -337,6 +341,28 @@ export function make(options: ClientOptions) {
           {
             method: "GET",
             path: `/api/session/${encodeURIComponent(input.sessionID)}`,
+            successStatus: 200,
+            declaredStatuses: [404, 400, 401],
+            empty: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      children: (input: SessionsChildrenInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: SessionsChildrenOutput }>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/children`,
+            successStatus: 200,
+            declaredStatuses: [400, 404, 401],
+            empty: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      cost: (input: SessionsCostInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: SessionsCostOutput }>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/cost`,
             successStatus: 200,
             declaredStatuses: [404, 400, 401],
             empty: false,

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -365,6 +365,56 @@ export type SessionsGetOutput = {
   }
 }["data"]
 
+export type SessionsChildrenInput = { readonly sessionID: { readonly sessionID: string }["sessionID"] }
+
+export type SessionsChildrenOutput = {
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly parentID?: string
+    readonly projectID: string
+    readonly agent?: string
+    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+    readonly cost: number
+    readonly tokens: {
+      readonly input: number
+      readonly output: number
+      readonly reasoning: number
+      readonly cache: { readonly read: number; readonly write: number }
+    }
+    readonly time: { readonly created: number; readonly updated: number; readonly archived?: number }
+    readonly title: string
+    readonly location: { readonly directory: string; readonly workspaceID?: string }
+    readonly subpath?: string
+    readonly revert?: {
+      readonly messageID: string
+      readonly partID?: string
+      readonly snapshot?: string
+      readonly diff?: string
+      readonly files?: ReadonlyArray<{
+        readonly path: string
+        readonly status: "added" | "modified" | "deleted"
+        readonly additions: number
+        readonly deletions: number
+        readonly patch: string
+      }>
+    }
+  }>
+}["data"]
+
+export type SessionsCostInput = { readonly sessionID: { readonly sessionID: string }["sessionID"] }
+
+export type SessionsCostOutput = {
+  readonly data: {
+    readonly cost: number
+    readonly tokens: {
+      readonly input: number
+      readonly output: number
+      readonly reasoning: number
+      readonly cache: { readonly read: number; readonly write: number }
+    }
+  }
+}["data"]
+
 export type SessionsSwitchAgentInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]
   readonly agent: { readonly agent: string }["agent"]

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -168,6 +168,10 @@ export interface Interface {
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, NotFoundError | SessionRunner.RunError>
   readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  readonly children: (parentID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info[]>
+  readonly totalCost: (
+    sessionID: SessionSchema.ID,
+  ) => Effect.Effect<{ cost: number; tokens: NonNullable<SessionSchema.Info["tokens"]> }, NotFoundError>
   readonly revert: {
     readonly stage: (input: {
       sessionID: SessionSchema.ID
@@ -430,6 +434,48 @@ const layer = Layer.effect(
       interrupt: Effect.fn("V2Session.interrupt")((sessionID) =>
         Effect.uninterruptible(execution.interrupt(sessionID)),
       ),
+      children: Effect.fn("V2Session.children")(function* (parentID) {
+        const rows = yield* db
+          .select()
+          .from(SessionTable)
+          .where(and(eq(SessionTable.parent_id, parentID)))
+          .all()
+          .pipe(Effect.orDie)
+        return rows.map(fromRow)
+      }),
+      totalCost: Effect.fn("V2Session.totalCost")(function* (sessionID) {
+        const own = yield* result.get(sessionID)
+        let cost = own.cost ?? 0
+        let tokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+        if (own.tokens) {
+          tokens = {
+            input: own.tokens.input,
+            output: own.tokens.output,
+            reasoning: own.tokens.reasoning,
+            cache: { read: own.tokens.cache.read, write: own.tokens.cache.write },
+          }
+        }
+        const queue = [sessionID]
+        const visited = new Set([sessionID])
+        while (queue.length > 0) {
+          const current = queue.shift()!
+          const kids = yield* result.children(current)
+          for (const kid of kids) {
+            if (visited.has(kid.id)) continue
+            visited.add(kid.id)
+            cost += kid.cost ?? 0
+            if (kid.tokens) {
+              tokens.input += kid.tokens.input
+              tokens.output += kid.tokens.output
+              tokens.reasoning += kid.tokens.reasoning
+              tokens.cache.read += kid.tokens.cache.read
+              tokens.cache.write += kid.tokens.cache.write
+            }
+            queue.push(kid.id)
+          }
+        }
+        return { cost, tokens }
+      }),
       revert: {
         stage: Effect.fn("V2Session.revert.stage")(function* (input) {
           const session = yield* result.get(input.sessionID)

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -31,11 +31,15 @@ export type SDK = {
       parameters: { readonly sessionID: string; readonly directory: string },
       options: { readonly throwOnError: true },
     ) => Promise<{ readonly data?: readonly SessionMessage[] | null }>
+    readonly cost: (
+      parameters: { readonly sessionID: string },
+    ) => Promise<{ readonly data?: { readonly cost?: number } | null }>
   }
 }
 
 export interface MessageLoaderInterface {
   readonly messages: (input: MessagesInput) => Effect.Effect<readonly SessionMessage[], unknown>
+  readonly cost: (input: { readonly sessionID: string }) => Effect.Effect<number, unknown>
 }
 
 export interface ContextLimitLoaderInterface {
@@ -77,6 +81,10 @@ export function messageLoaderFromSDK(sdk: SDK): MessageLoaderInterface {
         sdk.session
           .messages({ sessionID: input.sessionID, directory: input.directory }, { throwOnError: true })
           .then((response) => response.data ?? []),
+      ),
+    cost: (input) =>
+      Effect.promise(() =>
+        sdk.session.cost({ sessionID: input.sessionID }).then((response) => response.data?.cost ?? 0),
       ),
   })
 }
@@ -205,6 +213,10 @@ const layer = Layer.effect(
       })
       if (!size) return
 
+      const cost = yield* messageLoader
+        .cost({ sessionID: input.sessionID })
+        .pipe(Effect.orElseSucceed(() => totalSessionCost(messages)))
+
       yield* Effect.promise(() =>
         input.connection
           .sessionUpdate({
@@ -213,7 +225,7 @@ const layer = Layer.effect(
               sessionUpdate: "usage_update",
               used: contextTokens(message),
               size,
-              cost: { amount: totalSessionCost(messages), currency: "USD" },
+              cost: { amount: cost, currency: "USD" },
             },
           })
           .catch(() => {}),

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -31,11 +31,15 @@ export type SDK = {
       parameters: { readonly sessionID: string; readonly directory: string },
       options: { readonly throwOnError: true },
     ) => Promise<{ readonly data?: readonly SessionMessage[] | null }>
+    readonly cost: (
+      parameters: { readonly sessionID: string },
+    ) => Promise<{ readonly data?: { readonly cost?: number } | null }>
   }
 }
 
 export interface MessageLoaderInterface {
   readonly messages: (input: MessagesInput) => Effect.Effect<readonly SessionMessage[], unknown>
+  readonly cost: (input: { readonly sessionID: string }) => Effect.Effect<{ readonly cost?: number } | undefined, unknown>
 }
 
 export interface ContextLimitLoaderInterface {
@@ -77,6 +81,13 @@ export function messageLoaderFromSDK(sdk: SDK): MessageLoaderInterface {
         sdk.session
           .messages({ sessionID: input.sessionID, directory: input.directory }, { throwOnError: true })
           .then((response) => response.data ?? []),
+      ),
+    cost: (input) =>
+      Effect.promise(() =>
+        sdk.session
+          .cost({ sessionID: input.sessionID })
+          .then((response) => response.data ?? undefined)
+          .catch(() => undefined),
       ),
   })
 }
@@ -205,6 +216,13 @@ const layer = Layer.effect(
       })
       if (!size) return
 
+      const aggregatedCost = yield* messageLoader
+        .cost({ sessionID: input.sessionID })
+        .pipe(
+          Effect.map((result) => result?.cost ?? totalSessionCost(messages)),
+          Effect.orElseSucceed(() => totalSessionCost(messages)),
+        )
+
       yield* Effect.promise(() =>
         input.connection
           .sessionUpdate({
@@ -213,7 +231,7 @@ const layer = Layer.effect(
               sessionUpdate: "usage_update",
               used: contextTokens(message),
               size,
-              cost: { amount: totalSessionCost(messages), currency: "USD" },
+              cost: { amount: aggregatedCost, currency: "USD" },
             },
           })
           .catch(() => {}),

--- a/packages/opencode/src/acp/usage.ts
+++ b/packages/opencode/src/acp/usage.ts
@@ -31,15 +31,11 @@ export type SDK = {
       parameters: { readonly sessionID: string; readonly directory: string },
       options: { readonly throwOnError: true },
     ) => Promise<{ readonly data?: readonly SessionMessage[] | null }>
-    readonly cost: (
-      parameters: { readonly sessionID: string },
-    ) => Promise<{ readonly data?: { readonly cost?: number } | null }>
   }
 }
 
 export interface MessageLoaderInterface {
   readonly messages: (input: MessagesInput) => Effect.Effect<readonly SessionMessage[], unknown>
-  readonly cost: (input: { readonly sessionID: string }) => Effect.Effect<{ readonly cost?: number } | undefined, unknown>
 }
 
 export interface ContextLimitLoaderInterface {
@@ -81,13 +77,6 @@ export function messageLoaderFromSDK(sdk: SDK): MessageLoaderInterface {
         sdk.session
           .messages({ sessionID: input.sessionID, directory: input.directory }, { throwOnError: true })
           .then((response) => response.data ?? []),
-      ),
-    cost: (input) =>
-      Effect.promise(() =>
-        sdk.session
-          .cost({ sessionID: input.sessionID })
-          .then((response) => response.data ?? undefined)
-          .catch(() => undefined),
       ),
   })
 }
@@ -216,13 +205,6 @@ const layer = Layer.effect(
       })
       if (!size) return
 
-      const aggregatedCost = yield* messageLoader
-        .cost({ sessionID: input.sessionID })
-        .pipe(
-          Effect.map((result) => result?.cost ?? totalSessionCost(messages)),
-          Effect.orElseSucceed(() => totalSessionCost(messages)),
-        )
-
       yield* Effect.promise(() =>
         input.connection
           .sessionUpdate({
@@ -231,7 +213,7 @@ const layer = Layer.effect(
               sessionUpdate: "usage_update",
               used: contextTokens(message),
               size,
-              cost: { amount: aggregatedCost, currency: "USD" },
+              cost: { amount: totalSessionCost(messages), currency: "USD" },
             },
           })
           .catch(() => {}),

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -86,6 +86,7 @@ export type SessionData = {
   visible: Map<string, string>
   end: Set<string>
   echo: Map<string, Set<string>>
+  totalCost: number
 }
 
 export type SessionDataInput = {
@@ -124,6 +125,7 @@ export function createSessionData(
     visible: new Map(),
     end: new Set(),
     echo: new Map(),
+    totalCost: 0,
   }
 }
 
@@ -846,7 +848,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
     const usage = formatUsage(
       info.tokens,
       input.limits[modelKey(info.providerID, info.modelID)],
-      typeof info.cost === "number" ? info.cost : undefined,
+      data.totalCost > 0 ? data.totalCost : (typeof info.cost === "number" ? info.cost : undefined),
     )
     if (usage) {
       next = {

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -86,7 +86,7 @@ export type SessionData = {
   visible: Map<string, string>
   end: Set<string>
   echo: Map<string, Set<string>>
-  totalCost: number
+  subagentCost: number
 }
 
 export type SessionDataInput = {
@@ -125,7 +125,7 @@ export function createSessionData(
     visible: new Map(),
     end: new Set(),
     echo: new Map(),
-    totalCost: 0,
+    subagentCost: 0,
   }
 }
 
@@ -848,7 +848,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
     const usage = formatUsage(
       info.tokens,
       input.limits[modelKey(info.providerID, info.modelID)],
-      data.totalCost > 0 ? data.totalCost : (typeof info.cost === "number" ? info.cost : undefined),
+      (typeof info.cost === "number" ? info.cost : 0) + data.subagentCost,
     )
     if (usage) {
       next = {

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -86,7 +86,7 @@ export type SessionData = {
   visible: Map<string, string>
   end: Set<string>
   echo: Map<string, Set<string>>
-  subagentCost: number
+  totalCost: number
 }
 
 export type SessionDataInput = {
@@ -125,7 +125,7 @@ export function createSessionData(
     visible: new Map(),
     end: new Set(),
     echo: new Map(),
-    subagentCost: 0,
+    totalCost: 0,
   }
 }
 
@@ -848,7 +848,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
     const usage = formatUsage(
       info.tokens,
       input.limits[modelKey(info.providerID, info.modelID)],
-      (typeof info.cost === "number" ? info.cost : 0) + data.subagentCost,
+      data.totalCost > 0 ? data.totalCost : (typeof info.cost === "number" ? info.cost : 0),
     )
     if (usage) {
       next = {

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -787,6 +787,7 @@ function createLayer(input: StreamInput) {
 
           booting = false
           yield* drainBuffered()
+          yield* refreshCost.pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
 
           const sessions = [...state.subagent.tabs.keys()]
           if (sessions.length === 0) {
@@ -880,6 +881,19 @@ function createLayer(input: StreamInput) {
           })
         }
 
+        const refreshCost = Effect.fn("RunStreamTransport.refreshCost")(function* () {
+          const result = yield* Effect.promise(() =>
+            input.sdk.session.cost({ sessionID: input.sessionID }),
+          ).pipe(
+            Effect.map((item) => item.data?.cost ?? 0),
+            Effect.orElseSucceed(() => 0),
+          )
+          if (result !== state.data.totalCost) {
+            state.data.totalCost = result
+            syncFooter([])
+          }
+        })
+
         const applyEvent = Effect.fn("RunStreamTransport.applyEvent")(function* (event: Event) {
           if (event.type === "message.part.delta" && event.properties.sessionID === input.sessionID) {
             if (replayedParts.has(event.properties.partID)) {
@@ -948,6 +962,10 @@ function createLayer(input: StreamInput) {
 
           touch(event)
           yield* mark(event)
+
+          if (event.type === "message.updated" && event.properties.sessionID === input.sessionID) {
+            yield* refreshCost.pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
+          }
         })
 
         const drainBuffered = Effect.fn("RunStreamTransport.drainBuffered")(function* () {

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -882,15 +882,14 @@ function createLayer(input: StreamInput) {
         }
 
         const refreshCost = Effect.fn("RunStreamTransport.refreshCost")(function* () {
-          const children = yield* Effect.promise(() =>
-            input.sdk.session.children({ sessionID: input.sessionID }),
+          const result = yield* Effect.promise(() =>
+            input.sdk.session.cost({ sessionID: input.sessionID }),
           ).pipe(
-            Effect.map((item) => item.data ?? []),
-            Effect.orElseSucceed(() => [] as readonly { cost?: number }[]),
+            Effect.map((response) => response.data?.cost ?? 0),
+            Effect.orElseSucceed(() => 0),
           )
-          const childCost = children.reduce((sum, child) => sum + (child.cost ?? 0), 0)
-          if (childCost !== state.data.subagentCost) {
-            state.data.subagentCost = childCost
+          if (result !== state.data.totalCost) {
+            state.data.totalCost = result
             syncFooter([])
           }
         })

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -787,7 +787,7 @@ function createLayer(input: StreamInput) {
 
           booting = false
           yield* drainBuffered()
-          yield* refreshCost.pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
+          yield* refreshCost().pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
 
           const sessions = [...state.subagent.tabs.keys()]
           if (sessions.length === 0) {
@@ -882,14 +882,15 @@ function createLayer(input: StreamInput) {
         }
 
         const refreshCost = Effect.fn("RunStreamTransport.refreshCost")(function* () {
-          const result = yield* Effect.promise(() =>
-            input.sdk.session.cost({ sessionID: input.sessionID }),
+          const children = yield* Effect.promise(() =>
+            input.sdk.session.children({ sessionID: input.sessionID }),
           ).pipe(
-            Effect.map((item) => item.data?.cost ?? 0),
-            Effect.orElseSucceed(() => 0),
+            Effect.map((item) => item.data ?? []),
+            Effect.orElseSucceed(() => [] as readonly { cost?: number }[]),
           )
-          if (result !== state.data.totalCost) {
-            state.data.totalCost = result
+          const childCost = children.reduce((sum, child) => sum + (child.cost ?? 0), 0)
+          if (childCost !== state.data.subagentCost) {
+            state.data.subagentCost = childCost
             syncFooter([])
           }
         })
@@ -964,7 +965,7 @@ function createLayer(input: StreamInput) {
           yield* mark(event)
 
           if (event.type === "message.updated" && event.properties.sessionID === input.sessionID) {
-            yield* refreshCost.pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
+            yield* refreshCost().pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
           }
         })
 

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -169,7 +169,11 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])))
 
         const isTopLevel = !session.parentID
-        const totalCost = isTopLevel ? (yield* svc.totalCost(session.id)).cost : 0
+        const totalCost = isTopLevel
+          ? (yield* svc.totalCost(session.id).pipe(
+              Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed({ cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } })),
+            )).cost
+          : 0
         const sessionCost = isTopLevel ? totalCost : (session.cost ?? 0)
         const sessionTokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
         let sessionToolUsage: Record<string, number> = {}

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -168,7 +168,9 @@ const aggregateSessionStats = Effect.fn("Cli.stats.aggregate")(function* (
           .messages({ sessionID: session.id })
           .pipe(Effect.catchIf(NotFoundError.isInstance, () => Effect.succeed([])))
 
-        const sessionCost = session.cost ?? 0
+        const isTopLevel = !session.parentID
+        const totalCost = isTopLevel ? (yield* svc.totalCost(session.id)).cost : 0
+        const sessionCost = isTopLevel ? totalCost : (session.cost ?? 0)
         const sessionTokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
         let sessionToolUsage: Record<string, number> = {}
         let sessionModelUsage: Record<

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -80,6 +80,7 @@ export const SessionPaths = {
   status: `${root}/status`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
+  cost: `${root}/:sessionID/cost`,
   todo: `${root}/:sessionID/todo`,
   diff: `${root}/:sessionID/diff`,
   messages: `${root}/:sessionID/message`,
@@ -151,6 +152,30 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.children",
             summary: "Get session children",
             description: "Retrieve all child sessions that were forked from the specified parent session.",
+          }),
+        ),
+        HttpApiEndpoint.get("cost", SessionPaths.cost, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(
+            Schema.Struct({
+              cost: Schema.Finite,
+              tokens: Schema.Struct({
+                input: Schema.Finite,
+                output: Schema.Finite,
+                reasoning: Schema.Finite,
+                cache: Schema.Struct({ read: Schema.Finite, write: Schema.Finite }),
+              }),
+            }),
+            "Aggregated cost including all descendant sessions",
+          ),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.cost",
+            summary: "Get total session cost",
+            description:
+              "Retrieve the total cost and token usage for a session, aggregated across all descendant (subagent) sessions.",
           }),
         ),
         HttpApiEndpoint.get("todo", SessionPaths.todo, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -93,7 +93,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
 
     const cost = Effect.fn("SessionHttpApi.cost")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
-      return yield* session.totalCost(ctx.params.sessionID)
+      return yield* SessionError.mapStorageNotFound(session.totalCost(ctx.params.sessionID))
     })
 
     const todo = Effect.fn("SessionHttpApi.todo")(function* (ctx: { params: { sessionID: SessionID } }) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -91,6 +91,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* session.children(ctx.params.sessionID)
     })
 
+    const cost = Effect.fn("SessionHttpApi.cost")(function* (ctx: { params: { sessionID: SessionID } }) {
+      yield* requireSession(ctx.params.sessionID)
+      return yield* session.totalCost(ctx.params.sessionID)
+    })
+
     const todo = Effect.fn("SessionHttpApi.todo")(function* (ctx: { params: { sessionID: SessionID } }) {
       yield* requireSession(ctx.params.sessionID)
       return yield* todoSvc.get(ctx.params.sessionID)
@@ -415,6 +420,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("status", status)
       .handle("get", get)
       .handle("children", children)
+      .handle("cost", cost)
       .handle("todo", todo)
       .handle("diff", diff)
       .handle("messages", messages)

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -447,6 +447,7 @@ export interface Interface {
   readonly diff: (sessionID: SessionID) => Effect.Effect<Snapshot.FileDiff[]>
   readonly messages: (input: { sessionID: SessionID; limit?: number }) => Effect.Effect<SessionV1.WithParts[], NotFound>
   readonly children: (parentID: SessionID) => Effect.Effect<Info[]>
+  readonly totalCost: (sessionID: SessionID) => Effect.Effect<{ cost: number; tokens: NonNullable<Info["tokens"]> }>
   readonly remove: (sessionID: SessionID) => Effect.Effect<void, NotFound>
   readonly updateMessage: <T extends SessionV1.Info>(msg: T) => Effect.Effect<T>
   readonly removeMessage: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<MessageID>
@@ -603,6 +604,40 @@ const layer: Layer.Layer<
       return rows.map(fromRow)
     })
 
+    const totalCost = Effect.fn("Session.totalCost")(function* (sessionID: SessionID) {
+      const own = yield* get(sessionID)
+      let cost = own.cost ?? 0
+      let tokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+      if (own.tokens) {
+        tokens = {
+          input: own.tokens.input,
+          output: own.tokens.output,
+          reasoning: own.tokens.reasoning,
+          cache: { read: own.tokens.cache.read, write: own.tokens.cache.write },
+        }
+      }
+      const queue = [sessionID]
+      const visited = new Set([sessionID])
+      while (queue.length > 0) {
+        const current = queue.shift()!
+        const kids = yield* children(current)
+        for (const kid of kids) {
+          if (visited.has(kid.id)) continue
+          visited.add(kid.id)
+          cost += kid.cost ?? 0
+          if (kid.tokens) {
+            tokens.input += kid.tokens.input
+            tokens.output += kid.tokens.output
+            tokens.reasoning += kid.tokens.reasoning
+            tokens.cache.read += kid.tokens.cache.read
+            tokens.cache.write += kid.tokens.cache.write
+          }
+          queue.push(kid.id)
+        }
+      }
+      return { cost, tokens }
+    })
+
     const remove: Interface["remove"] = Effect.fnUntraced(function* (sessionID: SessionID) {
       const session = yield* get(sessionID)
       try {
@@ -721,6 +756,9 @@ const layer: Layer.Layer<
             id: PartID.ascending(),
             messageID: cloned.id,
             sessionID: session.id,
+            ...(part.type === "step-finish"
+              ? { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } }
+              : {}),
           }
           if (p.type === "compaction" && p.tail_start_id) {
             p.tail_start_id = idMap.get(p.tail_start_id)
@@ -923,6 +961,7 @@ const layer: Layer.Layer<
       diff,
       messages,
       children,
+      totalCost,
       remove,
       updateMessage,
       removeMessage,

--- a/packages/opencode/test/acp/usage.test.ts
+++ b/packages/opencode/test/acp/usage.test.ts
@@ -96,6 +96,7 @@ const providers = (context = 128_000): Record<ProviderV2.ID, Provider.Info> => {
 
 const fakeLayer = (input: {
   readonly messages?: Effect.Effect<readonly UsageService.SessionMessage[], unknown>
+  readonly cost?: number
   readonly providers?: (directory: string) => Effect.Effect<Record<ProviderV2.ID, Provider.Info>, unknown>
 }) =>
   LayerNode.compile(UsageService.node, [
@@ -105,6 +106,7 @@ const fakeLayer = (input: {
         UsageService.MessageLoader,
         UsageService.MessageLoader.of({
           messages: () => input.messages ?? Effect.succeed([]),
+          cost: () => Effect.succeed(input.cost ?? 0),
         }),
       ),
     ],
@@ -231,6 +233,7 @@ describe("acp usage", () => {
     }).pipe(
       Effect.provide(
         fakeLayer({
+          cost: 3,
           messages: Effect.succeed([
             assistant({ cost: 1 }),
             assistant({

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -1087,4 +1087,111 @@ describe("session HttpApi", () => {
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )
+
+  it.instance(
+    "serves session cost aggregated across children",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const parent = yield* createSession({ title: "parent" })
+        const child = yield* createSession({ title: "child", parentID: parent.id })
+        const grandchild = yield* createSession({ title: "grandchild", parentID: child.id })
+
+        yield* Session.use.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: parent.id,
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+          time: { created: Date.now() },
+        })
+        yield* Session.use.updatePart({
+          id: PartID.ascending(),
+          messageID: (yield* Session.use.messages({ sessionID: parent.id }))[0]!.info.id,
+          sessionID: parent.id,
+          type: "step-finish",
+          reason: "stop",
+          cost: 0.01,
+          tokens: { total: 100, input: 40, output: 60, reasoning: 0, cache: { read: 0, write: 0 } },
+        })
+
+        yield* Session.use.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: child.id,
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+          time: { created: Date.now() },
+        })
+        yield* Session.use.updatePart({
+          id: PartID.ascending(),
+          messageID: (yield* Session.use.messages({ sessionID: child.id }))[0]!.info.id,
+          sessionID: child.id,
+          type: "step-finish",
+          reason: "stop",
+          cost: 0.02,
+          tokens: { total: 200, input: 80, output: 120, reasoning: 0, cache: { read: 0, write: 0 } },
+        })
+
+        yield* Session.use.updateMessage({
+          id: MessageID.ascending(),
+          role: "user",
+          sessionID: grandchild.id,
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+          time: { created: Date.now() },
+        })
+        yield* Session.use.updatePart({
+          id: PartID.ascending(),
+          messageID: (yield* Session.use.messages({ sessionID: grandchild.id }))[0]!.info.id,
+          sessionID: grandchild.id,
+          type: "step-finish",
+          reason: "stop",
+          cost: 0.03,
+          tokens: { total: 300, input: 120, output: 180, reasoning: 0, cache: { read: 0, write: 0 } },
+        })
+
+        const parentCost = yield* requestJson<{ cost: number; tokens: { input: number; output: number } }>(
+          pathFor(SessionPaths.cost, { sessionID: parent.id }),
+          { headers },
+        )
+        expect(parentCost.cost).toBeCloseTo(0.06, 10)
+        expect(parentCost.tokens.input).toBe(240)
+        expect(parentCost.tokens.output).toBe(360)
+
+        const childCost = yield* requestJson<{ cost: number; tokens: { input: number; output: number } }>(
+          pathFor(SessionPaths.cost, { sessionID: child.id }),
+          { headers },
+        )
+        expect(childCost.cost).toBeCloseTo(0.05, 10)
+        expect(childCost.tokens.input).toBe(200)
+        expect(childCost.tokens.output).toBe(300)
+
+        const grandchildCost = yield* requestJson<{ cost: number }>(
+          pathFor(SessionPaths.cost, { sessionID: grandchild.id }),
+          { headers },
+        )
+        expect(grandchildCost.cost).toBeCloseTo(0.03, 10)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "returns 404 for cost of missing session",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const missingSession = SessionID.descending()
+
+        const response = yield* request(pathFor(SessionPaths.cost, { sessionID: missingSession }), { headers })
+        expect(response.status).toBe(404)
+        expect(yield* responseJson(response)).toEqual({
+          name: "NotFoundError",
+          data: { message: `Session not found: ${missingSession}` },
+        })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
 })

--- a/packages/opencode/test/session/cost-rollup.test.ts
+++ b/packages/opencode/test/session/cost-rollup.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect } from "bun:test"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Effect } from "effect"
+import { Session as SessionNs } from "@/session/session"
+import { MessageID, PartID, type SessionID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { InstanceStore } from "@/project/instance-store"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Layer } from "effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([
+      SessionNs.node,
+      EventV2Bridge.node,
+      SessionProjector.node,
+      CrossSpawnSpawner.node,
+      InstanceStore.node,
+    ]),
+    [
+      [RuntimeFlags.node, RuntimeFlags.layer({ experimentalWorkspaces: false })],
+      [
+        InstanceBootstrap.node,
+        Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void })),
+      ],
+    ],
+  ),
+)
+
+function makeUserMessage(sessionID: SessionID) {
+  return {
+    id: MessageID.ascending(),
+    sessionID,
+    role: "user" as const,
+    time: { created: Date.now() },
+    agent: "user",
+    model: { providerID: "test", modelID: "test" },
+    tools: {},
+    mode: "",
+  } as unknown as SessionV1.Info
+}
+
+function makeStepFinishPart(sessionID: SessionID, messageID: string, cost = 0.01) {
+  return {
+    id: PartID.ascending(),
+    messageID,
+    sessionID,
+    type: "step-finish" as const,
+    reason: "stop",
+    cost,
+    tokens: { total: 300, input: 100, output: 200, reasoning: 0, cache: { read: 0, write: 0 } },
+  }
+}
+
+function setupSessionWithCost(session: SessionNs.Service, sessionID: SessionID, cost = 0.01) {
+  return Effect.gen(function* () {
+    const userMsg = makeUserMessage(sessionID)
+    yield* session.updateMessage(userMsg)
+    yield* session.updatePart(makeStepFinishPart(sessionID, userMsg.id, cost))
+  })
+}
+
+describe("fork cost double-counting", () => {
+  it.instance("fork zeroes cost on cloned step-finish parts", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, created.id, 0.05)
+
+      const fork = yield* Effect.acquireRelease(session.fork({ sessionID: created.id }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      const forkedMessages = yield* session.messages({ sessionID: fork.id })
+      const stepFinishPart = forkedMessages
+        .flatMap((m) => m.parts)
+        .find((p) => p.type === "step-finish")
+      expect(stepFinishPart).toBeDefined()
+      expect(stepFinishPart!.cost).toBe(0)
+    }),
+  )
+
+  it.instance("fork does not inflate session.cost beyond post-fork spend", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, created.id, 0.05)
+
+      const fork = yield* Effect.acquireRelease(session.fork({ sessionID: created.id }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      const forkInfo = yield* session.get(fork.id)
+      expect(forkInfo.cost ?? 0).toBe(0)
+    }),
+  )
+})
+
+describe("totalCost rollup", () => {
+  it.instance("returns own cost when no children exist", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, created.id, 0.03)
+
+      const result = yield* session.totalCost(created.id)
+      expect(result.cost).toBe(0.03)
+    }),
+  )
+
+  it.instance("includes child session costs", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const parent = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, parent.id, 0.02)
+
+      const child = yield* Effect.acquireRelease(
+        session.create({ parentID: parent.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, child.id, 0.04)
+
+      const result = yield* session.totalCost(parent.id)
+      expect(result.cost).toBeCloseTo(0.06, 10)
+    }),
+  )
+
+  it.instance("includes nested child session costs", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const root = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, root.id, 0.01)
+
+      const child = yield* Effect.acquireRelease(
+        session.create({ parentID: root.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, child.id, 0.02)
+
+      const grandchild = yield* Effect.acquireRelease(
+        session.create({ parentID: child.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, grandchild.id, 0.03)
+
+      const result = yield* session.totalCost(root.id)
+      expect(result.cost).toBeCloseTo(0.06, 10)
+    }),
+  )
+})
+
+describe("e2e: subagent cost rollup via session hierarchy", () => {
+  it.instance("totalCost includes costs from multiple child sessions (subagent scenario)", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const parent = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, parent.id, 0.01)
+
+      const child1 = yield* Effect.acquireRelease(
+        session.create({ parentID: parent.id, title: "subagent 1" }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, child1.id, 0.03)
+
+      const child2 = yield* Effect.acquireRelease(
+        session.create({ parentID: parent.id, title: "subagent 2" }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, child2.id, 0.05)
+
+      const result = yield* session.totalCost(parent.id)
+      expect(result.cost).toBeCloseTo(0.09, 10)
+
+      const tokens = result.tokens
+      expect(tokens.input).toBe(300)
+      expect(tokens.output).toBe(600)
+    }),
+  )
+
+  it.instance("totalCost tokens accumulate across child sessions", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const parent = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, parent.id, 0.01)
+
+      const child = yield* Effect.acquireRelease(
+        session.create({ parentID: parent.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, child.id, 0.02)
+
+      const result = yield* session.totalCost(parent.id)
+      expect(result.tokens.input).toBe(200)
+      expect(result.tokens.output).toBe(400)
+      expect(result.tokens.cache.read).toBe(0)
+      expect(result.tokens.cache.write).toBe(0)
+    }),
+  )
+})
+
+describe("e2e: fork with subagent history", () => {
+  it.instance("fork of a session with child subagent costs does not double-count", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const parent = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* setupSessionWithCost(session, parent.id, 0.01)
+
+      const child = yield* Effect.acquireRelease(
+        session.create({ parentID: parent.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, child.id, 0.04)
+
+      const fork = yield* Effect.acquireRelease(session.fork({ sessionID: parent.id }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      const forkInfo = yield* session.get(fork.id)
+      expect(forkInfo.cost ?? 0).toBe(0)
+
+      const forkTotal = yield* session.totalCost(fork.id)
+      expect(forkTotal.cost).toBe(0)
+
+      const parentTotal = yield* session.totalCost(parent.id)
+      expect(parentTotal.cost).toBeCloseTo(0.05, 10)
+    }),
+  )
+
+  it.instance("fork then add subagent: fork total only includes own + new children", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const original = yield* Effect.acquireRelease(session.create({}), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, original.id, 0.02)
+
+      const fork = yield* Effect.acquireRelease(session.fork({ sessionID: original.id }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      const forkChild = yield* Effect.acquireRelease(
+        session.create({ parentID: fork.id }),
+        (info) => session.remove(info.id).pipe(Effect.ignore),
+      )
+      yield* setupSessionWithCost(session, forkChild.id, 0.03)
+
+      const originalTotal = yield* session.totalCost(original.id)
+      expect(originalTotal.cost).toBeCloseTo(0.02, 10)
+
+      const forkTotal = yield* session.totalCost(fork.id)
+      expect(forkTotal.cost).toBeCloseTo(0.03, 10)
+    }),
+  )
+})

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -170,6 +170,46 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
         ),
     )
     .add(
+      HttpApiEndpoint.get("session.children", "/api/session/:sessionID/children", {
+        params: { sessionID: Session.ID },
+        success: Schema.Struct({ data: Schema.Array(Session.Info) }),
+      })
+        .middleware(sessionLocationMiddleware)
+        .annotateMerge(
+          OpenApi.annotations({
+            identifier: "v2.session.children",
+            summary: "Get session children",
+            description: "Retrieve all child sessions forked from the specified parent session.",
+          }),
+        ),
+    )
+    .add(
+      HttpApiEndpoint.get("session.cost", "/api/session/:sessionID/cost", {
+        params: { sessionID: Session.ID },
+        success: Schema.Struct({
+          data: Schema.Struct({
+            cost: Schema.Finite,
+            tokens: Schema.Struct({
+              input: Schema.Finite,
+              output: Schema.Finite,
+              reasoning: Schema.Finite,
+              cache: Schema.Struct({ read: Schema.Finite, write: Schema.Finite }),
+            }),
+          }),
+        }),
+        error: SessionNotFoundError,
+      })
+        .middleware(sessionLocationMiddleware)
+        .annotateMerge(
+          OpenApi.annotations({
+            identifier: "v2.session.cost",
+            summary: "Get total session cost",
+            description:
+              "Retrieve the total cost and token usage for a session, aggregated across all descendant (subagent) sessions.",
+          }),
+        ),
+    )
+    .add(
       HttpApiEndpoint.post("session.switchAgent", "/api/session/:sessionID/agent", {
         params: { sessionID: Session.ID },
         payload: Schema.Struct({ agent: Agent.ID }),

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -181,6 +181,8 @@ import type {
   SessionChildrenResponses,
   SessionCommandErrors,
   SessionCommandResponses,
+  SessionCostErrors,
+  SessionCostResponses,
   SessionCreateErrors,
   SessionCreateResponses,
   SessionDeleteErrors,
@@ -335,10 +337,14 @@ import type {
   V2ReferenceListResponses,
   V2SessionActiveErrors,
   V2SessionActiveResponses,
+  V2SessionChildrenErrors,
+  V2SessionChildrenResponses,
   V2SessionCompactErrors,
   V2SessionCompactResponses,
   V2SessionContextErrors,
   V2SessionContextResponses,
+  V2SessionCostErrors,
+  V2SessionCostResponses,
   V2SessionCreateErrors,
   V2SessionCreateResponses,
   V2SessionEventsErrors,
@@ -3633,6 +3639,38 @@ export class Session2 extends HeyApiClient {
   }
 
   /**
+   * Get total session cost
+   *
+   * Retrieve the total cost and token usage for a session, aggregated across all descendant (subagent) sessions.
+   */
+  public cost<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionCostResponses, SessionCostErrors, ThrowOnError>({
+      url: "/session/{sessionID}/cost",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
    * Get session todos
    *
    * Retrieve the todo list associated with a specific session, showing tasks and action items.
@@ -5531,6 +5569,44 @@ export class Session3 extends HeyApiClient {
     const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "sessionID" }] }])
     return (options?.client ?? this.client).get<V2SessionGetResponses, V2SessionGetErrors, ThrowOnError>({
       url: "/api/session/{sessionID}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get session children
+   *
+   * Retrieve all child sessions forked from the specified parent session.
+   */
+  public children<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "sessionID" }] }])
+    return (options?.client ?? this.client).get<V2SessionChildrenResponses, V2SessionChildrenErrors, ThrowOnError>({
+      url: "/api/session/{sessionID}/children",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get total session cost
+   *
+   * Retrieve the total cost and token usage for a session, aggregated across all descendant (subagent) sessions.
+   */
+  public cost<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "sessionID" }] }])
+    return (options?.client ?? this.client).get<V2SessionCostResponses, V2SessionCostErrors, ThrowOnError>({
+      url: "/api/session/{sessionID}/cost",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -9687,6 +9687,51 @@ export type SessionChildrenResponses = {
 
 export type SessionChildrenResponse = SessionChildrenResponses[keyof SessionChildrenResponses]
 
+export type SessionCostData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/cost"
+}
+
+export type SessionCostErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionCostError = SessionCostErrors[keyof SessionCostErrors]
+
+export type SessionCostResponses = {
+  /**
+   * Aggregated cost including all descendant sessions
+   */
+  200: {
+    cost: number
+    tokens: {
+      input: number
+      output: number
+      reasoning: number
+      cache: {
+        read: number
+        write: number
+      }
+    }
+  }
+}
+
+export type SessionCostResponse = SessionCostResponses[keyof SessionCostResponses]
+
 export type SessionTodoData = {
   body?: never
   path: {
@@ -11475,6 +11520,91 @@ export type V2SessionGetResponses = {
 }
 
 export type V2SessionGetResponse = V2SessionGetResponses[keyof V2SessionGetResponses]
+
+export type V2SessionChildrenData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: never
+  url: "/api/session/{sessionID}/children"
+}
+
+export type V2SessionChildrenErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+  /**
+   * SessionNotFoundError
+   */
+  404: SessionNotFoundError
+}
+
+export type V2SessionChildrenError = V2SessionChildrenErrors[keyof V2SessionChildrenErrors]
+
+export type V2SessionChildrenResponses = {
+  /**
+   * Success
+   */
+  200: {
+    data: Array<SessionV2Info>
+  }
+}
+
+export type V2SessionChildrenResponse = V2SessionChildrenResponses[keyof V2SessionChildrenResponses]
+
+export type V2SessionCostData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: never
+  url: "/api/session/{sessionID}/cost"
+}
+
+export type V2SessionCostErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+  /**
+   * SessionNotFoundError
+   */
+  404: SessionNotFoundError
+}
+
+export type V2SessionCostError = V2SessionCostErrors[keyof V2SessionCostErrors]
+
+export type V2SessionCostResponses = {
+  /**
+   * Success
+   */
+  200: {
+    data: {
+      cost: number
+      tokens: {
+        input: number
+        output: number
+        reasoning: number
+        cache: {
+          read: number
+          write: number
+        }
+      }
+    }
+  }
+}
+
+export type V2SessionCostResponse = V2SessionCostResponses[keyof V2SessionCostResponses]
 
 export type V2SessionSwitchAgentData = {
   body: {

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -381,5 +381,30 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
           })
         }),
       )
+      .handle(
+        "session.children",
+        Effect.fn(function* (ctx) {
+          return {
+            data: yield* session.children(ctx.params.sessionID),
+          }
+        }),
+      )
+      .handle(
+        "session.cost",
+        Effect.fn(function* (ctx) {
+          return {
+            data: yield* session.totalCost(ctx.params.sessionID).pipe(
+              Effect.catchTag("Session.NotFoundError", (error) =>
+                Effect.fail(
+                  new SessionNotFoundError({
+                    sessionID: error.sessionID,
+                    message: `Session not found: ${error.sessionID}`,
+                  }),
+                ),
+              ),
+            ),
+          }
+        }),
+      )
   }),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #39740
Closes #31032
Closes #36944

### Type of change

- [x] Bug fix
- [x] New feature

### What does this PR do?

Subagent session costs were not rolled up to the parent session (#39740), and forked sessions double-counted pre-fork costs (#31032, #36944). This PR fixes both issues and exposes the aggregated cost through the protocol layer so the TUI, stats, and ACP can display it.

**Fork double-counting fix:** When a session is forked, the cloned step-finish parts now have their cost and tokens zeroed out. The forked session starts with zero cost and only accumulates cost from its own LLM calls, not the parent's pre-fork history.

**Cost rollup:** Added `children()` and `totalCost()` to both V1 `Session.Service` and V2 `SessionV2.Interface`. `totalCost()` does a BFS walk across all descendant sessions, summing cost and tokens.

**Protocol endpoint:** Added `session.cost` and `session.children` to the protocol session group (`/api/session/:sessionID/cost`, `/api/session/:sessionID/children`) with handlers in both the protocol handler (`packages/server`) and the server handler (`packages/opencode`). Both SDKs were regenerated.

**TUI:** `refreshCost` effect in `stream.transport.ts` calls `sdk.session.cost()` on `message.updated` and bootstrap. `SessionData.totalCost` field; footer `formatUsage` uses `totalCost` when > 0, falls back to `info.cost`.

**Stats + ACP:** Stats uses `totalCost()` for top-level sessions. ACP `sendUpdate` uses `sdk.session.cost()` with `totalSessionCost(messages)` fallback.

### How did you verify your code works?

- 9 service-level tests (`cost-rollup.test.ts`): fork zeroing, own cost, child cost, nested children, multiple children
- 10 ACP usage tests (`usage.test.ts`): mock updated with `cost` method
- 2 HTTP E2E tests (`httpapi-session.test.ts`): aggregated cost across nested children (parent -> child -> grandchild, verifying 0.06 = 0.01 + 0.02 + 0.03), 404 for missing session
- `bun typecheck` clean (0 source-code errors)
- Both SDKs regenerated via `bun run generate`

### Related PRs (used as reference)

- #25712 (open, incomplete — companion UI PR)
- #27952 (closed in favor of #25712)
- #32301 (related subagent spawning PR)
- #13588 (stale)
- #4611 (closed)
- #7763 (closed)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR