### PR TITLE
fix(core): prevent shell eviction loop

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -148,10 +148,10 @@ const layer = () =>
 
       const removeSession = Effect.fnUntraced(function* (id: Shell.ID) {
         const session = sessions.get(id)
-        if (!session) return
-        sessions.delete(id)
         const index = exitOrder.indexOf(id)
         if (index !== -1) exitOrder.splice(index, 1)
+        if (!session) return
+        sessions.delete(id)
         if (session.timeoutFiber) yield* Fiber.interrupt(session.timeoutFiber)
         // Unblock any wait still pending when the command is removed before it terminated.
         yield* Deferred.fail(session.done, new NotFoundError({ id }))

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -814,6 +814,30 @@ describe("ShellTool", () => {
     { timeout: 15_000 },
   )
 
+  it.live("does not retain removed running shells in exit order", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        withSession(tmp.path, () =>
+          Effect.gen(function* () {
+            const shell = yield* Shell.Service
+            yield* Effect.forEach(Array.from({ length: 26 }), () =>
+              Effect.gen(function* () {
+                const info = yield* shell.create({ command: idleCommand, timeout: 0 })
+                yield* shell.remove(info.id)
+                yield* Effect.sleep(Duration.millis(10))
+              }),
+            )
+
+            const info = yield* shell.create({ command: helloCommand, timeout: 0 })
+            const settled = yield* shell.wait(info.id).pipe(Effect.timeoutOption(Duration.seconds(2)))
+            expect(settled._tag).toBe("Some")
+          }),
+        ),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+    ),
+  )
+
   if (!isWindows) {
     it.live("settles a shell terminated by an external signal", () =>
       Effect.acquireUseRelease(


### PR DESCRIPTION
## Summary

- remove stale shell IDs from the exit-order queue even after their session entry is gone
- prevent retention eviction from spinning forever on an already-removed running shell
- cover repeated running-shell removal followed by normal shell completion

## Before and after

Before, a missing session returned before its stale ordering entry could be removed:

```ts
const session = sessions.get(id)
if (!session) return
sessions.delete(id)

const index = exitOrder.indexOf(id)
if (index !== -1) exitOrder.splice(index, 1)
```

After, ordering cleanup always happens first; only cleanup requiring the full session record is skipped:

```ts
const session = sessions.get(id)

const index = exitOrder.indexOf(id)
if (index !== -1) exitOrder.splice(index, 1)

if (!session) return
sessions.delete(id)
```

For a stale shell ID `A`:

```text
Before:
sessions:  {}
exitOrder: [A, B, C]
             |
             +-- A is missing, return
                 exitOrder stays [A, B, C]

After:
sessions:  {}
exitOrder: [A, B, C]
             |
             +-- remove A from exitOrder
                 exitOrder becomes [B, C]
                 then return because A is missing
```

For a normal ID present in both structures, both versions remove it from both structures. The behavioral change only ensures stale ordering entries are removed so eviction always makes progress.

## Testing

- `bun typecheck` in `packages/core`
- `bun test test/tool-shell.test.ts` in `packages/core` (24 pass)