### PR TITLE
fix(session): exclude 'unknown' finish from loop-exit condition

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1110,7 +1110,7 @@ const layer = Layer.effect(
 
           if (
             lastAssistant?.finish &&
-            !["tool-calls"].includes(lastAssistant.finish) &&
+            !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
             lastAssistant.parentID === lastUser.id
           ) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -461,6 +461,29 @@ noLLMServer.instance(
 )
 
 noLLMServer.instance(
+  "loop does not exit when finish is unknown",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      yield* seed(chat.id, { finish: "unknown" })
+
+      // The loop should NOT exit on "unknown" — it should treat it the
+      // same as "tool-calls" and keep running (or at least not break out
+      // of the loop as if the turn were completed).
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.role).toBe("assistant")
+      // "unknown" must not be treated as a terminal finish; the result
+      // should either continue or be re-evaluated, not silently exit.
+      if (result.info.role === "assistant") {
+        expect(result.info.finish).not.toBe("unknown")
+      }
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
   "loop exits for a completed parent turn with nonmonotonic message IDs",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Fixes #43622

The loop-exit check at `prompt.ts:1113` only excluded `"tool-calls"` from the finish reasons that keep the agent loop running. When a provider returns `finish_reason: "unknown"` (or omits it entirely), the session exits silently with exit 0 — indistinguishable from a successful completion.

The same file at line 1295 already correctly excludes both `"tool-calls"` and `"unknown"`. This PR aligns line 1113 with that logic.

## Changes

- **`packages/opencode/src/session/prompt.ts:1113`** — Added `"unknown"` to the exclusion list: `!["tool-calls"]` → `!["tool-calls", "unknown"]`
- **`packages/opencode/test/session/prompt.test.ts`** — Added regression test that seeds a session with `finish: "unknown"` and verifies the loop does not treat it as a terminal state

## Reproduction (from issue)

| Build | finish_reason sent | Steps | Result |
|-------|-------------------|-------|--------|
| v1.18.19 stock | none | 1 | reason: unknown, exiting loop, exit 0, silent |
| v1.18.19 + fix | none | 138+ | never exits (correct) |
| v1.18.19 stock (control) | stop | 1 | reason: stop, normal |

## Why this matters

For headless/API drivers, a silent exit-0 on `finish: "unknown"` is indistinguishable from the agent deciding it was done. This causes lost context and incomplete work without any error signal.