### PR TITLE
feat(session): pass system messages through to the model

### DIFF
--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -2,6 +2,7 @@ import { Binary } from "@opencode-ai/core/util/binary"
 import { retry } from "@opencode-ai/core/util/retry"
 import type { OpenCodeEvent, SessionApi, SessionMessageInfo } from "@opencode-ai/client/promise"
 import type {
+  AssistantMessage,
   Message,
   OpencodeClient,
   Part,
@@ -10,6 +11,7 @@ import type {
   Session,
   SessionStatus,
   Todo,
+  UserMessage,
 } from "@opencode-ai/sdk/v2/client"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import { batch } from "solid-js"
@@ -62,6 +64,7 @@ type MessagePage = {
 
 function legacyMessageSource(items: { info: Message; parts: Part[] }[]): SessionMessageInfo[] {
   return items
+    .filter((item): item is { info: UserMessage | AssistantMessage; parts: Part[] } => item.info.role !== "system")
     .slice()
     .sort((a, b) => compareMessages(a.info, b.info))
     .map((item) => {

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -1,6 +1,6 @@
 import { parseCommentNote, readCommentMetadata } from "@/utils/comment-note"
 import type { SessionMessageInfo } from "@opencode-ai/client/promise"
-import { AssistantMessage, Part, SessionStatus, UserMessage } from "@opencode-ai/sdk/v2"
+import { AssistantMessage, Message, Part, SessionStatus, UserMessage } from "@opencode-ai/sdk/v2"
 import { groupParts, renderable, type PartGroup } from "@opencode-ai/session-ui/message-part"
 import { TimelineRow, type SummaryDiff } from "./timeline-row"
 import { uniqueSummaryDiffs } from "./summary-diffs"
@@ -35,7 +35,7 @@ export type TimelineRowMap = {
 export namespace Timeline {
   export function constructSessionMessageRows(
     messages: SessionMessageInfo[],
-    getMessage: (messageID: string) => UserMessage | AssistantMessage | undefined,
+    getMessage: (messageID: string) => Message | undefined,
     getMessageParts: (messageID: string) => Part[],
     showReasoning: boolean,
     status: SessionStatus["type"],

--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -33,6 +33,7 @@ export {
   SubtaskPart,
   SubtaskPartInput,
   SymbolSource,
+  System,
   TextPart,
   TextPartInput,
   ToolPart,

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -701,7 +701,7 @@ type MessageInfo = {
   readonly modelID?: Extract<Message, { role: "assistant" }>["modelID"]
   readonly variant?: Extract<Message, { role: "assistant" }>["variant"]
   readonly mode?: Extract<Message, { role: "assistant" }>["mode"]
-  readonly agent?: Message["agent"]
+  readonly agent?: Extract<Message, { role: "user" }>["agent"]
 }
 
 type AssistantError = NonNullable<AssistantMessage["error"]>

--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -207,13 +207,15 @@ function sanitize(data: { info: Session.Info; messages: SessionV1.WithParts[] })
                     diffs: diff("message-diff", msg.info.summary.diffs),
                   },
             }
-          : {
-              ...msg.info,
-              path: {
-                cwd: redact("cwd", msg.info.id, msg.info.path.cwd),
-                root: redact("root", msg.info.id, msg.info.path.root),
-              },
-            },
+          : msg.info.role === "assistant"
+            ? {
+                ...msg.info,
+                path: {
+                  cwd: redact("cwd", msg.info.id, msg.info.path.cwd),
+                  root: redact("root", msg.info.id, msg.info.path.root),
+                },
+              }
+            : msg.info,
       parts: msg.parts.map(partFn),
     })),
   }

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -828,7 +828,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
     }
 
     const info = event.properties.info
-    if (typeof info.id === "string") {
+    if (typeof info.id === "string" && (info.role === "user" || info.role === "assistant")) {
       data.role.set(info.id, info.role)
       replay(data, commits, info.id, info.role, input.thinking)
     }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -277,7 +277,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       yield* revertSvc.cleanup(yield* requireSession(ctx.params.sessionID))
       const messages = yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
       const defaultAgent = yield* agentSvc.defaultAgent()
-      const currentAgent = messages.findLast((message) => message.info.role === "user")?.info.agent ?? defaultAgent
+      const currentAgent =
+        messages.findLast(
+          (message): message is SessionV1.WithParts & { info: SessionV1.User } => message.info.role === "user",
+        )?.info.agent ?? defaultAgent
 
       yield* compactSvc.create({
         sessionID: ctx.params.sessionID,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -241,6 +241,25 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       if (userMessage.parts.length > 0) result.push(userMessage)
     }
 
+    // System messages cannot be persisted, so they only reach this point when
+    // a plugin inserts them via the messages.transform hook. ConvertToModelMessages
+    // places them at their array position in the final ModelMessage[].
+    if (msg.info.role === "system") {
+      const systemMessage: UIMessage = {
+        id: msg.info.id,
+        role: "system",
+        parts: [],
+      }
+      for (const part of msg.parts) {
+        if (part.type === "text" && !part.ignored && part.text !== "")
+          systemMessage.parts.push({
+            type: "text",
+            text: part.text,
+          })
+      }
+      if (systemMessage.parts.length > 0) result.push(systemMessage)
+    }
+
     if (msg.info.role === "assistant") {
       const differentModel = `${model.providerID}/${model.id}` !== `${msg.info.providerID}/${msg.info.modelID}`
       const media: Array<{ mime: string; url: string; filename?: string }> = []

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -48,7 +48,9 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
     return input.messages
   }
 
-  const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
+  const assistantMessage = input.messages.findLast(
+    (msg): msg is SessionV1.WithParts & { info: SessionV1.Assistant } => msg.info.role === "assistant",
+  )
   if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
     const ctx = yield* InstanceState.context
     const plan = Session.plan(input.session, ctx)

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -103,6 +103,15 @@ function assistantInfo(
   } as unknown as SessionV1.Assistant
 }
 
+function systemInfo(id: string): SessionV1.System {
+  return {
+    id,
+    sessionID,
+    role: "system",
+    time: { created: 0 },
+  } as unknown as SessionV1.System
+}
+
 function basePart(messageID: string, id: string) {
   return {
     id: PartID.make(id.startsWith("prt") ? id : `prt_${id}`),
@@ -126,6 +135,166 @@ describe("session.message-v2.toModelMessage", () => {
             type: "text",
             text: "hello",
           },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+    ])
+  })
+
+  test("passes system messages through at their array position", async () => {
+    const input: SessionV1.WithParts[] = [
+      {
+        info: systemInfo("m-lead"),
+        parts: [{ ...basePart("m-lead", "s0"), type: "text", text: "leading marker" }] as SessionV1.Part[],
+      },
+      {
+        info: userInfo("m-user"),
+        parts: [{ ...basePart("m-user", "p1"), type: "text", text: "hello" }] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-mid"),
+        parts: [{ ...basePart("m-mid", "s1"), type: "text", text: "mid marker" }] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-mid-2"),
+        parts: [
+          { ...basePart("m-mid-2", "s2a"), type: "text", text: "multi " },
+          { ...basePart("m-mid-2", "s2b"), type: "text", text: "part" },
+        ] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo("m-assistant", "m-user"),
+        parts: [{ ...basePart("m-assistant", "a1"), type: "text", text: "done" }] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-trail"),
+        parts: [{ ...basePart("m-trail", "s3"), type: "text", text: "trailing marker" }] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "system",
+        content: "leading marker",
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+      {
+        role: "system",
+        content: "mid marker",
+      },
+      {
+        role: "system",
+        content: "multi part",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+      },
+      {
+        role: "system",
+        content: "trailing marker",
+      },
+    ])
+  })
+
+  test("keeps system message position across tool-result expansion", async () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1"), type: "text", text: "run tool" }] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-mid"),
+        parts: [{ ...basePart("m-mid", "s1"), type: "text", text: "mid marker" }] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "ok",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments: [],
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-trail"),
+        parts: [{ ...basePart("m-trail", "s2"), type: "text", text: "trailing marker" }] as SessionV1.Part[],
+      },
+    ]
+
+    expect(await MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "system",
+        content: "mid marker",
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: { type: "text", value: "ok" },
+          },
+        ],
+      },
+      {
+        role: "system",
+        content: "trailing marker",
+      },
+    ])
+  })
+
+  test("filters out system messages with no text parts", async () => {
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo("m-user"),
+        parts: [{ ...basePart("m-user", "p1"), type: "text", text: "hello" }] as SessionV1.Part[],
+      },
+      {
+        info: systemInfo("m-empty"),
+        parts: [
+          { ...basePart("m-empty", "s1"), type: "step-start" },
+          { ...basePart("m-empty", "s2"), type: "text", text: "", ignored: true },
         ] as SessionV1.Part[],
       },
     ]

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -487,8 +487,17 @@ export type Assistant = Omit<Types.DeepMutable<Schema.Schema.Type<typeof Assista
   error?: AssistantError
 }
 
-export const Info = Schema.Union([User, Assistant]).annotate({ discriminator: "role", identifier: "Message" })
-export type Info = User | Assistant
+export const System = Schema.Struct({
+  ...messageBase,
+  role: Schema.Literal("system"),
+  time: Schema.Struct({
+    created: Timestamp,
+  }),
+}).annotate({ identifier: "SystemMessage" })
+export type System = Types.DeepMutable<Schema.Schema.Type<typeof System>>
+
+export const Info = Schema.Union([User, Assistant, System]).annotate({ discriminator: "role", identifier: "Message" })
+export type Info = User | Assistant | System
 
 export const WithParts = Schema.Struct({
   info: Info,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -373,7 +373,16 @@ export type AssistantMessage = {
   finish?: string
 }
 
-export type Message = UserMessage | AssistantMessage
+export type SystemMessage = {
+  id: string
+  sessionID: string
+  role: "system"
+  time: {
+    created: number
+  }
+}
+
+export type Message = UserMessage | AssistantMessage | SystemMessage
 
 export type TextPart = {
   id: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16379,6 +16379,36 @@
         ],
         "additionalProperties": false
       },
+      "SystemMessage": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^msg"
+          },
+          "sessionID": {
+            "type": "string",
+            "pattern": "^ses"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["system"]
+          },
+          "time": {
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number",
+                "minimum": 0
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "sessionID", "role", "time"],
+        "additionalProperties": false
+      },
       "Message": {
         "anyOf": [
           {
@@ -16386,6 +16416,9 @@
           },
           {
             "$ref": "#/components/schemas/AssistantMessage"
+          },
+          {
+            "$ref": "#/components/schemas/SystemMessage"
           }
         ]
       },

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -588,7 +588,7 @@ export const {
           const messages = store.message[sessionID] ?? []
           const last = messages.at(-1)
           if (!last) return "idle"
-          if (last.role === "user") return "working"
+          if (last.role !== "assistant") return "working"
           return last.time.completed ? "idle" : "working"
         },
         async sync(sessionID: string) {

--- a/packages/tui/src/util/transcript.ts
+++ b/packages/tui/src/util/transcript.ts
@@ -1,4 +1,4 @@
-import type { AssistantMessage, Part, Provider, UserMessage } from "@opencode-ai/sdk/v2"
+import type { AssistantMessage, Part, Provider, SystemMessage, UserMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "./locale"
 import * as Model from "./model"
 
@@ -19,7 +19,7 @@ export type SessionInfo = {
 }
 
 export type MessageWithParts = {
-  info: UserMessage | AssistantMessage
+  info: UserMessage | AssistantMessage | SystemMessage
   parts: Part[]
 }
 
@@ -38,6 +38,7 @@ export function formatTranscript(
   for (const msg of messages.toSorted(
     (a, b) => a.info.time.created - b.info.time.created || a.info.id.localeCompare(b.info.id),
   )) {
+    if (msg.info.role === "system") continue
     transcript += formatMessage(msg.info, msg.parts, options, providers)
     transcript += `---\n\n`
   }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A plugin inserting a system message via `experimental.chat.messages.transform` had it silently discarded — `toModelMessagesEffect` dropped entries whose role was neither user nor assistant, right after the hook fired.

This makes transient system entries expressible and carries them through:

- **schema**: add a `System` struct (role `"system"`, messageBase + created time) to the session message `Info` union. System entries are not persisted — the message tables keep only user/assistant rows, so every DB-backed surface is unaffected by construction.
- **session**: map system entries onto a system UIMessage (text parts only) so `convertToModelMessages` places them at their array position in the `ModelMessage[]`, including across tool-result expansion.
- **consumers**: transcript export skips system rows, agent lookups get type guards, timeline `getMessage` widens. openapi + SDK types regenerated.

### How did you verify your code works?

- New tests in `packages/opencode/test/session/message-v2.test.ts` covering the system-message conversion path — 42 pass (`bun test test/session/message-v2.test.ts` from `packages/opencode`)
- `bun typecheck` passes
- `bun run generate` in `packages/client` produces no diff (SDK artifacts in sync)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
