### PR TITLE
feat(plugin): add HTTP route registration for server plugins

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -4,6 +4,7 @@ import type {
   PluginInput,
   Plugin as PluginInstance,
   PluginModule,
+  PluginRoute,
   WorkspaceAdapter as PluginWorkspaceAdapter,
 } from "@opencode-ai/plugin"
 import { Config } from "@/config/config"
@@ -33,8 +34,11 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
+type RouteTable = Array<{ id: string; routes: PluginRoute[] }>
+
 type State = {
   hooks: Hooks[]
+  routes: RouteTable
 }
 
 // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -53,6 +57,8 @@ export interface Interface {
     output: Output,
   ) => Effect.Effect<Output>
   readonly list: () => Effect.Effect<Hooks[]>
+  /** Plugin-registered HTTP routes keyed by plugin id, used by the /plugin/* dispatcher */
+  readonly routes: () => Effect.Effect<RouteTable>
   readonly init: () => Effect.Effect<void>
 }
 
@@ -109,17 +115,33 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
   return result
 }
 
-async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
+async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[], routes: RouteTable) {
   const plugin = readV1Plugin(load.mod, load.spec, "server", "detect")
   if (plugin) {
-    await resolvePluginId(load.source, load.spec, load.target, readPluginId(plugin.id, load.spec), load.pkg)
-    hooks.push(await (plugin as PluginModule).server(input, load.options))
+    const id = await resolvePluginId(load.source, load.spec, load.target, readPluginId(plugin.id, load.spec), load.pkg)
+    const hook = await (plugin as PluginModule).server(input, load.options)
+    hooks.push(hook)
+    registerRoutes(routes, id, hook)
     return
   }
 
   for (const server of getLegacyPlugins(load.mod)) {
-    hooks.push(await server(input, load.options))
+    const hook = await server(input, load.options)
+    hooks.push(hook)
+    registerRoutes(routes, legacyPluginID(load.spec, server), hook)
   }
+}
+
+function legacyPluginID(spec: string, server: PluginInstance): string {
+  if (server.name && server.name !== "anonymous") return server.name
+  return parsePluginSpecifier(spec).pkg
+}
+
+function registerRoutes(routes: RouteTable, id: string, hook: Hooks) {
+  if (!hook.routes?.length) return
+  const entry = routes.find((item) => item.id === id)
+  if (entry) entry.routes.push(...hook.routes)
+  else routes.push({ id, routes: [...hook.routes] })
 }
 
 const layer = Layer.effect(
@@ -132,6 +154,7 @@ const layer = Layer.effect(
     const state = yield* InstanceState.make<State>(
       Effect.fn("Plugin.state")(function* (ctx) {
         const hooks: Hooks[] = []
+        const routes: RouteTable = []
         const bridge = yield* EffectBridge.make()
 
         function publishPluginError(message: string) {
@@ -220,7 +243,7 @@ const layer = Layer.effect(
           // Keep plugin execution sequential so hook registration and execution
           // order remains deterministic across plugin runs.
           yield* Effect.tryPromise({
-            try: () => applyPlugin(load, input, hooks),
+            try: () => applyPlugin(load, input, hooks, routes),
             catch: (err) => {
               const message = errorMessage(err)
               return message
@@ -275,7 +298,7 @@ const layer = Layer.effect(
           ),
         )
 
-        return { hooks }
+        return { hooks, routes }
       }),
     )
 
@@ -299,11 +322,16 @@ const layer = Layer.effect(
       return s.hooks
     })
 
+    const routes = Effect.fn("Plugin.routes")(function* () {
+      const s = yield* InstanceState.get(state)
+      return s.routes
+    })
+
     const init = Effect.fn("Plugin.init")(function* () {
       yield* InstanceState.get(state)
     })
 
-    return Service.of({ trigger, list, init })
+    return Service.of({ trigger, list, routes, init })
   }),
 )
 

--- a/packages/opencode/src/server/plugin-routes.ts
+++ b/packages/opencode/src/server/plugin-routes.ts
@@ -1,0 +1,189 @@
+import { Cause, Effect } from "effect"
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
+import type { PluginRoute, PluginRouteRequest, PluginRouteResponse } from "@opencode-ai/plugin"
+import { Plugin } from "@/plugin"
+import { InstanceStore } from "@/project/instance-store"
+
+// Plugin routes are public by design: they are the inbound edge for external
+// systems (chat bridges, CI, webhooks) and plugins authenticate inside their
+// own handlers (for example with a shared secret). Do not wrap these in
+// ServerAuth.
+export const PluginRoutes = {
+  prefix: "plugin",
+  directoryHeader: "x-opencode-directory",
+} as const
+
+type Matched = {
+  route: PluginRoute
+  params: Record<string, string>
+}
+
+type RouteLayerRequirements = InstanceStore.Service | Plugin.Service
+
+// Static catch-all for plugin-registered routes. The Effect HttpApi surface
+// is built statically, so plugin routes are dispatched here at request time:
+// resolve the instance for the requested directory, then look up the routes
+// its plugins declared through the `routes` hook.
+export const layer = HttpRouter.use((router) =>
+  Effect.gen(function* () {
+    const store = yield* InstanceStore.Service
+    const plugin = yield* Plugin.Service
+
+    const dispatch = (request: HttpServerRequest.HttpServerRequest): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+      Effect.gen(function* () {
+        const url = new URL(request.url, "http://localhost")
+        const segments = url.pathname.split("/").filter((segment) => segment !== "")
+        const pluginID = decodeSegment(segments[1])
+        if (segments[0] !== PluginRoutes.prefix || !pluginID) return unknownRoute(request)
+        const remainder = "/" + segments.slice(2).map(decodeSegment).join("/").replace(/\/$/, "")
+        const method = request.method.toUpperCase()
+        const directory = resolveDirectory(url, request)
+
+        return yield* store
+          .provide({ directory }, dispatchInInstance(plugin, pluginID, method, remainder, request))
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.succeed(
+                HttpServerResponse.jsonUnsafe(
+                  { error: `Instance unavailable: ${Cause.pretty(cause)}` },
+                  { status: 500 },
+                ),
+              ),
+            ),
+          )
+      })
+
+    yield* router.add("*", `/${PluginRoutes.prefix}/*`, (request) => dispatch(request))
+  }),
+)
+
+function resolveDirectory(url: URL, request: HttpServerRequest.HttpServerRequest): string {
+  const fromQuery = url.searchParams.get("directory")
+  if (fromQuery) return fromQuery
+  const fromHeader = request.headers[PluginRoutes.directoryHeader]
+  if (typeof fromHeader === "string") return fromHeader
+  return process.cwd()
+}
+
+function dispatchInInstance(
+  plugin: Plugin.Interface,
+  pluginID: string,
+  method: string,
+  remainder: string,
+  request: HttpServerRequest.HttpServerRequest,
+) {
+  return Effect.gen(function* () {
+    yield* plugin.init()
+    const table = yield* plugin.routes()
+    const entry = table.find((item) => item.id === pluginID)
+    const matched = entry ? matchRoute(entry.routes, method, remainder) : undefined
+    if (!matched) return unknownRoute(request)
+    return yield* invoke(request, matched).pipe(
+      Effect.catchCause((cause) =>
+        Effect.succeed(
+          HttpServerResponse.jsonUnsafe(
+            { error: `Plugin route failed: ${Cause.pretty(cause)}` },
+            { status: 500 },
+          ),
+        ),
+      ),
+    )
+  })
+}
+
+function decodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    return segment
+  }
+}
+
+function unknownRoute(request: HttpServerRequest.HttpServerRequest): HttpServerResponse.HttpServerResponse {
+  const url = new URL(request.url, "http://localhost")
+  return HttpServerResponse.jsonUnsafe(
+    { error: `Unknown plugin route: ${request.method} ${url.pathname}` },
+    { status: 404 },
+  )
+}
+
+function matchRoute(routes: PluginRoute[], method: string, remainder: string): Matched | undefined {
+  let fallback
+  for (const route of routes) {
+    if (route.method.toUpperCase() !== method) continue
+    const params = matchPattern(route.path, remainder)
+    if (!params) continue
+    if (!route.path.includes(":")) return { route, params }
+    fallback ??= { route, params }
+  }
+  return fallback
+}
+
+function matchPattern(pattern: string, actual: string): Record<string, string> | undefined {
+  const patternSegments = pattern.split("/").filter((segment) => segment !== "")
+  const actualSegments = actual.split("/").filter((segment) => segment !== "")
+  if (patternSegments.length !== actualSegments.length) return
+  const params: Record<string, string> = {}
+  for (let i = 0; i < patternSegments.length; i++) {
+    const expected = patternSegments[i]
+    const value = actualSegments[i]
+    if (expected.startsWith(":")) {
+      if (!value) return
+      params[expected.slice(1)] = decodeSegment(value)
+      continue
+    }
+    if (expected !== value) return
+  }
+  return params
+}
+
+function invoke(
+  request: HttpServerRequest.HttpServerRequest,
+  matched: Matched,
+) {
+  const url = new URL(request.url, "http://localhost")
+  const query: Record<string, string> = {}
+  for (const [key, value] of url.searchParams) query[key] = value
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === "string") headers[key] = value
+  }
+  const input: PluginRouteRequest = {
+    method: request.method.toUpperCase(),
+    path: decodeSegment(url.pathname.replace(new RegExp(`^/${PluginRoutes.prefix}/[^/]+`), "") || "/"),
+    params: matched.params,
+    query,
+    headers,
+  }
+  return Effect.gen(function* () {
+    if (request.method !== "GET" && request.method !== "HEAD" && request.method !== "DELETE") {
+      const contentType = typeof request.headers["content-type"] === "string" ? (request.headers["content-type"] as string) : ""
+      const body = contentType.includes("application/json") ? request.json : request.text
+      input.body = yield* body.pipe(
+        Effect.catchCause((cause: Cause.Cause<unknown>) => Effect.die(new Error(`Failed to read request body: ${Cause.pretty(cause)}`))),
+      )
+    }
+    const result = yield* Effect.tryPromise({
+      try: () => Promise.resolve(matched.route.handler(input)),
+      catch: (error: unknown) => (error instanceof Error ? error : new Error(String(error))),
+    })
+    return respond(result)
+  })
+}
+
+function respond(result: PluginRouteResponse): HttpServerResponse.HttpServerResponse {
+  const status = result.status ?? (result.body === undefined ? 204 : 200)
+  const headers: Record<string, string> = { ...result.headers }
+  if (result.body === undefined) return HttpServerResponse.empty({ status, headers })
+  if (typeof result.body === "string")
+    return HttpServerResponse.text(result.body, {
+      status,
+      headers: { "content-type": "text/plain; charset=utf-8", ...headers },
+    })
+  return HttpServerResponse.jsonUnsafe(result.body, {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  })
+}
+
+export * as PluginRoutesDispatcher from "./plugin-routes"

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -106,6 +106,7 @@ import { sessionLocationLayer } from "@opencode-ai/server/middleware/session-loc
 import { PtyEnvironment } from "@opencode-ai/server/pty-environment"
 import { schemaErrorLayer as v2SchemaErrorLayer } from "@opencode-ai/server/middleware/schema-error"
 import { workspaceHandlers } from "./handlers/workspace"
+import { PluginRoutesDispatcher } from "@/server/plugin-routes"
 import { instanceContextLayer } from "./middleware/instance-context"
 import { workspaceRoutingLayer } from "./middleware/workspace-routing"
 import { disposeMiddleware } from "./lifecycle"
@@ -279,6 +280,7 @@ export function createRoutes(
     ptyConnectApiRoutes,
     instanceRoutes,
     serverRoutes,
+    PluginRoutesDispatcher.layer,
     docRoute,
     uiRoute,
   ).pipe(

--- a/packages/opencode/test/plugin/http-routes.test.ts
+++ b/packages/opencode/test/plugin/http-routes.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect } from "bun:test"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Context, Effect, Layer } from "effect"
+import { HttpRouter, HttpServer } from "effect/unstable/http"
+import type { PluginRoute } from "@opencode-ai/plugin"
+import { pathToFileURL } from "url"
+import path from "path"
+import { Config } from "@/config/config"
+import { InstanceRef } from "@/effect/instance-ref"
+import { PluginRoutesDispatcher } from "@/server/plugin-routes"
+import { Plugin } from "@/plugin/index"
+import { InstanceStore } from "@/project/instance-store"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+// CrossSpawnSpawner is required by tmpdirScoped (git operations) and the
+// plugin loader. Group it with FSUtil so both are available in the test layer.
+const spawnerLayer = LayerNode.compile(LayerNode.group([CrossSpawnSpawner.node, FSUtil.node]))
+
+const it = testEffect(Layer.mergeAll(spawnerLayer, testInstanceStoreLayer))
+
+function mockPlugin(table: { id: string; routes: PluginRoute[] }[]) {
+  return Layer.succeed(
+    Plugin.Service,
+    Plugin.Service.of({
+      init: () => Effect.void,
+      trigger: ((_name: string, _input: unknown, output: unknown) => Effect.succeed(output)) as Plugin.Interface["trigger"],
+      routes: () => Effect.succeed(table),
+      list: () => Effect.succeed([]),
+    }),
+  )
+}
+
+function app(directory: string, pluginLayer: Layer.Layer<never>) {
+  const handler = HttpRouter.toWebHandler(
+    PluginRoutesDispatcher.layer.pipe(
+      Layer.provide(pluginLayer),
+      Layer.provide(testInstanceStoreLayer),
+      Layer.provide(spawnerLayer),
+      Layer.provide(HttpServer.layerServices),
+    ) as unknown as Layer.Layer<never>,
+    { disableLogger: true },
+  ).handler
+  return (input: string, init?: RequestInit) =>
+    Effect.promise(() =>
+      handler(
+        new Request(`http://localhost${input}`, {
+          headers: { "x-opencode-directory": directory, ...(init?.headers as Record<string, string> | undefined) },
+          ...init,
+        }),
+        Context.makeUnsafe(new Map()),
+      ),
+    )
+}
+
+function json(response: Response) {
+  return Effect.promise(() => response.json() as Promise<unknown>)
+}
+
+function text(response: Response) {
+  return Effect.promise(() => response.text())
+}
+
+describe("plugin http routes", () => {
+  it.live("dispatches to a plugin route with params, query and json body", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const call = app(
+        directory,
+        mockPlugin([
+          {
+            id: "demo",
+            routes: [
+              {
+                method: "GET",
+                path: "/issue/:id",
+                handler: async (request) => ({
+                  body: { id: request.params.id, path: request.path, query: request.query, method: request.method },
+                }),
+              },
+              {
+                method: "POST",
+                path: "/webhook",
+                handler: async (request) => {
+                  if (request.headers["x-webhook-secret"] !== "s3cret")
+                    return { status: 401, body: { error: "invalid secret" } }
+                  const body = request.body as { text?: string; sessionID?: string }
+                  if (!body?.text) return { status: 400, body: { error: "text is required" } }
+                  const sessionID = body.sessionID ?? "created"
+                  return { status: 202, body: { sessionID } }
+                },
+              },
+            ],
+          },
+        ]),
+      )
+      return yield* provideInstance(directory)(
+        Effect.gen(function* () {
+          const list = yield* call("/plugin/demo/issue/42?x=1")
+          expect(list.status).toBe(200)
+          expect(yield* json(list)).toEqual({ id: "42", path: "/issue/42", query: { x: "1" }, method: "GET" })
+
+          const denied = yield* call("/plugin/demo/webhook", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ text: "hi" }),
+          })
+          expect(denied.status).toBe(401)
+
+          const bad = yield* call("/plugin/demo/webhook", {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-webhook-secret": "s3cret" },
+            body: JSON.stringify({}),
+          })
+          expect(bad.status).toBe(400)
+
+          const accepted = yield* call("/plugin/demo/webhook", {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-webhook-secret": "s3cret" },
+            body: JSON.stringify({ text: "fix it" }),
+          })
+          expect(accepted.status).toBe(202)
+          expect(yield* json(accepted)).toEqual({ sessionID: "created" })
+
+          const reused = yield* call("/plugin/demo/webhook", {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-webhook-secret": "s3cret" },
+            body: JSON.stringify({ text: "again", sessionID: "ses_existing" }),
+          })
+          expect(yield* json(reused)).toEqual({ sessionID: "ses_existing" })
+        }),
+      )
+    }),
+  )
+
+  it.live("returns 404 for unknown plugin, path or method", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const call = app(
+        directory,
+        mockPlugin([
+          {
+            id: "demo",
+            routes: [{ method: "GET", path: "/ping", handler: async () => ({ body: { pong: true } }) }],
+          },
+        ]),
+      )
+      return yield* provideInstance(directory)(
+        Effect.gen(function* () {
+          expect((yield* call("/plugin/other/ping")).status).toBe(404)
+          expect((yield* call("/plugin/demo/missing")).status).toBe(404)
+          expect((yield* call("/plugin/demo/ping", { method: "POST" })).status).toBe(404)
+        }),
+      )
+    }),
+  )
+
+  it.live("isolates handler failures and honors response shapes", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const call = app(
+        directory,
+        mockPlugin([
+          {
+            id: "demo",
+            routes: [
+              { method: "GET", path: "/boom", handler: async () => { throw new Error("boom") } },
+              { method: "GET", path: "/empty", handler: async () => ({}) },
+              { method: "GET", path: "/text", handler: async () => ({ body: "plain" }) },
+            ],
+          },
+        ]),
+      )
+      return yield* provideInstance(directory)(
+        Effect.gen(function* () {
+          const boom = yield* call("/plugin/demo/boom")
+          expect(boom.status).toBe(500)
+          expect(((yield* json(boom)) as { error: string }).error).toContain("boom")
+
+          expect((yield* call("/plugin/demo/empty")).status).toBe(204)
+
+          const textResponse = yield* call("/plugin/demo/text")
+          expect(textResponse.status).toBe(200)
+          expect(textResponse.headers.get("content-type")).toContain("text/plain")
+          expect(yield* text(textResponse)).toBe("plain")
+        }),
+      )
+    }),
+  )
+
+  it.live("serves routes from a plugin loaded from a file", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const file = path.join(directory, "plugin.ts")
+      const href = pathToFileURL(file).href
+      yield* Effect.promise(() =>
+        Bun.write(
+          file,
+          [
+            "export default {",
+            '  id: "webhook-plugin",',
+            "  server: async () => ({",
+            "    routes: [",
+            "      {",
+            '        method: "GET",',
+            '        path: "/ping",',
+            "        handler: async () => ({ status: 200, body: { pong: true } }),",
+            "      },",
+            "    ],",
+            "  }),",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+      const config = TestConfig.layer({
+        get: () =>
+          Effect.succeed({
+            plugin: [href],
+            plugin_origins: [{ spec: href, source: file, scope: "local" as const }],
+          }),
+        directories: () => Effect.succeed([directory]),
+      })
+      const handler = HttpRouter.toWebHandler(
+        PluginRoutesDispatcher.layer.pipe(
+          Layer.provide(LayerNode.compile(Plugin.node, [
+            [Config.node, config],
+            [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+          ])),
+          Layer.provide(testInstanceStoreLayer),
+          Layer.provide(spawnerLayer),
+          Layer.provide(HttpServer.layerServices),
+        ) as unknown as Layer.Layer<never>,
+        { disableLogger: true },
+      ).handler
+      return yield* provideInstance(directory)(
+        Effect.promise(() =>
+          handler(
+            new Request("http://localhost/plugin/webhook-plugin/ping", {
+              headers: { "x-opencode-directory": directory },
+            }),
+            Context.makeUnsafe(new Map()),
+          ),
+        ).pipe(
+          Effect.tap((response) => Effect.sync(() => expect(response.status).toBe(200))),
+          Effect.flatMap((response) => Effect.promise(() => response.json() as Promise<{ pong: boolean }>)),
+          Effect.map((body) => expect(body).toEqual({ pong: true })),
+        ),
+      )
+    }),
+  )
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -35,6 +35,7 @@ const brokenPluginLayer = Layer.succeed(
     init: () => Effect.void,
     trigger: ((_name: unknown, _input: unknown, output: unknown) =>
       Effect.succeed(output)) as Plugin.Interface["trigger"],
+    routes: () => Effect.succeed([]),
     list: () =>
       Effect.succeed([
         {

--- a/packages/plugin/docs/http-routes.md
+++ b/packages/plugin/docs/http-routes.md
@@ -1,0 +1,112 @@
+# HTTP routes for server plugins
+
+Server plugins can expose their own HTTP endpoints on the opencode server by
+returning a `routes` entry from the plugin's hooks. This is the official
+inbound channel for driving the agent from external systems (chat bridges,
+CI, webhooks) — see [anomalyco/opencode#41362](https://github.com/anomalyco/opencode/issues/41362).
+
+## Contract
+
+```ts
+import type { Plugin, PluginRoute, PluginRouteRequest, PluginRouteResponse } from "@opencode-ai/plugin"
+
+export const MyPlugin: Plugin = async (input) => ({
+  routes: [
+    {
+      method: "POST",
+      path: "/webhook",
+      async handler(request: PluginRouteRequest): Promise<PluginRouteResponse> {
+        return { status: 202, body: { ok: true } }
+      },
+    },
+  ],
+})
+```
+
+- `method` — `GET`, `POST`, `PUT`, `PATCH`, or `DELETE`.
+- `path` — relative to `/plugin/<pluginID>`, e.g. `/webhook` or `/issue/:id`.
+  Segments starting with `:` are path parameters, available in
+  `request.params` (exact matches win over parameterized ones).
+- `handler` receives a plain `PluginRouteRequest` and returns a
+  `PluginRouteResponse`. Objects are serialized as JSON, strings are sent as
+  `text/plain`. An undefined body produces `204 No Content`.
+
+Requests are dispatched by the server at request time (the typed HttpApi
+surface is static, so dynamic registration happens in a catch-all dispatcher),
+so routes are available without restarting the server after the plugin is
+loaded with the instance.
+
+## URL scheme and instance resolution
+
+Routes are mounted at:
+
+```
+/plugin/<pluginID>/<path>
+```
+
+`<pluginID>` is the plugin id: the exported `id` for path plugins, the
+`package.json` `name` for npm packages, or the plugin function name for
+anonymous legacy exports.
+
+Which project instance handles the request is resolved the same way as the
+rest of the API: `directory` query parameter, then the `x-opencode-directory`
+header, then the server's working directory. So a webhook for a specific
+project should send one of those:
+
+```bash
+curl -X POST 'http://localhost:4096/plugin/webhook-plugin/webhook?directory=/path/to/project' \
+  -H 'content-type: application/json' \
+  -H 'x-webhook-secret: s3cret' \
+  -d '{"text": "fix the failing tests"}'
+```
+
+## Security
+
+**Plugin routes are public.** They are intentionally outside `ServerAuth`
+because they are meant to be called by external systems that do not hold
+opencode credentials. Authenticate inside the handler instead — the
+convention used by the example plugin is a shared secret in the
+`x-webhook-secret` header, configured through the plugin options:
+
+```json
+{
+  "plugin": [
+    [
+      "file:///path/to/webhook-plugin.ts",
+      { "agent": "build", "secret": "s3cret" }
+    ]
+  ]
+}
+```
+
+Only bind the server to loopback or protect it at the network layer if
+unauthenticated access to the route is not acceptable for your setup.
+
+## Example: webhook that starts an agent run
+
+[`examples/webhook-plugin.ts`](../examples/webhook-plugin.ts) demonstrates the
+intended flow:
+
+1. The handler validates the `x-webhook-secret` header (401 on mismatch).
+2. If the request body carries a `sessionID`, that session is reused;
+   otherwise a fresh session is created with the `agent` from the plugin
+   options (or the `agent` field of the request body).
+3. The message is submitted through `client.session.promptAsync`, which
+   returns immediately — the agent runs in the background.
+4. The response is `202 Accepted` with the `sessionID`, so the caller can
+   follow the session through the regular API or SSE stream.
+
+```bash
+curl -X POST http://localhost:4096/plugin/webhook-plugin/webhook \
+  -H 'content-type: application/json' \
+  -H 'x-webhook-secret: s3cret' \
+  -d '{"text": "fix the failing tests"}'
+
+# → 202 {"sessionID":"ses_...","agent":"build"}
+```
+
+## Error handling
+
+Handler failures are isolated: a throwing handler produces a `500` with the
+error message and does not take the server down. Unknown plugin ids or
+paths produce `404`.

--- a/packages/plugin/examples/webhook-plugin.ts
+++ b/packages/plugin/examples/webhook-plugin.ts
@@ -1,0 +1,84 @@
+/**
+ * Example plugin: inbound webhook that starts an agent run.
+ *
+ * Register it in opencode.json:
+ *
+ *   {
+ *     "plugin": [
+ *       [
+ *         "file:///path/to/webhook-plugin.ts",
+ *         { "agent": "build", "secret": "s3cret" }
+ *       ]
+ *     ]
+ *   }
+ *
+ * Then POST to the opencode server:
+ *
+ *   curl -X POST http://localhost:4096/plugin/webhook-plugin/webhook \
+ *     -H 'content-type: application/json' \
+ *     -H 'x-webhook-secret: s3cret' \
+ *     -d '{"text": "fix the failing tests"}'
+ *
+ * The message is handed to the configured agent on a fresh session (or on
+ * an existing one when the request body carries a `sessionID`) and the
+ * server responds 202 immediately; the agent keeps running in the
+ * background.
+ */
+import type { Plugin } from "@opencode-ai/plugin"
+
+type WebhookOptions = {
+  /** Agent used for new sessions (default: "build") */
+  agent?: string
+  /** Shared secret required in the `x-webhook-secret` header */
+  secret?: string
+}
+
+export const WebhookPlugin: Plugin = async (input, options) => {
+  const agent = typeof options?.agent === "string" ? options.agent : "build"
+  const secret = typeof options?.secret === "string" ? options.secret : undefined
+
+  return {
+    routes: [
+      {
+        method: "POST",
+        path: "/webhook",
+        async handler(request) {
+          if (secret && request.headers["x-webhook-secret"] !== secret) {
+            return { status: 401, body: { error: "Invalid webhook secret" } }
+          }
+
+          const body = isRecord(request.body) ? (request.body as { text?: unknown; sessionID?: unknown; agent?: unknown }) : {}
+          const text = typeof body.text === "string" ? body.text : ""
+          if (!text) return { status: 400, body: { error: "Body must be JSON with a non-empty `text` field" } }
+
+          const runAgent = typeof body.agent === "string" ? body.agent : agent
+          let sessionID = typeof body.sessionID === "string" ? body.sessionID : ""
+          if (!sessionID) {
+            const created = await input.client.session.create({ agent: runAgent })
+            sessionID = created.data?.id
+            if (!sessionID) return { status: 500, body: { error: "Failed to create session" } }
+          }
+
+          await input.client.session.promptAsync({
+            path: { id: sessionID },
+            body: {
+              agent: runAgent,
+              parts: [{ type: "text" as const, text }],
+            },
+          })
+
+          return { status: 202, body: { sessionID, agent: runAgent } }
+        },
+      },
+    ],
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export default {
+  id: "webhook-plugin",
+  server: WebhookPlugin,
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -219,6 +219,33 @@ export type ProviderHook = {
 /** @deprecated Use AuthOAuthResult instead. */
 export type AuthOuathResult = AuthOAuthResult
 
+export type PluginRouteMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
+export type PluginRouteRequest = {
+  method: string
+  /** Path after the `/plugin/<pluginID>` prefix, with leading slash */
+  path: string
+  params: Record<string, string>
+  query: Record<string, string>
+  headers: Record<string, string>
+  /** Parsed JSON body when the request is JSON, otherwise raw text (may be undefined) */
+  body?: unknown
+}
+
+export type PluginRouteResponse = {
+  status?: number
+  headers?: Record<string, string>
+  /** Objects are serialized as JSON, strings are sent as text/plain */
+  body?: unknown
+}
+
+export type PluginRoute = {
+  method: PluginRouteMethod
+  /** Path relative to `/plugin/<pluginID>`, e.g. `/webhook` or `/issue/:id` */
+  path: string
+  handler: (request: PluginRouteRequest) => Promise<PluginRouteResponse> | PluginRouteResponse
+}
+
 export interface Hooks {
   dispose?: () => Promise<void>
   event?: (input: { event: Event }) => Promise<void>
@@ -226,6 +253,11 @@ export interface Hooks {
   tool?: {
     [key: string]: ToolDefinition
   }
+  /**
+   * HTTP routes mounted by the server at `/plugin/<pluginID><path>`.
+   * Routes are public (no server authentication); authenticate inside the handler.
+   */
+  routes?: PluginRoute[]
   auth?: AuthHook
   provider?: ProviderHook
   /**


### PR DESCRIPTION
### Issue for this PR

Closes #41362

### Type of change

- [x] New feature

### What does this PR do?

Plugins currently have no way to expose their own HTTP endpoints on the opencode server, which blocks use cases like chat bridges or CI systems driving the agent via webhook.

This adds a `routes` field to the plugin hooks. A plugin returns an array of `{ method, path, handler }` entries and the server mounts them under `/plugin/<pluginID>/<path>`. A static catch-all route dispatches at request time: it resolves the instance for the requested directory (query param, `x-opencode-directory` header, or cwd), matches the route by method and path (with `:param` segments), reads the body, and calls the handler.

Routes are intentionally public — no server auth. The plugin authenticates inside its own handler, e.g. by comparing a shared secret. That's what the example webhook plugin does: it checks `x-webhook-secret`, creates a session (or reuses one if `sessionID` is passed), fires `promptAsync` with a configured agent, and returns 202.

### How did you verify your code works?

- `bun typecheck` in both `packages/plugin` and `packages/opencode`
- `bun test test/plugin/http-routes.test.ts` — 4 tests covering dispatch with params/query/body, 404 cases, handler error isolation and response shapes, and a plugin loaded from a file
- `bun test test/tool/registry.test.ts` — no regressions from the `Plugin.Service` interface change

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
