### PR TITLE
feat(tui): optimistic session creation on first prompt

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -13,6 +13,7 @@ import type {
   McpResource,
   McpServer,
   ModelInfo,
+  ModelRef,
   PermissionSavedInfo,
   PermissionRequest,
   PermissionReplyInput,
@@ -34,6 +35,7 @@ import type {
   WebSearchProvider,
 } from "../promise"
 import { Worktree } from "@opencode-ai/schema/worktree"
+import { SessionID } from "@opencode-ai/schema/session-id"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
 import { isPermissionNotFoundError, type SessionPromptInput } from "../promise"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -226,6 +228,16 @@ export function createData(config: CreateDataInput) {
   // rollback — not on POST success, which typically precedes the echo.
   const outbox = new Set<string>()
 
+  // Session IDs of optimistic create admissions still awaiting acknowledgement
+  // (the session.created echo or the create response itself). A failed create
+  // only rolls back a session the server never acknowledged.
+  const sessionOutbox = new Set<string>()
+
+  // In-flight optimistic creates by session ID. prompt() gates its POST on
+  // this so a prompt sent to a still-creating session waits for the session
+  // to exist server-side instead of failing with "not found".
+  const creating = new Map<string, Promise<unknown>>()
+
   // Upsert an admitted inbox item into pending, input, and (for user and
   // synthetic items) the visible transcript. Used by the inbox.enqueued
   // handler and by optimistic prompt admission; the upsert is what reconciles
@@ -381,6 +393,7 @@ export function createData(config: CreateDataInput) {
     store.session.pending[sessionID]?.forEach((item) => outbox.delete(item.id))
     messageIndex.delete(sessionID)
     sync.invalidate(`session:${sessionID}`)
+    sync.invalidate(`session.family:${sessionID}`)
     sync.invalidate(`session.pending:${sessionID}`)
     sync.invalidate(`session.message:${sessionID}`)
     sync.invalidate(`session.permission:${sessionID}`)
@@ -430,6 +443,7 @@ export function createData(config: CreateDataInput) {
         void result.project.sync().catch((error) => console.error("Failed to preload projects", error))
         return
       case "session.created":
+        sessionOutbox.delete(event.data.sessionID)
         result.session.invalidate(event.data.sessionID)
         void result.session.sync(event.data.sessionID)
         // Band-aid: a newly created session starts empty, so live events can be its source of truth.
@@ -1103,44 +1117,116 @@ export function createData(config: CreateDataInput) {
           sync.invalidate(`session.pending:${sessionID}`)
         },
       },
+      // Optimistic session creation: admit a local record under a
+      // client-minted ID so a session view can mount immediately, then create
+      // the session on the server. The session.created echo re-syncs the
+      // record by ID, so the durable payload replaces the client's guess.
+      // Returns the ID synchronously along with the in-flight request:
+      // callers gate session-dependent sends on the request (prompt() gates
+      // itself on any in-flight create of its session automatically).
+      create(input: {
+        id?: string
+        title?: string
+        agent?: string
+        model?: ModelRef
+        location?: LocationRef
+        projectID?: string
+      }) {
+        const { projectID, ...payload } = input
+        const id = payload.id ?? SessionID.create()
+        const location = payload.location ?? defaultLocation()
+        const fresh = !store.session.info[id]
+        if (fresh) {
+          const now = Date.now()
+          sessionOutbox.add(id)
+          setStore("session", "info", id, {
+            id,
+            projectID: projectID ?? store.location[locationKey(location)]?.info?.project.id ?? "",
+            agent: payload.agent,
+            model: payload.model,
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: now, updated: now },
+            title: payload.title,
+            location,
+          })
+          // A view mounting this session would sync these and fail while the
+          // create is in flight. Mark them fresh: a new session starts empty,
+          // so live events are its source of truth (the session.created
+          // handler applies the same band-aid), and the session.created echo
+          // invalidates and re-syncs the info record itself.
+          sync.complete(`session:${id}`)
+          sync.complete(`session.family:${id}`)
+          sync.complete(`session.pending:${id}`)
+          sync.complete(`session.message:${id}`)
+          registerSession(id)
+        }
+        // Wrapped so even a synchronous client failure reaches the rollback.
+        const request = Promise.resolve()
+          .then(() => api().session.create({ ...payload, id, location }))
+          .then((info) => {
+            sessionOutbox.delete(id)
+            result.session.remember(info)
+            return info
+          })
+          .catch((error) => {
+            // Roll back only a record this call admitted and neither the echo
+            // nor the response has acknowledged: anything else is server state.
+            if (fresh && sessionOutbox.delete(id)) removeSession(id)
+            throw error
+          })
+        if (fresh) {
+          creating.set(id, request)
+          const settle = () => {
+            if (creating.get(id) === request) creating.delete(id)
+          }
+          void request.then(settle, settle)
+        }
+        return { id, request }
+      },
       // Optimistic prompt admission: render the prompt immediately under a
       // client-minted ID, send it, and let the durable inbox.enqueued echo
       // upsert that same ID with the server's payload. Server admission is
       // idempotent per ID, so retrying with the identical payload cannot
       // double-admit.
-      prompt(input: SessionPromptInput) {
-        const id = input.id ?? SessionMessage.ID.create()
+      prompt(input: SessionPromptInput & { gate?: Promise<unknown> }) {
+        const { gate, ...request } = input
+        const id = request.id ?? SessionMessage.ID.create()
         // A retry may reuse an ID that is already rendered — and possibly
         // already durable. Admit optimistically only for new IDs so a failed
         // retry cannot roll back acknowledged state.
         const fresh =
-          !messageIndex.get(input.sessionID)?.has(id) &&
-          !store.session.pending[input.sessionID]?.some((item) => item.id === id)
+          !messageIndex.get(request.sessionID)?.has(id) &&
+          !store.session.pending[request.sessionID]?.some((item) => item.id === id)
         if (fresh) {
           outbox.add(id)
           admitLocal({
             id,
-            sessionID: input.sessionID,
+            sessionID: request.sessionID,
             timeCreated: Date.now(),
             type: "user",
-            delivery: input.delivery ?? "steer",
+            delivery: request.delivery ?? "steer",
             // Files and skills stay off the optimistic row: their durable
             // forms are server-loaded (content, mime, resolution), so they
             // fill in when the echo upserts the row.
             payload: {
-              text: input.text,
-              agents: input.agents?.map((agent) => ({ ...agent })),
-              metadata: input.metadata,
+              text: request.text,
+              agents: request.agents?.map((agent) => ({ ...agent })),
+              metadata: request.metadata,
             },
           })
         }
         // Wrapped so even a synchronous client failure reaches the rollback.
+        // The POST additionally waits for the caller's gate and for any
+        // in-flight optimistic create of this session: the row renders now,
+        // the send happens once the session exists server-side.
         return Promise.resolve()
-          .then(() => api().session.prompt({ ...input, id }))
+          .then(() => Promise.all([gate, creating.get(request.sessionID)]))
+          .then(() => api().session.prompt({ ...request, id }))
           .catch((error) => {
             // Roll back only rows this call admitted and the echo has not
             // acknowledged: anything else is server state.
-            if (fresh && outbox.delete(id)) retractLocal(input.sessionID, id)
+            if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
             throw error
           })
       },

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -230,7 +230,8 @@ export function createData(config: CreateDataInput) {
 
   // Session IDs of optimistic create admissions still awaiting acknowledgement
   // (the session.created echo or the create response itself). A failed create
-  // only rolls back a session the server never acknowledged.
+  // only rolls back a session the server never acknowledged. Unlike
+  // `creating`, this clears on the echo rather than request settlement.
   const sessionOutbox = new Set<string>()
 
   // In-flight optimistic creates by session ID. prompt() gates its POST on
@@ -243,6 +244,16 @@ export function createData(config: CreateDataInput) {
   // for the previous prompt's POST (settled, so one failure does not block
   // the next) before sending its own.
   const sending = new Map<string, Promise<unknown>>()
+
+  // Register `promise` under `key` until it settles. A later registration
+  // replaces an earlier one; settlement only clears its own entry.
+  function track(map: Map<string, Promise<unknown>>, key: string, promise: Promise<unknown>) {
+    map.set(key, promise)
+    const settle = () => {
+      if (map.get(key) === promise) map.delete(key)
+    }
+    void promise.then(settle, settle)
+  }
 
   // Upsert an admitted inbox item into pending, input, and (for user and
   // synthetic items) the visible transcript. Used by the inbox.enqueued
@@ -1145,7 +1156,7 @@ export function createData(config: CreateDataInput) {
         if (fresh) {
           const now = Date.now()
           sessionOutbox.add(id)
-          setStore("session", "info", id, {
+          result.session.remember({
             id,
             projectID: projectID ?? store.location[locationKey(location)]?.info?.project.id ?? "",
             agent: payload.agent,
@@ -1156,16 +1167,11 @@ export function createData(config: CreateDataInput) {
             title: payload.title,
             location,
           })
-          // A view mounting this session would sync these and fail while the
-          // create is in flight. Mark them fresh: a new session starts empty,
-          // so live events are its source of truth (the session.created
-          // handler applies the same band-aid), and the session.created echo
-          // invalidates and re-syncs the info record itself.
-          sync.complete(`session:${id}`)
+          // A mounted optimistic session must not fetch its empty collections
+          // before creation settles. The session.created echo re-syncs info.
           sync.complete(`session.family:${id}`)
           sync.complete(`session.pending:${id}`)
           sync.complete(`session.message:${id}`)
-          registerSession(id)
         }
         // Wrapped so even a synchronous client failure reaches the rollback.
         const request = Promise.resolve()
@@ -1181,13 +1187,7 @@ export function createData(config: CreateDataInput) {
             if (fresh && sessionOutbox.delete(id)) removeSession(id)
             throw error
           })
-        if (fresh) {
-          creating.set(id, request)
-          const settle = () => {
-            if (creating.get(id) === request) creating.delete(id)
-          }
-          void request.then(settle, settle)
-        }
+        if (fresh) track(creating, id, request)
         return { id, request }
       },
       // Optimistic prompt admission: render the prompt immediately under a
@@ -1231,14 +1231,14 @@ export function createData(config: CreateDataInput) {
         const send = Promise.resolve()
           .then(() => Promise.all([gate, creating.get(request.sessionID), previous]))
           .then(() => api().session.prompt({ ...request, id }))
-        const settled = send.then(
-          () => undefined,
-          () => undefined,
+        track(
+          sending,
+          request.sessionID,
+          send.then(
+            () => undefined,
+            () => undefined,
+          ),
         )
-        sending.set(request.sessionID, settled)
-        void settled.then(() => {
-          if (sending.get(request.sessionID) === settled) sending.delete(request.sessionID)
-        })
         return send.catch((error) => {
           // Roll back only rows this call admitted and the echo has not
           // acknowledged: anything else is server state.

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -238,6 +238,12 @@ export function createData(config: CreateDataInput) {
   // to exist server-side instead of failing with "not found".
   const creating = new Map<string, Promise<unknown>>()
 
+  // Per-session send chain: prompts must be admitted in submission order,
+  // and HTTP gives no ordering across concurrent POSTs. Each prompt waits
+  // for the previous prompt's POST (settled, so one failure does not block
+  // the next) before sending its own.
+  const sending = new Map<string, Promise<unknown>>()
+
   // Upsert an admitted inbox item into pending, input, and (for user and
   // synthetic items) the visible transcript. Used by the inbox.enqueued
   // handler and by optimistic prompt admission; the upsert is what reconciles
@@ -1217,18 +1223,28 @@ export function createData(config: CreateDataInput) {
           })
         }
         // Wrapped so even a synchronous client failure reaches the rollback.
-        // The POST additionally waits for the caller's gate and for any
-        // in-flight optimistic create of this session: the row renders now,
-        // the send happens once the session exists server-side.
-        return Promise.resolve()
-          .then(() => Promise.all([gate, creating.get(request.sessionID)]))
+        // The POST additionally waits for the caller's gate, for any
+        // in-flight optimistic create of this session, and for the previous
+        // prompt's POST: the row renders now, the send happens once the
+        // session exists server-side and earlier prompts are admitted.
+        const previous = sending.get(request.sessionID)
+        const send = Promise.resolve()
+          .then(() => Promise.all([gate, creating.get(request.sessionID), previous]))
           .then(() => api().session.prompt({ ...request, id }))
-          .catch((error) => {
-            // Roll back only rows this call admitted and the echo has not
-            // acknowledged: anything else is server state.
-            if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
-            throw error
-          })
+        const settled = send.then(
+          () => undefined,
+          () => undefined,
+        )
+        sending.set(request.sessionID, settled)
+        void settled.then(() => {
+          if (sending.get(request.sessionID) === settled) sending.delete(request.sessionID)
+        })
+        return send.catch((error) => {
+          // Roll back only rows this call admitted and the echo has not
+          // acknowledged: anything else is server state.
+          if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
+          throw error
+        })
       },
       sync(sessionID: string, options?: { children?: boolean }) {
         return sync.run(options?.children ? `session.family:${sessionID}` : `session:${sessionID}`, async () => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1127,13 +1127,39 @@ export function Prompt(props: PromptProps) {
       return false
     }
 
+    // Snapshot the composer and clear it synchronously, before the first await.
+    // Everything below reads the snapshot: text typed while a request is in
+    // flight lands in the already-empty composer and survives, and prompt
+    // history records exactly what was submitted instead of the live store
+    // (which may have absorbed mid-flight typing). Failure paths restore the
+    // snapshot unless the user has started typing something new.
+    const currentMode = store.mode
+    const entry = { ...store.prompt, mode: currentMode }
+    history.append(entry)
+    input.extmarks.clear()
+    setStore("prompt", emptyPrompt())
+    setStore("extmarkToPart", new Map())
+    input.clear()
+    props.onSubmit?.()
+    const restoreEntry = () => {
+      if (disposed || input.isDestroyed || input.plainText !== "") return
+      input.setText(entry.text)
+      setStore("prompt", entry)
+      setStore("mode", entry.mode ?? "normal")
+      restoreExtmarksFromPrompt(entry)
+      input.cursorOffset = entry.text.length
+    }
+
     const variant = selection.variant
     let sessionID = props.sessionID
     let session = sessionID ? data.session.get(sessionID) : undefined
     let finishMoveProgress = false
     if (sessionID == null) {
       const directory = await move.getDirectory()
-      if (move.pending() && !directory) return false
+      if (move.pending() && !directory) {
+        restoreEntry()
+        return false
+      }
       finishMoveProgress = Boolean(move.progress())
       // The location context is where the next session is created: seeded by the home
       // route (launch cwd, inherited session location, or picked project) and updated
@@ -1158,7 +1184,7 @@ export function Prompt(props: PromptProps) {
           message: "Creating a session failed. Open console for more details.",
           variant: "error",
         })
-
+        restoreEntry()
         return true
       }
 
@@ -1174,14 +1200,13 @@ export function Prompt(props: PromptProps) {
         if (error) {
           if (finishMoveProgress) move.finishSubmit()
           toast.show({ title: "Failed to set session environment", message: errorMessage(error), variant: "error" })
+          restoreEntry()
           return true
         }
       }
     }
 
-    // Capture mode before it gets reset
-    const currentMode = store.mode
-    if (store.mode === "shell") {
+    if (currentMode === "shell") {
       move.startSubmit()
       void client.api.session.shell({
         sessionID,
@@ -1200,14 +1225,15 @@ export function Prompt(props: PromptProps) {
           arguments: slashHead.arguments,
           agent: agent.id,
           model,
-          files: store.prompt.files,
-          agents: store.prompt.agents,
-          skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
+          files: entry.files,
+          agents: entry.agents,
+          skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
         })
         .catch((error) => {
           cancelCommit()
           toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
+          restoreEntry()
         })
     } else if (isSkill) {
       move.startSubmit()
@@ -1231,10 +1257,16 @@ export function Prompt(props: PromptProps) {
       ) {
         const model = { providerID: selection.providerID, id: selection.modelID, variant }
         const cancelCommit = local.model.trackSessionCommit(sessionID, model)
-        await client.api.session.switchModel({ sessionID, model }).catch((error) => {
+        const switchError = await client.api.session.switchModel({ sessionID, model }).then(
+          () => undefined,
+          (error) => error,
+        )
+        if (switchError) {
           cancelCommit()
-          throw error
-        })
+          toast.show({ title: "Failed to switch model", message: errorMessage(switchError), variant: "error" })
+          restoreEntry()
+          return true
+        }
       }
       if (session?.revert) {
         const error = await client.api.session.revert.commit({ sessionID }).then(
@@ -1243,6 +1275,7 @@ export function Prompt(props: PromptProps) {
         )
         if (error) {
           toast.show({ title: "Failed to commit revert", message: errorMessage(error), variant: "error" })
+          restoreEntry()
           return false
         }
       }
@@ -1260,6 +1293,7 @@ export function Prompt(props: PromptProps) {
           )
         if (error) {
           toast.show({ title: "Failed to send editor context", message: errorMessage(error), variant: "error" })
+          restoreEntry()
           return false
         }
       }
@@ -1267,46 +1301,44 @@ export function Prompt(props: PromptProps) {
       // and rolls back if the server rejects it, so submission does not wait
       // on the network. On rejection the row is already rolled back; restore
       // the composer unless the user has started typing something new.
-      const entry = { ...store.prompt, mode: currentMode }
       data.session
         .prompt({
           sessionID,
           text: inputText,
-          files: store.prompt.files,
-          agents: store.prompt.agents,
-          skills: store.prompt.skills?.length ? store.prompt.skills : undefined,
+          files: entry.files,
+          agents: entry.agents,
+          skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
         })
         .catch((error) => {
           toast.show({ title: "Failed to send prompt", message: errorMessage(error), variant: "error" })
-          if (disposed || input.isDestroyed || input.plainText !== "") return
-          input.setText(entry.text)
-          setStore("prompt", entry)
-          setStore("mode", entry.mode ?? "normal")
-          restoreExtmarksFromPrompt(entry)
-          input.cursorOffset = entry.text.length
+          restoreEntry()
         })
       if (pendingEditorSelection) editor.markSelectionSent()
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
-    input.extmarks.clear()
-    setStore("prompt", emptyPrompt())
-    setStore("extmarkToPart", new Map())
-    props.onSubmit?.()
 
     // Optimistic admission puts the message in the store synchronously, so
     // the session view renders it on arrival.
     if (!props.sessionID) {
       if (pendingEditorSelection) editor.preserveSelectionFromNewSession()
+      // Text typed while session creation was in flight lives in this (home)
+      // prompt, which unmounts on navigation and would stash it under the
+      // home key. Re-stash it under the new session so that composer restores
+      // it, and clear it here so onCleanup does not also stash it for home.
+      if (!disposed && !input.isDestroyed && store.prompt.text) {
+        // Copy before clearing: unwrap returns the live store target, and the
+        // setStore(emptyPrompt()) below merges into that same object.
+        saveDraft(sessionID, { prompt: { ...unwrap(store.prompt) }, cursor: input.cursorOffset })
+        input.extmarks.clear()
+        setStore("prompt", emptyPrompt())
+        setStore("extmarkToPart", new Map())
+        input.clear()
+      }
       route.navigate({
         type: "session",
         sessionID,
       })
     }
-    input.clear()
     if (finishMoveProgress) move.finishSubmit()
     return true
   }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1154,6 +1154,10 @@ export function Prompt(props: PromptProps) {
     let sessionID = props.sessionID
     let session = sessionID ? data.session.get(sessionID) : undefined
     let finishMoveProgress = false
+    // For a brand-new session: the setup chain (create, then environment)
+    // that session-dependent sends gate on, plus the recovery that unwinds
+    // the optimistic navigation when setup or the send fails.
+    let newSession: { gate: Promise<unknown>; recover: (error: unknown) => void } | undefined
     if (sessionID == null) {
       const directory = await move.getDirectory()
       if (move.pending() && !directory) {
@@ -1166,61 +1170,64 @@ export function Prompt(props: PromptProps) {
       // by /cd before a session exists.
       const location = currentLocation.ref ?? data.location.default()
 
-      const created = await client.api.session
-        .create({
-          location: directory ? { directory } : location,
-          agent: agent.id,
-          model: {
-            providerID: selection.providerID,
-            id: selection.modelID,
-            variant,
-          },
-        })
-        .catch(() => undefined)
-
-      if (!created) {
-        if (finishMoveProgress) move.finishSubmit()
-        toast.show({
-          message: "Creating a session failed. Open console for more details.",
-          variant: "error",
-        })
-        restoreEntry()
-        return true
-      }
-
+      // Optimistic create: the data layer mints the ID client-side and admits
+      // a local session record synchronously, so the navigation below happens
+      // immediately — enter feels sent even while the create round-trip is in
+      // flight. Sends against the new session gate on the request.
+      const created = data.session.create({
+        location: directory ? { directory } : location,
+        agent: agent.id,
+        model: {
+          providerID: selection.providerID,
+          id: selection.modelID,
+          variant,
+        },
+      })
       sessionID = created.id
-      session = created
-      if (created.location.workspaceID === undefined && terminalEnvironment.variables !== undefined) {
-        const error = await client.api.session
-          .environment({ sessionID, variables: terminalEnvironment.variables })
-          .then(
-            () => undefined,
-            (error) => error,
-          )
-        if (error) {
-          if (finishMoveProgress) move.finishSubmit()
-          toast.show({ title: "Failed to set session environment", message: errorMessage(error), variant: "error" })
-          restoreEntry()
-          return true
-        }
+      session = data.session.get(created.id)
+      newSession = {
+        gate: created.request.then(async (info) => {
+          if (info.location.workspaceID === undefined && terminalEnvironment.variables !== undefined) {
+            await client.api.session.environment({ sessionID: created.id, variables: terminalEnvironment.variables })
+          }
+        }),
+        recover: (error) => {
+          // Setup or the send failed after the optimistic navigation. A
+          // failed create has already rolled back the local record (and the
+          // prompt row rolls back via its own catch). Put the draft back for
+          // the home composer and unwind the navigation.
+          toast.show({
+            title: data.session.get(created.id) ? "Failed to set up session" : "Creating a session failed",
+            message: errorMessage(error),
+            variant: "error",
+          })
+          saveDraft(undefined, { prompt: entry, cursor: entry.text.length })
+          if (route.data.type === "session" && route.data.sessionID === created.id) {
+            route.navigate({ type: "home" })
+          }
+        },
       }
     }
 
+    const target = sessionID
     if (currentMode === "shell") {
       move.startSubmit()
-      void client.api.session.shell({
-        sessionID,
-        command: inputText,
-      })
+      const send = () => client.api.session.shell({ sessionID: target, command: inputText })
+      if (newSession) {
+        const recover = newSession.recover
+        void newSession.gate.then(send).catch(recover)
+      } else {
+        void send()
+      }
       setStore("mode", "normal")
     } else if (slashHead && isCommand) {
       move.startSubmit()
       const model = { providerID: selection.providerID, id: selection.modelID, variant }
-      const cancelCommit = local.model.trackSessionCommit(sessionID, model)
+      const cancelCommit = local.model.trackSessionCommit(target, model)
 
-      void client.api.session
-        .command({
-          sessionID,
+      const send = () =>
+        client.api.session.command({
+          sessionID: target,
           command: slashHead.name,
           arguments: slashHead.arguments,
           agent: agent.id,
@@ -1230,17 +1237,21 @@ export function Prompt(props: PromptProps) {
           skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
         })
-        .catch((error) => {
-          cancelCommit()
-          toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
-          restoreEntry()
-        })
+      void (newSession ? newSession.gate.then(send) : send()).catch((error) => {
+        cancelCommit()
+        if (newSession) return newSession.recover(error)
+        toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
+        restoreEntry()
+      })
     } else if (isSkill) {
       move.startSubmit()
-      void client.api.session.skill({
-        sessionID,
-        skill: slashHead.name,
-      })
+      const send = () => client.api.session.skill({ sessionID: target, skill: slashHead.name })
+      if (newSession) {
+        const recover = newSession.recover
+        void newSession.gate.then(send).catch(recover)
+      } else {
+        void send()
+      }
     } else {
       move.startSubmit()
       if (!session) {
@@ -1281,20 +1292,26 @@ export function Prompt(props: PromptProps) {
       }
       if (pendingEditorSelection) {
         // Keep editor context hidden while admitting it before the corresponding user prompt.
-        const error = await client.api.session
-          .synthetic({
-            sessionID,
+        const send = () =>
+          client.api.session.synthetic({
+            sessionID: target,
             text: formatEditorContext(pendingEditorSelection),
             resume: false,
           })
-          .then(
+        if (newSession) {
+          // Fold into the setup gate so the context still admits before the
+          // user prompt once the session exists.
+          newSession = { ...newSession, gate: newSession.gate.then(send) }
+        } else {
+          const error = await send().then(
             () => undefined,
             (error) => error,
           )
-        if (error) {
-          toast.show({ title: "Failed to send editor context", message: errorMessage(error), variant: "error" })
-          restoreEntry()
-          return false
+          if (error) {
+            toast.show({ title: "Failed to send editor context", message: errorMessage(error), variant: "error" })
+            restoreEntry()
+            return false
+          }
         }
       }
       // The data layer admits optimistically: the prompt renders immediately
@@ -1303,14 +1320,16 @@ export function Prompt(props: PromptProps) {
       // the composer unless the user has started typing something new.
       data.session
         .prompt({
-          sessionID,
+          sessionID: target,
           text: inputText,
           files: entry.files,
           agents: entry.agents,
           skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
+          gate: newSession?.gate,
         })
         .catch((error) => {
+          if (newSession) return newSession.recover(error)
           toast.show({ title: "Failed to send prompt", message: errorMessage(error), variant: "error" })
           restoreEntry()
         })

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -19,6 +19,7 @@ import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
 import { useClient } from "../../context/client"
 import { useRoute } from "../../context/route"
+import { usePromptRef } from "../../context/prompt"
 import { useSessionTabs } from "../../context/session-tabs"
 import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
@@ -200,6 +201,7 @@ export function Prompt(props: PromptProps) {
   const client = useClient()
   const editor = useEditorContext()
   const route = useRoute()
+  const promptRef = usePromptRef()
   const sessionTabs = useSessionTabs()
   const data = useData()
   const directoryRecents = useDirectoryRecents()
@@ -649,14 +651,18 @@ export function Prompt(props: PromptProps) {
       input.gotoBufferEnd()
     },
     reset() {
-      input.clear()
-      input.extmarks.clear()
-      setStore("prompt", emptyPrompt())
-      setStore("extmarkToPart", new Map())
+      resetComposer()
     },
     submit() {
       void submit()
     },
+  }
+
+  function resetComposer() {
+    input.extmarks.clear()
+    setStore("prompt", emptyPrompt())
+    setStore("extmarkToPart", new Map())
+    input.clear()
   }
 
   // Captured once: the session route is keyed by sessionID, so this Prompt
@@ -834,10 +840,7 @@ export function Prompt(props: PromptProps) {
         run: () => {
           if (!store.prompt.text) return
           stash.push({ prompt: store.prompt })
-          input.extmarks.clear()
-          input.clear()
-          setStore("prompt", emptyPrompt())
-          setStore("extmarkToPart", new Map())
+          resetComposer()
           dialog.clear()
         },
       },
@@ -1138,10 +1141,7 @@ export function Prompt(props: PromptProps) {
     const currentMode = store.mode
     const entry = { ...store.prompt, mode: currentMode }
     history.append(entry)
-    input.extmarks.clear()
-    setStore("prompt", emptyPrompt())
-    setStore("extmarkToPart", new Map())
-    input.clear()
+    resetComposer()
     props.onSubmit?.()
     const restoreEntry = () => {
       if (disposed || input.isDestroyed || input.plainText !== "") return
@@ -1156,9 +1156,7 @@ export function Prompt(props: PromptProps) {
     let sessionID = props.sessionID
     let session = sessionID ? data.session.get(sessionID) : undefined
     let finishMoveProgress = false
-    // For a brand-new session: the setup chain (create, then environment)
-    // that session-dependent sends gate on, plus the recovery that unwinds
-    // the optimistic navigation when setup or the send fails.
+    // New-session sends wait for creation and environment setup.
     let newSession: { gate: Promise<unknown>; recover: (error: unknown) => void } | undefined
     if (sessionID == null) {
       const directory = await move.getDirectory()
@@ -1194,16 +1192,19 @@ export function Prompt(props: PromptProps) {
           }
         }),
         recover: (error) => {
-          // Setup or the send failed after the optimistic navigation. A
-          // failed create has already rolled back the local record (and the
-          // prompt row rolls back via its own catch). Put the draft back for
-          // the home composer and unwind the navigation.
           toast.show({
             title: data.session.get(created.id) ? "Failed to set up session" : "Creating a session failed",
             message: errorMessage(error),
             variant: "error",
           })
-          saveDraft(undefined, { prompt: entry, cursor: entry.text.length })
+          const active =
+            route.data.type === "session" && route.data.sessionID === created.id ? promptRef.current : undefined
+          const current = active?.current
+          const draft = current?.text
+            ? { prompt: { ...unwrap(current) }, cursor: current.text.length }
+            : (takeDraft(created.id) ?? { prompt: entry, cursor: entry.text.length })
+          saveDraft(undefined, draft)
+          active?.reset()
           if (sessionTabs.enabled()) {
             sessionTabs.close(created.id)
           } else if (route.data.type === "session" && route.data.sessionID === created.id) {
@@ -1214,15 +1215,14 @@ export function Prompt(props: PromptProps) {
     }
 
     const target = sessionID
+    const dispatch = (send: () => Promise<unknown>) => {
+      const setup = newSession
+      if (setup) void setup.gate.then(send).catch(setup.recover)
+      else void send()
+    }
     if (currentMode === "shell") {
       move.startSubmit()
-      const send = () => client.api.session.shell({ sessionID: target, command: inputText })
-      if (newSession) {
-        const recover = newSession.recover
-        void newSession.gate.then(send).catch(recover)
-      } else {
-        void send()
-      }
+      dispatch(() => client.api.session.shell({ sessionID: target, command: inputText }))
       setStore("mode", "normal")
     } else if (slashHead && isCommand) {
       move.startSubmit()
@@ -1241,29 +1241,30 @@ export function Prompt(props: PromptProps) {
           skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
         })
-      void (newSession ? newSession.gate.then(send) : send()).catch((error) => {
+      const setup = newSession
+      void (setup ? setup.gate.then(send) : send()).catch((error) => {
         cancelCommit()
-        if (newSession) return newSession.recover(error)
+        if (setup) return setup.recover(error)
         toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
         restoreEntry()
       })
     } else if (isSkill) {
       move.startSubmit()
-      const send = () => client.api.session.skill({ sessionID: target, skill: slashHead.name })
-      if (newSession) {
-        const recover = newSession.recover
-        void newSession.gate.then(send).catch(recover)
-      } else {
-        void send()
-      }
+      dispatch(() => client.api.session.skill({ sessionID: target, skill: slashHead.name }))
     } else {
       move.startSubmit()
-      if (!session) {
-        await data.session.sync(sessionID)
-        session = data.session.get(sessionID)
-      }
-      if (session?.agent !== agent.id) {
-        await client.api.session.switchAgent({ sessionID, agent: agent.id })
+      try {
+        if (!session) {
+          await data.session.sync(target)
+          session = data.session.get(target)
+        }
+        if (session?.agent !== agent.id) {
+          await client.api.session.switchAgent({ sessionID: target, agent: agent.id })
+        }
+      } catch (error) {
+        toast.show({ title: "Failed to prepare session", message: errorMessage(error), variant: "error" })
+        restoreEntry()
+        return true
       }
       if (
         session?.model?.providerID !== selection.providerID ||
@@ -1271,8 +1272,8 @@ export function Prompt(props: PromptProps) {
         (session.model.variant ?? "default") !== (variant ?? "default")
       ) {
         const model = { providerID: selection.providerID, id: selection.modelID, variant }
-        const cancelCommit = local.model.trackSessionCommit(sessionID, model)
-        const switchError = await client.api.session.switchModel({ sessionID, model }).then(
+        const cancelCommit = local.model.trackSessionCommit(target, model)
+        const switchError = await client.api.session.switchModel({ sessionID: target, model }).then(
           () => undefined,
           (error) => error,
         )
@@ -1284,7 +1285,7 @@ export function Prompt(props: PromptProps) {
         }
       }
       if (session?.revert) {
-        const error = await client.api.session.revert.commit({ sessionID }).then(
+        const error = await client.api.session.revert.commit({ sessionID: target }).then(
           () => undefined,
           (error) => error,
         )
@@ -1305,7 +1306,7 @@ export function Prompt(props: PromptProps) {
         if (newSession) {
           // Fold into the setup gate so the context still admits before the
           // user prompt once the session exists.
-          newSession = { ...newSession, gate: newSession.gate.then(send) }
+          newSession.gate = newSession.gate.then(send)
         } else {
           const error = await send().then(
             () => undefined,
@@ -1350,12 +1351,9 @@ export function Prompt(props: PromptProps) {
       // it, and clear it here so onCleanup does not also stash it for home.
       if (!disposed && !input.isDestroyed && store.prompt.text) {
         // Copy before clearing: unwrap returns the live store target, and the
-        // setStore(emptyPrompt()) below merges into that same object.
+        // resetComposer store write merges into that same object.
         saveDraft(sessionID, { prompt: { ...unwrap(store.prompt) }, cursor: input.cursorOffset })
-        input.extmarks.clear()
-        setStore("prompt", emptyPrompt())
-        setStore("extmarkToPart", new Map())
-        input.clear()
+        resetComposer()
       }
       route.navigate({
         type: "session",
@@ -1523,10 +1521,7 @@ export function Prompt(props: PromptProps) {
         mode: store.mode,
       })
     }
-    input.clear()
-    input.extmarks.clear()
-    setStore("prompt", emptyPrompt())
-    setStore("extmarkToPart", new Map())
+    resetComposer()
   }
 
   const highlight = createMemo(() => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -19,6 +19,7 @@ import { useClipboard } from "../../context/clipboard"
 import { Spinner } from "../spinner"
 import { useClient } from "../../context/client"
 import { useRoute } from "../../context/route"
+import { useSessionTabs } from "../../context/session-tabs"
 import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
@@ -199,6 +200,7 @@ export function Prompt(props: PromptProps) {
   const client = useClient()
   const editor = useEditorContext()
   const route = useRoute()
+  const sessionTabs = useSessionTabs()
   const data = useData()
   const directoryRecents = useDirectoryRecents()
   const keymapCommands = Keymap.useCommands()
@@ -1202,7 +1204,9 @@ export function Prompt(props: PromptProps) {
             variant: "error",
           })
           saveDraft(undefined, { prompt: entry, cursor: entry.text.length })
-          if (route.data.type === "session" && route.data.sessionID === created.id) {
+          if (sessionTabs.enabled()) {
+            sessionTabs.close(created.id)
+          } else if (route.data.type === "session" && route.data.sessionID === created.id) {
             route.navigate({ type: "home" })
           }
         },

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -76,6 +76,13 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     let history: SessionTabHistory = { entries: [], index: -1 }
     // User-closed tabs eligible for reopening; in-memory like history, deleted sessions pruned.
     let closedTabs: ClosedSessionTab[] = []
+    // Storage mutations apply against the on-disk draft under a file lock, so
+    // a registration queued by the route effect can land AFTER a removal that
+    // ran while the write was still in flight — resurrecting a tab that was
+    // just closed. Removing a tab marks it cancelled so any late-applying
+    // registration becomes a no-op; navigating to the session again clears
+    // the mark.
+    const cancelledTabs = new Set<string>()
     const scrollAnchors = new Map<string, ScrollAnchor>()
 
     const onFocus = () => setFocused(true)
@@ -152,6 +159,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       if (!enabled()) return
       if (route.data.type !== "session" || route.data.sessionID === "dummy") return
       const sessionID = root(route.data.sessionID)
+      cancelledTabs.delete(sessionID)
       history = recordSessionTabHistory(history, sessionID)
       const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
       const tabs = openSessionTab(state().tabs, {
@@ -160,6 +168,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       })
       if (tabs === state().tabs) return
       update((draft) => {
+        if (cancelledTabs.has(sessionID)) return
         draft.tabs = openSessionTab(draft.tabs, {
           sessionID,
           title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
@@ -266,6 +275,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
 
     function remove(sessionID: string, navigate: boolean) {
       const target = root(sessionID)
+      cancelledTabs.add(target)
       scrollAnchors.delete(target)
       const closed = closeSessionTab(state().tabs, target)
       const selected = navigate && current() === target
@@ -352,6 +362,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         closedTabs = result.stack
         const tabs = result.tabs
         if (!tabs || !result.sessionID) return
+        cancelledTabs.delete(result.sessionID)
         update((draft) => {
           draft.tabs = tabs
         })


### PR DESCRIPTION
## What

Optimistic session creation: pressing enter on the home screen now feels sent immediately, even on a slow connection. The TUI mints the session ID client-side, admits a local session record, renders the prompt row, and navigates to the session view synchronously — the `session.create` round trip happens in the background, and everything that needs the session to exist server-side gates on it.

This makes the type-during-submit destruction race (#43563) unrepresentable: there is no awaited window on the home path for text to die in. Text typed mid-flight lands in the live session composer, and a second enter submits it, gated on the in-flight create.

Closes #43563.

## Before / After

**Before** — on the home screen, `submitInner` awaited `session.create` and `session.environment` before doing anything visible:

1. Enter. Composer keeps your text; home screen stays up for the full round trips (~1.25s at 600ms wire on both create and environment).
2. Text typed during that window is appended to the still-visible previous prompt; its enter is dropped by the `submitting` guard.
3. The post-await `input.clear()` destroys the merged text, and prompt history records a merged entry that was never sent.

**After** — enter is synchronous on the home path:

1. Enter. Composer clears, session view opens with the prompt row already rendered (~35ms, independent of the wire).
2. The create request becomes a gate: prompt/shell/command/skill/editor-context sends against the new session wait for it to exist server-side before posting. A fast follow-up message gates on the same in-flight create instead of 404ing.
3. Failure unwinds: error toast, back to home (session tab closed), draft restored into the composer, optimistic record rolled back only when the server never acknowledged it.

Breadboard of the new-session flow:

1. **Home, composer full** — user presses enter.
   ```
   ┃ Fix the flaky test in ci.yml▌        ← enter
   ```
2. **Session view, instantly** — prompt row rendered from the optimistic admission, composer empty, create still in flight.
   ```
   1 New session                 +
   ┃ Fix the flaky test in ci.yml
   ┃ ▌
   ```
3. **Wire catches up** — create → environment → prompt POST resolve in order; the `session.created` echo re-syncs the record by ID; reply streams.
4. **Failure instead?** — toast + home + draft back in the composer, no phantom session, no ghost tab.
   ```
   ⚠ Creating a session failed
   ┃ Fix the flaky test in ci.yml▌
   ```

## How

- `packages/client/src/solid/data.ts`
  - `session.create(...)`: mints `SessionID.create()` client-side (the protocol already accepts a client-supplied `id`), admits an optimistic `SessionInfo`, marks the session's sync keys fresh so a mounting session route does not fetch a session the server does not have yet (the `session.created` handler applies the same band-aid), and returns `{ id, request }`. The echo or the create response acknowledges the record; a failed unacknowledged create rolls back via `removeSession`.
  - `session.prompt(...)` gains an optional `gate` and auto-gates on any in-flight create of its session (`creating` map).
  - Per-session send chain (`sending` map): prompts are admitted in submission order — HTTP gives no ordering across concurrent POSTs, and without the chain a follow-up prompt (gated only on create) could land before the first prompt (gated on create + environment), inverting the transcript.
- `packages/tui/src/component/prompt/index.tsx`
  - The new-session path calls `data.session.create` instead of awaiting `client.api.session.create`, navigates immediately, and folds environment + editor-context into the gate. Shell/command/skill sends against a new session go through the gate too; existing-session behavior is byte-identical.
  - `recover(...)` unwinds a failed setup: toast, draft re-stashed for the home composer, `sessionTabs.close` (or navigate home when tabs are disabled).
  - Retains the snapshot/clear-before-first-await + `restoreEntry` structure from the first commit, which fixes the same bug on the awaited existing-session paths (`switchAgent`, `switchModel`, `revert.commit`, editor synthetic).
- `packages/tui/src/context/session-tabs.tsx`
  - Fixes a latent close-races-open hazard the failure path hits reliably: storage mutations apply against the on-disk draft under a file lock, so a registration queued by the route effect can land *after* a removal that ran while the write was in flight, resurrecting a just-closed tab as a ghost. Removing a tab now marks it cancelled so late-applying registrations become no-ops; navigating to the session again (or reopening the tab) clears the mark.

```mermaid
sequenceDiagram
    participant User
    participant Composer as Prompt component
    participant Data as client data layer
    participant Server

    User->>Composer: enter
    Composer->>Data: session.create({model, agent, location})
    Data-->>Composer: { id, request } (record admitted locally)
    Composer->>Composer: navigate to session view (immediate)
    Composer->>Data: session.prompt({sessionID: id, gate})
    Data-->>User: prompt row rendered (optimistic)
    Data->>Server: POST /session (background)
    Server-->>Data: session.created echo → re-sync by ID
    Data->>Server: POST environment → prompt (gated, in order)
    Server-->>User: reply streams
    Note over Data,Server: failure → rollback record,<br/>toast, home, draft restored
```

## Scope

- `session.create` remains server-assigned when no `id` is supplied; only the TUI home path opts into client minting.
- Shell/command/skill sends from an *existing* session composer against a still-creating session are not chained (only `prompt` auto-gates); reaching that requires a sub-250ms mode switch after the first enter.
- The storage write-through semantics of session-tabs (`update()` applying to the in-memory store immediately) are untouched; the cancellation mark neutralizes the specific resurrect race.

## Testing

- `packages/client`: `bun run typecheck`, `bun run test` (one pre-existing failure on origin/v2 unrelated to this PR: `exposes every standard HTTP API group` expects a `question` group missing from the generated promise client).
- `packages/tui`: `bun run typecheck`, `bun run test` — 739 tests green.
- End-to-end via opencode-drive chaos proxy (probes in [anomalyco/opencode-drive](https://github.com/anomalyco/opencode-drive) `packages/drive/test/manual/tui-regressions/`):
  - `optimistic-create.ts` — 600ms wire latency; home wordmark gone **35ms** after enter on this branch vs **1254ms** on v2 (REPRO); optimistic row visible; follow-up prompt submitted during the create admitted exactly once (`admittedFirst:1, admittedSecond:1`).
  - `optimistic-create-failure.ts` — connections refused; unwinds to home in ~50ms with draft restored, toast shown, `serverSessions:0`, `ghostTab:false` (fails without the session-tabs fix).
  - `type-during-submit.ts` — updated contract: both prompts admitted exactly once **in submission order**, no merged history; passes 3/3 on this branch, REPROs on v2 (`admittedSecond:0, mergedHistory:true`).
  - `quiescence.ts` (5 scenarios) and `quiescence-tools.ts` (2 scenarios) — all green on this branch.

## Demo

The identical scripted scenario against both builds (600ms wire latency; type a prompt, enter, type a follow-up during the create window, enter). Segment labels bottom-left, elapsed time bottom-right.

**Before (v2 baseline)** — enter freezes the home screen with the text stuck in the composer for the create + environment round trips; the follow-up typed during that window is destroyed by the post-await `input.clear()` and never sent (only `FIRST_DONE` renders):

https://github.com/user-attachments/assets/a2b935f8-aa57-443c-9828-6db9fcfd5bf2

**After (this branch)** — enter opens the session view instantly with the prompt row rendered; the follow-up lands in the live session composer, submits gated on the in-flight create, and both prompts are admitted in order:

https://github.com/user-attachments/assets/cf57e3e1-744c-4c5b-989c-d1ff20de360c

