### PR TITLE
fix: preserve slashes in model IDs for legacy server parsing

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -289,7 +289,7 @@ describe("query keys", () => {
         calls.push(input)
         return {
           location: {},
-          data: [{ name: "review", template: "Review files" /* source: "command" as const */ }],
+          data: [{ name: "review", template: "Review files" /* source: "command" */ }],
         }
       },
     } as unknown as CommandApi
@@ -298,6 +298,30 @@ describe("query keys", () => {
 
     expect(calls).toEqual([{ location: { directory: "/repo" } }])
     expect(result).toEqual([{ name: "review", template: "Review files" /* source: "command" */ }])
+  })
+
+  test("preserves slashes in command model IDs for legacy servers", async () => {
+    const localApi = {
+      list: async () => ({ location: {}, data: [] }),
+    } as unknown as CommandApi
+
+    const legacy = {
+      command: {
+        list: async () => ({
+          data: [
+            { name: "test", template: "Test", description: "", agent: "build", model: "openrouter/openrouter/free", subtask: false },
+            { name: "test2", template: "Test2", description: "", agent: "build", model: "openrouter/anthropic/claude-sonnet-4.6", subtask: false },
+          ],
+        }),
+      },
+    } as unknown as OpencodeClient
+
+    const result = await loadCommands("/repo", localApi, legacy, Promise.resolve("v1"))
+
+    expect(result).toEqual([
+      { name: "test", template: "Test", description: "", agent: "build", model: { providerID: "openrouter", id: "openrouter/free" }, subtask: false },
+      { name: "test2", template: "Test2", description: "", agent: "build", model: { providerID: "openrouter", id: "anthropic/claude-sonnet-4.6" }, subtask: false },
+    ])
   })
 
   test("loads projects from the current endpoint", async () => {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -280,7 +280,8 @@ export const loadCommands = (
   retry(async () => {
     if ((await protocol) === "v1" && legacy) {
       return ((await legacy.command.list()).data ?? []).map((command) => {
-        const [providerID, id] = command.model?.split("/") ?? []
+        const [providerID, ...rest] = command.model?.split("/") ?? []
+        const id = rest.join("/")
         return {
           name: command.name,
           template: command.template,

--- a/packages/app/src/hooks/provider-catalog.test.ts
+++ b/packages/app/src/hooks/provider-catalog.test.ts
@@ -75,3 +75,14 @@ test("uses config for legacy servers", () => {
     modelID: "claude",
   })
 })
+
+test("preserves slashes in model IDs for legacy servers", () => {
+  expect(resolveDefaultModel(undefined, "openrouter/openrouter/free")).toEqual({
+    providerID: "openrouter",
+    modelID: "openrouter/free",
+  })
+  expect(resolveDefaultModel(undefined, "openrouter/anthropic/claude-sonnet-4.6")).toEqual({
+    providerID: "openrouter",
+    modelID: "anthropic/claude-sonnet-4.6",
+  })
+})

--- a/packages/app/src/hooks/provider-catalog.ts
+++ b/packages/app/src/hooks/provider-catalog.ts
@@ -32,6 +32,6 @@ export function resolveDefaultModel(
 ) {
   if (current !== undefined) return current ?? undefined
   if (!legacy) return undefined
-  const [providerID, modelID] = legacy.split("/")
-  return { providerID, modelID }
+  const [providerID, ...rest] = legacy.split("/")
+  return { providerID, modelID: rest.join("/") }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #43662

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvements
- [ ] Documentation

### What does this PR do?

Fixes model ID truncation when model IDs contain slashes (e.g., `openrouter/openrouter/free` was being truncated to `openrouter/openrouter`).

Two locations used simple destructuring that lost everything after the second slash:

**`packages/app/src/hooks/provider-catalog.ts`**
```typescript
// Before (buggy)
const [providerID, modelID] = legacy.split("/")

// After (fixed)
const [providerID, ...rest] = legacy.split("/")
return { providerID, modelID: rest.join("/") }
```

**`packages/app/src/context/global-sync/bootstrap.ts`**
```typescript
// Before (buggy)
const [providerID, id] = command.model?.split("/") ?? []

// After (fixed)
const [providerID, ...rest] = command.model?.split("/") ?? []
const id = rest.join("/")
```

The codebase already uses the correct pattern (`[providerID, ...rest]` + `rest.join("/")`) in several other locations. This PR applies the same pattern to the two remaining locations that had the bug.

### How did you verify your code works?

Added tests for both functions verifying that model IDs with slashes are preserved correctly:
- `resolveDefaultModel(undefined, "openrouter/openrouter/free")` → `{ providerID: "openrouter", modelID: "openrouter/free" }`
- `loadCommands` with legacy protocol correctly parses `openrouter/anthropic/claude-sonnet-4.6` → `{ providerID: "openrouter", id: "anthropic/claude-sonnet-4.6" }`

### Screenshots / recordings

_N/A - no UI changes_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR