### PR TITLE
fix(console): omit null tool call delta fields

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -323,6 +323,7 @@ export async function handler(
 
     // Handle streaming response
     const streamConverter = createStreamPartConverter(providerInfo.format, opts.format)
+    const convertStreamParts = providerInfo.format !== opts.format || providerInfo.format === "oa-compat"
     const usageParser = providerInfo.createUsageParser()
     const binaryDecoder = providerInfo.createBinaryStreamDecoder()
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
@@ -397,13 +398,13 @@ export async function handler(
                 part = part.trim()
                 usageParser.parse(part)
 
-                if (providerInfo.format !== opts.format) {
+                if (convertStreamParts) {
                   part = streamConverter(part)
                   c.enqueue(encoder.encode(part + "\n\n"))
                 }
               }
 
-              if (providerInfo.format === opts.format) {
+              if (!convertStreamParts) {
                 c.enqueue(value)
               }
 

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -80,6 +80,37 @@ export const oaCompatHelper: ProviderHelper = ({ adjustCacheUsage }) => ({
   },
 })
 
+export function normalizeOaCompatibleChunk(chunk: string): string {
+  if (!chunk.startsWith("data: ")) return chunk
+
+  let json: any
+  try {
+    json = JSON.parse(chunk.slice(6))
+  } catch {
+    return chunk
+  }
+
+  let changed = false
+  for (const choice of Array.isArray(json.choices) ? json.choices : []) {
+    for (const toolCall of Array.isArray(choice?.delta?.tool_calls) ? choice.delta.tool_calls : []) {
+      if (toolCall.id === null) {
+        delete toolCall.id
+        changed = true
+      }
+      if (toolCall.type === null) {
+        delete toolCall.type
+        changed = true
+      }
+      if (toolCall.function?.name === null) {
+        delete toolCall.function.name
+        changed = true
+      }
+    }
+  }
+
+  return changed ? `data: ${JSON.stringify(json)}` : chunk
+}
+
 export function fromOaCompatibleRequest(body: any): CommonRequest {
   if (!body || typeof body !== "object") return body
 

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -81,11 +81,13 @@ export const oaCompatHelper: ProviderHelper = ({ adjustCacheUsage }) => ({
 })
 
 export function normalizeOaCompatibleChunk(chunk: string): string {
-  if (!chunk.startsWith("data: ")) return chunk
+  if (!chunk.startsWith("data:") || !chunk.includes('"tool_calls"')) return chunk
+
+  const prefix = chunk.startsWith("data: ") ? "data: " : "data:"
 
   let json: any
   try {
-    json = JSON.parse(chunk.slice(6))
+    json = JSON.parse(chunk.slice(prefix.length))
   } catch {
     return chunk
   }
@@ -105,10 +107,14 @@ export function normalizeOaCompatibleChunk(chunk: string): string {
         delete toolCall.function.name
         changed = true
       }
+      if (toolCall.function && Object.keys(toolCall.function).length === 0) {
+        delete toolCall.function
+        changed = true
+      }
     }
   }
 
-  return changed ? `data: ${JSON.stringify(json)}` : chunk
+  return changed ? `${prefix}${JSON.stringify(json)}` : chunk
 }
 
 export function fromOaCompatibleRequest(body: any): CommonRequest {

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -19,6 +19,7 @@ import {
   fromOaCompatibleChunk,
   fromOaCompatibleRequest,
   fromOaCompatibleResponse,
+  normalizeOaCompatibleChunk,
   toOaCompatibleChunk,
   toOaCompatibleRequest,
   toOaCompatibleResponse,
@@ -196,7 +197,7 @@ export function createBodyConverter(from: ZenData.Format, to: ZenData.Format) {
 
 export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Format) {
   return (part: any): any => {
-    if (from === to) return part
+    if (from === to) return from === "oa-compat" ? normalizeOaCompatibleChunk(part) : part
 
     let raw: CommonChunk | string
     if (from === "anthropic") raw = fromAnthropicChunk(part)

--- a/packages/console/app/test/openai-compatible-stream.test.ts
+++ b/packages/console/app/test/openai-compatible-stream.test.ts
@@ -28,4 +28,32 @@ describe("OpenAI-compatible stream normalization", () => {
 
     expect(convert(chunk)).toBe(chunk)
   })
+
+  test("normalizes chunks without a space after the data prefix", () => {
+    const convert = createStreamPartConverter("oa-compat", "oa-compat")
+    const result = convert(
+      'data:{"choices":[{"delta":{"tool_calls":[{"index":0,"id":null,"function":{"name":null}}]}}]}',
+    )
+
+    expect(result).toBe('data:{"choices":[{"delta":{"tool_calls":[{"index":0}]}}]}')
+  })
+
+  test("passes the done sentinel through unchanged", () => {
+    const convert = createStreamPartConverter("oa-compat", "oa-compat")
+
+    expect(convert("data: [DONE]")).toBe("data: [DONE]")
+  })
+
+  test("does not leak null identity fields into cross-format continuations", () => {
+    const convert = createStreamPartConverter("oa-compat", "anthropic")
+    const result = convert(
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"{"}}]}}]}',
+    )
+
+    expect(JSON.parse(result)).toEqual({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "input_json_delta", partial_json: "{" },
+    })
+  })
 })

--- a/packages/console/app/test/openai-compatible-stream.test.ts
+++ b/packages/console/app/test/openai-compatible-stream.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { createStreamPartConverter } from "../src/routes/zen/util/provider/provider"
+
+describe("OpenAI-compatible stream normalization", () => {
+  test("omits null identity fields from tool call continuation deltas", () => {
+    const convert = createStreamPartConverter("oa-compat", "oa-compat")
+    const result = convert(
+      'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":null,"type":null,"function":{"name":null,"arguments":"{\\"x\\":"}}]}}]}',
+    )
+
+    expect(JSON.parse(result.slice(6))).toEqual({
+      id: "chatcmpl-1",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '{"x":' } }],
+          },
+        },
+      ],
+    })
+  })
+
+  test("leaves compliant chunks byte-for-byte unchanged", () => {
+    const convert = createStreamPartConverter("oa-compat", "oa-compat")
+    const chunk =
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}}],"provider_extension":true}'
+
+    expect(convert(chunk)).toBe(chunk)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #43328

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Zen gateway passed same-format OpenAI-compatible SSE bytes through unchanged, so provider continuation deltas containing explicit null id, type, or function.name values reached strict clients and overwrote the identity established by the first tool-call delta.

This change routes those SSE parts through a narrow normalizer. It removes only explicit null identity fields from tool-call continuation deltas; compliant chunks and provider extensions remain unchanged. The assumption is that these nulls represent absent continuation metadata, as shown by the issue captures and by the complete non-streaming response.

### How did you verify your code works?

- bun test test/openai-compatible-stream.test.ts (2 pass)
- bun typecheck (packages/console/app)
- oxlint on the four changed files (0 errors)
- git diff --check
- The full console-app suite also has two unrelated existing Google usage assertions expecting outputTokens 3 while current dev returns 5.

### Screenshots / recordings

N/A - server-side streaming fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR