### PR TITLE
fix(console): terminate converted chat streams

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -536,7 +536,8 @@ export function fromOpenaiChunk(chunk: string): CommonChunk | string {
       if (sr === "tool_call" || sr === "tool_calls") return "tool_calls"
       if (sr === "length" || sr === "max_output_tokens") return "length"
       if (sr === "content_filter") return "content_filter"
-      return null
+      const output = Array.isArray(respObj.output) ? respObj.output : []
+      return output.some((item: any) => item?.type === "function_call") ? "tool_calls" : "stop"
     })()
     out.choices.push({ index: 0, delta: {}, finish_reason: fr })
 

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -208,7 +208,11 @@ export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Form
 
     if (to === "anthropic") return toAnthropicChunk(raw)
     if (to === "openai") return toOpenaiChunk(raw)
-    if (to === "oa-compat") return toOaCompatibleChunk(raw)
+    if (to === "oa-compat") {
+      const result = toOaCompatibleChunk(raw)
+      const finished = raw.choices.some((choice) => choice.finish_reason != null)
+      return from === "openai" && finished ? `${result}\n\ndata: [DONE]` : result
+    }
   }
 }
 

--- a/packages/console/app/test/openai-stream.test.ts
+++ b/packages/console/app/test/openai-stream.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { createStreamPartConverter } from "../src/routes/zen/util/provider/provider"
+
+describe("OpenAI Responses stream conversion", () => {
+  test("terminates completed text responses in Chat Completions format", () => {
+    const convert = createStreamPartConverter("openai", "oa-compat")
+    const result = convert(
+      'event: response.completed\ndata: {"response":{"id":"resp_1","model":"muse-spark-1.2","status":"completed","output":[{"type":"message"}],"usage":{"input_tokens":4,"output_tokens":2}}}',
+    )
+    const [chunk, done] = result.split("\n\n")
+
+    expect(done).toBe("data: [DONE]")
+    expect(JSON.parse(chunk.slice(6))).toMatchObject({
+      id: "resp_1",
+      model: "muse-spark-1.2",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    })
+  })
+
+  test("uses tool_calls when the completed response contains a function call", () => {
+    const convert = createStreamPartConverter("openai", "oa-compat")
+    const result = convert(
+      'event: response.completed\ndata: {"response":{"id":"resp_2","model":"muse-spark-1.2","status":"completed","output":[{"type":"function_call"}]}}',
+    )
+    const [chunk] = result.split("\n\n")
+
+    expect(JSON.parse(chunk.slice(6)).choices[0].finish_reason).toBe("tool_calls")
+  })
+
+  test("does not terminate non-completion events", () => {
+    const convert = createStreamPartConverter("openai", "oa-compat")
+    const result = convert(
+      'event: response.output_text.done\ndata: {"response":{"id":"resp_3","model":"muse-spark-1.2"}}',
+    )
+
+    expect(result).not.toContain("data: [DONE]")
+    expect(JSON.parse(result.slice(6)).choices).toEqual([])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #43379

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Responses-to-Chat stream converter emitted a final Chat Completions chunk with finish_reason null when the upstream Responses stream ended with response.completed, then closed without the Chat SSE [DONE] terminator.

This change treats that explicit completion event as terminal, preserving known provider stop reasons and otherwise choosing tool_calls when the completed response contains a function call or stop for text output. It appends [DONE] only for completed OpenAI Responses streams converted to OpenAI-compatible Chat Completions. It does not infer completion from a bare EOF.

### How did you verify your code works?

- bun test test/openai-stream.test.ts (3 pass)
- bun typecheck (packages/console/app)
- oxlint on the three changed files (0 errors)
- git diff --check
- The full console-app suite also has two unrelated existing Google usage assertions expecting outputTokens 3 while current dev returns 5.

### Screenshots / recordings

N/A - server-side streaming fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR