### PR TITLE
feat(core): allow plan mode to write/edit PLAN files exclusively

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -236,7 +236,6 @@ const pre = [
   MCPCodeModeExclusionPlugin.Plugin,
   WellKnownPlugin.Plugin,
   AgentPlugin.Plugin,
-  PlanPlugin.Plugin,
   CommandPlugin.Plugin,
   SkillPlugin.Plugin,
   ...SystemPromptPlugin.Plugins,
@@ -275,6 +274,7 @@ const post = [
   ConfigWebSearchPlugin.Plugin,
   VariantPlugin.Plugin,
   ConfigPolicyPlugin.Plugin,
+  PlanPlugin.Plugin,
 ] as const satisfies readonly InternalPlugin[]
 
 export const list = Effect.fn("PluginInternal.list")(function* () {

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -2,14 +2,19 @@ export * as PlanPlugin from "./plan.js"
 
 import { Message, ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Effect, Stream } from "effect"
+import { Global } from "@opencode-ai/util/global"
+import { Patch } from "@opencode-ai/util/patch"
+import { Effect, Result, Stream } from "effect"
+import path from "path"
 import { Agent } from "../agent.js"
+import { Environment } from "../environment/index.js"
 import { SessionEvent } from "../session/event.js"
 
 const plan = Agent.ID.make("plan")
 
-const enter = `<system-reminder>
-You are in Plan mode. You are not allowed to edit or create files, and you may not ask a subagent to do that either.
+const enter = (directory: string) => `<system-reminder>
+You are in Plan mode. You may only edit or create files in the Plan directory: ${directory}
+You may not modify files outside that directory, and you may not ask a subagent to do that either.
 
 You are in Plan mode until the user switches agents. Plan mode is not changed by user intent, tone, or imperative language. If the user asks you to change files, do not edit. Tell them they need to switch agents.
 </system-reminder>`
@@ -21,6 +26,12 @@ You are NO LONGER in Plan mode. The previous Plan restrictions no longer apply. 
 export const Plugin = define({
   id: "opencode.plan",
   effect: Effect.fn(function* (ctx) {
+    const environment = yield* Environment.Service
+    const global = yield* Global.Service
+    const directory = path.join(global.home, ".opencode", "plan")
+    const enterReminder = enter(directory)
+    yield* environment.files.mkdir(directory).pipe(Effect.orDie)
+
     yield* ctx.agent.transform((draft) => {
       draft.update(plan, (item) => {
         item.name = Agent.Name.make("Plan")
@@ -33,18 +44,20 @@ export const Plugin = define({
     yield* ctx.tool.hook("execute.before", (event) => {
       if (event.agent !== plan) return Effect.void
       if (event.tool !== "edit" && event.tool !== "write" && event.tool !== "patch") return Effect.void
+      const outside = mutationPaths(event.tool, event.input).find((target) => !contained(directory, target))
+      if (!outside) return Effect.void
       return new ToolFailure({
-        message: `Cannot use ${event.tool} in Plan mode. You are in a read-only mode and must not modify files.`,
+        message: `Cannot use ${event.tool} to modify ${outside} in Plan mode. You can only edit files in the Plan directory: ${directory}`,
       })
     })
 
     // Compaction and committed reverts can strip reminders while the session's agent stays
     // put. Reconcile per request, appending near the tail so the cached prefix stays warm.
     yield* ctx.session.hook("context", (event) => {
-      const reminder = lastReminder(event.messages)
-      const missing = event.agent === plan && reminder !== enter
-      const stale = event.agent !== plan && reminder === enter
-      const text = missing ? enter : stale ? leave : undefined
+      const reminder = lastReminder(event.messages, enterReminder)
+      const missing = event.agent === plan && reminder !== enterReminder
+      const stale = event.agent !== plan && reminder === enterReminder
+      const text = missing ? enterReminder : stale ? leave : undefined
       if (!text) return Effect.void
       // Before the user's prompt, matching where agent-switch reminders land.
       const at = event.messages.at(-1)?.role === "user" ? event.messages.length - 1 : event.messages.length
@@ -64,7 +77,7 @@ export const Plugin = define({
           event.type === "session.created" || event.type === "session.agent.selected",
       ),
       Stream.runForEach((event) => {
-        const text = switchReminder(event)
+        const text = switchReminder(event, enterReminder)
         if (!text) return Effect.void
         return ctx.session
           .synthetic({
@@ -83,20 +96,47 @@ export const Plugin = define({
   }),
 })
 
-function switchReminder(event: SessionEvent.Created | SessionEvent.AgentSelected) {
+function switchReminder(
+  event: SessionEvent.Created | SessionEvent.AgentSelected,
+  enterReminder: string,
+): string | undefined {
   if (event.type === "session.created") {
-    if (event.data.agent !== plan) return
-    return enter
+    if (event.data.agent !== plan) return undefined
+    return enterReminder
   }
-  if (event.data.agent === event.data.previous) return
-  if (event.data.agent === plan) return enter
+  if (event.data.agent === event.data.previous) return undefined
+  if (event.data.agent === plan) return enterReminder
   if (event.data.previous === plan) return leave
+  return undefined
 }
 
-function lastReminder(messages: ReadonlyArray<Message>) {
+function lastReminder(messages: ReadonlyArray<Message>, enterReminder: string) {
   return messages.reduce<string | undefined>((found, message) => {
     const part = message.role === "user" && message.content.length === 1 ? message.content[0] : undefined
     if (part?.type !== "text") return found
-    return part.text === enter || part.text === leave ? part.text : found
+    return part.text === enterReminder || part.text === leave ? part.text : found
   }, undefined)
+}
+
+function mutationPaths(tool: "edit" | "write" | "patch", input: unknown) {
+  if (typeof input !== "object" || input === null) return []
+  if (tool !== "patch") {
+    const target = Reflect.get(input, "path")
+    return typeof target === "string" ? [path.resolve(target)] : []
+  }
+  const patchText = Reflect.get(input, "patchText")
+  if (typeof patchText !== "string") return []
+  const parsed = Patch.parse(patchText)
+  if (Result.isFailure(parsed)) return []
+  return parsed.success.flatMap((hunk) => [
+    path.resolve(hunk.path),
+    ...(hunk.type === "update" && hunk.movePath ? [path.resolve(hunk.movePath)] : []),
+  ])
+}
+
+function contained(directory: string, target: string) {
+  const relative = path.relative(directory, target)
+  return (
+    relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  )
 }

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -3,11 +3,11 @@ export * as PlanPlugin from "./plan.js"
 import { Message, ToolFailure } from "@opencode-ai/ai"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Global } from "@opencode-ai/util/global"
-import { Patch } from "@opencode-ai/util/patch"
-import { Effect, Result, Stream } from "effect"
+import { Effect, Stream } from "effect"
 import path from "path"
 import { Agent } from "../agent.js"
 import { Environment } from "../environment/index.js"
+import { Permission } from "../permission.js"
 import { SessionEvent } from "../session/event.js"
 
 const plan = Agent.ID.make("plan")
@@ -38,17 +38,21 @@ export const Plugin = define({
         item.description = "Read-only agent for exploring the codebase and planning work before implementation."
         item.mode = "primary"
         item.permissions.push({ action: "question", resource: "*", effect: "allow" })
+        item.permissions.push({ action: "edit", resource: "*", effect: "deny" })
+        item.permissions.push({ action: "edit", resource: path.join(directory, "*"), effect: "allow" })
+        item.permissions.push({ action: "external_directory", resource: path.join(directory, "*"), effect: "allow" })
       })
     })
 
-    yield* ctx.tool.hook("execute.before", (event) => {
+    yield* ctx.tool.hook("execute.after", (event) => {
       if (event.agent !== plan) return Effect.void
+      if (event.status !== "error") return Effect.void
       if (event.tool !== "edit" && event.tool !== "write" && event.tool !== "patch") return Effect.void
-      const outside = mutationPaths(event.tool, event.input).find((target) => !contained(directory, target))
-      if (!outside) return Effect.void
-      return new ToolFailure({
-        message: `Cannot use ${event.tool} to modify ${outside} in Plan mode. You can only edit files in the Plan directory: ${directory}`,
+      if (!(event.error.error instanceof Permission.BlockedError)) return Effect.void
+      event.error = new ToolFailure({
+        message: `Cannot use ${event.tool} to modify files outside the Plan directory: ${directory}`,
       })
+      return Effect.void
     })
 
     // Compaction and committed reverts can strip reminders while the session's agent stays
@@ -116,27 +120,4 @@ function lastReminder(messages: ReadonlyArray<Message>, enterReminder: string) {
     if (part?.type !== "text") return found
     return part.text === enterReminder || part.text === leave ? part.text : found
   }, undefined)
-}
-
-function mutationPaths(tool: "edit" | "write" | "patch", input: unknown) {
-  if (typeof input !== "object" || input === null) return []
-  if (tool !== "patch") {
-    const target = Reflect.get(input, "path")
-    return typeof target === "string" ? [path.resolve(target)] : []
-  }
-  const patchText = Reflect.get(input, "patchText")
-  if (typeof patchText !== "string") return []
-  const parsed = Patch.parse(patchText)
-  if (Result.isFailure(parsed)) return []
-  return parsed.success.flatMap((hunk) => [
-    path.resolve(hunk.path),
-    ...(hunk.type === "update" && hunk.movePath ? [path.resolve(hunk.movePath)] : []),
-  ])
-}
-
-function contained(directory: string, target: string) {
-  const relative = path.relative(directory, target)
-  return (
-    relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
-  )
 }

--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -13,10 +13,12 @@ import { SessionEvent } from "../session/event.js"
 const plan = Agent.ID.make("plan")
 
 const enter = (directory: string) => `<system-reminder>
-You are in Plan mode. You may only edit or create files in the Plan directory: ${directory}
-You may not modify files outside that directory, and you may not ask a subagent to do that either.
+You are in Plan mode. You may optionally create or update plan documents in:
+${directory}
 
-You are in Plan mode until the user switches agents. Plan mode is not changed by user intent, tone, or imperative language. If the user asks you to change files, do not edit. Tell them they need to switch agents.
+Do not modify any other files or ask a subagent to do so.
+
+You remain in Plan mode until the user switches agents. If the user asks you to implement changes, do not do so. Tell them they need to switch agents.
 </system-reminder>`
 
 const leave = `<system-reminder>

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -160,7 +160,9 @@ describe("plan plugin reminders", () => {
       const { persisted } = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
       yield* settle(persisted, 2)
       expect(persisted[0]).toContain("You are in Plan mode")
+      expect(persisted[0]).toContain("optionally create or update plan documents")
       expect(persisted[0]).toContain(planDirectory)
+      expect(persisted[0]).toContain("Do not modify any other files")
       expect(persisted[1]).toContain("NO LONGER in Plan mode")
     }),
   )

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -2,7 +2,9 @@ import { describe, expect } from "bun:test"
 import { Message } from "@opencode-ai/ai"
 import { DateTime, Effect, Stream } from "effect"
 import type { SessionContext } from "@opencode-ai/plugin/effect/session"
+import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Agent } from "@opencode-ai/core/agent"
+import { Environment } from "@opencode-ai/core/environment/index"
 import { Event } from "@opencode-ai/schema/event"
 import { Model } from "@opencode-ai/core/model"
 import { PlanPlugin } from "@opencode-ai/core/plugin/plan"
@@ -11,12 +13,17 @@ import { Session } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionInbox } from "@opencode-ai/core/session/inbox"
 import { SessionMessage } from "@opencode-ai/core/session/message"
+import { Tool } from "@opencode-ai/schema/tool"
+import { Global } from "@opencode-ai/util/global"
+import path from "path"
 import { it } from "../lib/effect"
 import { host } from "./host"
 
 const sessionID = Session.ID.make("ses_plan_test")
 const plan = Agent.ID.make("plan")
 const build = Agent.ID.make("build")
+const home = "/home/plan-test"
+const planDirectory = path.join(home, ".opencode", "plan")
 
 const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentSelected => ({
   id: Event.ID.create(),
@@ -30,6 +37,8 @@ const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentS
 const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.AgentSelected> = []) {
   const persisted = new Array<string>()
   let contextHook: ((input: SessionContext) => Effect.Effect<void>) | undefined
+  let toolHook: ((input: ToolHooks["execute.before"]) => Effect.Effect<void, Tool.Error>) | undefined
+  const driver = Environment.makeMemoryDriver()
   yield* PlanPlugin.Plugin.effect(
     host({
       agent: {
@@ -40,7 +49,14 @@ const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.Agen
       },
       tool: {
         transform: () => Effect.die("unused tool.transform"),
-        hook: () => Effect.succeed({ dispose: Effect.void }),
+        hook: (name, callback) => {
+          if (name === "execute.before") {
+            // Hook names and callbacks are correlated, but TypeScript does not narrow this generic registration API.
+            // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+            toolHook = callback as unknown as (input: ToolHooks["execute.before"]) => Effect.Effect<void, Tool.Error>
+          }
+          return Effect.succeed({ dispose: Effect.void })
+        },
       },
       event: {
         subscribe: () => Stream.fromIterable(events),
@@ -65,9 +81,16 @@ const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.Agen
         },
       },
     }),
+  ).pipe(
+    Effect.provideService(Global.Service, Global.Service.of({ ...Global.make(), home })),
+    Effect.provideService(
+      Environment.Service,
+      Environment.Service.of({ files: Environment.makeFiles(driver), spawner: driver.spawner }),
+    ),
   )
   if (!contextHook) return yield* Effect.die("plan plugin did not register a context hook")
-  return { persisted, contextHook }
+  if (!toolHook) return yield* Effect.die("plan plugin did not register a tool hook")
+  return { persisted, contextHook, toolHook, files: Environment.makeFiles(driver) }
 })
 
 const request = (agent: Agent.ID, messages: Array<Message>): SessionContext => ({
@@ -77,6 +100,15 @@ const request = (agent: Agent.ID, messages: Array<Message>): SessionContext => (
   system: [],
   messages,
   tools: {},
+})
+
+const toolRequest = (tool: "edit" | "write" | "patch", input: unknown): ToolHooks["execute.before"] => ({
+  tool,
+  input,
+  sessionID,
+  agent: plan,
+  messageID: SessionMessage.ID.make("msg_plan_tool"),
+  id: Tool.CallID.make("call_plan_tool"),
 })
 
 const settle = (persisted: ReadonlyArray<string>, expected: number, remaining = 1000): Effect.Effect<void, Error> =>
@@ -104,6 +136,7 @@ describe("plan plugin reminders", () => {
       const { persisted } = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
       yield* settle(persisted, 2)
       expect(persisted[0]).toContain("You are in Plan mode")
+      expect(persisted[0]).toContain(planDirectory)
       expect(persisted[1]).toContain("NO LONGER in Plan mode")
     }),
   )
@@ -175,6 +208,52 @@ describe("plan plugin reminders", () => {
       yield* contextHook(request(plan, messages))
       expect(messages).toHaveLength(2)
       expect(persisted).toHaveLength(1)
+    }),
+  )
+})
+
+describe("plan plugin mutations", () => {
+  it.effect("creates the Plan directory", () =>
+    Effect.gen(function* () {
+      const { files } = yield* run()
+      expect((yield* files.stat(planDirectory)).type).toBe("directory")
+    }),
+  )
+
+  it.effect("allows edit and write inside the Plan directory", () =>
+    Effect.gen(function* () {
+      const { toolHook } = yield* run()
+      yield* toolHook(toolRequest("write", { path: path.join(planDirectory, "work.md") }))
+      yield* toolHook(toolRequest("edit", { path: path.join(planDirectory, "work.md") }))
+    }),
+  )
+
+  it.effect("rejects edit and write outside the Plan directory with the allowed path", () =>
+    Effect.gen(function* () {
+      const { toolHook } = yield* run()
+      for (const tool of ["edit", "write"] as const) {
+        const failure = yield* toolHook(toolRequest(tool, { path: "/workspace/source.ts" })).pipe(Effect.flip)
+        expect(failure.message).toContain("You can only edit files in the Plan directory")
+        expect(failure.message).toContain(planDirectory)
+      }
+    }),
+  )
+
+  it.effect("rejects a patch when any target is outside the Plan directory", () =>
+    Effect.gen(function* () {
+      const { toolHook } = yield* run()
+      const failure = yield* toolHook(
+        toolRequest("patch", {
+          patchText: `*** Begin Patch
+*** Add File: ${path.join(planDirectory, "work.md")}
++plan
+*** Add File: /workspace/source.ts
++code
+*** End Patch`,
+        }),
+      ).pipe(Effect.flip)
+      expect(failure.message).toContain("/workspace/source.ts")
+      expect(failure.message).toContain(planDirectory)
     }),
   )
 })

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -45,7 +45,10 @@ const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.Agen
     request: { settings: {}, headers: {}, body: {} },
     mode: "primary",
     hidden: false,
-    permissions: [{ action: "*", resource: "*", effect: "allow" }],
+    permissions: [
+      { action: "*", resource: "*", effect: "allow" },
+      { action: "external_directory", resource: "*", effect: "ask" },
+    ],
   } satisfies Types.DeepMutable<Agent.Info>
   const driver = Environment.makeMemoryDriver()
   yield* PlanPlugin.Plugin.effect(
@@ -261,9 +264,13 @@ describe("plan plugin mutations", () => {
     Effect.gen(function* () {
       const { planAgent } = yield* run()
       expect(
+        Permission.evaluate("external_directory", path.join(planDirectory, "*"), planAgent.permissions).effect,
+      ).toBe("allow")
+      expect(
         Permission.evaluate("external_directory", path.join(planDirectory, "nested", "*"), planAgent.permissions)
           .effect,
       ).toBe("allow")
+      expect(Permission.evaluate("external_directory", "/outside/*", planAgent.permissions).effect).toBe("ask")
     }),
   )
 

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
-import { Message } from "@opencode-ai/ai"
-import { DateTime, Effect, Stream } from "effect"
+import { Message, ToolFailure } from "@opencode-ai/ai"
+import { DateTime, Effect, Stream, Types } from "effect"
 import type { SessionContext } from "@opencode-ai/plugin/effect/session"
 import type { ToolHooks } from "@opencode-ai/plugin/effect/tool"
 import { Agent } from "@opencode-ai/core/agent"
@@ -8,6 +8,7 @@ import { Environment } from "@opencode-ai/core/environment/index"
 import { Event } from "@opencode-ai/schema/event"
 import { Model } from "@opencode-ai/core/model"
 import { PlanPlugin } from "@opencode-ai/core/plugin/plan"
+import { Permission } from "@opencode-ai/core/permission"
 import { Provider } from "@opencode-ai/core/provider"
 import { Session } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
@@ -37,7 +38,15 @@ const agentSelected = (agent: Agent.ID, previous: Agent.ID): SessionEvent.AgentS
 const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.AgentSelected> = []) {
   const persisted = new Array<string>()
   let contextHook: ((input: SessionContext) => Effect.Effect<void>) | undefined
-  let toolHook: ((input: ToolHooks["execute.before"]) => Effect.Effect<void, Tool.Error>) | undefined
+  let toolHook: ((input: ToolHooks["execute.after"]) => Effect.Effect<void>) | undefined
+  const planAgent = {
+    id: plan,
+    name: Agent.Name.make("Plan"),
+    request: { settings: {}, headers: {}, body: {} },
+    mode: "primary",
+    hidden: false,
+    permissions: [{ action: "*", resource: "*", effect: "allow" }],
+  } satisfies Types.DeepMutable<Agent.Info>
   const driver = Environment.makeMemoryDriver()
   yield* PlanPlugin.Plugin.effect(
     host({
@@ -45,15 +54,26 @@ const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.Agen
         get: () => Effect.die("unused agent.get"),
         list: () => Effect.die("unused agent.list"),
         reload: () => Effect.die("unused agent.reload"),
-        transform: () => Effect.succeed({ dispose: Effect.void }),
+        transform: (callback) => {
+          callback({
+            list: () => [planAgent],
+            get: (id) => (id === plan ? planAgent : undefined),
+            default: () => {},
+            update: (id, update) => {
+              if (id === plan) update(planAgent)
+            },
+            remove: () => {},
+          })
+          return Effect.succeed({ dispose: Effect.void })
+        },
       },
       tool: {
         transform: () => Effect.die("unused tool.transform"),
         hook: (name, callback) => {
-          if (name === "execute.before") {
+          if (name === "execute.after") {
             // Hook names and callbacks are correlated, but TypeScript does not narrow this generic registration API.
             // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-            toolHook = callback as unknown as (input: ToolHooks["execute.before"]) => Effect.Effect<void, Tool.Error>
+            toolHook = callback as unknown as (input: ToolHooks["execute.after"]) => Effect.Effect<void>
           }
           return Effect.succeed({ dispose: Effect.void })
         },
@@ -90,7 +110,7 @@ const run = Effect.fnUntraced(function* (events: ReadonlyArray<SessionEvent.Agen
   )
   if (!contextHook) return yield* Effect.die("plan plugin did not register a context hook")
   if (!toolHook) return yield* Effect.die("plan plugin did not register a tool hook")
-  return { persisted, contextHook, toolHook, files: Environment.makeFiles(driver) }
+  return { persisted, contextHook, toolHook, files: Environment.makeFiles(driver), planAgent }
 })
 
 const request = (agent: Agent.ID, messages: Array<Message>): SessionContext => ({
@@ -102,13 +122,17 @@ const request = (agent: Agent.ID, messages: Array<Message>): SessionContext => (
   tools: {},
 })
 
-const toolRequest = (tool: "edit" | "write" | "patch", input: unknown): ToolHooks["execute.before"] => ({
+type ToolErrorEvent = Extract<ToolHooks["execute.after"], { readonly status: "error" }>
+
+const toolError = (tool: "edit" | "write" | "patch", error: Tool.Error): ToolErrorEvent => ({
   tool,
-  input,
+  input: {},
   sessionID,
   agent: plan,
   messageID: SessionMessage.ID.make("msg_plan_tool"),
   id: Tool.CallID.make("call_plan_tool"),
+  status: "error",
+  error,
 })
 
 const settle = (persisted: ReadonlyArray<string>, expected: number, remaining = 1000): Effect.Effect<void, Error> =>
@@ -220,40 +244,56 @@ describe("plan plugin mutations", () => {
     }),
   )
 
-  it.effect("allows edit and write inside the Plan directory", () =>
+  it.effect("allows edits only inside the Plan directory", () =>
     Effect.gen(function* () {
-      const { toolHook } = yield* run()
-      yield* toolHook(toolRequest("write", { path: path.join(planDirectory, "work.md") }))
-      yield* toolHook(toolRequest("edit", { path: path.join(planDirectory, "work.md") }))
+      const { planAgent } = yield* run()
+      expect(Permission.evaluate("edit", path.join(planDirectory, "work.md"), planAgent.permissions).effect).toBe(
+        "allow",
+      )
+      expect(Permission.evaluate("edit", "/workspace/source.ts", planAgent.permissions).effect).toBe("deny")
+      expect(Permission.evaluate("edit", "source.ts", planAgent.permissions).effect).toBe("deny")
     }),
   )
 
-  it.effect("rejects edit and write outside the Plan directory with the allowed path", () =>
+  it.effect("allows the Plan directory external boundary", () =>
+    Effect.gen(function* () {
+      const { planAgent } = yield* run()
+      expect(
+        Permission.evaluate("external_directory", path.join(planDirectory, "nested", "*"), planAgent.permissions)
+          .effect,
+      ).toBe("allow")
+    }),
+  )
+
+  it.effect("rewrites blocked mutation failures with the Plan directory", () =>
     Effect.gen(function* () {
       const { toolHook } = yield* run()
-      for (const tool of ["edit", "write"] as const) {
-        const failure = yield* toolHook(toolRequest(tool, { path: "/workspace/source.ts" })).pipe(Effect.flip)
-        expect(failure.message).toContain("You can only edit files in the Plan directory")
-        expect(failure.message).toContain(planDirectory)
+      for (const tool of ["edit", "write", "patch"] as const) {
+        const event = toolError(
+          tool,
+          new ToolFailure({
+            message: "Unable to modify file",
+            error: new Permission.BlockedError({
+              rules: [],
+              permission: "edit",
+              resources: ["source.ts"],
+            }),
+          }),
+        )
+        yield* toolHook(event)
+        expect(event.error.message).toContain("outside the Plan directory")
+        expect(event.error.message).toContain(planDirectory)
       }
     }),
   )
 
-  it.effect("rejects a patch when any target is outside the Plan directory", () =>
+  it.effect("preserves mutation failures unrelated to permissions", () =>
     Effect.gen(function* () {
       const { toolHook } = yield* run()
-      const failure = yield* toolHook(
-        toolRequest("patch", {
-          patchText: `*** Begin Patch
-*** Add File: ${path.join(planDirectory, "work.md")}
-+plan
-*** Add File: /workspace/source.ts
-+code
-*** End Patch`,
-        }),
-      ).pipe(Effect.flip)
-      expect(failure.message).toContain("/workspace/source.ts")
-      expect(failure.message).toContain(planDirectory)
+      const error = new ToolFailure({ message: "oldString was not found" })
+      const event = toolError("edit", error)
+      yield* toolHook(event)
+      expect(event.error).toBe(error)
     }),
   )
 })


### PR DESCRIPTION
## Summary
- create `~/.opencode/plan` when the Plan plugin starts
- enforce the Plan directory whitelist through final agent permission rules
- keep edit, write, and patch visible while denying mutation resources outside the Plan directory
- include the absolute directory in Plan reminders and blocked-mutation messages

## Testing
- `bun test test/plugin/plan.test.ts`
- `bun typecheck`
- `bunx oxlint packages/core/src/plugin/plan.ts packages/core/src/plugin/internal.ts packages/core/test/plugin/plan.test.ts`
- `git diff --check`