### PR TITLE
feat(opencode): support per-model compaction config

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -146,26 +146,7 @@ export const Info = Schema.Struct({
     description:
       "Thresholds for truncating tool output. When output exceeds either limit, the full text is written to the truncation directory and a preview is returned.",
   }),
-  compaction: Schema.optional(
-    Schema.Struct({
-      auto: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable automatic compaction when context is full (default: true)",
-      }),
-      prune: Schema.optional(Schema.Boolean).annotate({
-        description: "Enable pruning of old tool outputs (default: false)",
-      }),
-      tail_turns: Schema.optional(NonNegativeInt).annotate({
-        description:
-          "Maximum number of recent user turns, including their following assistant/tool responses, to keep verbatim during compaction. By default retention is limited only by the preserved token budget.",
-      }),
-      preserve_recent_tokens: Schema.optional(NonNegativeInt).annotate({
-        description: "Maximum number of tokens from recent turns to preserve verbatim after compaction",
-      }),
-      reserved: Schema.optional(NonNegativeInt).annotate({
-        description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
-      }),
-    }),
-  ),
+  compaction: Schema.optional(ConfigProviderV1.Compaction),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -1,9 +1,28 @@
 export * as ConfigProviderV1 from "./provider"
 
 import { Schema } from "effect"
-import { PositiveInt } from "../../schema"
+import { NonNegativeInt, PositiveInt } from "../../schema"
 
 export const ModelStatus = Schema.Literals(["alpha", "beta", "deprecated", "active"])
+
+export const Compaction = Schema.Struct({
+  auto: Schema.optional(Schema.Boolean).annotate({
+    description: "Enable automatic compaction when context is full (default: true)",
+  }),
+  prune: Schema.optional(Schema.Boolean).annotate({
+    description: "Enable pruning of old tool outputs (default: false)",
+  }),
+  tail_turns: Schema.optional(NonNegativeInt).annotate({
+    description:
+      "Maximum number of recent user turns, including their following assistant/tool responses, to keep verbatim during compaction. By default retention is limited only by the preserved token budget.",
+  }),
+  preserve_recent_tokens: Schema.optional(NonNegativeInt).annotate({
+    description: "Maximum number of tokens from recent turns to preserve verbatim after compaction",
+  }),
+  reserved: Schema.optional(NonNegativeInt).annotate({
+    description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
+  }),
+})
 
 const InterleavedField = Schema.Union([
   Schema.Literals(["reasoning", "reasoning_content", "reasoning_text"]),
@@ -51,6 +70,9 @@ export const Model = Schema.Struct({
       output: Schema.Finite,
     }),
   ),
+  compaction: Schema.optional(Compaction).annotate({
+    description: "Per-model compaction overrides. Merged over the global compaction config.",
+  }),
   modalities: Schema.optional(
     Schema.Struct({
       input: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1054,6 +1054,15 @@ export const Model = Schema.Struct({
   capabilities: ProviderCapabilities,
   cost: ProviderCost,
   limit: ProviderLimit,
+  compaction: optional(
+    Schema.Struct({
+      auto: optional(Schema.Boolean),
+      prune: optional(Schema.Boolean),
+      tail_turns: optional(Schema.Number),
+      preserve_recent_tokens: optional(Schema.Number),
+      reserved: optional(Schema.Number),
+    }),
+  ),
   status: ModelStatus,
   options: Schema.Record(Schema.String, Schema.Any),
   headers: Schema.Record(Schema.String, Schema.String),
@@ -1530,6 +1539,7 @@ const layer = Layer.effect(
                 input: model.limit?.input ?? existingModel?.limit?.input,
                 output: model.limit?.output ?? existingModel?.limit?.output ?? 0,
               },
+              compaction: model.compaction ?? existingModel?.compaction,
               headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
               family: model.family ?? existingModel?.family ?? "",
               release_date: model.release_date ?? existingModel?.release_date ?? "",

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -14,7 +14,7 @@ import { NotFoundError } from "@/storage/storage"
 
 import { Effect, Layer, Context } from "effect"
 import { InstanceState } from "@/effect/instance-state"
-import { isOverflow as overflow, usable } from "./overflow"
+import { isOverflow as overflow, usable, compactionConfig } from "./overflow"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -114,7 +114,7 @@ function completedCompactions(messages: SessionV1.WithParts[]) {
 
 function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model }) {
   return (
-    input.cfg.compaction?.preserve_recent_tokens ??
+    compactionConfig(input).preserve_recent_tokens ??
     Math.min(MAX_PRESERVE_RECENT_TOKENS, Math.max(MIN_PRESERVE_RECENT_TOKENS, Math.floor(usable(input) * 0.25)))
   )
 }
@@ -225,7 +225,7 @@ const layer = Layer.effect(
       cfg: ConfigV1.Info
       model: Provider.Model
     }) {
-      const limit = input.cfg.compaction?.tail_turns
+      const limit = compactionConfig(input).tail_turns
       if (limit !== undefined && limit <= 0) return { head: input.messages, tail_start_id: undefined }
       const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
       const all = turns(input.messages)

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -7,12 +7,22 @@ import type { MessageV2 } from "./message-v2"
 
 const COMPACTION_BUFFER = 20_000
 
+// Per-model compaction config merged over the global config. Model-level
+// fields win; anything unset falls back to the global compaction block.
+export function compactionConfig(input: { cfg: ConfigV1.Info; model: Provider.Model }) {
+  return {
+    ...input.cfg.compaction,
+    ...input.model.compaction,
+  }
+}
+
 export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outputTokenMax?: number }) {
   const context = input.model.limit.context
   if (context === 0) return 0
 
+  const compaction = compactionConfig(input)
   const reserved =
-    input.cfg.compaction?.reserved ??
+    compaction.reserved ??
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
@@ -25,7 +35,7 @@ export function isOverflow(input: {
   model: Provider.Model
   outputTokenMax?: number
 }) {
-  if (input.cfg.compaction?.auto === false) return false
+  if (compactionConfig(input).auto === false) return false
   if (input.model.limit.context === 0) return false
 
   const count =

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1163,7 +1163,12 @@ const layer = Layer.effect(
             lastFinished.summary !== true &&
             (yield* compaction.isOverflow({ tokens: lastFinished.tokens, model }))
           ) {
-            yield* compaction.create({ sessionID, agent: lastUser.agent, model: lastUser.model, auto: true })
+            yield* compaction.create({
+              sessionID,
+              agent: lastUser.agent,
+              model: lastUser.model,
+              auto: model.compaction?.auto ?? true,
+            })
             continue
           }
 
@@ -1322,7 +1327,7 @@ const layer = Layer.effect(
                 sessionID,
                 agent: lastUser.agent,
                 model: lastUser.model,
-                auto: true,
+                auto: model.compaction?.auto ?? true,
                 overflow: !handle.message.finish,
               })
             }

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -62,6 +62,7 @@ function createModel(opts: {
   input?: number
   cost?: Provider.Model["cost"]
   npm?: string
+  compaction?: Provider.Model["compaction"]
 }): Provider.Model {
   return {
     id: "test-model",
@@ -72,6 +73,7 @@ function createModel(opts: {
       input: opts.input,
       output: opts.output,
     },
+    compaction: opts.compaction,
     cost: opts.cost ?? { input: 0, output: 0, cache: { read: 0, write: 0 } },
     capabilities: {
       toolcall: true,
@@ -561,6 +563,73 @@ describe("session.compaction.isOverflow", () => {
       },
     ),
   )
+
+  it.live(
+    "per-model compaction.auto=false overrides global auto=true",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const compact = yield* SessionCompaction.Service
+          const model = createModel({
+            context: 100_000,
+            output: 32_000,
+            compaction: { auto: false },
+          })
+          const tokens = { input: 75_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
+          expect(yield* compact.isOverflow({ tokens, model })).toBe(false)
+        }),
+      {
+        config: {
+          compaction: { auto: true },
+        },
+      },
+    ),
+  )
+
+  it.live(
+    "per-model compaction.reserved overrides global reserved",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const compact = yield* SessionCompaction.Service
+          // Global reserved = 10k → usable = input - 10k = 90k
+          // Model reserved = 60k → usable = input - 60k = 40k
+          const model = createModel({
+            context: 100_000,
+            input: 100_000,
+            output: 32_000,
+            compaction: { reserved: 60_000 },
+          })
+          const tokens = { input: 50_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
+          // 55k > 40k → overflow with model reserved
+          expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
+        }),
+      {
+        config: {
+          compaction: { reserved: 10_000 },
+        },
+      },
+    ),
+  )
+
+  it.live(
+    "per-model compaction.reserved does not affect models without override",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const compact = yield* SessionCompaction.Service
+          const model = createModel({ context: 100_000, input: 100_000, output: 32_000 })
+          const tokens = { input: 50_000, output: 5_000, reasoning: 0, cache: { read: 0, write: 0 } }
+          // Global reserved = 10k → usable = 90k; 55k < 90k → no overflow
+          expect(yield* compact.isOverflow({ tokens, model })).toBe(false)
+        }),
+      {
+        config: {
+          compaction: { reserved: 10_000 },
+        },
+      },
+    ),
+  )
 })
 
 describe("session.compaction.create", () => {
@@ -959,6 +1028,44 @@ describe("session.compaction.process", () => {
       expect(part?.type).toBe("compaction")
       expect(part?.tail_start_id).toBe(keep.id)
     }).pipe(withCompaction({ config: cfg({ tail_turns: 2, preserve_recent_tokens: 10_000 }) })),
+  )
+
+  itCompaction.instance(
+    "per-model tail_turns overrides global tail_turns",
+    Effect.gen(function* () {
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      yield* createUserMessage(session.id, "first")
+      yield* createUserMessage(session.id, "second")
+      const keep = yield* createUserMessage(session.id, "third")
+      yield* createSummaryCompaction(session.id)
+
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+      yield* SessionCompaction.use.process({
+        parentID: parent!,
+        messages: msgs,
+        sessionID: session.id,
+        auto: false,
+      })
+
+      const part = yield* readCompactionPart(session.id)
+      expect(part?.type).toBe("compaction")
+      // Global tail_turns = 2 would keep "second"+"third"; model tail_turns = 1 keeps only "third"
+      expect(part?.tail_start_id).toBe(keep.id)
+    }).pipe(
+      withCompaction({
+        config: cfg({ tail_turns: 2, preserve_recent_tokens: 10_000 }),
+        provider: ProviderTest.fake({
+          model: createModel({
+            context: 100_000,
+            output: 32_000,
+            compaction: { tail_turns: 1 },
+          }),
+        }),
+      }),
+    ),
   )
 
   itCompaction.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #43703

### Type of change

- [x] New feature

### What does this PR do?

Adds per-model compaction configuration so models with different context
windows can use different compaction thresholds.

**Before:** the top-level `compaction` block (`auto`, `prune`,
`tail_turns`, `preserve_recent_tokens`, `reserved`) was global — one
value applied to every model. The only per-model lever was
`limit.context`, which shifts the trigger point but cannot set an
independent buffer per model.

**After:** each model can override any compaction field via
`provider.<id>.models.<model>.compaction`. Model-level fields are merged
over the global config (model wins per-field), so a 32k local model can
compact early while a 128k frontier model keeps a larger usable window.

Example:

```json
{
  "provider": {
    "my-provider": {
      "models": {
        "small-model": {
          "limit": { "context": 32000, "output": 4096 },
          "compaction": { "reserved": 4000 }
        },
        "big-model": {
          "limit": { "context": 128000, "output": 8192 },
          "compaction": { "reserved": 24000 }
        }
      }
    }
  }
}
```

Implementation:

- Extracted the compaction schema into `ConfigProviderV1.Compaction` and
  reused it for both the global config and the per-model `Model` schema
  (single source of truth, no behavior change for existing configs).
- Carried the resolved compaction config onto the runtime
  `Provider.Model` so the session layer can read it.
- Added `compactionConfig()` in `session/overflow.ts` that merges
  model-level fields over the global block; `usable()`, `isOverflow()`,
  `select()` (tail_turns / preserve_recent_tokens) and the auto-compact
  call sites in `session/prompt.ts` now resolve through it.
- `prune` intentionally stays on the global config: it is a background
  cleanup task keyed only by sessionID, and the model is not readily
  available at that call site.

### How did you verify your code works?

- `tsgo --noEmit` passes in `packages/core` and `packages/opencode`.
- `bun test test/session/compaction.test.ts` — 59 pass, 1 skip, 0 fail
  (added 4 tests: per-model `auto`, per-model `reserved`, per-model
  `tail_turns`, and a regression check that models without an override
  keep using the global config).
- `bun test test/provider/` — 557 pass, 0 fail.
- `bun test test/config/` (core) — 50 pass, 0 fail.
- The 5 failures in the full `test/session/` run are pre-existing
  `inotify_add_watch: No space left on device` environment failures —
  they fail identically on the base `dev` branch without these changes.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
