### PR TITLE
fix(core): steer manual compaction by default

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -819,7 +819,7 @@ const layer = Layer.effect(
         const admitted = yield* SessionInbox.admitCompaction(db, bus, {
           id: inputID,
           sessionID: input.sessionID,
-          delivery: input.delivery ?? "queue",
+          delivery: input.delivery ?? "steer",
         }).pipe(
           Effect.catchDefect((defect) =>
             defect instanceof SessionInbox.LifecycleConflict

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -179,8 +179,9 @@ const layer = Layer.effect(
       yield* settleStaleToolCalls(input.sessionID)
       while (true) {
         // Between-turn control items run under any drain scope: scope gates which user
-        // input may promote, not whether admitted housekeeping runs. Enqueue order still
-        // holds — a control item behind a queued prompt is not the next eligible item.
+        // input may promote, not whether admitted housekeeping runs. Steered control
+        // items go ahead of any queued input; only a queue-delivered control item
+        // parked behind a queued prompt is not the next eligible item.
         if (yield* runPendingCompaction(input.sessionID, "input")) {
           force = false
           continue
@@ -216,7 +217,8 @@ const layer = Layer.effect(
       let promotable: SessionInbox.Promotable = continuation ? "steer" : drainPromotable
       let step = continuation?.step ?? 1
       let next = continuation
-      // The drain admitted this work, so the first step always runs.
+      // The drain admitted this work, so the first step always runs — even after a
+      // control item consumed at this boundary (unlike drain's one-shot force).
       let first = true
       // Every boundary has the same shape: control items first, then one exit decision,
       // then the model. The turn continues only while the first step, a continuation, or
@@ -229,9 +231,9 @@ const layer = Layer.effect(
           return { type: "complete" as const }
         const result = yield* runStep(sessionID, promotable, step)
         first = false
-        next = result.needsContinuation ? { step: result.step + 1 } : undefined
         promotable = "steer"
         step = result.step + 1
+        next = result.needsContinuation ? { step } : undefined
       }
     })
 

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -216,19 +216,20 @@ const layer = Layer.effect(
       let promotable: SessionInbox.Promotable = continuation ? "steer" : drainPromotable
       let step = continuation?.step ?? 1
       let next = continuation
+      // The drain admitted this work, so the first step always runs.
+      let first = true
+      // Every boundary has the same shape: control items first, then one exit decision,
+      // then the model. The turn continues only while the first step, a continuation, or
+      // steer input is owed. Deciding after control items means consuming the last
+      // steered compaction ends the turn instead of issuing an input-free model call.
       while (true) {
-        if (yield* runPendingCompaction(sessionID, "steer")) {
-          // A compaction consumed here may have been the only steer input keeping the
-          // loop alive. Without model work owed and no steers waiting, calling the model
-          // again would send an input-free request; the drain loop finds any queued work.
-          if (!next && !(yield* SessionInbox.has(db, sessionID, "steer"))) return { type: "complete" as const }
-          continue
-        }
+        if (yield* runPendingCompaction(sessionID, "steer")) continue
         if (yield* runPendingMove(sessionID, "steer")) return { type: "moved" as const, continuation: next }
-        const result = yield* runStep(sessionID, promotable, step)
-        next = result.needsContinuation ? { step: result.step + 1 } : undefined
-        if (!result.needsContinuation && !(yield* SessionInbox.has(db, sessionID, "steer")))
+        if (!first && !next && !(yield* SessionInbox.has(db, sessionID, "steer")))
           return { type: "complete" as const }
+        const result = yield* runStep(sessionID, promotable, step)
+        first = false
+        next = result.needsContinuation ? { step: result.step + 1 } : undefined
         promotable = "steer"
         step = result.step + 1
       }

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -217,7 +217,13 @@ const layer = Layer.effect(
       let step = continuation?.step ?? 1
       let next = continuation
       while (true) {
-        if (yield* runPendingCompaction(sessionID, "steer")) continue
+        if (yield* runPendingCompaction(sessionID, "steer")) {
+          // A compaction consumed here may have been the only steer input keeping the
+          // loop alive. Without model work owed and no steers waiting, calling the model
+          // again would send an input-free request; the drain loop finds any queued work.
+          if (!next && !(yield* SessionInbox.has(db, sessionID, "steer"))) return { type: "complete" as const }
+          continue
+        }
         if (yield* runPendingMove(sessionID, "steer")) return { type: "moved" as const, continuation: next }
         const result = yield* runStep(sessionID, promotable, step)
         next = result.needsContinuation ? { step: result.step + 1 } : undefined

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -106,13 +106,13 @@ describe("Session.compact", () => {
       expect(second.id).toBe(first.id)
       expect(requests).toHaveLength(0)
       expect(yield* session.inbox(created.id)).toEqual([
-        expect.objectContaining({ id: first.id, type: "compaction", delivery: "queue" }),
+        expect.objectContaining({ id: first.id, type: "compaction", delivery: "steer" }),
       ])
       expect((yield* session.context(created.id)).find((message) => message.id === first.id)).toBeUndefined()
 
-      const steered = yield* session.create({ location })
-      const steer = yield* session.compact({ sessionID: steered.id, delivery: "steer" })
-      expect(steer).toMatchObject({ type: "compaction", delivery: "steer" })
+      const queued = yield* session.create({ location })
+      const queue = yield* session.compact({ sessionID: queued.id, delivery: "queue" })
+      expect(queue).toMatchObject({ type: "compaction", delivery: "queue" })
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2115,7 +2115,7 @@ describe("SessionRunnerLLM", () => {
       const active = yield* session.resume(sessionID).pipe(Effect.forkChild)
       yield* stream.started
 
-      const first = yield* session.compact({ sessionID })
+      const first = yield* session.compact({ sessionID, delivery: "queue" })
       expect(yield* SessionInbox.find((yield* Database.Service).db, first.id)).toMatchObject({
         id: first.id,
       })
@@ -2228,6 +2228,68 @@ describe("SessionRunnerLLM", () => {
         type: "compaction",
         status: "completed",
         summary: "Manual summary",
+      })
+    }),
+  )
+
+  it.effect("runs manual compaction at the next step boundary before queued prompts", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      currentModel = recoveryModel
+      const stream = yield* TestLLM.gate
+      yield* TestLLM.push(
+        TestLLM.text("Active complete", "text-active-steer-compact"),
+        [LLMEvent.textDelta({ id: "summary", text: "durable summary" })],
+        TestLLM.text("Queue complete", "text-queue-after-compact"),
+      )
+      yield* admit(session, "Active work")
+      const active = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* stream.started
+
+      const compaction = yield* session.compact({ sessionID })
+      yield* session.prompt({ sessionID, text: "Queued prompt", delivery: "queue", resume: false })
+      yield* stream.release
+      yield* Fiber.join(active)
+
+      // Steer-delivered compaction runs at the boundary after the active step, ahead of
+      // the queued prompt, and consuming it does not trigger an input-free model call.
+      expect(requests).toHaveLength(3)
+      expect(userTexts(requests[1])[0]).toContain("Create a new anchored summary")
+      expect(userTexts(requests[2])).toContain("Queued prompt")
+      expect(yield* SessionInbox.find((yield* Database.Service).db, compaction.id)).toBeUndefined()
+      expect((yield* session.messages({ sessionID })).find((message) => message.id === compaction.id)).toMatchObject({
+        type: "compaction",
+        status: "completed",
+        summary: "durable summary",
+      })
+    }),
+  )
+
+  it.effect("runs manual compaction before the continuation of an active tool turn", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      currentModel = recoveryModel
+      const stream = yield* TestLLM.gate
+      yield* TestLLM.push(
+        TestLLM.tool("call-active", "echo", { text: "active" }),
+        [LLMEvent.textDelta({ id: "summary", text: "durable summary" })],
+        TestLLM.text("Continued", "text-continued-after-compact"),
+      )
+      yield* admit(session, "Active work")
+      const active = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* stream.started
+
+      const compaction = yield* session.compact({ sessionID })
+      yield* stream.release
+      yield* Fiber.join(active)
+
+      // The compaction summary is requested before the tool turn's continuation step.
+      expect(requests).toHaveLength(3)
+      expect(userTexts(requests[1])[0]).toContain("Create a new anchored summary")
+      expect((yield* session.messages({ sessionID })).find((message) => message.id === compaction.id)).toMatchObject({
+        type: "compaction",
+        status: "completed",
+        summary: "durable summary",
       })
     }),
   )

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -440,7 +440,8 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           OpenApi.annotations({
             identifier: "v2.session.compact",
             summary: "Compact session",
-            description: "Queue a durable session compaction request.",
+            description:
+              "Durably admit a session compaction request. Steers by default: it runs at the next step boundary instead of waiting behind queued prompts.",
           }),
         ),
     )


### PR DESCRIPTION
## What

A manual `/compact` during an active turn now runs at the next step boundary instead of silently waiting for the whole turn — and any queued prompts — to finish.

`Session.compact` supported steer delivery all along, but defaulted to `"queue"`, and no client ever passed `delivery`. This flips the default to `"steer"` so user-initiated compaction means "compact soon", not "compact after all queued work".

## Before / After

**Before**: `/compact` during a long tool-heavy turn admits a `delivery:"queue"` compaction row. Queue rows are invisible at step boundaries (`runPendingCompaction(sessionID, "steer")` only sees the steer lane), so nothing happens until the turn goes idle — and if a queued prompt was enqueued earlier, the compaction waits behind that entire turn too. The user sees no `Compaction.Started` for the rest of the run and no indication of when it will fire.

**After**: `/compact` admits a steer-delivery row. At the next step boundary the runner consumes it ahead of queued prompts, requests the summary, and continues the turn (if steps remain) inside the compacted context. Explicit `delivery: "queue"` keeps the old parking behavior.

## How

- `packages/core/src/session.ts`: `Session.compact` default delivery `"queue"` → `"steer"`.
- `packages/core/src/session/runner/llm.ts`: `runSteps` restructured so every step boundary has one shape — control items first, then a single exit decision, then the model call. The turn continues only while the first step, a continuation, or steer input is owed; deciding after control items means consuming the last steered compaction ends the turn instead of issuing an input-free model call. The drain loop then picks up any queued work.
- `packages/protocol/src/groups/session.ts`: endpoint description updated (no generated client changes; verified `bun run generate` in `packages/client` is a no-op).

Ordering semantics are unchanged: enqueue order rules the steer lane, and the compaction row is a barrier. Steers admitted before `/compact` get one more step (so the summary reflects them); steers admitted after it deliver into the fresh compacted epoch.

```mermaid
sequenceDiagram
    participant U as User
    participant I as SessionInbox (steer lane)
    participant R as SessionRunner
    participant M as Model
    R->>M: step N (in flight)
    U->>I: steer "actually do X"
    U->>I: /compact (steer, barrier)
    M-->>R: step N settles
    R->>I: promote steers up to barrier
    R->>M: step N+1 (sees "actually do X")
    M-->>R: step N+1 settles
    R->>I: consume compaction barrier
    R->>M: summary request
    R->>M: continuation in compacted context
```

## Scope

- No TUI/ACP call-site changes needed: they omit `delivery` and inherit the new default.
- No change to queued-compaction semantics (`delivery: "queue"` still parks behind earlier queued prompts, per the existing drain-boundary tests).
- No hard `compact > steer` priority: a compaction never jumps ahead of steers enqueued before it. That's deliberate — enqueue order stays the single ordering law.

## Testing

From `packages/core`:

- `bun run test -- test/session-runner.test.ts` — 158 pass, including two new tests:
  - steer compaction admitted mid-turn runs at the boundary before queued prompts, with an exact request count proving no input-free model call after the barrier
  - steer compaction admitted mid-tool-turn runs before the turn's continuation step
- `bun run test -- test/session-compact.test.ts test/session-prompt.test.ts test/session-execution.test.ts test/session-projector.test.ts test/session-compaction.test.ts` — 80 pass
- `bun typecheck` in `packages/core` and `packages/protocol`

Existing coverage updated: the default-delivery assertion now expects `steer` (with a new explicit-queue assertion), and the queued-compaction ordering test passes `delivery: "queue"` explicitly.

