### PR TITLE
fix(core): avoid deep cloning session parts

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -636,7 +636,9 @@ const layer: Layer.Layer<
       Effect.gen(function* () {
         yield* events.publish(SessionV1.Event.PartUpdated, {
           sessionID: part.sessionID,
-          part: structuredClone(part),
+          // Parts reuse large immutable output strings while replacing mutable
+          // top-level fields. Isolate those updates without copying the payload.
+          part: { ...part },
           time: Date.now(),
         })
         return part

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -186,6 +186,7 @@ describe("step-finish token propagation via event", () => {
         }
 
         yield* session.updatePart(partInput)
+        partInput.cost = 1
         const receivedPart = yield* awaitDeferred(received, "timed out waiting for message.part.updated")
 
         expect(receivedPart.type).toBe("step-finish")


### PR DESCRIPTION
### Issue for this PR

Fixes #35107

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Session.updatePart` currently deep-clones every part before publishing it. Large text, reasoning, and tool-output strings are immutable, so deep-cloning duplicates the entire payload while Bun may retain the allocator pages after the temporary copy is released. Repeated updates can therefore make server RSS grow far beyond the live session data.

This keeps the event payload isolated from later top-level mutation with a shallow copy while reusing immutable output strings. It preserves the existing event-copy contract without copying large payloads.

### How did you verify your code works?

- Added a regression assertion that mutating the input part after `updatePart` does not change the published event.
- Ran `bun test test/session/session.test.ts test/session/processor-effect.test.ts` from `packages/opencode`: 24 passed, 0 failed.
- Ran `bun typecheck` from `packages/opencode`.
- The pre-push hook ran the repository typecheck: 30 tasks passed.

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR