### PR TITLE
fix(ai): accept nullable Anthropic input usage

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -234,7 +234,7 @@ export type AnthropicMessagesBody = Schema.Schema.Type<typeof AnthropicMessagesB
 
 const AnthropicUsage = Schema.StructWithRest(
   Schema.Struct({
-    input_tokens: Schema.optional(Schema.Number),
+    input_tokens: optionalNull(Schema.Number),
     output_tokens: Schema.optional(Schema.Number),
     cache_creation_input_tokens: optionalNull(Schema.Number),
     cache_read_input_tokens: optionalNull(Schema.Number),
@@ -692,7 +692,7 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
 // expose that subset through `output_tokens_details.thinking_tokens`.
 const mapUsage = (usage: AnthropicUsage | undefined): Usage | undefined => {
   if (!usage) return undefined
-  const nonCached = usage.input_tokens
+  const nonCached = usage.input_tokens ?? undefined
   const cacheRead = usage.cache_read_input_tokens ?? undefined
   const cacheWrite = usage.cache_creation_input_tokens ?? undefined
   const inputTokens = ProviderShared.sumTokens(nonCached, cacheRead, cacheWrite)

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -640,7 +640,7 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
-  it.effect("maps thinking tokens and preserves unknown Anthropic usage fields", () =>
+  it.effect("maps nullable input tokens and preserves unknown Anthropic usage fields", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -663,6 +663,7 @@ describe("Anthropic Messages route", () => {
                 type: "message_delta",
                 delta: { stop_reason: "end_turn" },
                 usage: {
+                  input_tokens: null,
                   output_tokens: 8,
                   server_tool_use: { web_search_requests: 2, terminal_counter: 3 },
                   output_tokens_details: { terminal_detail: "preserved" },
@@ -682,7 +683,7 @@ describe("Anthropic Messages route", () => {
         totalTokens: 15,
         providerMetadata: {
           anthropic: {
-            input_tokens: 5,
+            input_tokens: null,
             cache_read_input_tokens: 2,
             service_tier: "standard",
             cache_creation: { ephemeral_5m_input_tokens: 1 },


### PR DESCRIPTION
### Issue for this PR

Fixes #43759

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Accepts `null` for Anthropic Messages `message_delta.usage.input_tokens`, as specified by [Anthropic's official TypeScript SDK](https://github.com/anthropics/anthropic-sdk-typescript/blob/bfa9197f0182084941052be9752c948638421601/src/resources/messages/messages.ts#L2598-L2613).

A terminal null is treated as absent for normalized usage, preserving the non-null count reported by `message_start`, while the raw terminal value remains available in provider metadata.

### How did you verify your code works?

- `bun test test/provider/anthropic-messages.test.ts` from `packages/ai` (50 passed)
- `bun typecheck` from `packages/ai`
- `git diff --check`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR