### PR TITLE
fix(core): reduce Windows CPU under parallel sessions

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -864,7 +864,7 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
   return [{ ...state, lifecycle: Lifecycle.stepStart(state.lifecycle, events) }, [...events, result]]
 }
 
-const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(function* (
+const onContentBlockDelta = Effect.fnUntraced(function* (
   state: ParserState,
   event: AnthropicEvent,
 ) {

--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -67,6 +67,25 @@ const envelope = (aggregateID: string, seq: number, version: number) => ({
   version: Event.Version.make(version),
 })
 
+const encoders = new WeakMap<Event.Definition, (input: unknown) => unknown>()
+const decoders = new WeakMap<Event.Definition, (input: unknown) => unknown>()
+
+function encodeData(definition: Event.Definition, data: unknown) {
+  const cached = encoders.get(definition)
+  if (cached) return cached(data)
+  const encode = Schema.encodeUnknownSync(definition.data)
+  encoders.set(definition, encode)
+  return encode(data)
+}
+
+function decodeData(definition: Event.Definition, data: unknown) {
+  const cached = decoders.get(definition)
+  if (cached) return cached(data)
+  const decode = Schema.decodeUnknownSync(definition.data)
+  decoders.set(definition, decode)
+  return decode(data)
+}
+
 const decodeSerializedEvent = (event: SerializedEvent): Event.Payload => {
   const definition = Durable.get(event.type)
   if (!definition?.durable) {
@@ -77,7 +96,7 @@ const decodeSerializedEvent = (event: SerializedEvent): Event.Payload => {
     created: event.created ?? 0,
     type: definition.type,
     durable: envelope(event.aggregateID, event.seq, definition.durable.version),
-    data: Schema.decodeUnknownSync(definition.data)(event.data),
+    data: decodeData(definition, event.data),
   }
 }
 
@@ -260,10 +279,7 @@ export function configured(options?: Options) {
                               .get()
                               .pipe(Effect.orDie)
                             const latest = row?.seq ?? -1
-                            const encoded = Schema.encodeUnknownSync(definition.data)(event.data) as Record<
-                              string,
-                              unknown
-                            >
+                            const encoded = encodeData(definition, event.data) as Record<string, unknown>
                             if (input?.strictOwner && row?.ownerID && row.ownerID !== input.ownerID) {
                               yield* Effect.die(
                                 new InvalidDurableEventError({
@@ -529,10 +545,7 @@ export function configured(options?: Options) {
                           const ids = new Set<Event.ID>()
                           for (const [index, item] of payloads.entries()) {
                             const seq = firstSeq + index
-                            const encoded = Schema.encodeUnknownSync(item.definition.data)(item.event.data) as Record<
-                              string,
-                              unknown
-                            >
+                            const encoded = encodeData(item.definition, item.event.data) as Record<string, unknown>
                             if (persist) {
                               if (ids.has(item.event.id))
                                 yield* Effect.die(
@@ -621,7 +634,7 @@ export function configured(options?: Options) {
                     id: event.id,
                     created: event.created ?? 0,
                     type: definition.type,
-                    data: Schema.decodeUnknownSync(definition.data)(event.data),
+                    data: decodeData(definition, event.data),
                   } as Event.Payload
                   const committed = yield* commitDurableEvent(definition, payload, {
                     seq: event.seq,

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -72,12 +72,11 @@ export const ripgrepLayer = Layer.effect(
       const next = emptyIndex()
       const previous = index
       if (!initialized) index = next
-      yield* ripgrep.find({
+      yield* ripgrep.scan({
         cwd: location.directory,
         pattern: "*",
         limit: location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000,
         exclude: home ? [...Protected.names()].map((name) => `${name}/**`) : undefined,
-        collect: false,
         onEntry: (entry) =>
           Effect.sync(() => {
             const file = previous.files.get(entry.path) ?? fuzzysort.prepare(entry.path)

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -26,16 +26,22 @@ const REFRESH_INTERVAL = Duration.toMillis("10 seconds")
 type Prepared = ReturnType<typeof fuzzysort.prepare>
 
 function emptyIndex() {
-  return { files: new Map<string, Prepared>(), directories: new Map<string, Prepared>() }
+  return {
+    files: new Map<string, Prepared>(),
+    directories: new Map<string, Prepared>(),
+    fileTargets: [] as Prepared[],
+    directoryTargets: [] as Prepared[],
+    combinedTargets: undefined as Prepared[] | undefined,
+  }
 }
 
 function search(index: ReturnType<typeof emptyIndex>, input: FileSystem.FindInput) {
   const items =
     input.type === "file"
-      ? Array.from(index.files.values())
+      ? index.fileTargets
       : input.type === "directory"
-        ? Array.from(index.directories.values())
-        : [...index.files.values(), ...index.directories.values()]
+        ? index.directoryTargets
+        : (index.combinedTargets ??= [...index.fileTargets, ...index.directoryTargets])
   const result = fuzzysort.go(input.query, items, { limit: input.limit ?? 50 })
   // Targets are owned by the current location index. The only global fuzzysort
   // state left is its query cache, which must not retain every query forever.
@@ -71,15 +77,23 @@ export const ripgrepLayer = Layer.effect(
         pattern: "*",
         limit: location.vcs && !home ? Number.MAX_SAFE_INTEGER : 100_000,
         exclude: home ? [...Protected.names()].map((name) => `${name}/**`) : undefined,
+        collect: false,
         onEntry: (entry) =>
           Effect.sync(() => {
-            next.files.set(entry.path, previous.files.get(entry.path) ?? fuzzysort.prepare(entry.path))
+            const file = previous.files.get(entry.path) ?? fuzzysort.prepare(entry.path)
+            next.files.set(entry.path, file)
+            next.fileTargets.push(file)
             const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, offset) => {
-              const directory = parts.slice(0, offset + 1).join("/") + path.sep
-              if (!next.directories.has(directory))
-                next.directories.set(directory, previous.directories.get(directory) ?? fuzzysort.prepare(directory))
-            })
+            let prefix = ""
+            for (const [offset, part] of parts.entries()) {
+              if (offset === parts.length - 1) break
+              prefix = prefix ? `${prefix}/${part}` : part
+              const directory = prefix + path.sep
+              if (next.directories.has(directory)) continue
+              const prepared = previous.directories.get(directory) ?? fuzzysort.prepare(directory)
+              next.directories.set(directory, prepared)
+              next.directoryTargets.push(prepared)
+            }
           }),
       })
       index = next

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -83,6 +83,7 @@ export const ripgrepLayer = Layer.effect(
             const file = previous.files.get(entry.path) ?? fuzzysort.prepare(entry.path)
             next.files.set(entry.path, file)
             next.fileTargets.push(file)
+            next.combinedTargets = undefined
             const parts = entry.path.split("/")
             let prefix = ""
             for (const [offset, part] of parts.entries()) {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -318,6 +318,7 @@ const layer = Layer.effect(
             cwd: repository.worktree,
             env: options?.env,
             extendEnv: true,
+            stdin: "ignore",
           }),
           { stdin: options?.stdin },
         )
@@ -422,17 +423,20 @@ const layer = Layer.effect(
       ignores?: Repository
       maximumUntrackedFileBytes?: number
     }) {
-      const list = (args: string[]) =>
-        repositoryOperation("refresh", input.repository, args).pipe(
-          Effect.map((result) => result.text.split("\0").filter(Boolean)),
-        )
-      const [tracked, untracked] = yield* Effect.all(
-        [
-          list(["diff-files", "--name-only", "-z", "--", input.scope]),
-          list(["ls-files", "--others", "--exclude-standard", "-z", "--", input.scope]),
-        ],
-        { concurrency: 2 },
-      )
+      const entries = (yield* repositoryOperation("refresh", input.repository, [
+        "ls-files",
+        "--modified",
+        "--others",
+        "--exclude-standard",
+        "-t",
+        "-z",
+        "--",
+        input.scope,
+      ])).text
+        .split("\0")
+        .filter(Boolean)
+      const tracked = entries.filter((entry) => !entry.startsWith("? ")).map((entry) => entry.slice(2))
+      const untracked = entries.filter((entry) => entry.startsWith("? ")).map((entry) => entry.slice(2))
       const candidates = Array.from(new Set([...tracked, ...untracked]))
       if (!candidates.length) return { skipped: [] }
       const ignored = input.ignores
@@ -444,11 +448,11 @@ const layer = Layer.effect(
               .filter(Boolean),
           )
         : new Set<string>()
-      const allowed = candidates.filter((item) => !ignored.has(item))
+      const allowed = new Set(candidates.filter((item) => !ignored.has(item)))
       const maximum = input.maximumUntrackedFileBytes
       const skipped = maximum
         ? (yield* Effect.forEach(
-            untracked.filter((item) => allowed.includes(item)),
+            untracked.filter((item) => allowed.has(item)),
             (item) =>
               fs.stat(path.join(input.repository.worktree, item)).pipe(
                 Effect.map((info) =>
@@ -459,7 +463,8 @@ const layer = Layer.effect(
             { concurrency: 8 },
           )).filter((item): item is RelativePath => item !== undefined)
         : []
-      const stage = allowed.filter((item) => !skipped.includes(RelativePath.make(item)))
+      const skippedSet = new Set(skipped)
+      const stage = Array.from(allowed).filter((item) => !skippedSet.has(RelativePath.make(item)))
       const remove = [...ignored, ...skipped]
       if (remove.length)
         yield* repositoryOperation(
@@ -542,6 +547,7 @@ const layer = Layer.effect(
       from: TreeID
       to: TreeID
     }) {
+      if (input.from === input.to) return []
       return (yield* repositoryOperation("list_files", input.repository, [
         "diff",
         "--name-only",

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -9,6 +9,9 @@ import { AppProcess } from "@opencode-ai/util/process"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { File } from "./file.js"
 import { KeyedMutex } from "./effect/keyed-mutex.js"
+import { which } from "./util/which.js"
+
+const gitExecutable = which("git") ?? "git"
 
 export class Repository extends Schema.Class<Repository>("Git.Repository")({
   worktree: AbsolutePath,
@@ -314,7 +317,7 @@ const layer = Layer.effect(
     ) {
       const result = yield* proc
         .run(
-          ChildProcess.make("git", repositoryArgs(repository, args), {
+          ChildProcess.make(gitExecutable, repositoryArgs(repository, args), {
             cwd: repository.worktree,
             env: options?.env,
             extendEnv: true,
@@ -490,10 +493,14 @@ const layer = Layer.effect(
       if (!input.paths.length) return new Set<RelativePath>()
       const result = yield* proc
         .run(
-          ChildProcess.make("git", repositoryArgs(input.repository, ["check-ignore", "--no-index", "--stdin", "-z"]), {
-            cwd: input.repository.worktree,
-            extendEnv: true,
-          }),
+          ChildProcess.make(
+            gitExecutable,
+            repositoryArgs(input.repository, ["check-ignore", "--no-index", "--stdin", "-z"]),
+            {
+              cwd: input.repository.worktree,
+              extendEnv: true,
+            },
+          ),
           { stdin: input.paths.join("\0") + "\0" },
         )
         .pipe(
@@ -668,7 +675,7 @@ const layer = Layer.effect(
       cwd = repository.worktree,
     ) {
       const result = yield* proc
-        .run(ChildProcess.make("git", args, { cwd, extendEnv: true, stdin: "ignore" }))
+        .run(ChildProcess.make(gitExecutable, args, { cwd, extendEnv: true, stdin: "ignore" }))
         .pipe(
           Effect.mapError(
             (cause) => new WorktreeError({ operation, directory: worktreeDirectory, message: cause.message, cause }),
@@ -765,7 +772,7 @@ function execute(cwd: string, proc: AppProcess.Interface) {
   return (args: string[]) =>
     proc
       .run(
-        ChildProcess.make("git", args, {
+        ChildProcess.make(gitExecutable, args, {
           cwd,
           extendEnv: true,
           stdin: "ignore",

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -11,7 +11,8 @@ import { File } from "./file.js"
 import { KeyedMutex } from "./effect/keyed-mutex.js"
 import { which } from "./util/which.js"
 
-const gitExecutable = which("git") ?? "git"
+const resolvedGit = which("git")
+const gitExecutable = resolvedGit ? path.resolve(resolvedGit) : "git"
 
 export class Repository extends Schema.Class<Repository>("Git.Repository")({
   worktree: AbsolutePath,
@@ -554,7 +555,6 @@ const layer = Layer.effect(
       from: TreeID
       to: TreeID
     }) {
-      if (input.from === input.to) return []
       return (yield* repositoryOperation("list_files", input.repository, [
         "diff",
         "--name-only",

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -58,7 +58,10 @@ export interface FindInput {
   readonly follow?: boolean
   readonly signal?: AbortSignal
   readonly onEntry?: (entry: Entry) => Effect.Effect<void>
-  readonly collect?: boolean
+}
+
+export interface ScanInput extends Omit<FindInput, "onEntry"> {
+  readonly onEntry: (entry: Entry) => Effect.Effect<void>
 }
 
 export interface GlobInput {
@@ -81,6 +84,7 @@ export interface GrepInput {
 
 export interface Interface {
   readonly find: (input: FindInput) => Effect.Effect<readonly Entry[], Error>
+  readonly scan: (input: ScanInput) => Effect.Effect<void, Error>
   readonly glob: (input: GlobInput) => Effect.Effect<readonly Entry[], Error>
   readonly grep: (input: GrepInput) => Effect.Effect<readonly Match[], Error | InvalidPatternError>
 }
@@ -162,6 +166,40 @@ const layer = Layer.effect(
       )
     }
 
+    const find = (input: FindInput, collect = true) =>
+      run<Entry>({
+        cwd: input.cwd,
+        limit: input.limit,
+        signal: input.signal,
+        args: [
+          "--no-config",
+          "--files",
+          ...(input.hidden ? ["--hidden"] : []),
+          ...(input.follow ? ["--follow"] : []),
+          ...(input.pattern === "*" ? [] : [`--glob=${input.pattern}`]),
+          ...(input.exclude ?? []).map((pattern) => `--glob=!${pattern}`),
+          "--glob=!**/.git/**",
+          ".",
+        ],
+        parse: (line) => {
+          const relative = line
+            .replace(/^(?:\.[\\/])+/u, "")
+            .replace(/^[\\/]+/u, "")
+            .replaceAll("\\", "/")
+          return Effect.succeed(
+            Entry.make({
+              path: RelativePath.make(relative),
+              type: "file",
+            }),
+          )
+        },
+        onItem: input.onEntry,
+        collect,
+      }).pipe(
+        Effect.map((result) => result.items),
+        Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),
+      )
+
     return Service.of({
       glob: (input) =>
         run<string>({
@@ -195,39 +233,8 @@ const layer = Layer.effect(
           ),
           Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),
         ),
-      find: (input) =>
-        run<Entry>({
-          cwd: input.cwd,
-          limit: input.limit,
-          signal: input.signal,
-          args: [
-            "--no-config",
-            "--files",
-            ...(input.hidden ? ["--hidden"] : []),
-            ...(input.follow ? ["--follow"] : []),
-            ...(input.pattern === "*" ? [] : [`--glob=${input.pattern}`]),
-            ...(input.exclude ?? []).map((pattern) => `--glob=!${pattern}`),
-            "--glob=!**/.git/**",
-            ".",
-          ],
-          parse: (line) => {
-            const relative = line
-              .replace(/^(?:\.[\\/])+/u, "")
-              .replace(/^[\\/]+/u, "")
-              .replaceAll("\\", "/")
-            return Effect.succeed(
-              Entry.make({
-                path: RelativePath.make(relative),
-                type: "file",
-              }),
-            )
-          },
-          onItem: input.onEntry,
-          collect: input.collect,
-        }).pipe(
-          Effect.map((result) => result.items),
-          Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),
-        ),
+      find,
+      scan: (input) => find(input, false).pipe(Effect.asVoid),
       grep: (input) =>
         run<RawMatchData>({
           ...input,

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -58,6 +58,7 @@ export interface FindInput {
   readonly follow?: boolean
   readonly signal?: AbortSignal
   readonly onEntry?: (entry: Entry) => Effect.Effect<void>
+  readonly collect?: boolean
 }
 
 export interface GlobInput {
@@ -105,6 +106,7 @@ const layer = Layer.effect(
       readonly parse: (line: string) => Effect.Effect<A | undefined, Error>
       readonly pattern?: string
       readonly onItem?: (item: A) => Effect.Effect<void>
+      readonly collect?: boolean
     }) => {
       const program = Effect.scoped(
         Effect.gen(function* () {
@@ -127,11 +129,17 @@ const layer = Layer.effect(
               return input.onItem(row)
             }),
             Stream.take(input.limit + 1),
-            Stream.runCollect,
-            Effect.map((chunk) => [...chunk]),
+            Stream.runFold(
+              () => ({ count: 0, items: [] as A[] }),
+              (result, row) => {
+                result.count++
+                if (input.collect !== false) result.items.push(row)
+                return result
+              },
+            ),
           )
-          const truncated = rows.length > input.limit
-          if (truncated) return { items: rows.slice(0, input.limit), truncated, partial: false }
+          const truncated = rows.count > input.limit
+          if (truncated) return { items: rows.items.slice(0, input.limit), truncated, partial: false }
 
           const code = yield* handle.exitCode
           const stderr = yield* Fiber.join(stderrFiber)
@@ -141,7 +149,7 @@ const layer = Layer.effect(
           if (code !== 0 && code !== 1 && code !== 2) {
             return yield* failure(stderr.trim() || `ripgrep failed with code ${code}`)
           }
-          return { items: code === 1 ? [] : rows, truncated: false, partial: code === 2 }
+          return { items: code === 1 ? [] : rows.items, truncated: false, partial: code === 2 }
         }),
       )
       const abortable = input.signal ? program.pipe(Effect.raceFirst(waitForAbort(input.signal))) : program
@@ -215,6 +223,7 @@ const layer = Layer.effect(
             )
           },
           onItem: input.onEntry,
+          collect: input.collect,
         }).pipe(
           Effect.map((result) => result.items),
           Effect.catchTag("Ripgrep.InvalidPatternError", (cause) => Effect.fail(failure(cause.message, cause))),

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -393,9 +393,11 @@ const layer = Layer.effect(
         const snapshot = yield* snapshots.capture()
         const files =
           startSnapshot && snapshot
-            ? yield* snapshots
-                .files({ from: startSnapshot, to: snapshot })
-                .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            ? startSnapshot === snapshot
+              ? []
+              : yield* snapshots
+                  .files({ from: startSnapshot, to: snapshot })
+                  .pipe(Effect.catch(() => Effect.succeed(undefined)))
             : undefined
         return { snapshot, files }
       })

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -385,7 +385,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     return tool ? Effect.succeed(tool.assistantMessageID) : Effect.die(new Error(`Unknown tool call: ${id}`))
   }
 
-  const publish = Effect.fnUntraced(function* (event: LLMEvent) {
+  const dispatch = Effect.fnUntraced(function* (event: LLMEvent) {
     switch (event.type) {
       case "step-start":
         yield* startAssistant()
@@ -542,6 +542,13 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         return
     }
   })
+  const publishTraced = Effect.fn("SessionRunner.publishLLMEvent")(function* (event: LLMEvent) {
+    return yield* dispatch(event)
+  })
+  const publish = (event: LLMEvent) =>
+    event.type === "text-delta" || event.type === "reasoning-delta" || event.type === "tool-input-delta"
+      ? dispatch(event)
+      : publishTraced(event)
 
   const progress = Effect.fnUntraced(function* (id: string, update: Tool.Metadata) {
     const tool = tools.get(id)

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -385,7 +385,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     return tool ? Effect.succeed(tool.assistantMessageID) : Effect.die(new Error(`Unknown tool call: ${id}`))
   }
 
-  const publish = Effect.fn("SessionRunner.publishLLMEvent")(function* (event: LLMEvent) {
+  const publish = Effect.fnUntraced(function* (event: LLMEvent) {
     switch (event.type) {
       case "step-start":
         yield* startAssistant()

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -12,6 +12,7 @@ import { AbsolutePath, RelativePath } from "./schema.js"
 import { ID } from "@opencode-ai/schema/snapshot"
 import { Hash } from "@opencode-ai/util/hash"
 import { State } from "./state.js"
+import { EffectFlock } from "@opencode-ai/util/effect-flock"
 
 export { ID }
 
@@ -69,6 +70,10 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Snapshot") {}
 
+const LOCK_TIMEOUT_MS = 30_000
+const INITIAL_LOCK_RETRY_MS = 5_000
+const MAX_LOCK_RETRY_MS = 60_000
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -76,6 +81,7 @@ const layer = Layer.effect(
     const git = yield* Git.Service
     const global = yield* Global.Service
     const location = yield* Location.Service
+    const flock = yield* EffectFlock.Service
     const lifetime = yield* Scope.Scope
     const state = State.create<{ enabled: boolean }, Draft>({
       name: "snapshot",
@@ -86,6 +92,13 @@ const layer = Layer.effect(
         },
       }),
     })
+    const withLock = <A, E, R>(key: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* flock.acquire(key, undefined, { timeoutMs: LOCK_TIMEOUT_MS })
+          return yield* effect
+        }),
+      )
     // Cache a scope-owned fiber so caller cancellation stops waiting without poisoning shared initialization.
     const repositoryFiber = yield* Effect.cached(
       Effect.gen(function* () {
@@ -95,11 +108,16 @@ const layer = Layer.effect(
         const gitDirectory = AbsolutePath.make(
           path.join(global.data, "snapshot", location.project.id, Hash.fast(worktree)),
         )
-        const snapshotRepository = (yield* fs.existsSafe(path.join(gitDirectory, "HEAD")))
-          ? new Git.Repository({ worktree, gitDirectory, commonDirectory: gitDirectory })
-          : yield* git.repo
+        const snapshotRepository = yield* withLock(
+          gitDirectory,
+          Effect.gen(function* () {
+            if (yield* fs.existsSafe(path.join(gitDirectory, "HEAD")))
+              return new Git.Repository({ worktree, gitDirectory, commonDirectory: gitDirectory })
+            return yield* git.repo
               .create({ worktree, gitDirectory, seed: source })
               .pipe(Effect.mapError((cause) => failure("capture", cause)))
+          }),
+        )
         return { source, worktree, snapshotRepository }
       }).pipe(Effect.forkIn(lifetime)),
     )
@@ -113,21 +131,46 @@ const layer = Layer.effect(
     })
 
     const enabled = () => location.vcs?.type === "git" && state.get().enabled
+    let retryAt = Number.NEGATIVE_INFINITY
+    let retryMs = INITIAL_LOCK_RETRY_MS
 
     const capture = Effect.fn("Snapshot.capture")(function* () {
       if (!enabled()) return undefined
+      if ((yield* Effect.clockWith((clock) => clock.currentTimeMillis)) < retryAt) return undefined
       return yield* Effect.gen(function* () {
         const repo = yield* repository
-        return ID.make(
-          yield* git.tree.capture({
-            repository: repo.snapshotRepository,
-            scopes: [yield* scope(repo.worktree)],
-            ignores: repo.source,
-            maximumUntrackedFileBytes: 2 * 1024 * 1024,
+        const snapshot = yield* withLock(
+          repo.snapshotRepository.gitDirectory,
+          Effect.gen(function* () {
+            if ((yield* Effect.clockWith((clock) => clock.currentTimeMillis)) < retryAt) return undefined
+            return ID.make(
+              yield* git.tree.capture({
+                repository: repo.snapshotRepository,
+                scopes: [yield* scope(repo.worktree)],
+                ignores: repo.source,
+                maximumUntrackedFileBytes: 2 * 1024 * 1024,
+              }),
+            )
           }),
         )
+        if (snapshot !== undefined) {
+          retryAt = Number.NEGATIVE_INFINITY
+          retryMs = INITIAL_LOCK_RETRY_MS
+        }
+        return snapshot
       }).pipe(
-        Effect.catch((cause) => Effect.logWarning("failed to capture snapshot", { cause }).pipe(Effect.as(undefined))),
+        Effect.catch((cause) =>
+          Effect.gen(function* () {
+            const lock = lockFailure(cause)
+            const delay = lock ? retryMs : undefined
+            if (lock) {
+              retryAt = (yield* Effect.clockWith((clock) => clock.currentTimeMillis)) + retryMs
+              retryMs = Math.min(retryMs * 2, MAX_LOCK_RETRY_MS)
+            }
+            yield* Effect.logWarning("failed to capture snapshot", { cause, retryMs: delay })
+            return undefined
+          }),
+        ),
       )
     })
 
@@ -181,9 +224,10 @@ const layer = Layer.effect(
     const restore = Effect.fn("Snapshot.restore")(function* (input: RestoreInput) {
       if (!enabled()) return yield* new Error({ operation: "restore", message: "Snapshots are disabled" })
       const repo = yield* repository.pipe(Effect.mapError((cause) => failure("restore", cause)))
-      yield* git.tree
-        .restore({ repository: repo.snapshotRepository, files: yield* plan(repo.worktree, input) })
-        .pipe(Effect.mapError((cause) => failure("restore", cause)))
+      yield* withLock(
+        repo.snapshotRepository.gitDirectory,
+        git.tree.restore({ repository: repo.snapshotRepository, files: yield* plan(repo.worktree, input) }),
+      ).pipe(Effect.mapError((cause) => failure("restore", cause)))
     })
 
     return Service.of({ transform: state.transform, reload: state.reload, capture, files, diff, restore })
@@ -193,7 +237,7 @@ const layer = Layer.effect(
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [FSUtil.node, Git.node, Global.node, Location.node],
+  deps: [FSUtil.node, Git.node, Global.node, Location.node, EffectFlock.node],
 })
 
 export const noopLayer = Layer.succeed(
@@ -215,4 +259,9 @@ function failure(operation: Error["operation"], cause: unknown) {
     message: cause instanceof globalThis.Error ? cause.message : String(cause),
     cause,
   })
+}
+
+function lockFailure(cause: unknown) {
+  if (cause instanceof EffectFlock.LockTimeoutError || cause instanceof EffectFlock.LockCompromisedError) return true
+  return cause instanceof Git.OperationError && /index\.lock|another git process|unable to create.*lock/i.test(cause.message)
 }

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -2,7 +2,7 @@ export * as Snapshot from "./snapshot.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
-import { Context, Effect, Fiber, Layer, Schema, Scope } from "effect"
+import { Context, Duration, Effect, Fiber, Layer, Schema, Scope } from "effect"
 import { File } from "./file.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "./git.js"
@@ -100,7 +100,7 @@ const layer = Layer.effect(
         }),
       )
     // Cache a scope-owned fiber so caller cancellation stops waiting without poisoning shared initialization.
-    const repositoryFiber = yield* Effect.cached(
+    const [repositoryFiber, invalidateRepository] = yield* Effect.cachedInvalidateWithTTL(
       Effect.gen(function* () {
         const source = yield* git.repo.discover(location.project.directory)
         if (!source) return yield* new Error({ operation: "capture", message: "Project is not a Git repository" })
@@ -120,8 +120,13 @@ const layer = Layer.effect(
         )
         return { source, worktree, snapshotRepository }
       }).pipe(Effect.forkIn(lifetime)),
+      Duration.infinity,
     )
-    const repository = repositoryFiber.pipe(Effect.uninterruptible, Effect.flatMap(Fiber.join))
+    const repository = repositoryFiber.pipe(
+      Effect.uninterruptible,
+      Effect.flatMap(Fiber.join),
+      Effect.tapError(() => invalidateRepository),
+    )
 
     const scope = Effect.fnUntraced(function* (worktree: AbsolutePath) {
       const relative = path.relative(worktree, location.directory)

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -3,6 +3,11 @@ import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { Effect, JsonSchema, Schema } from "effect"
 
+const inputDecoders = new WeakMap<object, (value: unknown) => Effect.Effect<unknown, Schema.SchemaError>>()
+const outputEncoders = new WeakMap<object, (value: unknown) => Effect.Effect<unknown, Schema.SchemaError>>()
+const inputJsonSchemas = new WeakMap<object, JsonSchema.JsonSchema>()
+const outputJsonSchemas = new WeakMap<object, JsonSchema.JsonSchema>()
+
 export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
   name: effectiveName(tool),
   description: tool.description,
@@ -45,22 +50,30 @@ export const execute = (tool: Tool.Info<any, any>, input: unknown, context: Tool
   })
 
 const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
-  if (Schema.isSchema(schema))
-    return Schema.decodeUnknownEffect(schema)(value).pipe(
+  if (Schema.isSchema(schema)) {
+    const cached = inputDecoders.get(schema)
+    const decode = cached ?? Schema.decodeUnknownEffect(schema)
+    if (!cached) inputDecoders.set(schema, decode)
+    return decode(value).pipe(
       Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
     )
+  }
   if (isStandardSchema(schema)) return validateStandard(schema, value, "Invalid tool input")
   return Effect.succeed(value)
 }
 
 const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {
-  if (Schema.isSchema(schema))
-    return Schema.encodeEffect(schema)(value).pipe(
+  if (Schema.isSchema(schema)) {
+    const cached = outputEncoders.get(schema)
+    const encode = cached ?? Schema.encodeEffect(schema)
+    if (!cached) outputEncoders.set(schema, encode)
+    return encode(value).pipe(
       Effect.mapError(
         (error) =>
           new Tool.Error({ message: `Tool returned an invalid value for its output schema: ${error.message}` }),
       ),
     )
+  }
   if (isStandardSchema(schema))
     return validateStandard(schema, value, "Tool returned an invalid value for its output schema")
   return Schema.decodeUnknownEffect(Schema.Json)(value).pipe(
@@ -101,15 +114,25 @@ const standardFailure = (prefix: string, error: unknown) =>
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}
-  if (isStandardSchema(schema))
-    return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
-  return Schema.isSchema(schema) ? toJsonSchema(schema) : (schema as JsonSchema.JsonSchema)
+  if (!isStandardSchema(schema) && !Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
+  const cached = inputJsonSchemas.get(schema)
+  if (cached) return structuredClone(cached)
+  const compiled = isStandardSchema(schema)
+    ? (schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema)
+    : toJsonSchema(schema)
+  inputJsonSchemas.set(schema, compiled)
+  return structuredClone(compiled)
 }
 
 const outputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
-  if (isStandardSchema(schema))
-    return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
-  return Schema.isSchema(schema) ? toJsonSchema(schema) : (schema as JsonSchema.JsonSchema)
+  if (!isStandardSchema(schema) && !Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
+  const cached = outputJsonSchemas.get(schema)
+  if (cached) return structuredClone(cached)
+  const compiled = isStandardSchema(schema)
+    ? (schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema)
+    : toJsonSchema(schema)
+  outputJsonSchemas.set(schema, compiled)
+  return structuredClone(compiled)
 }
 
 const toJsonSchema = (schema: Schema.Top): JsonSchema.JsonSchema => {

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -114,23 +114,23 @@ const standardFailure = (prefix: string, error: unknown) =>
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}
-  if (!isStandardSchema(schema) && !Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
+  if (isStandardSchema(schema))
+    return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
+  if (!Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
   const cached = inputJsonSchemas.get(schema)
   if (cached) return structuredClone(cached)
-  const compiled = isStandardSchema(schema)
-    ? (schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema)
-    : toJsonSchema(schema)
+  const compiled = toJsonSchema(schema)
   inputJsonSchemas.set(schema, compiled)
   return structuredClone(compiled)
 }
 
 const outputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
-  if (!isStandardSchema(schema) && !Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
+  if (isStandardSchema(schema))
+    return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
+  if (!Schema.isSchema(schema)) return schema as JsonSchema.JsonSchema
   const cached = outputJsonSchemas.get(schema)
   if (cached) return structuredClone(cached)
-  const compiled = isStandardSchema(schema)
-    ? (schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema)
-    : toJsonSchema(schema)
+  const compiled = toJsonSchema(schema)
   outputJsonSchemas.set(schema, compiled)
   return structuredClone(compiled)
 }

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -13,6 +13,15 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { location } from "../fixture/location"
 
+function ripgrep(find: Ripgrep.Interface["find"]) {
+  return Ripgrep.Service.of({
+    find,
+    scan: (input) => find(input).pipe(Effect.asVoid),
+    glob: () => Effect.succeed([]),
+    grep: () => Effect.succeed([]),
+  })
+}
+
 describe("FileSystemSearch", () => {
   test("bounds a home scan even when home is detected as a repository", async () => {
     let observed: Ripgrep.FindInput | undefined
@@ -31,17 +40,14 @@ describe("FileSystemSearch", () => {
         Ripgrep.node,
         Layer.succeed(
           Ripgrep.Service,
-          Ripgrep.Service.of({
-            find: (input) =>
+          ripgrep((input) =>
               Effect.gen(function* () {
                 observed = input
                 if (input.onEntry)
                   yield* input.onEntry(FileSystem.Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" }))
                 return []
               }),
-            glob: () => Effect.succeed([]),
-            grep: () => Effect.succeed([]),
-          }),
+          ),
         ),
       ],
     ])
@@ -78,8 +84,7 @@ describe("FileSystemSearch", () => {
         Ripgrep.node,
         Layer.succeed(
           Ripgrep.Service,
-          Ripgrep.Service.of({
-            find: (input) =>
+          ripgrep((input) =>
               Effect.gen(function* () {
                 scans++
                 if (scans > 1) {
@@ -94,9 +99,7 @@ describe("FileSystemSearch", () => {
                 if (scans === 1) yield* Deferred.succeed(initial, undefined)
                 return [entry]
               }),
-            glob: () => Effect.succeed([]),
-            grep: () => Effect.succeed([]),
-          }),
+          ),
         ),
       ],
     ])
@@ -145,8 +148,7 @@ describe("FileSystemSearch", () => {
         Ripgrep.node,
         Layer.succeed(
           Ripgrep.Service,
-          Ripgrep.Service.of({
-            find: (input) =>
+          ripgrep((input) =>
               Effect.gen(function* () {
                 scans++
                 const entry = FileSystem.Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" })
@@ -154,9 +156,7 @@ describe("FileSystemSearch", () => {
                 yield* Deferred.succeed(scans === 1 ? first : second, undefined)
                 return [entry]
               }),
-            glob: () => Effect.succeed([]),
-            grep: () => Effect.succeed([]),
-          }),
+          ),
         ),
       ],
     ])
@@ -197,8 +197,7 @@ describe("FileSystemSearch", () => {
         Ripgrep.node,
         Layer.succeed(
           Ripgrep.Service,
-          Ripgrep.Service.of({
-            find: (input) =>
+          ripgrep((input) =>
               Effect.gen(function* () {
                 if (input.onEntry)
                   yield* input.onEntry(
@@ -213,9 +212,7 @@ describe("FileSystemSearch", () => {
                 yield* Deferred.succeed(complete, undefined)
                 return []
               }),
-            glob: () => Effect.succeed([]),
-            grep: () => Effect.succeed([]),
-          }),
+          ),
         ),
       ],
     ])

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -178,4 +178,57 @@ describe("FileSystemSearch", () => {
     prepare.mockRestore()
     cleanup.mockRestore()
   })
+
+  test("invalidates a mixed target list while the initial scan is still running", async () => {
+    const first = Effect.runSync(Deferred.make<void>())
+    const release = Effect.runSync(Deferred.make<void>())
+    const complete = Effect.runSync(Deferred.make<void>())
+    const layer = AppNodeBuilder.build(FileSystemSearch.node, [
+      [
+        Location.node,
+        Layer.succeed(
+          Location.Service,
+          Location.Service.of(
+            location({ directory: AbsolutePath.make(path.join(os.tmpdir(), "opencode-search-partial")) }),
+          ),
+        ),
+      ],
+      [
+        Ripgrep.node,
+        Layer.succeed(
+          Ripgrep.Service,
+          Ripgrep.Service.of({
+            find: (input) =>
+              Effect.gen(function* () {
+                if (input.onEntry)
+                  yield* input.onEntry(
+                    FileSystem.Entry.make({ path: RelativePath.make("src/first.ts"), type: "file" }),
+                  )
+                yield* Deferred.succeed(first, undefined)
+                yield* Deferred.await(release)
+                if (input.onEntry)
+                  yield* input.onEntry(
+                    FileSystem.Entry.make({ path: RelativePath.make("src/second.ts"), type: "file" }),
+                  )
+                yield* Deferred.succeed(complete, undefined)
+                return []
+              }),
+            glob: () => Effect.succeed([]),
+            grep: () => Effect.succeed([]),
+          }),
+        ),
+      ],
+    ])
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const search = yield* FileSystemSearch.Service
+        yield* Deferred.await(first)
+        expect((yield* search.find({ query: "first" }))[0]?.path).toBe(RelativePath.make("src/first.ts"))
+        yield* Deferred.succeed(release, undefined)
+        yield* Deferred.await(complete)
+        expect((yield* search.find({ query: "second" }))[0]?.path).toBe(RelativePath.make("src/second.ts"))
+      }).pipe(Effect.provide(layer), Effect.scoped),
+    )
+  })
 })

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -141,6 +141,7 @@ describe("Git trees", () => {
         await initRepo(root.path)
         await fs.mkdir(path.join(root.path, "scope"))
         await fs.writeFile(path.join(root.path, "scope", "tracked.txt"), "one\n")
+        await fs.writeFile(path.join(root.path, "scope", "deleted.txt"), "delete\n")
         await fs.writeFile(path.join(root.path, "outside.txt"), "outside\n")
         await $`git add .`.cwd(root.path).quiet()
         await $`git commit -m initial`.cwd(root.path).quiet()
@@ -169,18 +170,25 @@ describe("Git trees", () => {
       yield* Effect.promise(async () => {
         await fs.writeFile(path.join(root.path, "scope", "tracked.txt"), "two\n")
         await fs.writeFile(path.join(root.path, "scope", "added.txt"), "added\n")
+        await fs.writeFile(path.join(root.path, "scope", "C leading.txt"), "leading\n")
+        await fs.rm(path.join(root.path, "scope", "deleted.txt"))
         await fs.writeFile(path.join(root.path, "outside.txt"), "changed outside\n")
       })
       yield* git.index.refresh({ repository, scope: RelativePath.make("scope") })
       const after = yield* git.tree.write(repository)
 
       expect(yield* git.tree.files({ repository, from: before, to: after })).toEqual([
+        RelativePath.make("scope/C leading.txt"),
         RelativePath.make("scope/added.txt"),
+        RelativePath.make("scope/deleted.txt"),
         RelativePath.make("scope/tracked.txt"),
       ])
+      expect(yield* git.tree.files({ repository, from: after, to: after })).toEqual([])
       const diffs = yield* git.tree.diff({ repository, from: before, to: after, context: 1 })
       expect(diffs.map((item) => [item.file, item.status])).toEqual([
+        [RelativePath.make("scope/C leading.txt"), "added"],
         [RelativePath.make("scope/added.txt"), "added"],
+        [RelativePath.make("scope/deleted.txt"), "deleted"],
         [RelativePath.make("scope/tracked.txt"), "modified"],
       ])
 
@@ -189,6 +197,50 @@ describe("Git trees", () => {
       expect(yield* read(path.join(root.path, "scope", "tracked.txt"))).toBe("one\n")
       expect(yield* read(path.join(root.path, "scope", "added.txt"))).toBe("added\n")
       expect(yield* read(path.join(root.path, "outside.txt"))).toBe("changed outside\n")
+    }),
+  )
+
+  it.live("limits only untracked files during refresh", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(async () => {
+        await initRepo(root.path)
+        await fs.writeFile(path.join(root.path, "tracked.txt"), "one\n")
+        await $`git add .`.cwd(root.path).quiet()
+        await $`git commit -m initial`.cwd(root.path).quiet()
+      })
+      const git = yield* Git.Service
+      const source = yield* git.repo.discover(AbsolutePath.make(root.path))
+      if (!source) throw new Error("Repository not found")
+      const storage = AbsolutePath.make(`${root.path}-snapshot`)
+      yield* Effect.addFinalizer(() => Effect.promise(() => fs.rm(storage, { recursive: true, force: true })))
+      const repository = yield* git.repo.create({
+        worktree: source.worktree,
+        gitDirectory: storage,
+        seed: source,
+      })
+      const before = yield* git.tree.write(repository)
+
+      yield* Effect.promise(async () => {
+        await fs.writeFile(path.join(root.path, "tracked.txt"), "tracked files are not limited\n")
+        await fs.writeFile(path.join(root.path, "small.txt"), "ok\n")
+        await fs.writeFile(path.join(root.path, "large.txt"), "too large\n")
+      })
+      const refreshed = yield* git.index.refresh({
+        repository,
+        scope: RelativePath.make("."),
+        maximumUntrackedFileBytes: 4,
+      })
+      const after = yield* git.tree.write(repository)
+
+      expect(refreshed.skipped).toEqual([RelativePath.make("large.txt")])
+      expect(yield* git.tree.files({ repository, from: before, to: after })).toEqual([
+        RelativePath.make("small.txt"),
+        RelativePath.make("tracked.txt"),
+      ])
     }),
   )
 })

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Effect, Exit } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
@@ -184,6 +184,10 @@ describe("Git trees", () => {
         RelativePath.make("scope/tracked.txt"),
       ])
       expect(yield* git.tree.files({ repository, from: after, to: after })).toEqual([])
+      const missing = Git.TreeID.make("0000000000000000000000000000000000000000")
+      expect(
+        Exit.isFailure(yield* Effect.exit(git.tree.files({ repository, from: missing, to: missing }))),
+      ).toBeTrue()
       const diffs = yield* git.tree.diff({ repository, from: before, to: after, context: 1 })
       expect(diffs.map((item) => [item.file, item.status])).toEqual([
         [RelativePath.make("scope/C leading.txt"), "added"],

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -112,15 +112,14 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "one.txt"), "one\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "two.txt"), "two\n"))
           const observed: RelativePath[] = []
-          const files = yield* (yield* Ripgrep.Service).find({
+          const ripgrep = yield* Ripgrep.Service
+          yield* ripgrep.scan({
             cwd: tmp.path,
             pattern: "*",
             limit: 10,
-            collect: false,
             onEntry: (entry) => Effect.sync(() => observed.push(entry.path)),
           })
 
-          expect(files).toEqual([])
           expect(new Set(observed)).toEqual(new Set([RelativePath.make("one.txt"), RelativePath.make("two.txt")]))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -104,6 +104,29 @@ describe("Ripgrep", () => {
     ),
   )
 
+  it.live("streams find entries without retaining a result array", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "one.txt"), "one\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "two.txt"), "two\n"))
+          const observed: RelativePath[] = []
+          const files = yield* (yield* Ripgrep.Service).find({
+            cwd: tmp.path,
+            pattern: "*",
+            limit: 10,
+            collect: false,
+            onEntry: (entry) => Effect.sync(() => observed.push(entry.path)),
+          })
+
+          expect(files).toEqual([])
+          expect(new Set(observed)).toEqual(new Set([RelativePath.make("one.txt"), RelativePath.make("two.txt")]))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("excludes protected directory trees from catch-all find results", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -11,6 +11,7 @@ import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { Snapshot } from "@opencode-ai/core/snapshot"
 import { Hash } from "@opencode-ai/util/hash"
+import { EffectFlock } from "@opencode-ai/util/effect-flock"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
@@ -123,6 +124,49 @@ describe("Snapshot", () => {
             expect(yield* read(path.join(location, "added.txt"))).toBe("added\n")
             expect(yield* read(path.join(project, "outside.txt"))).toBe("changed outside\n")
           }).pipe(Effect.provide(layer))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  testEffect(Layer.empty).live("retries lazy repository initialization after lock timeout", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await initGit(project)
+          })
+          const flock = yield* EffectFlock.Service.pipe(Effect.provide(AppNodeBuilder.build(EffectFlock.node)))
+          let acquisitions = 0
+          const instrumented = EffectFlock.Service.of({
+            ...flock,
+            acquire: (key, directory, options) => {
+              acquisitions++
+              if (acquisitions === 1) return Effect.fail(new EffectFlock.LockTimeoutError({ key }))
+              return flock.acquire(key, directory, options)
+            },
+          })
+          const layer = AppNodeBuilder.build(Snapshot.node, [
+            [
+              Location.node,
+              Location.boundNode(Location.Ref.make({ directory: AbsolutePath.make(project) })),
+            ],
+            [Global.node, Global.layerWith({ data: tmp.path, config: path.join(tmp.path, "config") })],
+            [EffectFlock.node, Layer.succeed(EffectFlock.Service, instrumented)],
+          ])
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            expect(yield* snapshot.capture()).toBeUndefined()
+            expect(acquisitions).toBe(1)
+            yield* TestClock.adjust("5 seconds")
+            expect(yield* snapshot.capture()).toBeDefined()
+            expect(acquisitions).toBe(3)
+          }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer()))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Deferred, Effect, Fiber, Layer } from "effect"
+import { TestClock } from "effect/testing"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Git } from "@opencode-ai/core/git"
 import { Global } from "@opencode-ai/util/global"
@@ -122,6 +123,51 @@ describe("Snapshot", () => {
             expect(yield* read(path.join(location, "added.txt"))).toBe("added\n")
             expect(yield* read(path.join(project, "outside.txt"))).toBe("changed outside\n")
           }).pipe(Effect.provide(layer))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  testEffect(Layer.empty).live("backs off a stale index lock and recovers without removing it", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await fs.writeFile(path.join(project, "tracked.txt"), "one\n")
+            await initGit(project)
+          })
+          const projectID = yield* Effect.gen(function* () {
+            return (yield* Location.Service).project.id
+          }).pipe(
+            Effect.provide(
+              AppNodeBuilder.build(Location.boundNode(Location.Ref.make({ directory: AbsolutePath.make(project) }))),
+            ),
+          )
+          const lock = path.join(
+            tmp.path,
+            "snapshot",
+            projectID,
+            Hash.fast(yield* Effect.promise(() => fs.realpath(project))),
+            "index.lock",
+          )
+
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            expect(yield* snapshot.capture()).toBeDefined()
+            yield* Effect.promise(() => fs.writeFile(lock, ""))
+            yield* Effect.promise(() => fs.writeFile(path.join(project, "tracked.txt"), "two\n"))
+
+            expect(yield* snapshot.capture()).toBeUndefined()
+            expect(yield* Effect.promise(() => fs.stat(lock))).toBeDefined()
+            yield* Effect.promise(() => fs.rm(lock))
+            expect(yield* snapshot.capture()).toBeUndefined()
+
+            yield* TestClock.adjust("5 seconds")
+            expect(yield* snapshot.capture()).toBeDefined()
+          }).pipe(Effect.provide(snapshotLayer(tmp.path, project)), Effect.provide(TestClock.layer()))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -171,6 +171,31 @@ test("portable schema failures become tool failures", async () => {
   expect(error.toString()).toContain("Invalid tool input: expected a string")
 })
 
+test("portable schema definitions reflect current converter state", () => {
+  let type = "string"
+  const input = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: {
+        input: () => ({ type }),
+        output: () => ({ type }),
+      },
+    },
+  }
+  const tool: Info = {
+    name: "dynamic-portable",
+    description: "Dynamic portable schema",
+    input,
+    execute: () => Effect.succeed({ content: "unused" }),
+  }
+
+  expect(definition(tool).inputSchema).toEqual({ type: "string" })
+  type = "number"
+  expect(definition(tool).inputSchema).toEqual({ type: "number" })
+})
+
 test("canonical results carry metadata with typed output", async () => {
   const input = Schema.Struct({ value: Schema.String })
   const output = Schema.Struct({ value: Schema.String, internal: Schema.Boolean })

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -52,6 +52,10 @@ test("Effect tool schemas use exact optional keys and flatten compatible constra
     required: ["code"],
     additionalProperties: false,
   })
+  const first = definition(tool).inputSchema as { properties: object }
+  const second = definition(tool).inputSchema as { properties: object }
+  expect(first).not.toBe(second)
+  expect(first.properties).not.toBe(second.properties)
 })
 
 test("Effect tool schemas inline named child schemas", () => {

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -22,6 +22,7 @@ import { makeGlobalNode } from "./effect/app-node.js"
 import { filesystem, path } from "./effect/app-node-platform.js"
 
 const toError = (err: unknown): Error => (err instanceof globalThis.Error ? err : new globalThis.Error(String(err)))
+const nativeWindowsExtensions = new Set([".com", ".exe"])
 
 const toTag = (err: NodeJS.ErrnoException): PlatformError.SystemErrorTag => {
   switch (err.code) {
@@ -261,7 +262,14 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   const launchProcess = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-      const proc = launch(command.command, command.args, opts)
+      const native =
+        process.platform === "win32" &&
+        !opts.shell &&
+        path.isAbsolute(command.command) &&
+        nativeWindowsExtensions.has(path.extname(command.command).toLowerCase())
+      const proc = native
+        ? NodeChildProcess.spawn(command.command, command.args, opts)
+        : launch(command.command, command.args, opts)
       let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
       proc.on("error", (err) => {


### PR DESCRIPTION
# Cutting Windows server CPU without weakening snapshots

## TL;DR

**Snapshot CPU fell from 2,250 ms to 515 ms across ten clean completed steps (-77.1%). Git launches fell from 70 to 40. A stale-lock retry burst fell from 1,438 ms to 31 ms (-97.8%).**

The baseline is `upstream/v2` commit `212139ff95bb725d698bfe657d6fda37cbbfa01b`. This replaces the closed draft that was incorrectly based on `dev`.

| Commit | Change | Direct evidence | Cumulative target |
| --- | --- | --- | --- |
| `2df9fa7` | Combine snapshot candidate scans, make filtering linear, and skip known-equal step comparisons | Clean-step Git launches: 70 -> 40; CPU: 2,250 -> 1,219 ms (-45.8%) | Snapshot process count |
| `cc9cebe` | Resolve Git once and directly spawn absolute native Windows executables | Clean-step CPU: 1,219 -> 438 ms (-64.1% incremental, -80.5% from base) | 36.2% live `statSync` hotspot |
| `9446514` | Remove tracing only from high-frequency provider deltas | Provider fragment throughput: 63,464 -> 82,481 Events/s (+30%); CPU: 5,937 -> 4,688 ms (-21%) | Delta telemetry overhead |
| `d46b8ef` | Stream/discard ripgrep indexing, build path prefixes once, and reuse prepared target arrays | Targets the 10.22% cold-start filesystem-index path | Windows startup and autocomplete |
| `97e540c` | Cache durable Event codecs by immutable definition | One Schema adapter per definition instead of per durable Event | 8.09% Schema ancestry |
| `ab08e20` | Cache immutable Effect tool schema compilation and codecs | Definitions/s: 19,115 -> 54,530 (+185%); CPU: 578 -> 94 ms (-83.7%) | Repeated physical model attempts |
| `ba040ef` | Coordinate snapshot writers across processes and back off lock failures | Ten stale-lock calls: 30 Git launches -> 3; CPU: 312 -> 32 ms (-89.7% incremental) | Cross-channel snapshot safety |
| `bb43664` | Keep a mixed file-search target cache current during an active scan | Regression coverage for partial initial indexes | Search correctness |
| `85347fe` | Preserve boundary contracts found in review | Retries failed initialization, keeps Git validation, traces non-deltas, and avoids caching mutable Standard schemas | Review hardening |

Percentages from CPU profiles are overlapping sampled-stack categories. Do not add them.

## What the real beta server does

A 30-second profiler plugin ran inside the installed beta server process (`0.0.0-beta-17759`, PID `34464`) under the real application workload. It did not use a generated Event benchmark.

| Metric | Result |
| --- | ---: |
| Process CPU | 8,609 ms over 30 seconds |
| Average CPU | 28.7% of one core |
| Git launches in the profile window | 73 |
| Ripgrep launches | 2 |
| PowerShell launches | 1 |
| `statSync` self samples | 36.2% of active samples |
| Native `spawn` self samples | 14.3% of active samples |
| SQLite `values` self samples | 2.5% of active samples |

The profile's representative `statSync` stack enters the bundled `cross-spawn` command-resolution path. The matching server log confirms that 73 of 76 child launches were Git. The server was resolving and launching about 2.43 Git processes per second during this window.

The earlier 81.7-second profile (`0.0.0-beta-17498`) showed the same shape:

- 70.45% post-start process ancestry;
- 52.11% post-start native `spawn` leaf samples;
- 11.81% post-start executable resolution;
- 36 snapshot failures against one private `index.lock`;
- an older server/channel process accessing the same snapshot repository.

This is primarily a Windows process-launch and snapshot-amplification problem, not model inference or EventFeed encoding.

## Snapshot flow before this branch

Each physical model attempt captures the filesystem before `llm.stream(...)`. A terminal attempt captures it again and compares the two trees.

One clean capture used:

```text
git diff-files --name-only
git ls-files --others --exclude-standard
git write-tree
```

The completed step then ran `git diff --name-only` even when the two captured tree IDs were equal.

```text
start capture: 3 Git processes
end capture:   3 Git processes
comparison:    1 Git process
total:         7 Git processes
```

Ten clean completed steps therefore launched 70 Git processes.

## Snapshot flow after this branch

Candidate discovery now uses one tagged, NUL-delimited [`git ls-files`](https://git-scm.com/docs/git-ls-files) call:

```text
git ls-files --modified --others --exclude-standard -t -z
```

The tag keeps tracked and untracked paths distinct, so the 2 MiB limit still applies only to untracked files. Tests cover tracked changes, deletion, untracked additions, status-like filename prefixes, and oversized untracked files.

The Session runner now skips comparison only when its two freshly captured IDs are equal. `Git.tree.files` still validates arbitrary IDs, including equal invalid IDs.

```text
start capture: 2 Git processes
end capture:   2 Git processes
comparison:    0 Git processes when freshly captured IDs match
total:         4 Git processes
```

Snapshots remain Git trees. This PR does **not** replace snapshot storage or correctness with raw filesystem watchers. Restore, diff, ignored-file filtering, external edits, and the persistent private index keep their existing semantics.

## Windows executable resolution

The V2 spawner currently sends every command through `cross-spawn`. On Windows, each bare `git` launch can repeat `PATH`, `PATHEXT`, `which`, `isexe`, `statSync`, and shebang work before native process creation.

The Git service now resolves Git once. A relative lookup result is normalized once against the server startup directory. The process spawner bypasses `cross-spawn` only when all of these conditions hold:

- Windows;
- an absolute executable path;
- `.exe` or `.com` extension;
- no shell option.

Shell commands, `.cmd`, `.bat`, shebang scripts, and relative commands keep the existing `cross-spawn` behavior. Focused Windows tests cover the direct native executable and spaced `.cmd` paths.

This commit does not reduce Git command count. Its direct value is removing repeated synchronous executable discovery from every remaining Git launch.

## Snapshot ownership and failure control

V2 already serializes one process's private-index mutations with a `KeyedMutex`. It did not coordinate separate beta, local, or replacement server processes that share the same deterministic snapshot path.

Snapshot repository initialization, capture, and restore now use the existing `EffectFlock` boundary. Its heartbeat is renewed every `staleMs / 3` until release. Different worktrees still use different lock keys and run independently.

Lock-related capture failures use bounded backoff:

```text
5s -> 10s -> 20s -> 40s -> 60s
```

The code does not delete Git lock files. A failed lazy initialization invalidates its cached fiber, so a later call can recover after contention clears.

This changes only an already-failed best-effort capture path. Successful snapshots do not back off.

## Provider delta path

Normal text and reasoning output is already batched before public Session delta publication. The raw provider dispatcher still entered a named traced `Effect.fn` for every provider chunk, before batching.

The final implementation keeps `SessionRunner.publishLLMEvent` spans for:

- step boundaries;
- text/reasoning starts and ends;
- tool calls and results;
- provider errors;
- finish Events.

Only text, reasoning, and tool-input deltas use the untraced dispatcher. Anthropic's content-block delta handler is also untraced.

The benchmark reconstructs provider fragment events from 583 real V2 Session fragment Events. Each run processes 291,500 provider Events. Results use seven runs, remove the fastest and slowest complete runs by wall time, then take the median of the remaining five.

| Mode | Events/s | CPU time | CPU change |
| --- | ---: | ---: | ---: |
| Traced | 63,464 | 5,937 ms | baseline |
| Delta-only untraced | 82,481 | 4,688 ms | -21% |

## File indexing

Windows uses the ripgrep/fuzzysort fallback because FFF is disabled there by default. The cold profile attributed 10.22% of pre-cutoff samples to filesystem indexing.

The old scan:

- retained every parsed ripgrep row even though search consumed only the callback;
- repeatedly used `slice(...).join(...)` for every directory prefix;
- rebuilt prepared target arrays for every query.

The new `Ripgrep.scan` operation has a void result and requires `onEntry`, so callers cannot silently request discarded results through an optional boolean. File search builds prefixes in one pass, retains one prepared target per path, and invalidates its mixed list when new scan entries arrive.

## Event and tool schemas

Durable Bus data codecs are cached by immutable Event definition. Replay and publication retain the same Schema validation.

Tool runtime caching is deliberately narrower:

- Effect Schemas are immutable and cache JSON Schema compilation plus codec adapters;
- every request receives a deep fresh JSON-schema value for mutable plugin hooks;
- Standard-schema converters are not cached because they may reflect mutable plugin state;
- raw JSON schemas keep their existing behavior.

The tool benchmark registers 40 nested Effect-schema tools and renders 4,000 definitions per run. It uses the same seven-run trimmed-median rule.

| Mode | Definitions/s | CPU time | CPU change |
| --- | ---: | ---: | ---: |
| Uncached | 19,115 | 578 ms | baseline |
| Cached | 54,530 | 94 ms | -83.7% |

## Snapshot benchmark

The snapshot fixture has 200 tracked files. Each run measures:

- ten complete clean steps (start capture, end capture, comparison);
- one changed complete step;
- ten capture calls while a stale Git `index.lock` exists.

Every commit was run seven times. For each scenario, the fastest and slowest complete runs were removed by wall time, then the median of the remaining five was reported.

### Clean completed steps

| Revision | Git launches | Wall time | CPU time | CPU change |
| --- | ---: | ---: | ---: | ---: |
| V2 base | 70 | 5,434 ms | 2,250 ms | baseline |
| Combined scan + equal skip | 40 | 4,147 ms | 1,219 ms | -45.8% |
| Absolute native Git | 40 | 3,021 ms | 438 ms | -80.5% cumulative |
| Final branch | 40 | 3,029 ms | 515 ms | -77.1% cumulative |

### Changed completed step

| Revision | Git launches | Wall time | CPU time | CPU change |
| --- | ---: | ---: | ---: | ---: |
| V2 base | 10 | 883 ms | 359 ms | baseline |
| Combined scan | 8 | 849 ms | 235 ms | -34.5% |
| Absolute native Git | 8 | 699 ms | 94 ms | -73.8% cumulative |

### Stale-lock calls

| Revision | Git launches | Wall time | CPU time | CPU change |
| --- | ---: | ---: | ---: | ---: |
| V2 base | 40 | 3,335 ms | 1,438 ms | baseline |
| Process optimizations | 30 | 2,345 ms | 280 ms | -80.5% |
| Flock + backoff | 3 | 222 ms | 32 ms | -97.8% cumulative |

## Event replay

A separate real trace contained 1,961 public V2 Events. The long four-subscriber replay processed 49,025 source Events and 196,100 delivered frames per run.

The full branch changed delivered throughput from 31,437 to 35,608 Events/s (+13.3%) and CPU from 49.72 to 47.57 ms per thousand delivered Events (-4.3%). This benchmark is reported only as an aggregate regression check. It is not used to attribute snapshot, spawn, search, or tool-schema commits because those paths are outside EventFeed.

## Verification

- Pre-push workspace typecheck: 34/34 tasks passed.
- Core, AI, Util, and Server package typechecks passed.
- Git tree tests: 2 passed.
- Snapshot tests: 7 passed.
- Bus, ripgrep, filesystem search, tool schema, and registry tests: 93 passed.
- Provider-delta Session runner tests: 2 passed.
- Anthropic protocol tests: 50 passed.
- Windows absolute executable test: passed.
- Windows spaced `.cmd` routing test: passed.
- One unchanged cross-spawn `echo` assertion remains platform-specific when the full file runs: Windows returns quoted output. Focused changed routes pass.

## Compatibility

- Public Protocol and Server `HttpApi` contracts do not change.
- Snapshot IDs, Git trees, diff behavior, restore behavior, and user-index isolation do not change.
- No Git lock file is deleted automatically.
- Different worktrees retain parallel snapshot execution.
- Non-delta operational spans remain.
- Standard-schema converter mutability remains observable.
- No generated client files change.

The result keeps the normal flow direct: capture with fewer Git commands, launch Git without repeated Windows lookup, compare only when tree IDs differ, and stop retrying an already-failed lock on every model boundary.
