### PR TITLE
fix(plugin): skip module exports that are not plugin factories

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -96,31 +96,61 @@ function getServerPlugin(value: unknown) {
   return value.server
 }
 
-function getLegacyPlugins(mod: Record<string, unknown>) {
-  const seen = new Set<unknown>()
-  const result: PluginInstance[] = []
+// A plugin factory must resolve to a Hooks record. Every consumer of the shared hooks array
+// indexes entries directly, so a helper that resolves to undefined, a string, or a boolean would
+// be read as a hook and break unrelated plugins.
+function isHooks(value: unknown): value is Hooks {
+  return typeof value === "object" && value !== null
+}
 
-  for (const entry of Object.values(mod)) {
+// The legacy path treats every export as a plugin factory, so modules that ship helpers next to
+// their plugin are common. Report the exports we drop instead of failing the whole module.
+type SkipReport = (name: string, reason: string) => void
+
+function getLegacyPlugins(mod: Record<string, unknown>, skip: SkipReport) {
+  const seen = new Set<unknown>()
+  const result: { name: string; plugin: PluginInstance }[] = []
+
+  for (const [name, entry] of Object.entries(mod)) {
     if (seen.has(entry)) continue
     seen.add(entry)
     const plugin = getServerPlugin(entry)
-    if (!plugin) throw new TypeError("Plugin export is not a function")
-    result.push(plugin)
+    if (!plugin) {
+      skip(name, `export is ${entry === null ? "null" : typeof entry}, not a plugin function`)
+      continue
+    }
+    result.push({ name, plugin })
   }
 
   return result
 }
 
-async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
+async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[], skip: SkipReport) {
   const plugin = readV1Plugin(load.mod, load.spec, "server", "detect")
   if (plugin) {
     await resolvePluginId(load.source, load.spec, load.target, readPluginId(plugin.id, load.spec), load.pkg)
-    hooks.push(await (plugin as PluginModule).server(input, load.options))
+    const result = await (plugin as PluginModule).server(input, load.options)
+    if (!isHooks(result)) throw new TypeError(`Plugin ${load.spec} server() did not return hooks`)
+    hooks.push(result)
     return
   }
 
-  for (const server of getLegacyPlugins(load.mod)) {
-    hooks.push(await server(input, load.options))
+  const legacy = getLegacyPlugins(load.mod, skip)
+  if (!legacy.length) throw new TypeError(`Plugin ${load.spec} does not export a plugin function`)
+
+  for (const { name, plugin: server } of legacy) {
+    let result
+    try {
+      result = await server(input, load.options)
+    } catch (error) {
+      skip(name, errorMessage(error))
+      continue
+    }
+    if (!isHooks(result)) {
+      skip(name, `export returned ${result === null ? "null" : typeof result}, not hooks`)
+      continue
+    }
+    hooks.push(result)
   }
 }
 
@@ -219,10 +249,12 @@ const layer = Layer.effect(
         for (const load of loaded) {
           if (!load) continue
 
+          const skipped: { name: string; reason: string }[] = []
+
           // Keep plugin execution sequential so hook registration and execution
           // order remains deterministic across plugin runs.
           yield* Effect.tryPromise({
-            try: () => applyPlugin(load, input, hooks),
+            try: () => applyPlugin(load, input, hooks, (name, reason) => skipped.push({ name, reason })),
             catch: (err) => {
               const message = errorMessage(err)
               return message
@@ -239,6 +271,14 @@ const layer = Layer.effect(
               return Effect.void
             }),
           )
+
+          for (const entry of skipped) {
+            yield* Effect.logWarning("plugin export skipped", {
+              path: load.spec,
+              export: entry.name,
+              reason: entry.reason,
+            })
+          }
         }
 
         // Notify plugins of current config

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -105,4 +105,57 @@ describe("plugin.trigger", () => {
       }),
     ),
   )
+
+  it.instance("ignores helper exports that do not return hooks", () =>
+    withProject(
+      [
+        "export function helper() {}",
+        "export const plugin = async () => ({",
+        `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+        '    output.system.unshift("hooks")',
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["hooks"])
+      }),
+    ),
+  )
+
+  it.instance("ignores non-function exports", () =>
+    withProject(
+      [
+        "export const VERSION = 1",
+        "export const plugin = async () => ({",
+        `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+        '    output.system.unshift("named")',
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["named"])
+      }),
+    ),
+  )
+
+  it.instance("keeps loading when a helper export throws", () =>
+    withProject(
+      [
+        "export function helper() {",
+        '  throw new Error("helper called as a plugin")',
+        "}",
+        "export const plugin = async () => ({",
+        `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+        '    output.system.unshift("survived")',
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["survived"])
+      }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #42451
Closes #41234

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The legacy plugin path treats **every** export of a plugin module as a plugin factory:
`getLegacyPlugins` iterates `Object.values(mod)`, `getServerPlugin` accepts anything that is a
function, and `applyPlugin` pushes whatever each call returns straight into the shared `hooks`
array. A module that exports helpers next to its plugin — a very common shape, since helpers are
often exported just to be unit-testable — produces two failures:

1. **Non-function exports throw** (`Plugin export is not a function`), the throw is swallowed by
   the `Effect.catch` in the apply loop, and the module's real plugin silently never registers.
   (#41234, #31575)
2. **Helper functions get called with `PluginInput`**, and their return values — strings, booleans,
   `undefined` — get pushed into `hooks`. Four consumers then index that array as if every entry
   were a `Hooks` object, and two of them are not guarded:
   `Plugin.trigger` (`plugin/index.ts:291-294`) and `provider.ts:1424-1425`. The first one means
   **no session in the process can create a user message**. (#42451)

This PR makes the legacy path fail soft per export and name the offender:

- non-function exports are skipped with a warning instead of aborting the module;
- a factory whose result is not an object is skipped with a warning instead of poisoning `hooks`;
- a factory that throws is skipped with a warning naming the export, instead of dropping the
  whole module behind an opaque error (this is the `parseCommandFile(input)` →
  `path must be a string or a file descriptor` symptom reported in #42451);
- a module with **no** usable plugin export still throws, so genuinely broken plugins stay loud;
- the v1 `export default { id, server }` path throws if `server()` does not return hooks, since a
  v1 module has a single factory and there is nothing to fall back to.

Warnings go through `Effect.logWarning` at the existing apply-loop call site and include the
plugin path, the export name, and the reason, so the log finally says *which* export is the
problem — previously it did not (see #41234, comment 3).

This supersedes #35489, which fixed only the first failure and was auto-closed by the PR cleanup
bot rather than reviewed.

### How did you verify your code works?

Three tests added to `test/plugin/trigger.test.ts` using the existing `withProject` harness, one
per failure mode: a helper returning `undefined`, a non-function `export const`, and a helper that
throws when invoked. All three fail on `dev` (the hook never fires and `trigger` returns `[]`) and
pass with this change.

- `bun test test/plugin/ test/config/plugin.test.ts test/agent/plugin-agent-regression.test.ts` —
  179 pass, 0 fail across 19 files.
- `bun run typecheck` clean, Prettier clean, `oxlint` reports the same 13 pre-existing warnings and
  0 errors as on `dev`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---
