### PR TITLE
fix(ai): classify transient provider failures

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -74,6 +74,7 @@ const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error"
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
+const TRANSIENT_TEXT = /\bcurrently at capacity due to high demand\b/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -128,6 +129,12 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
       rateLimit: input.rateLimit,
     })
   if (codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable")))
+    return new ProviderInternalReason({
+      ...common,
+      status: input.status,
+      retryAfterMs: input.retryAfterMs,
+    })
+  if (TRANSIENT_TEXT.test(text))
     return new ProviderInternalReason({
       ...common,
       status: input.status,

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -74,7 +74,7 @@ const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error"
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
-const TRANSIENT_TEXT = /\bcurrently at capacity due to high demand\b/i
+const TRANSIENT_TEXT = /\btry again (?:later|in\b)|\b(?:currently|temporarily) at capacity\b|\bretry your request\b/i
 
 export interface ProviderFailure {
   readonly message: string

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -128,13 +128,10 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
       retryAfterMs: input.retryAfterMs,
       rateLimit: input.rateLimit,
     })
-  if (codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable")))
-    return new ProviderInternalReason({
-      ...common,
-      status: input.status,
-      retryAfterMs: input.retryAfterMs,
-    })
-  if (TRANSIENT_TEXT.test(text))
+  if (
+    TRANSIENT_TEXT.test(text) ||
+    codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable"))
+  )
     return new ProviderInternalReason({
       ...common,
       status: input.status,

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -75,7 +75,7 @@ describe("provider error classification", () => {
     ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal"])
   })
 
-  test("classifies xAI capacity text as provider internal", () => {
+  test("classifies transient provider text as provider internal", () => {
     const message =
       "The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing"
     const http = new HttpContext({
@@ -84,10 +84,14 @@ describe("provider error classification", () => {
     })
 
     expect(
-      [classifyProviderFailure({ message }), classifyProviderFailure({ message: "Provider request failed", http })].map(
-        (failure) => failure._tag,
-      ),
-    ).toEqual(["ProviderInternal", "ProviderInternal"])
+      [
+        message,
+        "The service is temporarily at capacity.",
+        "Please try again later.",
+        "Please retry your request shortly.",
+      ].map((message) => classifyProviderFailure({ message })._tag),
+    ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal", "ProviderInternal"])
+    expect(classifyProviderFailure({ message: "Provider request failed", http })._tag).toBe("ProviderInternal")
   })
 
   test("classifies transient client statuses as provider internal", () => {

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { isContextOverflow } from "../src/index.js"
+import { HttpContext, HttpRequestDetails, isContextOverflow } from "../src/index.js"
 import { classifyProviderFailure } from "../src/provider-error.js"
 
 describe("provider error classification", () => {
@@ -73,6 +73,21 @@ describe("provider error classification", () => {
         (message) => classifyProviderFailure({ message })._tag,
       ),
     ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal"])
+  })
+
+  test("classifies xAI capacity text as provider internal", () => {
+    const message =
+      "The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing"
+    const http = new HttpContext({
+      request: new HttpRequestDetails({ method: "POST", url: "https://api.x.ai/v1/responses", headers: {} }),
+      body: message,
+    })
+
+    expect(
+      [classifyProviderFailure({ message }), classifyProviderFailure({ message: "Provider request failed", http })].map(
+        (failure) => failure._tag,
+      ),
+    ).toEqual(["ProviderInternal", "ProviderInternal"])
   })
 
   test("classifies transient client statuses as provider internal", () => {


### PR DESCRIPTION
## Summary
- classify known transient provider messages as provider-internal failures
- match `try again`, capacity, and `retry your request` wording from both stream text and captured HTTP response bodies
- leave unknown stream errors on their existing classification path

## Testing
- `bun test test/provider-error.test.ts`
- `bun test test/provider/openai-responses.test.ts`
- `bun typecheck`