### PR TITLE
feat(core): use copilot utility models for titles

### DIFF
--- a/packages/core/src/plugin/provider/github-copilot.ts
+++ b/packages/core/src/plugin/provider/github-copilot.ts
@@ -148,6 +148,7 @@ const oauth = (app: App.Info) =>
 export const GithubCopilotPlugin = define({
   id: "opencode.provider.github.copilot",
   effect: Effect.fn(function* (ctx) {
+    const agents = yield* Agent.Service
     const catalog = yield* Catalog.Service
     const bus = yield* Bus.Service
     const loading = Semaphore.makeUnsafe(1)
@@ -246,8 +247,14 @@ export const GithubCopilotPlugin = define({
       (evt) =>
         Effect.gen(function* () {
           if (evt.model.providerID !== Provider.ID.githubCopilot) return
-          if (evt.agent === Agent.ID.make("title"))
+          if (evt.agent === Agent.ID.make("title")) {
             evt.request.headers.set("X-Interaction-Type", "conversation-background")
+            // Auto-selected title models come from the regular catalog and consume
+            // premium request quota, so reroute them to a utility model unless the
+            // user explicitly configured a title model.
+            if (!(yield* agents.get(Agent.ID.make("title")))?.model)
+              evt.request = (yield* utilityTitleRequest(catalog, evt.request)) ?? evt.request
+          }
           if (evt.agent === Agent.ID.make("compaction"))
             evt.request.headers.set("X-Interaction-Type", "conversation-compaction")
           const token = evt.request.headers.get("x-api-key")
@@ -282,6 +289,32 @@ export const GithubCopilotPlugin = define({
     )
   }),
 } satisfies PluginInternal.InternalPlugin)
+
+// GitHub exposes utility models for background work such as title generation
+// without including them in the model picker or premium request quota.
+const utilityModels = ["gpt-5.4-nano", "gpt-4.1", "gpt-4o", "gpt-4o-mini"].map((id) => Model.ID.make(id))
+
+const utilityTitleRequest = Effect.fn("GithubCopilotPlugin.utilityTitleRequest")(function* (
+  catalog: Catalog.Interface,
+  request: Request,
+) {
+  const endpoint = request.url.includes("/chat/completions")
+    ? "chat"
+    : request.url.includes("/responses")
+      ? "responses"
+      : undefined
+  if (!endpoint) return
+  const target = (yield* Effect.forEach(utilityModels, (id) => catalog.model.get(Provider.ID.githubCopilot, id)))
+    .filter((model) => model !== undefined)
+    .find((model) => (model.settings?.endpoint ?? "chat") === endpoint)
+  if (!target) return
+  const body = Option.getOrUndefined(decodeBody(yield* Effect.promise(() => request.clone().text())))
+  if (!record(body) || typeof body.model !== "string" || body.model === target.modelID) return
+  const rewritten = new Request(request, { body: JSON.stringify({ ...body, model: target.modelID }) })
+  // The stale length would no longer match the rewritten body.
+  rewritten.headers.delete("content-length")
+  return rewritten
+})
 
 function normalizeDomain(input: string) {
   return input.replace(/^https?:\/\//, "").replace(/\/$/, "")

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -1,6 +1,6 @@
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { App } from "@opencode-ai/core/app"
-import { Agent } from "@opencode-ai/schema/agent"
+import { Agent } from "@opencode-ai/core/agent"
 import { Session } from "@opencode-ai/schema/session"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
@@ -151,6 +151,94 @@ describe("GithubCopilotPlugin", () => {
         request: new Request("https://api.githubcopilot.com/chat/completions"),
       })
       expect(event.request.headers.get("x-interaction-type")).toBe("conversation-background")
+    }),
+  )
+
+  it.effect("reroutes auto-selected title requests to a utility model", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* addPlugin()
+      yield* catalog.transform((evt) => {
+        evt.model.update(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4-nano"), (model) => {
+          model.enabled = false
+          model.settings = { endpoint: "responses" }
+        })
+      })
+      const event = yield* (yield* PluginHooks.Service).trigger("session", "http.request", {
+        sessionID: Session.ID.make("ses_title"),
+        agent: Agent.ID.make("title"),
+        model: Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("gpt-5.6-luna") }),
+        request: new Request("https://api.githubcopilot.com/responses", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "gpt-5.6-luna", input: [{ role: "user", content: "hello" }] }),
+        }),
+      })
+      expect(yield* Effect.promise(() => event.request.clone().json())).toEqual({
+        model: "gpt-5.4-nano",
+        input: [{ role: "user", content: "hello" }],
+      })
+      expect(event.request.headers.get("x-interaction-type")).toBe("conversation-background")
+    }),
+  )
+
+  it.effect("keeps an explicitly configured title model", () =>
+    Effect.gen(function* () {
+      const agents = yield* Agent.Service
+      const catalog = yield* Catalog.Service
+      yield* addPlugin()
+      yield* agents.transform((draft) => {
+        draft.update(Agent.ID.make("title"), (agent) => {
+          agent.model = Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("gpt-5.6-luna") })
+        })
+      })
+      yield* catalog.transform((evt) => {
+        evt.model.update(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4-nano"), (model) => {
+          model.enabled = false
+          model.settings = { endpoint: "responses" }
+        })
+      })
+      const event = yield* (yield* PluginHooks.Service).trigger("session", "http.request", {
+        sessionID: Session.ID.make("ses_title"),
+        agent: Agent.ID.make("title"),
+        model: Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("gpt-5.6-luna") }),
+        request: new Request("https://api.githubcopilot.com/responses", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "gpt-5.6-luna", input: [{ role: "user", content: "hello" }] }),
+        }),
+      })
+      expect(yield* Effect.promise(() => event.request.clone().json())).toEqual({
+        model: "gpt-5.6-luna",
+        input: [{ role: "user", content: "hello" }],
+      })
+    }),
+  )
+
+  it.effect("keeps title requests on an endpoint without a utility model", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* addPlugin()
+      yield* catalog.transform((evt) => {
+        evt.model.update(Provider.ID.githubCopilot, Model.ID.make("gpt-5.4-nano"), (model) => {
+          model.enabled = false
+          model.settings = { endpoint: "responses" }
+        })
+      })
+      const event = yield* (yield* PluginHooks.Service).trigger("session", "http.request", {
+        sessionID: Session.ID.make("ses_title"),
+        agent: Agent.ID.make("title"),
+        model: Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("claude-haiku-4.5") }),
+        request: new Request("https://api.githubcopilot.com/v1/messages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "claude-haiku-4.5", messages: [{ role: "user", content: "hello" }] }),
+        }),
+      })
+      expect(yield* Effect.promise(() => event.request.clone().json())).toEqual({
+        model: "claude-haiku-4.5",
+        messages: [{ role: "user", content: "hello" }],
+      })
     }),
   )
 


### PR DESCRIPTION
Follow-up to #43702.

GitHub exposes utility models (`gpt-5.4-nano`, `gpt-4.1`, `gpt-4o`, `gpt-4o-mini`) for background work such as title generation. They are picker-disabled (`model_picker_enabled: false`) and stay off premium request quota, so the small-model selection from #43702 never picks them — Copilot titles currently resolve to a regular catalog model (typically `gpt-5.6-luna`) and consume premium requests. The dev branch handled this with the `experimental.provider.small_model` hook; V2 needs no new hooks.

The Copilot plugin now reroutes title requests in its existing `session.http.request` hook:

- Only when the user has not explicitly configured a title model (`agents.title.model`, including migrated legacy `small_model`, lands on the title agent's `model` field).
- The first utility model present in the catalog whose endpoint matches the outgoing request (`responses` or `chat/completions`) replaces the `model` field in the request body. Requests on the Anthropic `/v1/messages` shim are left alone since the utility models do not speak that protocol.
- On any rewrite failure the request goes out unchanged, and a failed title attempt still falls back to the session's primary model per #43702.

Known tradeoff: the swap happens after request construction, so usage accounting records the model core resolved rather than the utility model actually used. Copilot billing is subscription/premium-request based, so this only affects cosmetic per-token cost display for tiny title requests.

Tests cover the rewrite, the explicit-config opt-out, and the messages-endpoint skip.