### PR TITLE
fix(desktop): use Effect platform subpath imports

### DIFF
--- a/packages/desktop/src/main/files/attachment-picker.test.ts
+++ b/packages/desktop/src/main/files/attachment-picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { NodeFileSystem } from "@effect/platform-node"
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
 import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -1,4 +1,6 @@
-import { NodeFileSystem, NodePath, NodeRuntime } from "@effect/platform-node"
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
+import * as NodePath from "@effect/platform-node/NodePath"
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime"
 import { app } from "electron"
 import { Effect, Layer } from "effect"
 import { Ipc } from "./ipc"

--- a/packages/desktop/src/main/service/shell-env.test.ts
+++ b/packages/desktop/src/main/service/shell-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { NodePath } from "@effect/platform-node"
+import * as NodePath from "@effect/platform-node/NodePath"
 import { Effect } from "effect"
 
 import { isNushell, mergeShellEnv, parseShellEnv, resolveUserShell } from "./shell-env"

--- a/packages/desktop/src/main/storage/cleanup.test.ts
+++ b/packages/desktop/src/main/storage/cleanup.test.ts
@@ -1,4 +1,5 @@
-import { NodeFileSystem, NodePath } from "@effect/platform-node"
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
+import * as NodePath from "@effect/platform-node/NodePath"
 import { afterEach, describe, expect, test } from "bun:test"
 import { tmpdir } from "node:os"
 import { Effect, FileSystem, Layer, Path } from "effect"


### PR DESCRIPTION
## Summary
- replace root `@effect/platform-node` imports with direct subpath imports
- avoid loading the platform barrel and its unused `NodeRedis` export

## Testing
- `bun typecheck` in `packages/desktop`
- `bun test src/main/files/attachment-picker.test.ts src/main/service/shell-env.test.ts src/main/storage/cleanup.test.ts`
- `bun run build` in `packages/desktop`
- repository typecheck push hook
