### PR TITLE
feat(opencode): honor provider-reported usage.cost from LLM gateways

### DIFF
--- a/packages/llm/src/schema/events.ts
+++ b/packages/llm/src/schema/events.ts
@@ -56,6 +56,15 @@ export class Usage extends Schema.Class<Usage>("LLM.Usage")({
   cacheWriteInputTokens: Schema.optional(Schema.Number),
   reasoningTokens: Schema.optional(Schema.Number),
   totalTokens: Schema.optional(Schema.Number),
+  /**
+   * USD cost reported by the provider on the response (`usage.cost`), as
+   * emitted by gateway routers (OpenRouter, LiteLLM, Manifest, etc.). When a
+   * provider reports this, it is authoritative for `Session.getUsage` because
+   * the actual routed model and any cache/subscription discounts are already
+   * priced into it — a static models.dev rate cannot account for those.
+   * `0` is meaningful (flat-fee subscription route) and is preserved.
+   */
+  cost: Schema.optional(Schema.Number),
   providerMetadata: Schema.optional(ProviderMetadata),
 }) {
   /**

--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -42,6 +42,16 @@ function copilotTotalNanoAiu(value: unknown) {
   return total
 }
 
+// Gateways (OpenRouter, LiteLLM, Manifest) report a `usage.cost` (USD) that the
+// openai-compatible provider preserves under `usage.raw` but is not part of the
+// normalized `LanguageModelUsage`. Surface it so `Session.getUsage` can prefer
+// provider-reported cost over static models.dev rates.
+function reportedCost(raw: unknown) {
+  if (!raw || typeof raw !== "object") return undefined
+  const cost = (raw as { cost?: unknown }).cost
+  return typeof cost === "number" && Number.isFinite(cost) && cost >= 0 ? cost : undefined
+}
+
 function usage(value: unknown) {
   if (!value || typeof value !== "object") return undefined
   const item = value as {
@@ -52,6 +62,7 @@ function usage(value: unknown) {
     cachedInputTokens?: number
     inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number }
     outputTokenDetails?: { reasoningTokens?: number }
+    raw?: unknown
   }
   const entries = Object.entries({
     inputTokens: item.inputTokens,
@@ -60,6 +71,7 @@ function usage(value: unknown) {
     reasoningTokens: item.outputTokenDetails?.reasoningTokens ?? item.reasoningTokens,
     cacheReadInputTokens: item.inputTokenDetails?.cacheReadTokens ?? item.cachedInputTokens,
     cacheWriteInputTokens: item.inputTokenDetails?.cacheWriteTokens,
+    cost: reportedCost(item.raw),
   }).filter((entry) => entry[1] !== undefined)
   return entries.length === 0 ? undefined : Object.fromEntries(entries)
 }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -384,12 +384,15 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
     (input.model.cost?.experimentalOver200K && contextTokens > 200_000
       ? input.model.cost.experimentalOver200K
       : input.model.cost)
+  const reportedCost = input.usage.cost
   const totalNanoAiu = input.metadata?.["copilot"]?.["totalNanoAiu"]
   return {
     cost:
-      typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu) && totalNanoAiu >= 0
-        ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
-        : safe(
+      typeof reportedCost === "number" && Number.isFinite(reportedCost) && reportedCost >= 0
+        ? reportedCost
+        : typeof totalNanoAiu === "number" && Number.isFinite(totalNanoAiu) && totalNanoAiu >= 0
+          ? new Decimal(totalNanoAiu).div(100_000_000_000).toNumber()
+          : safe(
             new Decimal(0)
               .add(new Decimal(tokens.input).mul(finite(costInfo?.input ?? 0)).div(1_000_000))
               .add(new Decimal(tokens.output).mul(finite(costInfo?.output ?? 0)).div(1_000_000))

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -504,6 +504,102 @@ describe("session.llm.ai-sdk adapter", () => {
     expect(result.tokens.cache.read).toBe(200)
   })
 
+  test("surfaces provider-reported usage.cost from gateway raw usage and prefers it in getUsage", async () => {
+    const events = await adapt([
+      {
+        type: "finish-step",
+        response: { id: "chatcmpl-1", timestamp: new Date(0), modelId: "manifest/auto" },
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+          inputTokenDetails: { noCacheTokens: 100, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+          outputTokenDetails: { textTokens: 50, reasoningTokens: undefined },
+          raw: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, cost: 0.0042 },
+        },
+        providerMetadata: { manifest: {} },
+      },
+    ])
+
+    expect(events).toHaveLength(1)
+    const stepFinish = events[0]
+    if (stepFinish.type !== "step-finish") throw new Error("expected step-finish")
+    expect(stepFinish.usage?.cost).toBe(0.0042)
+
+    // A non-zero catalog rate proves the reported cost wins over local pricing.
+    const result = SessionNs.getUsage({
+      model: {
+        id: "manifest/auto",
+        providerID: "manifest",
+        name: "Manifest",
+        limit: { context: 200_000, output: 8_000 },
+        cost: { input: 3, output: 15, cache: { read: 0, write: 0 } },
+        capabilities: {
+          toolcall: true,
+          attachment: false,
+          reasoning: false,
+          temperature: true,
+          input: { text: true, image: false, audio: false, video: false },
+          output: { text: true, image: false, audio: false, video: false },
+        },
+        api: { npm: "@ai-sdk/openai-compatible" },
+        options: {},
+      } as never,
+      usage: stepFinish.usage!,
+      metadata: stepFinish.providerMetadata,
+    })
+    expect(result.cost).toBe(0.0042)
+  })
+
+  test("treats a reported cost of 0 as authoritative (flat-fee subscription route)", async () => {
+    const events = await adapt([
+      {
+        type: "finish-step",
+        response: { id: "chatcmpl-1", timestamp: new Date(0), modelId: "manifest/auto" },
+        finishReason: "stop",
+        rawFinishReason: "stop",
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+          inputTokenDetails: { noCacheTokens: 100, cacheReadTokens: undefined, cacheWriteTokens: undefined },
+          outputTokenDetails: { textTokens: 50, reasoningTokens: undefined },
+          raw: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, cost: 0 },
+        },
+        providerMetadata: { manifest: {} },
+      },
+    ])
+
+    expect(events).toHaveLength(1)
+    const stepFinish = events[0]
+    if (stepFinish.type !== "step-finish") throw new Error("expected step-finish")
+
+    const result = SessionNs.getUsage({
+      model: {
+        id: "manifest/auto",
+        providerID: "manifest",
+        name: "Manifest",
+        limit: { context: 200_000, output: 8_000 },
+        cost: { input: 3, output: 15, cache: { read: 0, write: 0 } },
+        capabilities: {
+          toolcall: true,
+          attachment: false,
+          reasoning: false,
+          temperature: true,
+          input: { text: true, image: false, audio: false, video: false },
+          output: { text: true, image: false, audio: false, video: false },
+        },
+        api: { npm: "@ai-sdk/openai-compatible" },
+        options: {},
+      } as never,
+      usage: stepFinish.usage!,
+      metadata: stepFinish.providerMetadata,
+    })
+    expect(result.cost).toBe(0)
+  })
+
   test("captures Copilot billed usage from raw Anthropic message deltas per step", async () => {
     const events = await adapt([
       uncheckedAdapterEvent({


### PR DESCRIPTION
Closes #43818

### Type of change

- [x] New feature

### What does this PR do?

Gateways (OpenRouter, LiteLLM, Manifest, Kilo) report the real USD cost per request as `usage.cost` on the response. opencode ignores it and instead computes cost from tokens × models.dev catalog rates, so any `auto` router model (`openrouter/auto`, `manifest/auto`, …) — which has no static catalog price — always shows $0.00.

I verified `@ai-sdk/openai-compatible` v2 + `ai` v6 preserve the non-standard `cost` field under `LanguageModelUsage.raw` (an officially-typed raw-usage escape hatch), and that opencode's `usage()` adapter drops `raw` — that is the loss point. This PR:

- adds an optional `cost` (USD) field to the `Usage` schema (`packages/llm`)
- surfaces `usage.raw.cost` through the AI SDK adapter as `cost` (`packages/opencode`)
- prefers a valid reported cost in `getUsage` (including `0` for flat-fee subscription routes), falling back to Copilot `totalNanoAiu`, then catalog rates

### How did you verify your code works?

- Mock OpenAI-compatible server returning `usage.cost`; inspected AI SDK `fullStream` to confirm the field lands in `usage.raw`.
- `bun test packages/opencode/test/session/llm.test.ts` → 31 pass (2 new tests: reported cost wins over a non-zero catalog rate; reported `0` is authoritative).
- `bun run typecheck` (full monorepo) → 30/30 tasks.

### Screenshots / recordings

_n/a_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

**Note on #41933:** that PR implements the same feature against the `v2` branch (`packages/core` / `packages/ai`). This one targets the current default `dev` branch (`packages/opencode` / `packages/llm`) so the fix reaches current users; the two are complementary, not competing.