### PR TITLE
fix: Cannot add project folder that contains a .git directory #43822

### DIFF
--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -1,9 +1,11 @@
 import { useGlobal } from "@/context/global"
+import { useLanguage } from "@/context/language"
 import { type HomeProjectSelection, useLayout } from "@/context/layout"
 import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
 import { useTabs } from "@/context/tabs"
-import { toggleHomeProjectSelection } from "@/pages/layout/helpers"
+import { errorMessage, toggleHomeProjectSelection } from "@/pages/layout/helpers"
+import { showToast } from "@/utils/toast"
 import { createEffect, createMemo } from "solid-js"
 
 export function createHomeController() {
@@ -11,6 +13,7 @@ export function createHomeController() {
   const layout = useLayout()
   const server = useServer()
   const global = useGlobal()
+  const language = useLanguage()
   const tabs = useTabs()
   const selection = layout.home.selection
   const focusedServer = createMemo(
@@ -93,16 +96,24 @@ export function createHomeController() {
         directories.forEach((item) => {
           if (ctx.projects.list().some((project) => project.worktree === item)) return
           const location = { directory: item }
-          void ctx.sdk.api.file
-            .list({ path: ".", location })
-            .then(async (files) => {
-              if (files.data.length > 0) return ctx.sdk.api.project.current({ location })
-              const result = await ctx.sdk.client.project.initGit({ directory: item })
-              return result.data ?? ctx.sdk.api.project.current({ location })
+          ctx.projects.open(item)
+          void ctx.sdk.api.project
+            .current({ location })
+            .then(async (project) => {
+              const files = await ctx.sdk.api.file.list({ path: ".", location }).catch(() => undefined)
+              if (files?.data && files.data.length === 0) {
+                const result = await ctx.sdk.client.project.initGit({ directory: item })
+                return result.data ?? project
+              }
+              return project
             })
             .then((project) => ctx.sync.child(item, { bootstrap: false })[1]("project", project.id))
-            .catch(() => undefined)
-          ctx.projects.open(item)
+            .catch((cause: unknown) => {
+              showToast({
+                title: language.t("common.requestFailed"),
+                description: errorMessage(cause, language.t("common.requestFailed")),
+              })
+            })
         })
         ctx.projects.touch(directory)
         setSelection({ server: ServerConnection.key(conn), directory })

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -93,7 +93,7 @@ const layer = Layer.effect(
     const location = yield* Location.Service
     const source = yield* git.repo.discover(location.project.directory)
     const worktree = source
-      ? AbsolutePath.make(yield* fs.realPath(source.worktree).pipe(Effect.orDie))
+      ? AbsolutePath.make(yield* fs.realPath(source.worktree).pipe(Effect.catch(() => Effect.succeed(source.worktree))))
       : location.project.directory
     const gitDirectory = AbsolutePath.make(path.join(global.data, "snapshot", location.project.id, Hash.fast(worktree)))
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -84,10 +84,7 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
             path: item.path,
             absolute: path.resolve(location.directory, item.path),
             type: item.type,
-            ignored: ignored.ignores(
-              path.relative(location.project.directory, path.resolve(location.directory, item.path)) +
-                (item.type === "directory" ? "/" : ""),
-            ),
+            ignored: ignoredEntry(ignored, location.project.directory, location.directory, item),
           }))
         }),
       )
@@ -137,3 +134,24 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       .handle("status", status)
   }),
 ).pipe(Layer.provide(locationServiceMapLayer))
+
+function ignoredEntry(
+  ignored: ReturnType<typeof ignore>,
+  root: string,
+  directory: string,
+  item: { path: string; type: "file" | "directory" },
+) {
+  const relative =
+    path.relative(root, path.resolve(directory, item.path)).replaceAll("\\", "/") +
+    (item.type === "directory" ? "/" : "")
+  if (
+    !relative ||
+    relative === "." ||
+    relative === ".." ||
+    relative.startsWith("../") ||
+    relative.startsWith("/") ||
+    path.win32.isAbsolute(relative)
+  )
+    return false
+  return ignored.ignores(relative)
+}

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -52,6 +52,13 @@ describe("file HttpApi", () => {
     expect(await status.json()).toEqual([])
   })
 
+  test("lists a git repository that only contains .git", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const list = await request(FilePaths.list, tmp.path, { path: "." })
+    expect(list.status).toBe(200)
+    expect(await list.json()).toContainEqual(expect.objectContaining({ name: ".git", type: "directory" }))
+  })
+
   test("serves search endpoints", async () => {
     await using tmp = await tmpdir({ git: true })
     await Bun.write(path.join(tmp.path, "hello.txt"), "needle")


### PR DESCRIPTION
### Issue for this PR

Closes #43822

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add Project failed on folders that already had a `.git` directory (normal cloned repos). The home add path listed files first, and that listing can throw for git worktrees — especially on Windows, where `ignore()` rejects backslash/absolute relative paths. The error was swallowed, so the project never finished registering and nothing showed in the UI.

Add now calls `project.current` first so the folder is registered even if listing fails. `git init` only runs when the listing succeeds and the folder is actually empty. File listing skips invalid ignore paths instead of throwing. Snapshot boot falls back to the git-reported worktree if `realpath` fails. Failures surface as a toast instead of disappearing.

### How did you verify your code works?

- `bun test test/server/httpapi-file.test.ts` from `packages/opencode` (covers listing a git repo that contains `.git`)
- Manually: Add Project on an existing git repo → project appears; empty non-git folder still gets `git init`

### Screenshots / recordings

_n/a — no visual change besides the project actually appearing and an error toast if add fails_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR