### PR TITLE
fix(app): preserve file search results while loading

### DIFF
--- a/packages/app/src/session/files/session-file-browser-tab.tsx
+++ b/packages/app/src/session/files/session-file-browser-tab.tsx
@@ -1,6 +1,6 @@
 import { createMemo, createUniqueId, Show } from "solid-js"
 import { createStore } from "solid-js/store"
-import { createQuery } from "@tanstack/solid-query"
+import { createQuery, keepPreviousData } from "@tanstack/solid-query"
 import { Icon } from "@opencode/ui/icon"
 import { SessionFilePanelV2, SessionFilePanelV2Empty } from "@opencode/session-ui/v2/session-file-panel-v2"
 import { SessionReviewV2Sidebar } from "@opencode/session-ui/v2/session-review-v2"
@@ -56,6 +56,7 @@ export function SessionFileBrowserTab(props: {
       queryKey: [serverSDK.scope, "session-open-file", workspaceKey(), value] as const,
       enabled: serverSDK.connection.status() === "connected" && value.length > 0,
       queryFn: ({ signal }) => file.searchFiles(value, { limit: 200, signal }),
+      placeholderData: keepPreviousData,
     }
   })
   const files = createMemo(() => {


### PR DESCRIPTION
## Summary
- retain the previous file-search result list while a replacement query is loading
- keep the initial search loading state unchanged
- add regression coverage for swapping results only after the next response resolves

## Testing
- `bun typecheck` in `packages/app`
- `bun run typecheck:e2e` in `packages/app`
- `PLAYWRIGHT_PORT=45272 bunx playwright test e2e/regression/file-browser-sidebar-tab-switch.spec.ts --grep "previous file search results"`
- repository-wide typecheck push hook

## Benchmark
- production review-pane benchmark was attempted before and after; both runs failed before metric collection because the fixture session heading did not render