### PR TITLE
fix(app): show folder names in file tree

### DIFF
--- a/packages/app/e2e/regression/open-file-expand-folder.spec.ts
+++ b/packages/app/e2e/regression/open-file-expand-folder.spec.ts
@@ -60,7 +60,7 @@ test("expands a folder whose path has a trailing Windows separator", async ({ pa
       if (path) return []
       return [
         {
-          name: "frontend",
+          name: "",
           path: "frontend\\",
           absolute: `${directory}/frontend`,
           type: "directory" as const,
@@ -116,6 +116,7 @@ test("expands a folder whose path has a trailing Windows separator", async ({ pa
 
   const frontendRow = panel.locator('[data-slot="file-tree-v2-row"][data-path="frontend"]')
   await expect(frontendRow).toBeVisible()
+  await expect(frontendRow.getByText("frontend", { exact: true })).toBeVisible()
   await expect(frontendRow).toHaveAttribute("aria-expanded", "false")
   await frontendRow.click()
   await expect(frontendRow).toHaveAttribute("aria-expanded", "true")

--- a/packages/app/e2e/regression/review-terminal-stacked.spec.ts
+++ b/packages/app/e2e/regression/review-terminal-stacked.spec.ts
@@ -143,6 +143,7 @@ test("keeps the review tree and terminal sized when both panels are open", async
 
 async function expectTree(page: Page, total: number, file: string) {
   await expectMountedTree(page, total)
+  await expect(page.getByText(".github", { exact: true })).toBeVisible()
   await expect(page.getByRole("button", { name: file })).toBeVisible()
 }
 

--- a/packages/app/e2e/regression/review-terminal-stacked.spec.ts
+++ b/packages/app/e2e/regression/review-terminal-stacked.spec.ts
@@ -143,7 +143,6 @@ test("keeps the review tree and terminal sized when both panels are open", async
 
 async function expectTree(page: Page, total: number, file: string) {
   await expectMountedTree(page, total)
-  await expect(page.getByText(".github", { exact: true })).toBeVisible()
   await expect(page.getByRole("button", { name: file })).toBeVisible()
 }
 

--- a/packages/app/src/session/files/file-tree-v2.tsx
+++ b/packages/app/src/session/files/file-tree-v2.tsx
@@ -100,7 +100,11 @@ const FileTreeNodeV2 = (
     >
       {local.children}
       <span class="flex-1 min-w-0 text-start text-12-medium whitespace-nowrap truncate">
-        <bdi dir="auto">{local.node.name || local.node.path.split("/").at(-1)}</bdi>
+        <bdi dir="auto">
+          {local.node.type === "directory"
+            ? normalizeFileTreeV2Path(local.node.path).split("/").at(-1)
+            : local.node.name}
+        </bdi>
       </span>
       {(() => {
         const value = kind()

--- a/packages/app/src/session/files/file-tree-v2.tsx
+++ b/packages/app/src/session/files/file-tree-v2.tsx
@@ -100,7 +100,7 @@ const FileTreeNodeV2 = (
     >
       {local.children}
       <span class="flex-1 min-w-0 text-start text-12-medium whitespace-nowrap truncate">
-        <bdi dir="auto">{local.node.name}</bdi>
+        <bdi dir="auto">{local.node.name || local.node.path.split("/").at(-1)}</bdi>
       </span>
       {(() => {
         const value = kind()


### PR DESCRIPTION
## Summary

- derive directory labels from normalized paths instead of potentially empty or raw node names
- preserve bidirectional isolation and existing file labels
- cover empty directory names with a trailing Windows separator in the file-tree regression

## Validation

- `bun typecheck` (`packages/app`)
- `bun typecheck:e2e` (`packages/app`)
- `bun test --conditions=solid --preload ./happydom.ts ./src/session/files/file-tree-v2-model.test.ts`
- `PLAYWRIGHT_PORT=43137 bunx playwright test e2e/regression/open-file-expand-folder.spec.ts --reporter=line`
- `PLAYWRIGHT_PORT=43132 bunx playwright test e2e/regression/review-terminal-stacked.spec.ts`

## Benchmark

The production review-pane benchmark was attempted before and after the change. Both runs were blocked before reaching the review pane by the existing session-title fixture timeout, so no comparison metrics were emitted.