### PR TITLE
fix(server): reject requests for missing project directories

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -1,8 +1,10 @@
 import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceStore } from "@/project/instance-store"
 import { Effect, Layer } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
+import { notFound } from "../errors"
 import { WorkspaceRouteContext } from "./workspace-routing"
 
 export class InstanceContextMiddleware extends HttpApiMiddleware.Service<
@@ -23,10 +25,16 @@ function decode(input: string): string {
 function provideInstanceContext<E>(
   effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E>,
   store: InstanceStore.Interface,
+  fs: FSUtil.Interface,
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
+    const directory = decode(route.directory)
+    if (!(yield* fs.isDir(directory))) {
+      return HttpServerResponse.jsonUnsafe(notFound(`Project directory not found: ${directory}`), { status: 404 })
+    }
+
+    const ctx = yield* store.load({ directory })
     return yield* effect.pipe(
       Effect.provideService(InstanceRef, ctx),
       Effect.provideService(WorkspaceRef, route.workspaceID),
@@ -38,6 +46,7 @@ export const instanceContextLayer = Layer.effect(
   InstanceContextMiddleware,
   Effect.gen(function* () {
     const store = yield* InstanceStore.Service
-    return InstanceContextMiddleware.of((effect) => provideInstanceContext(effect, store))
+    const fs = yield* FSUtil.Service
+    return InstanceContextMiddleware.of((effect) => provideInstanceContext(effect, store, fs))
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -30,6 +30,8 @@ function provideInstanceContext<E>(
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
     const directory = decode(route.directory)
+    // Validate the requested directory before loading: load may return a cached context or resolve a missing child
+    // through an ancestor repository.
     if (!(yield* fs.isDir(directory))) {
       return HttpServerResponse.jsonUnsafe(notFound(`Project directory not found: ${directory}`), { status: 404 })
     }

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -288,4 +288,25 @@ describe("instance HttpApi", () => {
       })
     }),
   )
+
+  it.live("rejects cached instance requests after the project directory is deleted", () =>
+    Effect.gen(function* () {
+      const parent = yield* tmpdirScoped({ git: true })
+      const dir = `${parent}/deleted-project`
+      const fs = yield* FileSystem.FileSystem
+      yield* fs.makeDirectory(dir, { recursive: true })
+
+      const initial = yield* HttpClientRequest.get(InstancePaths.path).pipe(directoryHeader(dir), HttpClient.execute)
+      expect(initial.status).toBe(200)
+
+      yield* fs.remove(dir, { recursive: true })
+
+      const response = yield* HttpClientRequest.get(InstancePaths.path).pipe(directoryHeader(dir), HttpClient.execute)
+      expect(response.status).toBe(404)
+      expect(yield* response.json).toEqual({
+        name: "NotFoundError",
+        data: { message: `Project directory not found: ${dir}` },
+      })
+    }),
+  )
 })

--- a/packages/opencode/test/server/httpapi-instance.test.ts
+++ b/packages/opencode/test/server/httpapi-instance.test.ts
@@ -262,4 +262,30 @@ describe("instance HttpApi", () => {
       )
     }),
   )
+
+  it.live("rejects instance requests for missing project directories", () =>
+    Effect.gen(function* () {
+      const parent = yield* tmpdirScoped({ git: true })
+      const dir = `${parent}/deleted-project`
+      const response = yield* HttpClientRequest.get(InstancePaths.path).pipe(directoryHeader(dir), HttpClient.execute)
+
+      expect(response.status).toBe(404)
+      expect(yield* response.json).toEqual({
+        name: "NotFoundError",
+        data: { message: `Project directory not found: ${dir}` },
+      })
+
+      const prompt = yield* HttpClientRequest.post(SessionPaths.promptAsync.replace(":sessionID", "ses_missing")).pipe(
+        directoryHeader(dir),
+        HttpClientRequest.bodyJson({ agent: "build", parts: [{ type: "text", text: "hello" }] }),
+        Effect.flatMap(HttpClient.execute),
+      )
+
+      expect(prompt.status).toBe(404)
+      expect(yield* prompt.json).toEqual({
+        name: "NotFoundError",
+        data: { message: `Project directory not found: ${dir}` },
+      })
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #39471

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a saved project directory has been deleted or moved, the instance HTTP middleware now checks the decoded project directory before loading the instance context.

If the directory is missing, the server returns the declared 404 `NotFoundError` JSON response instead of allowing the request to complete silently without an assistant response. The regression test covers `GET /path` and `POST /session/:sessionID/prompt_async`.

### How did you verify your code works?

- Targeted regression test passed: `bun test test/server/httpapi-instance.test.ts -t "rejects instance requests for missing project directories"` — 1 pass, 0 fail.
- Full repository typecheck passed: `bun run typecheck` — 30 successful tasks.
- The full `httpapi-instance.test.ts` file had one unrelated 5-second timeout in `emits a sync fence header for fixed-workspace mutations`; the new regression test passed.
- Built and manually exercised the desktop dev app.
- `git diff --check` passed.
- Pre-push typecheck passed. Bun 1.4.0 emitted only a version-difference warning against the repository's expected 1.3.14.

### Screenshots

![Online version reproduction](https://github.com/user-attachments/assets/d0ff5c35-0fff-4386-ae94-81fb7da46e7a)

![Fixed version result](https://github.com/user-attachments/assets/53f41ff8-26f7-460d-bae8-c93d42c868b6)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR