### PR TITLE
fix(core): bump session time_updated on execution events

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -213,6 +213,14 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
     yield* InstructionState.initialize(db, event.data.sessionID, event.durable.seq, event.data.instructions)
 })
 
+const bumpTimeUpdated = (db: DatabaseService, sessionID: SessionSchema.ID, created: number) =>
+  db
+    .update(SessionTable)
+    .set({ time_updated: created })
+    .where(eq(SessionTable.id, sessionID))
+    .run()
+    .pipe(Effect.orDie)
+
 function run(db: DatabaseService, event: MessageEvent) {
   return Effect.gen(function* () {
     const decodeRow = (row: typeof SessionMessageTable.$inferSelect) =>
@@ -580,9 +588,27 @@ const layer = Layer.effectDiscard(
         delivery: event.data.delivery,
       }),
     )
-    yield* bus.project(SessionEvent.Execution.Succeeded, (event) => run(db, event))
-    yield* bus.project(SessionEvent.Execution.Failed, (event) => run(db, event))
-    yield* bus.project(SessionEvent.Execution.Interrupted, (event) => run(db, event))
+    yield* bus.project(SessionEvent.Execution.Started, (event) =>
+      bumpTimeUpdated(db, event.data.sessionID, event.created),
+    )
+    yield* bus.project(SessionEvent.Execution.Succeeded, (event) =>
+      Effect.gen(function* () {
+        yield* run(db, event)
+        yield* bumpTimeUpdated(db, event.data.sessionID, event.created)
+      }),
+    )
+    yield* bus.project(SessionEvent.Execution.Failed, (event) =>
+      Effect.gen(function* () {
+        yield* run(db, event)
+        yield* bumpTimeUpdated(db, event.data.sessionID, event.created)
+      }),
+    )
+    yield* bus.project(SessionEvent.Execution.Interrupted, (event) =>
+      Effect.gen(function* () {
+        yield* run(db, event)
+        yield* bumpTimeUpdated(db, event.data.sessionID, event.created)
+      }),
+    )
     yield* bus.project(SessionEvent.InstructionsUpdated, (event) =>
       Effect.gen(function* () {
         yield* run(db, event)

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
 import { DateTime, Effect, Fiber, Option, Schema, Stream } from "effect"
+import * as TestClock from "effect/testing/TestClock"
 import { asc, eq, sql } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { Agent } from "@opencode-ai/core/agent"
@@ -778,6 +779,59 @@ describe("SessionProjector", () => {
           time: { created },
         }),
       ])
+    }),
+  )
+  it.effect("bumps session time_updated on execution lifecycle events", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+          time_updated: 0,
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const bus = yield* Bus.Service
+      const timeUpdated = () =>
+        db
+          .select({ time_updated: SessionTable.time_updated })
+          .from(SessionTable)
+          .where(eq(SessionTable.id, sessionID))
+          .get()
+          .pipe(Effect.orDie)
+
+      // Admitted without any turn yet: recency untouched.
+      expect((yield* timeUpdated())?.time_updated).toBe(0)
+
+      // A turn starts: recency should move forward immediately.
+      yield* TestClock.adjust(1_000)
+      yield* bus.publish(SessionEvent.Execution.Started, { sessionID })
+      const afterStart = yield* timeUpdated()
+      expect(afterStart!.time_updated).toBe(1_000)
+
+      // The turn ends: recency advances again, so an actively worked session
+      // never keeps a stale time_updated while the list sorts by it.
+      yield* TestClock.adjust(1_000)
+      yield* bus.publish(SessionEvent.Execution.Succeeded, { sessionID })
+      const afterEnd = yield* timeUpdated()
+      expect(afterEnd!.time_updated).toBe(2_000)
+
+      // A terminal interrupt (e.g. user cancel) advances recency the same way.
+      yield* TestClock.adjust(1_000)
+      yield* bus.publish(SessionEvent.Execution.Interrupted, { sessionID, reason: "user" })
+      const afterInterrupt = yield* timeUpdated()
+      expect(afterInterrupt!.time_updated).toBe(3_000)
     }),
   )
 })

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -832,6 +832,15 @@ describe("SessionProjector", () => {
       yield* bus.publish(SessionEvent.Execution.Interrupted, { sessionID, reason: "user" })
       const afterInterrupt = yield* timeUpdated()
       expect(afterInterrupt!.time_updated).toBe(3_000)
+
+      // A terminal failure advances recency the same way as the other two terminal handlers.
+      yield* TestClock.adjust(1_000)
+      yield* bus.publish(SessionEvent.Execution.Failed, {
+        sessionID,
+        error: { type: "execution.failed", message: "boom" },
+      })
+      const afterFailed = yield* timeUpdated()
+      expect(afterFailed!.time_updated).toBe(4_000)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #36893

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionTable.time_updated` is only advanced by the projector on session
creation, move, agent/model/title selection, inbox admission, and revert
events. Step and execution lifecycle events project session *messages* but
never touch the session row's `time_updated`. Since `Session.list` sorts by
`time_updated` (`packages/core/src/session.ts`), a session that is actively
streaming a long turn keeps a stale timestamp and drops out of recency
ordering — the most recent activity can appear old in session pickers and the
web app list.

The fix bumps `time_updated` (to the event time) when projecting execution
lifecycle events, which bracket every turn cheaply: `Execution.Started` bumps
immediately when a busy period begins, and `Execution.Succeeded` /
`Execution.Failed` / `Execution.Interrupted` bump after the existing message
projection. A small `bumpTimeUpdated` helper is shared by all four events,
matching the inline update already used for inbox admission.

### How did you verify your code works?

- New regression test `bumps session time_updated on execution lifecycle
  events` covers Started, Succeeded, and Interrupted with TestClock-controlled
  timestamps.
- `bun test test/session-projector.test.ts`: 12 pass / 0 fail.
- Full `packages/core` suite: 1920 pass (1 pre-existing environment flake in
  the mercurial watcher, unrelated to this change).
- `bun run typecheck`: pass.

### Screenshots / recordings

N/A — this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
