### PR TITLE
fix(ai): classify plain stream errors

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -24,12 +24,12 @@ import {
   ProviderMetadata,
   TransportError,
   ToolResultValue,
-  UnknownProviderError,
   type ContentPart,
   type LLMRequest,
   type ToolDefinition,
   type UsageInput,
 } from "@opencode/ai"
+import { classifyProviderFailure } from "@opencode/ai/provider-error"
 import { Auth, Endpoint, RequestExecutor, type AnyRoute } from "@opencode/ai/route"
 import { ProviderShared } from "@opencode/ai/protocols/shared"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
@@ -833,9 +833,9 @@ function llmError(error: unknown, operation: "request" | "read") {
       }),
     })
   return new AIError({
-    reason: new UnknownProviderError({
+    reason: classifyProviderFailure({
       message: unknownErrorMessage(error),
-      body: errorBody(error),
+      rawBody: errorBody(error),
       cause: error,
     }),
   })

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -853,6 +853,16 @@ it.effect("preserves existing AI errors and their retry semantics unchanged", ()
   }),
 )
 
+it.effect("classifies plain AI SDK capacity errors for retry", () =>
+  Effect.gen(function* () {
+    const message = "The model is currently at capacity due to high demand. Please try again in a few minutes."
+    const error = yield* streamFailure(new Error(message))
+
+    expect(error.reason).toMatchObject({ _tag: "ProviderInternal", message })
+    expect(SessionRunnerRetry.isRetryable(error)).toBeTrue()
+  }),
+)
+
 const apiCallError = (input: Partial<ConstructorParameters<typeof APICallError>[0]>) =>
   new APICallError({
     message: "",


### PR DESCRIPTION
### Issue for this PR

Closes #43791 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plain errors from AI SDK streams skipped the shared provider-failure classifier, so transient capacity failures became non-retryable `UnknownProvider` errors.

This routes plain stream errors through `classifyProviderFailure`, recognizes transient capacity messages, and keeps unknown messages classified as `UnknownProvider`.

### How did you verify your code works?

- Added regression coverage for capacity-message classification and the AI SDK retry path
- Verified the changed entry points with `bun build`
- Ran Prettier and `git diff --check`

The full package tests could not be run locally because the currently pinned prerelease dependencies (`effect@4.0.0-rc.110` and OpenTUI `0.5.6`) were unavailable from the registry.

### Screenshots / recordings

Not applicable — this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR