### PR TITLE
fix(session): retry transient TLS handshake and certificate verificat…

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -35,6 +35,7 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   /rate increased too quickly|rate limit|rate-limit|rate_limit|too many requests/i,
   /overloaded|service unavailable|service_unavailable|service-unavailable|internal error|internal_error|internal server error|server error|server_error|server-error|provider returned error|provider_returned_error|provider-returned-error/i,
   /terminated|fetch failed|failed to fetch|network[-_\s]error|upstream connect|connection error|connection refused|connection lost|socket connection was closed|socket hang up|reset before headers|getaddrinfo|enotfound|eai_again|econnrefused|econnreset|etimedout/i,
+  /certificate verif|unable to verify|tls handshake|handshake failed|ssl error|connection closed during handshake/i,
   /^timeout$|\b(?:request|response|connection|network|stream|read) (?:timeout|timed out|time out)\b/i,
   /try your request again|retry your request|resource exhausted|resource_exhausted/i,
   /\btry again (?:later|in\b)|\b(?:currently|temporarily) at capacity\b/i,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -222,6 +222,10 @@ describe("session.retry.retryable", () => {
     "The model is currently at capacity due to high demand",
     "The service is temporarily at capacity",
     "upstream returned status 524",
+    "Error: unknown certificate verification error",
+    "unable to verify the first certificate",
+    "TLS handshake failed",
+    "connection closed during handshake",
   ])("retries matching API error text: %s", (message) => {
     expect(SessionRetry.retryable(wrap(message), retryProvider)).toEqual({ message })
   })


### PR DESCRIPTION
### Issue for this PR

Closes #43864

### Type of change

- [x] Bug fix

### What does this PR do?

Bun raises `unknown certificate verification error` when the TCP connection to a
provider is reset mid-handshake. This is a transient transport failure, but none of
the existing `RETRYABLE_MESSAGE_PATTERNS` in `packages/opencode/src/session/retry.ts`
matched it, so opencode aborted the run instead of retrying.

I hit this repeatedly against one provider on a lossy route (~45 occurrences in two
weeks). This PR adds one pattern line covering TLS handshake / certificate
verification messages (`certificate verif`, `tls handshake`, `handshake failed`,
`ssl error`, `connection closed during handshake`, `unable to verify`), placing them
alongside the existing transport errors (`econnreset`, `socket hang up`, etc.), plus
4 test cases using the exact message strings Bun and Node emit.

### How did you verify your code works?

`bun test test/session/retry.test.ts` — 64 pass, including the 4 new cases
("Error: unknown certificate verification error", "unable to verify the first
certificate", "TLS handshake failed", "connection closed during handshake").
Full `bun test test/session/` suite passes (414 tests). Also verified a locally
built binary picks up the pattern.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR