### PR TITLE
docs(go): add DeepSeek vision model

### DIFF
--- a/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
@@ -356,9 +356,11 @@ export function LiteSection(props: { lite: LiteSubscription | undefined }) {
             <li>Qwen3.6 Plus</li>
             <li>DeepSeek V4 Pro</li>
             <li>DeepSeek V4 Flash</li>
+            <li>DeepSeek V4 Flash Vision Exp</li>
             <li>MiMo-V2.5</li>
             <li>MiMo-V2.5-Pro</li>
             <li>Hy3</li>
+            <li>Ox Alpha Free</li>
           </ul>
           <p data-slot="promo-description">{i18n.t("workspace.lite.promo.footer")}</p>
           <div data-slot="subscribe-actions">

--- a/packages/web/src/content/docs/ar/go.mdx
+++ b/packages/web/src/content/docs/ar/go.mdx
@@ -68,6 +68,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (لفترة محدودة)
 
@@ -108,6 +109,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | Qwen3.6 Plus               | 3,300               | 8,200              | 16,300           |
 | DeepSeek V4 Pro            | 1,050               | 2,600              | 5,200            |
 | DeepSeek V4 Flash          | 7,600               | 18,900             | 37,800           |
+| DeepSeek V4 Flash Vision Exp | 3,800               | 9,450              | 18,900           |
 | Hy3                        | 4,300               | 10,750             | 21,500           |
 | Ox Alpha Free              | -                   | -                  | -                |
 
@@ -120,6 +122,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 - Kimi K2.7/K2.6 — ‏870 input، و55,000 cached، و200 output tokens لكل طلب
 - DeepSeek V4 Pro — ‏750 input، و82,000 cached، و290 output tokens لكل طلب
 - DeepSeek V4 Flash — ‏410 input، و71,300 cached، و310 output tokens لكل طلب
+- DeepSeek V4 Flash Vision Exp — ‏410 input، و71,300 cached، و310 output tokens لكل طلب
 - MiniMax M3 — ‏510 input، و56,000 cached، و190 output tokens لكل طلب
 - MiniMax M2.7 — ‏300 input، و55,000 cached، و125 output tokens لكل طلب
 - Muse Spark 1.2 Contributor — ‏620 input، و71,400 cached، و300 output tokens لكل طلب
@@ -160,10 +163,14 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | DeepSeek V4 Pro (Peak)       | $1.32   | $3.96   | $0.044          | -               | $15       |
 | DeepSeek V4 Flash (Off-Peak) | $0.22   | $0.66   | $0.007          | -               | $30       |
 | DeepSeek V4 Flash (Peak)     | $0.44   | $1.32   | $0.014          | -               | $30       |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22   | $0.66   | $0.007          | -               | $15       |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44   | $1.32   | $0.014          | -               | $15       |
 | Hy3                          | $0.14   | $0.58   | $0.035          | -               | $60       |
 | Ox Alpha Free                | -       | -       | -               | -               | -         |
 
-**DeepSeek V4 Flash / Pro:** ساعات Peak هي 01:00-04:00 و06:00-10:00 UTC؛ وجميع الساعات الأخرى Off-Peak. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ساعات Peak هي 01:00-04:00 و06:00-10:00 UTC؛ وجميع الساعات الأخرى Off-Peak. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** يتم تحويل الصور إلى رموز بناءً على أبعادها، وتُحتسب كرموز إدخال إلى جانب رموز النص. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** مجاني لفترة محدودة.
 
@@ -211,6 +218,7 @@ OpenCode Go هو اشتراك منخفض التكلفة — **$5 للشهر ال
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | نعم           | ليست ZDR           |
 | DeepSeek V4 Pro            | غير مستخدَمة  | 0 أيام             |
 | DeepSeek V4 Flash          | غير مستخدَمة  | 0 أيام             |
+| DeepSeek V4 Flash Vision Exp | غير مستخدَمة  | 0 أيام             |
 | Hy3                        | غير مستخدَمة  | 0 أيام             |
 | Ox Alpha Free              | غير مستخدَمة  | 0 أيام             |
 

--- a/packages/web/src/content/docs/bs/go.mdx
+++ b/packages/web/src/content/docs/bs/go.mdx
@@ -78,6 +78,7 @@ Trenutna lista modela uključuje:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (ograničeno vrijeme)
 
@@ -118,6 +119,7 @@ Tabela ispod pruža procijenjeni broj zahtjeva na osnovu tipičnih obrazaca kori
 | Qwen3.6 Plus               | 3,300              | 8,200             | 16,300            |
 | DeepSeek V4 Pro            | 1,050              | 2,600             | 5,200             |
 | DeepSeek V4 Flash          | 7,600              | 18,900            | 37,800            |
+| DeepSeek V4 Flash Vision Exp | 3,800              | 9,450             | 18,900            |
 | Hy3                        | 4,300              | 10,750            | 21,500            |
 | Ox Alpha Free              | -                  | -                 | -                 |
 
@@ -130,6 +132,7 @@ Procjene se zasnivaju na zapaženim obrascima zahtjeva:
 - Kimi K2.7/K2.6 — 870 ulaznih, 55,000 keširanih, 200 izlaznih tokena po zahtjevu
 - DeepSeek V4 Pro — 750 ulaznih, 82,000 keširanih, 290 izlaznih tokena po zahtjevu
 - DeepSeek V4 Flash — 410 ulaznih, 71,300 keširanih, 310 izlaznih tokena po zahtjevu
+- DeepSeek V4 Flash Vision Exp — 410 ulaznih, 71,300 keširanih, 310 izlaznih tokena po zahtjevu
 - MiniMax M3 — 510 ulaznih, 56,000 keširanih, 190 izlaznih tokena po zahtjevu
 - MiniMax M2.7 — 300 ulaznih, 55,000 keširanih, 125 izlaznih tokena po zahtjevu
 - Muse Spark 1.2 Contributor — 620 ulaznih, 71,400 keširanih, 300 izlaznih tokena po zahtjevu
@@ -170,10 +173,14 @@ Procjene se također zasnivaju na sljedećim cijenama po 1M tokena i mjesečnoj 
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15       |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30       |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30       |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15       |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15       |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60       |
 | Ox Alpha Free                | -      | -      | -           | -            | -         |
 
-**DeepSeek V4 Flash / Pro:** Peak sati su 01:00-04:00 i 06:00-10:00 UTC; svi ostali sati su Off-Peak. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak sati su 01:00-04:00 i 06:00-10:00 UTC; svi ostali sati su Off-Peak. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Slike se pretvaraju u tokene na osnovu svojih dimenzija i naplaćuju kao ulazni tokeni zajedno s tekstualnim tokenima. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Besplatan ograničeno vrijeme.
 
@@ -223,6 +230,7 @@ Također možete pristupiti Go modelima putem sljedećih API endpointa.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Da                | Nije ZDR             |
 | DeepSeek V4 Pro            | Ne koristi se     | 0 dana               |
 | DeepSeek V4 Flash          | Ne koristi se     | 0 dana               |
+| DeepSeek V4 Flash Vision Exp | Ne koristi se     | 0 dana               |
 | Hy3                        | Ne koristi se     | 0 dana               |
 | Ox Alpha Free              | Ne koristi se     | 0 dana               |
 

--- a/packages/web/src/content/docs/da/go.mdx
+++ b/packages/web/src/content/docs/da/go.mdx
@@ -78,6 +78,7 @@ Den nuværende liste over modeller inkluderer:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (i en begrænset periode)
 
@@ -118,6 +119,7 @@ Tabellen nedenfor giver et estimeret antal anmodninger baseret på typiske Go-fo
 | Qwen3.6 Plus               | 3,300                   | 8,200               | 16,300                |
 | DeepSeek V4 Pro            | 1,050                   | 2,600               | 5,200                 |
 | DeepSeek V4 Flash          | 7,600                   | 18,900              | 37,800                |
+| DeepSeek V4 Flash Vision Exp | 3,800                   | 9,450               | 18,900                |
 | Hy3                        | 4,300                   | 10,750              | 21,500                |
 | Ox Alpha Free              | -                       | -                   | -                     |
 
@@ -130,6 +132,7 @@ Estimaterne er baseret på observerede anmodningsmønstre:
 - Kimi K2.7/K2.6 — 870 input, 55.000 cachelagrede, 200 output-tokens pr. anmodning
 - DeepSeek V4 Pro — 750 input, 82.000 cachelagrede, 290 output-tokens pr. anmodning
 - DeepSeek V4 Flash — 410 input, 71.300 cachelagrede, 310 output-tokens pr. anmodning
+- DeepSeek V4 Flash Vision Exp — 410 input, 71.300 cachelagrede, 310 output-tokens pr. anmodning
 - MiniMax M3 — 510 input, 56.000 cachelagrede, 190 output-tokens pr. anmodning
 - MiniMax M2.7 — 300 input, 55.000 cachelagrede, 125 output-tokens pr. anmodning
 - Muse Spark 1.2 Contributor — 620 input, 71.400 cachelagrede, 300 output-tokens pr. anmodning
@@ -170,10 +173,14 @@ Estimaterne er også baseret på følgende priser pr. 1M tokens og det månedlig
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15     |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30     |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30     |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15     |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15     |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60     |
 | Ox Alpha Free                | -      | -      | -           | -            | -       |
 
-**DeepSeek V4 Flash / Pro:** Peak-tiderne er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tiderne er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Billeder konverteres til tokens baseret på deres dimensioner og afregnes som inputtokens sammen med teksttokens. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratis i en begrænset periode.
 
@@ -223,6 +230,7 @@ Du kan også få adgang til Go-modeller gennem følgende API-endpoints.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Ja           | Ikke ZDR       |
 | DeepSeek V4 Pro            | Ikke brugt   | 0 dage         |
 | DeepSeek V4 Flash          | Ikke brugt   | 0 dage         |
+| DeepSeek V4 Flash Vision Exp | Ikke brugt   | 0 dage         |
 | Hy3                        | Ikke brugt   | 0 dage         |
 | Ox Alpha Free              | Ikke brugt   | 0 dage         |
 

--- a/packages/web/src/content/docs/de/go.mdx
+++ b/packages/web/src/content/docs/de/go.mdx
@@ -70,6 +70,7 @@ Die aktuelle Liste der Modelle umfasst:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (für begrenzte Zeit)
 
@@ -110,6 +111,7 @@ Die folgende Tabelle zeigt eine geschätzte Anzahl von Anfragen basierend auf ty
 | Qwen3.6 Plus               | 3,300                  | 8,200              | 16,300             |
 | DeepSeek V4 Pro            | 1,050                  | 2,600              | 5,200              |
 | DeepSeek V4 Flash          | 7,600                  | 18,900             | 37,800             |
+| DeepSeek V4 Flash Vision Exp | 3,800                  | 9,450              | 18,900             |
 | Hy3                        | 4,300                  | 10,750             | 21,500             |
 | Ox Alpha Free              | -                      | -                  | -                  |
 
@@ -122,6 +124,7 @@ Die Schätzungen basieren auf beobachteten Anfragemustern:
 - Kimi K2.7/K2.6 — 870 Input-, 55.000 Cached-, 200 Output-Tokens pro Anfrage
 - DeepSeek V4 Pro — 750 Input-, 82.000 Cached-, 290 Output-Tokens pro Anfrage
 - DeepSeek V4 Flash — 410 Input-, 71.300 Cached-, 310 Output-Tokens pro Anfrage
+- DeepSeek V4 Flash Vision Exp — 410 Input-, 71.300 Cached-, 310 Output-Tokens pro Anfrage
 - MiniMax M3 — 510 Input-, 56.000 Cached-, 190 Output-Tokens pro Anfrage
 - MiniMax M2.7 — 300 Input-, 55.000 Cached-, 125 Output-Tokens pro Anfrage
 - Muse Spark 1.2 Contributor — 620 Input-, 71.400 Cached-, 300 Output-Tokens pro Anfrage
@@ -162,10 +165,14 @@ Die Schätzungen basieren außerdem auf den folgenden Preisen pro 1M Tokens und 
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15     |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30     |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30     |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15     |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15     |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60     |
 | Ox Alpha Free                | -      | -      | -           | -            | -       |
 
-**DeepSeek V4 Flash / Pro:** Die Peak-Zeiten sind 01:00-04:00 und 06:00-10:00 UTC; alle anderen Zeiten sind Off-Peak. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Die Peak-Zeiten sind 01:00-04:00 und 06:00-10:00 UTC; alle anderen Zeiten sind Off-Peak. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Bilder werden anhand ihrer Abmessungen in Tokens umgewandelt und zusammen mit Text-Tokens als Input-Tokens abgerechnet. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Für begrenzte Zeit kostenlos.
 
@@ -213,6 +220,7 @@ Du kannst auf die Go-Modelle auch über die folgenden API-Endpunkte zugreifen.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -263,6 +271,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Ja              | Kein ZDR          |
 | DeepSeek V4 Pro            | Nicht verwendet | 0 Tage            |
 | DeepSeek V4 Flash          | Nicht verwendet | 0 Tage            |
+| DeepSeek V4 Flash Vision Exp | Nicht verwendet | 0 Tage            |
 | Hy3                        | Nicht verwendet | 0 Tage            |
 | Ox Alpha Free              | Nicht verwendet | 0 Tage            |
 

--- a/packages/web/src/content/docs/es/go.mdx
+++ b/packages/web/src/content/docs/es/go.mdx
@@ -78,6 +78,7 @@ La lista actual de modelos incluye:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (por tiempo limitado)
 
@@ -118,6 +119,7 @@ La siguiente tabla proporciona una cantidad estimada de peticiones basada en los
 | Qwen3.6 Plus               | 3,300                  | 8,200                 | 16,300             |
 | DeepSeek V4 Pro            | 1,050                  | 2,600                 | 5,200              |
 | DeepSeek V4 Flash          | 7,600                  | 18,900                | 37,800             |
+| DeepSeek V4 Flash Vision Exp | 3,800                  | 9,450                 | 18,900             |
 | Hy3                        | 4,300                  | 10,750                | 21,500             |
 | Ox Alpha Free              | -                      | -                     | -                  |
 
@@ -130,6 +132,7 @@ Las estimaciones se basan en los patrones de peticiones observados:
 - Kimi K2.7/K2.6 — 870 tokens de entrada, 55,000 en caché, 200 tokens de salida por petición
 - DeepSeek V4 Pro — 750 tokens de entrada, 82,000 en caché, 290 tokens de salida por petición
 - DeepSeek V4 Flash — 410 tokens de entrada, 71,300 en caché, 310 tokens de salida por petición
+- DeepSeek V4 Flash Vision Exp — 410 tokens de entrada, 71,300 en caché, 310 tokens de salida por petición
 - MiniMax M3 — 510 tokens de entrada, 56,000 en caché, 190 tokens de salida por petición
 - MiniMax M2.7 — 300 tokens de entrada, 55,000 en caché, 125 tokens de salida por petición
 - Muse Spark 1.2 Contributor — 620 tokens de entrada, 71,400 en caché, 300 tokens de salida por petición
@@ -170,10 +173,14 @@ Las estimaciones también se basan en los siguientes precios por 1M tokens y en 
 | DeepSeek V4 Pro (Peak)       | $1.32   | $3.96  | $0.044           | -                  | $15 |
 | DeepSeek V4 Flash (Off-Peak) | $0.22   | $0.66  | $0.007           | -                  | $30 |
 | DeepSeek V4 Flash (Peak)     | $0.44   | $1.32  | $0.014           | -                  | $30 |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22   | $0.66  | $0.007           | -                  | $15 |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44   | $1.32  | $0.014           | -                  | $15 |
 | Hy3                          | $0.14   | $0.58  | $0.035           | -                  | $60 |
 | Ox Alpha Free                | -       | -      | -                | -                  | -   |
 
-**DeepSeek V4 Flash / Pro:** Las horas Peak son 01:00-04:00 y 06:00-10:00 UTC; todas las demás horas son Off-Peak. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Las horas Peak son 01:00-04:00 y 06:00-10:00 UTC; todas las demás horas son Off-Peak. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Las imágenes se convierten en tokens según sus dimensiones y se facturan como tokens de entrada junto con los tokens de texto. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratis por tiempo limitado.
 
@@ -223,6 +230,7 @@ También puedes acceder a los modelos de Go a través de los siguientes endpoint
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Sí                       | Sin ZDR            |
 | DeepSeek V4 Pro            | No utilizado             | 0 días             |
 | DeepSeek V4 Flash          | No utilizado             | 0 días             |
+| DeepSeek V4 Flash Vision Exp | No utilizado             | 0 días             |
 | Hy3                        | No utilizado             | 0 días             |
 | Ox Alpha Free              | No utilizado             | 0 días             |
 

--- a/packages/web/src/content/docs/fr/go.mdx
+++ b/packages/web/src/content/docs/fr/go.mdx
@@ -68,6 +68,7 @@ La liste actuelle des modèles comprend :
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (pour une durée limitée)
 
@@ -108,6 +109,7 @@ Le tableau ci-dessous fournit une estimation du nombre de requêtes basée sur d
 | Qwen3.6 Plus               | 3,300                 | 8,200                | 16,300            |
 | DeepSeek V4 Pro            | 1,050                 | 2,600                | 5,200             |
 | DeepSeek V4 Flash          | 7,600                 | 18,900               | 37,800            |
+| DeepSeek V4 Flash Vision Exp | 3,800                 | 9,450                | 18,900            |
 | Hy3                        | 4,300                 | 10,750               | 21,500            |
 | Ox Alpha Free              | -                     | -                    | -                 |
 
@@ -120,6 +122,7 @@ Les estimations sont basées sur les schémas de requêtes observés :
 - Kimi K2.7/K2.6 — 870 tokens en entrée, 55,000 en cache, 200 tokens en sortie par requête
 - DeepSeek V4 Pro — 750 tokens en entrée, 82,000 en cache, 290 tokens en sortie par requête
 - DeepSeek V4 Flash — 410 tokens en entrée, 71,300 en cache, 310 tokens en sortie par requête
+- DeepSeek V4 Flash Vision Exp — 410 tokens en entrée, 71,300 en cache, 310 tokens en sortie par requête
 - MiniMax M3 — 510 tokens en entrée, 56,000 en cache, 190 tokens en sortie par requête
 - MiniMax M2.7 — 300 tokens en entrée, 55,000 en cache, 125 tokens en sortie par requête
 - Muse Spark 1.2 Contributor — 620 tokens en entrée, 71,400 en cache, 300 tokens en sortie par requête
@@ -160,10 +163,14 @@ Les estimations sont également basées sur les prix suivants par 1M tokens et s
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15         |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30         |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30         |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15         |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15         |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60         |
 | Ox Alpha Free                | -      | -      | -           | -            | -           |
 
-**DeepSeek V4 Flash / Pro:** Les heures Peak sont 01:00-04:00 et 06:00-10:00 UTC ; toutes les autres heures sont Off-Peak. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Les heures Peak sont 01:00-04:00 et 06:00-10:00 UTC ; toutes les autres heures sont Off-Peak. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Les images sont converties en tokens selon leurs dimensions et facturées comme tokens d’entrée avec les tokens de texte. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratuit pour une durée limitée.
 
@@ -211,6 +218,7 @@ Vous pouvez également accéder aux modèles Go via les points de terminaison d'
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Oui                      | Pas de ZDR               |
 | DeepSeek V4 Pro            | Non utilisé              | 0 jour                   |
 | DeepSeek V4 Flash          | Non utilisé              | 0 jour                   |
+| DeepSeek V4 Flash Vision Exp | Non utilisé              | 0 jour                   |
 | Hy3                        | Non utilisé              | 0 jour                   |
 | Ox Alpha Free              | Non utilisé              | 0 jour                   |
 

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -78,6 +78,7 @@ The current list of models includes:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (limited time)
 
@@ -118,6 +119,7 @@ The table below provides an estimated request count based on typical Go usage pa
 | Qwen3.6 Plus               | 3,300               | 8,200             | 16,300             |
 | DeepSeek V4 Pro            | 1,050               | 2,600             | 5,200              |
 | DeepSeek V4 Flash          | 7,600               | 18,900            | 37,800             |
+| DeepSeek V4 Flash Vision Exp | 3,800               | 9,450             | 18,900             |
 | Hy3                        | 4,300               | 10,750            | 21,500             |
 | Ox Alpha Free              | -                   | -                 | -                  |
 
@@ -130,6 +132,7 @@ The estimates are based on observed request patterns:
 - Kimi K2.7/K2.6 — 870 input, 55,000 cached, 200 output tokens per request
 - DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens per request
 - DeepSeek V4 Flash — 410 input, 71,300 cached, 310 output tokens per request
+- DeepSeek V4 Flash Vision Exp — 410 input, 71,300 cached, 310 output tokens per request
 - MiniMax M3 — 510 input, 56,000 cached, 190 output tokens per request
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens per request
 - Muse Spark 1.2 Contributor — 620 input, 71,400 cached, 300 output tokens per request
@@ -170,10 +173,14 @@ The estimates are also based on the following prices per 1M tokens and the month
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15   |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30   |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30   |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15   |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15   |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / Pro:** Peak hours are 01:00-04:00 and 06:00-10:00 UTC; all other hours are Off-Peak. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak hours are 01:00-04:00 and 06:00-10:00 UTC; all other hours are Off-Peak. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Images are converted into tokens based on their dimensions and billed as input tokens alongside text tokens. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Free for a limited time.
 
@@ -223,6 +230,7 @@ You can also access Go models through the following API endpoints.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Yes            | Not ZDR        |
 | DeepSeek V4 Pro            | Not used       | 0 days\*       |
 | DeepSeek V4 Flash          | Not used       | 0 days\*       |
+| DeepSeek V4 Flash Vision Exp | Not used       | 0 days\*       |
 | Hy3                        | Not used       | 0 days         |
 | Ox Alpha Free              | Not used       | 0 days         |
 

--- a/packages/web/src/content/docs/it/go.mdx
+++ b/packages/web/src/content/docs/it/go.mdx
@@ -76,6 +76,7 @@ L'elenco attuale dei modelli include:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (per un periodo limitato)
 
@@ -116,6 +117,7 @@ La tabella seguente fornisce una stima del conteggio delle richieste in base a p
 | Qwen3.6 Plus               | 3,300                | 8,200                 | 16,300            |
 | DeepSeek V4 Pro            | 1,050                | 2,600                 | 5,200             |
 | DeepSeek V4 Flash          | 7,600                | 18,900                | 37,800            |
+| DeepSeek V4 Flash Vision Exp | 3,800                | 9,450                 | 18,900            |
 | Hy3                        | 4,300                | 10,750                | 21,500            |
 | Ox Alpha Free              | -                    | -                     | -                 |
 
@@ -128,6 +130,7 @@ Le stime si basano sui pattern di richieste osservati:
 - Kimi K2.7/K2.6 — 870 di input, 55.000 in cache, 200 token di output per richiesta
 - DeepSeek V4 Pro — 750 di input, 82.000 in cache, 290 token di output per richiesta
 - DeepSeek V4 Flash — 410 di input, 71.300 in cache, 310 token di output per richiesta
+- DeepSeek V4 Flash Vision Exp — 410 di input, 71.300 in cache, 310 token di output per richiesta
 - MiniMax M3 — 510 di input, 56.000 in cache, 190 token di output per richiesta
 - MiniMax M2.7 — 300 di input, 55.000 in cache, 125 token di output per richiesta
 - Muse Spark 1.2 Contributor — 620 di input, 71.400 in cache, 300 token di output per richiesta
@@ -168,10 +171,14 @@ Le stime si basano anche sui seguenti prezzi per 1M token e sull'utilizzo mensil
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15      |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30      |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30      |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15      |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15      |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60      |
 | Ox Alpha Free                | -      | -      | -           | -            | -        |
 
-**DeepSeek V4 Flash / Pro:** Gli orari Peak sono 01:00-04:00 e 06:00-10:00 UTC; tutti gli altri orari sono Off-Peak. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Gli orari Peak sono 01:00-04:00 e 06:00-10:00 UTC; tutti gli altri orari sono Off-Peak. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Le immagini vengono convertite in token in base alle loro dimensioni e fatturate come token di input insieme ai token di testo. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratis per un periodo limitato.
 
@@ -221,6 +228,7 @@ Puoi anche accedere ai modelli Go tramite i seguenti endpoint API.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -273,6 +281,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Sì                        | Non ZDR                |
 | DeepSeek V4 Pro            | Non utilizzato            | 0 giorni               |
 | DeepSeek V4 Flash          | Non utilizzato            | 0 giorni               |
+| DeepSeek V4 Flash Vision Exp | Non utilizzato            | 0 giorni               |
 | Hy3                        | Non utilizzato            | 0 giorni               |
 | Ox Alpha Free              | Non utilizzato            | 0 giorni               |
 

--- a/packages/web/src/content/docs/ja/go.mdx
+++ b/packages/web/src/content/docs/ja/go.mdx
@@ -68,6 +68,7 @@ OpenCode Goをサブスクライブできるのは、1つのワークスペー�
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (期間限定)
 
@@ -108,6 +109,7 @@ OpenCode Goには以下の制限が含まれています：
 | Qwen3.6 Plus               | 3,300                     | 8,200            | 16,300           |
 | DeepSeek V4 Pro            | 1,050                     | 2,600            | 5,200            |
 | DeepSeek V4 Flash          | 7,600                     | 18,900           | 37,800           |
+| DeepSeek V4 Flash Vision Exp | 3,800                     | 9,450            | 18,900           |
 | Hy3                        | 4,300                     | 10,750           | 21,500           |
 | Ox Alpha Free              | -                         | -                | -                |
 
@@ -120,6 +122,7 @@ OpenCode Goには以下の制限が含まれています：
 - Kimi K2.7/K2.6 — リクエストあたり 入力 870トークン、キャッシュ 55,000トークン、出力 200トークン
 - DeepSeek V4 Pro — リクエストあたり 入力 750トークン、キャッシュ 82,000トークン、出力 290トークン
 - DeepSeek V4 Flash — リクエストあたり 入力 410トークン、キャッシュ 71,300トークン、出力 310トークン
+- DeepSeek V4 Flash Vision Exp — リクエストあたり 入力 410トークン、キャッシュ 71,300トークン、出力 310トークン
 - MiniMax M3 — リクエストあたり 入力 510トークン、キャッシュ 56,000トークン、出力 190トークン
 - MiniMax M2.7 — リクエストあたり 入力 300トークン、キャッシュ 55,000トークン、出力 125トークン
 - Muse Spark 1.2 Contributor — リクエストあたり 入力 620トークン、キャッシュ 71,400トークン、出力 300トークン
@@ -160,10 +163,14 @@ OpenCode Goには以下の制限が含まれています：
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15   |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30   |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30   |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15   |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15   |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / Pro:** Peak時間は01:00-04:00と06:00-10:00 UTCで、それ以外の時間はすべてOff-Peakです。[詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak時間は01:00-04:00と06:00-10:00 UTCで、それ以外の時間はすべてOff-Peakです。[詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
+
+**DeepSeek V4 Flash Vision Exp:** 画像はサイズに基づいてトークンに変換され、テキストトークンと合わせて入力トークンとして課金されます。 [詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **Ox Alpha Free:** 期間限定で無料です。
 
@@ -211,6 +218,7 @@ Goでは月額$10を支払い、その6倍の利用枠を提供することを�
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | はい                 | ZDRではない |
 | DeepSeek V4 Pro            | 使用なし             | 0日         |
 | DeepSeek V4 Flash          | 使用なし             | 0日         |
+| DeepSeek V4 Flash Vision Exp | 使用なし                 | 0日          |
 | Hy3                        | 使用なし             | 0日         |
 | Ox Alpha Free              | 使用なし             | 0日         |
 

--- a/packages/web/src/content/docs/ko/go.mdx
+++ b/packages/web/src/content/docs/ko/go.mdx
@@ -68,6 +68,7 @@ workspace당 한 명의 멤버만 OpenCode Go를 구독할 수 있습니다.
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (한정된 기간)
 
@@ -108,6 +109,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | Qwen3.6 Plus               | 3,300             | 8,200          | 16,300         |
 | DeepSeek V4 Pro            | 1,050             | 2,600          | 5,200          |
 | DeepSeek V4 Flash          | 7,600             | 18,900         | 37,800         |
+| DeepSeek V4 Flash Vision Exp | 3,800             | 9,450          | 18,900         |
 | Hy3                        | 4,300             | 10,750         | 21,500         |
 | Ox Alpha Free              | -                 | -              | -              |
 
@@ -120,6 +122,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 - Kimi K2.7/K2.6 — 요청당 입력 870, 캐시 55,000, 출력 토큰 200
 - DeepSeek V4 Pro — 요청당 입력 750, 캐시 82,000, 출력 토큰 290
 - DeepSeek V4 Flash — 요청당 입력 410, 캐시 71,300, 출력 토큰 310
+- DeepSeek V4 Flash Vision Exp — 요청당 입력 410, 캐시 71,300, 출력 토큰 310
 - MiniMax M3 — 요청당 입력 510, 캐시 56,000, 출력 토큰 190
 - MiniMax M2.7 — 요청당 입력 300, 캐시 55,000, 출력 토큰 125
 - Muse Spark 1.2 Contributor — 요청당 입력 620, 캐시 71,400, 출력 토큰 300
@@ -160,10 +163,14 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15   |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30   |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30   |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15   |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15   |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / Pro:** Peak 시간은 01:00-04:00 및 06:00-10:00 UTC이며, 그 외 모든 시간은 Off-Peak입니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 시간은 01:00-04:00 및 06:00-10:00 UTC이며, 그 외 모든 시간은 Off-Peak입니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** 이미지는 크기에 따라 토큰으로 변환되며 텍스트 토큰과 함께 입력 토큰으로 청구됩니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** 한정된 기간 동안 무료입니다.
 
@@ -211,6 +218,7 @@ Go에서는 월 $10를 지불하며, 저희는 그 6배의 사용량을 제공�
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | 예            | ZDR 아님    |
 | DeepSeek V4 Pro            | 사용되지 않음 | 0일         |
 | DeepSeek V4 Flash          | 사용되지 않음 | 0일         |
+| DeepSeek V4 Flash Vision Exp | 사용되지 않음       | 0일          |
 | Hy3                        | 사용되지 않음 | 0일         |
 | Ox Alpha Free              | 사용되지 않음 | 0일         |
 

--- a/packages/web/src/content/docs/nb/go.mdx
+++ b/packages/web/src/content/docs/nb/go.mdx
@@ -78,6 +78,7 @@ Den nåværende listen over modeller inkluderer:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (i en begrenset periode)
 
@@ -118,6 +119,7 @@ Tabellen nedenfor gir et estimert antall forespørsler basert på typiske bruksm
 | Qwen3.6 Plus               | 3,300                    | 8,200                | 16,300                 |
 | DeepSeek V4 Pro            | 1,050                    | 2,600                | 5,200                  |
 | DeepSeek V4 Flash          | 7,600                    | 18,900               | 37,800                 |
+| DeepSeek V4 Flash Vision Exp | 3,800                    | 9,450                | 18,900                 |
 | Hy3                        | 4,300                    | 10,750               | 21,500                 |
 | Ox Alpha Free              | -                        | -                    | -                      |
 
@@ -130,6 +132,7 @@ Estimatene er basert på observerte forespørselsmønstre:
 - Kimi K2.7/K2.6 — 870 input, 55 000 bufret, 200 output-tokens per forespørsel
 - DeepSeek V4 Pro — 750 input, 82 000 bufret, 290 output-tokens per forespørsel
 - DeepSeek V4 Flash — 410 input, 71 300 bufret, 310 output-tokens per forespørsel
+- DeepSeek V4 Flash Vision Exp — 410 input, 71 300 bufret, 310 output-tokens per forespørsel
 - MiniMax M3 — 510 input, 56 000 bufret, 190 output-tokens per forespørsel
 - MiniMax M2.7 — 300 input, 55 000 bufret, 125 output-tokens per forespørsel
 - Muse Spark 1.2 Contributor — 620 input, 71 400 bufret, 300 output-tokens per forespørsel
@@ -170,10 +173,14 @@ Estimatene er også basert på følgende priser per 1M tokens og den månedlige 
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15  |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30  |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30  |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15  |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15  |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60  |
 | Ox Alpha Free                | -      | -      | -           | -            | -    |
 
-**DeepSeek V4 Flash / Pro:** Peak-tidene er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tidene er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Bilder konverteres til tokens basert på dimensjonene og faktureres som input-tokens sammen med tekst-tokens. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratis i en begrenset periode.
 
@@ -223,6 +230,7 @@ Du kan også få tilgang til Go-modeller gjennom følgende API-endepunkter.
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Ja            | Ikke ZDR        |
 | DeepSeek V4 Pro            | Brukes ikke   | 0 dager         |
 | DeepSeek V4 Flash          | Brukes ikke   | 0 dager         |
+| DeepSeek V4 Flash Vision Exp | Brukes ikke   | 0 dager         |
 | Hy3                        | Brukes ikke   | 0 dager         |
 | Ox Alpha Free              | Brukes ikke   | 0 dager         |
 

--- a/packages/web/src/content/docs/pl/go.mdx
+++ b/packages/web/src/content/docs/pl/go.mdx
@@ -72,6 +72,7 @@ Obecna lista modeli obejmuje:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (przez ograniczony czas)
 
@@ -112,6 +113,7 @@ Poniższa tabela przedstawia szacunkową liczbę żądań na podstawie typowych 
 | Qwen3.6 Plus               | 3,300               | 8,200              | 16,300             |
 | DeepSeek V4 Pro            | 1,050               | 2,600              | 5,200              |
 | DeepSeek V4 Flash          | 7,600               | 18,900             | 37,800             |
+| DeepSeek V4 Flash Vision Exp | 3,800               | 9,450              | 18,900             |
 | Hy3                        | 4,300               | 10,750             | 21,500             |
 | Ox Alpha Free              | -                   | -                  | -                  |
 
@@ -124,6 +126,7 @@ Szacunki te opierają się na zaobserwowanych wzorcach żądań:
 - Kimi K2.7/K2.6 — 870 tokenów wejściowych, 55 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
 - DeepSeek V4 Pro — 750 tokenów wejściowych, 82 000 w pamięci podręcznej, 290 tokenów wyjściowych na żądanie
 - DeepSeek V4 Flash — 410 tokenów wejściowych, 71 300 w pamięci podręcznej, 310 tokenów wyjściowych na żądanie
+- DeepSeek V4 Flash Vision Exp — 410 tokenów wejściowych, 71 300 w pamięci podręcznej, 310 tokenów wyjściowych na żądanie
 - MiniMax M3 — 510 tokenów wejściowych, 56 000 w pamięci podręcznej, 190 tokenów wyjściowych na żądanie
 - MiniMax M2.7 — 300 tokenów wejściowych, 55 000 w pamięci podręcznej, 125 tokenów wyjściowych na żądanie
 - Muse Spark 1.2 Contributor — 620 tokenów wejściowych, 71 400 w pamięci podręcznej, 300 tokenów wyjściowych na żądanie
@@ -164,10 +167,14 @@ Szacunki opierają się również na następujących cenach za 1M tokenów oraz 
 | DeepSeek V4 Pro (Peak)       | $1.32   | $3.96   | $0.044         | -              | $15    |
 | DeepSeek V4 Flash (Off-Peak) | $0.22   | $0.66   | $0.007         | -              | $30    |
 | DeepSeek V4 Flash (Peak)     | $0.44   | $1.32   | $0.014         | -              | $30    |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22   | $0.66   | $0.007         | -              | $15    |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44   | $1.32   | $0.014         | -              | $15    |
 | Hy3                          | $0.14   | $0.58   | $0.035         | -              | $60    |
 | Ox Alpha Free                | -       | -       | -              | -              | -      |
 
-**DeepSeek V4 Flash / Pro:** Godziny Peak to 01:00-04:00 i 06:00-10:00 UTC; wszystkie pozostałe godziny to Off-Peak. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Godziny Peak to 01:00-04:00 i 06:00-10:00 UTC; wszystkie pozostałe godziny to Off-Peak. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Obrazy są przeliczane na tokeny na podstawie ich wymiarów i rozliczane jako tokeny wejściowe razem z tokenami tekstowymi. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Bezpłatny przez ograniczony czas.
 
@@ -215,6 +222,7 @@ Możesz również uzyskać dostęp do modeli Go za pośrednictwem następującyc
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -267,6 +275,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Tak               | Nie ZDR         |
 | DeepSeek V4 Pro            | Niewykorzystywane | 0 dni           |
 | DeepSeek V4 Flash          | Niewykorzystywane | 0 dni           |
+| DeepSeek V4 Flash Vision Exp | Niewykorzystywane | 0 dni           |
 | Hy3                        | Niewykorzystywane | 0 dni           |
 | Ox Alpha Free              | Niewykorzystywane | 0 dni           |
 

--- a/packages/web/src/content/docs/pt-br/go.mdx
+++ b/packages/web/src/content/docs/pt-br/go.mdx
@@ -78,6 +78,7 @@ A lista atual de modelos inclui:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (por tempo limitado)
 
@@ -118,6 +119,7 @@ A tabela abaixo fornece uma contagem estimada de requisições com base nos padr
 | Qwen3.6 Plus               | 3,300                   | 8,200                  | 16,300              |
 | DeepSeek V4 Pro            | 1,050                   | 2,600                  | 5,200               |
 | DeepSeek V4 Flash          | 7,600                   | 18,900                 | 37,800              |
+| DeepSeek V4 Flash Vision Exp | 3,800                   | 9,450                  | 18,900              |
 | Hy3                        | 4,300                   | 10,750                 | 21,500              |
 | Ox Alpha Free              | -                       | -                      | -                   |
 
@@ -130,6 +132,7 @@ As estimativas se baseiam nos padrões de requisições observados:
 - Kimi K2.7/K2.6 — 870 tokens de entrada, 55.000 em cache, 200 tokens de saída por requisição
 - DeepSeek V4 Pro — 750 tokens de entrada, 82.000 em cache, 290 tokens de saída por requisição
 - DeepSeek V4 Flash — 410 tokens de entrada, 71.300 em cache, 310 tokens de saída por requisição
+- DeepSeek V4 Flash Vision Exp — 410 tokens de entrada, 71.300 em cache, 310 tokens de saída por requisição
 - MiniMax M3 — 510 tokens de entrada, 56.000 em cache, 190 tokens de saída por requisição
 - MiniMax M2.7 — 300 tokens de entrada, 55.000 em cache, 125 tokens de saída por requisição
 - Muse Spark 1.2 Contributor — 620 tokens de entrada, 71.400 em cache, 300 tokens de saída por requisição
@@ -170,10 +173,14 @@ As estimativas também se baseiam nos seguintes preços por 1M tokens e no uso m
 | DeepSeek V4 Pro (Peak)       | $1.32   | $3.96  | $0.044           | -                | $15 |
 | DeepSeek V4 Flash (Off-Peak) | $0.22   | $0.66  | $0.007           | -                | $30 |
 | DeepSeek V4 Flash (Peak)     | $0.44   | $1.32  | $0.014           | -                | $30 |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22   | $0.66  | $0.007           | -                | $15 |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44   | $1.32  | $0.014           | -                | $15 |
 | Hy3                          | $0.14   | $0.58  | $0.035           | -                | $60 |
 | Ox Alpha Free                | -       | -      | -                | -                | -   |
 
-**DeepSeek V4 Flash / Pro:** Os horários Peak são 01:00-04:00 e 06:00-10:00 UTC; todos os demais horários são Off-Peak. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Os horários Peak são 01:00-04:00 e 06:00-10:00 UTC; todos os demais horários são Off-Peak. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** As imagens são convertidas em tokens com base em suas dimensões e cobradas como tokens de entrada junto com os tokens de texto. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Gratuito por tempo limitado.
 
@@ -223,6 +230,7 @@ Você também pode acessar os modelos do Go através dos seguintes endpoints de 
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Sim                    | Não é ZDR         |
 | DeepSeek V4 Pro            | Não usado              | 0 dias            |
 | DeepSeek V4 Flash          | Não usado              | 0 dias            |
+| DeepSeek V4 Flash Vision Exp | Não usado              | 0 dias            |
 | Hy3                        | Não usado              | 0 dias            |
 | Ox Alpha Free              | Não usado              | 0 dias            |
 

--- a/packages/web/src/content/docs/ru/go.mdx
+++ b/packages/web/src/content/docs/ru/go.mdx
@@ -78,6 +78,7 @@ OpenCode Go работает так же, как и любой другой пр
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (ограниченное время)
 
@@ -118,6 +119,7 @@ OpenCode Go включает следующие лимиты:
 | Qwen3.6 Plus               | 3,300               | 8,200             | 16,300           |
 | DeepSeek V4 Pro            | 1,050               | 2,600             | 5,200            |
 | DeepSeek V4 Flash          | 7,600               | 18,900            | 37,800           |
+| DeepSeek V4 Flash Vision Exp | 3,800               | 9,450             | 18,900           |
 | Hy3                        | 4,300               | 10,750            | 21,500           |
 | Ox Alpha Free              | -                   | -                 | -                |
 
@@ -130,6 +132,7 @@ OpenCode Go включает следующие лимиты:
 - Kimi K2.7/K2.6 — 870 входных, 55,000 кешированных, 200 выходных токенов на запрос
 - DeepSeek V4 Pro — 750 входных, 82,000 кешированных, 290 выходных токенов на запрос
 - DeepSeek V4 Flash — 410 входных, 71,300 кешированных, 310 выходных токенов на запрос
+- DeepSeek V4 Flash Vision Exp — 410 входных, 71,300 кешированных, 310 выходных токенов на запрос
 - MiniMax M3 — 510 входных, 56,000 кешированных, 190 выходных токенов на запрос
 - MiniMax M2.7 — 300 входных, 55,000 кешированных, 125 выходных токенов на запрос
 - Muse Spark 1.2 Contributor — 620 входных, 71,400 кешированных, 300 выходных токенов на запрос
@@ -170,10 +173,14 @@ OpenCode Go включает следующие лимиты:
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15           |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30           |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30           |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15           |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15           |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60           |
 | Ox Alpha Free                | -      | -      | -           | -            | -             |
 
-**DeepSeek V4 Flash / Pro:** Часы Peak: 01:00-04:00 и 06:00-10:00 UTC; все остальные часы относятся к Off-Peak. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Часы Peak: 01:00-04:00 и 06:00-10:00 UTC; все остальные часы относятся к Off-Peak. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Изображения преобразуются в токены с учётом их размеров и оплачиваются как входные токены вместе с текстовыми токенами. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Бесплатно в течение ограниченного времени.
 
@@ -223,6 +230,7 @@ OpenCode Go включает следующие лимиты:
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -275,6 +283,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Да               | Не ZDR          |
 | DeepSeek V4 Pro            | Не используется  | 0 дней          |
 | DeepSeek V4 Flash          | Не используется  | 0 дней          |
+| DeepSeek V4 Flash Vision Exp | Не используется  | 0 дней          |
 | Hy3                        | Не используется  | 0 дней          |
 | Ox Alpha Free              | Не используется  | 0 дней          |
 

--- a/packages/web/src/content/docs/th/go.mdx
+++ b/packages/web/src/content/docs/th/go.mdx
@@ -68,6 +68,7 @@ OpenCode Go ทำงานเหมือนกับผู้ให้บร�
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (ในช่วงเวลาจำกัด)
 
@@ -108,6 +109,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | Qwen3.6 Plus               | 3,300                  | 8,200               | 16,300            |
 | DeepSeek V4 Pro            | 1,050                  | 2,600               | 5,200             |
 | DeepSeek V4 Flash          | 7,600                  | 18,900              | 37,800            |
+| DeepSeek V4 Flash Vision Exp | 3,800                  | 9,450               | 18,900            |
 | Hy3                        | 4,300                  | 10,750              | 21,500            |
 | Ox Alpha Free              | -                      | -                   | -                 |
 
@@ -120,6 +122,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 - Kimi K2.7/K2.6 — 870 input, 55,000 cached, 200 output tokens ต่อ request
 - DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens ต่อ request
 - DeepSeek V4 Flash — 410 input, 71,300 cached, 310 output tokens ต่อ request
+- DeepSeek V4 Flash Vision Exp — 410 input, 71,300 cached, 310 output tokens ต่อ request
 - MiniMax M3 — 510 input, 56,000 cached, 190 output tokens ต่อ request
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens ต่อ request
 - Muse Spark 1.2 Contributor — 620 input, 71,400 cached, 300 output tokens ต่อ request
@@ -160,10 +163,14 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15   |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30   |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30   |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15   |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15   |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / Pro:** ช่วงเวลา Peak คือ 01:00-04:00 และ 06:00-10:00 UTC ส่วนเวลาอื่นทั้งหมดเป็น Off-Peak [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ช่วงเวลา Peak คือ 01:00-04:00 และ 06:00-10:00 UTC ส่วนเวลาอื่นทั้งหมดเป็น Off-Peak [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
+
+**DeepSeek V4 Flash Vision Exp:** รูปภาพจะถูกแปลงเป็น token ตามขนาด และคิดค่าบริการเป็น input token รวมกับ text token [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
 
 **Ox Alpha Free:** ใช้งานฟรีในช่วงเวลาจำกัด
 
@@ -211,6 +218,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | ใช่         | ไม่ใช่ ZDR         |
 | DeepSeek V4 Pro            | ไม่นำไปใช้  | 0 วัน              |
 | DeepSeek V4 Flash          | ไม่นำไปใช้  | 0 วัน              |
+| DeepSeek V4 Flash Vision Exp | ไม่นำไปใช้  | 0 วัน              |
 | Hy3                        | ไม่นำไปใช้  | 0 วัน              |
 | Ox Alpha Free              | ไม่นำไปใช้  | 0 วัน              |
 

--- a/packages/web/src/content/docs/tr/go.mdx
+++ b/packages/web/src/content/docs/tr/go.mdx
@@ -68,6 +68,7 @@ Mevcut model listesi şunları içerir:
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (sınırlı bir süre için)
 
@@ -108,6 +109,7 @@ Aşağıdaki tablo, tipik Go kullanım modellerine dayalı tahmini bir istek say
 | Qwen3.6 Plus               | 3,300              | 8,200          | 16,300      |
 | DeepSeek V4 Pro            | 1,050              | 2,600          | 5,200       |
 | DeepSeek V4 Flash          | 7,600              | 18,900         | 37,800      |
+| DeepSeek V4 Flash Vision Exp | 3,800              | 9,450          | 18,900      |
 | Hy3                        | 4,300              | 10,750         | 21,500      |
 | Ox Alpha Free              | -                  | -              | -           |
 
@@ -120,6 +122,7 @@ Tahminler, gözlemlenen istek modellerine dayanır:
 - Kimi K2.7/K2.6 — İstek başına 870 girdi, 55.000 önbelleğe alınmış, 200 çıktı token'ı
 - DeepSeek V4 Pro — İstek başına 750 girdi, 82.000 önbelleğe alınmış, 290 çıktı token'ı
 - DeepSeek V4 Flash — İstek başına 410 girdi, 71.300 önbelleğe alınmış, 310 çıktı token'ı
+- DeepSeek V4 Flash Vision Exp — İstek başına 410 girdi, 71.300 önbelleğe alınmış, 310 çıktı token'ı
 - MiniMax M3 — İstek başına 510 girdi, 56.000 önbelleğe alınmış, 190 çıktı token'ı
 - MiniMax M2.7 — İstek başına 300 girdi, 55.000 önbelleğe alınmış, 125 çıktı token'ı
 - Muse Spark 1.2 Contributor — İstek başına 620 girdi, 71.400 önbelleğe alınmış, 300 çıktı token'ı
@@ -160,10 +163,14 @@ Tahminler ayrıca 1M token başına aşağıdaki fiyatlara ve her modelle birlik
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044      | -            | $15      |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $30      |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014      | -            | $30      |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007      | -            | $15      |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014      | -            | $15      |
 | Hy3                          | $0.14  | $0.58  | $0.035      | -            | $60      |
 | Ox Alpha Free                | -      | -      | -           | -            | -        |
 
-**DeepSeek V4 Flash / Pro:** Peak saatleri 01:00-04:00 ve 06:00-10:00 UTC'dir; diğer tüm saatler Off-Peak'tir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak saatleri 01:00-04:00 ve 06:00-10:00 UTC'dir; diğer tüm saatler Off-Peak'tir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
+
+**DeepSeek V4 Flash Vision Exp:** Görseller boyutlarına göre token'lara dönüştürülür ve metin token'larıyla birlikte girdi token'ları olarak ücretlendirilir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **Ox Alpha Free:** Sınırlı bir süre için ücretsiz.
 
@@ -211,6 +218,7 @@ Go modellerine aşağıdaki API uç noktaları aracılığıyla da erişebilirsi
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | Evet          | ZDR değil    |
 | DeepSeek V4 Pro            | Kullanılmaz   | 0 gün        |
 | DeepSeek V4 Flash          | Kullanılmaz   | 0 gün        |
+| DeepSeek V4 Flash Vision Exp | Kullanılmaz   | 0 gün        |
 | Hy3                        | Kullanılmaz   | 0 gün        |
 | Ox Alpha Free              | Kullanılmaz   | 0 gün        |
 

--- a/packages/web/src/content/docs/zh-cn/go.mdx
+++ b/packages/web/src/content/docs/zh-cn/go.mdx
@@ -68,6 +68,7 @@ OpenCode Go 的工作方式与 OpenCode 中的其他提供商一样。
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (限时)
 
@@ -108,6 +109,7 @@ OpenCode Go 包含以下限制：
 | Qwen3.6 Plus               | 3,300           | 8,200      | 16,300     |
 | DeepSeek V4 Pro            | 1,050           | 2,600      | 5,200      |
 | DeepSeek V4 Flash          | 7,600           | 18,900     | 37,800     |
+| DeepSeek V4 Flash Vision Exp | 3,800           | 9,450      | 18,900     |
 | Hy3                        | 4,300           | 10,750     | 21,500     |
 | Ox Alpha Free              | -               | -          | -          |
 
@@ -120,6 +122,7 @@ OpenCode Go 包含以下限制：
 - Kimi K2.7/K2.6 — 每次请求 870 个输入 token，55,000 个缓存 token，200 个输出 token
 - DeepSeek V4 Pro — 每次请求 750 个输入 token，82,000 个缓存 token，290 个输出 token
 - DeepSeek V4 Flash — 每次请求 410 个输入 token，71,300 个缓存 token，310 个输出 token
+- DeepSeek V4 Flash Vision Exp — 每次请求 410 个输入 token，71,300 个缓存 token，310 个输出 token
 - MiMo-V2.5 — 每次请求 830 个输入 token，71,500 个缓存 token，295 个输出 token
 - MiMo-V2.5-Pro — 每次请求 790 个输入 token，86,000 个缓存 token，305 个输出 token
 - MiniMax M3 — 每次请求 510 个输入 token，56,000 个缓存 token，190 个输出 token
@@ -160,10 +163,14 @@ OpenCode Go 包含以下限制：
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044    | -        | $15      |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007    | -        | $30      |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014    | -        | $30      |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007    | -        | $15      |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014    | -        | $15      |
 | Hy3                          | $0.14  | $0.58  | $0.035    | -        | $60      |
 | Ox Alpha Free                | -      | -      | -         | -        | -        |
 
-**DeepSeek V4 Flash / Pro:** Peak 时段为 01:00-04:00 和 06:00-10:00 UTC；其他所有时段均为 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 时段为 01:00-04:00 和 06:00-10:00 UTC；其他所有时段均为 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+
+**DeepSeek V4 Flash Vision Exp:** 图片会根据尺寸转换为 token，并与文本 token 一起按输入 token 计费。 [了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **Ox Alpha Free:** 限时免费。
 
@@ -211,6 +218,7 @@ OpenCode Go 包含以下限制：
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | 是       | 非 ZDR   |
 | DeepSeek V4 Pro            | 不使用   | 0 天     |
 | DeepSeek V4 Flash          | 不使用   | 0 天     |
+| DeepSeek V4 Flash Vision Exp | 不使用      | 0 天      |
 | Hy3                        | 不使用   | 0 天     |
 | Ox Alpha Free              | 不使用   | 0 天     |
 

--- a/packages/web/src/content/docs/zh-tw/go.mdx
+++ b/packages/web/src/content/docs/zh-tw/go.mdx
@@ -68,6 +68,7 @@ OpenCode Go 的運作方式與 OpenCode 中的任何其他供應商相同。
 - **Qwen3.6 Plus**
 - **DeepSeek V4 Pro**
 - **DeepSeek V4 Flash**
+- **DeepSeek V4 Flash Vision Exp**
 - **Hy3**
 - **Ox Alpha Free** (限時)
 
@@ -108,6 +109,7 @@ OpenCode Go 包含以下限制：
 | Qwen3.6 Plus               | 3,300           | 8,200      | 16,300     |
 | DeepSeek V4 Pro            | 1,050           | 2,600      | 5,200      |
 | DeepSeek V4 Flash          | 7,600           | 18,900     | 37,800     |
+| DeepSeek V4 Flash Vision Exp | 3,800           | 9,450      | 18,900     |
 | Hy3                        | 4,300           | 10,750     | 21,500     |
 | Ox Alpha Free              | -               | -          | -          |
 
@@ -120,6 +122,7 @@ OpenCode Go 包含以下限制：
 - Kimi K2.7/K2.6 — 每次請求 870 個輸入 token、55,000 個快取 token、200 個輸出 token
 - DeepSeek V4 Pro — 每次請求 750 個輸入 token、82,000 個快取 token、290 個輸出 token
 - DeepSeek V4 Flash — 每次請求 410 個輸入 token、71,300 個快取 token、310 個輸出 token
+- DeepSeek V4 Flash Vision Exp — 每次請求 410 個輸入 token、71,300 個快取 token、310 個輸出 token
 - MiniMax M3 — 每次請求 510 個輸入 token、56,000 個快取 token、190 個輸出 token
 - MiniMax M2.7 — 每次請求 300 個輸入 token、55,000 個快取 token、125 個輸出 token
 - Muse Spark 1.2 Contributor — 每次請求 620 個輸入 token、71,400 個快取 token、300 個輸出 token
@@ -160,10 +163,14 @@ OpenCode Go 包含以下限制：
 | DeepSeek V4 Pro (Peak)       | $1.32  | $3.96  | $0.044    | -        | $15    |
 | DeepSeek V4 Flash (Off-Peak) | $0.22  | $0.66  | $0.007    | -        | $30    |
 | DeepSeek V4 Flash (Peak)     | $0.44  | $1.32  | $0.014    | -        | $30    |
+| DeepSeek V4 Flash Vision Exp (Off-Peak) | $0.22  | $0.66  | $0.007    | -        | $15    |
+| DeepSeek V4 Flash Vision Exp (Peak) | $0.44  | $1.32  | $0.014    | -        | $15    |
 | Hy3                          | $0.14  | $0.58  | $0.035    | -        | $60    |
 | Ox Alpha Free                | -      | -      | -         | -        | -      |
 
-**DeepSeek V4 Flash / Pro:** Peak 時段為 01:00-04:00 和 06:00-10:00 UTC；其他所有時段均為 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 時段為 01:00-04:00 和 06:00-10:00 UTC；其他所有時段均為 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+
+**DeepSeek V4 Flash Vision Exp:** 圖片會根據尺寸轉換為 token，並與文字 token 一起按輸入 token 計費。 [了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **Ox Alpha Free:** 限時免費。
 
@@ -211,6 +218,7 @@ OpenCode Go 包含以下限制：
 | Kimi K2.6                  | kimi-k2.6                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro            | deepseek-v4-pro            | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash          | deepseek-v4-flash          | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| DeepSeek V4 Flash Vision Exp | deepseek-v4-flash-vision-exp | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5                  | mimo-v2.5                  | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiMo-V2.5-Pro              | mimo-v2.5-pro              | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | MiniMax M3                 | minimax-m3                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -261,6 +269,7 @@ https://opencode.ai/zen/go/v1/models
 | Muse Spark 1.2 Contributor | 是       | 非 ZDR   |
 | DeepSeek V4 Pro            | 不使用   | 0 天     |
 | DeepSeek V4 Flash          | 不使用   | 0 天     |
+| DeepSeek V4 Flash Vision Exp | 不使用      | 0 天      |
 | Hy3                        | 不使用   | 0 天     |
 | Ox Alpha Free              | 不使用   | 0 天     |
 


### PR DESCRIPTION
## Summary
- add DeepSeek V4 Flash Vision Exp to localized Go documentation

## Testing
- `bun run build` from `packages/web`
- `bun typecheck` from `packages/console/app`
- `git diff --check`