### PR TITLE
fix(session): retry empty unknown-finish streams instead of stopping

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -13,6 +13,7 @@ import { Session } from "./session"
 import { LLM } from "./llm"
 import { MessageV2 } from "./message-v2"
 import { isOverflow } from "./overflow"
+import { ProviderError } from "@/provider/error"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
@@ -644,6 +645,21 @@ const layer = Layer.effect(
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
+
+            // A provider can close the stream cleanly without emitting any
+            // content or a real finish reason; the AI SDK reports finishReason
+            // "unknown" with zero usage in that case. Fail so the retry policy
+            // treats it like any other transient provider error instead of
+            // ending the turn silently.
+            if (
+              !ctx.needsCompaction &&
+              ctx.assistantMessage.finish === "unknown" &&
+              ctx.assistantMessage.tokens.output === 0
+            ) {
+              return yield* Effect.fail(
+                new ProviderError.ResponseStreamError("Provider returned an empty stream"),
+              )
+            }
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #41469
Closes #43622

### Type of change

- [x] Bug fix

### What does this PR do?

A provider or gateway can close the SSE stream cleanly without sending content or a finish frame. The AI SDK then reports a step finish reason of `unknown` with zero usage. The processor persists `finish=unknown`, and the prompt loop only excludes `tool-calls` from its exit check, so the turn ends silently and looks like a normal completion.

I hit this repeatedly on `opencode/x-preview-f-free`: 189 logged `stream error` entries in one day, and many assistant messages stored with `finish=unknown`, zero output tokens, and no error field. Their parts contain only `step-start` + `step-finish(reason=unknown)`, which shows the stream ended cleanly instead of throwing.

The fix fails such streams after a clean drain: if `finish === "unknown"` and output tokens are zero (and compaction did not request the early stop), `process` fails with `ProviderError.ResponseStreamError`. `MessageV2.fromError` already maps that to a retryable `APIError`, so the existing `SessionRetry.policy` applies backoff and retries, and `halt` sets a visible error if all retries fail. Streams that end `unknown` but produced real output are untouched.

Note: #41466 addresses the same problem. This PR was developed independently and keeps the change smaller by reusing the existing error type instead of adding a new one.

### How did you verify your code works?

- `bun run typecheck` passes
- `bun test test/session/processor-effect.test.ts test/session/retry.test.ts`: 77 pass
- Rebuilt the desktop app with this patch and ran it against the same flaky gateway; empty streams now trigger the visible retry flow instead of ending the turn
- Verification with long-running tasks is still being performed; I will post results here

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR