### PR TITLE
refactor(ai): declare responses websocket capability

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -1000,7 +1000,7 @@ export type ModelCapabilities = {
   tools: boolean
   input: Array<string>
   output: Array<string>
-  responsesWebSocket?: boolean
+  responsesWebsockets?: boolean
 }
 
 export type ModelCost = {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -996,7 +996,12 @@ export type ProviderInfo = {
   body?: { [x: string]: any }
 }
 
-export type ModelCapabilities = { tools: boolean; input: Array<string>; output: Array<string> }
+export type ModelCapabilities = {
+  tools: boolean
+  input: Array<string>
+  output: Array<string>
+  responsesWebSocket?: boolean
+}
 
 export type ModelCost = {
   tier?: { type: "context"; size: number }

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -194,7 +194,7 @@ export const OpenAIPlugin = define({
       if (!item) return
       for (const model of item.models.values()) {
         evt.model.update(item.provider.id, model.id, (draft) => {
-          draft.capabilities.responsesWebSocket = true
+          draft.capabilities.responsesWebsockets = true
         })
       }
       if (!chatgpt) return

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -190,9 +190,14 @@ export const OpenAIPlugin = define({
     })
     yield* load()
     yield* ctx.catalog.transform((evt) => {
-      if (!chatgpt) return
       const item = evt.provider.get(Provider.ID.openai)
       if (!item) return
+      for (const model of item.models.values()) {
+        evt.model.update(item.provider.id, model.id, (draft) => {
+          draft.capabilities.responsesWebSocket = true
+        })
+      }
+      if (!chatgpt) return
       item.provider.settings = Provider.mergeOverlay(item.provider.settings, { baseURL: codexBaseURL })
       const account = chatgpt.metadata?.accountID
       item.provider.headers = Provider.mergeHeaders(item.provider.headers, {

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -7,7 +7,6 @@ import { Cause, Config, Context, Effect, Layer, Result } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { App } from "../app.js"
 import { Model } from "../model.js"
-import { Provider } from "../provider.js"
 import { Permission } from "../permission.js"
 import { PluginHooks } from "../plugin/hooks.js"
 import { QuestionTool } from "../tool/plugin/question.js"
@@ -283,8 +282,7 @@ export const layer = Layer.effect(
         ...(input.webSocket === "session" &&
         webSocket &&
         webSocketEligible &&
-        resolved.ref.providerID === Provider.ID.openai &&
-        request.model.route.id === "openai-responses"
+        resolved.capabilities.responsesWebSocket === true
           ? { webSocket: transport.bind(session.id) }
           : {}),
       }

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -282,7 +282,7 @@ export const layer = Layer.effect(
         ...(input.webSocket === "session" &&
         webSocket &&
         webSocketEligible &&
-        resolved.capabilities.responsesWebSocket === true
+        resolved.capabilities.responsesWebsockets === true
           ? { webSocket: transport.bind(session.id) }
           : {}),
       }

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -197,7 +197,7 @@ describe("OpenAIPlugin", () => {
       expect(model.package).toBe(Provider.aisdk("@ai-sdk/openai"))
       expect(model.enabled).toBe(true)
       expect(model.limit).toEqual({ context: 1_050_000, input: 922_000, output: 128_000 })
-      expect(model.capabilities.responsesWebSocket).toBe(true)
+      expect(model.capabilities.responsesWebsockets).toBe(true)
       expect(direct.headers).not.toHaveProperty("originator")
       expect(direct.hasHttpHooks).toBe(false)
       expect(provider.headers).not.toHaveProperty("originator")
@@ -227,7 +227,7 @@ describe("OpenAIPlugin", () => {
         provider: Provider.ID.make("deployment"),
       })
       const model = SessionRunnerModel.resolved(route.model({ id: "gpt-5.5" }), {
-        capabilities: { tools: true, input: ["text"], output: ["text"], responsesWebSocket: true },
+        capabilities: { tools: true, input: ["text"], output: ["text"], responsesWebsockets: true },
         cost: [],
         limit: { context: 200_000, output: 32_000 },
       })

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -197,6 +197,7 @@ describe("OpenAIPlugin", () => {
       expect(model.package).toBe(Provider.aisdk("@ai-sdk/openai"))
       expect(model.enabled).toBe(true)
       expect(model.limit).toEqual({ context: 1_050_000, input: 922_000, output: 128_000 })
+      expect(model.capabilities.responsesWebSocket).toBe(true)
       expect(direct.headers).not.toHaveProperty("originator")
       expect(direct.hasHttpHooks).toBe(false)
       expect(provider.headers).not.toHaveProperty("originator")
@@ -204,7 +205,7 @@ describe("OpenAIPlugin", () => {
     }),
   )
 
-  it.effect("selects WebSocket with the built-in provider hooks enabled", () =>
+  it.effect("selects WebSocket from deployment capability with built-in provider hooks enabled", () =>
     Effect.gen(function* () {
       const credentials = yield* Credential.Service
       yield* credentials.create({
@@ -221,8 +222,12 @@ describe("OpenAIPlugin", () => {
       })
       const sessionID = Session.ID.make("ses_websocket_hooks")
       const agentID = Agent.ID.make("build")
-      const model = SessionRunnerModel.resolved(OpenAIResponses.route.model({ id: "gpt-5.5" }), {
-        capabilities: { tools: true, input: ["text"], output: ["text"] },
+      const route = OpenAIResponses.route.with({
+        id: "deployment-responses",
+        provider: Provider.ID.make("deployment"),
+      })
+      const model = SessionRunnerModel.resolved(route.model({ id: "gpt-5.5" }), {
+        capabilities: { tools: true, input: ["text"], output: ["text"], responsesWebSocket: true },
         cost: [],
         limit: { context: 200_000, output: 32_000 },
       })

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -64,7 +64,7 @@ export const Capabilities = Schema.Struct({
   tools: Schema.Boolean,
   input: Schema.Array(Schema.String),
   output: Schema.Array(Schema.String),
-  responsesWebSocket: Schema.Boolean.pipe(optional),
+  responsesWebsockets: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Model.Capabilities" })
 
 export interface Cost extends Schema.Schema.Type<typeof Cost> {}

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -64,6 +64,7 @@ export const Capabilities = Schema.Struct({
   tools: Schema.Boolean,
   input: Schema.Array(Schema.String),
   output: Schema.Array(Schema.String),
+  responsesWebSocket: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Model.Capabilities" })
 
 export interface Cost extends Schema.Schema.Type<typeof Cost> {}

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -58,3 +58,13 @@ describe("Model.Info", () => {
     expect(model.limit).toEqual({ context: 200_000, output: 32_000 })
   })
 })
+
+describe("Model.Capabilities", () => {
+  test("decodes optional Responses WebSocket support", () => {
+    const decode = Schema.decodeUnknownSync(Model.Capabilities)
+    const base = { tools: true, input: ["text"], output: ["text"] }
+
+    expect(decode(base)).toEqual(base)
+    expect(decode({ ...base, responsesWebSocket: true })).toEqual({ ...base, responsesWebSocket: true })
+  })
+})

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -65,6 +65,6 @@ describe("Model.Capabilities", () => {
     const base = { tools: true, input: ["text"], output: ["text"] }
 
     expect(decode(base)).toEqual(base)
-    expect(decode({ ...base, responsesWebSocket: true })).toEqual({ ...base, responsesWebSocket: true })
+    expect(decode({ ...base, responsesWebsockets: true })).toEqual({ ...base, responsesWebsockets: true })
   })
 })


### PR DESCRIPTION
## summary
- add optional `responsesWebsockets` deployment metadata to model capabilities
- mark native OpenAI catalog deployments as WebSocket-capable
- select Session WebSocket transport from declared capability instead of hard-coded provider and route IDs
- regenerate the public client model capability type

## testing
- `bun typecheck`: 34 packages pass
- `bun test --only-failures` (`packages/core`): 1,921 pass, 9 skip
- `bun test test/plugin/provider-openai.test.ts` (`packages/core`)
- `bun test test/model.test.ts` (`packages/schema`)
- Core, Schema, Protocol, and Client typechecks
- focused Prettier and Oxlint checks

The full Schema suite has one existing unrelated `Agent.Color` contract-hygiene failure; the focused model contract suite passes.
