### PR TITLE
fix(image): degrade photon resizer load failure to typed error on workerd

### DIFF
--- a/packages/core/src/image/photon.ts
+++ b/packages/core/src/image/photon.ts
@@ -8,13 +8,27 @@ import { DecodeError, ResizerUnavailableError, SizeError } from "../image.js"
 const JPEG_QUALITIES = [80, 85, 70, 55, 40]
 
 export const make = Effect.gen(function* () {
-  ;(globalThis as typeof globalThis & { __OPENCODE_PHOTON_WASM_PATH?: string }).__OPENCODE_PHOTON_WASM_PATH =
-    path.isAbsolute(photonWasm) ? photonWasm : fileURLToPath(new URL(photonWasm, import.meta.url))
   const loadPhoton = yield* Effect.cached(
-    Effect.tryPromise({
-      try: () => import("@silvia-odwyer/photon-node"),
-      catch: () => new ResizerUnavailableError(),
-    }),
+    // A runtime without a photon wasm artifact (#photon-wasm resolves to the
+    // empty string on workerd) has no resizer, by declaration: fail typed
+    // before touching URLs or module loading. The path resolution and import
+    // for runtimes that DO have an artifact stay inside the guard too — a
+    // throw outside it (workerd's undefined import.meta.url was one) is a
+    // defect that escapes the ResizerUnavailableError handling and turns any
+    // image-bearing prompt into a 500 instead of degrading to passthrough.
+    photonWasm === ""
+      ? Effect.fail(new ResizerUnavailableError())
+      : Effect.tryPromise({
+          try: async () => {
+            ;(
+              globalThis as typeof globalThis & { __OPENCODE_PHOTON_WASM_PATH?: string }
+            ).__OPENCODE_PHOTON_WASM_PATH = path.isAbsolute(photonWasm)
+              ? photonWasm
+              : fileURLToPath(new URL(photonWasm, import.meta.url))
+            return await import("@silvia-odwyer/photon-node")
+          },
+          catch: () => new ResizerUnavailableError(),
+        }),
   )
   return Effect.fn("Image.Photon.normalize")(function* (
     resource: string,


### PR DESCRIPTION
## What

Any image-bearing prompt against an embedded workerd runtime returned HTTP 500 from `POST /session/:id/prompt`, permanently: prompt admission retries hit the same defect forever, so the session wedged with the message stuck in its inbox. Text prompts were unaffected.

## Before / After

**Before:** `Image.Photon.make` resolved the wasm path synchronously in its Effect body, outside any guard:

```ts
;(globalThis as ...).__OPENCODE_PHOTON_WASM_PATH =
  path.isAbsolute(photonWasm) ? photonWasm : fileURLToPath(new URL(photonWasm, import.meta.url))
```

On workerd `import.meta.url` is `undefined` (verified against workerd via `wrangler dev --local`: `new URL("", import.meta.url)` throws `TypeError: Invalid URL string.`). The throw is a **defect**, not the typed `ResizerUnavailableError`, so `Session.materializeAttachment`'s `catchTag("Image.ResizerUnavailableError", ...)` and `mapError(AttachmentError)` both miss it and the prompt handler dies with 500. `photon-wasm.workerd.ts` documents the intended behavior — "surfaces a typed ResizerUnavailableError when loading fails, so an empty path degrades cleanly" — but the path resolution sat outside the guarded load, so the intent never held.

Observed in production (opencode-slack, 2026-08-21): a Slack mention with a 49KB PNG screenshot wedged its session with 18+ identical `500 POST .../prompt` retries; every text-only prompt on the same deployment worked.

**After:** the path resolution moves inside the existing `Effect.tryPromise`, so any load failure — path resolution or the `@silvia-odwyer/photon-node` import — is the typed `ResizerUnavailableError`, and image attachments degrade to byte passthrough as designed. The same Slack session unwedged immediately after deploying with this fix and answered with correct image understanding.

## How

- `packages/core/src/image/photon.ts`: the only change — `__OPENCODE_PHOTON_WASM_PATH` assignment moves from the `make` body into the guarded `tryPromise` alongside the dynamic import.

## Scope

Does not attempt to make the resizer actually work on workerd (no wasm artifact path exists there); it restores the designed degradation. Pre-existing type diagnostics in this file (`TS2554`/`TS2488` around the tagged error constructors) are untouched and identical before/after.

## Testing

- `import.meta.url === undefined` in workerd confirmed with a minimal module worker under `wrangler dev --local`.
- Consumer validation (opencode-slack embedded runtime, linked checkout): full hermetic integration suite green, including the vision inlining E2E.
- Live: the wedged production session recovered on deploy — prompt admitted, turn ran, image understood.

## Flow

```mermaid
sequenceDiagram
    participant P as Session.prompt
    participant M as materializeAttachment
    participant I as Image.Photon.make
    P->>M: data:image attachment
    M->>I: normalize()
    rect rgb(255, 235, 235)
    Note over I: Before: fileURLToPath(new URL(..., undefined))<br/>throws OUTSIDE tryPromise → defect → 500
    end
    rect rgb(235, 255, 235)
    Note over I: After: resolution inside tryPromise<br/>→ ResizerUnavailableError (typed)
    end
    I-->>M: ResizerUnavailableError
    M-->>P: byte passthrough → prompt admits
```