### PR TITLE
docs(ecosystem): add opencode-plugin-goal-dsh

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-plugin-goal-dsh](https://github.com/V-dev-388/opencode-plugin-goal-dsh)                  | `/goal` mode ported from DeepSeek Harness: persistent objectives, autonomous same-session continuation, evidence-gated completion |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
 
 ---


### PR DESCRIPTION
### Issue for this PR

Closes #

No existing issue. Adding my plugin to the ecosystem list, as invited by the note on the docs page ("Want to add your OpenCode related project to this list? Submit a PR.").

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx` for [opencode-plugin-goal-dsh](https://github.com/V-dev-388/opencode-plugin-goal-dsh).

It's a `/goal` mode plugin ported from DeepSeek Harness's `packages/goal/` (MIT; attribution noted in my README). Published on npm as `opencode-plugin-goal-dsh`, so users can enable it with `"plugin": ["opencode-plugin-goal-dsh"]`.

### How did you verify your code works?

Docs-only change. Rendered the table locally and confirmed the new row displays correctly. The plugin itself is on npm and tested against opencode 1.18.15.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
