### PR TITLE
fix(provider): guard textVerbosity injection for @ai-sdk/openai-compatible providers

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1303,13 +1303,13 @@ export function options(input: {
       }
     }
 
-    // Only set textVerbosity for non-chat gpt-5.x models
-    // Chat models (e.g. gpt-5.2-chat-latest) only support "medium" verbosity
+    // Generic OpenAI-compatible APIs do not necessarily support OpenAI's verbosity parameter.
+    // Only enable the default for integrations known to implement it.
     if (
       input.model.api.id.includes("gpt-5.") &&
       !input.model.api.id.includes("codex") &&
       !input.model.api.id.includes("-chat") &&
-      input.model.providerID !== "azure"
+      (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle")
     ) {
       result["textVerbosity"] = "low"
     }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -523,6 +523,7 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.reasoningEffort).toBe("medium")
     expect(result.reasoningSummary).toBeUndefined()
     expect(result.include).toBeUndefined()
+    expect(result.textVerbosity).toBeUndefined()
   })
 
   test("azure chat completions omit Responses-only reasoning options after variants merge", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #43911

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`options()` in `transform.ts` sets `textVerbosity: "low"` for any `gpt-5.x` model as long as `providerID !== "azure"`. That guard allows the default through for generic `@ai-sdk/openai-compatible` providers too (e.g. a LiteLLM proxy), which is wrong: `verbosity` is an OpenAI-specific parameter, and non-OpenAI backends behind such a proxy reject it outright.

Concretely, a `gpt-5.6` model routed through a LiteLLM `@ai-sdk/openai-compatible` provider to AWS Bedrock ("Bedrock Mantle") fails every request with:

```
litellm.UnsupportedParamsError: bedrock_mantle does not support parameters: ['verbosity'], for model=openai.gpt-5.6-luna...
```

This is the same bug class already fixed for `reasoningSummary` in #21237 / #22352 (unconditional injection for gpt-5.x, guarded only against Azure instead of an explicit allowlist). `textVerbosity` never got the equivalent fix.

The fix switches the check from a denylist (`providerID !== "azure"`) to an allowlist of providers known to actually implement `verbosity`: `@ai-sdk/openai` and `@ai-sdk/amazon-bedrock/mantle`. Everything else (including `@ai-sdk/openai-compatible`, `@ai-sdk/azure`, `@ai-sdk/github-copilot`) no longer receives `textVerbosity`, matching how `reasoningSummary`/`include` are already scoped a few lines above in the same function.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts` — 411 pass, 0 fail (added an explicit `expect(result.textVerbosity).toBeUndefined()` assertion to the existing `openai-compatible gpt-5 models omit Responses-only reasoningSummary` test).
- `bun turbo typecheck` — 30/30 packages pass.
- Reproduced the original error against a LiteLLM proxy fronting Bedrock Mantle; after this change `textVerbosity` is correctly omitted from the request and the call succeeds.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
