### PR TITLE
fix(tui): treat missing kv.json as empty state

### DIFF
--- a/packages/tui/src/context/kv.tsx
+++ b/packages/tui/src/context/kv.tsx
@@ -20,6 +20,11 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
     let write = Promise.resolve()
 
     Flock.withLock(lock, () => readJson<Record<string, unknown>>(file))
+      .catch((error: { code?: string }) => {
+        // Fresh installs have no KV file yet; start from empty state.
+        if (error.code === "ENOENT") return {}
+        throw error
+      })
       .then((x) => {
         setStore(x)
       })


### PR DESCRIPTION
### Issue for this PR

Closes #43916

### Type of change

- [x] Bug fix

### What does this PR do?

On first run, `~/.local/state/opencode/kv.json` doesn't exist yet, so opening the console logged a 'Failed to read KV state' ENOENT error. The file is only created on first write, so a missing file is expected state, not an error.

The KV loader now treats ENOENT as empty state and still logs other read failures (e.g. corrupt JSON).

### How did you verify your code works?

Renamed kv.json away and toggled the console: no error logged, defaults apply. Restored a corrupt kv.json: error is still logged. `bun typecheck` and `bun test` pass in packages/tui (193 pass), plus full monorepo typecheck via the pre-push hook.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
