### PR TITLE
fix(ai): filter empty Anthropic text blocks

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -8,7 +8,6 @@ import { Protocol } from "../route/protocol.js"
 import {
   AIError,
   LLMEvent,
-  Message,
   mergeJsonRecords,
   Usage,
   type CacheHint,
@@ -449,10 +448,7 @@ const lowerToolResultContent = Effect.fnUntraced(function* (part: ToolResultPart
   if (part.result.type !== "content") return ProviderShared.toolResultText(part)
   // Preserve the narrowed array element type when compiled through a consumer package.
   const content: ReadonlyArray<Tool.Content> = part.result.value
-  return yield* Effect.forEach(
-    content.filter((item) => item.type !== "text" || hasText(item)),
-    lowerToolResultContentItem,
-  )
+  return yield* Effect.forEach(content, lowerToolResultContentItem)
 })
 
 // Mid-conversation system messages became available with Opus 4.8 and version
@@ -469,8 +465,7 @@ const supportsNativeSystemUpdates = (request: LLMRequest) => {
   return match[3] !== undefined && match[3].length <= 2 && Number(match[3]) >= 8
 }
 
-const endsInServerToolUse = (message: LLMRequest["messages"][number] | undefined) => {
-  if (!message) return false
+const endsInServerToolUse = (message: LLMRequest["messages"][number]) => {
   const last = message.content.at(-1)
   return message.role === "assistant" && last?.type === "tool-call" && last.providerExecuted === true
 }
@@ -522,26 +517,13 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
 
   for (const [index, message] of request.messages.entries()) {
     if (message.role === "system") {
-      const content = (yield* ProviderShared.systemUpdateText("Anthropic Messages", message)).filter(hasText)
-      if (content.length === 0) continue
       if (splitsLocalToolResults(request.messages, index))
         return yield* invalid("Anthropic Messages system updates cannot split a local tool call from its tool result")
-      const normalized = Message.make({
-        id: message.id,
-        role: "system",
-        content,
-        metadata: message.metadata,
-        native: message.native,
-      })
-      if (
-        supportsNativeSystemUpdates(request) &&
-        canUseNativeSystemUpdate(request.messages, index) &&
-        (messages.at(-1)?.role === "user" || endsInServerToolUse(request.messages[index - 1]))
-      ) {
-        messages.push(yield* lowerNativeSystemUpdate(normalized, breakpoints))
+      if (supportsNativeSystemUpdates(request) && canUseNativeSystemUpdate(request.messages, index)) {
+        messages.push(yield* lowerNativeSystemUpdate(message, breakpoints))
         continue
       }
-      const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", normalized)
+      const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", message)
       const block = { type: "text" as const, text: part.text, cache_control: cacheControl(breakpoints, part.cache) }
       const previous = messages.at(-1)
       if (previous?.role === "user")
@@ -618,7 +600,6 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       })
     }
     const previous = messages.at(-1)
-    if (content.length === 0) continue
     if (previous?.role === "user" && previous.content.every((block) => block.type === "tool_result"))
       messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] }
     else messages.push({ role: "user", content })
@@ -678,11 +659,10 @@ const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (reques
         )
   // Anthropic rejects tool_choice when tools are absent; "none" is only meaningful with tools present.
   const toolChoice = tools === undefined || !request.toolChoice ? undefined : yield* lowerToolChoice(request.toolChoice)
-  const systemParts = request.system.filter(hasText)
   const system =
-    systemParts.length === 0
+    request.system.length === 0
       ? undefined
-      : systemParts.map((part) => ({
+      : request.system.map((part) => ({
           type: "text" as const,
           text: part.text,
           cache_control: cacheControl(breakpoints, part.cache),

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -8,6 +8,7 @@ import { Protocol } from "../route/protocol.js"
 import {
   AIError,
   LLMEvent,
+  Message,
   mergeJsonRecords,
   Usage,
   type CacheHint,
@@ -359,6 +360,8 @@ const redactedDataFromMetadata = (metadata: ProviderMetadata | undefined): strin
   return typeof anthropic.redactedData === "string" ? anthropic.redactedData : undefined
 }
 
+const hasText = (part: { readonly text: string }) => part.text.trim().length > 0
+
 const lowerTool = (breakpoints: Cache.Breakpoints, tool: ToolDefinition, inputSchema: JsonSchema): AnthropicTool => ({
   name: tool.name,
   description: tool.description,
@@ -446,7 +449,10 @@ const lowerToolResultContent = Effect.fnUntraced(function* (part: ToolResultPart
   if (part.result.type !== "content") return ProviderShared.toolResultText(part)
   // Preserve the narrowed array element type when compiled through a consumer package.
   const content: ReadonlyArray<Tool.Content> = part.result.value
-  return yield* Effect.forEach(content, lowerToolResultContentItem)
+  return yield* Effect.forEach(
+    content.filter((item) => item.type !== "text" || hasText(item)),
+    lowerToolResultContentItem,
+  )
 })
 
 // Mid-conversation system messages became available with Opus 4.8 and version
@@ -463,7 +469,8 @@ const supportsNativeSystemUpdates = (request: LLMRequest) => {
   return match[3] !== undefined && match[3].length <= 2 && Number(match[3]) >= 8
 }
 
-const endsInServerToolUse = (message: LLMRequest["messages"][number]) => {
+const endsInServerToolUse = (message: LLMRequest["messages"][number] | undefined) => {
+  if (!message) return false
   const last = message.content.at(-1)
   return message.role === "assistant" && last?.type === "tool-call" && last.providerExecuted === true
 }
@@ -515,13 +522,26 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
 
   for (const [index, message] of request.messages.entries()) {
     if (message.role === "system") {
+      const content = (yield* ProviderShared.systemUpdateText("Anthropic Messages", message)).filter(hasText)
+      if (content.length === 0) continue
       if (splitsLocalToolResults(request.messages, index))
         return yield* invalid("Anthropic Messages system updates cannot split a local tool call from its tool result")
-      if (supportsNativeSystemUpdates(request) && canUseNativeSystemUpdate(request.messages, index)) {
-        messages.push(yield* lowerNativeSystemUpdate(message, breakpoints))
+      const normalized = Message.make({
+        id: message.id,
+        role: "system",
+        content,
+        metadata: message.metadata,
+        native: message.native,
+      })
+      if (
+        supportsNativeSystemUpdates(request) &&
+        canUseNativeSystemUpdate(request.messages, index) &&
+        (messages.at(-1)?.role === "user" || endsInServerToolUse(request.messages[index - 1]))
+      ) {
+        messages.push(yield* lowerNativeSystemUpdate(normalized, breakpoints))
         continue
       }
-      const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", message)
+      const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", normalized)
       const block = { type: "text" as const, text: part.text, cache_control: cacheControl(breakpoints, part.cache) }
       const previous = messages.at(-1)
       if (previous?.role === "user")
@@ -534,6 +554,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       const content: AnthropicUserBlock[] = []
       for (const part of message.content) {
         if (part.type === "text") {
+          if (!hasText(part)) continue
           content.push({ type: "text", text: part.text, cache_control: cacheControl(breakpoints, part.cache) })
           continue
         }
@@ -543,7 +564,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         }
         return yield* ProviderShared.unsupportedContent("Anthropic Messages", "user", ["text", "media"])
       }
-      messages.push({ role: "user", content })
+      if (content.length > 0) messages.push({ role: "user", content })
       continue
     }
 
@@ -551,6 +572,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       const content: AnthropicAssistantBlock[] = []
       for (const part of message.content) {
         if (part.type === "text") {
+          if (!hasText(part)) continue
           content.push({ type: "text", text: part.text, cache_control: cacheControl(breakpoints, part.cache) })
           continue
         }
@@ -579,7 +601,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
           `Anthropic Messages assistant messages only support text, reasoning, and tool-call content for now`,
         )
       }
-      messages.push({ role: "assistant", content })
+      if (content.length > 0) messages.push({ role: "assistant", content })
       continue
     }
 
@@ -596,6 +618,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       })
     }
     const previous = messages.at(-1)
+    if (content.length === 0) continue
     if (previous?.role === "user" && previous.content.every((block) => block.type === "tool_result"))
       messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] }
     else messages.push({ role: "user", content })
@@ -655,10 +678,11 @@ const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (reques
         )
   // Anthropic rejects tool_choice when tools are absent; "none" is only meaningful with tools present.
   const toolChoice = tools === undefined || !request.toolChoice ? undefined : yield* lowerToolChoice(request.toolChoice)
+  const systemParts = request.system.filter(hasText)
   const system =
-    request.system.length === 0
+    systemParts.length === 0
       ? undefined
-      : request.system.map((part) => ({
+      : systemParts.map((part) => ({
           type: "text" as const,
           text: part.text,
           cache_control: cacheControl(breakpoints, part.cache),

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -554,7 +554,11 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       const content: AnthropicAssistantBlock[] = []
       for (const part of message.content) {
         if (part.type === "text") {
-          if (!hasText(part)) continue
+          if (!hasText(part)) {
+            if (part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
+              return yield* invalid("Anthropic Messages cannot discard provider state attached to empty assistant text")
+            continue
+          }
           content.push({ type: "text", text: part.text, cache_control: cacheControl(breakpoints, part.cache) })
           continue
         }

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -58,6 +58,93 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
+  it.effect("filters empty text blocks while preserving assistant replay state", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          system: [
+            { type: "text", text: " \n\t" },
+            { type: "text", text: "  Keep this system prompt.  " },
+          ],
+          messages: [
+            Message.user([
+              { type: "text", text: "" },
+              { type: "text", text: "  Use the tool.  " },
+              { type: "text", text: " \n\t" },
+            ]),
+            Message.assistant([
+              { type: "text", text: "", providerMetadata: { anthropic: { itemId: "ignored" } } },
+              { type: "reasoning", text: "", providerMetadata: { anthropic: { signature: "sig_1" } } },
+              ToolCallPart.make({ id: "call_1", name: "lookup", input: {} }),
+            ]),
+            Message.tool({
+              id: "call_1",
+              name: "lookup",
+              resultType: "content",
+              result: [
+                { type: "text", text: " \n\t" },
+                { type: "text", text: " Tool result. " },
+              ],
+            }),
+            Message.assistant(" \n\t"),
+            Message.user("Continue."),
+          ],
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body).toMatchObject({
+        system: [{ type: "text", text: "  Keep this system prompt.  " }],
+        messages: [
+          { role: "user", content: [{ type: "text", text: "  Use the tool.  " }] },
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "", signature: "sig_1" },
+              { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+            ],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "call_1",
+                content: [{ type: "text", text: " Tool result. " }],
+              },
+            ],
+          },
+          { role: "user", content: [{ type: "text", text: "Continue." }] },
+        ],
+      })
+    }),
+  )
+
+  it.effect("filters empty native system update blocks", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model: opus48,
+          messages: [
+            Message.user("Before."),
+            Message.system([
+              { type: "text", text: " \n\t" },
+              { type: "text", text: "Operator update." },
+            ]),
+            Message.assistant("After."),
+          ],
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body.messages[1]).toEqual({
+        role: "system",
+        content: [{ type: "text", text: "Operator update." }],
+      })
+    }),
+  )
+
   it.effect("lowers adaptive thinking settings with effort", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -71,7 +71,7 @@ describe("Anthropic Messages route", () => {
               { type: "text", text: " \n\t" },
             ]),
             Message.assistant([
-              { type: "text", text: "", providerMetadata: { anthropic: { itemId: "ignored" } } },
+              { type: "text", text: "" },
               { type: "reasoning", text: "", providerMetadata: { anthropic: { signature: "sig_1" } } },
               ToolCallPart.make({ id: "call_1", name: "lookup", input: {} }),
             ]),
@@ -111,6 +111,23 @@ describe("Anthropic Messages route", () => {
           { role: "user", content: [{ type: "text", text: "Continue." }] },
         ],
       })
+    }),
+  )
+
+  it.effect("rejects empty assistant text carrying provider state", () =>
+    Effect.gen(function* () {
+      const error = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              { type: "text", text: "", providerMetadata: { anthropic: { encryptedContent: "opaque" } } },
+            ]),
+          ],
+        }),
+      ).pipe(Effect.flip)
+
+      expect(error.message).toContain("cannot discard provider state attached to empty assistant text")
     }),
   )
 

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -58,16 +58,13 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
-  it.effect("filters empty text blocks while preserving assistant replay state", () =>
+  it.effect("filters empty user and assistant text while preserving replay state", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(
         LLM.request({
           model,
-          system: [
-            { type: "text", text: " \n\t" },
-            { type: "text", text: "  Keep this system prompt.  " },
-          ],
           messages: [
+            Message.user(" \n\t"),
             Message.user([
               { type: "text", text: "" },
               { type: "text", text: "  Use the tool.  " },
@@ -81,11 +78,8 @@ describe("Anthropic Messages route", () => {
             Message.tool({
               id: "call_1",
               name: "lookup",
-              resultType: "content",
-              result: [
-                { type: "text", text: " \n\t" },
-                { type: "text", text: " Tool result. " },
-              ],
+              resultType: "text",
+              result: "Tool result.",
             }),
             Message.assistant(" \n\t"),
             Message.user("Continue."),
@@ -95,7 +89,6 @@ describe("Anthropic Messages route", () => {
       )
 
       expect(prepared.body).toMatchObject({
-        system: [{ type: "text", text: "  Keep this system prompt.  " }],
         messages: [
           { role: "user", content: [{ type: "text", text: "  Use the tool.  " }] },
           {
@@ -111,36 +104,12 @@ describe("Anthropic Messages route", () => {
               {
                 type: "tool_result",
                 tool_use_id: "call_1",
-                content: [{ type: "text", text: " Tool result. " }],
+                content: "Tool result.",
               },
             ],
           },
           { role: "user", content: [{ type: "text", text: "Continue." }] },
         ],
-      })
-    }),
-  )
-
-  it.effect("filters empty native system update blocks", () =>
-    Effect.gen(function* () {
-      const prepared = yield* compileRequest(
-        LLM.request({
-          model: opus48,
-          messages: [
-            Message.user("Before."),
-            Message.system([
-              { type: "text", text: " \n\t" },
-              { type: "text", text: "Operator update." },
-            ]),
-            Message.assistant("After."),
-          ],
-          cache: "none",
-        }),
-      )
-
-      expect(prepared.body.messages[1]).toEqual({
-        role: "system",
-        content: [{ type: "text", text: "Operator update." }],
       })
     }),
   )

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -7,6 +7,9 @@ import type { FileAttachment } from "@opencode-ai/schema/prompt"
 
 const imageMimes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"])
 
+const hasProviderMetadata = (metadata: ProviderMetadata | undefined) =>
+  metadata !== undefined && Object.keys(metadata).length > 0
+
 const media = (file: FileAttachment): ContentPart => ({
   type: "media",
   mediaType: file.mime,
@@ -188,9 +191,9 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
     return result ? [call, result] : [call]
   })
   const meaningful = content.filter((part) => {
-    if (part.type === "text") return part.text !== ""
+    if (part.type === "text") return part.text !== "" || hasProviderMetadata(part.providerMetadata)
     if (part.type !== "reasoning") return true
-    return part.text !== "" || (part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
+    return part.text !== "" || hasProviderMetadata(part.providerMetadata)
   })
   const results = message.content
     .filter((item): item is SessionMessage.AssistantTool => item.type === "tool" && item.executed !== true)

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -1031,7 +1031,7 @@ Recent work
           content: [
             SessionMessage.AssistantText.make({
               type: "text",
-              text: "Checking.",
+              text: "",
               state: { phase: "commentary" },
             }),
           ],
@@ -1045,7 +1045,7 @@ Recent work
     expect(messages[0]?.content).toEqual([
       {
         type: "text",
-        text: "Checking.",
+        text: "",
         providerMetadata: { provider: { phase: "commentary" } },
       },
     ])


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic rejects ordinary message text blocks that contain only whitespace. Filter stateless blank blocks from user and assistant messages at the final Messages protocol boundary while preserving non-empty text verbatim. System updates and tool-result content retain their existing semantics.

Metadata-bearing empty assistant text remains available in canonical Core history for protocols that need replay identity. Anthropic request lowering rejects that stateful case instead of silently discarding provider state, while signed thinking, redacted thinking, tool calls, and hosted-tool state retain their native representations.

### How did you verify your code works?

- `bun test test/provider/anthropic-messages.test.ts` from `packages/ai`
- `bun typecheck` from `packages/ai`
- `bun test test/session-runner-message.test.ts` from `packages/core`
- Targeted `oxlint` on changed source files

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR