### PR TITLE
refactor(config): clarify discovery workflows

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -71,65 +71,69 @@ const layer = Layer.effect(
       return provider.integrationID === undefined && !integration
     }
 
-    const projectModel = (model: Model.Info, provider: Provider.Info) =>
-      ({
+    const projectModel = (model: Model.Info, provider: Provider.Info) => {
+      return {
         ...model,
         package: model.package ?? provider.package,
         settings: Provider.mergeOverlay(provider.settings, model.settings),
         headers: Provider.mergeHeaders(provider.headers, model.headers),
         body: Provider.mergeOverlay(provider.body, model.body),
-      }) satisfies Model.Info
+      } satisfies Model.Info
+    }
 
     const state = State.create<Data, Draft>({
       name: "catalog",
       initial: () => ({ providers: new Map() }),
-      draft: (draft): Draft => ({
-        provider: {
-          list: () => Array.fromIterable(draft.providers.values()) as ProviderRecord[],
-          get: (providerID) => draft.providers.get(providerID),
-          update: (providerID, fn) => {
-            let current = draft.providers.get(providerID)
-            if (!current) {
-              current = {
-                provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
-                models: new Map<Model.ID, Model.MutableInfo>(),
+      draft: (draft) => {
+        const result: Draft = {
+          provider: {
+            list: () => Array.fromIterable(draft.providers.values()) as ProviderRecord[],
+            get: (providerID) => draft.providers.get(providerID),
+            update: (providerID, fn) => {
+              let current = draft.providers.get(providerID)
+              if (!current) {
+                current = {
+                  provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
+                  models: new Map<Model.ID, Model.MutableInfo>(),
+                }
+                draft.providers.set(providerID, current)
               }
-              draft.providers.set(providerID, current)
-            }
-            fn(current.provider)
-          },
-          remove: (providerID) => {
-            draft.providers.delete(providerID)
-          },
-        },
-        model: {
-          get: (providerID, modelID) => draft.providers.get(providerID)?.models.get(modelID),
-          update: (providerID, modelID, fn) => {
-            let record = draft.providers.get(providerID)
-            if (!record) {
-              record = {
-                provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
-                models: new Map<Model.ID, Model.MutableInfo>(),
-              }
-              draft.providers.set(providerID, record)
-            }
-            const model = record.models.get(modelID) ?? (Model.Info.default(providerID, modelID) as Model.MutableInfo)
-            if (!record.models.has(modelID)) record.models.set(modelID, model)
-            fn(model)
-            model.id = modelID
-            model.providerID = providerID
-          },
-          remove: (providerID, modelID) => {
-            draft.providers.get(providerID)?.models.delete(modelID)
-          },
-          default: {
-            get: () => draft.defaultModel,
-            set: (providerID, modelID) => {
-              draft.defaultModel = { providerID, modelID }
+              fn(current.provider)
+            },
+            remove: (providerID) => {
+              draft.providers.delete(providerID)
             },
           },
-        },
-      }),
+          model: {
+            get: (providerID, modelID) => draft.providers.get(providerID)?.models.get(modelID),
+            update: (providerID, modelID, fn) => {
+              let record = draft.providers.get(providerID)
+              if (!record) {
+                record = {
+                  provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
+                  models: new Map<Model.ID, Model.MutableInfo>(),
+                }
+                draft.providers.set(providerID, record)
+              }
+              const model = record.models.get(modelID) ?? (Model.Info.default(providerID, modelID) as Model.MutableInfo)
+              if (!record.models.has(modelID)) record.models.set(modelID, model)
+              fn(model)
+              model.id = modelID
+              model.providerID = providerID
+            },
+            remove: (providerID, modelID) => {
+              draft.providers.get(providerID)?.models.delete(modelID)
+            },
+            default: {
+              get: () => draft.defaultModel,
+              set: (providerID, modelID) => {
+                draft.defaultModel = { providerID, modelID }
+              },
+            },
+          },
+        }
+        return result
+      },
       finalize: Effect.fn("Catalog.finalize")(function* () {
         yield* bus.publish(Catalog.Event.Updated, {})
       }),

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -71,70 +71,66 @@ const layer = Layer.effect(
       return provider.integrationID === undefined && !integration
     }
 
-    const projectModel = (model: Model.Info, provider: Provider.Info) => {
-      return {
+    const projectModel = (model: Model.Info, provider: Provider.Info) =>
+      ({
         ...model,
         package: model.package ?? provider.package,
         settings: Provider.mergeOverlay(provider.settings, model.settings),
         headers: Provider.mergeHeaders(provider.headers, model.headers),
         body: Provider.mergeOverlay(provider.body, model.body),
-      } satisfies Model.Info
-    }
+      }) satisfies Model.Info
 
     const state = State.create<Data, Draft>({
       name: "catalog",
       initial: () => ({ providers: new Map() }),
-      draft: (draft) => {
-        const result: Draft = {
-          provider: {
-            list: () => Array.fromIterable(draft.providers.values()) as ProviderRecord[],
-            get: (providerID) => draft.providers.get(providerID),
-            update: (providerID, fn) => {
-              let current = draft.providers.get(providerID)
-              if (!current) {
-                current = {
-                  provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
-                  models: new Map<Model.ID, Model.MutableInfo>(),
-                }
-                draft.providers.set(providerID, current)
+      draft: (draft): Draft => ({
+        provider: {
+          list: () => Array.fromIterable(draft.providers.values()) as ProviderRecord[],
+          get: (providerID) => draft.providers.get(providerID),
+          update: (providerID, fn) => {
+            let current = draft.providers.get(providerID)
+            if (!current) {
+              current = {
+                provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
+                models: new Map<Model.ID, Model.MutableInfo>(),
               }
-              fn(current.provider)
-            },
-            remove: (providerID) => {
-              draft.providers.delete(providerID)
+              draft.providers.set(providerID, current)
+            }
+            fn(current.provider)
+          },
+          remove: (providerID) => {
+            draft.providers.delete(providerID)
+          },
+        },
+        model: {
+          get: (providerID, modelID) => draft.providers.get(providerID)?.models.get(modelID),
+          update: (providerID, modelID, fn) => {
+            let record = draft.providers.get(providerID)
+            if (!record) {
+              record = {
+                provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
+                models: new Map<Model.ID, Model.MutableInfo>(),
+              }
+              draft.providers.set(providerID, record)
+            }
+            const model = record.models.get(modelID) ?? (Model.Info.default(providerID, modelID) as Model.MutableInfo)
+            if (!record.models.has(modelID)) record.models.set(modelID, model)
+            fn(model)
+            model.id = modelID
+            model.providerID = providerID
+          },
+          remove: (providerID, modelID) => {
+            draft.providers.get(providerID)?.models.delete(modelID)
+          },
+          default: {
+            get: () => draft.defaultModel,
+            set: (providerID, modelID) => {
+              draft.defaultModel = { providerID, modelID }
             },
           },
-          model: {
-            get: (providerID, modelID) => draft.providers.get(providerID)?.models.get(modelID),
-            update: (providerID, modelID, fn) => {
-              let record = draft.providers.get(providerID)
-              if (!record) {
-                record = {
-                  provider: Provider.Info.empty(providerID) as Provider.MutableInfo,
-                  models: new Map<Model.ID, Model.MutableInfo>(),
-                }
-                draft.providers.set(providerID, record)
-              }
-              const model = record.models.get(modelID) ?? (Model.Info.default(providerID, modelID) as Model.MutableInfo)
-              if (!record.models.has(modelID)) record.models.set(modelID, model)
-              fn(model)
-              model.id = modelID
-              model.providerID = providerID
-            },
-            remove: (providerID, modelID) => {
-              draft.providers.get(providerID)?.models.delete(modelID)
-            },
-            default: {
-              get: () => draft.defaultModel,
-              set: (providerID, modelID) => {
-                draft.defaultModel = { providerID, modelID }
-              },
-            },
-          },
-        }
-        return result
-      },
-      finalize: Effect.fn("Catalog.finalize")(function* (catalog) {
+        },
+      }),
+      finalize: Effect.fn("Catalog.finalize")(function* () {
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -157,6 +157,37 @@ export const layer = (options?: Options) =>
         return new Document({ type: "document", path: AbsolutePath.make(filepath), info })
       })
 
+      const loadWellknownEntry = Effect.fnUntraced(function* (entry: WellKnown.Entry) {
+        const auth = entry.manifest.auth
+        if (!auth) return []
+        const credential = (yield* credentials.list(entry.integrationID)).findLast(
+          (credential) => credential.value.type === "key",
+        )
+        if (!credential || credential.value.type !== "key") return []
+        const variables = { [auth.env]: credential.value.key }
+        const configs = yield* wellknown
+          .resolve(entry, variables)
+          .pipe(
+            Effect.catch(() =>
+              Effect.logWarning("failed to load wellknown config", { source: entry.origin }).pipe(
+                Effect.as([] as const),
+              ),
+            ),
+          )
+        return yield* Effect.forEach(configs, (config) =>
+          ConfigVariable.substitute({
+            type: "virtual",
+            source: entry.origin,
+            dir: entry.origin,
+            text: JSON.stringify(config),
+            env: variables,
+          }).pipe(
+            Effect.flatMap((text) => parseInfo(text, entry.origin)),
+            Effect.map((info) => (info ? new Document({ type: "document", info }) : undefined)),
+          ),
+        ).pipe(Effect.map((documents) => documents.filter((document) => document !== undefined)))
+      })
+
       const loadWellknown = Effect.fn("Config.loadWellknown")(function* () {
         const entries = yield* wellknown
           .entries()
@@ -165,38 +196,7 @@ export const layer = (options?: Options) =>
               Effect.logWarning("failed to discover wellknown config", { error }).pipe(Effect.as([] as const)),
             ),
           )
-        return yield* Effect.forEach(entries, (entry) =>
-          Effect.gen(function* () {
-            const auth = entry.manifest.auth
-            if (!auth) return []
-            const credential = (yield* credentials.list(entry.integrationID)).findLast(
-              (credential) => credential.value.type === "key",
-            )
-            if (!credential || credential.value.type !== "key") return []
-            const variables = { [auth.env]: credential.value.key }
-            const configs = yield* wellknown
-              .resolve(entry, variables)
-              .pipe(
-                Effect.catch(() =>
-                  Effect.logWarning("failed to load wellknown config", { source: entry.origin }).pipe(
-                    Effect.as([] as const),
-                  ),
-                ),
-              )
-            return yield* Effect.forEach(configs, (config) =>
-              ConfigVariable.substitute({
-                type: "virtual",
-                source: entry.origin,
-                dir: entry.origin,
-                text: JSON.stringify(config),
-                env: variables,
-              }).pipe(
-                Effect.flatMap((text) => parseInfo(text, entry.origin)),
-                Effect.map((info) => (info ? new Document({ type: "document", info }) : undefined)),
-              ),
-            ).pipe(Effect.map((documents) => documents.filter((document) => document !== undefined)))
-          }),
-        ).pipe(Effect.map((documents) => documents.flat()))
+        return yield* Effect.forEach(entries, loadWellknownEntry).pipe(Effect.map((documents) => documents.flat()))
       })
 
       const loadDirectory = Effect.fnUntraced(function* (directory: AbsolutePath) {

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -52,23 +52,19 @@ export const Plugin = define({
     const config = yield* Config.Service
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
+    const loadEntry = Effect.fnUntraced(function* (entry: Entry) {
+      if (entry.type === "document") return [entry]
+      if (entry.type !== "directory") return []
+      const files = yield* discover(fs, entry.path)
+      return yield* Effect.forEach(files, (file) =>
+        fs.readFileStringSafe(file.filepath).pipe(
+          Effect.map((content) => (content ? decode(file, content) : undefined)),
+          Effect.catch(() => Effect.succeed(undefined)),
+        ),
+      ).pipe(Effect.map((documents) => documents.filter((document): document is Document => document !== undefined)))
+    })
     const load = Effect.fn("ConfigAgentPlugin.load")(function* () {
-      return yield* Effect.forEach(
-        yield* config.entries(),
-        Effect.fnUntraced(function* (entry) {
-          if (entry.type === "document") return [entry]
-          if (entry.type !== "directory") return []
-          const files = yield* discover(fs, entry.path)
-          return yield* Effect.forEach(files, (file) =>
-            fs.readFileStringSafe(file.filepath).pipe(
-              Effect.map((content) => (content ? decode(file, content) : undefined)),
-              Effect.catch(() => Effect.succeed(undefined)),
-            ),
-          ).pipe(
-            Effect.map((documents) => documents.filter((document): document is Document => document !== undefined)),
-          )
-        }),
-      ).pipe(Effect.map((documents) => documents.flat()))
+      return yield* Effect.forEach(yield* config.entries(), loadEntry).pipe(Effect.map((documents) => documents.flat()))
     })
     const loaded = { documents: [] as Document[] }
     const reload = load().pipe(

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -53,10 +53,11 @@ export const Plugin = define({
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
     const load = Effect.fn("ConfigAgentPlugin.load")(function* () {
-      return yield* Effect.forEach(yield* config.entries(), (entry) => {
-        if (entry.type === "document") return Effect.succeed([entry])
-        if (entry.type !== "directory") return Effect.succeed([])
-        return Effect.gen(function* () {
+      return yield* Effect.forEach(
+        yield* config.entries(),
+        Effect.fnUntraced(function* (entry) {
+          if (entry.type === "document") return [entry]
+          if (entry.type !== "directory") return []
           const files = yield* discover(fs, entry.path)
           return yield* Effect.forEach(files, (file) =>
             fs.readFileStringSafe(file.filepath).pipe(
@@ -66,8 +67,8 @@ export const Plugin = define({
           ).pipe(
             Effect.map((documents) => documents.filter((document): document is Document => document !== undefined)),
           )
-        })
-      }).pipe(Effect.map((documents) => documents.flat()))
+        }),
+      ).pipe(Effect.map((documents) => documents.flat()))
     })
     const loaded = { documents: [] as Document[] }
     const reload = load().pipe(

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -18,15 +18,15 @@ export const Plugin = define({
     const config = yield* Config.Service
     const fs = yield* FSUtil.Service
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
-      return yield* Effect.forEach(yield* config.entries(), (entry) => {
-        if (entry.type === "document") return Effect.succeed([{ commands: entry.info.commands }])
-        if (entry.type !== "directory") return Effect.succeed([])
-        return loadDirectory(fs, entry.path).pipe(
-          Effect.map((commands) => [
-            { commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) },
-          ]),
-        )
-      }).pipe(Effect.map((documents) => documents.flat()))
+      return yield* Effect.forEach(
+        yield* config.entries(),
+        Effect.fnUntraced(function* (entry) {
+          if (entry.type === "document") return [{ commands: entry.info.commands }]
+          if (entry.type !== "directory") return []
+          const commands = yield* loadDirectory(fs, entry.path)
+          return [{ commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) }]
+        }),
+      ).pipe(Effect.map((documents) => documents.flat()))
     })
     const loaded = { documents: [] as { commands: Info["commands"] }[] }
     const reload = load().pipe(

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -17,16 +17,14 @@ export const Plugin = define({
   effect: Effect.fn(function* (ctx) {
     const config = yield* Config.Service
     const fs = yield* FSUtil.Service
+    const loadEntry = Effect.fnUntraced(function* (entry: Entry) {
+      if (entry.type === "document") return [{ commands: entry.info.commands }]
+      if (entry.type !== "directory") return []
+      const commands = yield* loadDirectory(fs, entry.path)
+      return [{ commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) }]
+    })
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
-      return yield* Effect.forEach(
-        yield* config.entries(),
-        Effect.fnUntraced(function* (entry) {
-          if (entry.type === "document") return [{ commands: entry.info.commands }]
-          if (entry.type !== "directory") return []
-          const commands = yield* loadDirectory(fs, entry.path)
-          return [{ commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) }]
-        }),
-      ).pipe(Effect.map((documents) => documents.flat()))
+      return yield* Effect.forEach(yield* config.entries(), loadEntry).pipe(Effect.map((documents) => documents.flat()))
     })
     const loaded = { documents: [] as { commands: Info["commands"] }[] }
     const reload = load().pipe(


### PR DESCRIPTION
## What

Make Config discovery read as named entry-loading workflows instead of nested per-reload Effect construction. The refactor preserves source ordering, diagnostics, credential selection, substitution, document priority, and catalog publication behavior.

## How

- Extract one well-known entry loader for credential lookup, remote resolution, substitution, and parsing.
- Hoist stable Agent and Command entry loaders outside their reload functions.
- Remove the unused Catalog finalizer parameter without reformatting its draft implementation.

## Scope

Behavior-preserving Config cleanup only; no source priority, watch, credential, manifest, parsing, or catalog semantics change.

## Testing

- Config, Catalog, Agent, and Command tests: 72 passed
- Simplify follow-up tests: 37 passed
- `bun typecheck` from `packages/core`
- Three-pass simplify review: reuse clean; syntax-only Catalog churn removed; loader allocation fixed
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
