### PR TITLE
refactor(plugin): simplify websearch effects

### DIFF
--- a/packages/core/src/plugin/websearch/mcp.ts
+++ b/packages/core/src/plugin/websearch/mcp.ts
@@ -45,24 +45,26 @@ export const call = <F extends Schema.Struct.Fields, R extends Schema.Struct.Fie
           params: Schema.Struct({ name: Schema.String, arguments: schema.input }),
         }),
       )({
-        jsonrpc: "2.0" as const,
-        id: 1 as const,
-        method: "tools/call" as const,
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
         params: { name: tool, arguments: value },
       }),
     )
-    return yield* Effect.gen(function* () {
-      const response = yield* HttpClient.filterStatusOk(http).execute(request)
-      const body = yield* collectBoundedResponseBody(
-        response,
-        MAX_RESPONSE_BYTES,
-        () => new Error(`${tool} response exceeded ${MAX_RESPONSE_BYTES} bytes`),
+    return yield* HttpClient.filterStatusOk(http)
+      .execute(request)
+      .pipe(
+        Effect.flatMap((response) =>
+          collectBoundedResponseBody(
+            response,
+            MAX_RESPONSE_BYTES,
+            () => new Error(`${tool} response exceeded ${MAX_RESPONSE_BYTES} bytes`),
+          ),
+        ),
+        Effect.flatMap((body) => parseResponse(body.toString("utf8"), schema.output)),
+        Effect.timeoutOrElse({
+          duration: Duration.seconds(25),
+          orElse: () => Effect.fail(new Error(`${tool} request timed out`)),
+        }),
       )
-      return yield* parseResponse(body.toString("utf8"), schema.output)
-    }).pipe(
-      Effect.timeoutOrElse({
-        duration: Duration.seconds(25),
-        orElse: () => Effect.fail(new Error(`${tool} request timed out`)),
-      }),
-    )
   })

--- a/packages/core/src/plugin/websearch/mcp.ts
+++ b/packages/core/src/plugin/websearch/mcp.ts
@@ -51,20 +51,18 @@ export const call = <F extends Schema.Struct.Fields, R extends Schema.Struct.Fie
         params: { name: tool, arguments: value },
       }),
     )
-    return yield* HttpClient.filterStatusOk(http)
-      .execute(request)
-      .pipe(
-        Effect.flatMap((response) =>
-          collectBoundedResponseBody(
-            response,
-            MAX_RESPONSE_BYTES,
-            () => new Error(`${tool} response exceeded ${MAX_RESPONSE_BYTES} bytes`),
-          ),
-        ),
-        Effect.flatMap((body) => parseResponse(body.toString("utf8"), schema.output)),
-        Effect.timeoutOrElse({
-          duration: Duration.seconds(25),
-          orElse: () => Effect.fail(new Error(`${tool} request timed out`)),
-        }),
+    return yield* Effect.gen(function* () {
+      const response = yield* HttpClient.filterStatusOk(http).execute(request)
+      const body = yield* collectBoundedResponseBody(
+        response,
+        MAX_RESPONSE_BYTES,
+        () => new Error(`${tool} response exceeded ${MAX_RESPONSE_BYTES} bytes`),
       )
+      return yield* parseResponse(body.toString("utf8"), schema.output)
+    }).pipe(
+      Effect.timeoutOrElse({
+        duration: Duration.seconds(25),
+        orElse: () => Effect.fail(new Error(`${tool} request timed out`)),
+      }),
+    )
   })

--- a/packages/core/src/plugin/websearch/tavily.ts
+++ b/packages/core/src/plugin/websearch/tavily.ts
@@ -63,15 +63,15 @@ export const Plugin = define<HttpClient.HttpClient | Scope.Scope>({
                 max_results: 8,
               }),
             )
-            const response = yield* Effect.gen(function* () {
-              const httpResponse = yield* HttpClient.filterStatusOk(http).execute(request)
-              return yield* HttpClientResponse.schemaBodyJson(SearchResponse)(httpResponse)
-            }).pipe(
-              Effect.timeoutOrElse({
-                duration: Duration.seconds(25),
-                orElse: () => Effect.fail(new Error("Tavily web search request timed out")),
-              }),
-            )
+            const response = yield* HttpClient.filterStatusOk(http)
+              .execute(request)
+              .pipe(
+                Effect.flatMap(HttpClientResponse.schemaBodyJson(SearchResponse)),
+                Effect.timeoutOrElse({
+                  duration: Duration.seconds(25),
+                  orElse: () => Effect.fail(new Error("Tavily web search request timed out")),
+                }),
+              )
             return response.results.map((item) => ({
               url: item.url,
               title: item.title,


### PR DESCRIPTION
## What

Simplify Websearch Effect code where the result is genuinely clearer without hiding named response boundaries. Tavily uses a direct execute/decode pipeline, while MCP retains its readable response/body generator and drops only unnecessary literal assertions.

## How

- Flatten Tavily request execution and schema decoding under the existing timeout.
- Remove redundant `as const` assertions from the schema-contextual MCP JSON-RPC request.
- Preserve MCP's named `response` and `body` steps after simplify review rejected a denser callback pipeline.

## Scope

Behavior-preserving Plugin cleanup only; no timeout, HTTP status, response limit, decoding, JSON-RPC, or provider behavior changes.

## Testing

- Websearch tests: 5 passed
- MCP and MCP integration tests: 37 passed
- Simplify follow-up combined tests: 42 passed
- `bun typecheck` from `packages/core`
- Three-pass simplify review: reuse and efficiency clean; denser MCP pipeline removed
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
