### PR TITLE
refactor(core): clarify guards and constants

### DIFF
--- a/packages/core/src/bus.ts
+++ b/packages/core/src/bus.ts
@@ -227,7 +227,7 @@ export function configured(options?: Options) {
           commit?: (seq: number) => Effect.Effect<void>,
         ) {
           return Effect.gen(function* () {
-            const durable = definition?.durable
+            const durable = definition.durable
             if (durable) {
               const aggregateID = (event.data as Record<string, unknown>)[durable.aggregate]
               if (typeof aggregateID !== "string") {
@@ -391,14 +391,14 @@ export function configured(options?: Options) {
           commit?: PublishOptions["commit"],
         ) {
           return Effect.gen(function* () {
-            if (!definition?.durable && commit)
+            if (!definition.durable && commit)
               return yield* Effect.die(
                 new InvalidDurableEventError({
                   type: event.type,
                   message: "Local commit hooks require a durable event",
                 }),
               )
-            if (definition?.durable) {
+            if (definition.durable) {
               const aggregateID = (event.data as Record<string, unknown>)[definition.durable.aggregate]
               if (typeof aggregateID !== "string")
                 return yield* commitDurableEvent(definition, event as Event.Payload, undefined, commit).pipe(
@@ -610,37 +610,35 @@ export function configured(options?: Options) {
         ) {
           return Effect.gen(function* () {
             const definition = Durable.get(event.type)
-            if (!definition?.durable) {
-              yield* Effect.die(
+            if (!definition?.durable)
+              return yield* Effect.die(
                 new InvalidDurableEventError({ type: event.type, message: `Unknown durable event type ${event.type}` }),
               )
-            } else {
-              yield* durableLocks.withLock(event.aggregateID)(
-                Effect.gen(function* () {
-                  const payload = {
-                    id: event.id,
-                    created: event.created ?? 0,
-                    type: definition.type,
-                    data: Schema.decodeUnknownSync(definition.data)(event.data),
-                  } as Event.Payload
-                  const committed = yield* commitDurableEvent(definition, payload, {
-                    seq: event.seq,
-                    aggregateID: event.aggregateID,
-                    ownerID: options?.ownerID,
-                    strictOwner: options?.strictOwner,
-                  })
-                  if (committed && options?.publish) {
-                    yield* notify(
-                      {
-                        ...payload,
-                        durable: envelope(committed.aggregateID, committed.seq, definition.durable.version),
-                      },
-                      true,
-                    )
-                  }
-                }),
-              )
-            }
+            yield* durableLocks.withLock(event.aggregateID)(
+              Effect.gen(function* () {
+                const payload = {
+                  id: event.id,
+                  created: event.created ?? 0,
+                  type: definition.type,
+                  data: Schema.decodeUnknownSync(definition.data)(event.data),
+                } as Event.Payload
+                const committed = yield* commitDurableEvent(definition, payload, {
+                  seq: event.seq,
+                  aggregateID: event.aggregateID,
+                  ownerID: options?.ownerID,
+                  strictOwner: options?.strictOwner,
+                })
+                if (committed && options?.publish) {
+                  yield* notify(
+                    {
+                      ...payload,
+                      durable: envelope(committed.aggregateID, committed.seq, definition.durable.version),
+                    },
+                    true,
+                  )
+                }
+              }),
+            )
           })
         }
 

--- a/packages/core/src/event-logger.ts
+++ b/packages/core/src/event-logger.ts
@@ -4,13 +4,13 @@ import { Effect, Layer } from "effect"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "./bus.js"
 
-const Types = new Set(["agent.updated", "catalog.updated", "command.updated", "config.updated"])
+const EVENT_TYPES = new Set(["agent.updated", "catalog.updated", "command.updated", "config.updated"])
 
 export const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const unsubscribe = yield* bus.listen((event) =>
-      Types.has(event.type) ? Effect.logInfo("event", { event }) : Effect.void,
+      EVENT_TYPES.has(event.type) ? Effect.logInfo("event", { event }) : Effect.void,
     )
     yield* Effect.addFinalizer(() => unsubscribe)
   }),

--- a/packages/core/src/id/id.ts
+++ b/packages/core/src/id/id.ts
@@ -42,8 +42,7 @@ export { createID as create }
 export function timestamp(id: string): number {
   const prefix = id.split("_")[0]
   const hex = id.slice(prefix.length + 1, prefix.length + 13)
-  const encoded = BigInt("0x" + hex)
-  return Number(encoded / BigInt(0x1000))
+  return Number(BigInt(`0x${hex}`) / 0x1000n)
 }
 
 export * as Identifier from "./id.js"


### PR DESCRIPTION
## What

Remove misleading optional access and stale nesting from durable Bus guards, then simplify two Core constants. The changes preserve durable lookup, lock, transaction, replay, ID timestamp, and event filtering behavior.

## How

- Access `definition.durable` directly where the Event definition is statically present.
- Return early for an unknown replay definition before the unchanged lock and commit path.
- Inline ID timestamp decoding and rename the event-type Set as a runtime constant.

## Scope

Behavior-preserving Core cleanup only; no event, transaction, replay, identifier, or logging semantics change.

## Testing

- 68 targeted Bus, event logger, schema, and identifier tests passed
- `bun typecheck` from `packages/core`
- Three-pass simplify review: reuse, quality, and efficiency clean
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
