### PR TITLE
refactor(config): simplify utility workflows

### DIFF
--- a/packages/core/src/config/normalize.ts
+++ b/packages/core/src/config/normalize.ts
@@ -793,7 +793,7 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function own(value: Record<string, unknown>, key: string) {
-  return Object.prototype.hasOwnProperty.call(value, key)
+  return Object.hasOwn(value, key)
 }
 
 function setOwn(value: Record<string, unknown>, key: string, item: unknown) {

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -160,8 +160,7 @@ function isPathAction(action: string): action is PathAction {
 }
 
 function expandHome(resource: string, home: string) {
-  if (resource === "~") return home
-  if (resource === "$HOME") return home
+  if (resource === "~" || resource === "$HOME") return home
   const relative = resource.startsWith("~/")
     ? resource.slice(2)
     : resource.startsWith("$HOME/") || resource.startsWith("$HOME\\")

--- a/packages/core/src/config/variable.ts
+++ b/packages/core/src/config/variable.ts
@@ -37,11 +37,10 @@ const substituteFiles = Effect.fnUntraced(function* (input: SubstituteInput, tex
   const fs = yield* FSUtil.Service
   const configDir = input.type === "path" ? path.dirname(input.path) : input.dir
   const configSource = input.type === "path" ? input.path : input.source
-  const matches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
   let out = ""
   let cursor = 0
 
-  for (const match of matches) {
+  for (const match of text.matchAll(/\{file:[^}]+\}/g)) {
     const token = match[0]
     const index = match.index
     out += text.slice(cursor, index)
@@ -54,7 +53,7 @@ const substituteFiles = Effect.fnUntraced(function* (input: SubstituteInput, tex
       continue
     }
 
-    const filePath = token.replace(/^\{file:/, "").replace(/\}$/, "")
+    const filePath = token.slice("{file:".length, -1)
     const expandedPath = filePath.startsWith("~/") ? path.join(os.homedir(), filePath.slice(2)) : filePath
     const resolvedPath = path.isAbsolute(expandedPath) ? expandedPath : path.resolve(configDir, expandedPath)
     const fileContent = yield* fs.readFileString(resolvedPath).pipe(

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -19,7 +19,7 @@ export const EmbeddedSource = Skill.EmbeddedSource
 export type EmbeddedSource = Skill.EmbeddedSource
 
 export const Source = Skill.Source
-export type Source = typeof Source.Type
+export type Source = Skill.Source
 
 export const Info = Skill.Info
 export type Info = Skill.Info

--- a/packages/core/src/skill/instructions.ts
+++ b/packages/core/src/skill/instructions.ts
@@ -72,8 +72,7 @@ const layer = Layer.effect(
       load: Effect.fn("SkillInstructions.load")(function* (selection) {
         const agent = selection.info
         if (!agent) return Instructions.empty
-        const permitted = Skill.available(yield* skills.list(), agent)
-        const available = permitted
+        const available = Skill.available(yield* skills.list(), agent)
           .flatMap((skill) =>
             skill.description === undefined || skill.autoinvoke === false
               ? []

--- a/packages/core/src/wellknown.ts
+++ b/packages/core/src/wellknown.ts
@@ -180,9 +180,9 @@ const layer = Layer.effect(
           }),
         )
       }),
-      resolve: Effect.fn("WellKnown.resolveEntry")(function* (entry, variables) {
-        return yield* resolveEntry(entry, variables).pipe(Effect.provideService(HttpClient.HttpClient, http))
-      }),
+      resolve: Effect.fn("WellKnown.resolveEntry")((entry, variables) =>
+        resolveEntry(entry, variables).pipe(Effect.provideService(HttpClient.HttpClient, http)),
+      ),
     })
   }),
 )


### PR DESCRIPTION
## What

Simplify Config and Skill utility code by using canonical type façades, guaranteed token structure, and direct Effect callbacks. The changes preserve normalization, substitution order, path expansion, Skill filtering, and well-known resolution behavior.

## How

- Re-export the canonical `Skill.Source` type and use `Object.hasOwn` for record checks.
- Iterate file substitutions lazily and strip their guaranteed delimiters with `slice`.
- Simplify identical home aliases, one-use Skill filtering state, and well-known Effect delegation.

## Scope

Behavior-preserving Config cleanup only; no config format, substitution, permission, discovery, or resolution semantics change.

## Testing

- 86 targeted Config, Skill, Agent, and WellKnown tests passed
- `bun typecheck` from `packages/core`
- Three-pass simplify review: reuse, quality, and efficiency clean
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
