### PR TITLE
refactor(core): simplify tool and shell code

### DIFF
--- a/packages/core/src/shell/select.ts
+++ b/packages/core/src/shell/select.ts
@@ -158,7 +158,6 @@ function info(file: string, options?: Options, bin?: string): Item {
 
 export function args(file: string, command: string) {
   const n = name(file)
-  if (n === "nu" || n === "fish" || n === "zsh" || n === "bash") return ["-c", command]
   if (n === "cmd") return ["/c", command]
   if (ps(file)) return ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command]
   return ["-c", command]

--- a/packages/core/src/shell/select.ts
+++ b/packages/core/src/shell/select.ts
@@ -158,8 +158,7 @@ function info(file: string, options?: Options, bin?: string): Item {
 
 export function args(file: string, command: string) {
   const n = name(file)
-  if (n === "nu" || n === "fish") return ["-c", command]
-  if (n === "zsh" || n === "bash") return ["-c", command]
+  if (n === "nu" || n === "fish" || n === "zsh" || n === "bash") return ["-c", command]
   if (n === "cmd") return ["/c", command]
   if (ps(file)) return ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command]
   return ["-c", command]

--- a/packages/core/src/tool/html-markdown.ts
+++ b/packages/core/src/tool/html-markdown.ts
@@ -109,9 +109,10 @@ export function convertHTMLToMarkdown(html: string) {
     outputBytes -= encoder.encode(value).byteLength
     return value
   }
+  const quotePrefix = () => "> ".repeat(Math.min(8, quoteDepth))
   const prefixQuote = () => {
     if (!needsQuotePrefix || quoteDepth === 0 || activeCell) return
-    append("> ".repeat(Math.min(8, quoteDepth)))
+    append(quotePrefix())
     needsQuotePrefix = false
   }
   const flushSpace = () => {
@@ -228,7 +229,7 @@ export function convertHTMLToMarkdown(html: string) {
     const fence = marker.repeat(length)
     block()
     const prefix = `${fence}${code.language ?? ""}\n`
-    const quote = quoteDepth > 0 ? "> ".repeat(Math.min(8, quoteDepth)) : ""
+    const quote = quoteDepth > 0 ? quotePrefix() : ""
     let payload = code.text
     for (;;) {
       const candidate = `${prefix}${payload}${payload.endsWith("\n") ? "" : "\n"}${fence}`
@@ -605,7 +606,7 @@ export function convertHTMLToMarkdown(html: string) {
               block()
             }
             if (!table.fallback && rectangular) {
-              const prefix = `${quoteDepth > 0 ? "> ".repeat(Math.min(8, quoteDepth)) : ""}${pendingIndent}`
+              const prefix = `${quoteDepth > 0 ? quotePrefix() : ""}${pendingIndent}`
               pendingIndent = ""
               append(`${prefix}| ${table.rows[0].join(" | ")} |\n${prefix}|${" --- |".repeat(width)}`)
               for (const row of table.rows.slice(1)) append(`\n${prefix}| ${row.join(" | ")} |`)

--- a/packages/core/src/tool/html-markdown.ts
+++ b/packages/core/src/tool/html-markdown.ts
@@ -111,7 +111,7 @@ export function convertHTMLToMarkdown(html: string) {
   }
   const prefixQuote = () => {
     if (!needsQuotePrefix || quoteDepth === 0 || activeCell) return
-    append(`${"> ".repeat(Math.min(8, quoteDepth))}`)
+    append("> ".repeat(Math.min(8, quoteDepth)))
     needsQuotePrefix = false
   }
   const flushSpace = () => {
@@ -228,8 +228,7 @@ export function convertHTMLToMarkdown(html: string) {
     const fence = marker.repeat(length)
     block()
     const prefix = `${fence}${code.language ?? ""}\n`
-    const quote = quoteDepth > 0 ? `${"> ".repeat(Math.min(8, quoteDepth))}` : ""
-    const closing = `${code.text.endsWith("\n") ? "" : "\n"}${fence}`
+    const quote = quoteDepth > 0 ? "> ".repeat(Math.min(8, quoteDepth)) : ""
     let payload = code.text
     for (;;) {
       const candidate = `${prefix}${payload}${payload.endsWith("\n") ? "" : "\n"}${fence}`
@@ -606,7 +605,7 @@ export function convertHTMLToMarkdown(html: string) {
               block()
             }
             if (!table.fallback && rectangular) {
-              const prefix = `${quoteDepth > 0 ? `${"> ".repeat(Math.min(8, quoteDepth))}` : ""}${pendingIndent}`
+              const prefix = `${quoteDepth > 0 ? "> ".repeat(Math.min(8, quoteDepth)) : ""}${pendingIndent}`
               pendingIndent = ""
               append(`${prefix}| ${table.rows[0].join(" | ")} |\n${prefix}|${" --- |".repeat(width)}`)
               for (const row of table.rows.slice(1)) append(`\n${prefix}| ${row.join(" | ")} |`)

--- a/packages/core/src/tool/plugin/edit.ts
+++ b/packages/core/src/tool/plugin/edit.ts
@@ -87,7 +87,7 @@ const findLineOccurrences = (content: string, search: string) => {
     if (
       !actual.every(
         (item, lineIndex) =>
-          normalizeForMatch(item.text.trimEnd()) === normalizeForMatch(expected[lineIndex]!.trimEnd()),
+          normalizeForMatch(item.text.trimEnd()) === normalizeForMatch(expected[lineIndex].trimEnd()),
       )
     )
       return []

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -101,15 +101,13 @@ const standardFailure = (prefix: string, error: unknown) =>
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}
-  if (isStandardSchema(schema))
-    return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
-  return Schema.isSchema(schema) ? toJsonSchema(schema) : (schema as JsonSchema.JsonSchema)
+  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" })
+  return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
 }
 
 const outputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
-  if (isStandardSchema(schema))
-    return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
-  return Schema.isSchema(schema) ? toJsonSchema(schema) : (schema as JsonSchema.JsonSchema)
+  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" })
+  return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
 }
 
 const toJsonSchema = (schema: Schema.Top): JsonSchema.JsonSchema => {


### PR DESCRIPTION
## What

Remove dead Markdown expressions, erased schema assertions, and redundant shell selection logic. The simplify pass further centralizes quote-prefix construction and proves ordinary shells can use the existing fallback directly.

## How

- Reuse one capped Markdown quote prefix and remove unused string construction.
- Trust existing schema and indexed-access narrowing instead of erased assertions.
- Keep only the `cmd` and PowerShell argument special cases before the standard fallback.

## Scope

Behavior-preserving Tool and Shell cleanup only; no Markdown output, schema, edit matching, or shell argument behavior changes.

## Testing

- 112 targeted Tool, WebFetch, Edit, and Shell tests passed
- Simplify follow-up: 57 tests passed
- `bun typecheck` from `packages/core`
- Three-pass simplify review completed; both findings applied
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
