### PR TITLE
refactor(core): simplify provider runtime code

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -127,7 +127,7 @@ function prepareOptions(model: Info, pkg: string) {
       options.timeout !== undefined && options.timeout !== null && options.timeout !== false
         ? AbortSignal.timeout(options.timeout)
         : undefined,
-    ].filter((item): item is AbortSignal | AbortController => item !== undefined)
+    ].filter((item): item is AbortSignal | AbortController => item !== undefined && item !== null)
     const chunkAbortCtl = signals.find((item): item is AbortController => item instanceof AbortController)
     const abortSignals = signals.map((item) => (item instanceof AbortController ? item.signal : item))
     if (abortSignals.length === 1) opts.signal = abortSignals[0]

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -127,7 +127,7 @@ function prepareOptions(model: Info, pkg: string) {
       options.timeout !== undefined && options.timeout !== null && options.timeout !== false
         ? AbortSignal.timeout(options.timeout)
         : undefined,
-    ].filter((item): item is AbortSignal | AbortController => Boolean(item))
+    ].filter((item): item is AbortSignal | AbortController => item !== undefined)
     const chunkAbortCtl = signals.find((item): item is AbortController => item instanceof AbortController)
     const abortSignals = signals.map((item) => (item instanceof AbortController ? item.signal : item))
     if (abortSignals.length === 1) opts.signal = abortSignals[0]
@@ -346,8 +346,7 @@ function gatewayProviderOptions(modelID: ID, settings: Readonly<Record<string, u
   const prefix = separator > 0 ? modelID.slice(0, separator) : undefined
   if (prefix)
     return { ...(gateway === undefined ? {} : { gateway }), [prefix === "amazon" ? "bedrock" : prefix]: model }
-  if (typeof gateway === "object" && gateway !== null && !Array.isArray(gateway))
-    return { gateway: { ...gateway, ...model } }
+  if (gateway !== undefined) return { gateway: { ...gateway, ...model } }
   return { gateway: model }
 }
 

--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -112,15 +112,15 @@ export const create = (
           files: collected,
           ...(result.ok ? {} : { error: true }),
         }
-        const content: Array<Content> = [{ type: "text", text: value.output }]
-        content.push(
+        const content: Array<Content> = [
+          { type: "text", text: value.output },
           ...value.files.map((file) => ({
             type: "file" as const,
             uri: `data:${file.mime};base64,${file.data}`,
             mime: file.mime,
             ...(file.name === undefined ? {} : { name: file.name }),
           })),
-        )
+        ]
         const metadata: Metadata = {
           toolCalls: value.toolCalls,
           ...(value.error ? { error: true } : {}),

--- a/packages/core/src/plugin/provider/amazon-bedrock.ts
+++ b/packages/core/src/plugin/provider/amazon-bedrock.ts
@@ -86,10 +86,6 @@ export const AmazonBedrockPlugin = define({
           process.env.AWS_BEARER_TOKEN_BEDROCK ??
           (typeof options.bearerToken === "string" ? options.bearerToken : undefined)
         if (bearerToken && !process.env.AWS_BEARER_TOKEN_BEDROCK) process.env.AWS_BEARER_TOKEN_BEDROCK = bearerToken
-        const containerCreds = Boolean(
-          process.env.AWS_CONTAINER_CREDENTIALS_RELATIVE_URI || process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI,
-        )
-
         options.region = region
         if (typeof options.endpoint === "string") options.baseURL = options.endpoint
         if (!bearerToken && options.credentialProvider === undefined) {

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -113,6 +113,34 @@ it.effect("projects request settings, headers, and body overlays", () =>
   }),
 )
 
+it.effect("uses only the provider timeout signal when the request signal is null", () =>
+  Effect.gen(function* () {
+    const aisdk = yield* AISDK.Service
+    let wrappedFetch: typeof fetch | undefined
+    let requestSignal: AbortSignal | null | undefined
+    yield* aisdk.hook.sdk((event) => {
+      wrappedFetch = event.options.fetch
+      event.sdk = { languageModel: () => ({ provider: event.model.providerID }) }
+    })
+
+    yield* aisdk.language(
+      model("test-ai-sdk", {
+        timeout: 60_000,
+        fetch: async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+          requestSignal = init?.signal
+          return new Response()
+        },
+      }),
+    )
+    const request = wrappedFetch
+    if (!request) return yield* Effect.die("Expected wrapped fetch")
+    yield* Effect.promise(() => request("https://example.com", { signal: null }))
+
+    expect(requestSignal).toBeInstanceOf(AbortSignal)
+    expect(requestSignal?.aborted).toBeFalse()
+  }),
+)
+
 it.effect("lowers chronological system updates to wrapped user messages", () =>
   Effect.gen(function* () {
     const aisdk = yield* AISDK.Service


### PR DESCRIPTION
## What

Simplify provider option projection, remove dead Bedrock credential reads, and construct Code Mode result content immutably without changing request or output behavior.

## How

- Narrow nullable request signals explicitly before timeout composition, with focused regression coverage.
- Trust the gateway value's construction invariant instead of re-validating its shape.
- Remove unused Bedrock environment reads and build Code Mode content in one expression.

## Scope

Behavior-preserving Core cleanup only; no provider credential selection, gateway routing, timeout, or Code Mode output semantics change.

## Testing

- 57 targeted Bedrock, AISDK, AISDK-native, and Code Mode tests passed
- 40 AISDK tests passed after adding null-signal regression coverage
- `bun typecheck` from `packages/core`
- Three-pass simplify review completed; nullable-signal finding fixed and covered
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
