### PR TITLE
refactor(core): simplify vcs state helpers

### DIFF
--- a/packages/core/src/file-retention.ts
+++ b/packages/core/src/file-retention.ts
@@ -13,10 +13,10 @@ export const cleanup = Effect.fn("FileRetention.cleanup")(function* (
     files,
     (file) =>
       Effect.gen(function* () {
-        const info = yield* fs.stat(file).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        const info = yield* fs.stat(file).pipe(Effect.orElseSucceed(() => undefined))
         const mtime = info && Option.getOrUndefined(info.mtime)
         if (!mtime || mtime.getTime() >= cutoff) return
-        yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
+        yield* fs.remove(file).pipe(Effect.ignore)
       }),
     { concurrency: 8, discard: true },
   )

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -171,7 +171,7 @@ const layer = Layer.effect(
     const discover = Effect.fn("Git.repo.discover")(function* (input: AbsolutePath) {
       const dotgit = yield* fs.up({ targets: [".git"], start: input, mode: "first" }).pipe(
         Effect.map((matches) => matches[0]),
-        Effect.catch(() => Effect.succeed(undefined)),
+        Effect.orElseSucceed(() => undefined),
       )
       if (!dotgit) return undefined
 
@@ -346,17 +346,9 @@ const layer = Layer.effect(
       gitDirectory: AbsolutePath
       seed?: Repository
     }) {
-      yield* fs.ensureDir(input.gitDirectory).pipe(
-        Effect.mapError(
-          (cause) =>
-            new OperationError({
-              operation: "create",
-              directory: input.gitDirectory,
-              message: "Failed to create Git storage",
-              cause,
-            }),
-        ),
-      )
+      const operationError = (message: string) => (cause: unknown) =>
+        new OperationError({ operation: "create", directory: input.gitDirectory, message, cause })
+      yield* fs.ensureDir(input.gitDirectory).pipe(Effect.mapError(operationError("Failed to create Git storage")))
       const repository = new Repository({
         worktree: input.worktree,
         gitDirectory: input.gitDirectory,
@@ -371,45 +363,17 @@ const layer = Layer.effect(
         yield* fs.writeFileString(config, `${current.endsWith("\n") ? "\n" : "\n\n"}${snapshotConfigInclude}`, {
           flag: "a",
         })
-      }).pipe(
-        Effect.mapError(
-          (cause) =>
-            new OperationError({
-              operation: "create",
-              directory: input.gitDirectory,
-              message: "Failed to configure Git storage",
-              cause,
-            }),
-        ),
-      )
+      }).pipe(Effect.mapError(operationError("Failed to configure Git storage")))
       if (!input.seed) return repository
-      yield* fs.ensureDir(path.join(input.gitDirectory, "objects", "info")).pipe(
-        Effect.mapError(
-          (cause) =>
-            new OperationError({
-              operation: "create",
-              directory: input.gitDirectory,
-              message: "Failed to configure shared Git objects",
-              cause,
-            }),
-        ),
-      )
+      yield* fs
+        .ensureDir(path.join(input.gitDirectory, "objects", "info"))
+        .pipe(Effect.mapError(operationError("Failed to configure shared Git objects")))
       yield* fs
         .writeFileString(
           path.join(input.gitDirectory, "objects", "info", "alternates"),
           path.join(input.seed.commonDirectory, "objects") + "\n",
         )
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new OperationError({
-                operation: "create",
-                directory: input.gitDirectory,
-                message: "Failed to configure shared Git objects",
-                cause,
-              }),
-          ),
-        )
+        .pipe(Effect.mapError(operationError("Failed to configure shared Git objects")))
       yield* fs
         .copyFile(path.join(input.seed.gitDirectory, "index"), path.join(input.gitDirectory, "index"))
         .pipe(Effect.catch(() => Effect.void))
@@ -439,7 +403,7 @@ const layer = Layer.effect(
         ? new Set(
             (yield* repositoryOperation("refresh", input.ignores, ["check-ignore", "--no-index", "--stdin", "-z"], {
               stdin: candidates.join("\0") + "\0",
-            }).pipe(Effect.catch(() => Effect.succeed({ text: "", stderr: "" })))).text
+            }).pipe(Effect.orElseSucceed(() => ({ text: "", stderr: "" })))).text
               .split("\0")
               .filter(Boolean),
           )
@@ -454,7 +418,7 @@ const layer = Layer.effect(
                 Effect.map((info) =>
                   info.type === "File" && Number(info.size) > maximum ? RelativePath.make(item) : undefined,
                 ),
-                Effect.catch(() => Effect.succeed(undefined)),
+                Effect.orElseSucceed(() => undefined),
               ),
             { concurrency: 8 },
           )).filter((item): item is RelativePath => item !== undefined)
@@ -752,7 +716,7 @@ interface Result {
 
 function run(cwd: string, proc: AppProcess.Interface) {
   return (args: string[]) =>
-    execute(cwd, proc)(args).pipe(Effect.catch(() => Effect.succeed({ exitCode: 1, text: "", stderr: "" })))
+    execute(cwd, proc)(args).pipe(Effect.orElseSucceed(() => ({ exitCode: 1, text: "", stderr: "" })))
 }
 
 function execute(cwd: string, proc: AppProcess.Interface) {

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -376,7 +376,7 @@ const layer = Layer.effect(
         .pipe(Effect.mapError(operationError("Failed to configure shared Git objects")))
       yield* fs
         .copyFile(path.join(input.seed.gitDirectory, "index"), path.join(input.gitDirectory, "index"))
-        .pipe(Effect.catch(() => Effect.void))
+        .pipe(Effect.ignore)
       return repository
     })
 

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -15,6 +15,10 @@ export interface Registration {
   readonly dispose: Effect.Effect<void>
 }
 
+/**
+ * Registers and applies a scoped transform. Closing the owning Scope removes
+ * the transform and reloads the materialized state.
+ */
 export type Transform<DraftApi> = (
   transform: TransformCallback<DraftApi>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
@@ -69,10 +73,6 @@ export interface Options<State, DraftApi> {
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
   readonly get: () => State
-  /**
-   * Registers and applies a scoped transform. Closing the owning Scope removes
-   * the transform and reloads the materialized state.
-   */
 }
 
 export function create<State, DraftApi>(options: Options<State, DraftApi>): Interface<State, DraftApi> {

--- a/packages/core/src/vcs/hg.ts
+++ b/packages/core/src/vcs/hg.ts
@@ -77,25 +77,14 @@ export function make(
       return { branch: { current: yield* hg.branch(), default: "default" } } satisfies Info
     }),
     status: Effect.fn("VcsHg.status")(function* () {
-      const [items, batch] = yield* Effect.all(
-        // Zero-context patches are enough to count changed lines.
-        [hg.status(undefined, scope), hg.diff(undefined, scope, { context: 0 })],
-        { concurrency: 2 },
-      )
-      const chunks = chunksByFile(batch, () => undefined)
-      return yield* Effect.forEach(
-        items.toSorted((a, b) => a.file.localeCompare(b.file)),
+      return (yield* diffAgainst(undefined, { context: 0 })).map(
         (item) =>
-          Effect.gen(function* () {
-            const patch = yield* patchFor(item, undefined, chunks.get(item.file))
-            const counts = countPatch(patch)
-            return {
-              file: item.file,
-              additions: counts.additions,
-              deletions: counts.deletions,
-              status: item.status,
-            } satisfies FileStatus
-          }),
+          ({
+            file: item.file,
+            additions: item.additions,
+            deletions: item.deletions,
+            status: item.status,
+          }) satisfies FileStatus,
       )
     }),
     diff: Effect.fn("VcsHg.diff")(function* (mode: Mode, options?: DiffOptions) {

--- a/packages/core/src/vcs/hg.ts
+++ b/packages/core/src/vcs/hg.ts
@@ -39,7 +39,7 @@ export function make(
     if (item.code === "?") {
       const content = yield* fs
         .readFileString(path.join(input.worktree, item.file))
-        .pipe(Effect.catch(() => Effect.succeed(undefined)))
+        .pipe(Effect.orElseSucceed(() => undefined))
       if (content === undefined || Buffer.byteLength(content) > MAX_PATCH_BYTES) return emptyPatch(item.file)
       return addPatch(item.file, content)
     }
@@ -77,14 +77,25 @@ export function make(
       return { branch: { current: yield* hg.branch(), default: "default" } } satisfies Info
     }),
     status: Effect.fn("VcsHg.status")(function* () {
-      return (yield* diffAgainst(undefined, { context: 0 })).map(
+      const [items, batch] = yield* Effect.all(
+        // Zero-context patches are enough to count changed lines.
+        [hg.status(undefined, scope), hg.diff(undefined, scope, { context: 0 })],
+        { concurrency: 2 },
+      )
+      const chunks = chunksByFile(batch, () => undefined)
+      return yield* Effect.forEach(
+        items.toSorted((a, b) => a.file.localeCompare(b.file)),
         (item) =>
-          ({
-            file: item.file,
-            additions: item.additions,
-            deletions: item.deletions,
-            status: item.status,
-          }) satisfies FileStatus,
+          Effect.gen(function* () {
+            const patch = yield* patchFor(item, undefined, chunks.get(item.file))
+            const counts = countPatch(patch)
+            return {
+              file: item.file,
+              additions: counts.additions,
+              deletions: counts.deletions,
+              status: item.status,
+            } satisfies FileStatus
+          }),
       )
     }),
     diff: Effect.fn("VcsHg.diff")(function* (mode: Mode, options?: DiffOptions) {
@@ -131,7 +142,7 @@ function makeHg(proc: AppProcess.Interface, worktree: string) {
         truncated: result.stdoutTruncated || result.stderrTruncated,
       }
     },
-    Effect.catch(() => Effect.succeed({ exitCode: 1, text: () => "", truncated: false })),
+    Effect.orElseSucceed(() => ({ exitCode: 1, text: () => "", truncated: false })),
   )
 
   const status = Effect.fn("VcsHg.statusNames")(function* (rev: string | undefined, scope: string) {

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -269,7 +269,8 @@ const layer = Layer.effect(
       const worktreeDirectory = yield* canonical(fs, input.directory)
       const stored = yield* ops.find(input.projectID, worktreeDirectory)
       if (!stored?.strategy) return yield* new InvalidDirectoryError({ directory: worktreeDirectory })
-      yield* (yield* getStrategy(StrategyID.make(stored.strategy))).remove({
+      const strategy = yield* getStrategy(StrategyID.make(stored.strategy))
+      yield* strategy.remove({
         directory: worktreeDirectory,
         force: input.force,
       })


### PR DESCRIPTION
## What

Simplify Git, Mercurial, retention, Worktree, and State helper code while preserving command count, streaming status projection, error payloads, and cleanup behavior.

## How

- Reuse one local Git operation-error mapper and dedicated Effect fallback/discard combinators.
- Keep Mercurial status projection streaming while simplifying constant failure recovery.
- Bind the Worktree strategy before removal and attach State registration documentation to the type it describes.

## Scope

Behavior-preserving Core cleanup only. Mercurial `status()` deliberately remains separate from `diffAgainst()` so large patch strings are not accumulated when callers only need file status.

## Testing

- `bun run test --timeout 15000 test/vcs-hg.test.ts test/git.test.ts test/snapshot.test.ts test/state.test.ts test/worktree.test.ts test/shell-cleanup.test.ts test/tool-output.test.ts`
- 42 tests passed; 6 Mercurial/platform tests skipped
- `bun typecheck` from `packages/core`
- Three-pass simplify review completed; streaming and Effect-combinator findings applied
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
