### PR TITLE
refactor(core): simplify persistence runtime code

### DIFF
--- a/packages/core/src/credential.ts
+++ b/packages/core/src/credential.ts
@@ -51,7 +51,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Cr
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const { db } = yield* Database.Service
+    const db = (yield* Database.Service).db
     const decode = Schema.decodeUnknownSync(Value)
     const stored = (row: typeof CredentialTable.$inferSelect) => {
       if (!row.integration_id) return

--- a/packages/core/src/database/v1-migration.bun.ts
+++ b/packages/core/src/database/v1-migration.bun.ts
@@ -481,7 +481,7 @@ export function transformSession(input: TransformInput): TransformResult {
 
 export function status(): Effect.Effect<Status, never, Database.Service> {
   return Effect.gen(function* () {
-    const { db } = yield* Database.Service
+    const db = (yield* Database.Service).db
     if (!(yield* hasLegacySessions(db))) return { status: "completed" as const }
     const state = yield* readState(db)
     if (runtimeState.status === "running") return runtimeState
@@ -523,7 +523,7 @@ function updateProgress(progress: Progress) {
 export function run(options: Options = {}): Effect.Effect<RunResult, never, Database.Service | Global.Service> {
   return lock.withPermit(
     Effect.gen(function* () {
-      const { db } = yield* Database.Service
+      const db = (yield* Database.Service).db
       const global = yield* Global.Service
       const state = yield* readState(db)
       if (state?.phase === "completed") return { status: "completed" as const }

--- a/packages/core/src/effect/websocket-constructor.ts
+++ b/packages/core/src/effect/websocket-constructor.ts
@@ -23,13 +23,13 @@ const environmentValue = (environment: Environment, name: string) =>
 const bypassesProxy = (url: URL, value: string | undefined) => {
   if (!value) return false
   const port = url.port || (url.protocol === "wss:" ? "443" : "80")
+  const hostname = url.hostname.toLowerCase()
   return value.split(/[\s,]+/).some((entry) => {
     if (!entry) return false
     if (entry === "*") return true
     const match = entry.match(/^(.+?):(\d+)$/)
     if (match?.[2] && match[2] !== port) return false
     const host = (match?.[1] ?? entry).toLowerCase().replace(/^\*/, "")
-    const hostname = url.hostname.toLowerCase()
     return host.startsWith(".") ? hostname.endsWith(host) : hostname === host
   })
 }

--- a/packages/core/src/kv.ts
+++ b/packages/core/src/kv.ts
@@ -36,7 +36,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/KV
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const { db } = yield* Database.Service
+    const db = (yield* Database.Service).db
     return Service.of({
       get: Effect.fn("KV.get")(function* (key) {
         return (yield* db

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -177,7 +177,7 @@ const layer = Layer.effect(
       return false
     })
 
-    function denied(input: AssertInput, rules: Permission.Ruleset) {
+    function denied(input: Pick<Request, "action" | "resources">, rules: Permission.Ruleset) {
       return input.resources.some((resource) => evaluate(input.action, resource, rules).effect === "deny")
     }
 
@@ -301,12 +301,11 @@ const layer = Layer.effect(
 
           const rememberedRules = yield* savedRules()
           for (const [id, item] of pending) {
-            const input = { ...item.request }
             const rules = yield* configured(item.request.sessionID, item.agent).pipe(
               Effect.catchTag("Session.NotFoundError", () => Effect.succeed(undefined)),
             )
             if (!rules) continue
-            if (denied(input, rules)) continue
+            if (denied(item.request, rules)) continue
             const effective = [...rules, ...rememberedRules]
             if (
               !item.request.resources.every(

--- a/packages/core/src/permission/saved.ts
+++ b/packages/core/src/permission/saved.ts
@@ -37,7 +37,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Pe
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const { db } = yield* Database.Service
+    const db = (yield* Database.Service).db
 
     const list = Effect.fnUntraced(function* (input?: ListInput) {
       const rows = yield* db

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -185,7 +185,7 @@ const layer = Layer.effect(
       return `${host.toLowerCase()}/${pathname}`
     }
 
-    const root = Effect.fnUntraced(function* (repo: Git.Repository) {
+    const rootCommit = Effect.fnUntraced(function* (repo: Git.Repository) {
       const root = (yield* git.history.rootCommits(repo))[0]
       return root ? ID.make(root) : undefined
     })
@@ -235,7 +235,7 @@ const layer = Layer.effect(
       const repo = yield* git.repo.discover(input)
       if (repo) {
         const previous = yield* cached(repo.commonDirectory)
-        const id = (yield* remote(repo)) ?? previous ?? (yield* root(repo))
+        const id = (yield* remote(repo)) ?? previous ?? (yield* rootCommit(repo))
         const canonical =
           repo.gitDirectory === repo.commonDirectory
             ? repo.worktree


### PR DESCRIPTION
## What

Simplify persistence-adjacent runtime code without changing stored formats, migration behavior, permission decisions, or proxy matching.

## How

- Access `Database.Service.db` directly in credential, KV, permission, and legacy migration paths.
- Pass permission requests directly to the narrowed denial predicate instead of cloning them.
- Name the project root commit explicitly and normalize a WebSocket hostname once per request.

## Scope

Behavior-preserving Core cleanup only. The legacy JSON decoder remains unchanged because the package's pinned Effect declarations do not yet expose `Schema.UnknownFromJsonString`.

## Testing

- 69 targeted database migration, credential, permission, project, KV, and WebSocket tests passed; 1 skipped
- `bun typecheck` from `packages/core`
- Three-pass simplify review: reuse, quality, and efficiency clean
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
