### PR TITLE
refactor(core): simplify mcp utility flows

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -695,11 +695,11 @@ const layer = Layer.effect(
             ?.methods.find((method) => method.type === "key")
           if (!method) return yield* Effect.die(new Error(`Key method not found: ${input.integrationID}`))
           const answer = input.answer ?? {}
-          if (method.type === "key" && method.form) {
+          if (method.form) {
             const invalid = Form.validateFields(method.form) ?? Form.validateAnswer(method.form, answer)
             if (invalid) return yield* new AuthorizationError({ cause: new Error(invalid) })
           }
-          if (method.type === "key" && !method.form && Object.keys(answer).length > 0) {
+          if (!method.form && Object.keys(answer).length > 0) {
             return yield* new AuthorizationError({ cause: new Error("Key method does not accept a form answer") })
           }
           yield* credentials.create({

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -424,7 +424,7 @@ export const layer = (options?: Options) =>
 
       const refreshPrompts = (name: ServerName, entry: ServerEntry, connection: MCPClient.Connection) =>
         connection.prompts().pipe(
-          Effect.catch(() => Effect.succeed([])),
+          Effect.orElseSucceed(() => []),
           Effect.map((defs) => {
             entry.prompts = defs.map((def) => toPrompt(name, def))
           }),
@@ -777,7 +777,7 @@ export const layer = (options?: Options) =>
           if (!target.entry.client) return undefined
           const result = yield* target.entry.client
             .prompt({ name: input.name, args: input.args })
-            .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            .pipe(Effect.orElseSucceed(() => undefined))
           if (!result) return undefined
           return new PromptResult({
             server: target.name,
@@ -795,8 +795,8 @@ export const layer = (options?: Options) =>
               if (!entry.client) return Effect.succeed({ resources: [], templates: [] })
               return Effect.all(
                 {
-                  resources: entry.client.resources().pipe(Effect.catch(() => Effect.succeed([]))),
-                  templates: entry.client.resourceTemplates().pipe(Effect.catch(() => Effect.succeed([]))),
+                  resources: entry.client.resources().pipe(Effect.orElseSucceed(() => [])),
+                  templates: entry.client.resourceTemplates().pipe(Effect.orElseSucceed(() => [])),
                 },
                 { concurrency: "unbounded" },
               ).pipe(
@@ -831,7 +831,7 @@ export const layer = (options?: Options) =>
           if (!target.entry.client) return undefined
           const result = yield* target.entry.client
             .readResource({ uri: input.uri })
-            .pipe(Effect.catch(() => Effect.succeed(undefined)))
+            .pipe(Effect.orElseSucceed(() => undefined))
           if (!result) return undefined
           return ResourceContent.make({
             server: target.name,

--- a/packages/core/src/util/process-lock.ts
+++ b/packages/core/src/util/process-lock.ts
@@ -54,9 +54,7 @@ export namespace ProcessLock {
         }),
       ),
     )
-    if (result.acquired) {
-      return fd
-    }
+    if (result.acquired) return fd
     closeSync(fd)
     return yield* result.held
       ? new HeldError({ file })

--- a/packages/core/src/util/which.ts
+++ b/packages/core/src/util/which.ts
@@ -4,10 +4,9 @@ import path from "path"
 export function which(cmd: string, env?: NodeJS.ProcessEnv, bin?: string) {
   const base = env?.PATH ?? env?.Path ?? process.env.PATH ?? process.env.Path ?? ""
   const full = base && bin ? base + path.delimiter + bin : base || bin
-  const result = whichPkg.sync(cmd, {
+  return whichPkg.sync(cmd, {
     nothrow: true,
     path: full,
     pathExt: env?.PATHEXT ?? env?.PathExt ?? process.env.PATHEXT ?? process.env.PathExt,
   })
-  return typeof result === "string" ? result : null
 }


### PR DESCRIPTION
## What

Simplify MCP fallback handling and adjacent Integration and process utilities without changing connection, credential, executable lookup, or lock behavior.

## How

- Use `Effect.orElseSucceed` for five constant MCP failure fallbacks.
- Trust the discriminant established by Integration key-method lookup.
- Return the pinned `which` result directly and flatten the successful process-lock branch.

## Scope

Behavior-preserving Core cleanup only; no MCP lifecycle, OAuth, credential persistence, process spawning, or lock semantics change.

## Testing

- 59 targeted MCP, Integration, `which`, and process-lock tests passed
- `bun typecheck` from `packages/core`
- `git diff --check`; edited lines formatted (two unrelated existing MCP expressions remain outside scope)
- Three-pass simplify review: reuse, quality, and efficiency clean
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
