### PR TITLE
refactor(session): simplify effect workflows

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -964,7 +964,8 @@ const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
   const requested = input.skills
   const selected = yield* Effect.gen(function* () {
     if (!requested?.length) return undefined
-    const available = yield* (yield* skills).list()
+    const skillService = yield* skills
+    const available = yield* skillService.list()
     return yield* Effect.forEach(requested, (attachment) => {
       const skill = available.find((item) => item.id === attachment.id)
       if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -345,11 +345,10 @@ const make = (dependencies: Dependencies) => {
         reason: "auto",
         ...content,
       })
-    const error = { type: "compaction.unavailable" as const, message: "Nothing to compact yet" }
     return yield* failed({
       sessionID: input.session.id,
       reason: "auto",
-      error,
+      error: { type: "compaction.unavailable", message: "Nothing to compact yet" },
     })
   })
   const required = (input: RequiredInput) => {

--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -319,7 +319,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
                     }).pipe(
                       Effect.andThen(metric("connect_failure")),
                       Effect.andThen(metric("fallback")),
-                      Effect.andThen(Effect.succeed(undefined)),
+                      Effect.asVoid,
                     ),
               ),
             )

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -71,7 +71,7 @@ export const make = <Key, E, Reason = never>(options: {
 
     const loop = (key: Key, execution: Execution<E, Reason>, force: boolean): Effect.Effect<void, E> =>
       Effect.suspend(() => options.drain(key, force, execution.scope)).pipe(
-        Effect.flatMap(() =>
+        Effect.andThen(
           Effect.suspend(() => {
             if (execution.stopping || execution.pendingWake === undefined) return Effect.void
             execution.scope = execution.pendingWake

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -405,7 +405,7 @@ const layer = Layer.effect(
               ? []
               : yield* snapshots
                   .files({ from: startSnapshot, to: snapshot })
-                  .pipe(Effect.catch(() => Effect.succeed(undefined)))
+                  .pipe(Effect.orElseSucceed(() => undefined))
             : undefined
         return { snapshot, files }
       })
@@ -440,11 +440,13 @@ const layer = Layer.effect(
         Stream.runForEach((event) =>
           Effect.gen(function* () {
             if (overflowFailure || publisher.hasProviderError()) return
-            if (LLMEvent.is.providerError(event)) {
-              if (isContextOverflowFailure(event) && !publisher.record().outputStarted) {
-                overflowFailure = event
-                return
-              }
+            if (
+              LLMEvent.is.providerError(event) &&
+              isContextOverflowFailure(event) &&
+              !publisher.record().outputStarted
+            ) {
+              overflowFailure = event
+              return
             }
             yield* publisher.publish(event)
             if (event.type !== "tool-call" || event.providerExecuted) return

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -316,9 +316,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     })
   })
 
-  const flush = Effect.fn("SessionRunner.flush")(function* () {
-    yield* flushFragments()
-  })
+  const flush = Effect.fn("SessionRunner.flush")(flushFragments)
 
   const failTool = Effect.fnUntraced(function* (id: string, error: SessionError.Error, metadata?: Tool.Metadata) {
     const tool = tools.get(id)
@@ -335,7 +333,10 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     return true
   })
 
-  const failTools = Effect.fnUntraced(function* (error: SessionError.Error, mode: "all" | "hosted" | "uncalled") {
+  const failTools = Effect.fnUntraced(function* (
+    error: SessionError.Error,
+    mode: "all" | "hosted" | "uncalled" = "all",
+  ) {
     let failed = false
     for (const [id, tool] of tools) {
       if (tool.settled || (mode === "hosted" && !tool.providerExecuted) || (mode === "uncalled" && tool.called))
@@ -372,12 +373,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     })
   })
 
-  const failUnsettledTools = Effect.fn("SessionRunner.failUnsettledTools")(function* (
-    error: SessionError.Error,
-    scope: "hosted" | "all" = "all",
-  ) {
-    return yield* failTools(error, scope)
-  })
+  const failUnsettledTools = Effect.fn("SessionRunner.failUnsettledTools")(failTools)
 
   const assistantMessageIDForTool = (id: string) => {
     const tool = tools.get(id)

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -333,10 +333,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     return true
   })
 
-  const failTools = Effect.fnUntraced(function* (
-    error: SessionError.Error,
-    mode: "all" | "hosted" | "uncalled" = "all",
-  ) {
+  const failTools = Effect.fnUntraced(function* (error: SessionError.Error, mode: "all" | "hosted" | "uncalled") {
     let failed = false
     for (const [id, tool] of tools) {
       if (tool.settled || (mode === "hosted" && !tool.providerExecuted) || (mode === "uncalled" && tool.called))
@@ -373,7 +370,9 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     })
   })
 
-  const failUnsettledTools = Effect.fn("SessionRunner.failUnsettledTools")(failTools)
+  const failUnsettledTools = Effect.fn("SessionRunner.failUnsettledTools")(
+    (error: SessionError.Error, scope: "hosted" | "all" = "all") => failTools(error, scope),
+  )
 
   const assistantMessageIDForTool = (id: string) => {
     const tool = tools.get(id)

--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -117,7 +117,7 @@ const make = (dependencies: Dependencies) => {
     if (!firstUser) return
     const agent = yield* dependencies.agents.get(Agent.ID.make("title"))
     if (!agent) return
-    const primary = yield* dependencies.models.resolve(session).pipe(Effect.catch(() => Effect.succeed(undefined)))
+    const primary = yield* dependencies.models.resolve(session).pipe(Effect.orElseSucceed(() => undefined))
     const info = yield* Effect.gen(function* () {
       if (agent.model) return yield* dependencies.catalog.model.get(agent.model.providerID, agent.model.id)
       if (!primary) return
@@ -136,7 +136,7 @@ const make = (dependencies: Dependencies) => {
             ...(variant ? { variant } : {}),
           }),
         })
-        .pipe(Effect.catch(() => Effect.succeed(undefined))))
+        .pipe(Effect.orElseSucceed(() => undefined)))
     const selected = preferred ?? primary
     if (!selected) return
     const title =


### PR DESCRIPTION
## What

Simplify Session execution Effect pipelines while preserving suspension, tracing, retry, failure, and tool-settlement behavior.

## How

- Use direct named Effect delegation and dedicated fallback/result combinators.
- Preserve deferred coordinator state reads while replacing a value-ignoring `flatMap`.
- Flatten equivalent provider-error guards, inline a one-use compaction error, and bind the Skill service before use.
- Keep the public unsettled-tool scope restricted to `"all" | "hosted"`; internal `"uncalled"` settlement remains private.

## Scope

Behavior-preserving Session cleanup only; no step orchestration, stream continuation, compaction, retry, tool publication, or model transport semantics change.

## Testing

- 247 focused coordinator, transport, title, compaction, tool-event, and Skill tests passed
- 17 tool-event tests passed after preserving the public failure-scope boundary
- `bun typecheck` from `packages/core`
- Three-pass simplify review completed; public scope finding applied
- Push hook: `bun turbo typecheck --concurrency=3` (40-package workspace)
