### PR TITLE
feat(desktop): add Windows taskbar session badge

### DIFF
--- a/artifacts/taskbar-attention/taskbar-after.svg
+++ b/artifacts/taskbar-attention/taskbar-after.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360">
+  <rect width="1200" height="360" fill="#f3f4f6"/>
+  <rect x="40" y="40" width="1120" height="190" rx="12" fill="#ffffff" stroke="#d1d5db"/>
+  <text x="70" y="82" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#111827">OpenCode Desktop</text>
+  <text x="70" y="116" font-family="Arial, sans-serif" font-size="16" fill="#4b5563">After: distinct sessions needing attention appear as a taskbar badge</text>
+  <rect x="40" y="260" width="1120" height="60" rx="10" fill="#202124"/>
+  <circle cx="600" cy="290" r="19" fill="#f5f5f5"/>
+  <text x="600" y="297" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#202124">O</text>
+  <circle cx="616" cy="274" r="12" fill="#d70015" stroke="#202124" stroke-width="3"/>
+  <text x="616" y="279" text-anchor="middle" font-family="Arial, sans-serif" font-size="11" font-weight="700" fill="#ffffff">3</text>
+  <text x="600" y="348" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#374151">Illustrative Windows taskbar state</text>
+</svg>

--- a/artifacts/taskbar-attention/taskbar-before.svg
+++ b/artifacts/taskbar-attention/taskbar-before.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360">
+  <rect width="1200" height="360" fill="#f3f4f6"/>
+  <rect x="40" y="40" width="1120" height="190" rx="12" fill="#ffffff" stroke="#d1d5db"/>
+  <text x="70" y="82" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#111827">OpenCode Desktop</text>
+  <text x="70" y="116" font-family="Arial, sans-serif" font-size="16" fill="#4b5563">Before: no native taskbar attention marker</text>
+  <rect x="40" y="260" width="1120" height="60" rx="10" fill="#202124"/>
+  <circle cx="600" cy="290" r="19" fill="#f5f5f5"/>
+  <text x="600" y="297" text-anchor="middle" font-family="Arial, sans-serif" font-size="22" font-weight="700" fill="#202124">O</text>
+  <text x="600" y="348" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#374151">Illustrative Windows taskbar state</text>
+</svg>

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -10,13 +10,16 @@ import { useSettings } from "@/context/settings"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { decode64 } from "@/utils/base64"
 import { EventSessionError } from "@opencode-ai/sdk/v2"
+import type { PermissionRequest } from "@opencode-ai/sdk/v2/client"
 import { Persist, persisted } from "@/utils/persist"
 import { playSoundById } from "@/utils/sound"
 import { useGlobal } from "./global"
+import { usePermission } from "./permission"
 import { ServerConnection, useServer } from "./server"
 import { type DraftTab, useTabs } from "./tabs"
 import { requireServerKey } from "@/utils/session-route"
 import type { ServerScope } from "@/utils/server-scope"
+import { createTaskbarAttentionState } from "./taskbar-attention"
 
 type NotificationBase = {
   directory?: string
@@ -116,6 +119,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     const params = useParams<{ serverKey?: string; dir?: string; id?: string }>()
     const [search] = useSearchParams<{ draftId?: string }>()
     const global = useGlobal()
+    const permission = usePermission()
     const server = useServer()
     const tabs = useTabs()
     const navigate = useNavigate()
@@ -124,6 +128,14 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     const language = useLanguage()
     const owner = getOwner()
     const states = new Map<ServerScope, { dispose: () => void; state: NotificationState }>()
+
+    const syncTaskbarAttention = () => {
+      const sessions = new Set<string>()
+      states.forEach((value, scope) => {
+        value.state.taskbarAttentionSessions().forEach((sessionID) => sessions.add(`${scope}\0${sessionID}`))
+      })
+      void platform.setTaskbarAttention?.(sessions.size)
+    }
 
     const activeServer = createMemo(() => {
       if (params.serverKey) return requireServerKey(params.serverKey)
@@ -142,6 +154,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       const ctx = global.ensureServerCtx(conn)
       const existing = states.get(ctx.sdk.scope)
       if (existing) return existing.state
+      const permissionState = permission.ensureServerState(key)
       const root = createRoot(
         (dispose) => ({
           dispose,
@@ -155,11 +168,14 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
             settings,
             language,
             navigate,
+            isPermissionAutoResponded: permissionState.autoResponds,
+            onTaskbarAttentionChanged: syncTaskbarAttention,
           }),
         }),
         owner ?? undefined,
       )
       states.set(ctx.sdk.scope, root)
+      syncTaskbarAttention()
       return root.state
     }
 
@@ -174,6 +190,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
         value.dispose()
         states.delete(scope)
       })
+      syncTaskbarAttention()
     })
 
     onCleanup(() => states.forEach((value) => value.dispose()))
@@ -186,6 +203,15 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
       if (!conn) throw new Error("Notification server not found")
       return ensure(ServerConnection.key(conn))
     }
+
+    const clearFocusedSessionTaskbarAttention = () => {
+      if (!platform.setTaskbarAttention) return
+      const sessionID = activeSession()
+      if (!sessionID) return
+      selected().session.markViewed(sessionID)
+    }
+    window.addEventListener("focus", clearFocusedSessionTaskbarAttention)
+    onCleanup(() => window.removeEventListener("focus", clearFocusedSessionTaskbarAttention))
 
     return {
       ready: () => selected().ready(),
@@ -220,17 +246,24 @@ function createServerNotificationState(input: {
   settings: ReturnType<typeof useSettings>
   language: ReturnType<typeof useLanguage>
   navigate: (href: string) => void
+  isPermissionAutoResponded: (request: PermissionRequest, directory?: string) => boolean
+  onTaskbarAttentionChanged: () => void
 }) {
   const serverSDK = () => input.sdk
   const serverSync = () => input.sync
   const platform = input.platform
   const settings = input.settings
   const language = input.language
+  const windowFocused = () => {
+    if (!input.platform.getWindowFocused) return Promise.resolve(true)
+    return input.platform.getWindowFocused().catch(() => document.hasFocus())
+  }
 
   const empty: Notification[] = []
 
   const currentDirectory = input.directory
   const currentSession = input.sessionID
+  const taskbarAttention = createTaskbarAttentionState()
 
   const [store, setStore, _, ready] = persisted(
     Persist.serverGlobal(serverSDK().scope, "notification", ["notification.v1"]),
@@ -239,6 +272,26 @@ function createServerNotificationState(input: {
     }),
   )
   const [index, setIndex] = createStore<NotificationIndex>(buildNotificationIndex(store.list))
+  const taskbarAttentionSessions = () => {
+    const unread = Object.entries(index.session.unseen).flatMap(([session, notifications]) =>
+      notifications.length ? [session] : [],
+    )
+    const pending = new Map<string, string>()
+    Object.entries(input.sync.session.data.permission).forEach(([sessionID, requests]) => {
+      const active = requests.filter(
+        (request) => !input.isPermissionAutoResponded(request, input.sync.session.data.info[sessionID]?.directory),
+      )
+      if (!active.length) return
+      pending.set(sessionID, `permission:${active.map((request) => request.id).join(",")}`)
+    })
+    Object.entries(input.sync.session.data.question).forEach(([sessionID, requests]) => {
+      if (!requests.length) return
+      const token = `question:${requests.map((request) => request.id).join(",")}`
+      pending.set(sessionID, pending.has(sessionID) ? `${pending.get(sessionID)}|${token}` : token)
+    })
+    taskbarAttention.sync([...pending].map(([sessionID, token]) => ({ sessionID, token })))
+    return taskbarAttention.sessions(unread)
+  }
 
   const meta = { pruned: false, disposed: false }
 
@@ -302,6 +355,12 @@ function createServerNotificationState(input: {
     })
   })
 
+  createEffect(() => {
+    if (!ready()) return
+    taskbarAttentionSessions()
+    input.onTaskbarAttentionChanged()
+  })
+
   const append = (notification: Notification) => {
     const list = pruneNotifications([...store.list, notification])
     const keep = new Set(list)
@@ -312,6 +371,7 @@ function createServerNotificationState(input: {
       removed.forEach((n) => removeFromIndex(n))
       setStore("list", list)
     })
+    input.onTaskbarAttentionChanged()
   }
 
   const lookup = async (directory: string, sessionID?: string) => {
@@ -337,10 +397,15 @@ function createServerNotificationState(input: {
 
   const handleSessionIdle = (directory: string, event: { properties: { sessionID?: string } }, time: number) => {
     const sessionID = event.properties.sessionID
-    void lookup(directory, sessionID).then((session) => {
+    void lookup(directory, sessionID).then(async (session) => {
       if (meta.disposed) return
       if (!session) return
       if (session.parentID) return
+
+      taskbarAttention.remove(sessionID ?? "global")
+      const focused = await windowFocused()
+      const viewed = viewedInCurrentSession(directory, sessionID)
+      if (!viewed || !focused) taskbarAttention.add(sessionID ?? "global")
 
       if (settings.sounds.agentEnabled()) {
         void playSoundById(settings.sounds.agent())
@@ -349,7 +414,7 @@ function createServerNotificationState(input: {
       append({
         directory,
         time,
-        viewed: viewedInCurrentSession(directory, sessionID),
+        viewed,
         type: "turn-complete",
         session: sessionID,
       })
@@ -369,9 +434,14 @@ function createServerNotificationState(input: {
     time: number,
   ) => {
     const sessionID = event.properties.sessionID
-    void lookup(directory, sessionID).then((session) => {
+    void lookup(directory, sessionID).then(async (session) => {
       if (meta.disposed) return
       if (session?.parentID) return
+
+      taskbarAttention.remove(sessionID ?? "global")
+      const focused = await windowFocused()
+      const viewed = viewedInCurrentSession(directory, sessionID)
+      if (!viewed || !focused) taskbarAttention.add(sessionID ?? "global")
 
       if (settings.sounds.errorsEnabled()) {
         void playSoundById(settings.sounds.errors())
@@ -381,7 +451,7 @@ function createServerNotificationState(input: {
       append({
         directory,
         time,
-        viewed: viewedInCurrentSession(directory, sessionID),
+        viewed,
         type: "error",
         session: sessionID ?? "global",
         error,
@@ -398,6 +468,29 @@ function createServerNotificationState(input: {
 
   const unsub = serverSDK().event.listen((e) => {
     const event = e.details
+    if (event.type === "permission.asked" || event.type === "question.asked") {
+      const sessionID = event.properties.sessionID
+      if (!sessionID) return
+      if (event.type === "permission.asked" && input.isPermissionAutoResponded(event.properties, e.name)) return
+      void windowFocused().then((focused) => {
+        const viewed = viewedInCurrentSession(e.name, sessionID)
+        if (viewed && focused) return
+        const prefix = event.type === "permission.asked" ? "permission" : "question"
+        taskbarAttention.add(sessionID, `${prefix}:${event.properties.id}`)
+        input.onTaskbarAttentionChanged()
+      })
+      return
+    }
+    if (
+      event.type === "permission.replied" ||
+      event.type === "question.replied" ||
+      event.type === "question.rejected"
+    ) {
+      const prefix = event.type === "permission.replied" ? "permission" : "question"
+      taskbarAttention.removePending(event.properties.sessionID, `${prefix}:${event.properties.requestID}`)
+      input.onTaskbarAttentionChanged()
+      return
+    }
     if (event.type !== "session.idle" && event.type !== "session.error") return
 
     const directory = e.name
@@ -429,8 +522,12 @@ function createServerNotificationState(input: {
         return index.session.unseenHasError[session] ?? false
       },
       markViewed(session: string) {
+        taskbarAttention.remove(session)
         const unseen = index.session.unseen[session] ?? empty
-        if (!unseen.length) return
+        if (!unseen.length) {
+          input.onTaskbarAttentionChanged()
+          return
+        }
 
         const projects = [
           ...new Set(unseen.flatMap((notification) => (notification.directory ? [notification.directory] : []))),
@@ -445,6 +542,7 @@ function createServerNotificationState(input: {
             updateUnseen("project", directory, next)
           })
         })
+        input.onTaskbarAttentionChanged()
       },
     },
     project: {
@@ -471,13 +569,16 @@ function createServerNotificationState(input: {
           setStore("list", (n) => n.directory === directory && !n.viewed, "viewed", true)
           updateUnseen("project", directory, [])
           sessions.forEach((session) => {
+            taskbarAttention.remove(session)
             const next = (index.session.unseen[session] ?? empty).filter(
               (notification) => notification.directory !== directory,
             )
             updateUnseen("session", session, next)
           })
         })
+        input.onTaskbarAttentionChanged()
       },
     },
+    taskbarAttentionSessions,
   }
 }

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -50,6 +50,12 @@ type PlatformBase = {
   /** Send a system notification */
   notify(title: string, description?: string, onClick?: () => void): Promise<void>
 
+  /** Show the number of sessions needing attention on the native taskbar icon (desktop only) */
+  setTaskbarAttention?(count: number): Promise<void> | void
+
+  /** Read whether the native desktop window is focused. */
+  getWindowFocused?(): Promise<boolean>
+
   /** Open a native attachment picker and read selected files sequentially (desktop only) */
   openAttachmentPickerDialog?(
     opts: OpenAttachmentPickerOptions,

--- a/packages/app/src/context/taskbar-attention.test.ts
+++ b/packages/app/src/context/taskbar-attention.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test"
+import { createTaskbarAttentionState } from "./taskbar-attention"
+
+describe("taskbar attention state", () => {
+  test("counts each session once across unread and pending attention", () => {
+    const attention = createTaskbarAttentionState()
+
+    attention.add("session-1")
+    attention.add("session-1")
+    attention.add("session-2")
+
+    expect(attention.count(["session-1", "session-3"])).toBe(3)
+  })
+
+  test("removes a session when it is viewed", () => {
+    const attention = createTaskbarAttentionState()
+    attention.add("session-1")
+    attention.add("session-2")
+
+    attention.remove("session-1")
+
+    expect(attention.count([])).toBe(1)
+    expect(attention.count(["session-1"])).toBe(1)
+  })
+
+  test("re-adds a synchronized request only when a request is added", () => {
+    const attention = createTaskbarAttentionState()
+    attention.sync([{ sessionID: "session-1", token: "question:a,b" }])
+    attention.remove("session-1")
+
+    expect(attention.count([])).toBe(0)
+
+    attention.sync([{ sessionID: "session-1", token: "question:b" }])
+
+    expect(attention.count([])).toBe(0)
+
+    attention.sync([{ sessionID: "session-1", token: "question:b,c" }])
+
+    expect(attention.count([])).toBe(1)
+  })
+
+  test("keeps a session pending while another live request remains", () => {
+    const attention = createTaskbarAttentionState()
+    attention.add("session-1", "permission:a")
+    attention.add("session-1", "question:b")
+
+    attention.removePending("session-1", "permission:a")
+
+    expect(attention.count([])).toBe(1)
+
+    attention.removePending("session-1", "question:b")
+
+    expect(attention.count([])).toBe(0)
+  })
+
+  test("does not add a request after its reply was observed", () => {
+    const attention = createTaskbarAttentionState()
+
+    attention.removePending("session-1", "question:a")
+    attention.add("session-1", "question:a")
+
+    expect(attention.count([])).toBe(0)
+  })
+
+  test("reconciles live requests removed by synchronized state", () => {
+    const attention = createTaskbarAttentionState()
+    attention.sync([{ sessionID: "session-1", token: "question:a" }])
+    attention.add("session-1", "question:a")
+
+    attention.sync([])
+
+    expect(attention.count([])).toBe(0)
+  })
+})

--- a/packages/app/src/context/taskbar-attention.ts
+++ b/packages/app/src/context/taskbar-attention.ts
@@ -1,0 +1,68 @@
+export function createTaskbarAttentionState() {
+  const pending = new Map<string, Set<string>>()
+  const cancelled = new Map<string, Set<string>>()
+  const synced = new Map<string, string>()
+  const syncHistory = new Map<string, string>()
+  const dismissed = new Set<string>()
+  const requestIDs = (token: string) =>
+    new Set(
+      token.split("|").flatMap((part) =>
+        part
+          .slice(part.indexOf(":") + 1)
+          .split(",")
+          .filter(Boolean),
+      ),
+    )
+
+  const sessions = (unread: readonly string[]) =>
+    [...new Set([...unread, ...pending.keys(), ...synced.keys()])].filter((sessionID) => !dismissed.has(sessionID))
+
+  return {
+    add(sessionID: string, token = "attention") {
+      if (cancelled.get(sessionID)?.has(token)) return
+      const tokens = pending.get(sessionID) ?? new Set<string>()
+      tokens.add(token)
+      pending.set(sessionID, tokens)
+      dismissed.delete(sessionID)
+    },
+    remove(sessionID: string) {
+      pending.delete(sessionID)
+      dismissed.add(sessionID)
+    },
+    removePending(sessionID: string, token: string) {
+      const cancelledTokens = cancelled.get(sessionID) ?? new Set<string>()
+      cancelledTokens.add(token)
+      cancelled.set(sessionID, cancelledTokens)
+      const tokens = pending.get(sessionID)
+      if (!tokens) return
+      tokens.delete(token)
+      if (tokens.size === 0) pending.delete(sessionID)
+    },
+    sync(next: readonly { sessionID: string; token: string }[]) {
+      const current = new Map(next.map((item) => [item.sessionID, item.token]))
+      pending.forEach((tokens, sessionID) => {
+        if (!current.has(sessionID) && !syncHistory.has(sessionID)) return
+        const active = new Set((current.get(sessionID) ?? "").split("|"))
+        tokens.forEach((token) => {
+          if ((token.startsWith("permission:") || token.startsWith("question:")) && !active.has(token)) {
+            tokens.delete(token)
+          }
+        })
+        if (tokens.size === 0) pending.delete(sessionID)
+      })
+      current.forEach((token, sessionID) => {
+        const previous = syncHistory.get(sessionID)
+        if (!previous) return
+        const previousIDs = requestIDs(previous)
+        if ([...requestIDs(token)].some((id) => !previousIDs.has(id))) dismissed.delete(sessionID)
+      })
+      current.forEach((token, sessionID) => syncHistory.set(sessionID, token))
+      synced.clear()
+      current.forEach((token, sessionID) => synced.set(sessionID, token))
+    },
+    sessions,
+    count(unread: readonly string[]) {
+      return sessions(unread).length
+    },
+  }
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -308,7 +308,6 @@ function MarkSessionNotificationsViewed(props: { sessionID?: () => string | unde
   createEffect(() => {
     const sessionID = props.sessionID?.()
     if (!notification.ready() || !sessionID) return
-    if (notification.session.unseenCount(sessionID) === 0) return
     notification.session.markViewed(sessionID)
   })
   return null

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -17,6 +17,7 @@ import {
   openExternalURL,
   openLocalFileURL,
   setPinchZoomEnabled,
+  setTaskbarAttention,
   setTitlebar,
   updateTitlebar,
 } from "./windows"
@@ -254,6 +255,12 @@ export function registerIpcHandlers(deps: Deps) {
   ipcMain.handle("get-window-focused", (event: IpcMainInvokeEvent) => {
     const win = BrowserWindow.fromWebContents(event.sender)
     return win?.isFocused() ?? false
+  })
+
+  ipcMain.handle("set-taskbar-attention", (event: IpcMainInvokeEvent, count: number) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win) return
+    setTaskbarAttention(win, count)
   })
 
   ipcMain.handle("get-window-fullscreen", (event: IpcMainInvokeEvent) => {

--- a/packages/desktop/src/main/taskbar-attention.test.ts
+++ b/packages/desktop/src/main/taskbar-attention.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { formatTaskbarAttentionCount } from "./taskbar-attention"
+
+describe("taskbar attention count", () => {
+  test("clears empty counts and formats visible counts", () => {
+    expect(formatTaskbarAttentionCount(0)).toBeUndefined()
+    expect(formatTaskbarAttentionCount(1)).toBe("1")
+    expect(formatTaskbarAttentionCount(9)).toBe("9")
+    expect(formatTaskbarAttentionCount(10)).toBe("10")
+    expect(formatTaskbarAttentionCount(99)).toBe("99")
+  })
+
+  test("caps counts that do not fit in the overlay", () => {
+    expect(formatTaskbarAttentionCount(100)).toBe("99+")
+  })
+})

--- a/packages/desktop/src/main/taskbar-attention.ts
+++ b/packages/desktop/src/main/taskbar-attention.ts
@@ -1,0 +1,4 @@
+export function formatTaskbarAttentionCount(count: number) {
+  if (count <= 0) return undefined
+  return count > 99 ? "99+" : String(count)
+}

--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -16,6 +16,7 @@ import { nativeT } from "./native-translations"
 import { createWindowRegistry } from "./window-registry"
 import { safeWindowURL } from "./window-state"
 import { resolveExternalURL, resolveLocalFilePath } from "./external-url"
+import { formatTaskbarAttentionCount } from "./taskbar-attention"
 
 const root = dirname(fileURLToPath(import.meta.url))
 const rendererRoot = join(root, "../renderer")
@@ -53,6 +54,7 @@ let relaunchHandler = () => {
 const titlebarThemes = new WeakMap<BrowserWindow, Partial<TitlebarTheme>>()
 const pinchZoomEnabled = new WeakMap<BrowserWindow, boolean>()
 const windowIDs = new WeakMap<BrowserWindow, string>()
+const taskbarAttentionCounts = new WeakMap<BrowserWindow, number>()
 const registry = createWindowRegistry<BrowserWindow>({
   read: () => getStore().get(WINDOW_IDS_KEY),
   write: (ids) => getStore().set(WINDOW_IDS_KEY, ids),
@@ -165,6 +167,34 @@ export function setDockIcon() {
   if (!icon.isEmpty()) app.dock?.setIcon(icon)
 }
 
+export function setTaskbarAttention(win: BrowserWindow, count: number) {
+  if (process.platform !== "win32" || win.isDestroyed()) return
+
+  const normalized = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0
+  taskbarAttentionCounts.set(win, normalized)
+  if (normalized === 0) {
+    win.setOverlayIcon(null, "")
+    return
+  }
+  if (win.isFocused()) {
+    win.setOverlayIcon(null, "")
+    return
+  }
+
+  const label = formatTaskbarAttentionCount(normalized)
+  if (!label) return
+  const fontSize = label.length > 2 ? 7 : label.length > 1 ? 9 : 11
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="8" fill="#d70015"/><text x="8" y="11" fill="white" font-family="Arial" font-size="${fontSize}" font-weight="700" text-anchor="middle">${label}</text></svg>`
+  const icon = nativeImage.createFromDataURL(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`)
+  win.setOverlayIcon(icon, nativeT("desktop.menu.app"))
+}
+
+function updateTaskbarAttention(win: BrowserWindow) {
+  const count = taskbarAttentionCounts.get(win)
+  if (count === undefined) return
+  setTaskbarAttention(win, count)
+}
+
 export function createMainWindow(id: string = randomUUID()) {
   const state = windowState({
     file: windowStateFile(id),
@@ -271,7 +301,11 @@ function registerWindow(win: BrowserWindow, id: string) {
   windowIDs.set(win, id)
   registry.register(id, win)
 
-  win.on("focus", () => registry.focused(id))
+  win.on("focus", () => {
+    registry.focused(id)
+    if (process.platform === "win32") win.setOverlayIcon(null, "")
+  })
+  win.on("blur", () => updateTaskbarAttention(win))
   // Windows never emits before-quit on OS shutdown/logoff, but each window
   // gets session-end before it closes; flag the quit so ids stay persisted.
   win.on("session-end", () => registry.setQuitting())

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -103,6 +103,7 @@ const api: ElectronAPI = {
   revealPath: (path) => ipcRenderer.invoke("reveal-path", path),
   readClipboardImage: () => ipcRenderer.invoke("read-clipboard-image"),
   getWindowFocused: () => ipcRenderer.invoke("get-window-focused"),
+  setTaskbarAttention: (count) => ipcRenderer.invoke("set-taskbar-attention", count),
   getWindowFullscreen: () => ipcRenderer.invoke("get-window-fullscreen"),
   onWindowFullscreenChanged: (cb) => {
     const handler = (_: unknown, fullscreen: boolean) => cb(fullscreen)

--- a/packages/desktop/src/preload/types.ts
+++ b/packages/desktop/src/preload/types.ts
@@ -95,6 +95,7 @@ export type ElectronAPI = {
   revealPath: (path: string) => Promise<boolean>
   readClipboardImage: () => Promise<{ buffer: ArrayBuffer; width: number; height: number } | null>
   getWindowFocused: () => Promise<boolean>
+  setTaskbarAttention: (count: number) => Promise<void>
   getWindowFullscreen: () => Promise<boolean>
   onWindowFullscreenChanged: (cb: (fullscreen: boolean) => void) => () => void
   setWindowFocus: () => Promise<void>

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -267,6 +267,13 @@ const createPlatform = (windowState: DesktopWindowState): Platform => {
       }
     },
 
+    setTaskbarAttention: (count) => {
+      if (os !== "windows") return
+      return window.api.setTaskbarAttention(count)
+    },
+
+    getWindowFocused: () => window.api.getWindowFocused(),
+
     fetch: (input, init) => {
       if (input instanceof Request) return fetch(input)
       return fetch(input, init)


### PR DESCRIPTION
### Issue for this PR

Closes #43937

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a Windows-only numeric taskbar overlay badge for distinct sessions that are unread or need attention. It reuses the existing app notification/session state, includes pending permission and question requests, clears the relevant session when it is viewed, and preserves counts for other sessions. The Electron integration uses `BrowserWindow.setOverlayIcon`; non-Windows platforms and the app layout are unchanged.

This does not add broader system notifications or the TUI progress behavior discussed in #24807. #37120 remains notification-permission context only.

### How did you verify your code works?

- `packages/app`: focused taskbar state tests, 6 passing; `bun typecheck` passing.
- `packages/desktop`: focused overlay count tests, 2 passing; `bun typecheck` passing.
- `bun run --cwd packages/desktop build` passing.
- Push hook `bun turbo typecheck`: 30 tasks successful.
- Full desktop test run: 53 passing; one unrelated baseline failure because this Linux runtime lacks `node:sqlite`.
- Windows taskbar rendering itself needs Windows validation.

### Screenshots / recordings

These are illustrative before/after taskbar states for review; this environment cannot capture a real Windows taskbar.

![Before: no taskbar badge](https://raw.githubusercontent.com/TonisOrmisson/opencode/taskbar-attention/artifacts/taskbar-attention/taskbar-before.svg)

![After: numeric taskbar badge](https://raw.githubusercontent.com/TonisOrmisson/opencode/taskbar-attention/artifacts/taskbar-attention/taskbar-after.svg)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR