### PR TITLE
fix(ci): check PR body for linked issue on non-default branches

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -135,7 +135,16 @@ jobs:
 
             const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
-            if (linkedIssues === 0) {
+            // GitHub only populates closingIssuesReferences when a PR targets the repository's
+            // default branch (dev). PRs targeting other branches like v2 always return totalCount 0.
+            // Fall back to checking the PR description for closing keywords (e.g. Closes #123).
+            const body = pr.body || '';
+            const issueMatch = body.match(/### Issue for this PR\s*\n([\s\S]*?)(?=###|$)/);
+            const issueContent = issueMatch ? issueMatch[1].trim() : body;
+            const hasBodyIssueRef = /(closes|fixes|resolves)\s+#\d+/i.test(issueContent) || /#\d+/.test(issueContent);
+            const hasLinkedIssue = linkedIssues > 0 || hasBodyIssueRef;
+
+            if (!hasLinkedIssue) {
               await addLabel('needs:issue');
               await comment('issue', `Thanks for your contribution!
 


### PR DESCRIPTION
### Issue for this PR

Closes #43963

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `check-standards` job in `.github/workflows/pr-standards.yml` previously checked for linked issues exclusively via GraphQL `pullRequest.closingIssuesReferences.totalCount`.
Because GitHub only recognizes closing keywords on PRs targeting the repository's default branch (`dev`), PRs targeting `v2` always return `0` and trigger false-positive `needs:issue` warnings.

This PR adds a fallback that inspects the PR description for closing keywords (such as `Closes #<number>` or `Fixes #<number>`).
This matches the parsing logic in `check-compliance` and allows PRs targeting `v2` and other non-default branches to pass validation.

### How did you verify your code works?

- Verified regex patterns against PR body formats containing closing keywords.
- Confirmed compatibility with existing `check-compliance` checks in `pr-standards.yml`.

### Screenshots / recordings

_N/A (CI workflow fix)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
