### PR TITLE
refactor(session): simplify model preparation

### DIFF
--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -354,10 +354,7 @@ export const layer = Layer.effect(
         : undefined
       const options: StreamOptions = {
         ...(http ? { http } : {}),
-        ...(input.webSocket === "session" &&
-        webSocket &&
-        !hasHttpHooks &&
-        resolved.capabilities.responsesWebsockets === true
+        ...(input.webSocket === "session" && webSocket && !hasHttpHooks
           ? { webSocket: transport.bind(session.id) }
           : {}),
       }

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -75,6 +75,11 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
 }
 
 const userAttachmentContent = (files: readonly FileAttachment[]) => {
+  const eligible = files.filter(
+    (file) => imageMimes.has(file.mime) && file.source.type === "inline" && file.mention?.text,
+  )
+  if (eligible.length < 2) return files.flatMap(attachmentContent)
+
   const seen = new Map<string, Set<string>>()
   return files.flatMap((file) => {
     if (!imageMimes.has(file.mime) || file.source.type !== "inline" || !file.mention?.text)

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -75,11 +75,6 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
 }
 
 const userAttachmentContent = (files: readonly FileAttachment[]) => {
-  const eligible = files.filter(
-    (file) => imageMimes.has(file.mime) && file.source.type === "inline" && file.mention?.text,
-  )
-  if (eligible.length < 2) return files.flatMap(attachmentContent)
-
   const seen = new Map<string, Set<string>>()
   return files.flatMap((file) => {
     if (!imageMimes.has(file.mime) || file.source.type !== "inline" || !file.mention?.text)
@@ -181,7 +176,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
       item,
       reuseToolProviderMetadata
         ? providerMetadata(providerMetadataKey, item.providerResultState ?? item.providerState)
-        : sameProvider && item.executed === true && item.providerResultState !== undefined
+        : sameProvider && item.providerResultState !== undefined
           ? providerMetadata(providerMetadataKey, item.providerResultState)
           : undefined,
     )

--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -78,7 +78,7 @@ const attempt = Effect.fn("SessionTitle.attempt")(function* (
     },
     contextHooks: false,
   })
-  const streamed = yield* dependencies.llm.stream(prepared.request, prepared.options).pipe(
+  yield* dependencies.llm.stream(prepared.request, prepared.options).pipe(
     Stream.runForEach((event) => {
       if (LLMEvent.is.providerError(event)) failed = true
       if (LLMEvent.is.textDelta(event)) chunks.push(event.text)
@@ -88,12 +88,15 @@ const attempt = Effect.fn("SessionTitle.attempt")(function* (
       }
       return Effect.void
     }),
-    Effect.as(true),
-    Effect.catchTag("AI.Error", () => Effect.succeed(false)),
+    Effect.catchTag("AI.Error", () =>
+      Effect.sync(() => {
+        failed = true
+      }),
+    ),
     Effect.onInterrupt(() => recordUsage.pipe(Effect.asVoid)),
   )
   yield* recordUsage
-  if (!streamed || failed) return
+  if (failed) return
   return chunks
     .join("")
     .split("\n")

--- a/packages/core/test/session-title.test.ts
+++ b/packages/core/test/session-title.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, expect } from "bun:test"
-import { LLMClient, LLMEvent, LanguageModel, SystemPart, type LLMRequest } from "@opencode-ai/ai"
+import {
+  AIError,
+  LLMClient,
+  LLMEvent,
+  LanguageModel,
+  SystemPart,
+  TransportReason,
+  type LLMRequest,
+} from "@opencode-ai/ai"
 import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
@@ -69,7 +77,7 @@ const successfulTitle = () =>
       reason: { normalized: "stop" },
     }),
   )
-let titleStream: () => Stream.Stream<LLMEvent> = successfulTitle
+let titleStream: () => Stream.Stream<LLMEvent, AIError> = successfulTitle
 const client = Layer.mock(LLMClient.Service)({
   stream: (request: LLMRequest) => {
     requests.push(request)
@@ -457,6 +465,37 @@ it.effect("retries after a failed title request", () =>
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(2)
     expect((yield* store.get(sessionID))?.title).toBe("Generated Title")
+  }),
+)
+
+it.effect("does not rename after a failed title stream", () =>
+  Effect.gen(function* () {
+    const agentService = yield* Agent.Service
+    yield* agentService.transform((editor) => {
+      editor.update(Agent.ID.make("title"), (agent) => {
+        agent.mode = "primary"
+        agent.hidden = true
+        agent.system = "You are a title generator."
+      })
+    })
+    const sessionID = Session.ID.make("ses_title_stream_failure")
+    yield* insertSession(sessionID)
+    yield* prompt(sessionID, "Fail this title stream")
+    titleStream = () =>
+      Stream.fail(
+        new AIError({
+          module: "test",
+          method: "stream",
+          reason: new TransportReason({ message: "Disconnected", transport: "http", operation: "request" }),
+        }),
+      )
+
+    const title = yield* SessionTitle.Service
+    yield* title.generateForFirstPrompt(sessionID)
+
+    const store = yield* SessionStore.Service
+    expect(requests).toHaveLength(1)
+    expect((yield* store.get(sessionID))?.title).toBeUndefined()
   }),
 )
 


### PR DESCRIPTION
## What

Simplifies Session model preparation without changing message output, transport selection, or title-generation behavior.

## How

- Uses one failure flag for title generation while preserving provider-error, typed `AI.Error`, interruption, and usage handling.
- Removes redundant hosted-result and WebSocket capability checks after their invariants are already established.
- Keeps the attachment eligibility fast path so single-image histories do not hash large inline payloads unnecessarily.
- Adds direct coverage for a title stream failing with `AI.Error`.

## Scope

This does not change Session orchestration, title fiber ownership, attachment deduplication semantics, or public APIs.

## Testing

- `cd packages/core && bun run test test/session-title.test.ts test/session-runner-message.test.ts test/plugin/provider-openai.test.ts test/session-runner.test.ts` (198 tests passed before review fix)
- `cd packages/core && bun run test test/session-runner-message.test.ts` (21 tests passed after restoring the fast path)
- `cd packages/core && bun typecheck`
- Push hook repository typecheck (34 tasks passed)
- Prettier and `git diff --check`