### PR TITLE
fix(tui): preserve model label during location boot

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -262,6 +262,7 @@ export function Prompt(props: PromptProps) {
       (props.sessionID ? data.session.get(props.sessionID)?.projectID : undefined) ?? data.location.info()?.project.id,
     sessionID: () => props.sessionID,
   })
+  const [pendingDirectory, setPendingDirectory] = createSignal<string>()
   Keymap.createLayer(() => ({
     mode: "global",
     commands: [
@@ -285,13 +286,18 @@ export function Prompt(props: PromptProps) {
             expanded,
           )
           if (!sessionID) {
+            setPendingDirectory(directory)
             const location = await client.api.location.get({ location: { directory } }).catch((error) => {
               toast.show({ title: "Failed to change directory", message: errorMessage(error), variant: "error" })
               return undefined
             })
-            if (!location) return
+            if (!location) {
+              setPendingDirectory(undefined)
+              return
+            }
             if (sourceProjectID) directoryRecents.touch(sourceProjectID, location.directory)
             currentLocation.set(location)
+            setPendingDirectory(undefined)
             return
           }
           const error = await client.api.session.move({ sessionID, directory: input }).then(
@@ -1596,13 +1602,12 @@ export function Prompt(props: PromptProps) {
         agent: agent ? Locale.titlecase(agent.id) : undefined,
         model: model.model,
         provider: model.provider,
-        variant: local.model.variant.list().length > 0 ? local.model.variant.current() : undefined,
+        variant: local.model.variant.current(),
       }
     },
     {
       agent: undefined,
-      model: "No provider selected",
-      provider: "Connect a provider",
+      ...local.model.parsed(),
       variant: undefined,
     },
   )
@@ -1639,7 +1644,8 @@ export function Prompt(props: PromptProps) {
     return data.session.get(props.sessionID)?.location
   })
   const locationLabel = createMemo(() => {
-    const location = footerLocation()
+    const pending = pendingDirectory()
+    const location = pending ? { directory: pending } : footerLocation()
     if (!location) return
     const directory = abbreviateHome(location.directory, paths.home)
     const branch = data.location.vcs.info(location)?.branch.current

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -58,7 +58,7 @@ import {
   MAX_LOCAL_ATTACHMENT_BYTES,
   type LocalAttachment,
 } from "./local-attachment"
-import { useData } from "../../context/data"
+import { locationKey, useData } from "../../context/data"
 import { useLocation } from "../../context/location"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
@@ -308,7 +308,6 @@ export function Prompt(props: PromptProps) {
     ],
   }))
   const [cursorVersion, setCursorVersion] = createSignal(0)
-  const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const connected = useConnected()
   const hasRightContent = createMemo(() => Boolean(props.right))
 
@@ -1572,23 +1571,46 @@ export function Prompt(props: PromptProps) {
     if (!agent) return theme.border.default
     return local.agent.color(agent.id)
   })
-  const agentLabel = createMemo(() => {
-    if (store.mode === "shell") return "Shell"
-    const agent = local.agent.current()
-    return agent ? Locale.titlecase(agent.id) : undefined
-  })
+  // Keep the last resolved identity visible while destination catalogs load;
+  // availability and submission still use the live location-scoped catalog.
+  const identity = createMemo<{
+    agent: string | undefined
+    model: string
+    provider: string
+    variant: string | undefined
+  }>(
+    (previous) => {
+      const location = currentLocation.ref ?? data.location.default()
+      const sessionLocation = props.sessionID ? data.session.get(props.sessionID)?.location : location
+      if (!sessionLocation || locationKey(sessionLocation) !== locationKey(location)) return previous
 
-  const showVariant = createMemo(() => {
-    const variants = local.model.variant.list()
-    if (variants.length === 0) return false
-    const current = local.model.variant.current()
-    return !!current
-  })
+      const loading =
+        data.location.agent.list(location) === undefined || data.location.model.list(location) === undefined
+      const error = currentLocation.error
+      const failed = error && locationKey(error.location) === locationKey(location)
+      if (loading && !failed) return previous
 
-  const agentMetaAlpha = createFadeIn(() => store.mode === "shell" || !!local.agent.current(), animationsEnabled)
-  const modelMetaAlpha = createFadeIn(() => !!local.agent.current() && store.mode === "normal", animationsEnabled)
+      const agent = local.agent.current()
+      const model = local.model.parsed()
+      return {
+        agent: agent ? Locale.titlecase(agent.id) : undefined,
+        model: model.model,
+        provider: model.provider,
+        variant: local.model.variant.list().length > 0 ? local.model.variant.current() : undefined,
+      }
+    },
+    {
+      agent: undefined,
+      model: "No provider selected",
+      provider: "Connect a provider",
+      variant: undefined,
+    },
+  )
+  const agentLabel = createMemo(() => (store.mode === "shell" ? "Shell" : identity().agent))
+  const agentMetaAlpha = createFadeIn(() => !!agentLabel(), animationsEnabled)
+  const modelMetaAlpha = createFadeIn(() => !!identity().agent && store.mode === "normal", animationsEnabled)
   const variantMetaAlpha = createFadeIn(
-    () => !!local.agent.current() && store.mode === "normal" && showVariant(),
+    () => !!identity().agent && store.mode === "normal" && !!identity().variant,
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
@@ -1851,14 +1873,14 @@ export function Prompt(props: PromptProps) {
                             truncate
                             fg={fadeColor(leader() ? theme.text.subdued : theme.text.default, modelMetaAlpha())}
                           >
-                            {local.model.parsed().model}
+                            {identity().model}
                           </text>
                           <Show when={dimensions().width >= 50}>
                             <text flexShrink={0} fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>
-                              {currentProviderLabel()}
+                              {identity().provider}
                             </text>
                           </Show>
-                          <Show when={showVariant() && dimensions().width >= 70}>
+                          <Show when={identity().variant && dimensions().width >= 70}>
                             <text fg={fadeColor(theme.text.subdued, variantMetaAlpha())}>·</text>
                             <text>
                               <span
@@ -1867,7 +1889,7 @@ export function Prompt(props: PromptProps) {
                                   bold: true,
                                 }}
                               >
-                                {local.model.variant.current()}
+                                {identity().variant}
                               </span>
                             </text>
                           </Show>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1570,13 +1570,13 @@ export function Prompt(props: PromptProps) {
     resetComposer()
   }
 
-  // Keep the last resolved identity visible while destination catalogs load;
+  // Keep the last resolved prompt display visible while destination catalogs load;
   // availability and submission still use the live location-scoped catalog.
-  const identity = createMemo<{
-    agent: string | undefined
-    color: RGBA | undefined
-    model: string
-    provider: string
+  const promptDisplay = createMemo<{
+    agentLabel: string | undefined
+    agentColor: RGBA | undefined
+    modelLabel: string
+    providerLabel: string
     variant: string | undefined
   }>(
     (previous) => {
@@ -1584,8 +1584,7 @@ export function Prompt(props: PromptProps) {
       const sessionLocation = props.sessionID ? data.session.get(props.sessionID)?.location : location
       if (!sessionLocation || locationKey(sessionLocation) !== locationKey(location)) return previous
 
-      const loading =
-        data.location.agent.list(location) === undefined || data.location.model.list(location) === undefined
+      const loading = data.location.agent.list(location) === undefined || !local.model.catalogReady
       const error = currentLocation.error
       const failed = error && locationKey(error.location) === locationKey(location)
       if (loading && !failed) return previous
@@ -1593,30 +1592,31 @@ export function Prompt(props: PromptProps) {
       const agent = local.agent.current()
       const model = local.model.parsed()
       return {
-        agent: agent ? Locale.titlecase(agent.id) : undefined,
-        color: agent ? local.agent.color(agent.id) : undefined,
-        model: model.model,
-        provider: model.provider,
+        agentLabel: agent ? Locale.titlecase(agent.id) : undefined,
+        agentColor: agent ? local.agent.color(agent.id) : undefined,
+        modelLabel: model.model,
+        providerLabel: model.provider,
         variant: local.model.variant.current(),
       }
     },
     {
-      agent: undefined,
-      color: undefined,
-      ...local.model.parsed(),
+      agentLabel: undefined,
+      agentColor: undefined,
+      modelLabel: local.model.parsed().model,
+      providerLabel: local.model.parsed().provider,
       variant: undefined,
     },
   )
   const highlight = createMemo(() => {
     if (leader()) return theme.border.default
     if (store.mode === "shell") return theme.text.action.primary.selected
-    return identity().color ?? theme.border.default
+    return promptDisplay().agentColor ?? theme.border.default
   })
-  const agentLabel = createMemo(() => (store.mode === "shell" ? "Shell" : identity().agent))
+  const agentLabel = createMemo(() => (store.mode === "shell" ? "Shell" : promptDisplay().agentLabel))
   const agentMetaAlpha = createFadeIn(() => !!agentLabel(), animationsEnabled)
-  const modelMetaAlpha = createFadeIn(() => !!identity().agent && store.mode === "normal", animationsEnabled)
+  const modelMetaAlpha = createFadeIn(() => !!promptDisplay().agentLabel && store.mode === "normal", animationsEnabled)
   const variantMetaAlpha = createFadeIn(
-    () => !!identity().agent && store.mode === "normal" && !!identity().variant,
+    () => !!promptDisplay().agentLabel && store.mode === "normal" && !!promptDisplay().variant,
     animationsEnabled,
   )
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
@@ -1664,8 +1664,7 @@ export function Prompt(props: PromptProps) {
   })
 
   const spinnerDef = createMemo(() => {
-    const agent = status() === "running" ? local.agent.current() : local.agent.current()
-    const color = agent ? local.agent.color(agent.id) : theme.border.default
+    const color = promptDisplay().agentColor ?? theme.border.default
     return {
       frames: createFrames({
         color,
@@ -1880,14 +1879,14 @@ export function Prompt(props: PromptProps) {
                             truncate
                             fg={fadeColor(leader() ? theme.text.subdued : theme.text.default, modelMetaAlpha())}
                           >
-                            {identity().model}
+                            {promptDisplay().modelLabel}
                           </text>
                           <Show when={dimensions().width >= 50}>
                             <text flexShrink={0} fg={fadeColor(theme.text.subdued, modelMetaAlpha())}>
-                              {identity().provider}
+                              {promptDisplay().providerLabel}
                             </text>
                           </Show>
-                          <Show when={identity().variant && dimensions().width >= 70}>
+                          <Show when={promptDisplay().variant && dimensions().width >= 70}>
                             <text fg={fadeColor(theme.text.subdued, variantMetaAlpha())}>·</text>
                             <text>
                               <span
@@ -1896,7 +1895,7 @@ export function Prompt(props: PromptProps) {
                                   bold: true,
                                 }}
                               >
-                                {identity().variant}
+                                {promptDisplay().variant}
                               </span>
                             </text>
                           </Show>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1570,17 +1570,11 @@ export function Prompt(props: PromptProps) {
     resetComposer()
   }
 
-  const highlight = createMemo(() => {
-    if (leader()) return theme.border.default
-    if (store.mode === "shell") return theme.text.action.primary.selected
-    const agent = local.agent.current()
-    if (!agent) return theme.border.default
-    return local.agent.color(agent.id)
-  })
   // Keep the last resolved identity visible while destination catalogs load;
   // availability and submission still use the live location-scoped catalog.
   const identity = createMemo<{
     agent: string | undefined
+    color: RGBA | undefined
     model: string
     provider: string
     variant: string | undefined
@@ -1600,6 +1594,7 @@ export function Prompt(props: PromptProps) {
       const model = local.model.parsed()
       return {
         agent: agent ? Locale.titlecase(agent.id) : undefined,
+        color: agent ? local.agent.color(agent.id) : undefined,
         model: model.model,
         provider: model.provider,
         variant: local.model.variant.current(),
@@ -1607,10 +1602,16 @@ export function Prompt(props: PromptProps) {
     },
     {
       agent: undefined,
+      color: undefined,
       ...local.model.parsed(),
       variant: undefined,
     },
   )
+  const highlight = createMemo(() => {
+    if (leader()) return theme.border.default
+    if (store.mode === "shell") return theme.text.action.primary.selected
+    return identity().color ?? theme.border.default
+  })
   const agentLabel = createMemo(() => (store.mode === "shell" ? "Shell" : identity().agent))
   const agentMetaAlpha = createFadeIn(() => !!agentLabel(), animationsEnabled)
   const modelMetaAlpha = createFadeIn(() => !!identity().agent && store.mode === "normal", animationsEnabled)

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -301,8 +301,10 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
   const events = createEventStream()
   const source = process.cwd()
   const target = "/tmp/opencode-target"
+  const locationCatalog = Promise.withResolvers<void>()
   const catalog = Promise.withResolvers<void>()
   const providerCatalog = Promise.withResolvers<void>()
+  const locationRequested = Promise.withResolvers<void>()
   const modelRequested = Promise.withResolvers<void>()
   const ready = Promise.withResolvers<void>()
   const calls = createFetch(async (url) => {
@@ -315,7 +317,13 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
         canonical: requestedDirectory,
       },
     }
-    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/location") {
+      if (requestedDirectory === target) {
+        locationRequested.resolve()
+        await locationCatalog.promise
+      }
+      return json(location)
+    }
     if (url.pathname === "/api/agent") {
       if (requestedDirectory === target) await catalog.promise
       return json({
@@ -370,6 +378,16 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
     setup.mockInput.pressEscape()
     setup.mockInput.pressEnter()
     await Promise.race([
+      locationRequested.promise,
+      Bun.sleep(2_000).then(() => {
+        throw new Error("target location was not requested")
+      }),
+    ])
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain(target)
+
+    locationCatalog.resolve()
+    await Promise.race([
       modelRequested.promise,
       Bun.sleep(2_000).then(() => {
         throw new Error("target model catalog was not requested")
@@ -389,6 +407,7 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
     setup.renderer.destroy()
     await task
   } finally {
+    locationCatalog.resolve()
     catalog.resolve()
     providerCatalog.resolve()
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -296,7 +296,7 @@ test("session startup prompt is submitted exactly once", async () => {
   }
 })
 
-test("keeps the prompt identity visible while a new location catalog loads", async () => {
+test("keeps the prompt display stable while a new location catalog loads", async () => {
   const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
   setup.renderer.start()
   const events = createEventStream()

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -3,6 +3,7 @@ import { createTestRenderer } from "@opentui/core/testing"
 import { Effect, FileSystem } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Global } from "@opencode-ai/util/global"
+import path from "node:path"
 import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
 
 test("SIGHUP clears title and disposes scoped resources once", async () => {
@@ -300,7 +301,7 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
   setup.renderer.start()
   const events = createEventStream()
   const source = process.cwd()
-  const target = "/tmp/opencode-target"
+  const target = path.join(path.parse(source).root, "opencode-target")
   const locationCatalog = Promise.withResolvers<void>()
   const catalog = Promise.withResolvers<void>()
   const providerCatalog = Promise.withResolvers<void>()
@@ -372,6 +373,13 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
 
     await ready.promise
     await setup.waitForFrame((frame) => frame.includes("Build · Source Model Provider"))
+    const agentSpan = () =>
+      setup
+        .captureSpans()
+        .lines.flatMap((line) => line.spans)
+        .find((span) => span.text.trim() === "Build")
+    const sourceAgentColor = agentSpan()?.fg.toInts()
+    expect(sourceAgentColor).toBeDefined()
     await setup.mockInput.typeText(`/cd ${target}`)
     await setup.renderOnce()
     expect(setup.captureCharFrame()).toContain(`/cd ${target}`)
@@ -396,6 +404,7 @@ test("keeps the prompt identity visible while a new location catalog loads", asy
     await setup.renderOnce()
 
     expect(setup.captureCharFrame()).toContain("Build · Source Model Provider")
+    expect(agentSpan()?.fg.toInts()).toEqual(sourceAgentColor)
 
     catalog.resolve()
     const resolved = await setup.waitForFrame((frame) => frame.includes("Build · Target Model provider"))

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -295,6 +295,107 @@ test("session startup prompt is submitted exactly once", async () => {
   }
 })
 
+test("keeps the prompt identity visible while a new location catalog loads", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const events = createEventStream()
+  const source = process.cwd()
+  const target = "/tmp/opencode-target"
+  const catalog = Promise.withResolvers<void>()
+  const providerCatalog = Promise.withResolvers<void>()
+  const modelRequested = Promise.withResolvers<void>()
+  const ready = Promise.withResolvers<void>()
+  const calls = createFetch(async (url) => {
+    const requestedDirectory = url.searchParams.get("location[directory]") ?? source
+    const location = {
+      directory: requestedDirectory,
+      project: {
+        id: requestedDirectory === target ? "target" : "source",
+        directory: requestedDirectory,
+        canonical: requestedDirectory,
+      },
+    }
+    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/agent") {
+      if (requestedDirectory === target) await catalog.promise
+      return json({
+        location,
+        data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }],
+      })
+    }
+    if (url.pathname === "/api/provider") {
+      if (requestedDirectory === target) await providerCatalog.promise
+      return json({ location, data: [{ id: "provider", name: "Provider" }] })
+    }
+    if (url.pathname === "/api/model") {
+      if (requestedDirectory === target) {
+        modelRequested.resolve()
+        await catalog.promise
+      }
+      return json({
+        location,
+        data: [
+          {
+            id: requestedDirectory === target ? "target-model" : "source-model",
+            providerID: "provider",
+            name: requestedDirectory === target ? "Target Model" : "Source Model",
+            variants: [],
+          },
+        ],
+      })
+    }
+    return undefined
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: {},
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+
+    await ready.promise
+    await setup.waitForFrame((frame) => frame.includes("Build · Source Model Provider"))
+    await setup.mockInput.typeText(`/cd ${target}`)
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain(`/cd ${target}`)
+    setup.mockInput.pressEscape()
+    setup.mockInput.pressEnter()
+    await Promise.race([
+      modelRequested.promise,
+      Bun.sleep(2_000).then(() => {
+        throw new Error("target model catalog was not requested")
+      }),
+    ])
+    await setup.renderOnce()
+
+    expect(setup.captureCharFrame()).toContain("Build · Source Model Provider")
+
+    catalog.resolve()
+    const resolved = await setup.waitForFrame((frame) => frame.includes("Build · Target Model provider"))
+    expect(resolved).not.toContain("Source Model")
+
+    providerCatalog.resolve()
+    await setup.waitForFrame((frame) => frame.includes("Build · Target Model Provider"))
+
+    setup.renderer.destroy()
+    await task
+  } finally {
+    catalog.resolve()
+    providerCatalog.resolve()
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
 test("configured app bindings execute settings and permission commands", async () => {
   const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
   setup.renderer.start()


### PR DESCRIPTION
## What

Keep the prompt's agent, model, and provider labels and agent highlight visible while a newly selected location initializes its catalogs, and show a requested Home `/cd` target immediately while the server validates it.

## Before / After

**Before:** On Home, `/cd` kept showing the source directory while location validation was in flight. Once validation completed, the footer switched to the target, but the prompt blanked its labels until the destination agent and model catalogs arrived.

**After:** The footer presents the requested directory immediately, while the real `LocationRef` still changes only after validation succeeds. The prompt retains its last resolved display and agent highlight until the destination catalogs become authoritative. A failed `/cd` restores the source footer, and model availability and submission remain tied to the destination catalog.

## How

- `packages/tui/src/component/prompt/index.tsx` keeps a display-only snapshot, including the resolved agent color, across a location bootstrap.
- The snapshot updates only when the session and active location agree, preventing mixed-location labels during route transitions.
- A presentation-only pending directory drives the Home footer during `/cd` validation without changing location-scoped actions or data.
- Model availability and submission continue to use the live location-scoped catalog; the retained label never makes a stale model selectable.
- Provider metadata may resolve later without holding back the destination model name.
- `packages/tui/test/app-lifecycle.test.tsx` delays location validation and the destination catalogs independently, verifying the optimistic footer, retained agent color, and each display transition on a platform-native target path.

## Scope

This changes prompt presentation only. Validated location synchronization, model selection, availability checks, and prompt admission are unchanged.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test` from `packages/tui` (736 passed, 5 skipped)
- Pre-push monorepo typecheck (40 packages successful)
- Deterministic OpenCode Drive comparison against the exact PR parent and fixed branch using the same script, viewport, keystrokes, sleeps, and 650 ms simulated network latency

## Demo

Left is the exact PR parent; right is the fixed branch. Both sides run the same OpenCode Drive script and timing. The simulated provider/model keeps the comparison deterministic.

https://github.com/user-attachments/assets/e0d58305-d5db-4cea-a29f-1426159488f1

## Flow

```mermaid
sequenceDiagram
    participant User
    participant Prompt
    participant Location
    participant Catalogs

    User->>Prompt: /cd target
    Prompt->>Prompt: Present target in footer
    Prompt->>Location: Validate target
    Location-->>Prompt: Validated LocationRef
    Prompt->>Prompt: Retain last resolved prompt display
    Catalogs-->>Prompt: Destination agent + model catalogs
    Prompt->>Prompt: Render destination prompt display
    Catalogs-->>Prompt: Provider metadata (may arrive later)
    Prompt->>Prompt: Replace provider ID with friendly name
```
