### PR TITLE
fix(codegen): write prettier-stable schema snapshot

### DIFF
--- a/packages/core/script/migration.ts
+++ b/packages/core/script/migration.ts
@@ -48,7 +48,7 @@ async function generate() {
           renderMigration(name, await Bun.file(path.join(incremental, name, "migration.sql")).text()),
         ),
       )
-      await fs.copyFile(path.join(incremental, name, "snapshot.json"), snapshot)
+      await Bun.write(snapshot, await formatJson(await Bun.file(path.join(incremental, name, "snapshot.json")).text()))
     }
 
     await fs.mkdir(full)
@@ -188,6 +188,19 @@ async function formatTypescript(input: string) {
     parser: "typescript",
     plugins: [typescript.default, estree.default],
     semi: false,
+    printWidth: 120,
+  })
+}
+
+// Drizzle emits every array multi-line; format the snapshot so regeneration
+// diffs stay minimal against the prettier-styled checked-in copy.
+async function formatJson(input: string) {
+  const prettier = await import("prettier")
+  const babel = await import("prettier/plugins/babel")
+  const estree = await import("prettier/plugins/estree")
+  return prettier.format(input, {
+    parser: "json",
+    plugins: [babel.default, estree.default],
     printWidth: 120,
   })
 }


### PR DESCRIPTION
## What

Regenerating a database migration reformats the entire checked-in `packages/core/schema.json`, burying the real change in hundreds of lines of array-reflow noise. This applies the same treatment #23228 gave the OpenAPI documents: format the generated snapshot in place so regeneration diffs contain only real schema changes.

## Before / After

**Before**: `bun script/migration.ts` raw-copies drizzle's `snapshot.json`, which emits every array multi-line. The checked-in snapshot is prettier-styled (short arrays collapsed), so adding a single column reflows every `"columns": [...]` array in the file — a 3-column addition produced a 206-line diff, ~170 of them formatting churn.

**After**: the snapshot is piped through prettier (`parser: "json"`, `printWidth: 120`) before writing. The formatter is a byte-for-byte no-op on the current checked-in snapshot, and a test column addition now produces a 14-line diff.

## How

- `packages/core/script/migration.ts`: replaces the `fs.copyFile` of drizzle's snapshot with a formatted `Bun.write`, adding a `formatJson` helper mirroring the existing `formatTypescript`.
- No behavior change for consumers: `--check` feeds the snapshot to drizzle as a parsed baseline and never byte-compares it, so formatting is invisible to validation.

## Testing

- Verified the formatter is a no-op on the checked-in `schema.json` (byte-identical input/output).
- Exercised the write path with a throwaway column: generated migration, confirmed the new snapshot stays prettier-compact and diffs at 14 lines, then reverted.
- `bun script/migration.ts --check` and `bun typecheck` clean from `packages/core`.
