### PR TITLE
docs: add kowork to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Kowork](https://github.com/MrHertal/kowork) | Open-source Claude Cowork alternative for non-technical users, powered by OpenCode |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — no tracking issue, this adds an ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [Kowork](https://github.com/MrHertal/kowork) to the Projects section of the ecosystem page. Kowork is an open-source Claude Cowork alternative for non-technical users, built as an Electron desktop app that runs OpenCode as a sidecar.

### How did you verify your code works?

Docs-only change: a single row added to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`. Verified the markdown table renders correctly.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR