### PR TITLE
fix(tui): treat missing kv.json as empty state on first read

### DIFF
--- a/packages/tui/src/context/kv.tsx
+++ b/packages/tui/src/context/kv.tsx
@@ -24,6 +24,8 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
         setStore(x)
       })
       .catch((error) => {
+        // Missing kv.json is expected on first run; it is created lazily on first write.
+        if (error?.code === "ENOENT") return
         console.error("Failed to read KV state", { error })
       })
       .finally(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #43916

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On a fresh install, `~/.local/state/opencode/kv.json` doesn't exist yet, so the TUI KV context logged a 'Failed to read KV state' ENOENT error when opening the console. A missing file is expected on first run — kv.json is created lazily on first write — so the read failure handler now returns early on `ENOENT` instead of logging, and KV starts from empty state. Any other read error still logs.

This works because `Flock.withLock` returns `await fn()` directly, so the ENOENT error from `Bun.file().json()` reaches the catch handler unwrapped with its `code` property intact. Same ENOENT-is-expected pattern already used in `packages/opencode/src/plugin/install.ts`.

### How did you verify your code works?

- Wrote a temporary test in `packages/tui` that mirrors the exact read chain from `kv.tsx` (`Flock.setGlobal` + `Flock.withLock` + `readJson` on a missing path): with the fix, no error is logged and the ready flag is still set. Same test against the old catch logic logs the error.
- Confirmed `Bun.file().json()` throws with `code: "ENOENT"` on a missing file
- `bun typecheck` passes
- All 193 existing tests in `packages/tui` pass

Repro for reviewers: delete `~/.local/state/opencode/kv.json`, launch the TUI, ctrl+p → toggle console. Before: ENOENT error logged. After: no error; kv.json still created on first write.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR