### PR TITLE
fix(core): omit active assistants from forks

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -181,6 +181,8 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
           eq(SessionMessageTable.session_id, event.data.parentID),
           gt(SessionMessageTable.seq, cursor),
           lt(SessionMessageTable.seq, copiedSeq + 1),
+          // Terminal events for active projections stay on the parent, so forks copy only settled history.
+          sql`${SessionMessageTable.type} != 'assistant' or json_extract(${SessionMessageTable.data}, '$.time.completed') is not null`,
           sql`${SessionMessageTable.type} != 'compaction' or json_extract(${SessionMessageTable.data}, '$.status') != 'running'`,
         ),
       )

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -401,6 +401,56 @@ describe("Session.create", () => {
     }),
   )
 
+  it.effect("does not copy a running assistant into a fork", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const bus = yield* Bus.Service
+      const { db } = yield* Database.Service
+      const parent = yield* session.create({ location })
+      yield* session.prompt({ sessionID: parent.id, text: "Run both tools", resume: false })
+      yield* SessionInbox.promote(db, bus, parent.id, "steer")
+      const assistantMessageID = SessionMessage.ID.create()
+      const model = Model.Ref.make({ id: Model.ID.make("model"), providerID: Provider.ID.make("provider") })
+
+      yield* bus.publish(SessionEvent.Step.Started, {
+        sessionID: parent.id,
+        assistantMessageID,
+        agent: Agent.ID.make("build"),
+        model,
+      })
+      yield* bus.publish(SessionEvent.Tool.Input.Started, {
+        sessionID: parent.id,
+        assistantMessageID,
+        id: "call_running",
+        name: "shell",
+      })
+      yield* bus.publish(SessionEvent.Tool.Input.Ended, {
+        sessionID: parent.id,
+        assistantMessageID,
+        id: "call_running",
+        text: '{"command":"sleep 10"}',
+      })
+      yield* bus.publish(SessionEvent.Tool.Called, {
+        sessionID: parent.id,
+        assistantMessageID,
+        id: "call_running",
+        input: { command: "sleep 10" },
+        executed: true,
+      })
+
+      const forked = yield* session.fork({ sessionID: parent.id, boundary: { type: "through" } })
+
+      expect(yield* session.context(parent.id)).toMatchObject([
+        { type: "user", text: "Run both tools" },
+        {
+          type: "assistant",
+          content: [{ type: "tool", id: "call_running", state: { status: "running" } }],
+        },
+      ])
+      expect(yield* session.context(forked.id)).toMatchObject([{ type: "user", text: "Run both tools" }])
+    }),
+  )
+
   it.effect("rejects forking an empty session", () =>
     Effect.gen(function* () {
       const session = yield* Session.Service
@@ -470,6 +520,11 @@ describe("Session.create", () => {
       expect(forked).toMatchObject({ cost: 0, tokens: { input: 0, output: 0, reasoning: 0 } })
       expect(yield* session.context(beforeFirst.id)).toEqual([])
       expect(beforeFirst).toMatchObject({ cost: 0, tokens: { input: 0, output: 0, reasoning: 0 } })
+      expect(yield* session.context(complete.id)).toMatchObject([
+        { type: "user", text: "First" },
+        { type: "user", text: "Second" },
+        { type: "assistant", finish: "stop" },
+      ])
       expect(complete).toMatchObject({
         cost: 0,
         tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },


### PR DESCRIPTION
## What

Forked sessions now retain settled history without inheriting an assistant projection that is still running in the parent. This prevents inherited tools and subagents from appearing permanently active in the child session.

## Before / After

**Before:** When `/fork` ran while the parent assistant had active tool calls, `projectFork` copied that mutable assistant row into the child. Its terminal events remained on the parent, so the child continued to show the copied tools as running.

**After:** Fork projection excludes assistants without `time.completed`, matching the existing treatment of running compactions. The child retains the admitted user prompt and all completed assistant history, but active work stays with the parent.

## How

- `packages/core/src/session/projector.ts` filters incomplete assistant projections from the bounded parent history copied into a fork.
- `packages/core/test/session-create.test.ts` reproduces a running tool projection and verifies the parent retains it while the child omits it.
- The existing fork boundary coverage now explicitly verifies completed assistants are still copied.

## Scope

This does not change prompt admission, execution ownership, fork boundaries, or settled session history.

## Testing

- `bun run test session-create.test.ts session-projector.test.ts` from `packages/core` (47 pass)
- `bun typecheck` from `packages/core`
- Repository pre-push typecheck (33 packages)
- `bunx prettier --check packages/core/src/session/projector.ts packages/core/test/session-create.test.ts`
- `git diff --check origin/v2...HEAD`
- Deterministic OpenCode Drive run through the real TUI `/fork` flow at `110x34`: the probe changed from `child shows inherited running work: true` to `false`

## Demo

Side-by-side matched recordings. The shorter pre-fix capture holds its final broken frame so both outcomes remain visible.

https://github.com/user-attachments/assets/48d032e9-bccd-4c84-8d19-abffff7b4af9

## Flow

```mermaid
flowchart TD
  A[Parent history through fork boundary] --> B{Projected row state}
  B -->|User or completed assistant| C[Copy into child]
  B -->|Active assistant| D[Keep only on parent]
  B -->|Running compaction| D
  C --> E[Child contains settled history]
  D --> E
```