### PR TITLE
fix(server): match project copy errors by _tag instead of instanceof

### DIFF
--- a/packages/server/src/handlers/project-copy.ts
+++ b/packages/server/src/handlers/project-copy.ts
@@ -1,6 +1,5 @@
 import { Location } from "@opencode-ai/core/location"
 import { ProjectCopy } from "@opencode-ai/core/project/copy"
-import { Git } from "@opencode-ai/core/git"
 import { Effect } from "effect"
 import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Api } from "../api"
@@ -47,7 +46,7 @@ function badRequest<A, R>(effect: Effect.Effect<A, ProjectCopy.Error, R>) {
           name: "ProjectCopyError",
           data: {
             message: message(error),
-            forceRequired: error instanceof Git.WorktreeError ? error.forceRequired : undefined,
+            forceRequired: error._tag === "Git.WorktreeError" ? error.forceRequired : undefined,
           },
         }),
     ),
@@ -55,14 +54,14 @@ function badRequest<A, R>(effect: Effect.Effect<A, ProjectCopy.Error, R>) {
 }
 
 function message(error: ProjectCopy.Error) {
-  if (error instanceof ProjectCopy.SourceDirectoryNotFoundError)
+  if (error._tag === "ProjectCopy.SourceDirectoryNotFoundError")
     return `Project copy source not found: ${error.directory}`
-  if (error instanceof ProjectCopy.DestinationExistsError)
+  if (error._tag === "ProjectCopy.DestinationExistsError")
     return `Project copy destination already exists: ${error.directory}`
-  if (error instanceof ProjectCopy.DirectoryUnavailableError)
+  if (error._tag === "ProjectCopy.DirectoryUnavailableError")
     return `Project copy directory unavailable: ${error.directory}`
-  if (error instanceof ProjectCopy.InvalidDirectoryError) return `Invalid project copy directory: ${error.directory}`
-  if (error instanceof ProjectCopy.StrategyUnavailableError)
+  if (error._tag === "ProjectCopy.InvalidDirectoryError") return `Invalid project copy directory: ${error.directory}`
+  if (error._tag === "ProjectCopy.StrategyUnavailableError")
     return `Project copy strategy unavailable: ${error.strategy}`
   return error.message
 }


### PR DESCRIPTION
### Issue for this PR

Closes #43995

Related to #40613, which reports the same symptom (forceRequired false when it should be true) from a different cause — the regex in git.ts only matches English git output. The two are independent: this PR doesn't address the locale case, and fixing the locale case wouldn't address this one.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`project-copy.ts` identifies errors with `instanceof`, which compares class identity. If `@opencode-ai/core` is ever loaded twice in one process, the service constructs the error from one copy of the module and the handler tests it against the other, so every check returns false while the code still looks correct.

I hit this in a workspace that path-maps the core specifiers. It won't reproduce on a stock checkout, and since core isn't published, a normal install can't produce two copies — so I'm not claiming this is currently broken for anyone else. The reason I think it's still worth changing: `_tag` comparison doesn't depend on identity, it's already the pattern used in ~52 places in this codebase (including error handling, e.g. `error._tag === "FileSystemError"`), and this handler is the outlier.

Six checks changed, plus the now-unused `Git` import removed. No behaviour change when only one copy of core is loaded.

### Impact when the checks do fail

- `forceRequired` is dropped from the 400 response, so a client can't tell the user to retry with force after a failed project-copy delete. The operation looks like a plain failure.
- All five ProjectCopy errors fall through to `error.message`, surfacing raw git text ("fatal: '...' contains modified or untracked files") instead of the formatted messages.

Both fail silently — `instanceof` returning false doesn't throw, so nothing surfaces except the degraded response.

### How did you verify your code works?

From `packages/opencode`: `bun test test/server/project-copy.test.ts` — the "lists directories and manages git worktree copies" case asserts `forceRequired: true` after deleting a dirty worktree. It passes before and after on a stock checkout. In my path-mapped setup it failed before and passes now. `tsgo --noEmit` on `packages/server` is clean.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
