### PR TITLE
fix(core): omit running shells from forks

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -183,6 +183,7 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
           lt(SessionMessageTable.seq, copiedSeq + 1),
           // Terminal events for active projections stay on the parent, so forks copy only settled history.
           sql`${SessionMessageTable.type} != 'assistant' or json_extract(${SessionMessageTable.data}, '$.time.completed') is not null`,
+          sql`${SessionMessageTable.type} != 'shell' or json_extract(${SessionMessageTable.data}, '$.status') != 'running'`,
           sql`${SessionMessageTable.type} != 'compaction' or json_extract(${SessionMessageTable.data}, '$.status') != 'running'`,
         ),
       )

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import path from "path"
 import { DateTime, Effect, Layer, Stream } from "effect"
 import { Money } from "@opencode-ai/schema/money"
+import { Shell } from "@opencode-ai/schema/shell"
 import { Agent } from "@opencode-ai/core/agent"
 import { asc, eq } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
@@ -448,6 +449,49 @@ describe("Session.create", () => {
         },
       ])
       expect(yield* session.context(forked.id)).toMatchObject([{ type: "user", text: "Run both tools" }])
+    }),
+  )
+
+  it.effect("copies only settled shell messages into forks", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const bus = yield* Bus.Service
+      const { db } = yield* Database.Service
+      const parent = yield* session.create({ location })
+      yield* session.prompt({ sessionID: parent.id, text: "Run a shell", resume: false })
+      yield* SessionInbox.promote(db, bus, parent.id, "steer")
+      const shell = Shell.Info.make({
+        id: Shell.ID.make("sh_fork_running"),
+        status: "running",
+        command: "sleep 10",
+        cwd: location.directory,
+        shell: "/bin/sh",
+        file: "/tmp/sh_fork_running.out",
+        metadata: {},
+        time: { started: 0 },
+      })
+      yield* bus.publish(SessionEvent.Shell.Started, { sessionID: parent.id, shell })
+
+      const running = yield* session.fork({ sessionID: parent.id, boundary: { type: "through" } })
+
+      expect(yield* session.context(parent.id)).toMatchObject([
+        { type: "user", text: "Run a shell" },
+        { type: "shell", command: "sleep 10", status: "running" },
+      ])
+      expect(yield* session.context(running.id)).toMatchObject([{ type: "user", text: "Run a shell" }])
+
+      yield* bus.publish(SessionEvent.Shell.Ended, {
+        sessionID: parent.id,
+        shell: { ...shell, status: "exited", exit: 0, time: { started: 0, completed: 1 } },
+        output: { output: "complete", cursor: 8, size: 8, truncated: false },
+      })
+      const completed = yield* session.fork({ sessionID: parent.id, boundary: { type: "through" } })
+
+      expect(yield* session.context(running.id)).toMatchObject([{ type: "user", text: "Run a shell" }])
+      expect(yield* session.context(completed.id)).toMatchObject([
+        { type: "user", text: "Run a shell" },
+        { type: "shell", command: "sleep 10", status: "exited", output: { output: "complete" } },
+      ])
     }),
   )
 


### PR DESCRIPTION
## What

Prevent forked sessions from inheriting a standalone shell projection that is still running in the parent.

## Before / After

**Before:** `session.shell.started` appended a running shell message. If the session was forked before `session.shell.ended`, the child copied that row, but the eventual terminal event updated only the parent. The child permanently retained a running shell with no output and exposed it to model history as an executed command with blank output.

**After:** forks copy only terminal standalone shell messages. A shell that is still running remains parent-owned; once it exits, times out, or is killed, later forks inherit its settled status and output.

## How

- `packages/core/src/session/projector.ts` excludes shell rows whose projected status is still `running` from fork materialization.
- `packages/core/test/session-create.test.ts` covers both lifecycle states: a fork during execution omits the shell, while a fork after completion retains it and its output.

## Scope

This PR only handles standalone Session shell messages. Active assistants and running compactions are already excluded by the same settled-history query. Instruction-entry inheritance, transfer snapshots, and deterministic fork replay remain separate follow-ups.

## Testing

- Red: the new regression failed because the first child contained the copied `status: "running"` shell.
- Green: `bun run test session-create.test.ts` (35 passed)
- `bun run test session-projector.test.ts` (13 passed)
- `bun typecheck` from `packages/core`
- Repository pre-push typecheck (33 packages passed)
- `bunx prettier --check packages/core/src/session/projector.ts packages/core/test/session-create.test.ts`
- `git diff --check`
