### PR TITLE
fix(tui): contain MCP sidebar errors

### DIFF
--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -33,14 +33,23 @@ function Status(props: { status: McpServer["status"]; loading: boolean }) {
   return <>Disabled ○</>
 }
 
-export function DialogMcp() {
+export function DialogMcp(props: { initialServer?: string; details?: boolean } = {}) {
   const data = useData()
   const dialog = useDialog()
   const client = useClient()
   const toast = useToast()
   const theme = useTheme("elevated")
-  const [focused, setFocused] = createSignal<string>()
-  const [detail, setDetail] = createSignal<McpServer>()
+  const servers = createMemo(() =>
+    pipe(
+      data.location.mcp.server.list() ?? [],
+      sortBy((server) => server.name),
+    ),
+  )
+  const initial = props.initialServer ? servers().find((server) => server.name === props.initialServer) : undefined
+  const [focused, setFocused] = createSignal<string | undefined>(props.initialServer)
+  const [detail, setDetail] = createSignal<McpServer | undefined>(
+    props.details && initial?.status.status === "failed" ? initial : undefined,
+  )
   const [loading, setLoading] = createSignal<string | null>(null)
 
   const statusColor = (status: McpServer["status"]) => {
@@ -49,13 +58,6 @@ export function DialogMcp() {
     if (status.status === "needs_auth") return theme.text.feedback.warning.default
     return theme.text.subdued
   }
-
-  const servers = createMemo(() =>
-    pipe(
-      data.location.mcp.server.list() ?? [],
-      sortBy((server) => server.name),
-    ),
-  )
 
   createEffect(() => {
     if (focused()) return
@@ -153,7 +155,7 @@ export function DialogMcp() {
             title={`MCP server: ${server().name}`}
             error={statusError(server().status) ?? "Unknown MCP connection error"}
             onBack={() => {
-              setDetail()
+              setDetail(undefined)
               dialog.setSize("medium")
             }}
           />

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -1,5 +1,6 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createMemo, For, Match, Show, Switch, createSignal } from "solid-js"
+import { DialogMcp } from "../../component/dialog-mcp"
 
 function View(props: { context: Plugin.Context; sessionID: string }) {
   const [open, setOpen] = createSignal(true)
@@ -39,7 +40,16 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
         <Show when={list().length <= 2 || open()}>
           <For each={list()}>
             {(item) => (
-              <box flexDirection="row" gap={1} minWidth={0}>
+              <box
+                flexDirection="row"
+                gap={1}
+                minWidth={0}
+                onMouseUp={() =>
+                  props.context.ui.dialog.show(() => (
+                    <DialogMcp initialServer={item.name} details={item.status.status === "failed"} />
+                  ))
+                }
+              >
                 <text
                   flexShrink={0}
                   style={{
@@ -51,11 +61,15 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
                 <text fg={theme.text.default} wrapMode="none" truncate flexGrow={1} flexShrink={1} minWidth={0}>
                   <b>{item.name}</b>
                 </text>
-                <text fg={dot(item.status.status)} wrapMode="none" flexShrink={0}>
+                <text
+                  fg={item.status.status === "failed" ? theme.text.feedback.error.default : theme.text.subdued}
+                  wrapMode="none"
+                  flexShrink={0}
+                >
                   <Switch fallback={item.status.status}>
                     <Match when={item.status.status === "connected"}>Connected</Match>
                     <Match when={item.status.status === "pending"}>Connecting</Match>
-                    <Match when={item.status.status === "failed"}>Failed</Match>
+                    <Match when={item.status.status === "failed"}>Error</Match>
                     <Match when={item.status.status === "disabled"}>Disabled</Match>
                     <Match when={item.status.status === "needs_auth"}>Sign in</Match>
                   </Switch>

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -39,7 +39,7 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
         <Show when={list().length <= 2 || open()}>
           <For each={list()}>
             {(item) => (
-              <box flexDirection="row" gap={1}>
+              <box flexDirection="row" gap={1} minWidth={0}>
                 <text
                   flexShrink={0}
                   style={{
@@ -48,18 +48,17 @@ function View(props: { context: Plugin.Context; sessionID: string }) {
                 >
                   •
                 </text>
-                <text fg={theme.text.default} wrapMode="word">
-                  {item.name}{" "}
-                  <span style={{ fg: theme.text.subdued }}>
-                    <Switch fallback={item.status.status}>
-                      <Match when={item.status.status === "connected"}>Connected</Match>
-                      <Match when={item.status.status === "failed"}>
-                        <i>{item.status.status === "failed" ? item.status.error : undefined}</i>
-                      </Match>
-                      <Match when={item.status.status === "disabled"}>Disabled</Match>
-                      <Match when={item.status.status === "needs_auth"}>Needs auth</Match>
-                    </Switch>
-                  </span>
+                <text fg={theme.text.default} wrapMode="none" truncate flexGrow={1} flexShrink={1} minWidth={0}>
+                  <b>{item.name}</b>
+                </text>
+                <text fg={dot(item.status.status)} wrapMode="none" flexShrink={0}>
+                  <Switch fallback={item.status.status}>
+                    <Match when={item.status.status === "connected"}>Connected</Match>
+                    <Match when={item.status.status === "pending"}>Connecting</Match>
+                    <Match when={item.status.status === "failed"}>Failed</Match>
+                    <Match when={item.status.status === "disabled"}>Disabled</Match>
+                    <Match when={item.status.status === "needs_auth"}>Sign in</Match>
+                  </Switch>
                 </text>
               </box>
             )}


### PR DESCRIPTION
## What

Keep MCP connection failures compact and scannable in the session sidebar. Server names now truncate cleanly, routine state labels stay neutral, and errored rows open their existing diagnostics on click.

## Before / After

**Before:** A failed MCP server rendered its complete error string inline. An HTML response or verbose transport error could wrap across dozens of sidebar lines and bury every other server and sidebar section.

**After:** The sidebar renders only `Error`, `Connected`, `Connecting`, `Disabled`, or `Sign in`. The dot carries routine state color, only `Error` is emphasized, and clicking an errored row opens its full diagnostics in the existing MCP modal.

## How

- `packages/tui/src/feature-plugins/sidebar/mcp.tsx` no longer renders `status.error`.
- Server names use a shrinking, truncating column.
- Statuses use a fixed-width trailing column; only errors use feedback color because the leading dot already communicates other states.
- Sidebar rows open `DialogMcp` focused on the selected server, with failed rows entering the existing error-details view directly.

## Scope

This only changes the session sidebar summary. The MCP dialog continues to expose complete error details and retry/sign-in actions.

## Testing

- `bun typecheck` from `packages/tui`
- Full workspace typecheck from the push hook, 33 packages passed
- `bunx prettier --check src/feature-plugins/sidebar/mcp.tsx`
- `git diff --check`
- The same OpenCode Drive script against `origin/v2` and this branch at 132x34, with four failed servers (including a long HTML response), one connected local server, one disabled server, and an overlong server name
- A synchronized click on `uidotsh` verifies the baseline row is inert while the changed row opens the MCP error-details modal

## Demo

The recording presents synchronized, equal-length runs from the same Drive script and fixture side by side. `BEFORE` runs `origin/v2`; `AFTER` runs this branch. Both sides receive the same click after two seconds. The production TUI uses a simulated model response, while MCP states and the raw HTML failure come from real connection attempts inside the isolated fixture.

https://github.com/user-attachments/assets/35ba3d31-93ce-47c9-ac0c-803aa1c57be7
