### PR TITLE
fix(core): recover and validate session locations

### DIFF
--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer, LayerMap } from "effect"
+import { existsSync } from "fs"
 import path from "path"
 import { Agent } from "./agent.js"
 import { AISDK } from "./aisdk.js"
@@ -146,7 +147,7 @@ export function buildLocationServiceMap(
             Layer.provide(LayerNode.compile(location.hoisted)),
           )
         },
-        { idleTimeToLive: "60 minutes" },
+        { idleTimeToLive: (ref) => (existsSync(ref.directory) ? "60 minutes" : 0) },
       ),
       (inner) => ({
         ...inner,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,7 +1,7 @@
 export * as Session from "./session.js"
 export * from "./session/schema.js"
 
-import { Effect, Layer, Schema, Context, RcMap, Stream, Scope } from "effect"
+import { Cause, Effect, Layer, Schema, Context, RcMap, Stream, Scope } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
 import { and, asc, desc, eq, gt, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { Project } from "./project.js"
@@ -156,6 +156,11 @@ export class DestinationNotDirectoryError extends Schema.TaggedError<Destination
   "Session.DestinationNotDirectoryError",
   { directory: AbsolutePath },
 ) {}
+
+export class DestinationUnavailableError extends Schema.TaggedError<DestinationUnavailableError>()(
+  "Session.DestinationUnavailableError",
+  { directory: AbsolutePath },
+) {}
 export const MessageNotFoundError = SessionRevert.MessageNotFoundError
 export type MessageNotFoundError = SessionRevert.MessageNotFoundError
 
@@ -218,7 +223,10 @@ export interface Interface {
     directory: AbsolutePath
     workspaceID?: Location.Ref["workspaceID"]
     delivery?: SessionInbox.Delivery
-  }) => Effect.Effect<void, NotFoundError | DestinationNotFoundError | DestinationNotDirectoryError>
+  }) => Effect.Effect<
+    void,
+    NotFoundError | DestinationNotFoundError | DestinationNotDirectoryError | DestinationUnavailableError
+  >
   readonly prompt: (input: {
     id?: SessionMessage.ID
     sessionID: SessionSchema.ID
@@ -772,12 +780,22 @@ const layer = Layer.effect(
         if (!info) return yield* new DestinationNotFoundError({ directory })
         if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
         const project = yield* projects.resolve(directory)
-        yield* persistProject(project)
         const payload: SessionInbox.MovePayload = {
           location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
           projectID: project.id,
           subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
         }
+        yield* Location.Service.pipe(
+          Effect.provide(locations.get(payload.location)),
+          Effect.scoped,
+          Effect.catchCause((cause) => {
+            if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause)
+            return Effect.logWarning("session move destination unavailable", { directory, cause }).pipe(
+              Effect.andThen(Effect.fail(new DestinationUnavailableError({ directory }))),
+            )
+          }),
+        )
+        yield* persistProject(project)
         const item = SessionInbox.Item.make({
           type: "move",
           payload,

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -43,6 +43,28 @@ const itWithSdk = testEffect(
 )
 
 describe("LocationServiceMap", () => {
+  it.live("retries a location after its missing directory is recreated", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const directory = path.join(dir.path, "recreated")
+          const ref = Location.Ref.make({ directory: AbsolutePath.make(directory) })
+
+          const first = yield* Location.Service.pipe(Effect.provide(locations.get(ref)), Effect.scoped, Effect.exit)
+          expect(first._tag).toBe("Failure")
+
+          yield* Effect.promise(() => fs.mkdir(directory))
+          const location = yield* Location.Service.pipe(Effect.provide(locations.get(ref)), Effect.scoped)
+          expect(location.directory).toBe(ref.directory)
+        }),
+      ),
+    ),
+  )
+
   itWithSdk.live("preserves embedded SDK plugins after Location eviction", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect } from "bun:test"
 import path from "path"
 import { mkdir, rm } from "fs/promises"
-import { Effect } from "effect"
+import { Effect, Layer, LayerMap } from "effect"
 import { Worktree } from "@opencode-ai/schema/worktree"
 import { Bus } from "@opencode-ai/core/bus"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
+import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import type { LocationServices } from "@opencode-ai/core/location-services"
 import { Project } from "@opencode-ai/core/project"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
@@ -28,8 +30,47 @@ const it = testEffect(
     ],
   ),
 )
+const unavailableLocations = Layer.effect(
+  LocationServiceMap.Service,
+  LayerMap.make(
+    () => Layer.effectDiscard(Effect.fail(new Error("broken location"))) as unknown as Layer.Layer<LocationServices>,
+  ),
+)
+const itWithUnavailableDestination = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Database.node, Bus.node, SessionProjector.node, SessionStore.node, Session.node]),
+    [
+      [Project.node, globalProjectLayer],
+      [SessionExecution.node, SessionExecution.noopLayer],
+      [LocationServiceMap.node, unavailableLocations],
+    ],
+  ),
+)
 
 describe("Session.move", () => {
+  itWithUnavailableDestination.effect("rejects an unavailable destination before admitting the move", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const source = AbsolutePath.make(path.join(tmp.path, "source"))
+          const destination = AbsolutePath.make(path.join(tmp.path, "destination"))
+          yield* Effect.promise(() => Promise.all([mkdir(source), mkdir(destination)]))
+          const created = yield* session.create({ location: Location.Ref.make({ directory: source }) })
+
+          const error = yield* session.move({ sessionID: created.id, directory: destination }).pipe(Effect.flip)
+
+          expect(error).toEqual(new Session.DestinationUnavailableError({ directory: destination }))
+          expect((yield* session.get(created.id)).location.directory).toBe(source)
+          expect(yield* session.inbox(created.id)).toEqual([])
+        }),
+      ),
+    ),
+  )
+
   it.effect("applies a move immediately when the source directory no longer exists", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -240,6 +240,9 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
               Effect.catchTag("Session.DestinationNotDirectoryError", (error) =>
                 Effect.fail(new InvalidRequestError({ message: `Not a directory: ${error.directory}` })),
               ),
+              Effect.catchTag("Session.DestinationUnavailableError", (error) =>
+                Effect.fail(new InvalidRequestError({ message: `Directory is unavailable: ${error.directory}` })),
+              ),
             )
           return HttpApiSchema.NoContent.make()
         }),


### PR DESCRIPTION
## What

Allow a location to recover immediately when its directory is recreated after an initial missing-directory failure, and reject moves into destinations whose location runtime cannot initialize.

## Before / After

**Before**

1. A session referenced a worktree directory that no longer existed.
2. Opening the session attempted to build its location services and cached the resulting failure in `LayerMap`.
3. Recreating the directory did not help because the failed entry remained cached for the normal 60-minute idle TTL.
4. Session moves queued behind execution at the failed location, so the TUI repeatedly showed `Session location unavailable` even though the path existed again.
5. Move validation checked only that a destination existed and was a directory, so another unusable location could be admitted and strand the session again.

**After**

Entries first acquired while their directory is absent use a zero idle TTL. Once the failed requester releases the entry, the next attempt rebuilds the location from the recreated directory. Existing locations retain the 60-minute cache behavior.

Before admitting a move, the server now acquires the destination's full location runtime. A failed destination returns `Directory is unavailable`, leaves the session at its source, and admits no inbox move. A broken source still does not prevent moving away from it.

## How

- `packages/core/src/location-services.ts` selects the `LayerMap` idle TTL from directory availability at entry creation.
- `packages/core/test/location-layer.test.ts` reproduces a failed acquisition, recreates the exact directory, and verifies the next acquisition succeeds.
- `packages/core/src/session.ts` preflights destination location services before persisting or admitting a move.
- `packages/server/src/handlers/session.ts` maps an unavailable destination to a clear invalid-request response.
- `packages/core/test/session-move.test.ts` verifies a broken destination does not change session state or enqueue work.

## Scope

This does not change the TUI recovery UI or hide broken workareas from management lists. Broken workareas remain visible so users can repair or delete them, but they cannot become a session's destination.

## Testing

- `bun run test test/location-layer.test.ts test/session-move.test.ts` from `packages/core` (23 passed)
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/server`
- Push hook workspace typecheck (33 packages passed)
- `bunx prettier --check packages/core/src/location-services.ts packages/core/test/location-layer.test.ts`
- Live beta recovery: moved an affected session to a recreated persistent worktree, submitted a prompt through the V2 API, and observed the completed `SESSION_RECOVERED` assistant response.

## Flow

```mermaid
sequenceDiagram
    participant Client as TUI / session runner
    participant Map as LocationServiceMap
    participant FS as Filesystem

    Client->>Map: Acquire missing location
    Map->>FS: Check directory
    FS-->>Map: Missing
    Map-->>Client: Location build fails
    Note over Map: Entry releases immediately (TTL 0)
    Client->>FS: Recreate directory
    Client->>Map: Acquire same location
    Map->>FS: Check directory
    FS-->>Map: Exists
    Map-->>Client: Fresh location services
    Client->>Map: Preflight move destination
    alt destination initializes
        Map-->>Client: Admit move
    else destination fails
        Map-->>Client: Reject without changing session
    end
```
