### PR TITLE
fix(tui): auto-approve background tab permissions

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -11,6 +11,7 @@ import { useConfig } from "../config"
 import { useLocation } from "./location"
 import { useStorage } from "./storage"
 import { useTuiPaths } from "./runtime"
+import { usePermission } from "./permission"
 import { newSessionLocation } from "../config/new-session-location"
 import {
   closeSessionTab,
@@ -59,6 +60,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
     const location = useLocation()
     const paths = useTuiPaths()
     const renderer = useRenderer()
+    const permission = usePermission()
     const enabled = () => config.tabs.enabled
     // Focus reporting emits transitions, so an interactive launch owns unread state until its first blur.
     const [focused, setFocused] = createSignal(true)
@@ -124,6 +126,28 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       }, {}),
     })
     const current = () => (route.data.type === "session" ? root(route.data.sessionID) : undefined)
+    const autoApproved = new Set<string>()
+    createEffect(() => {
+      if (permission.mode !== "auto") return
+      const active = current()
+      const roots = [
+        ...(active ? [active] : []),
+        ...(enabled() ? state().tabs.map((tab) => root(tab.sessionID)) : []),
+      ]
+      const sessions = Array.from(new Set(roots.flatMap((sessionID) => [sessionID, ...data.session.family(sessionID)])))
+      sessions
+        .flatMap((sessionID) => data.session.permission.list(sessionID) ?? [])
+        .forEach((request) => {
+          if (autoApproved.has(request.id)) return
+          autoApproved.add(request.id)
+          void data.session.permission
+            .reply({ sessionID: request.sessionID, reply: "once", requestID: request.id })
+            .catch((error) => {
+              console.error("Failed to auto-approve permission", error)
+            })
+            .finally(() => autoApproved.delete(request.id))
+        })
+    })
     const newTab = createMemo((open = false) => {
       if (route.data.type === "home") return true
       if (!open) return false
@@ -229,16 +253,19 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         )
       })()
       const timer = setTimeout(async () => {
-        const sessions = state()
-          .tabs.map((tab) => tab.sessionID)
-          .filter((sessionID) => sessionID !== current())
+        const sessions = state().tabs.map((tab) => tab.sessionID)
         for (const sessionID of sessions) {
           if (stale) return
+          const family = Array.from(new Set([sessionID, ...data.session.family(sessionID)]))
           await Promise.allSettled([
-            data.session.message.sync(sessionID),
-            data.session.pending.sync(sessionID),
-            data.session.permission.sync(sessionID),
-            data.session.form.sync(sessionID),
+            ...(sessionID === current()
+              ? []
+              : [
+                  data.session.message.sync(sessionID),
+                  data.session.pending.sync(sessionID),
+                  data.session.form.sync(sessionID),
+                ]),
+            ...family.map((id) => data.session.permission.sync(id)),
           ])
         }
       }, TAB_PREFETCH_DELAY)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -247,24 +247,6 @@ export function Session(props: { verticalTabsWidth: number }) {
   const scrollAcceleration = createMemo(() => getScrollAcceleration(config))
   const toast = useToast()
   const client = useClient()
-  const autoApproved = new Set<string>()
-  createEffect(() => {
-    if (local.permission.mode !== "auto") return
-    permissions().forEach((request) => {
-      if (autoApproved.has(request.id)) return
-      autoApproved.add(request.id)
-      void data.session.permission
-        .reply({
-          sessionID: request.sessionID,
-          reply: "once",
-          requestID: request.id,
-        })
-        .catch((error) => {
-          autoApproved.delete(request.id)
-          toast.error(error)
-        })
-    })
-  })
   const editor = useEditorContext()
   const [rowsSynced, setRowsSynced] = createSignal(false)
   const rows = createSessionRows(

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -5,9 +5,11 @@ import { testRender } from "@opentui/solid"
 import { mkdirSync, watch } from "fs"
 import path from "path"
 import { ConfigProvider } from "../../src/config"
+import { ArgsProvider } from "../../src/context/args"
 import { ClientProvider, useClient } from "../../src/context/client"
 import { DataProvider, useData } from "../../src/context/data"
 import { LocationProvider } from "../../src/context/location"
+import { PermissionProvider } from "../../src/context/permission"
 import { RouteProvider, useRoute } from "../../src/context/route"
 import { TuiAppProvider } from "../../src/context/runtime"
 import { SessionTabsProvider, useSessionTabs } from "../../src/context/session-tabs"
@@ -36,6 +38,7 @@ async function renderSessionTabs(
     sessionGate?: Promise<void>
     sessionDirectories?: Record<string, string>
     newLocation?: "launch" | "inherit"
+    auto?: boolean
   },
 ) {
   const temporary = options?.state ? undefined : await tmpdir()
@@ -55,6 +58,7 @@ async function renderSessionTabs(
   const sessions: string[] = []
   const locations: string[] = []
   const vcsLocations: string[] = []
+  const permissionReplies: string[] = []
   const calls = createFetch(async (url) => {
     if (url.pathname === "/api/location") {
       const requested = url.searchParams.get("location[directory]") ?? directory
@@ -71,6 +75,11 @@ async function renderSessionTabs(
         location: { directory: requested },
         data: { branch: { current: "main", default: "main" } },
       })
+    }
+    const permissionReply = url.pathname.match(/^\/api\/session\/[^/]+\/permission\/([^/]+)\/reply$/)?.[1]
+    if (permissionReply) {
+      permissionReplies.push(permissionReply)
+      return new Response(null, { status: 204 })
     }
     const sessionID = url.pathname.match(/^\/api\/session\/([^/]+)$/)?.[1]
     if (!sessionID) return undefined
@@ -107,26 +116,30 @@ async function renderSessionTabs(
     <TestTuiContexts paths={{ state }}>
       <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
         <StorageProvider>
-          <ConfigProvider
-            config={createTuiResolvedConfig({
-              tabs: { enabled: true },
-              session: { new_location: options?.newLocation ?? "launch" },
-            })}
-          >
-            <RouteProvider
-              initialRoute={options?.home ? { type: "home" } : { type: "session", sessionID: initialSessionID }}
+          <ArgsProvider auto={options?.auto}>
+            <ConfigProvider
+              config={createTuiResolvedConfig({
+                tabs: { enabled: true },
+                session: { new_location: options?.newLocation ?? "launch" },
+              })}
             >
-              <ClientProvider api={createApi(calls.fetch)}>
-                <DataProvider>
-                  <LocationProvider>
-                    <SessionTabsProvider>
-                      <Probe />
-                    </SessionTabsProvider>
-                  </LocationProvider>
-                </DataProvider>
-              </ClientProvider>
-            </RouteProvider>
-          </ConfigProvider>
+              <RouteProvider
+                initialRoute={options?.home ? { type: "home" } : { type: "session", sessionID: initialSessionID }}
+              >
+                <ClientProvider api={createApi(calls.fetch)}>
+                  <PermissionProvider>
+                    <DataProvider>
+                      <LocationProvider>
+                        <SessionTabsProvider>
+                          <Probe />
+                        </SessionTabsProvider>
+                      </LocationProvider>
+                    </DataProvider>
+                  </PermissionProvider>
+                </ClientProvider>
+              </RouteProvider>
+            </ConfigProvider>
+          </ArgsProvider>
         </StorageProvider>
       </TuiAppProvider>
     </TestTuiContexts>
@@ -140,6 +153,7 @@ async function renderSessionTabs(
     sessions,
     locations,
     vcsLocations,
+    permissionReplies,
     state,
     emit: (event: OpenCodeEvent) => events.emit({ ...event, location: { directory } }),
     focus: () => app.renderer.emit("focus"),
@@ -152,6 +166,31 @@ async function renderSessionTabs(
     },
   }
 }
+
+test("auto-approves a permission requested by a background tab", async () => {
+  const setup = await renderSessionTabs("background", { auto: true })
+  try {
+    await wait(() => setup.tabs.tabs().some((tab) => tab.sessionID === "background"))
+    setup.route.navigate({ type: "session", sessionID: "active" })
+    await wait(() => setup.tabs.current() === "active" && setup.tabs.tabs().length === 2)
+
+    setup.emit({
+      id: "evt_permission_background",
+      created: Date.now(),
+      type: "permission.asked",
+      data: {
+        id: "per_background",
+        sessionID: "background",
+        action: "external_directory",
+        resources: ["/tmp/background-worktree/*"],
+      },
+    })
+
+    await wait(() => setup.permissionReplies.includes("per_background"))
+  } finally {
+    await setup.destroy()
+  }
+})
 
 const executionSucceeded = (sessionID: string): OpenCodeEvent => ({
   id: `evt_done_${sessionID}`,


### PR DESCRIPTION
### Issue for this PR

Closes #44007

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves the existing auto-approval responder from the selected session route to the tab context. Auto mode now handles the selected session, open background tabs, and their child sessions. Permission state for open session families is refreshed after reconnect.

The responder remains event-driven and scoped to sessions owned by the current TUI tabs; it does not poll or scan all server sessions.

### How did you verify your code works?

- `bun test test/context/session-tabs.test.tsx` (12 passed)
- `bun typecheck` in `packages/tui`
- repository pre-commit typecheck (33 packages passed)

### Screenshots / recordings

No visual change. The regression test reproduces a permission request arriving for a background tab and verifies that auto mode replies without selecting it.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR