### PR TITLE
refactor: reuse undefined effect

### DIFF
--- a/packages/ai/src/protocols/openai-images.ts
+++ b/packages/ai/src/protocols/openai-images.ts
@@ -110,7 +110,7 @@ export const model = (input: ModelInput) => {
       const multipartImages = yield* Effect.forEach(sourceImages, (image) => {
         if (image.type === "bytes") return Effect.succeed({ data: image.data, mediaType: image.mediaType })
         if (image.type === "url") return ImageInputs.decodeDataUrl(image.url, ADAPTER)
-        return Effect.succeed(undefined)
+        return Effect.undefined
       })
       const multipartMask =
         mask === undefined

--- a/packages/ai/src/protocols/utils/image-input.ts
+++ b/packages/ai/src/protocols/utils/image-input.ts
@@ -16,7 +16,7 @@ export const decodeDataUrl = (
   url: string,
   module: string,
 ): Effect.Effect<{ readonly mediaType: string; readonly data: Uint8Array } | undefined, AIError> => {
-  if (!url.startsWith("data:")) return Effect.succeed(undefined)
+  if (!url.startsWith("data:")) return Effect.undefined
   const match = /^data:([^;,]+);base64,(.*)$/s.exec(url)
   if (!match) return Effect.fail(invalid(module, "Image data URLs must contain a MIME type and base64 data"))
   return Effect.fromResult(Encoding.decodeBase64(match[2])).pipe(

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -841,17 +841,17 @@ export class Interpreter<R> {
 
   private customIterator(value: unknown, node: AstNode, allowAsync = true) {
     if (value instanceof CodeModeGenerator) {
-      if (value.asynchronous && !allowAsync) return Effect.succeed(undefined)
+      if (value.asynchronous && !allowAsync) return Effect.undefined
       return Effect.succeed({
         iterator: value,
         next: new GeneratorMethodReference(value, "next"),
         asynchronous: value.asynchronous,
       })
     }
-    if (!isRecord(value) || isRuntimeReference(value)) return Effect.succeed(undefined)
+    if (!isRecord(value) || isRuntimeReference(value)) return Effect.undefined
     const asyncMethod = allowAsync ? Reflect.get(value, AsyncIteratorSymbol) : undefined
     const method = asyncMethod ?? Reflect.get(value, IteratorSymbol)
-    if (method === undefined || method === null) return Effect.succeed(undefined)
+    if (method === undefined || method === null) return Effect.undefined
     const self = this
     return Effect.map(
       this.invokeCallable(this.requireIteratorMethod(method, "Iterator method", node), [], node),

--- a/packages/core/src/config/plugin/skill.ts
+++ b/packages/core/src/config/plugin/skill.ts
@@ -46,7 +46,7 @@ export const Plugin = define({
 
     function firstMissing(target: string): Effect.Effect<string | undefined> {
       const parent = path.dirname(target)
-      if (parent === target) return Effect.succeed(undefined)
+      if (parent === target) return Effect.undefined
       return fs.isDir(parent).pipe(Effect.flatMap((exists) => (exists ? Effect.succeed(target) : firstMissing(parent))))
     }
 

--- a/packages/core/src/file-mutation.ts
+++ b/packages/core/src/file-mutation.ts
@@ -109,7 +109,7 @@ const layer = Layer.effect(
           const next = Bom.split(input.content)
           const current = yield* environment.files.read(input.target.absolute, { offset: 0, length: 3 }).pipe(
             Effect.map((result) => result.bytes),
-            Effect.catchTag("Environment.NotFound", () => Effect.succeed(undefined)),
+            Effect.catchTag("Environment.NotFound", () => Effect.undefined),
           )
           yield* environment.files.write(
             input.target.absolute,

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -78,9 +78,8 @@ const layer = Layer.effect(
           ? "Directory"
           : input.kind === "file"
             ? "File"
-            : (yield* fs
-                .stat(absolute)
-                .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined))))?.type
+            : (yield* fs.stat(absolute).pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.undefined)))
+                ?.type
       const externalDirectory = type === "Directory" ? absolute : path.dirname(absolute)
       const externalResource = slash(path.join(externalDirectory, "*"))
       return {

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -624,11 +624,11 @@ export const layer = (options?: Options) =>
             Effect.map((input) => input as Record<string, SourceProvider>),
             Effect.orElseSucceed(() => undefined),
           )
-        : Effect.succeed(undefined)
+        : Effect.undefined
 
       // The bundled snapshot is the boot-time floor for the catalog; the
       // periodic fetch below still refreshes on top.
-      const loadSnapshot = options?.snapshot === false ? Effect.succeed(undefined) : bundledSnapshot
+      const loadSnapshot = options?.snapshot === false ? Effect.undefined : bundledSnapshot
 
       const fetchAndWrite = Effect.fn("ModelsDev.fetchAndWrite")(function* () {
         const text = yield* fetchApi()

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -302,7 +302,7 @@ const layer = Layer.effect(
           const rememberedRules = yield* savedRules()
           for (const [id, item] of pending) {
             const rules = yield* configured(item.request.sessionID, item.agent).pipe(
-              Effect.catchTag("Session.NotFoundError", () => Effect.succeed(undefined)),
+              Effect.catchTag("Session.NotFoundError", () => Effect.undefined),
             )
             if (!rules) continue
             if (denied(item.request, rules)) continue

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -213,7 +213,7 @@ function fetchProviders(http: HttpClient.HttpClient, value: Credential.Value) {
     )
     .pipe(
       Effect.flatMap((response) => {
-        if (response.status === 404) return Effect.succeed(undefined)
+        if (response.status === 404) return Effect.undefined
         return HttpClientResponse.filterStatusOk(response).pipe(
           Effect.flatMap(HttpClientResponse.schemaBodyJson(RemoteResponse)),
           Effect.map((remote) => remote.config.provider),

--- a/packages/core/src/plugin/websearch/mcp.ts
+++ b/packages/core/src/plugin/websearch/mcp.ts
@@ -10,7 +10,7 @@ export const parseResponse = <F extends Schema.Struct.Fields>(body: string, resu
   const decode = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Struct({ result })))
   const parse = (payload: string) => {
     const trimmed = payload.trim()
-    if (!trimmed.startsWith("{")) return Effect.succeed(undefined)
+    if (!trimmed.startsWith("{")) return Effect.undefined
     return decode(trimmed).pipe(Effect.map((response) => response.result))
   }
   return Effect.gen(function* () {

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -235,7 +235,7 @@ const layer = Layer.effect(
               Effect.mapError((cause) => failure("Invalid ripgrep JSON output", cause)),
               Effect.flatMap((json) => {
                 if (!json || typeof json !== "object" || !("type" in json) || json.type !== "match")
-                  return Effect.succeed(undefined)
+                  return Effect.undefined
                 return Schema.decodeUnknownEffect(RawMatch)(json).pipe(
                   Effect.map((match) => ({
                     ...match.data,

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -201,7 +201,7 @@ export const noopLayer = Layer.succeed(
   Service.of({
     transform: () => Effect.succeed({ dispose: Effect.void }),
     reload: () => Effect.void,
-    capture: () => Effect.succeed(undefined),
+    capture: () => Effect.undefined,
     files: () => Effect.succeed([]),
     diff: () => Effect.succeed([]),
     restore: () => Effect.void,

--- a/packages/core/src/tool/plugin/write.ts
+++ b/packages/core/src/tool/plugin/write.ts
@@ -78,7 +78,7 @@ export const Plugin = {
                   source,
                 })
               const current = yield* FileMutation.readText(environment.files, target.absolute).pipe(
-                Effect.catchTag("Environment.NotFound", () => Effect.succeed(undefined)),
+                Effect.catchTag("Environment.NotFound", () => Effect.undefined),
               )
               const next = Bom.split(input.content)
               const preview = fileDiff(target.resource, current?.text ?? "", next.text, current ? "modified" : "added")

--- a/packages/core/src/worktree/git.ts
+++ b/packages/core/src/worktree/git.ts
@@ -31,7 +31,7 @@ export const make = Effect.gen(function* () {
       return yield* Effect.forEach(entries, (entry) =>
         canonical(fs, entry.directory).pipe(
           Effect.map((directory) => ({ directory, type: entry.kind === "main" ? "root" : "worktree" }) as const),
-          Effect.catchTag("Worktree.DirectoryUnavailableError", () => Effect.succeed(undefined)),
+          Effect.catchTag("Worktree.DirectoryUnavailableError", () => Effect.undefined),
         ),
       ).pipe(Effect.map((items) => items.filter((item): item is ListEntry => item !== undefined)))
     }),

--- a/packages/core/test/fixture/config-nodes.ts
+++ b/packages/core/test/fixture/config-nodes.ts
@@ -10,7 +10,7 @@ export const emptyCredentialNode = makeGlobalNode({
     Credential.Service.of({
       all: () => Effect.succeed([]),
       list: () => Effect.succeed([]),
-      get: () => Effect.succeed(undefined),
+      get: () => Effect.undefined,
       create: () => Effect.die("unused Credential.create"),
       update: () => Effect.die("unused Credential.update"),
       remove: () => Effect.die("unused Credential.remove"),

--- a/packages/core/test/fixture/mcp.ts
+++ b/packages/core/test/fixture/mcp.ts
@@ -19,9 +19,9 @@ export const emptyMcpLayer = Layer.succeed(
     callTool: () => Effect.die("unused mcp.callTool"),
     instructions: () => Effect.succeed([]),
     prompts: () => Effect.succeed([]),
-    prompt: () => Effect.succeed(undefined),
+    prompt: () => Effect.undefined,
     resourceCatalog: () => Effect.succeed(MCP.ResourceCatalog.make({ resources: [], templates: [] })),
-    readResource: () => Effect.succeed(undefined),
+    readResource: () => Effect.undefined,
   }),
 )
 

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -21,7 +21,7 @@ const runtime = LanguageModel.make({ id: "gemini", provider: "test-provider", ro
 
 const catalog = Layer.mock(Catalog.Service, {
   provider: {
-    get: () => Effect.succeed(undefined),
+    get: () => Effect.undefined,
     all: () => Effect.die("unused"),
     available: () => Effect.die("unused"),
   },
@@ -35,7 +35,7 @@ const catalog = Layer.mock(Catalog.Service, {
 })
 const integrations = Layer.mock(Integration.Service, {
   connection: {
-    active: () => Effect.succeed(undefined),
+    active: () => Effect.undefined,
     resolve: () => Effect.die("unused"),
     key: () => Effect.die("unused"),
     update: () => Effect.die("unused"),

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -405,7 +405,7 @@ describe("ConfigInstructionPlugin.Plugin", () => {
           FSUtil.Service.of({
             ...fs,
             up: () => Effect.succeed([discovered]),
-            readFileStringSafe: () => Effect.succeed(undefined),
+            readFileStringSafe: () => Effect.undefined,
           }),
         ),
       ),

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -17,7 +17,7 @@ const failingCredentialNode = makeGlobalNode({
     Credential.Service.of({
       all: () => Effect.succeed([]),
       list: () => Effect.succeed([]),
-      get: () => Effect.succeed(undefined),
+      get: () => Effect.undefined,
       create: () => Effect.die(new Error("credential persistence failed")),
       update: () => Effect.void,
       remove: () => Effect.void,

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -309,7 +309,7 @@ describe("ModelResolver", () => {
     })
     const integrations = Layer.mock(Integration.Service, {
       connection: {
-        active: () => Effect.succeed(undefined),
+        active: () => Effect.undefined,
         resolve: () => Effect.die("unused"),
         key: () => Effect.die("unused"),
         update: () => Effect.die("unused"),

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -33,7 +33,7 @@ const npmLayer = Layer.succeed(
   Npm.Service.of({
     add: () => Effect.succeed({ directory: "", entrypoint: undefined }),
     resolve: () => Effect.succeed({ directory: "", entrypoint: undefined }),
-    which: () => Effect.succeed(undefined),
+    which: () => Effect.undefined,
   }),
 )
 

--- a/packages/core/test/plugin/provider-dynamic.test.ts
+++ b/packages/core/test/plugin/provider-dynamic.test.ts
@@ -24,7 +24,7 @@ function npmEntrypoint(entrypoint?: string) {
   return Npm.Service.of({
     add: () => Effect.succeed({ directory: "", entrypoint }),
     resolve: () => Effect.succeed({ directory: "", entrypoint }),
-    which: () => Effect.succeed(undefined),
+    which: () => Effect.undefined,
   })
 }
 

--- a/packages/core/test/plugin/provider-sap-ai-core.test.ts
+++ b/packages/core/test/plugin/provider-sap-ai-core.test.ts
@@ -15,7 +15,7 @@ const it = testEffect(PluginTestLayer)
 const npm = Npm.Service.of({
   add: () => Effect.succeed({ directory: "", entrypoint: undefined }),
   resolve: () => Effect.succeed({ directory: "", entrypoint: undefined }),
-  which: () => Effect.succeed(undefined),
+  which: () => Effect.undefined,
 })
 
 const addPlugin = Effect.fn(function* () {

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -74,7 +74,7 @@ const locations = Layer.effect(
             }),
             Layer.mock(Snapshot.Service, {
               capture: () =>
-                ready ? Effect.succeed(undefined) : Effect.die(new Error("Snapshot used before plugins were ready")),
+                ready ? Effect.undefined : Effect.die(new Error("Snapshot used before plugins were ready")),
               restore: () =>
                 ready ? Effect.void : Effect.die(new Error("Snapshot used before plugins were ready")),
             }),

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -88,16 +88,16 @@ const config = Config.testLayer()
 const pluginSupervisor = Layer.succeed(PluginSupervisor.Service, PluginSupervisor.Service.of({ flush: Effect.void }))
 const promptCatalog = Layer.mock(Catalog.Service, {
   provider: {
-    get: () => Effect.succeed(undefined),
+    get: () => Effect.undefined,
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
   },
   model: {
-    get: () => Effect.succeed(undefined),
+    get: () => Effect.undefined,
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
-    default: () => Effect.succeed(undefined),
-    small: () => Effect.succeed(undefined),
+    default: () => Effect.undefined,
+    small: () => Effect.undefined,
   },
 })
 const runnerLayer = (llmClient: Layer.Layer<typeof LLMClient.Service>) =>

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -378,16 +378,16 @@ const pluginSupervisor = Layer.succeed(
 )
 const promptCatalog = Layer.mock(Catalog.Service, {
   provider: {
-    get: () => Effect.succeed(undefined),
+    get: () => Effect.undefined,
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
   },
   model: {
-    get: () => Effect.succeed(undefined),
+    get: () => Effect.undefined,
     all: () => Effect.succeed([]),
     available: () => Effect.succeed([]),
-    default: () => Effect.succeed(undefined),
-    small: () => Effect.succeed(undefined),
+    default: () => Effect.undefined,
+    small: () => Effect.undefined,
   },
 })
 const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [

--- a/packages/httpapi-codegen/src/index.ts
+++ b/packages/httpapi-codegen/src/index.ts
@@ -1426,7 +1426,7 @@ export function write(
       output.files,
       (file) =>
         fs.exists(join(directory, file.path)).pipe(
-          Effect.flatMap((exists) => (exists ? fs.stat(join(directory, file.path)) : Effect.succeed(undefined))),
+          Effect.flatMap((exists) => (exists ? fs.stat(join(directory, file.path)) : Effect.undefined)),
           Effect.flatMap((info) =>
             info?.type === "SymbolicLink"
               ? new GenerationError({ reason: `Unsafe output path: ${file.path}` })

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -70,8 +70,8 @@ export namespace FSUtil {
 
       const readFileStringSafe = Effect.fn("FileSystem.readFileStringSafe")(function* (path: string) {
         return yield* fs.readFileString(path).pipe(
-          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
-          Effect.catchReason("PlatformError", "PermissionDenied", () => Effect.succeed(undefined)),
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.undefined),
+          Effect.catchReason("PlatformError", "PermissionDenied", () => Effect.undefined),
         )
       })
 


### PR DESCRIPTION
## What

Replace every `Effect.succeed(undefined)` construction with the canonical cached `Effect.undefined` value across production code and test fixtures.

This preserves the exact `Effect<undefined>` success type while avoiding a fresh Effect primitive allocation at each call site. The candidates were surfaced while evaluating the official `@effect/tsgo` diagnostics against V2.

## How

- Update 20 production call sites across AI, Code Mode, Core, HTTP API codegen, and Util.
- Update 20 matching test and fixture call sites for consistency.
- Keep `Effect.undefined` rather than the official rule's broader `Effect.void` suggestion so inferred APIs continue to distinguish `undefined` from `void`.

## Scope

This PR does not add the official Effect Oxlint plugin. That integration requires coordinated upgrades of `oxlint`, `oxlint-tsgolint`, and `@effect/tsgo`, so it belongs in a separate tooling change.

## Testing

- `bun typecheck` in `packages/ai`, `packages/codemode`, `packages/core`, `packages/httpapi-codegen`, and `packages/util`
- `bun run test test/image.test.ts` in `packages/ai` (10 tests)
- `bun run test test/generator-test262.test.ts test/for-await-test262.test.ts` in `packages/codemode` (83 tests)
- Focused Core suite across 16 affected test files (354 tests)
- `bun run test test/generate.test.ts test/write.test.ts` in `packages/httpapi-codegen` (91 tests)
- `bun run test` in `packages/util` (21 tests)
- `bun run lint`
- `bun run lint:effect-simplifications`
- Push hook: monorepo typecheck, 33 packages
- Three-pass reuse, correctness, and efficiency review
