### PR TITLE
fix(core): stabilize forked message IDs

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -196,7 +196,7 @@ const projectFork = Effect.fn("SessionProjector.projectFork")(function* (
       .insert(SessionMessageTable)
       .values(
         rows.map((row) => ({
-          id: SessionMessage.ID.create(),
+          id: SessionMessage.ID.make(`${SessionMessage.ID.fromEvent(event.id)}_${row.seq}`),
           session_id: event.data.sessionID,
           type: row.type,
           seq: row.seq,

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -401,6 +401,41 @@ describe("Session.create", () => {
     }),
   )
 
+  it.effect("replays a fork with stable projected identities", () =>
+    Effect.gen(function* () {
+      const session = yield* Session.Service
+      const bus = yield* Bus.Service
+      const { db } = yield* Database.Service
+      const parent = yield* session.create({ location, title: "Parent" })
+      yield* session.prompt({ sessionID: parent.id, text: "First", resume: false })
+      yield* SessionInbox.promote(db, bus, parent.id, "steer")
+      yield* session.synthetic({ sessionID: parent.id, text: "Second", resume: false })
+      yield* SessionInbox.promote(db, bus, parent.id, "steer")
+      const forked = yield* session.fork({ sessionID: parent.id, boundary: { type: "through" } })
+      const original = (yield* session.context(forked.id)).map((message) => message.id)
+      const recorded = yield* db
+        .select()
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, forked.id))
+        .get()
+        .pipe(Effect.orDie)
+      if (!recorded) return yield* Effect.die(new Error("Fork event not found"))
+
+      yield* bus.remove(forked.id)
+      yield* db.delete(SessionTable).where(eq(SessionTable.id, forked.id)).run().pipe(Effect.orDie)
+      yield* bus.replay({
+        id: recorded.id,
+        created: recorded.created,
+        aggregateID: recorded.aggregate_id,
+        seq: recorded.seq,
+        type: recorded.type,
+        data: recorded.data,
+      })
+
+      expect((yield* session.context(forked.id)).map((message) => message.id)).toEqual(original)
+    }),
+  )
+
   it.effect("does not copy a running assistant into a fork", () =>
     Effect.gen(function* () {
       const session = yield* Session.Service


### PR DESCRIPTION
## What

Make copied message identities deterministic when a durable `session.forked` event is replayed.

## Before / After

**Before:** `projectFork` called `SessionMessage.ID.create()` for every copied parent row. Rebuilding the child from the exact same durable fork event produced new message IDs, so references and idempotent retries against the original copied messages no longer matched the replayed projection.

**After:** each copied ID is derived from the globally unique fork event ID plus the source message sequence. The first projection and every replay produce the same unique child IDs while remaining distinct from the parent IDs.

## How

- `packages/core/src/session/projector.ts` composes the existing event-derived message ID with the stable source aggregate sequence.
- `packages/core/test/session-create.test.ts` forks a two-message transcript, removes the child event log and projection, replays the original serialized event, and verifies both copied IDs are unchanged.

## Scope

This PR stabilizes identities derived by the fork projector. It does not change fork boundaries, settled-history selection, or snapshot mutable parent metadata into the fork event.

## Testing

- Red: replay produced two different copied message IDs.
- Green: `bun run test session-create.test.ts` (35 passed)
- `bun run test session-projector.test.ts` (13 passed)
- `bun typecheck` from `packages/core`
- Repository pre-push typecheck (33 packages passed)
- `bunx prettier --check packages/core/src/session/projector.ts packages/core/test/session-create.test.ts`
- `git diff --check`
