### PR TITLE
fix(core): canonicalize macos session paths

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -366,9 +366,15 @@ const layer = Layer.effect(
         if (recorded) return recorded
         const parent = input.parentID ? yield* store.get(input.parentID) : undefined
         if (input.parentID && parent === undefined) return yield* new NotFoundError({ sessionID: input.parentID })
-        const location = parent?.location ?? input.location
-        if (location === undefined)
+        const requestedLocation = parent?.location ?? input.location
+        if (requestedLocation === undefined)
           return yield* Effect.die(new Error("Session.create requires either location or an existing parentID"))
+        const location = parent
+          ? parent.location
+          : Location.Ref.make({
+              ...requestedLocation,
+              directory: AbsolutePath.make(yield* fs.resolve(requestedLocation.directory)),
+            })
         const project = yield* projects.resolve(location.directory)
         yield* persistProject(project)
         const projected = yield* bus
@@ -474,7 +480,8 @@ const layer = Layer.effect(
         const order = direction === "previous" ? (requestedOrder === "asc" ? "desc" : "asc") : requestedOrder
         const sortColumn = SessionTable.time_updated
         const conditions: SQL[] = []
-        if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
+        if ("directory" in input)
+          conditions.push(eq(SessionTable.directory, AbsolutePath.make(yield* fs.resolve(input.directory))))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
         if ("project" in input && input.subpath !== undefined) conditions.push(eq(SessionTable.path, input.subpath))
@@ -775,7 +782,7 @@ const layer = Layer.effect(
         const value = input.directory.trim()
         const expanded =
           value === "~" ? global.home : value.startsWith("~/") ? path.join(global.home, value.slice(2)) : value
-        const directory = AbsolutePath.make(path.resolve(current.location.directory, expanded))
+        const directory = AbsolutePath.make(yield* fs.resolve(path.resolve(current.location.directory, expanded)))
         const info = yield* fs.stat(directory).pipe(Effect.orElseSucceed(() => undefined))
         if (!info) return yield* new DestinationNotFoundError({ directory })
         if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -83,6 +83,27 @@ function withTmp<A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) {
 }
 
 describe("Session.create", () => {
+  liveIt.live("uses on-disk macOS casing for creation and directory listing", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        if (process.platform !== "darwin") return
+        const session = yield* Session.Service
+        const actual = path.join(directory, "Academic", "Project")
+        yield* Effect.promise(() => fs.mkdir(actual, { recursive: true }))
+        const requested = path.join(directory, "academic", "project")
+        if (!(yield* Effect.promise(() => fs.access(requested).then(() => true, () => false)))) return
+
+        const created = yield* session.create({
+          location: Location.Ref.make({ directory: AbsolutePath.make(requested) }),
+        })
+
+        expect(created.location.directory).toBe(AbsolutePath.make(actual))
+        expect((yield* session.list({ directory: AbsolutePath.make(requested) })).data).toEqual([created])
+        expect((yield* session.list({ directory: AbsolutePath.make(actual) })).data).toEqual([created])
+      }),
+    ),
+  )
+
   liveIt.live("follows the directory's project identity established after creation", () =>
     withTmp((directory) =>
       Effect.gen(function* () {

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -103,6 +103,7 @@ export namespace FSUtil {
       const resolve = Effect.fn("FileSystem.resolve")(function* (input: string) {
         const resolved = path.resolve(windowsPath(input))
         return yield* fs.realPath(resolved).pipe(
+          Effect.map((real) => (process.platform === "darwin" ? realpathSync.native(resolved) : real)),
           Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(resolved)),
           Effect.orDie,
         )


### PR DESCRIPTION
### Issue for this PR

Closes #44014

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Resolves existing macOS paths to their on-disk component casing, then uses that path for session creation, directory filters, and moves. Other platforms and missing paths keep their current behavior.

### How did you verify your code works?

- `bun test test/session-create.test.ts` in `packages/core` (35 pass)
- `bun typecheck` in `packages/core` and `packages/util`
- repository pre-commit typecheck (33 tasks)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR