### PR TITLE
fix(core): migrate provider-local state

### DIFF
--- a/packages/core/src/database/v1-migration.bun.ts
+++ b/packages/core/src/database/v1-migration.bun.ts
@@ -384,19 +384,23 @@ export function transformSession(input: TransformInput): TransformResult {
       )
         return []
       const content = owned.flatMap((part): Array<Record<string, unknown>> => {
-        if (part.type === "text")
-          return [{ type: "text", text: part.text, ...(part.metadata ? { state: part.metadata } : {}) }]
-        if (part.type === "reasoning")
+        if (part.type === "text") {
+          const state = migrateProviderState(assistant.providerID, part.metadata)
+          return [{ type: "text", text: part.text, ...(state ? { state } : {}) }]
+        }
+        if (part.type === "reasoning") {
+          const state = migrateProviderState(assistant.providerID, part.metadata)
           return [
             {
               type: "reasoning",
               text: part.text,
-              ...(part.metadata ? { state: part.metadata } : {}),
+              ...(state ? { state } : {}),
               time: { created: part.time.start, ...(part.time.end === undefined ? {} : { completed: part.time.end }) },
             },
           ]
+        }
         if (part.type !== "tool") return []
-        return [migrateTool(part, item.row.time_created)]
+        return [migrateTool(part, item.row.time_created, assistant.providerID)]
       })
       const start =
         owned.flatMap((part) => (part.type === "step-start" && part.snapshot ? [part.snapshot] : []))[0] ??
@@ -888,12 +892,20 @@ function row(
   }
 }
 
-function migrateTool(part: typeof SessionV1.ToolPart.Type, fallback: number) {
+function migrateProviderState(providerID: string, metadata: Record<string, unknown> | undefined) {
+  if (!metadata) return undefined
+  const state = metadata[providerID]
+  if (typeof state === "object" && state !== null && !Array.isArray(state)) return state
+  return metadata
+}
+
+function migrateTool(part: typeof SessionV1.ToolPart.Type, fallback: number, providerID: string) {
+  const providerState = migrateProviderState(providerID, part.metadata)
   const base = {
     type: "tool" as const,
     id: part.callID,
     name: part.tool,
-    ...(part.metadata ? { providerState: part.metadata } : {}),
+    ...(providerState ? { providerState } : {}),
   }
   if (part.state.status === "completed")
     return {

--- a/packages/core/test/v1-migration.test.ts
+++ b/packages/core/test/v1-migration.test.ts
@@ -308,7 +308,7 @@ describe("V1Migration.transformSession", () => {
         part("prt_2", message.id, {
           type: "reasoning",
           text: "think",
-          metadata: { provider: 1 },
+          metadata: { provider: { signature: "sig" } },
           time: { start: 21, end: 22 },
         }),
         part("prt_3", message.id, { type: "step-start", snapshot: "snap_start" }),
@@ -335,7 +335,7 @@ describe("V1Migration.transformSession", () => {
       model: { id: "model", providerID: "provider", variant: "fast" },
       content: [
         { type: "text", text: "", state: { separator: true } },
-        { type: "reasoning", text: "think", state: { provider: 1 }, time: { created: 21, completed: 22 } },
+        { type: "reasoning", text: "think", state: { signature: "sig" }, time: { created: 21, completed: 22 } },
       ],
       snapshot: { start: "snap_start", end: "snap_end", files: ["a.ts", "b.ts", "c.ts"] },
       finish: "stop",
@@ -383,7 +383,7 @@ describe("V1Migration.transformSession", () => {
               },
             ],
           },
-          { provider: true },
+          { provider: { tool: "state" } },
         ),
         tool("prt_4", "compacted", {
           status: "completed",
@@ -427,7 +427,7 @@ describe("V1Migration.transformSession", () => {
     })
     expect(content[2]).toMatchObject({
       id: "completed",
-      providerState: { provider: true },
+      providerState: { tool: "state" },
       state: {
         status: "completed",
         content: [


### PR DESCRIPTION
### Issue for this PR

Closes #44019

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extracts the current assistant provider's metadata object when migrating text, reasoning, and tool parts. Metadata that is already provider-local is preserved unchanged.

### How did you verify your code works?

- `bun test test/v1-migration.test.ts` in `packages/core` (24 pass)
- `bun typecheck` in `packages/core`
- repository pre-commit typecheck (33 tasks)

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR