### PR TITLE
fix(core): resolve device verification URL

### DIFF
--- a/.changeset/device-authorization-url.md
+++ b/.changeset/device-authorization-url.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Fix OpenCode Console device authorization URLs when the server returns an origin-rooted verification path.

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -46,10 +46,15 @@ function oauth(http: HttpClient.HttpClient) {
       Effect.gen(function* () {
         const server = yield* normalizeServer(answer.server ?? defaultServer)
         const device = yield* post(http, `${server}/auth/device/code`, { client_id: clientID }, Device)
-        const verification = new URL(device.verification_uri_complete, `${server}/`)
-        if (verification.protocol !== "http:" && verification.protocol !== "https:") {
-          return yield* Effect.fail(new Error("Invalid device verification URL: expected HTTP(S)"))
-        }
+        const verification = yield* Effect.try({
+          try: () => {
+            const url = new URL(device.verification_uri_complete, `${server}/`)
+            if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("expected HTTP(S)")
+            return url
+          },
+          catch: (cause) =>
+            new Error(`Invalid device verification URL: ${cause instanceof Error ? cause.message : String(cause)}`),
+        })
         return {
           mode: "auto" as const,
           url: verification.href,

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -46,15 +46,13 @@ function oauth(http: HttpClient.HttpClient) {
       Effect.gen(function* () {
         const server = yield* normalizeServer(answer.server ?? defaultServer)
         const device = yield* post(http, `${server}/auth/device/code`, { client_id: clientID }, Device)
-        const verification = URL.canParse(device.verification_uri_complete)
-          ? new URL(device.verification_uri_complete)
-          : undefined
-        if (verification && verification.protocol !== "http:" && verification.protocol !== "https:") {
+        const verification = new URL(device.verification_uri_complete, `${server}/`)
+        if (verification.protocol !== "http:" && verification.protocol !== "https:") {
           return yield* Effect.fail(new Error("Invalid device verification URL: expected HTTP(S)"))
         }
         return {
           mode: "auto" as const,
-          url: verification?.href ?? `${server}/${device.verification_uri_complete.replace(/^\/+/, "")}`,
+          url: verification.href,
           instructions: `Enter code: ${device.user_code}`,
           callback: poll(http, server, device.device_code, Duration.seconds(device.interval)),
         }

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -148,6 +148,38 @@ describe("OpencodePlugin", () => {
     ),
   )
 
+  it.live("rejects malformed device verification URLs", () =>
+    Effect.acquireUseRelease(
+      Effect.sync(() =>
+        Bun.serve({
+          port: 0,
+          fetch: () =>
+            Response.json({
+              device_code: "device",
+              user_code: "user",
+              verification_uri_complete: "http://[::1",
+              expires_in: 60,
+              interval: 0,
+            }),
+        }),
+      ),
+      (server) =>
+        Effect.gen(function* () {
+          yield* addPlugin()
+          const error = yield* (yield* Integration.Service).oauth
+            .connect({
+              integrationID: Integration.ID.make("opencode"),
+              methodID: Integration.MethodID.make("device"),
+              answer: { server: server.url.origin },
+            })
+            .pipe(Effect.flip)
+          expect(error).toBeInstanceOf(Integration.AuthorizationError)
+          expect(String(error.cause)).toContain("Invalid device verification URL")
+        }),
+      (server) => Effect.promise(() => server.stop(true)),
+    ),
+  )
+
   it.effect("rejects non-HTTP OpenCode servers", () =>
     Effect.gen(function* () {
       yield* addPlugin()

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -105,7 +105,7 @@ describe("OpencodePlugin", () => {
               return Response.json({
                 device_code: "device",
                 user_code: "user",
-                verification_uri_complete: `${url.origin}/verify`,
+                verification_uri_complete: "/console/device?user_code=user&client_id=opencode-cli",
                 expires_in: 60,
                 interval: 0,
               })
@@ -130,7 +130,7 @@ describe("OpencodePlugin", () => {
             methodID: Integration.MethodID.make("device"),
             answer: { server: `${server.url.origin}/console///?ignored=true#ignored` },
           })
-          expect(attempt.url).toBe(`${server.url.origin}/verify`)
+          expect(attempt.url).toBe(`${server.url.origin}/console/device?user_code=user&client_id=opencode-cli`)
           yield* eventually(
             integrations.oauth.status({ integrationID, attemptID: attempt.attemptID }),
             (status) => status.status === "complete",


### PR DESCRIPTION
## What

Fix OpenCode Console device authorization links when the Console API returns an origin-rooted verification path.

## Before / After

**Before:** The Console API returns `/console/device?...`. Since the default server is `https://opencode.ai/console`, the client stripped the leading slash and appended the response to that full base, producing `https://opencode.ai/console/console/device?...`. The Console did not recognize that route and redirected a signed-in user to their organization page instead of device approval.

**After:** Verification URLs use standard URL resolution. Origin-rooted paths resolve against the server origin, relative paths resolve beneath the configured server base, and absolute HTTP(S) URLs remain unchanged. Malformed or non-HTTP(S) verification URLs fail as typed authorization errors instead of defects.

## How

- `packages/core/src/plugin/provider/opencode.ts` resolves `verification_uri_complete` with `new URL(value, base)` inside `Effect.try` and retains the HTTP(S) protocol check.
- `packages/core/test/plugin/provider-opencode.test.ts` reproduces the production response shape, asserts that `/console` appears exactly once, and covers malformed verification responses.
- Adds a patch changeset for `@opencode-ai/core`.

## Scope

This does not change the Console API response or router. It only corrects client-side handling of the existing response contract.

## Testing

- `bun run test test/plugin/provider-opencode.test.ts` from `packages/core`: 13 passed
- `bun typecheck` from `packages/core`
- Push hook: repository-wide Turbo typecheck, 33 tasks passed
- Production contract checked with `POST https://opencode.ai/console/auth/device/code`, which returned an origin-rooted `/console/device?...` verification URL

## Flow

```mermaid
sequenceDiagram
  participant CLI
  participant Core
  participant ConsoleAPI as Console API
  participant Browser
  CLI->>Core: Start device authorization
  Core->>ConsoleAPI: POST /console/auth/device/code
  ConsoleAPI-->>Core: verification_uri_complete=/console/device?...
  Core-->>CLI: https://opencode.ai/console/device?...
  CLI->>Browser: Open device approval route
```

## Root Cause

Commit `40cd6989d2` changed the default server from `https://console.opencode.ai` to `https://opencode.ai/console` without updating the fallback path join or covering the production response shape in a test.
