### PR TITLE
fix(app): tolerate incomplete agent configuration

### DIFF
--- a/packages/app/src/runtime/server/global-sync/utils.test.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.test.ts
@@ -36,6 +36,52 @@ describe("normalizeAgentList", () => {
       },
     ])
   })
+
+  test("tolerates agents whose request omits settings", () => {
+    const result = normalizeAgentList([
+      {
+        id: "build",
+        name: "Build",
+        mode: "primary",
+        hidden: false,
+        request: { headers: {}, body: {} },
+        permissions: [{ action: "read", resource: "*", effect: "allow" }],
+      },
+    ] as unknown as AgentListOutput["data"])
+
+    expect(result).toMatchObject([
+      {
+        name: "build",
+        temperature: undefined,
+        topP: undefined,
+        options: {},
+      },
+    ])
+  })
+
+  test("tolerates agents missing request and permissions in a mixed list", () => {
+    const result = normalizeAgentList([
+      {
+        id: "build",
+        name: "Build",
+        mode: "primary",
+        hidden: false,
+        request: { settings: { temperature: 0.2 }, headers: {}, body: {} },
+        permissions: [],
+      },
+      {
+        id: "plan",
+        name: "Plan",
+        mode: "primary",
+        hidden: false,
+      },
+    ] as unknown as AgentListOutput["data"])
+
+    expect(result).toMatchObject([
+      { name: "build", temperature: 0.2 },
+      { name: "plan", temperature: undefined, permission: [], options: {} },
+    ])
+  })
 })
 
 describe("normalizeProviderList", () => {

--- a/packages/app/src/runtime/server/global-sync/utils.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.ts
@@ -7,9 +7,6 @@ export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
 export function normalizeAgentList(input: AgentListOutput["data"] | Agent[]): Agent[] {
   if (input.every((agent) => !("request" in agent))) return input as Agent[]
-  // Responses are not validated at the client layer, so an older or third-party
-  // server may send agents whose request lacks settings; runs inside reactive
-  // computations during bootstrap, where a throw takes down the whole app.
   return (input as AgentListOutput["data"]).map((agent) => {
     const settings = agent.request?.settings ?? {}
     return {

--- a/packages/app/src/runtime/server/global-sync/utils.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.ts
@@ -7,26 +7,31 @@ export const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 
 export function normalizeAgentList(input: AgentListOutput["data"] | Agent[]): Agent[] {
   if (input.every((agent) => !("request" in agent))) return input as Agent[]
-  return (input as AgentListOutput["data"]).map((agent) => ({
-    name: agent.id,
-    description: agent.description,
-    mode: agent.mode,
-    hidden: agent.hidden,
-    temperature:
-      typeof agent.request.settings.temperature === "number" ? agent.request.settings.temperature : undefined,
-    topP: typeof agent.request.settings.topP === "number" ? agent.request.settings.topP : undefined,
-    color: agent.color,
-    permission: agent.permissions.map((rule) => ({
-      permission: rule.action,
-      pattern: rule.resource,
-      action: rule.effect,
-    })),
-    model: agent.model && { providerID: agent.model.providerID, modelID: agent.model.id },
-    variant: agent.model?.variant,
-    prompt: agent.system,
-    options: agent.request.settings,
-    steps: agent.steps,
-  }))
+  // Responses are not validated at the client layer, so an older or third-party
+  // server may send agents whose request lacks settings; runs inside reactive
+  // computations during bootstrap, where a throw takes down the whole app.
+  return (input as AgentListOutput["data"]).map((agent) => {
+    const settings = agent.request?.settings ?? {}
+    return {
+      name: agent.id,
+      description: agent.description,
+      mode: agent.mode,
+      hidden: agent.hidden,
+      temperature: typeof settings.temperature === "number" ? settings.temperature : undefined,
+      topP: typeof settings.topP === "number" ? settings.topP : undefined,
+      color: agent.color,
+      permission: (agent.permissions ?? []).map((rule) => ({
+        permission: rule.action,
+        pattern: rule.resource,
+        action: rule.effect,
+      })),
+      model: agent.model && { providerID: agent.model.providerID, modelID: agent.model.id },
+      variant: agent.model?.variant,
+      prompt: agent.system,
+      options: settings,
+      steps: agent.steps,
+    }
+  })
 }
 
 export function normalizeProviderList(


### PR DESCRIPTION
### Issue for this PR

Fixes #44023

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a whole-app crash on desktop when a connected server runs an older opencode version.

`normalizeAgentList` reads `agent.request.settings.temperature` unguarded. Servers built before 140224b0fc (2026-07-02) serialize agents as `request: { headers, body }` without `settings`, the client stores API responses without validation, and the normalizer runs inside a reactive computation during bootstrap — so the TypeError escapes to the root error boundary and the app never loads. Restarting refetches the same response and crashes again.

The fix defaults the missing fields (`agent.request?.settings ?? {}`, `agent.permissions ?? []`) so a malformed agent degrades to default temperature/topP instead of killing the app. Output is unchanged for well-formed agents.

### How did you verify your code works?

- Added unit tests feeding the exact old-server shape into `normalizeAgentList` — they throw the reported TypeError before the fix and pass after (`bun test src/runtime/server/global-sync/utils.test.ts`).
- Reproduced end-to-end: ran `opencode-ai@0.0.0-beta-202607011659 serve`, confirmed its `/api/agent` returns `request` without `settings`, and that the desktop app loads fine against it with this fix.
- `bun run typecheck` in packages/app passes.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR