### PR TITLE
fix(app): load workspace sessions by directory

### DIFF
--- a/packages/app/src/settings/workspaces/workspaces.tsx
+++ b/packages/app/src/settings/workspaces/workspaces.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js"
-import { For, Show, createMemo } from "solid-js"
+import { For, Show, batch, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { SessionInfo } from "@opencode-ai/client/promise"
 import { useQuery } from "@tanstack/solid-query"
@@ -93,14 +93,27 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       activeDirectory: props.activeDirectory,
     }
   }
-  const loadSessions = async (context = captureDeleteContext()) => {
-    const fetched = await listAllSessions(context.sdk.api.session, { order: "desc" })
-    fetched.forEach(context.data.session.remember)
-    return mergeWorkspaceSessionInventory(fetched, context.data.session.list())
+  // Fetch sessions per workspace directory instead of paging through every
+  // session on the server; batch the store writes so thousands of remember
+  // calls don't each re-run the store's sorted-session memo and block the UI.
+  const loadSessions = async (directories: readonly string[], context = captureDeleteContext()) => {
+    const fetched = await Promise.all(
+      directories.map((directory) => listAllSessions(context.sdk.api.session, { order: "desc", directory })),
+    )
+    const sessions = fetched.flat()
+    batch(() => sessions.forEach(context.data.session.remember))
+    return mergeWorkspaceSessionInventory(sessions, context.data.session.list())
   }
+  const workspaceDirectories = createMemo(() => workspaces().map((workspace) => workspace.directory))
   const sessionQuery = useQuery(() => ({
-    queryKey: [serverSDK.scope, null, "settings-workspace-sessions"] as const,
-    queryFn: () => loadSessions().then(() => Date.now()),
+    queryKey: [
+      serverSDK.scope,
+      null,
+      "settings-workspace-sessions",
+      workspaceDirectories().map((directory) => String(pathKey(directory))),
+    ] as const,
+    queryFn: () => loadSessions(workspaceDirectories()).then(() => Date.now()),
+    enabled: workspaceDirectories().length > 0,
     refetchOnMount: "always",
   }))
   const sessionsByWorkspace = createMemo(
@@ -136,7 +149,7 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
     const [working, branch, sessions] = await Promise.all([
       context.sdk.api.vcs.status({ location: { directory: workspace.directory } }),
       context.sdk.api.vcs.diff({ location: { directory: workspace.directory }, mode: "branch" }),
-      loadSessions(context),
+      loadSessions([workspace.directory], context),
     ])
     const result = inspectWorkspaceDeletion({
       workspace: workspace.directory,

--- a/packages/app/src/settings/workspaces/workspaces.tsx
+++ b/packages/app/src/settings/workspaces/workspaces.tsx
@@ -1,5 +1,5 @@
 import type { Component } from "solid-js"
-import { For, Show, batch, createMemo } from "solid-js"
+import { For, Show, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { SessionInfo } from "@opencode-ai/client/promise"
 import { useQuery } from "@tanstack/solid-query"
@@ -93,15 +93,12 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       activeDirectory: props.activeDirectory,
     }
   }
-  // Fetch sessions per workspace directory instead of paging through every
-  // session on the server; batch the store writes so thousands of remember
-  // calls don't each re-run the store's sorted-session memo and block the UI.
+  // Fetch sessions per workspace directory instead of paging through every session on the server.
   const loadSessions = async (directories: readonly string[], context = captureDeleteContext()) => {
     const fetched = await Promise.all(
       directories.map((directory) => listAllSessions(context.sdk.api.session, { order: "desc", directory })),
     )
     const sessions = fetched.flat()
-    batch(() => sessions.forEach(context.data.session.remember))
     return mergeWorkspaceSessionInventory(sessions, context.data.session.list())
   }
   const workspaceDirectories = createMemo(() => workspaces().map((workspace) => workspace.directory))
@@ -112,7 +109,7 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       "settings-workspace-sessions",
       workspaceDirectories().map((directory) => String(pathKey(directory))),
     ] as const,
-    queryFn: () => loadSessions(workspaceDirectories()).then(() => Date.now()),
+    queryFn: () => loadSessions(workspaceDirectories()),
     enabled: workspaceDirectories().length > 0,
     refetchOnMount: "always",
   }))
@@ -121,7 +118,7 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       new Map(
         workspaces().map((workspace) => [
           pathKey(workspace.directory),
-          sessionQuery.isSuccess ? sessionsForWorkspace(data.session.list(), workspace.directory) : [],
+          sessionQuery.data ? sessionsForWorkspace(sessionQuery.data, workspace.directory) : [],
         ]),
       ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #44022

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops Settings → Workspaces from freezing the app.

Before: the page fetched every session on the server (serial 100-per-page pagination, no filter) and wrote each one into the store with an unbatched `session.remember`, so every write re-ran the sorted-sessions memo — O(N² log N) main-thread work that locked the whole UI.

Now: sessions are fetched per workspace directory (the session.list API already supports a `directory` filter), requests run in parallel, and the store writes are wrapped in Solid's `batch()` so memos/subscribers update once per fetch. The delete preflight fetches only the target workspace's sessions. Displayed counts still come from the same `sessionsForWorkspace` prefix match over the store, so rendering behavior is unchanged.

### How did you verify your code works?

- Tested against a copy of my real production database (12 GB, ~1,600 sessions). Without the fix, opening Settings → Workspaces pages through all ~1,600 sessions in serial requests and freezes the whole app for several seconds. With the fix, the page opens instantly and counts/last-active times match the unfixed version.
- `bun test src/session/list.test.ts` and `bun run typecheck` in packages/app pass.

### Screenshots / recordings

**BEFORE**

https://github.com/user-attachments/assets/c45fc450-c2b1-47c2-8c61-030bc923bf64

**AFTER**

https://github.com/user-attachments/assets/a95b40df-7eeb-483f-880b-a712816390bf

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
