### PR TITLE
fix: resolve console device URLs

### DIFF
--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -45,9 +45,18 @@ function oauth(http: HttpClient.HttpClient) {
     authorize: () =>
       Effect.gen(function* () {
         const device = yield* post(http, `${defaultServer}/auth/device/code`, { client_id: clientID }, Device)
+        const verification = yield* Effect.try({
+          try: () => {
+            const url = new URL(device.verification_uri_complete, `${defaultServer}/`)
+            if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("expected HTTP(S)")
+            return url
+          },
+          catch: (cause) =>
+            new Error(`Invalid device verification URL: ${cause instanceof Error ? cause.message : String(cause)}`),
+        })
         return {
           mode: "auto" as const,
-          url: `${defaultServer}${device.verification_uri_complete}`,
+          url: verification.href,
           instructions: `Enter code: ${device.user_code}`,
           callback: poll(http, defaultServer, device.device_code, Duration.seconds(device.interval)),
         }

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -14,14 +15,16 @@ import { PluginTestLayer } from "./fixture"
 
 const it = testEffect(PluginTestLayer)
 
-const addPlugin = Effect.fn(function* () {
+const addPlugin = Effect.fn(function* (http?: HttpClient.HttpClient) {
   const plugin = yield* PluginV2.Service
   const host = yield* PluginHost.make(plugin)
   const events = yield* EventV2.Service
   const integration = yield* Integration.Service
+  const client = yield* HttpClient.HttpClient
   yield* OpencodePlugin.effect(host).pipe(
     Effect.provideService(EventV2.Service, events),
     Effect.provideService(Integration.Service, integration),
+    Effect.provideService(HttpClient.HttpClient, http ?? client),
   )
 })
 
@@ -79,6 +82,63 @@ describe("OpencodePlugin", () => {
         },
         { type: "key", label: "API key (service account)" },
       ])
+    }),
+  )
+
+  it.effect("resolves origin-rooted device verification URLs", () =>
+    Effect.gen(function* () {
+      const http = HttpClient.make((request) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              device_code: "device",
+              user_code: "user",
+              verification_uri_complete: "/console/device?user_code=user&client_id=opencode-cli",
+              expires_in: 60,
+              interval: 60,
+            }),
+          ),
+        ),
+      )
+      yield* addPlugin(http)
+      const integration = yield* Integration.Service
+      const attempt = yield* integration.connection.oauth({
+        integrationID: Integration.ID.make("opencode"),
+        methodID: Integration.MethodID.make("device"),
+        inputs: {},
+      })
+      expect(attempt.url).toBe("https://opencode.ai/console/device?user_code=user&client_id=opencode-cli")
+    }),
+  )
+
+  it.effect("rejects malformed device verification URLs", () =>
+    Effect.gen(function* () {
+      const http = HttpClient.make((request) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              device_code: "device",
+              user_code: "user",
+              verification_uri_complete: "http://[::1",
+              expires_in: 60,
+              interval: 60,
+            }),
+          ),
+        ),
+      )
+      yield* addPlugin(http)
+      const integration = yield* Integration.Service
+      const error = yield* integration.connection
+        .oauth({
+          integrationID: Integration.ID.make("opencode"),
+          methodID: Integration.MethodID.make("device"),
+          inputs: {},
+        })
+        .pipe(Effect.flip)
+      expect(error).toBeInstanceOf(Integration.AuthorizationError)
+      expect(String(error.cause)).toContain("Invalid device verification URL")
     }),
   )
 

--- a/packages/opencode/src/account/account.ts
+++ b/packages/opencode/src/account/account.ts
@@ -396,10 +396,18 @@ const layer: Layer.Layer<Service, never, AccountRepo.Service | HttpClient.HttpCl
       const parsed = yield* HttpClientResponse.schemaBodyJson(DeviceAuth)(response).pipe(
         mapAccountServiceError("Failed to decode response"),
       )
+      const verification = yield* Effect.try({
+        try: () => {
+          const url = new URL(parsed.verification_uri_complete, `${normalizedServer}/`)
+          if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("expected HTTP(S)")
+          return url.href
+        },
+        catch: (cause) => new AccountServiceError({ message: "Invalid device verification URL", cause }),
+      })
       return new Login({
         code: parsed.device_code,
         user: parsed.user_code,
-        url: `${normalizedServer}${parsed.verification_uri_complete}`,
+        url: verification,
         server: normalizedServer,
         expiry: parsed.expires_in,
         interval: parsed.interval,

--- a/packages/opencode/test/account/service.test.ts
+++ b/packages/opencode/test/account/service.test.ts
@@ -10,6 +10,7 @@ import { Account } from "../../src/account/account"
 import {
   AccessToken,
   AccountID,
+  AccountServiceError,
   AccountTransportError,
   DeviceCode,
   Login,
@@ -71,18 +72,18 @@ const deviceTokenClient = (body: unknown, status = 400) =>
 const poll = (body: unknown, status = 400) =>
   Account.Service.use((s) => s.poll(login())).pipe(Effect.provide(live(deviceTokenClient(body, status))))
 
-it.live("login normalizes trailing slashes in the provided server URL", () =>
+it.live("login resolves origin-rooted verification URLs from servers with base paths", () =>
   Effect.gen(function* () {
     const seen: Array<string> = []
     const client = HttpClient.make((req) =>
       Effect.gen(function* () {
         seen.push(`${req.method} ${req.url}`)
 
-        if (req.url === "https://one.example.com/auth/device/code") {
+        if (req.url === "https://one.example.com/console/auth/device/code") {
           return json(req, {
             device_code: "device-code",
             user_code: "user-code",
-            verification_uri_complete: "/device?user_code=user-code",
+            verification_uri_complete: "/console/device?user_code=user-code",
             expires_in: 600,
             interval: 5,
           })
@@ -92,11 +93,31 @@ it.live("login normalizes trailing slashes in the provided server URL", () =>
       }),
     )
 
-    const result = yield* Account.use.login("https://one.example.com/").pipe(Effect.provide(live(client)))
+    const result = yield* Account.use.login("https://one.example.com/console/").pipe(Effect.provide(live(client)))
 
-    expect(seen).toEqual(["POST https://one.example.com/auth/device/code"])
-    expect(result.server).toBe("https://one.example.com")
-    expect(result.url).toBe("https://one.example.com/device?user_code=user-code")
+    expect(seen).toEqual(["POST https://one.example.com/console/auth/device/code"])
+    expect(result.server).toBe("https://one.example.com/console")
+    expect(result.url).toBe("https://one.example.com/console/device?user_code=user-code")
+  }),
+)
+
+it.live("login rejects malformed device verification URLs", () =>
+  Effect.gen(function* () {
+    const client = HttpClient.make((req) =>
+      Effect.succeed(
+        json(req, {
+          device_code: "device-code",
+          user_code: "user-code",
+          verification_uri_complete: "http://[::1",
+          expires_in: 600,
+          interval: 5,
+        }),
+      ),
+    )
+
+    const error = yield* Effect.flip(Account.use.login("https://one.example.com").pipe(Effect.provide(live(client))))
+    expect(error).toBeInstanceOf(AccountServiceError)
+    if (error instanceof AccountServiceError) expect(error.message).toBe("Invalid device verification URL")
   }),
 )
 


### PR DESCRIPTION
## What

Port the Console device authorization URL fix to both implementations currently present on `dev`.

## Before / After

**Before:** The Console API returns an origin-rooted `/console/device?...` verification path. Both dev implementations appended that value to the path-bearing `https://opencode.ai/console` server string, producing `/console/console/device` and routing signed-in users to their organization instead of device approval.

**After:** Both implementations use standard URL resolution. Origin-rooted paths resolve from the origin, path-relative values resolve beneath the configured server base, absolute HTTP(S) URLs remain unchanged, and malformed or non-HTTP(S) values enter each implementation's existing typed error channel.

## How

- `packages/opencode/src/account/account.ts` resolves the verification URL inside `Account.login` and maps invalid values to `AccountServiceError`.
- `packages/core/src/plugin/provider/opencode.ts` resolves the verification URL inside the existing V2 OAuth method and maps invalid values through `Integration.AuthorizationError`.
- Adds production-shaped and malformed-response regressions to each implementation's existing test suite.

## Scope

This does not change account APIs, integration APIs, endpoints, credentials, token polling, or the Console response. It only replaces string concatenation at the two verification URL boundaries on `dev`.

## Testing

- `bun run test test/account/service.test.ts` from `packages/opencode`: 15 passed
- `bun run test test/plugin/provider-opencode.test.ts` from `packages/core`: 12 passed
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/core`
- Push hook: repository-wide Turbo typecheck, 30 tasks passed
- `git diff --check`

## Flow

```mermaid
sequenceDiagram
  participant Client as Account/Core client
  participant Console as Console API
  participant Browser
  Client->>Console: POST /console/auth/device/code
  Console-->>Client: verification_uri_complete=/console/device?...
  Client-->>Client: Resolve against server URL
  Client->>Browser: Open https://opencode.ai/console/device?...
```

Ports the fix from #44021 to `dev`.
