### PR TITLE
fix(opencode): stop looping after unknown finish with text

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -99,6 +99,10 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   return part.state.status === "error" && part.state.metadata?.interrupted === true
 }
 
+function hasAssistantText(parts: SessionV1.Part[] | undefined) {
+  return parts?.some((part) => part.type === "text" && part.text.trim().length > 0) ?? false
+}
+
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
   readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
@@ -1103,17 +1107,22 @@ const layer = Layer.effect(
           // Some providers return "stop" even when the assistant message contains
           // tool calls. Keep the loop running so tool results can be sent back to
           // the model, but ignore cleanup-marked interrupted orphans.
+          //
+          // `unknown` means the stream ended without a recognized stop reason.
+          // Empty unknown turns are still open so a later call can recover
+          // (#43892). Unknown turns that already produced assistant text are
+          // complete; continuing them requests redundant generations forever
+          // (#43939). Reasoning-only unknown stays open so a text turn can still
+          // arrive.
           const hasToolCalls =
             lastAssistantMsg?.parts.some(
               (part) => part.type === "tool" && !part.metadata?.providerExecuted && !isOrphanedInterruptedTool(part),
             ) ?? false
+          const unfinished =
+            lastAssistant?.finish === "tool-calls" ||
+            (lastAssistant?.finish === "unknown" && !hasAssistantText(lastAssistantMsg?.parts))
 
-          if (
-            lastAssistant?.finish &&
-            !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-            !hasToolCalls &&
-            lastAssistant.parentID === lastUser.id
-          ) {
+          if (lastAssistant?.finish && !unfinished && !hasToolCalls && lastAssistant.parentID === lastUser.id) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
             )

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -248,6 +248,22 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // Regression for #43939: a complete text turn that the provider labels
+  // `unknown` must not start another generation. Empty unknown still continues
+  // (covered above); this is the output-bearing case.
+  cliIt.concurrent(
+    "unknown finish with complete text does not continue",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.push(reply().text("complete answer"))
+        yield* llm.text("redundant")
+        const result = yield* opencode.run("return one object", { timeoutMs: 30_000 })
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBe("complete answer\n")
+      }),
+    60_000,
+  )
+
   cliIt.concurrent(
     "rejects requested permissions by default and allows them with the dangerous flag",
     ({ home, llm, opencode }) =>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -878,6 +878,61 @@ it.instance("loop continues when finish is unknown", () =>
   }),
 )
 
+it.instance("loop settles unknown finish that already produced text", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.push(reply().text("complete answer"))
+    yield* llm.text("should not run")
+
+    const result = yield* prompt.loop({ sessionID: session.id })
+    expect(yield* llm.pending).toBe(1)
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") {
+      expect(result.info.finish).toBe("unknown")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "complete answer")).toBe(true)
+    }
+  }),
+)
+
+it.instance("loop continues unknown finish that only produced reasoning", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.push(reply().reason("thoughts"))
+    yield* llm.text("final")
+
+    const result = yield* prompt.loop({ sessionID: session.id })
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") {
+      expect(result.info.finish).toBe("stop")
+      expect(result.parts.some((part) => part.type === "text" && part.text === "final")).toBe(true)
+    }
+  }),
+)
+
 it.instance("glob tool keeps instance context during prompt runs", () =>
   Effect.gen(function* () {
     const { dir, llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #43939

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#43892 keeps the prompt loop running on every `unknown` finish so an empty dropped stream can recover. Providers also label complete text turns as `unknown`. Those turns then start another generation, and if the next one is `unknown` too the loop never ends.

This treats `unknown` as done when the assistant already produced text and has no pending tool calls. Empty `unknown` still continues. Reasoning-only `unknown` still continues so a later text turn can arrive.

### How did you verify your code works?

- `bun test ./test/session/prompt.test.ts -t unknown` (empty unknown still recovers; text unknown settles; reasoning-only continues)
- `bun test ./test/cli/run/run-process.test.ts -t unknown` including the existing continuation tests and a new `opencode run` case that must not consume a follow-up reply
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR