### PR TITLE
fix(desktop): align webfetch link styling with figma

### DIFF
--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -145,6 +145,57 @@
         color: var(--text-interactive-base);
       }
     }
+
+    &.webfetch-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      color: var(--v2-text-text-accent, var(--text-interactive-base));
+      text-decoration: none;
+
+      [data-slot="webfetch-link-text"] {
+        text-decoration: none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .webfetch-link-icon {
+        display: none;
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
+        color: var(--v2-icon-icon-accent, var(--v2-text-text-accent, var(--text-interactive-base)));
+      }
+
+      &:hover {
+        color: var(--v2-text-text-accent, var(--text-interactive-base));
+        text-decoration: none;
+
+        [data-slot="webfetch-link-text"] {
+          text-decoration: underline;
+          text-underline-offset: 2px;
+        }
+
+        .webfetch-link-icon {
+          display: inline-flex;
+        }
+      }
+
+      &:focus-visible {
+        outline: 1px solid var(--v2-text-text-accent, var(--text-interactive-base));
+        outline-offset: 2px;
+
+        [data-slot="webfetch-link-text"] {
+          text-decoration: underline;
+          text-underline-offset: 2px;
+        }
+
+        .webfetch-link-icon {
+          display: inline-flex;
+        }
+      }
+    }
   }
 
   [data-slot="basic-tool-tool-arg"] {

--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -150,8 +150,13 @@
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      color: var(--v2-text-text-accent, var(--text-interactive-base));
+      color: var(--v2-text-text-accent);
       text-decoration: none;
+
+      &:visited,
+      &:active {
+        color: var(--v2-text-text-accent);
+      }
 
       [data-slot="webfetch-link-text"] {
         text-decoration: none;
@@ -165,11 +170,11 @@
         width: 16px;
         height: 16px;
         flex-shrink: 0;
-        color: var(--v2-icon-icon-accent, var(--v2-text-text-accent, var(--text-interactive-base)));
+        color: var(--v2-icon-icon-accent, var(--v2-text-text-accent));
       }
 
       &:hover {
-        color: var(--v2-text-text-accent, var(--text-interactive-base));
+        color: var(--v2-text-text-accent);
         text-decoration: none;
 
         [data-slot="webfetch-link-text"] {
@@ -183,7 +188,7 @@
       }
 
       &:focus-visible {
-        outline: 1px solid var(--v2-text-text-accent, var(--text-interactive-base));
+        outline: 1px solid var(--v2-text-text-accent);
         outline-offset: 2px;
 
         [data-slot="webfetch-link-text"] {

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -898,21 +898,17 @@ ToolRegistry.register({
               <Show when={!pending() && url()}>
                 <a
                   data-slot="basic-tool-tool-subtitle"
-                  class="clickable subagent-link"
+                  class="clickable subagent-link webfetch-link"
                   href={url()}
                   target="_blank"
                   rel="noopener noreferrer"
                   onClick={(event) => event.stopPropagation()}
                 >
-                  {url()}
+                  <span data-slot="webfetch-link-text">{url()}</span>
+                  <Icon name="outline-square-arrow" class="webfetch-link-icon" />
                 </a>
               </Show>
             </div>
-            <Show when={!pending() && url()}>
-              <div data-component="tool-action">
-                <Icon name="square-arrow-top-right" size="small" />
-              </div>
-            </Show>
           </div>
         }
       />

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -898,7 +898,7 @@ ToolRegistry.register({
               <Show when={!pending() && url()}>
                 <a
                   data-slot="basic-tool-tool-subtitle"
-                  class="clickable subagent-link webfetch-link"
+                  class="clickable webfetch-link"
                   href={url()}
                   target="_blank"
                   rel="noopener noreferrer"


### PR DESCRIPTION
Aligns the \webfetch\ tool presentation in session-ui with the Figma design specification:

- Displays the URL with accent color (\#3b5cf6\) and no underline or icon in the resting state.
- Underlines the URL text and reveals the \outline-square-arrow\ icon inline on hover.
- Moves the external link icon directly inside the link element.