### PR TITLE
docs: add ShipFrame to ecosystem agents

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -78,7 +78,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Agents
 
-| Name                                                              | Description                                                  |
-| ----------------------------------------------------------------- | ------------------------------------------------------------ |
-| [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
-| [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+| Name                                                              | Description                                                                                                                                        |
+| ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development                                                                                          |
+| [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows                                                                                       |
+| [ShipFrame](https://github.com/juanitourquiza/shipframe)          | AI coding workflow toolkit with installable OpenCode skills, converted agents, project profiles, release evidence, and disciplined PR/MR workflows |


### PR DESCRIPTION
### Issue for this PR

N/A — docs-only ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds ShipFrame to the OpenCode ecosystem page under the Agents section.

ShipFrame is listed as an agent/workflow toolkit rather than a plugin because it installs OpenCode skills and converted agents; it is not an in-process npm plugin.

### How did you verify your code works?

- Ran `bunx prettier --check packages/web/src/content/docs/ecosystem.mdx`.
- Confirmed the entry is in the Agents table and links to `https://github.com/juanitourquiza/shipframe`.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
