### PR TITLE
fix(provider): extract nested error.message from OpenAI-shaped bodies

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -47,9 +47,14 @@ function message(providerID: ProviderV2.ID, e: APICallError) {
 
     try {
       const body = JSON.parse(e.responseBody)
-      // try to extract common error message fields
-      const errMsg = body.message || body.error || body.error?.message
-      if (errMsg && typeof errMsg === "string") {
+      // Prefer string fields in order. OpenAI-shaped bodies use `{ error: { message } }`,
+      // so reading `body.error` before `body.error?.message` would grab the object and
+      // never reach the nested string.
+      const errMsg =
+        (typeof body.error?.message === "string" ? body.error.message : undefined) ??
+        (typeof body.message === "string" ? body.message : undefined) ??
+        (typeof body.error === "string" ? body.error : undefined)
+      if (errMsg) {
         return `${msg}: ${errMsg}`
       }
     } catch {}

--- a/packages/opencode/test/provider/error.test.ts
+++ b/packages/opencode/test/provider/error.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, test } from "bun:test"
+import { APICallError } from "ai"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ProviderError } from "@/provider/error"
+
+describe("provider api call errors", () => {
+  test("extracts nested error.message from an OpenAI-shaped body", () => {
+    const error = new APICallError({
+      message: "Too Many Requests",
+      url: "https://api.openai.com/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({
+        error: { message: "Rate limit reached for gpt-4 in org X", code: "rate_limit" },
+      }),
+      isRetryable: true,
+    })
+
+    const parsed = ProviderError.parseAPICallError({
+      providerID: ProviderV2.ID.make("openai"),
+      error,
+    })
+
+    expect(parsed.message).toBe("Too Many Requests: Rate limit reached for gpt-4 in org X")
+  })
+
+  test("still extracts a top-level string error field", () => {
+    const error = new APICallError({
+      message: "Bad Request",
+      url: "https://example.com/v1/chat",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: JSON.stringify({ error: "model not found" }),
+      isRetryable: false,
+    })
+
+    const parsed = ProviderError.parseAPICallError({
+      providerID: ProviderV2.ID.make("openai"),
+      error,
+    })
+
+    expect(parsed.message).toBe("Bad Request: model not found")
+  })
+})
 
 describe("provider stream errors", () => {
   test("retries provider stream errors without a code", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #36410

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`message()` in `packages/opencode/src/provider/error.ts` extracts a fallback error string from the response body with:

```ts
const errMsg = body.message || body.error || body.error?.message
```

For the common OpenAI-shaped body `{"error":{"message":"..."}}`, `body.error` is a truthy object, so it wins the `||` chain before `body.error.message` is ever read. The `typeof errMsg === "string"` check then fails and the real message is dropped — users see a generic status line or a raw JSON dump instead of the actual reason (rate limit, quota, invalid key, etc.).

There was an earlier PR for this (#36411) that implemented essentially the same fix, but it went stale and was closed by the automated cleanup bot (>1 month old, no reactions) rather than rejected on the merits — no maintainer raised any objection to the approach there.

This PR reorders the extraction to type-check each field explicitly and prefer the nested string first:

```ts
const errMsg =
  (typeof body.error?.message === "string" ? body.error.message : undefined) ??
  (typeof body.message === "string" ? body.message : undefined) ??
  (typeof body.error === "string" ? body.error : undefined)
```

### How did you verify your code works?

- Added two tests to `packages/opencode/test/provider/error.test.ts`: one for the nested `{error:{message}}` shape, one for the pre-existing top-level string `error` shape (to make sure that path still works).
- `bun test test/provider/error.test.ts` — both new tests pass.
- `bun turbo typecheck` — 30/30 packages pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR