### PR TITLE
fix(desktop): omit shared rail from framed disclosures

### DIFF
--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -256,7 +256,7 @@
   }
 }
 
-[data-component="collapsible"].tool-collapsible {
+[data-component="collapsible"].tool-collapsible:not([data-rail="false"]) {
   > [data-slot="collapsible-content"] {
     position: relative;
     margin-inline-start: 12px;

--- a/packages/session-ui/src/components/basic-tool.tsx
+++ b/packages/session-ui/src/components/basic-tool.tsx
@@ -36,6 +36,7 @@ export interface BasicToolProps {
   defer?: boolean
   locked?: boolean
   animated?: boolean
+  rail?: boolean
   onSubtitleClick?: () => void
   onTriggerClick?: JSX.EventHandlerUnion<HTMLElement, MouseEvent>
   onTriggerKeyDown?: JSX.EventHandlerUnion<HTMLElement, KeyboardEvent>
@@ -255,7 +256,12 @@ export function BasicTool(props: BasicToolProps) {
   )
 
   return (
-    <Collapsible open={open()} onOpenChange={handleOpenChange} class="tool-collapsible">
+    <Collapsible
+      open={open()}
+      onOpenChange={handleOpenChange}
+      class="tool-collapsible"
+      data-rail={props.rail === false ? "false" : undefined}
+    >
       <Show
         when={props.triggerAsLink || props.triggerHref}
         fallback={

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1135,6 +1135,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="console"
+        rail={false}
         allowOpenWhilePending
         trigger={(open) => (
           <div data-slot="basic-tool-tool-info-structured">
@@ -1178,6 +1179,7 @@ ToolRegistry.register({
       <BasicTool
         {...props}
         icon="console"
+        rail={false}
         allowOpenWhilePending
         trigger={(open) => (
           <div data-slot="basic-tool-tool-info-structured">

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1296,6 +1296,7 @@ ToolRegistry.register({
         <BasicTool
           {...props}
           icon="code-lines"
+          rail={false}
           defer={props.deferContent !== false}
           trigger={
             <div data-component="edit-trigger">
@@ -1364,6 +1365,7 @@ ToolRegistry.register({
         <BasicTool
           {...props}
           icon="code-lines"
+          rail={false}
           defer={props.deferContent !== false}
           trigger={
             <div data-component="write-trigger">
@@ -1447,6 +1449,7 @@ ToolRegistry.register({
             <BasicTool
               {...props}
               icon="code-lines"
+              rail={false}
               defer={props.deferContent !== false}
               trigger={{
                 title: i18n.t("ui.tool.patch"),
@@ -1544,6 +1547,7 @@ ToolRegistry.register({
           <BasicTool
             {...props}
             icon="code-lines"
+            rail={false}
             defer={props.deferContent !== false}
             trigger={
               <div data-component="edit-trigger">


### PR DESCRIPTION
Disable the shared collapsible rail for content that already has its own frame: Shell and Execute console surfaces, plus Edit, Write, and Patch diff cards. Keep the rail enabled for unframed nested disclosure content.