### PR TITLE
fix(core): read dir/.npmrc deterministically regardless of ancestor package.json/node_modules

### DIFF
--- a/packages/core/src/npm-config.ts
+++ b/packages/core/src/npm-config.ts
@@ -16,7 +16,12 @@ export const load = (dir: string) =>
         npmPath,
         cwd: dir,
         env: { ...process.env },
-        argv: [process.execPath, process.execPath],
+        // Pin the project prefix so `dir/.npmrc` is always read as the project
+        // config. Without this, @npmcli/config walks up looking for the nearest
+        // package.json/node_modules, and when an ancestor contains either
+        // (commonly the user's home directory on Windows), `dir/.npmrc` is
+        // silently ignored and installs fall back to the default registry.
+        argv: [process.execPath, process.execPath, `--prefix=${dir}`],
         execPath: process.execPath,
         platform: process.platform,
         definitions,

--- a/packages/core/src/npm-config.ts
+++ b/packages/core/src/npm-config.ts
@@ -21,6 +21,8 @@ export const load = (dir: string) =>
         // package.json/node_modules, and when an ancestor contains either
         // (commonly the user's home directory on Windows), `dir/.npmrc` is
         // silently ignored and installs fall back to the default registry.
+        // This intentionally deviates from npm's nearest-anchor walk: callers
+        // pass opencode-managed cache directories, not user project roots.
         argv: [process.execPath, process.execPath, `--prefix=${dir}`],
         execPath: process.execPath,
         platform: process.platform,

--- a/packages/core/test/npm-config.test.ts
+++ b/packages/core/test/npm-config.test.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { mkdir } from "fs/promises"
 import { describe, expect, test } from "bun:test"
 import { Effect } from "effect"
 import { NpmConfig } from "@opencode-ai/core/npm-config"
@@ -12,6 +13,22 @@ describe("NpmConfig.load", () => {
     const config = await Effect.runPromise(NpmConfig.load(tmp.path))
 
     expect(config.registry).toBe("https://registry.example.test/")
+  })
+
+  test("prefers the requested directory over ancestor package.json anchors", async () => {
+    await using tmp = await tmpdir()
+    // An ancestor holding package.json captures @npmcli/config's prefix walk,
+    // which would otherwise read this .npmrc instead of the requested dir's.
+    await Bun.write(path.join(tmp.path, "package.json"), JSON.stringify({ name: "anchor" }))
+    await Bun.write(path.join(tmp.path, ".npmrc"), "registry=https://ancestor.example.test/\n")
+
+    const dir = path.join(tmp.path, "project")
+    await mkdir(dir)
+    await Bun.write(path.join(dir, ".npmrc"), "registry=https://project.example.test/\n")
+
+    const config = await Effect.runPromise(NpmConfig.load(dir))
+
+    expect(config.registry).toBe("https://project.example.test/")
   })
 
   test("reads scoped registries from project .npmrc", async () => {

--- a/packages/core/test/npm-config.test.ts
+++ b/packages/core/test/npm-config.test.ts
@@ -31,6 +31,20 @@ describe("NpmConfig.load", () => {
     expect(config.registry).toBe("https://project.example.test/")
   })
 
+  test("prefers the requested directory over ancestor node_modules anchors", async () => {
+    await using tmp = await tmpdir()
+    await mkdir(path.join(tmp.path, "node_modules"))
+    await Bun.write(path.join(tmp.path, ".npmrc"), "registry=https://ancestor.example.test/\n")
+
+    const dir = path.join(tmp.path, "project")
+    await mkdir(dir)
+    await Bun.write(path.join(dir, ".npmrc"), "registry=https://project.example.test/\n")
+
+    const config = await Effect.runPromise(NpmConfig.load(dir))
+
+    expect(config.registry).toBe("https://project.example.test/")
+  })
+
   test("reads scoped registries from project .npmrc", async () => {
     await using tmp = await tmpdir()
     await Bun.write(path.join(tmp.path, ".npmrc"), "@acme:registry=https://npm.acme.test/\n")


### PR DESCRIPTION
### Issue for this PR

Closes #44062

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`NpmConfig.load(dir)` relies on `@npmcli/config`'s prefix walk to locate the "project" `.npmrc`. The walk stops at the first ancestor containing `package.json` or `node_modules`, so on machines where such an ancestor exists between the target dir and the filesystem root, `dir/.npmrc` is silently ignored. On Windows the common polluter is the user profile root, and opencode's package cache sits under `%LOCALAPPDATA%`, inside that profile — so plugin dependency installs configured through a private registry/mirror in a `.npmrc` quietly fall back to registry.npmjs.org.

The fix pins the synthetic CLI argv to `--prefix=<dir>`, which makes `loadLocalPrefix()` short-circuit and read exactly the requested directory as project root. That matches what callers already assume: `Npm.install` passes `path: dir` to Arborist explicitly rather than trusting config-derived locations.

### How did you verify your code works?

- On my Windows machine (home dir contains a stray package.json/node_modules, a real-world trigger), all five existing npm-config tests failed before this change because the temp dir's `.npmrc` was never read; after the change all pass.
- Added a portable regression test ("prefers the requested directory over ancestor package.json anchors") that fails on every platform without the fix: it places a package.json + .npmrc in an ancestor of the requested dir and asserts the requested dir's registry wins.
- Full packages/core suite shows no new failures vs clean dev (the git/snapshot 5s-timeout flakes in this environment reproduce identically with the changes stashed).
- `tsgo --noEmit` passes.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR