### PR TITLE
fix(core): register only credential-shaped env names for integrations

### DIFF
--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -10,6 +10,19 @@ function released(date: string) {
   return Number.isFinite(time) ? time : 0
 }
 
+const CREDENTIAL_ENV_SUFFIXES = ["_API_KEY", "_TOKEN", "_PAT"]
+
+// models.dev lists env vars in setup order, so account/host/region/project names
+// that configure a provider often precede the actual credential (e.g. Cloudflare's
+// `[CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY]`). Connection resolution picks the
+// first set var, so an unfiltered list can hand a non-secret value out as the
+// bearer key. Narrow to credential-shaped names when any exist; otherwise fall
+// back to the full list rather than guess wrong for an unfamiliar naming scheme.
+function credentialEnvNames(names: readonly string[]) {
+  const credentials = names.filter((name) => CREDENTIAL_ENV_SUFFIXES.some((suffix) => name.endsWith(suffix)))
+  return credentials.length > 0 ? credentials : [...names]
+}
+
 function cost(input: ModelsDev.Model["cost"]): ModelV2Info["cost"] {
   const base = {
     input: input?.input ?? 0,
@@ -134,7 +147,7 @@ export const ModelsDevPlugin = define({
           })
           integrations.method.update({
             integrationID,
-            method: { type: "env", names: [...item.env] },
+            method: { type: "env", names: credentialEnvNames(item.env) },
           })
         }
       }),

--- a/packages/core/test/plugin/fixtures/models-dev.json
+++ b/packages/core/test/plugin/fixtures/models-dev.json
@@ -10,5 +10,11 @@
     "name": "Local",
     "env": [],
     "models": {}
+  },
+  "cloudy": {
+    "id": "cloudy",
+    "name": "Cloudy",
+    "env": ["CLOUDY_ACCOUNT_ID", "CLOUDY_API_KEY"],
+    "models": {}
   }
 }

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -158,6 +158,19 @@ describe("ModelsDevPlugin", () => {
               ],
               connections: [],
             }),
+            new Integration.Info({
+              id: Integration.ID.make("cloudy"),
+              name: "Cloudy",
+              methods: [
+                { type: "key" },
+                {
+                  // CLOUDY_ACCOUNT_ID is not a credential; only the key-shaped name is registered.
+                  type: "env",
+                  names: ["CLOUDY_API_KEY"],
+                },
+              ],
+              connections: [],
+            }),
           ])
         }).pipe(Effect.provide(AppNodeBuilder.build(ModelsDev.node))),
       (previous) =>


### PR DESCRIPTION
### Issue for this PR

Closes #44065

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ModelsDevPlugin` (`packages/core/src/plugin/models-dev.ts`) registers every env var
name models.dev lists for a provider, verbatim, as one `env` auth method. Connection
resolution takes the first set var as the credential. For providers where models.dev
lists a non-secret setup value before the key — `cloudflare-workers-ai`
(`CLOUDFLARE_ACCOUNT_ID` → `CLOUDFLARE_API_KEY`), `snowflake-cortex`, `databricks`,
`neon` — the non-key value wins and gets sent as the bearer token, so a standard setup
gets a deterministic 401.

#43077 hit the same bug for `google-vertex` and fixed it by hardcoding a per-provider
`environmentNames()` filter on the `v2` branch (azure + google-vertex only). This PR
generalizes that instead of adding more per-provider cases: `credentialEnvNames()`
keeps only names ending in `_API_KEY`/`_TOKEN`/`_PAT` when any of the provider's env
names match that shape, and falls back to the full list otherwise (so providers with
unfamiliar naming still register their env var same as before).

### How did you verify your code works?

- Added a `cloudy` fixture provider (`CLOUDY_ACCOUNT_ID`, `CLOUDY_API_KEY`) to
  `packages/core/test/plugin/fixtures/models-dev.json` and asserted only the
  `_API_KEY` name gets registered (`packages/core/test/plugin/models-dev.test.ts`)
- `bun test test/plugin/models-dev.test.ts` — 2 pass
- `bun run typecheck` in `packages/core` — clean
- `bun test` (full `packages/core` suite) has 2 pre-existing failures in
  `snapshot.test.ts` unrelated to this change — reproduced identically with this
  diff stashed out, so confirmed pre-existing (git/hg sandbox issue in this
  environment, not caused by this PR)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
