### PR TITLE
fix(desktop): configure app before instance lock

### DIFF
--- a/packages/desktop/src/main/lifecycle/index.ts
+++ b/packages/desktop/src/main/lifecycle/index.ts
@@ -147,8 +147,9 @@ const platform = Layer.merge(DesktopLogging.layer, Shutdown.layer)
 
 export const layer = Layer.unwrap(
   Effect.gen(function* () {
-    if (!acquireApplicationLock()) return yield* Effect.interrupt
+    // Electron scopes the single-instance lock to userData.
     yield* configureApplication()
+    if (!acquireApplicationLock()) return yield* Effect.interrupt
     return runtime.pipe(Layer.provideMerge(platform))
   }),
 )


### PR DESCRIPTION
## Summary
- configure the Electron application identity and channel-specific `userData` path before acquiring the single-instance lock
- keep the lock scoped to `ai.opencode.desktop.dev` instead of the package-name fallback directory

## Reproduction
On Windows, current `upstream/v2` exits immediately with code `130` at `starting electron app...`. A direct Electron launch reproduces the same exit. Instrumentation showed `requestSingleInstanceLock()` returning `false` while using `C:\Users\Lukem\AppData\Roaming\@opencode-ai\desktop`; configuration had not yet switched to the intended dev path.

## Testing
- `bun typecheck` in `packages/desktop`
- `bun test ./src/main` in `packages/desktop` (50 passed)
- desktop startup benchmark reached the Electron debug endpoint and rendered the app; it then encountered a separate background-service startup failure

The repository pre-push typecheck also reached and passed `@opencode-ai/desktop`, but failed in unrelated `@opencode-ai/www` setup because `@astrojs/mdx` was unavailable.