### PR TITLE
docs(ecosystem): add Chat Sidebar for OpenCode (VS Code extension)

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Chat Sidebar for OpenCode](https://github.com/SenCha930511/chat-sidebar-for-opencode)     | VS Code sidebar chat GUI for a locally running OpenCode server |
 
 ---
 


### PR DESCRIPTION
Adds **[Chat Sidebar for OpenCode](https://github.com/SenCha930511/chat-sidebar-for-opencode)** to the ecosystem projects table.

VS Code extension (MIT, published on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=SenCha930511.chat-sidebar-for-opencode)) that provides a sidebar chat GUI for a locally installed OpenCode server via the official `@opencode-ai/sdk`: multi-session streaming chat, inline permission approvals and question cards, slash commands, agent/model pickers, @-mention file attachments, todos and native diff previews, bilingual EN/繁體中文 UI.

Appended at the end of the table, matching the existing row format.