### PR TITLE
fix(llm): ignore unknown Anthropic SSE events

### DIFF
--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -237,6 +237,17 @@ const invalid = ProviderShared.invalidRequest
 // that exceed it.
 const ANTHROPIC_BREAKPOINT_CAP = 4
 
+const ANTHROPIC_SSE_EVENTS = new Set([
+  "message",
+  "message_start",
+  "message_delta",
+  "message_stop",
+  "content_block_start",
+  "content_block_delta",
+  "content_block_stop",
+  "error",
+])
+
 const EPHEMERAL_5M = { type: "ephemeral" as const }
 const EPHEMERAL_1H = { type: "ephemeral" as const, ttl: "1h" as const }
 
@@ -848,7 +859,7 @@ export const route = Route.make({
   protocol,
   endpoint: Endpoint.path(PATH, { baseURL: DEFAULT_BASE_URL }),
   auth: Auth.none,
-  framing: Framing.sse,
+  framing: Framing.sseByEventName(ANTHROPIC_SSE_EVENTS),
   headers: () => ({ "anthropic-version": "2023-06-01" }),
 })
 

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -239,14 +239,20 @@ export const errorText = (error: unknown) => {
  * implement client-driven retries) so the public error channel stays
  * `LLMError`.
  */
-export const sseFraming = (bytes: Stream.Stream<Uint8Array, LLMError>): Stream.Stream<string, LLMError> =>
-  bytes.pipe(
-    Stream.decodeText(),
-    Stream.pipeThroughChannel(Sse.decode()),
-    Stream.catchTag("Retry", () => Stream.empty),
-    Stream.filter((event) => event.data.length > 0 && event.data !== "[DONE]"),
-    Stream.map((event) => event.data),
-  )
+const sseFramingWith =
+  (accept: (event: Sse.Event) => boolean) =>
+  (bytes: Stream.Stream<Uint8Array, LLMError>): Stream.Stream<string, LLMError> =>
+    bytes.pipe(
+      Stream.decodeText(),
+      Stream.pipeThroughChannel(Sse.decode()),
+      Stream.catchTag("Retry", () => Stream.empty),
+      Stream.filter((event) => event.data.length > 0 && event.data !== "[DONE]" && accept(event)),
+      Stream.map((event) => event.data),
+    )
+
+export const sseFraming = sseFramingWith(() => true)
+
+export const sseFramingByEventName = (names: ReadonlySet<string>) => sseFramingWith((event) => names.has(event.event))
 
 /**
  * Canonical invalid-request constructor. Lift one-line `const invalid =

--- a/packages/llm/src/route/framing.ts
+++ b/packages/llm/src/route/framing.ts
@@ -24,4 +24,9 @@ export interface Framing<Frame> {
 /** Server-Sent Events framing. Used by every JSON-streaming HTTP provider. */
 export const sse: Framing<string> = { id: "sse", frame: ProviderShared.sseFraming }
 
+export const sseByEventName = (names: ReadonlySet<string>): Framing<string> => ({
+  id: "sse",
+  frame: ProviderShared.sseFramingByEventName(names),
+})
+
 export * as Framing from "./framing"

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -7,7 +7,7 @@ import * as AnthropicMessages from "../../src/protocols/anthropic-messages"
 import { continuationRequest, nativeAnthropicMessagesContinuation } from "../continuation-scenarios"
 import { it } from "../lib/effect"
 import { dynamicResponse, fixedResponse } from "../lib/http"
-import { sseEvents } from "../lib/sse"
+import { sseEvents, sseRaw } from "../lib/sse"
 
 const model = AnthropicMessages.route
   .with({ endpoint: { baseURL: "https://api.anthropic.test/v1/" }, auth: Auth.header("x-api-key", "test") })
@@ -404,6 +404,33 @@ describe("Anthropic Messages route", () => {
         reason: "stop",
         providerMetadata: { anthropic: { stopSequence: "\n\nHuman:" } },
       })
+    }),
+  )
+
+  it.effect("ignores unknown named SSE events before decoding data", () =>
+    Effect.gen(function* () {
+      const body = sseRaw(
+        "event: future_event\ndata: not-json",
+        `event: message_start\ndata: ${JSON.stringify({ type: "message_start", message: { usage: { input_tokens: 1 } } })}`,
+        `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+        `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } })}`,
+        `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+        `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } })}`,
+      )
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.text).toBe("Hello")
+    }),
+  )
+
+  it.effect("rejects malformed data for recognized named SSE events", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(fixedResponse(sseRaw("event: message_start\ndata: not-json"))),
+        Effect.flip,
+      )
+
+      expect(error.message).toContain("Invalid anthropic/anthropic-messages stream event")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #43765

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic may add named SSE events that clients must ignore. The Messages route discarded event names, so an unknown event with non-JSON data failed the whole response.

This filters Anthropic Messages streams to recognized event names before JSON decoding. Unnamed SSE data still uses the standard `message` event, and malformed data for recognized events remains an error.

### How did you verify your code works?

- `bun test` from `packages/llm` (300 passed, 30 skipped)
- `bun typecheck` from `packages/llm`
- pre-push `bun turbo typecheck`
- `bun run lint` on the changed files (0 errors)

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
