### PR TITLE
feat(app): align moved location notice

### DIFF
--- a/packages/app/e2e/regression/session-timeline-notices.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-notices.spec.ts
@@ -97,6 +97,57 @@ test("shows a delegating row while subagent input streams", async ({ page }) => 
   await expect(page.locator('[data-timeline-row="Thinking"]')).toHaveCount(0)
 })
 
+test("renders the moved location notice in its compact timeline style", async ({ page }) => {
+  const directory = `/Users/usrnk1/Developer/opencode/${"nested-directory/".repeat(24)}session`
+  await page.setViewportSize({ width: 480, height: 720 })
+  await setupTimeline(page, {
+    sessionMessages: [
+      user,
+      {
+        id: "msg_location",
+        type: "location-switched",
+        location: { directory },
+        time: { created: 2 },
+      },
+    ],
+  })
+
+  const notice = page.locator('[data-slot="session-timeline-notice"][data-type="location-switched"]')
+  const label = notice.locator('[data-slot="session-timeline-notice-label"]')
+  const value = notice.locator('[data-slot="session-timeline-notice-value"]')
+  const tooltipTrigger = notice.locator('[data-component="tooltip-v2-trigger"]')
+
+  await expect(label).toHaveText("Moved to")
+  await expect(value).toHaveText(directory)
+  await expect(notice).not.toContainText("·")
+  await expect(notice.locator("svg")).toHaveCount(0)
+  await expect(notice).toHaveCSS("height", "28px")
+  await expect(notice).toHaveCSS("gap", "8px")
+  await expect(notice).toHaveCSS("padding-top", "4px")
+  await expect(notice).toHaveCSS("padding-bottom", "4px")
+  await expect(label).toHaveCSS("font-size", "13px")
+  await expect(label).toHaveCSS("font-weight", "530")
+  await expect(label).toHaveCSS("line-height", "13px")
+  await expect(label).toHaveCSS("color", "rgb(128, 128, 128)")
+  await expect(value).toHaveCSS("font-size", "13px")
+  await expect(value).toHaveCSS("font-weight", "440")
+  await expect(value).toHaveCSS("line-height", "13px")
+  await expect(value).toHaveCSS("color", "rgb(128, 128, 128)")
+  await expect(value).toHaveCSS("text-overflow", "ellipsis")
+  await expect(value).toHaveCSS("white-space", "nowrap")
+  await expect(value).toHaveAttribute("dir", "ltr")
+  await expect.poll(() => value.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true)
+
+  const tooltip = page.getByText("Session working directory changed", { exact: true })
+  await label.hover()
+  await expect(tooltip).toBeVisible()
+  await page.mouse.move(0, 0)
+  await expect(tooltip).toBeHidden()
+  await tooltipTrigger.focus()
+  await expect(tooltipTrigger).toBeFocused()
+  await expect(tooltip).toBeVisible()
+})
+
 test("moves blocking work to the background with Ctrl+B", async ({ page }) => {
   await setupTimeline(page, { sessionMessages: [user, assistant(false, true)] })
   const card = page.locator('[data-component="task-tool-card"]')

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -109,12 +109,7 @@ export function createSessionTimelineRowRenderer(input: {
           return message?.type === "assistant" && content?.type === "tool" ? [content] : []
         })
       })
-      return (
-        <SessionPatchToolGroup
-          tools={tools()}
-          onSizeChange={onSizeChange}
-        />
-      )
+      return <SessionPatchToolGroup tools={tools()} onSizeChange={onSizeChange} />
     }
 
     const ref = createMemo(() => {

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -109,7 +109,12 @@ export function createSessionTimelineRowRenderer(input: {
           return message?.type === "assistant" && content?.type === "tool" ? [content] : []
         })
       })
-      return <SessionPatchToolGroup tools={tools()} onSizeChange={onSizeChange} />
+      return (
+        <SessionPatchToolGroup
+          tools={tools()}
+          onSizeChange={onSizeChange}
+        />
+      )
     }
 
     const ref = createMemo(() => {
@@ -168,11 +173,7 @@ export function createSessionTimelineRowRenderer(input: {
     if (message.type === "system") {
       const prefix = "Instructions updated: "
       if (message.description?.startsWith(prefix)) {
-        const keys = message.description
-          .slice(prefix.length)
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean)
+        const keys = message.description.slice(prefix.length).split(",").map((s) => s.trim()).filter(Boolean)
         return {
           label: i18n.t("ui.sessionTimeline.notice.instructionsUpdated"),
           items: keys,

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -8,6 +8,7 @@ import { Card } from "@opencode-ai/ui/card"
 import { useI18n } from "@opencode-ai/ui/context/i18n"
 import { TextReveal } from "@opencode-ai/ui/text-reveal"
 import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { For, Show, createMemo, type Accessor, type JSX } from "solid-js"
 import type { SessionUserActions, SessionUserComment } from "../actions"
 import {
@@ -168,13 +169,15 @@ export function createSessionTimelineRowRenderer(input: {
         label: i18n.t("ui.sessionTimeline.notice.model"),
         data: `${message.model.providerID}/${message.model.id}`,
       }
-    if (message.type === "location-switched")
-      return { label: i18n.t("ui.patch.action.moved"), data: message.location.directory }
     if (message.type === "skill") return { label: i18n.t("ui.tool.skill"), data: message.name }
     if (message.type === "system") {
       const prefix = "Instructions updated: "
       if (message.description?.startsWith(prefix)) {
-        const keys = message.description.slice(prefix.length).split(",").map((s) => s.trim()).filter(Boolean)
+        const keys = message.description
+          .slice(prefix.length)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
         return {
           label: i18n.t("ui.sessionTimeline.notice.instructionsUpdated"),
           items: keys,
@@ -293,56 +296,89 @@ export function createSessionTimelineRowRenderer(input: {
         if (value._tag !== "Notice") throw new Error("Expected a notice timeline row")
         return value
       }
+      const message = createMemo(() => input.projection.messageByID().get(current().messageID))
+      const moved = createMemo(() => {
+        const value = message()
+        return value?.type === "location-switched" ? value : undefined
+      })
       const content = createMemo(() => {
-        const message = input.projection.messageByID().get(current().messageID)
-        return message ? notice(message) : undefined
+        const value = message()
+        return value ? notice(value) : undefined
       })
       return (
         <Frame row={current()}>
-          <Show when={content()}>
-            {(content) => (
-              <Show
-                when={content().items?.length}
-                fallback={
-                  <div
-                    data-slot="session-timeline-notice"
-                    class={`w-full pt-3 pb-1 text-13-regular text-text-weak ${padding()}`}
+          <Show
+            when={moved()}
+            fallback={
+              <Show when={content()}>
+                {(content) => (
+                  <Show
+                    when={content().items?.length}
+                    fallback={
+                      <div
+                        data-slot="session-timeline-notice"
+                        class={`w-full pt-3 pb-1 text-13-regular text-text-weak ${padding()}`}
+                      >
+                        <bdi dir="auto" class="text-13-medium">
+                          {content().label}
+                        </bdi>
+                        <Show when={content().data}>
+                          {(data) => (
+                            <span>
+                              {" "}
+                              · <bdi dir="auto">{data()}</bdi>
+                            </span>
+                          )}
+                        </Show>
+                      </div>
+                    }
                   >
-                    <bdi dir="auto" class="text-13-medium">
-                      {content().label}
-                    </bdi>
-                    <Show when={content().data}>
-                      {(data) => (
-                        <span>
-                          {" "}
-                          · <bdi dir="auto">{data()}</bdi>
-                        </span>
-                      )}
-                    </Show>
-                  </div>
-                }
-              >
-                <div data-slot="session-timeline-notice" class={`w-full py-1 ${padding()}`}>
-                  <div class="flex min-h-5 min-w-0 items-center gap-2 overflow-hidden">
-                    <bdi
-                      dir="auto"
-                      class="shrink-0 text-[13px] font-[530] leading-none tracking-[-0.04px] text-v2-text-text-faint"
-                    >
-                      {content().label}
-                    </bdi>
-                    <For each={content().items}>
-                      {(item) => (
+                    <div data-slot="session-timeline-notice" class={`w-full py-1 ${padding()}`}>
+                      <div class="flex min-h-5 min-w-0 items-center gap-2 overflow-hidden">
                         <bdi
                           dir="auto"
-                          class="min-w-0 truncate text-[13px] font-[440] leading-none tracking-[-0.04px] text-v2-text-text-faint"
+                          class="shrink-0 text-[13px] font-[530] leading-none tracking-[-0.04px] text-v2-text-text-faint"
                         >
-                          {item}
+                          {content().label}
                         </bdi>
-                      )}
-                    </For>
-                  </div>
-                </div>
+                        <For each={content().items}>
+                          {(item) => (
+                            <bdi
+                              dir="auto"
+                              class="min-w-0 truncate text-[13px] font-[440] leading-none tracking-[-0.04px] text-v2-text-text-faint"
+                            >
+                              {item}
+                            </bdi>
+                          )}
+                        </For>
+                      </div>
+                    </div>
+                  </Show>
+                )}
               </Show>
+            }
+          >
+            {(message) => (
+              <div
+                data-slot="session-timeline-notice"
+                data-type="location-switched"
+                class={`flex h-7 w-full min-w-0 items-center gap-2 py-1 text-[13px] leading-none tracking-[-0.04px] text-v2-text-text-faint ${padding()}`}
+              >
+                <Tooltip
+                  appearance="compact"
+                  placement="top"
+                  value={i18n.t("ui.sessionTimeline.notice.movedTooltip")}
+                  class="shrink-0"
+                  triggerTabIndex={0}
+                >
+                  <bdi data-slot="session-timeline-notice-label" dir="auto" class="font-[530]">
+                    {i18n.t("ui.sessionTimeline.notice.movedTo")}
+                  </bdi>
+                </Tooltip>{" "}
+                <bdi data-slot="session-timeline-notice-value" dir="ltr" class="min-w-0 truncate font-[440]">
+                  {message().location.directory}
+                </bdi>
+              </div>
             )}
           </Show>
         </Frame>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -210,6 +210,8 @@ const source = {
   "ui.message.duration.minutesSeconds": "{{minutes}}m {{seconds}}s",
   "ui.message.interrupted": "Interrupted",
   "ui.sessionTimeline.notice.model": "Model",
+  "ui.sessionTimeline.notice.movedTo": "Moved to",
+  "ui.sessionTimeline.notice.movedTooltip": "Session working directory changed",
   "ui.sessionTimeline.notice.failed": "{{actor}} failed",
   "ui.sessionTimeline.notice.cancelled": "{{actor}} cancelled",
   "ui.sessionTimeline.notice.finished": "{{actor}} finished",

--- a/packages/ui/src/overlays/tooltip/tooltip.tsx
+++ b/packages/ui/src/overlays/tooltip/tooltip.tsx
@@ -12,6 +12,7 @@ export interface TooltipProps extends ComponentProps<typeof Root> {
   contentStyle?: JSX.CSSProperties
   inactive?: boolean
   forceOpen?: boolean
+  triggerTabIndex?: number
 }
 
 export function Tooltip(props: TooltipProps) {
@@ -29,6 +30,7 @@ export function Tooltip(props: TooltipProps) {
     "contentStyle",
     "inactive",
     "forceOpen",
+    "triggerTabIndex",
     "ignoreSafeArea",
     "value",
   ])
@@ -110,6 +112,7 @@ export function Tooltip(props: TooltipProps) {
           <Trigger
             ref={ref}
             as="div"
+            tabIndex={local.triggerTabIndex}
             data-component="tooltip-v2-trigger"
             class={local.class}
             onPointerDownCapture={arm}


### PR DESCRIPTION
## Summary
- render `location-switched` as the Figma `Moved to` label plus destination path
- match the 28 px row, faint text, 530/440 weights, 8 px gap, and no dot or icon
- preserve long paths with ellipsis and LTR path isolation in RTL layouts
- expose Figma's `Session working directory changed` tooltip to pointer and keyboard users

Figma: section `1890:15347`, final row `1890:115109`, hover row `1890:114882`, tooltip `1890:115065`.

## Testing
- `bun typecheck` in `packages/app`, `packages/session-ui`, and `packages/ui`
- `bun test` in `packages/session-ui` (91 passed)
- `bun test` in `packages/ui` (27 passed)
- `session-timeline-notices.spec.ts` in Chromium (8 passed)
- focused moved-location regression after the final rebase (passed)
- verified exact row height, padding, gap, font size, weights, line height, light-theme color, no separator/icon, real path truncation, LTR path isolation, hover tooltip, and keyboard tooltip

## Performance
The initial production baseline passed at 17.40 deltas/s with zero long tasks and zero missed-frame equivalents. A post-change run passed at 16.66 deltas/s with the same frame-clean result. After rebasing onto the latest `v2`, the production build succeeded, but the benchmark harness hit its existing blank-app readiness failure before fixture setup and emitted no metrics.

## Known base issue
`bun run typecheck:e2e` currently fails in the merged delegation test at `session-timeline-notices.spec.ts:82`: `toolPart(...)` returns a `ToolSeed` without the protocol tool part's required `time`. The browser test passes, and this PR does not change that fixture or delegation test.