### PR TITLE
fix: increase markdown bold weight and bound status popover scroll

### DIFF
--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -175,7 +175,7 @@ function ServerStatusPopoverView(props: { state: ServerStatusState }) {
     <div class="flex items-center gap-1 w-[360px] rounded-xl shadow-[var(--shadow-lg-border-base)]">
       <Tabs
         aria-label={props.state.ariaLabel}
-        class="tabs bg-background-strong rounded-xl overflow-hidden"
+        class="tabs bg-background-strong rounded-xl overflow-hidden max-h-[60vh]"
         data-component="tabs"
         data-active="servers"
         defaultValue="servers"
@@ -301,7 +301,7 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
     <div class="flex items-center gap-1 w-[360px] rounded-xl shadow-[var(--shadow-lg-border-base)]">
       <Tabs
         aria-label={language.t("status.popover.ariaLabel")}
-        class="tabs bg-background-strong rounded-xl overflow-hidden"
+        class="tabs bg-background-strong rounded-xl overflow-hidden max-h-[60vh]"
         data-component="tabs"
         data-active={settings.general.newLayoutDesigns() ? "mcp" : "servers"}
         defaultValue={settings.general.newLayoutDesigns() ? "mcp" : "servers"}

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -73,7 +73,7 @@
   strong,
   b {
     color: var(--v2-text-text-base);
-    font-weight: var(--font-weight-medium);
+    font-weight: 700;
   }
 
   /* Paragraphs */
@@ -346,6 +346,7 @@ body:not([data-new-layout]) [data-component="markdown"] {
   strong,
   b {
     color: var(--text-strong);
+    font-weight: 700;
   }
 
   li::marker {

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -70,6 +70,8 @@
   }
 
   /* Emphasis & Strong: Neutral strong color */
+  /* Literal weight: theme.css defines no bold/semibold token today, only
+     --font-weight-regular (400) and --font-weight-medium (500). */
   strong,
   b {
     color: var(--v2-text-text-base);
@@ -343,6 +345,7 @@ body:not([data-new-layout]) [data-component="markdown"] {
     font-weight: var(--font-weight-medium);
   }
 
+  /* Literal weight: no bold/semibold token exists yet (see above). */
   strong,
   b {
     color: var(--text-strong);


### PR DESCRIPTION
### Issue for this PR

Closes #43597
Closes #43668

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two small, independent UI bugs bundled together since each is a one-line-ish fix in a different file:

1. **Bold markdown text was nearly invisible.** `**bold**` rendered at `font-weight: 500` in the new layout, and with no weight override at all in the legacy layout — both cases looked almost identical to regular text. Both `strong`/`b` rules in `markdown.css` now use `font-weight: 700`.
2. **The status popover's MCP/plugin list grew off-screen instead of scrolling.** `tabs.css` already has working `overflow-y: auto` scroll CSS, but nothing above it constrained a height, so with many entries the popover just grew unbounded. Added `max-h-[60vh]` to both `<Tabs>` instances in `status-popover-body.tsx` so the existing scroll CSS actually activates.

### How did you verify your code works?

- `bun run typecheck` passes (`packages/app`, and the full monorepo pre-push typecheck).
- `oxlint` on both changed files shows the same pre-existing warnings as before the change (0 new warnings, 0 errors) — confirmed by diffing lint output against the base branch.
- Confirmed via source inspection that `tabs.css`'s `[data-slot="tabs-content"] { overflow-y: auto }` only needed a bounded ancestor height to activate, and that `markdown.css` is the single shared component both Desktop and Web UI render through.
- I was not able to get a live browser screenshot in this environment (no browser automation tooling available here), so I can't attach before/after images. Both changes are single-property CSS/class edits with no logic change, verified above via typecheck, lint, and source-level tracing of the existing (unmodified) scroll/weight CSS they depend on.

### Screenshots / recordings

_No response — no browser tooling available in the environment I used to prepare this PR. Happy to add screenshots if a maintainer can't easily verify visually._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
