### PR TITLE
fix(app): collapse failed patch cards

### DIFF
--- a/packages/session-ui/src/message/current-message.test.ts
+++ b/packages/session-ui/src/message/current-message.test.ts
@@ -29,6 +29,22 @@ describe("current content default open", () => {
     expect(currentContentDefaultOpen(tool("patch"), false, false)).toBe(true)
   })
 
+  test("collapses failed patches", () => {
+    const patch: SessionMessageAssistantTool = {
+      type: "tool",
+      id: "tool_patch",
+      name: "patch",
+      state: {
+        status: "error",
+        input: {},
+        error: { type: "ToolError", message: "Verification failed" },
+        metadata: {},
+      },
+      time: { created: 1, completed: 2 },
+    }
+    expect(currentContentDefaultOpen(patch, false, false)).toBe(false)
+  })
+
   test("opens deletion-only patches", () => {
     expect(
       currentContentDefaultOpen(

--- a/packages/session-ui/src/message/current-tool-state.ts
+++ b/packages/session-ui/src/message/current-tool-state.ts
@@ -36,7 +36,7 @@ export function currentContentDefaultOpen(
 ) {
   if (content.type !== "tool") return undefined
   if (content.name === "shell" || content.name === "execute") return shellExpanded
-  if (content.name === "patch") return true
+  if (content.name === "patch") return content.state.status !== "error"
   if (content.name !== "edit" && content.name !== "write") return undefined
   if (!editExpanded) return false
   const files = currentToolMetadata(content).files


### PR DESCRIPTION
## Summary
- collapse failed patch tool cards by default
- keep successful patch cards expanded
- add regression coverage for failed patch disclosure state

## Testing
- `bun test src/message/current-message.test.ts`
- `bun typecheck` in `packages/session-ui`
- repository pre-push typecheck
