### PR TITLE
feat(app): fade the background move hint

### DIFF
--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createMemo, createSignal, For, on, Show, type Accessor } from "solid-js"
+import createPresence from "solid-presence"
 import { createStore } from "solid-js/store"
 import type { SessionUserActions } from "@opencode-ai/session-ui/actions"
 import { Badge } from "@opencode-ai/ui/badge"
@@ -62,6 +63,32 @@ export function BackgroundMoveHint(props: { keybind?: string[] }) {
       <Keybind keys={keys()} variant="neutral" />
       <span class="min-w-0 truncate">{parts()[1].trim()}</span>
     </div>
+  )
+}
+
+function BackgroundMoveHintRow(props: { show: boolean; centered: boolean; padding: string }) {
+  const [ref, setRef] = createSignal<HTMLDivElement>()
+  const presence = createPresence({ show: () => props.show, element: () => ref() ?? null })
+  return (
+    <Show when={presence.present()}>
+      <div
+        classList={{
+          "min-w-0 w-full max-w-full": true,
+          "md:max-w-200 2xl:max-w-[1000px] md:mx-auto": props.centered,
+        }}
+      >
+        {/* both directions are gated on data-visible because animate-in and animate-out both write the
+            animation shorthand, and presence only detects the exit when the animation name changes */}
+        <div
+          ref={setRef}
+          data-visible={props.show}
+          class="duration-150 data-[visible=true]:animate-in data-[visible=true]:fade-in data-[visible=false]:animate-out data-[visible=false]:fade-out data-[visible=false]:fill-mode-forwards motion-reduce:animate-none"
+          classList={{ [`flex h-10 items-start pt-4 ${props.padding}`]: true }}
+        >
+          <BackgroundMoveHint />
+        </div>
+      </div>
+    </Show>
   )
 }
 
@@ -474,18 +501,7 @@ function MessageTimelineView(
       renderRow={(row, onSizeChange) => (
         <>
           <rowRenderer.Row row={row} onSizeChange={onSizeChange} />
-          <Show when={backgroundHint(row())}>
-            <div
-              classList={{
-                "min-w-0 w-full max-w-full": true,
-                "md:max-w-200 2xl:max-w-[1000px] md:mx-auto": props.centered,
-              }}
-            >
-              <div class={`flex h-10 items-start pt-4 ${turnPadding()}`}>
-                <BackgroundMoveHint />
-              </div>
-            </div>
-          </Show>
+          <BackgroundMoveHintRow show={backgroundHint(row())} centered={props.centered} padding={turnPadding()} />
         </>
       )}
       header={

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -68,7 +68,11 @@ export function BackgroundMoveHint(props: { keybind?: string[] }) {
 
 function BackgroundMoveHintRow(props: { show: boolean; centered: boolean; padding: string }) {
   const [ref, setRef] = createSignal<HTMLDivElement>()
-  const presence = createPresence({ show: () => props.show, element: () => ref() ?? null })
+  const visibility = createMemo<{ show: boolean; animate: boolean }>(
+    (previous) => ({ show: props.show, animate: previous.animate || previous.show !== props.show }),
+    { show: props.show, animate: false },
+  )
+  const presence = createPresence({ show: () => visibility().show, element: () => ref() ?? null })
   return (
     <Show when={presence.present()}>
       <div
@@ -77,13 +81,14 @@ function BackgroundMoveHintRow(props: { show: boolean; centered: boolean; paddin
           "md:max-w-200 2xl:max-w-[1000px] md:mx-auto": props.centered,
         }}
       >
-        {/* both directions are gated on data-visible because animate-in and animate-out both write the
-            animation shorthand, and presence only detects the exit when the animation name changes */}
         <div
           ref={setRef}
-          data-visible={props.show}
-          class="duration-150 data-[visible=true]:animate-in data-[visible=true]:fade-in data-[visible=false]:animate-out data-[visible=false]:fade-out data-[visible=false]:fill-mode-forwards motion-reduce:animate-none"
-          classList={{ [`flex h-10 items-start pt-4 ${props.padding}`]: true }}
+          class="duration-150 motion-reduce:animate-none"
+          classList={{
+            [`flex h-10 items-start pt-4 ${props.padding}`]: true,
+            "animate-in fade-in": visibility().animate && visibility().show,
+            "animate-out fade-out fill-mode-forwards": visibility().animate && !visibility().show,
+          }}
         >
           <BackgroundMoveHint />
         </div>

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1251,7 +1251,10 @@ ToolRegistry.register({
           <div data-slot="basic-tool-tool-info-structured">
             <div data-slot="basic-tool-tool-info-main">
               <span data-slot="basic-tool-tool-title">
-                <TextShimmer text={i18n.t("ui.tool.shell")} active={streaming()} />
+                <TextShimmer
+                  text={i18n.t("ui.tool.shell")}
+                  active={streaming() || props.status === "running" || props.metadata.status === "running"}
+                />
               </span>
               <Show when={!open()}>
                 <Show


### PR DESCRIPTION
The "Press ⌘B to move running work to the background" hint now fades when its visibility changes on an already-mounted timeline. Initial page and tab mounts render it immediately without animation.

\`solid-presence\` keeps the row mounted until the exit animation finishes. A memo seeded with the initial visibility distinguishes mounting from later enter/exit transitions.

This also restores the active shimmer for backgrounded shell tasks. The current \`v2\` base regressed that state in #44095 by checking only \`streaming\`; backgrounded shells use a completed tool state with \`metadata.status === "running"\`, which caused this PR's initial E2E checks to fail before exercising the fade.

Verification:
- \`bun typecheck\` in \`packages/app\`
- \`bun typecheck\` in \`packages/session-ui\`
- Full pre-push monorepo typecheck (32 packages)