### PR TITLE
fix(app): prevent duplicate web mounts

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -61,7 +61,9 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   })
 }
 
-if (root instanceof HTMLElement) {
+if (root instanceof HTMLElement && root.dataset.opencodeMounted === undefined) {
+  // Lazy chunks can import the entry chunk back under a distinct URL, so claim the root before async startup.
+  root.dataset.opencodeMounted = ""
   void loadInitialLocale().then((locale) => {
     const auth = authFromToken(new URLSearchParams(location.search).get("auth_token"))
     clearAuthToken()


### PR DESCRIPTION
## Summary

- claim the web root synchronously before asynchronous locale startup
- ignore repeated entry evaluation instead of appending another Solid application tree
- prevent lazy chunk loading from producing a duplicate full-page UI

## Validation

- `bun typecheck` from `packages/app`
- `bun run build` from `packages/app`
- repository pre-push typecheck (32 packages)
