### PR TITLE
fix(app): avoid duplicate retry errors

### DIFF
--- a/packages/session-ui/src/timeline/projection.ts
+++ b/packages/session-ui/src/timeline/projection.ts
@@ -291,8 +291,7 @@ export namespace Timeline {
     }
 
     if (isActive && retry) rows.push(new TimelineRow.Retry({ userMessageID: turnID }))
-
-    if (error && !interrupted) {
+    else if (error && !interrupted) {
       rows.push(new TimelineRow.Error({ userMessageID: turnID, text: unwrapErrorMessage(error.message) }))
     }
 

--- a/packages/session-ui/src/timeline/rows-current.test.ts
+++ b/packages/session-ui/src/timeline/rows-current.test.ts
@@ -217,6 +217,35 @@ describe("current session timeline rows", () => {
     expect(result.rows.map((row) => row._tag)).toEqual(["UserMessage", "Retry"])
   })
 
+  test("does not render the retry error twice", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "retry", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [],
+        error: { type: "ProviderError", message: "The provider response ended unexpectedly." },
+        retry: {
+          attempt: 2,
+          at: 10,
+          error: { type: "ProviderError", message: "The provider response ended unexpectedly." },
+        },
+        time: { created: 2 },
+      },
+    ] satisfies SessionMessageInfo[]
+
+    const result = Timeline.constructSessionMessageRows(source, true, {
+      type: "retry",
+      attempt: 2,
+      next: 10,
+      message: "The provider response ended unexpectedly.",
+    })
+
+    expect(result.rows.map((row) => row._tag)).toEqual(["UserMessage", "Retry"])
+  })
+
   test("removes a failed assistant error when the turn continues streaming", () => {
     const source = [
       { id: "msg_user", type: "user", text: "recover", time: { created: 1 } },


### PR DESCRIPTION
## Summary

- render an active retry as the sole error-state timeline row
- preserve terminal error rows when no retry is active
- add regression coverage for assistant messages containing both retry and error data

## Validation

- `bun test src/timeline/rows-current.test.ts` from `packages/session-ui`
- `bun typecheck` from `packages/session-ui`
- full workspace typecheck from the pre-push hook

## Screenshots

Not included: the existing mocked timeline screenshot fixture fails on `v2` before rendering the session page, so it could not produce a trustworthy before/after comparison.
