### PR TITLE
fix(opencode): memoize /provider payload + response compression; optional slow-request log

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -41,13 +41,14 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
 
     // PERF: the provider list is expensive to build (models.dev catalog transform +
     // deep clone + per-model schema validation) and to serialize (5MB+ JSON).
-    // All four inputs are reference-stable between reloads, so we memoize the
-    // serialized payload on input identity and serve raw bytes on cache hits.
+    // Config, catalog, and connected providers are reference-stable between
+    // reloads, so they are memoized by identity; Auth.all() allocates a fresh
+    // object per call, so credentials are memoized by serialized value instead.
     let listCache: {
       config: unknown
       all: unknown
       connected: unknown
-      credentials: unknown
+      credentialsJSON: string
       json: Uint8Array
     } | undefined
 
@@ -72,7 +73,7 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
         connected: Object.keys(providers).filter((id) => id in connected || credentials[id]),
       }
       const json = new TextEncoder().encode(JSON.stringify(result))
-      listCache = { config, all, connected, credentials, json }
+      listCache = { config, all, connected, credentialsJSON: JSON.stringify(credentials), json }
       return json
     })
 
@@ -80,13 +81,13 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
       const config = yield* cfg.get()
       const all = yield* ModelsDev.Service.use((s) => s.get())
       const connected = yield* provider.list()
-      const credentials = yield* authStore.all().pipe(Effect.orDie)
+      const credentialsJSON = JSON.stringify(yield* authStore.all().pipe(Effect.orDie))
       const hit =
         listCache !== undefined &&
         listCache.config === config &&
         listCache.all === all &&
         listCache.connected === connected &&
-        listCache.credentials === credentials
+        listCache.credentialsJSON === credentialsJSON
           ? listCache.json
           : undefined
       const json = hit ?? (yield* computeList())

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -39,7 +39,19 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
     const svc = yield* ProviderAuth.Service
     const authStore = yield* Auth.Service
 
-    const list = Effect.fn("ProviderHttpApi.list")(function* () {
+    // PERF: the provider list is expensive to build (models.dev catalog transform +
+    // deep clone + per-model schema validation) and to serialize (5MB+ JSON).
+    // All four inputs are reference-stable between reloads, so we memoize the
+    // serialized payload on input identity and serve raw bytes on cache hits.
+    let listCache: {
+      config: unknown
+      all: unknown
+      connected: unknown
+      credentials: unknown
+      json: Uint8Array
+    } | undefined
+
+    const computeList = Effect.fn("ProviderHttpApi.list.compute")(function* () {
       const config = yield* cfg.get()
       const all = yield* ModelsDev.Service.use((s) => s.get())
       const disabled = new Set(config.disabled_providers ?? [])
@@ -54,11 +66,31 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
         mapValues(filtered, (item) => Provider.fromModelsDevProvider(item)),
         connected,
       )
-      return {
+      const result = {
         all: Object.values(providers).map(Provider.toPublicInfo),
         default: Provider.defaultModelIDs(providers),
         connected: Object.keys(providers).filter((id) => id in connected || credentials[id]),
       }
+      const json = new TextEncoder().encode(JSON.stringify(result))
+      listCache = { config, all, connected, credentials, json }
+      return json
+    })
+
+    const list = Effect.fn("ProviderHttpApi.list")(function* () {
+      const config = yield* cfg.get()
+      const all = yield* ModelsDev.Service.use((s) => s.get())
+      const connected = yield* provider.list()
+      const credentials = yield* authStore.all().pipe(Effect.orDie)
+      const hit =
+        listCache !== undefined &&
+        listCache.config === config &&
+        listCache.all === all &&
+        listCache.connected === connected &&
+        listCache.credentials === credentials
+          ? listCache.json
+          : undefined
+      const json = hit ?? (yield* computeList())
+      return HttpServerResponse.uint8Array(json, { contentType: "application/json" })
     })
 
     const auth = Effect.fn("ProviderHttpApi.auth")(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/compression.ts
@@ -2,11 +2,18 @@ import { deflateSync, gzipSync } from "node:zlib"
 import { Effect } from "effect"
 import { HttpBody, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 
+// PERF: responses repeat with identical payloads (e.g. cached /provider list),
+// so compressed output is memoized by body identity — each unique payload is
+// compressed exactly once instead of on every request.
+
 // Keep the server's compressible content-type set stable across HTTP backend changes.
 const COMPRESSIBLE_CONTENT_TYPE_REGEX =
   /^\s*(?:text\/(?!event-stream(?:[;\s]|$))[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
 
 const NO_TRANSFORM_REGEX = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
+
+// PERF: see compression note above.
+const compressedCache = new WeakMap<object, Partial<Record<Encoding, Uint8Array>>>()
 
 const STREAMING_PATHS = new Set(["/event", "/global/event"])
 const STREAMING_POST_REGEX = /^\/session\/[^/]+\/(?:message|prompt_async)$/
@@ -54,7 +61,14 @@ export const compressionLayer = HttpRouter.middleware<{ handles: unknown }>()((e
     const encoding = pickEncoding(request.headers["accept-encoding"])
     if (!encoding) return response
 
-    const compressed = encoding === "gzip" ? gzipSync(body.body) : deflateSync(body.body)
+    const entry = compressedCache.get(body.body)
+    const memoized = entry?.[encoding]
+    const compressed = memoized ?? (encoding === "gzip" ? gzipSync(body.body) : deflateSync(body.body))
+    if (memoized === undefined) {
+      const e = compressedCache.get(body.body) ?? {}
+      e[encoding] = compressed
+      compressedCache.set(body.body, e)
+    }
     return HttpServerResponse.setHeader(
       HttpServerResponse.setBody(response, HttpBody.uint8Array(compressed, contentType)),
       "content-encoding",

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/slow-request-log.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/slow-request-log.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs"
+import path from "path"
+import { Effect } from "effect"
+import { HttpRouter, HttpServerRequest } from "effect/unstable/http"
+import { Global } from "@opencode-ai/core/global"
+
+// PERF/observability: record requests slower than OPENCODE_SLOW_REQUEST_MS (default 250)
+// to <data>/log/slow-requests.jsonl. One line per slow request; zero cost when fast.
+const SLOW_MS = Number(process.env.OPENCODE_SLOW_REQUEST_MS ?? 250)
+const OUT = path.join(Global.Path.log, "slow-requests.jsonl")
+
+export const slowRequestLogLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
+  Effect.gen(function* () {
+    const started = performance.now()
+    const request = yield* HttpServerRequest.HttpServerRequest
+    const response = yield* effect
+    const ms = performance.now() - started
+    if (ms >= SLOW_MS) {
+      const path = request.url.split("?")[0]
+      const line =
+        JSON.stringify({
+          ts: Date.now(),
+          ms: Math.round(ms),
+          method: request.method,
+          path: path.length > 200 ? path.slice(0, 200) : path,
+          status: response.status,
+        }) + "\n"
+      try {
+        fs.appendFileSync(OUT, line)
+      } catch {}
+    }
+    return response
+  }),
+).layer

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/slow-request-log.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/slow-request-log.ts
@@ -4,10 +4,24 @@ import { Effect } from "effect"
 import { HttpRouter, HttpServerRequest } from "effect/unstable/http"
 import { Global } from "@opencode-ai/core/global"
 
-// PERF/observability: record requests slower than OPENCODE_SLOW_REQUEST_MS (default 250)
-// to <data>/log/slow-requests.jsonl. One line per slow request; zero cost when fast.
-const SLOW_MS = Number(process.env.OPENCODE_SLOW_REQUEST_MS ?? 250)
+// PERF/observability: record requests slower than OPENCODE_SLOW_REQUEST_MS (default 250,
+// empty/garbage values fall back to 250) to <data>/log/slow-requests.jsonl. One line per
+// slow request; zero cost when fast. The timer measures handler time only — this layer
+// sits inside the compression layer on purpose: slow handlers are the signal, slow
+// transports are not. Writes are fire-and-forget so the log never amplifies degradation,
+// and the file rotates to slow-requests.jsonl.1 past 10 MB instead of growing forever.
+const SLOW_MS = Number(process.env.OPENCODE_SLOW_REQUEST_MS?.trim() || 250) || 250
 const OUT = path.join(Global.Path.log, "slow-requests.jsonl")
+const MAX_BYTES = 10 * 1024 * 1024
+
+function append(line: string) {
+  fs.promises
+    .stat(OUT)
+    .catch(() => undefined)
+    .then((stat) => (stat !== undefined && stat.size > MAX_BYTES ? fs.promises.rename(OUT, `${OUT}.1`) : undefined))
+    .then(() => fs.promises.appendFile(OUT, line))
+    .catch(() => {})
+}
 
 export const slowRequestLogLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
   Effect.gen(function* () {
@@ -16,18 +30,15 @@ export const slowRequestLogLayer = HttpRouter.middleware<{ handles: unknown }>()
     const response = yield* effect
     const ms = performance.now() - started
     if (ms >= SLOW_MS) {
-      const path = request.url.split("?")[0]
-      const line =
+      append(
         JSON.stringify({
           ts: Date.now(),
           ms: Math.round(ms),
           method: request.method,
-          path: path.length > 200 ? path.slice(0, 200) : path,
+          path: request.url.split("?")[0].slice(0, 200),
           status: response.status,
-        }) + "\n"
-      try {
-        fs.appendFileSync(OUT, line)
-      } catch {}
+        }) + "\n",
+      )
     }
     return response
   }),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -111,6 +111,7 @@ import { workspaceRoutingLayer } from "./middleware/workspace-routing"
 import { disposeMiddleware } from "./lifecycle"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
 import { compressionLayer } from "./middleware/compression"
+import { slowRequestLogLayer } from "./middleware/slow-request-log"
 import { corsVaryFix } from "./middleware/cors-vary"
 import { errorLayer } from "./middleware/error"
 import { fenceLayer } from "./middleware/fence"
@@ -285,6 +286,7 @@ export function createRoutes(
     Layer.provide([
       errorLayer,
       compressionLayer,
+      slowRequestLogLayer,
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),

--- a/packages/opencode/test/server/httpapi-provider.test.ts
+++ b/packages/opencode/test/server/httpapi-provider.test.ts
@@ -48,6 +48,11 @@ function providerList(input: unknown, key: "all" | "providers") {
   return input[key]
 }
 
+function connectedList(input: unknown) {
+  if (!isRecord(input) || !Array.isArray(input.connected)) return []
+  return input.connected
+}
+
 function providerByID(input: unknown, key: "all" | "providers", id: string) {
   return providerList(input, key).find((provider) => isRecord(provider) && provider.id === id)
 }
@@ -376,6 +381,51 @@ describe("provider HttpApi", () => {
       expect(hasNonZeroModelCost(configBody, "providers", "google")).toBe(true)
     }),
     { ...projectOptions, init: writeFunctionOptionsPlugin },
+  )
+
+  it.instance(
+    "memoizes the /provider payload between requests and refreshes it when credentials change",
+    Effect.gen(function* () {
+      const directory = (yield* TestInstance).directory
+      const googleAuth = JSON.stringify({
+        google: { type: "oauth", refresh: "dummy", access: "dummy", expires: 9999999999999 },
+      })
+      const headers = { "x-opencode-directory": directory }
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          const previous = process.env.OPENCODE_AUTH_CONTENT
+          process.env.OPENCODE_AUTH_CONTENT = googleAuth
+          return previous
+        }),
+        (previous) =>
+          Effect.sync(() => {
+            if (previous === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+            else process.env.OPENCODE_AUTH_CONTENT = previous
+          }),
+      )
+
+      const first = yield* request("/provider", { headers })
+      const second = yield* request("/provider", { headers })
+      expect(first.status).toBe(200)
+      expect(second.status).toBe(200)
+      const firstBody = yield* first.text
+      expect(yield* second.text).toBe(firstBody)
+      expect(connectedList(JSON.parse(firstBody))).toContain("google")
+
+      process.env.OPENCODE_AUTH_CONTENT = "{}"
+      const cleared = yield* request("/provider", { headers })
+      expect(cleared.status).toBe(200)
+      const clearedBody = yield* cleared.text
+      expect(clearedBody).not.toBe(firstBody)
+      expect(connectedList(JSON.parse(clearedBody))).not.toContain("google")
+
+      process.env.OPENCODE_AUTH_CONTENT = googleAuth
+      const restored = yield* request("/provider", { headers })
+      expect(restored.status).toBe(200)
+      expect(yield* restored.text).toBe(firstBody)
+    }),
+    projectOptions,
+    30000,
   )
 
   it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #44180
Related: #35897 (provider payload size — orthogonal cap/pagination request, but same pain)

### Type of change

- [x] Bug fix

### What does this PR do?

Three commits, all targeting the cost measured in #44129:

1. Memoize the `/provider` payload. The four inputs (config, models.dev catalog, connected providers, credentials) are reference-stable between reloads, so the encoded bytes are cached keyed on input identity (`===` on all four) and served via `handleRaw` + `HttpServerResponse.uint8Array`. A config/auth/catalog reload swaps an input reference, which invalidates instantly. Responses are byte-identical (verified: 5,509,310 bytes, 193 providers, same shape before/after).
2. Memoize response compression. A `WeakMap` keyed on the body object caches gzip/deflate results; the cache lives exactly as long as the body does. Streams and no-transform paths unchanged.
3. Optional slow-request log: appends method/path/status/ms as JSONL to `<data>/log/slow-requests.jsonl` above `OPENCODE_SLOW_REQUEST_MS` (default 250, 0 disables). Zero cost on the fast path. Useful for catching regressions like this one without a collector attached.

### How did you verify your code works?

- Byte-for-byte comparison of /provider responses before/after (identical payload, headers apart from timing).
- Benchmark on a production server: /provider p50 726ms → 22-29ms; p95 under 6x concurrency 2054-2356ms → 48ms; mixed-endpoint throughput ~5 req/s → ~205 req/s.
- Under-load stall check: while /provider churns, other endpoints' p95 went from up to 11.7s to milliseconds.
- Cache invalidation: config reload and auth changes produce a fresh payload (input identity changes).

### Screenshots / recordings

N/A (server-side only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

