### PR TITLE
fix(app): allow selecting diff text

### DIFF
--- a/packages/session-ui/src/components/file.tsx
+++ b/packages/session-ui/src/components/file.tsx
@@ -702,7 +702,7 @@ function ViewerShell(props: {
       data-mode={props.mode}
       dir="ltr"
       style={styleVariables}
-      class="relative outline-none"
+      class="relative select-text outline-none"
       classList={{
         ...props.classList,
         [props.class ?? ""]: !!props.class,


### PR DESCRIPTION
## Summary
- explicitly allow text selection on the shared file viewer host
- restore copy/paste from shadow-DOM diff views in the web session timeline

## Testing
- `bun typecheck` in `packages/session-ui`
- `bun test src --only-failures` in `packages/session-ui` (93 passed)
- `bun typecheck` in `packages/app`
- repository pre-push typecheck (32 tasks passed)

## Performance
- production timeline benchmark was attempted before and after the change, but the existing fixture failed before metrics collection because the expected session heading did not render
