### PR TITLE
fix(provider): select DeepSeek adapter for Azure deployments

### DIFF
--- a/packages/core/src/plugin/provider/azure.ts
+++ b/packages/core/src/plugin/provider/azure.ts
@@ -3,6 +3,10 @@ import { define } from "../internal"
 import { ProviderV2 } from "../../provider"
 
 function selectLanguage(sdk: any, modelID: string, useChat: boolean) {
+  // Azure DeepSeek deployments need the DeepSeek-specific adapter for reasoning
+  // effort and reasoning_content across agentic turns; it is chat-completions
+  // based, so it also applies when useCompletionUrls is set.
+  if (modelID.toLowerCase().includes("deepseek") && sdk.deepseek) return sdk.deepseek(modelID)
   if (useChat && sdk.chat) return sdk.chat(modelID)
   if (sdk.responses) return sdk.responses(modelID)
   if (sdk.messages) return sdk.messages(modelID)

--- a/packages/core/src/plugin/provider/azure.ts
+++ b/packages/core/src/plugin/provider/azure.ts
@@ -6,6 +6,10 @@ function selectLanguage(sdk: any, modelID: string, useChat: boolean) {
   // Azure DeepSeek deployments need the DeepSeek-specific adapter for reasoning
   // effort and reasoning_content across agentic turns; it is chat-completions
   // based, so it also applies when useCompletionUrls is set.
+  // Note: this predicate (any "deepseek" deployment) deliberately differs from
+  // the "deepseek-v4" gate in transform.ts reasoningVariants, which only
+  // exposes a max effort for v4 models.
+  // Keep in sync with packages/opencode/src/provider/provider.ts selectAzureLanguageModel.
   if (modelID.toLowerCase().includes("deepseek") && sdk.deepseek) return sdk.deepseek(modelID)
   if (useChat && sdk.chat) return sdk.chat(modelID)
   if (sdk.responses) return sdk.responses(modelID)

--- a/packages/core/test/plugin/provider-azure.test.ts
+++ b/packages/core/test/plugin/provider-azure.test.ts
@@ -55,6 +55,7 @@ function fakeSelectorSdk(calls: string[]) {
     responses: make("responses"),
     messages: make("messages"),
     chat: make("chat"),
+    deepseek: make("deepseek"),
     languageModel: make("languageModel"),
   }
 }
@@ -258,6 +259,64 @@ describe("AzurePlugin", () => {
       })
       expect(calls).toEqual(["responses:deployment"])
       expect(ignored.language).toBeUndefined()
+    }),
+  )
+
+  it.effect("selects deepseek adapter for DeepSeek deployments", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const calls: string[] = []
+      yield* addPlugin()
+      yield* aisdk.runLanguage({
+        model: ModelV2.Info.make({
+          ...ModelV2.Info.empty(ProviderV2.ID.azure, ModelV2.ID.make("deepseek-v4-pro")),
+          api: { id: ModelV2.ID.make("deepseek-v4-pro"), type: "aisdk", package: "test-provider" },
+        }),
+        sdk: fakeSelectorSdk(calls),
+        options: {},
+      })
+      expect(calls).toEqual(["deepseek:deepseek-v4-pro"])
+    }),
+  )
+
+  it.effect("keeps the deepseek adapter when useCompletionUrls is set", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const calls: string[] = []
+      yield* addPlugin()
+      yield* aisdk.runLanguage({
+        model: ModelV2.Info.make({
+          ...ModelV2.Info.empty(ProviderV2.ID.azure, ModelV2.ID.make("deepseek-v4-pro")),
+          api: { id: ModelV2.ID.make("deepseek-v4-pro"), type: "aisdk", package: "test-provider" },
+        }),
+        sdk: fakeSelectorSdk(calls),
+        options: { useCompletionUrls: true },
+      })
+      expect(calls).toEqual(["deepseek:deepseek-v4-pro"])
+    }),
+  )
+
+  it.effect("falls back to responses when the sdk has no deepseek adapter", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+      const calls: string[] = []
+      const make = (method: string) => (id: string) => {
+        calls.push(`${method}:${id}`)
+        return { modelId: id, provider: method, specificationVersion: "v3" }
+      }
+      yield* addPlugin()
+      yield* aisdk.runLanguage({
+        model: ModelV2.Info.make({
+          ...ModelV2.Info.empty(ProviderV2.ID.azure, ModelV2.ID.make("deepseek-v4-pro")),
+          api: { id: ModelV2.ID.make("deepseek-v4-pro"), type: "aisdk", package: "test-provider" },
+        }),
+        sdk: { responses: make("responses"), chat: make("chat"), languageModel: make("languageModel") },
+        options: {},
+      })
+      expect(calls).toEqual(["responses:deepseek-v4-pro"])
     }),
   )
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -158,6 +158,10 @@ type CustomDep = {
 }
 
 function selectAzureLanguageModel(sdk: any, modelID: string, useChat: boolean) {
+  // Azure DeepSeek deployments need the DeepSeek-specific adapter for reasoning
+  // effort and reasoning_content across agentic turns; it is chat-completions
+  // based, so it also applies when useCompletionUrls is set.
+  if (modelID.toLowerCase().includes("deepseek") && sdk.deepseek) return sdk.deepseek(modelID)
   if (useChat && sdk.chat) return sdk.chat(modelID)
   if (sdk.responses) return sdk.responses(modelID)
   if (sdk.messages) return sdk.messages(modelID)

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -161,6 +161,10 @@ function selectAzureLanguageModel(sdk: any, modelID: string, useChat: boolean) {
   // Azure DeepSeek deployments need the DeepSeek-specific adapter for reasoning
   // effort and reasoning_content across agentic turns; it is chat-completions
   // based, so it also applies when useCompletionUrls is set.
+  // Note: this predicate (any "deepseek" deployment) deliberately differs from
+  // the "deepseek-v4" gate in transform.ts reasoningVariants, which only
+  // exposes a max effort for v4 models.
+  // Keep in sync with packages/core/src/plugin/provider/azure.ts selectLanguage.
   if (modelID.toLowerCase().includes("deepseek") && sdk.deepseek) return sdk.deepseek(modelID)
   if (useChat && sdk.chat) return sdk.chat(modelID)
   if (sdk.responses) return sdk.responses(modelID)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -941,8 +941,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     case "@ai-sdk/azure":
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
+      const azureEfforts = [...openaiReasoningEfforts(id, model.release_date)]
+      if (model.api.id.toLowerCase().includes("deepseek-v4")) azureEfforts.push("max")
       return Object.fromEntries(
-        openaiReasoningEfforts(id, model.release_date).map((effort) => [
+        azureEfforts.map((effort) => [
           effort,
           {
             reasoningEffort: effort,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -942,7 +942,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       // https://v5.ai-sdk.dev/providers/ai-sdk-providers/azure
       if (id === "o1-mini") return {}
       const azureEfforts = [...openaiReasoningEfforts(id, model.release_date)]
-      if (model.api.id.toLowerCase().includes("deepseek-v4")) azureEfforts.push("max")
+      // Only deepseek-v4 deployments expose a max effort; the adapter
+      // selection in the azure loaders gates on any "deepseek" deployment,
+      // which is deliberately broader.
+      if (model.api.id.toLowerCase().includes("deepseek-v4") && !azureEfforts.includes("max")) azureEfforts.push("max")
       return Object.fromEntries(
         azureEfforts.map((effort) => [
           effort,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -809,6 +809,71 @@ it.instance("getSmallModel skips inferred models for Azure Cognitive Services", 
   }),
 )
 
+const azureTestConfig = {
+  provider: {
+    azure: {
+      npm: "@ai-sdk/azure",
+      options: { resourceName: "test-resource", apiKey: "test-key" },
+      models: {
+        "deepseek-v4-pro": { name: "DeepSeek V4 Pro" },
+        "gpt-5": { name: "GPT-5" },
+      },
+    },
+  },
+}
+
+it.instance(
+  "azure deepseek deployments select the DeepSeek adapter",
+  Effect.gen(function* () {
+    yield* set("AZURE_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_API_KEY", "test-key")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.azure, ModelV2.ID.make("deepseek-v4-pro"))
+    const language = yield* provider.getLanguage(model)
+    expect(language.provider).toBe("azure.deepseek")
+  }),
+  { config: azureTestConfig },
+)
+
+it.instance(
+  "azure deepseek deployments keep the DeepSeek adapter with useCompletionUrls",
+  Effect.gen(function* () {
+    yield* set("AZURE_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_API_KEY", "test-key")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.azure, ModelV2.ID.make("deepseek-v4-pro"))
+    const language = yield* provider.getLanguage({ ...model, options: { ...model.options, useCompletionUrls: true } })
+    expect(language.provider).toBe("azure.deepseek")
+  }),
+  { config: azureTestConfig },
+)
+
+it.instance(
+  "azure non-deepseek deployments keep responses routing",
+  Effect.gen(function* () {
+    yield* set("AZURE_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_API_KEY", "test-key")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.azure, ModelV2.ID.make("gpt-5"))
+    const language = yield* provider.getLanguage(model)
+    expect(language.provider).toBe("azure.responses")
+  }),
+  { config: azureTestConfig },
+)
+
+it.instance(
+  "azure non-deepseek deployments keep chat routing with useCompletionUrls",
+  Effect.gen(function* () {
+    yield* set("AZURE_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_API_KEY", "test-key")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.azure, ModelV2.ID.make("gpt-5"))
+    const language = yield* provider.getLanguage({ ...model, options: { ...model.options, useCompletionUrls: true } })
+    expect(language.provider).toBe("azure.chat")
+  }),
+  { config: azureTestConfig },
+)
+
 it.instance(
   "getSmallModel respects config small_model override",
   Effect.gen(function* () {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3702,6 +3702,35 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("azure deepseek-v4 deployments include a max reasoning effort variant", () => {
+    const model = createMockModel({
+      id: "azure/deepseek-v4-pro",
+      providerID: "azure",
+      api: {
+        id: "deepseek-v4-pro",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "max"])
+    expect(result.max).toMatchObject({ reasoningEffort: "max" })
+  })
+
+  test("azure non-deepseek deployments do not include a max reasoning effort variant", () => {
+    const model = createMockModel({
+      id: "azure/gpt-5",
+      providerID: "azure",
+      api: {
+        id: "gpt-5",
+        url: "https://azure.com",
+        npm: "@ai-sdk/azure",
+      },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result.max).toBeUndefined()
+  })
+
   test("minimax returns empty object", () => {
     const model = createMockModel({
       id: "minimax/minimax-model",


### PR DESCRIPTION
### Issue for this PR

Closes #43106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Azure-hosted `DeepSeek-V4-Pro` / `DeepSeek-V4-Flash` deployments currently route through the generic chat or responses adapter in both the V2 provider plugin (`packages/core/src/plugin/provider/azure.ts`) and the legacy loader (`packages/opencode/src/provider/provider.ts`). The bundled `@ai-sdk/azure` provider exposes `sdk.deepseek()`, which handles DeepSeek Chat Completions semantics — `max_tokens`, `reasoning_effort` (`low`/`medium`/`high`/`xhigh`/`max`), and `reasoning_content` across reasoning/tool-call turns. It was never selected, so `reasoningEffort: max` variants failed with a generic Azure error.

Changes:

- **`packages/core/src/plugin/provider/azure.ts`** and **`packages/opencode/src/provider/provider.ts`**: prefer `sdk.deepseek(modelID)` for deployment names containing `deepseek`, before the `useCompletionUrls`/responses routing (the DeepSeek adapter is chat-completions based, so it also applies when completion URLs are used). Explicit routing overrides for non-DeepSeek deployments are unchanged.
- **`packages/opencode/src/provider/transform.ts`**: azure `reasoningVariants` now emits a `max` effort variant for `deepseek-v4` deployments (mirrors the existing `@ai-sdk/openai-compatible` behavior), so `azure/deepseek-v4-pro:max` exists.
- Tests: adapter selection via the real `@ai-sdk/azure` SDK (asserting `azure.deepseek` provider, plus unchanged `responses`/`chat` routing for non-DeepSeek models), variant generation, and the V2 plugin selector with a fake SDK.

### How did you verify your code works?

- `bun typecheck` in `packages/core` and `packages/opencode` — clean.
- `bun test test/provider/provider.test.ts test/provider/transform.test.ts` in `packages/opencode` — 518 pass; the single failure (`Google Vertex: uses REP endpoint for Gemini continental multi-regions`) also fails on clean `dev` and is unrelated.
- `packages/core/test/plugin/provider-azure.test.ts` cannot load in this environment due to a pre-existing circular import (`plugin/provider.ts` ↔ `plugin/internal.ts`) that fails on clean `dev` too; the new core tests follow the existing pattern exactly and the core package typechecks.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR