### PR TITLE
fix(provider): guard defaultModelIDs against providers with no models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1110,7 +1110,13 @@ export function toPublicInfo(provider: Info): Info {
 }
 
 export function defaultModelIDs<T extends { models: Record<string, { id: string }> }>(providers: Record<string, T>) {
-  return mapValues(providers, (item) => sort(Object.values(item.models))[0].id)
+  // Zero-model providers are a supported state (e.g. a bare custom provider
+  // declared in opencode.jsonc that the catalog does not yet know about), so
+  // skip them rather than crash on `[].id`.
+  return mapValues(
+    pickBy(providers, (item) => Object.keys(item.models).length > 0),
+    (item) => sort(Object.values(item.models))[0].id,
+  )
 }
 
 export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundError>()("ProviderModelNotFoundError", {

--- a/packages/opencode/test/provider/default-model-ids.test.ts
+++ b/packages/opencode/test/provider/default-model-ids.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { Provider } from "@/provider/provider"
+
+describe("Provider.defaultModelIDs", () => {
+  test("returns the first model id for every provider with models", () => {
+    const providers = {
+      alpha: { models: { sonnet: { id: "alpha-sonnet" }, haiku: { id: "alpha-haiku" } } },
+      beta: { models: { pro: { id: "beta-pro" } } },
+    } as unknown as Parameters<typeof Provider.defaultModelIDs>[0]
+
+    const result = Provider.defaultModelIDs(providers)
+
+    expect(result.alpha).toBe("alpha-sonnet")
+    expect(result.beta).toBe("beta-pro")
+    expect(Object.keys(result)).toEqual(["alpha", "beta"])
+  })
+
+  test("omits providers with no models instead of throwing", () => {
+    const providers = {
+      "bare-gateway": { models: {} },
+      anthropic: { models: { "claude-sonnet-4-6": { id: "anthropic-sonnet" } } },
+    } as unknown as Parameters<typeof Provider.defaultModelIDs>[0]
+
+    let result: ReturnType<typeof Provider.defaultModelIDs> | undefined
+    expect(() => {
+      result = Provider.defaultModelIDs(providers)
+    }).not.toThrow()
+
+    expect(result).toBeDefined()
+    expect(result!["bare-gateway"]).toBeUndefined()
+    expect(result!.anthropic).toBe("anthropic-sonnet")
+    expect(Object.keys(result!)).toEqual(["anthropic"])
+  })
+
+  test("returns an empty object when every provider has no models", () => {
+    const providers = {
+      a: { models: {} },
+      b: { models: {} },
+    } as unknown as Parameters<typeof Provider.defaultModelIDs>[0]
+
+    expect(() => Provider.defaultModelIDs(providers)).not.toThrow()
+    expect(Provider.defaultModelIDs(providers)).toEqual({})
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #44088

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Provider.defaultModelIDs` calls `sort(Object.values(item.models))[0].id` unconditionally, which throws `TypeError: Cannot read properties of undefined (reading 'id')` whenever a provider's `models` map is empty.

A bare custom provider declared in `opencode.jsonc` (a common LiteLLM / corporate gateway pattern, see #25630 and the comments on #44088) is a supported state: `packages/opencode/src/provider/provider.ts` seeds `models: existing?.models ?? {}` for every config-declared provider at L1465, and the unconditional `database[providerID] = parsed` at L1554 keeps the entry in the live `providers` map even when the catalog has no models for it. `ProviderHttpApi.list` (`/provider`) and `ConfigHttpApi.providers` (`/config/providers`) both feed that map into `Provider.defaultModelIDs`, so the first request after startup crashes with a 500.

The fix filters out zero-model providers with `pickBy` before mapping, so the returned `Record<string, string>` only contains entries that have a real default model. Both call sites stay on the same shape, and the live map is left intact for the model picker.

`packages/opencode/test/provider/default-model-ids.test.ts` adds three regression cases (happy path, mixed empty/real, all-empty). Two of them fail with the original `TypeError` on the pre-fix code, all three pass after the fix.

### How did you verify your code works?

- Sabotage run before fix: `bun test packages/opencode/test/provider/default-model-ids.test.ts` → 2/3 fail with `TypeError: undefined is not an object (evaluating 'sort(Object.values(item.models))[0].id')` matching the reporter's stack.
- After fix: same command → 3/3 pass.
- `bun test packages/opencode/test/provider/` → 562 pass, 0 fail (covers the existing `provider.sort`, `toPublicInfo`, `ModelNotFoundError`, and config-driven model loading paths).
- `bun test packages/opencode/test/server/httpapi-authorization.test.ts` and the related `httpapi-schema-error-body` / `httpapi-query-schema-drift` suites → all pass with no behavioral change at the handler layer.
- `bun turbo typecheck --filter=opencode` → clean (uses `tsgo --noEmit`).

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A — server-side only; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
