### PR TITLE
fix(tui): sanitize clipboard text

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -51,7 +51,7 @@ export function createClipboardAdapter(clipboard: CoreClipboardService): OwnedCl
       throw new Error(`Unexpected clipboard MIME type: ${result.representation.mimeType}`)
     },
     async write(text) {
-      const result = await clipboard.writeText(text, {
+      const result = await clipboard.writeText(text.replaceAll("\0", ""), {
         destination: "all-available",
         selection: "clipboard",
       })

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -102,6 +102,18 @@ test("uses all available routes but skips the process host remotely", async () =
   expect(writes).toEqual({ host: 0, terminal: 1 })
 })
 
+test("removes NUL characters before writing", async () => {
+  const writes: string[] = []
+  const clipboard = createClipboardAdapter(
+    coreClipboard({
+      onWrite: (text) => writes.push(text),
+    }),
+  )
+
+  expect(await clipboard.write("before\0after")).toBeUndefined()
+  expect(writes).toEqual(["beforeafter"])
+})
+
 test("rejects only when no clipboard route accepted the write", async () => {
   const writes: [string, ClipboardWriteOptions][] = []
   const failure = new Error("native clipboard failed")


### PR DESCRIPTION
### Issue for this PR

Fixes #44198

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenTUI rejects clipboard text containing NUL characters, so shell output with NUL bytes caused `/copy` to fail. This strips NUL characters at the shared TUI clipboard boundary and adds a regression test, covering transcript, message, and selection copy paths.

### How did you verify your code works?

- Ran the TUI test suite: 748 passed, 5 skipped.
- Ran the repository typecheck: 32 packages passed.
- Opened the affected session with `dev:live`, ran `/copy`, and pasted the complete 669 KB transcript with Cmd+V.

### Screenshots / recordings

#### Before


https://github.com/user-attachments/assets/6fe2906d-6f6d-45e7-8c65-bc163a5b0bf5



#### After

https://github.com/user-attachments/assets/ad7b616f-2560-4e1a-8e12-1b593cd44e25

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR