### PR TITLE
fix(app): lighten background move hint

### DIFF
--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -54,7 +54,7 @@ export function BackgroundMoveHint(props: { keybind?: string[] }) {
   return (
     <div
       data-component="session-background-hint"
-      class="flex h-6 max-w-full items-center justify-center gap-[3px] overflow-hidden text-[13px] font-[530] leading-5 tracking-[-0.04px] text-v2-text-text-muted"
+      class="flex h-6 max-w-full items-center justify-center gap-[3px] overflow-hidden text-[13px] font-[440] leading-5 tracking-[-0.04px] text-v2-text-text-muted"
       aria-label={language.t("session.background.moveInline", { keybind: keybind() })}
     >
       <span data-slot="session-background-hint-prefix" class="shrink-0">


### PR DESCRIPTION
## Summary

- reduce the background move hint font weight from 530 to the regular 440 UI weight

## Before / After

| Before | After |
| --- | --- |
| ![Before: heavier background move hint](https://github.com/user-attachments/assets/84f16fac-95e3-4d08-84a8-ff1782ec5489) | ![After: lighter background move hint](https://github.com/user-attachments/assets/b964522a-fc94-48a0-9e4e-6c9b0f47c69e) |

## Validation

- `bun typecheck` in `packages/app`
- `bun run build` in `packages/app`
- `PLAYWRIGHT_PORT=3322 bunx playwright test e2e/regression/session-timeline-notices.spec.ts --grep "moves blocking work to the background"`
- timeline benchmark attempted, but the fixture could not resolve its session on an alternate port
