### PR TITLE
fix(cloudflare-ai-gateway): translate dotted Anthropic ids for the Unified route

### DIFF
--- a/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
+++ b/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
@@ -33,7 +33,7 @@ export const CloudflareAIGatewayPlugin = define({
             // gateway's stored/BYOK keys instead.
             const isWorkersAi = modelID.startsWith("workers-ai/") || modelID.startsWith("@cf/")
             const unified = createUnified(isWorkersAi ? { apiKey: config.apiKey } : {})
-            return gateway(unified(modelID))
+            return gateway(unified(nativeModelId(modelID)))
           },
         }
       }),
@@ -84,4 +84,16 @@ function gatewayOptions(options: Record<string, unknown>, metadata: unknown) {
 
 function stringOption(options: Record<string, unknown>, key: string) {
   return typeof options[key] === "string" ? options[key] : undefined
+}
+
+// models.dev publishes Anthropic ids with dot-separated version numbers (e.g.
+// "claude-haiku-4.5") to match its site-wide display convention, but Anthropic's
+// real API model slugs use dashes ("claude-haiku-4-5"). The gateway's Unified API
+// forwards the model id straight through to the upstream provider, so an
+// unmodified dotted id 404s against Anthropic with a "model not found" error.
+// Every other proxied provider in the catalog (OpenAI, xAI, Google, ...) already
+// uses dots natively, so this translation is scoped to the "anthropic/" prefix.
+function nativeModelId(modelID: string): string {
+  if (!modelID.startsWith("anthropic/")) return modelID
+  return modelID.replaceAll(".", "-")
 }

--- a/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
+++ b/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
@@ -401,6 +401,61 @@ describe("CloudflareAIGatewayPlugin", () => {
     ),
   )
 
+  it.effect("translates models.dev's dotted Anthropic ids to Anthropic's native dashed slugs", () =>
+    withEnv(cloudflareEnv(), () =>
+      Effect.gen(function* () {
+        resetCalls()
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(
+              ProviderV2.ID.make("cloudflare-ai-gateway"),
+              ModelV2.ID.make("anthropic/claude-haiku-4.5"),
+            ),
+            api: {
+              id: ModelV2.ID.make("anthropic/claude-haiku-4.5"),
+              type: "aisdk",
+              package: "test-provider",
+            },
+          }),
+          package: "ai-gateway-provider",
+          options: { name: "cloudflare-ai-gateway" },
+        })
+
+        result.sdk.languageModel("anthropic/claude-haiku-4.5")
+
+        expect(unifiedCalls).toEqual(["anthropic/claude-haiku-4-5"])
+      }),
+    ),
+  )
+
+  it.effect("leaves non-Anthropic ids with dots untouched (e.g. OpenAI's gpt-4.1)", () =>
+    withEnv(cloudflareEnv(), () =>
+      Effect.gen(function* () {
+        resetCalls()
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(ProviderV2.ID.make("cloudflare-ai-gateway"), ModelV2.ID.make("openai/gpt-4.1")),
+            api: { id: ModelV2.ID.make("openai/gpt-4.1"), type: "aisdk", package: "test-provider" },
+          }),
+          package: "ai-gateway-provider",
+          options: { name: "cloudflare-ai-gateway" },
+        })
+
+        result.sdk.languageModel("openai/gpt-4.1")
+
+        expect(unifiedCalls).toEqual(["openai/gpt-4.1"])
+      }),
+    ),
+  )
+
   it.effect("ignores non Cloudflare AI Gateway packages", () =>
     withEnv(cloudflareEnv(), () =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

Unified billing (and BYOK) is broken for every proxied Anthropic model behind `cloudflare-ai-gateway`. The Cloudflare AI Gateway's Unified API forwards the requested model id straight through to the upstream provider. models.dev publishes Anthropic ids with dot-separated version numbers to match its site-wide display convention (`anthropic/claude-haiku-4.5`), but Anthropic's real API model slugs use dashes (`claude-haiku-4-5`). The unmodified dotted id 404s against Anthropic before the request ever gets a chance to use the gateway's stored/unified-billing credentials.

This is scoped to Anthropic — every other proxied provider in the `cloudflare-ai-gateway` catalog (OpenAI, xAI, Google, Alibaba, DeepSeek, Moonshot AI, Thinking Machines) already uses dots as part of its actual upstream slug (e.g. OpenAI's `gpt-4.1` is really `gpt-4.1`), so translating dots to dashes only for `anthropic/` ids is safe and doesn't touch anyone else.

## Root cause / verification

- Reproduced directly against `ai-gateway-provider`'s `createUnified()` (the same call this plugin makes), bypassing opencode's CLI entirely:
  - `anthropic/claude-haiku-4.5` → `APICallError: model: claude-haiku-4.5` (`not_found_error`, straight from Anthropic via the gateway)
  - `anthropic/claude-haiku-4-5` → succeeds, billed through the gateway's unified billing with no Anthropic key configured anywhere
- Confirmed this is unrelated to any pending models.dev catalog change: models.dev's `cloudflare-ai-gateway` provider files for Anthropic models have used the dotted filename/id (with `base_model` pointing at the dashed lab model, e.g. `base_model = "anthropic/claude-haiku-4-5"`) since before the currently open [anomalyco/models.dev#4922](https://github.com/anomalyco/models.dev/pull/4922), and that PR doesn't touch id/filename conventions. `base_model` is parse-time-only in models.dev and doesn't propagate into the generated catalog JSON opencode consumes, so the plugin can't recover the native slug from data — it has to derive it.
- A raw curl to the gateway's native `/anthropic/v1/messages` route (not the Unified API) with no upstream Anthropic key succeeds today, confirming unified billing itself is correctly configured account-side; the bug is purely in how the model id reaches the Unified route.

## Change

- `packages/core/src/plugin/provider/cloudflare-ai-gateway.ts`: add `nativeModelId()`, which replaces `.` with `-` for ids prefixed `anthropic/` before calling `unified(modelID)`. No-op for every other provider.
- Added two tests: dotted Anthropic id → dashed id sent to `createUnified`, and a non-Anthropic dotted id (OpenAI's `gpt-4.1`) passed through unchanged.

## Test plan

- [x] `bun test` in `packages/core` — 1095 pass / 0 fail (includes the 2 new cases)
- [x] `tsgo --noEmit` — clean
- [x] `oxlint` — 0 new errors (pre-existing warnings only, unrelated to this file)
- [x] Live repro against a real Cloudflare AI Gateway (unified billing enabled, no Anthropic key) confirms the fix

Marked as a draft since I don't have a way to run this through opencode's own CLI test harness end-to-end from this environment — happy to iterate on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)