### PR TITLE
fix(todo): align in-progress guidance with concurrent work

### DIFF
--- a/packages/opencode/src/tool/todowrite.txt
+++ b/packages/opencode/src/tool/todowrite.txt
@@ -6,7 +6,7 @@ Use proactively when:
 - The work is non-trivial and benefits from planning
 - The user provides multiple tasks (numbered or comma-separated) or explicitly asks for a todo list
 - New instructions arrive - capture them as todos
-- You start a task - mark it `in_progress` (only one at a time) before working
+- You start work on a task - mark it `in_progress` before working; do this for every task actually running, including concurrent or delegated work
 - You finish a task - mark it `completed` and add any follow-ups discovered during the work
 
 ## When NOT to use
@@ -17,14 +17,14 @@ Skip when:
 
 ## States
 - `pending` - not started
-- `in_progress` - actively working (exactly ONE at a time)
+- `in_progress` - actively working
 - `completed` - finished successfully
 - `cancelled` - no longer needed
 
 ## Rules
 - Update status in real time; don't batch completions
 - Mark `completed` only after the required work is actually done, including any required verification. Never based on intent.
-- Keep exactly one `in_progress` while work remains
+- Keep at least one `in_progress` while work remains
 - If blocked or partial, keep it `in_progress` and add a follow-up todo describing the blocker
 - Preserve user-provided commands verbatim (flags, args, order)
 - Items should be specific and actionable; break large work into smaller steps


### PR DESCRIPTION
### Issue for this PR

Closes #44221

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `todowrite` description required exactly one `in_progress` item even though the runtime supports multiple. In a GPT-5.6 Sol session, this was interpreted as a scheduling constraint and caused independent ready work to be serialized.

This PR updates only the model-facing description:

- mark every task actually running as `in_progress`, including concurrent or delegated work;
- remove the single-active-task upper limit;
- keep at least one task `in_progress` while work remains.

No runtime or UI behavior is changed.

### How did you verify your code works?

`git diff --check` passes.

No functional tests were run because this is a text-only tool description change and does not alter runtime behavior.

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
