### PR TITLE
fix(session): stop the legacy 200k price from overriding a model's real context tier

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -377,13 +377,20 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   }
 
   const contextTokens = inputTokens
+  // `experimentalOver200K` is the legacy spelling of the *lowest* context tier, from
+  // when 200k was the only threshold in the catalog. It is only a fallback for data
+  // that has no `tiers` at all — if `tiers` is present, a request that matches no tier
+  // is genuinely below every threshold and must bill at the base price. Consulting the
+  // hardcoded 200_000 there would charge the high rate for every request between 200k
+  // and the model's real threshold (272k for the GPT-5.6 family, 256k, 512k, ...).
+  const contextTiers = input.model.cost?.tiers?.filter((item) => item.tier.type === "context") ?? []
   const costInfo =
-    input.model.cost?.tiers
-      ?.filter((item) => item.tier.type === "context" && contextTokens > item.tier.size)
-      .sort((a, b) => b.tier.size - a.tier.size)[0] ??
-    (input.model.cost?.experimentalOver200K && contextTokens > 200_000
-      ? input.model.cost.experimentalOver200K
-      : input.model.cost)
+    contextTiers.length > 0
+      ? (contextTiers.filter((item) => contextTokens > item.tier.size).sort((a, b) => b.tier.size - a.tier.size)[0] ??
+        input.model.cost)
+      : input.model.cost?.experimentalOver200K && contextTokens > 200_000
+        ? input.model.cost.experimentalOver200K
+        : input.model.cost
   const totalNanoAiu = input.metadata?.["copilot"]?.["totalNanoAiu"]
   return {
     cost:

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -1873,7 +1873,7 @@ describe("SessionNs.getUsage", () => {
     expect(result.cost).toBe(2.75 + 0.6 + 0.05)
   })
 
-  test("falls back to over-200k pricing when no cost tier matches", () => {
+  test("falls back to over-200k pricing when the model has no cost tiers", () => {
     const model = createModel({
       context: 1_000_000,
       output: 32_000,
@@ -1881,14 +1881,6 @@ describe("SessionNs.getUsage", () => {
         input: 1,
         output: 2,
         cache: { read: 0.1, write: 0.5 },
-        tiers: [
-          {
-            input: 5,
-            output: 6,
-            cache: { read: 0.5, write: 2.5 },
-            tier: { type: "context", size: 500_000 },
-          },
-        ],
         experimentalOver200K: {
           input: 3,
           output: 4,
@@ -1902,6 +1894,50 @@ describe("SessionNs.getUsage", () => {
     })
 
     expect(result.cost).toBe(0.9 + 0.4)
+  })
+
+  // Regression: `experimentalOver200K` is the legacy spelling of the lowest context
+  // tier, not a separate cheaper threshold — across every models.dev entry that
+  // carries both, its prices equal the lowest tier's exactly. Treating it as a live
+  // 200k threshold charged the high rate for every request between 200k and the
+  // model's real threshold. The GPT-5.6 family steps at 272k, so a 250k Luna request
+  // was estimated at 2x the documented rate.
+  test("does not use the 200k fallback below a higher real threshold", () => {
+    const model = createModel({
+      context: 1_050_000,
+      output: 128_000,
+      cost: {
+        input: 0.2,
+        output: 1.2,
+        cache: { read: 0.02, write: 0.25 },
+        tiers: [
+          {
+            input: 0.4,
+            output: 1.8,
+            cache: { read: 0.04, write: 0.5 },
+            tier: { type: "context", size: 272_000 },
+          },
+        ],
+        // Same prices as the tier above, which is what models.dev actually ships.
+        experimentalOver200K: {
+          input: 0.4,
+          output: 1.8,
+          cache: { read: 0.04, write: 0.5 },
+        },
+      },
+    })
+
+    const under = SessionNs.getUsage({
+      model,
+      usage: usage({ inputTokens: 250_000, outputTokens: 10_000, totalTokens: 260_000 }),
+    })
+    expect(under.cost).toBe(0.05 + 0.012)
+
+    const over = SessionNs.getUsage({
+      model,
+      usage: usage({ inputTokens: 300_000, outputTokens: 10_000, totalTokens: 310_000 }),
+    })
+    expect(over.cost).toBe(0.138)
   })
 
   test.each(["@ai-sdk/anthropic", "@ai-sdk/amazon-bedrock", "@ai-sdk/google-vertex/anthropic"])(


### PR DESCRIPTION
### Issue for this PR

Closes #44224

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `??` in `getUsage` fires whenever the context-tier filter comes back empty — and the filter is empty precisely when the request is *below* the model's real threshold. Control then falls to `experimentalOver200K && contextTokens > 200_000`, a different, hardcoded number, so a request between 200,001 tokens and the model's actual threshold gets the high price. For the GPT-5.6 family, which steps at 272k, a 250k request is estimated at $0.40/M instead of the documented $0.20/M.

`experimentalOver200K` reads like an independent, cheaper threshold, but in the data it is just the lowest context tier under an older name, from when 200k was the only number in the catalog. Against today's `models.dev/api.json`: 361 models carry both `tiers` and `context_over_200k`; in all 361 the `context_over_200k` prices equal the lowest tier's exactly; 0 carry it without `tiers`. So for correct catalog data that branch is only ever reached below the real threshold, where the base price is the right answer.

The change: consult `experimentalOver200K` only when the model has no context tiers at all. A tiered model matching no tier is genuinely below every threshold, so it bills at base. Models carrying only the legacy field behave exactly as before — there are none in models.dev today, but hand-written and third-party model configs can still have that shape.

252 tier entries in the catalog sit at a threshold other than 200k (272k, 256k, 128k, 32k, 262144, 512k), and every one has this band.

### How did you verify your code works?

- `bun test test/session/compaction.test.ts` — 56 pass, 1 skip, 0 fail
- `bun test test/session/llm.test.ts test/server/negative-tokens-regression.test.ts` — 30 pass, 0 fail
- `bun run typecheck` — clean
- `oxlint` on both changed files — 0 errors, no new warnings on the changed lines

On the tests themselves: `falls back to over-200k pricing when no cost tier matches` pinned the old behaviour using a model shape that does not occur in the catalog — a tier at 500k plus an `experimentalOver200K` at a *lower* price, i.e. the two fields disagreeing. I kept the case actually worth covering, the legacy-only model, renamed it `...when the model has no cost tiers`, and dropped the contradictory `tiers` entry; its assertion is unchanged. Added `does not use the 200k fallback below a higher real threshold`, built from `gpt-5.6-luna`'s real numbers: 250k bills at base, 300k bills at the tier.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Two related things from #42910 I deliberately left alone, since they are separate calls: Zen's handler trips its tier on a hardcoded `200_000` over `input + cacheRead + cacheWrite5m + cacheWrite1h`, which both uses the wrong constant and double-counts cache-write tokens; and line 382 uses strictly-greater for every provider, while vendors disagree about the token exactly *at* the line (xAI's models page says a prompt that "reaches" the threshold bills high; Google's Gemini pricing page says `<= 200k` bills low). Same number, opposite answers, and the `tier` object has no field to record which one a model means. Worth one token at most, so not worth mixing in here.
