### PR TITLE
fix(zen): OpenAI cache-write tokens are part of input_tokens, not extra

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -51,7 +51,12 @@ export const openaiHelper: ProviderHelper = ({ workspaceID }) => ({
     const cacheReadTokens = usage.input_tokens_details?.cached_tokens ?? undefined
     const cacheWriteTokens = usage.input_tokens_details?.cache_write_tokens ?? undefined
     return {
-      inputTokens: inputTokens - (cacheReadTokens ?? 0),
+      // `input_tokens` is the whole prompt: cached_tokens and cache_write_tokens are
+      // both subsets of it, not addends on top of it (OpenAI's own sample: 2600 =
+      // 2000 read + 400 written + 200 neither). Subtract both so the four buckets
+      // downstream are disjoint -- handler.ts sums them for the long-context
+      // threshold and prices each one separately.
+      inputTokens: inputTokens - (cacheReadTokens ?? 0) - (cacheWriteTokens ?? 0),
       outputTokens,
       reasoningTokens,
       cacheReadTokens,

--- a/packages/console/app/test/providerUsage.test.ts
+++ b/packages/console/app/test/providerUsage.test.ts
@@ -103,4 +103,60 @@ describe("provider usage extraction", () => {
       (normalized.cacheWrite1hTokens ?? 0)
     expect(promptTokens).toBe(2600)
   })
+
+  // The invariant above is not OpenAI-specific: handler.ts adds the same four
+  // buckets for every provider to pick the long-context tier. The wire shapes
+  // disagree about whether the cache buckets live inside the prompt count --
+  // OpenAI's input_tokens includes them, Anthropic's excludes them, Google has
+  // no cache-write bucket at all -- so the guard belongs on the normalized
+  // side, where all three must agree. Same 2,600-token prompt three ways.
+  test("every helper partitions the prompt into the same four buckets", () => {
+    const cases = [
+      {
+        name: "openai",
+        expectedInput: 200,
+        normalized: providers.openai.normalizeUsage({
+          input_tokens: 2600,
+          input_tokens_details: { cached_tokens: 2000, cache_write_tokens: 400 },
+          output_tokens: 10,
+        }),
+      },
+      {
+        name: "anthropic",
+        expectedInput: 200,
+        normalized: providers.anthropic.normalizeUsage({
+          input_tokens: 200,
+          cache_read_input_tokens: 2000,
+          cache_creation: { ephemeral_5m_input_tokens: 400 },
+          output_tokens: 10,
+        }),
+      },
+      {
+        name: "google",
+        expectedInput: 600,
+        normalized: providers.google.normalizeUsage(
+          providers.google.extractUsage({
+            usageMetadata: {
+              promptTokenCount: 2600,
+              cachedContentTokenCount: 2000,
+              candidatesTokenCount: 10,
+            },
+          }),
+        ),
+      },
+    ]
+
+    for (const { name, expectedInput, normalized } of cases) {
+      const promptTokens =
+        normalized.inputTokens +
+        (normalized.cacheReadTokens ?? 0) +
+        (normalized.cacheWrite5mTokens ?? 0) +
+        (normalized.cacheWrite1hTokens ?? 0)
+      expect({ name, inputTokens: normalized.inputTokens, promptTokens }).toEqual({
+        name,
+        inputTokens: expectedInput,
+        promptTokens: 2600,
+      })
+    }
+  })
 })

--- a/packages/console/app/test/providerUsage.test.ts
+++ b/packages/console/app/test/providerUsage.test.ts
@@ -73,12 +73,34 @@ describe("provider usage extraction", () => {
     )
 
     expect(providers.openai.normalizeUsage(usageParser.retrieve())).toEqual({
-      inputTokens: 6,
+      inputTokens: 3,
       outputTokens: 2,
       reasoningTokens: undefined,
       cacheReadTokens: 4,
       cacheWrite5mTokens: 3,
       cacheWrite1hTokens: undefined,
     })
+  })
+
+  test("OpenAI cache buckets are subsets of input_tokens, not addends", () => {
+    // The sample from OpenAI's prompt-caching guide: 2600 input tokens made up of
+    // 2000 read from cache, 400 newly written, and 200 that were neither.
+    const normalized = providers.openai.normalizeUsage({
+      input_tokens: 2600,
+      input_tokens_details: { cached_tokens: 2000, cache_write_tokens: 400 },
+      output_tokens: 10,
+    })
+
+    expect(normalized.inputTokens).toBe(200)
+
+    // The four buckets must partition the prompt exactly -- handler.ts adds them
+    // up to pick the long-context tier, and double-counting the written tokens
+    // trips that threshold early.
+    const promptTokens =
+      normalized.inputTokens +
+      (normalized.cacheReadTokens ?? 0) +
+      (normalized.cacheWrite5mTokens ?? 0) +
+      (normalized.cacheWrite1hTokens ?? 0)
+    expect(promptTokens).toBe(2600)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Refs #42910 (comment: https://github.com/anomalyco/opencode/issues/42910#issuecomment-5382367625). Independent of #44223, which fixes the local-side `experimentalOver200K` fallback.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`normalizeUsage` in the Zen OpenAI helper subtracts `cached_tokens` from `input_tokens` but leaves `cache_write_tokens` in. Both are subsets of `input_tokens`, per OpenAI's own sample in the prompt-caching guide:

```
usage.input_tokens = 2600
usage.input_tokens_details.cached_tokens = 2000
usage.input_tokens_details.cache_write_tokens = 400
```

> In this example, 2,000 tokens were read from the cache and 400 additional tokens were written.
> The remaining 200 input tokens were neither read nor written.

2,000 + 400 + 200 = 2,600 — https://developers.openai.com/api/docs/guides/prompt-caching

So the written tokens stayed inside `inputTokens` *and* were reported as `cacheWrite5mTokens`, and `handler.ts` uses those buckets two ways:

**1. Long-context threshold trips early.** `calculateCost` sums all four buckets to pick the tier. Substituting, that sum is `(input_tokens − cached) + cached + written` = `input_tokens + written` — over the real prompt by exactly `cache_write_tokens`, every request. On a well-cached turn `written ≈ inputTokens`, so the sum runs near 2× the prompt and the gate trips at roughly half the real context. This matches what @Zaczero measured on a 302-request Luna burst in #42910: `inputTokens` and `cacheWrite5mTokens` differing by 3 on almost every row (that 3 is the "neither read nor written" remainder), 94 requests in the 200–272k band paying the high rate, +$2.53 on one afternoon.

**2. The same tokens are billed twice.** `inputCost = modelCost.input * inputTokens` charges the written tokens at the input rate, then `cacheWrite5mCost = modelCost.cacheWrite5m * cacheWrite5mTokens` charges them again. OpenAI rules that out explicitly: *"Tokens written to the cache are billed at 1.25× the uncached input token rate."* … *"It is not an additional charge on top of another full input-token charge."* On `gpt-5.6-luna` ($0.20/M input) a written token should cost $0.25/M and is billed $0.45/M — 1.8×, on every cached request, regardless of any threshold.

One line fixes both.

`session.ts` already does this correctly on the local side (it subtracts both, with a comment explaining why), so this brings Zen in line with it.

**Anthropic is deliberately untouched** and must stay that way — Anthropic's `input_tokens` genuinely excludes both cache buckets, so `anthropic.ts` is right to pass it through and the four-bucket sum is already correct there. Google has no cache-write bucket. That asymmetry is why the fix belongs in `openai.ts` rather than in `calculateCost`.

### How did you verify your code works?

`packages/console/app/test/providerUsage.test.ts`:

- The existing "parses OpenAI stream cache write usage" case (`input_tokens: 10`, `cached_tokens: 4`, `cache_write_tokens: 3`) expected `inputTokens: 6`; it now expects `3`. That existing expectation was pinning the bug, so it changes with the fix rather than being worked around.
- New case using OpenAI's documented sample verbatim: `2600 / 2000 / 400` → `inputTokens: 200`, plus an assertion that the four buckets sum back to exactly `2600`, which is the invariant `handler.ts` relies on for the tier.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
