### PR TITLE
fix(tui): drop NUL characters before clipboard writes

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -118,7 +118,13 @@ function getCopyMethod() {
   })())
 }
 
-export async function write(text: string) {
+export function withoutNul(text: string) {
+  // Host clipboard backends reject NUL bytes (e.g. spawn refuses argv containing them), so they must be dropped first.
+  return text.replace(/\0/g, "")
+}
+
+export async function write(input: string) {
+  const text = withoutNul(input)
   writeOsc52(text)
   const method = await getCopyMethod()
   await method(text)

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { copyCommand } from "../src/clipboard"
+import { copyCommand, withoutNul } from "../src/clipboard"
 
 test("prefers Wayland clipboard when available", () => {
   expect(copyCommand("linux", true, (name) => name === "wl-copy")).toEqual(["wl-copy"])
@@ -16,4 +16,9 @@ test("falls back through X11 clipboard commands", () => {
 
 test("returns undefined when native clipboard is unavailable", () => {
   expect(copyCommand("linux", false, () => false)).toBeUndefined()
+})
+
+test("drops NUL characters before writing", () => {
+  expect(withoutNul("before\0after")).toBe("beforeafter")
+  expect(withoutNul("clean")).toBe("clean")
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44198

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shell output can contain NUL characters, and clipboard backends reject text that contains them (e.g. spawn refuses argv with NUL bytes on macOS), so `/copy` fails and the clipboard is left unchanged. This drops NUL characters from the text in `write()` before it reaches any backend (OSC52 included), matching the behavior requested in the issue.

### How did you verify your code works?

- Added a unit test for `withoutNul` covering NUL-containing and clean input (`bun test test/clipboard.test.ts` in `packages/tui`, all pass).
- Ran `bun run typecheck` in `packages/tui` successfully.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR