### PR TITLE
fix(provider): ignore GITHUB_TOKEN when activating github-copilot

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1579,6 +1579,8 @@ const layer = Layer.effect(
         for (const [id, provider] of Object.entries(database)) {
           const providerID = ProviderV2.ID.make(id)
           if (disabled.has(providerID)) continue
+          // GITHUB_TOKEN is commonly set for GitHub tooling; github-copilot must only activate through its OAuth plugin flow.
+          if (providerID === ProviderV2.ID.githubCopilot) continue
           const apiKey = provider.env.map((item) => envs[item]).find(Boolean)
           if (!apiKey) continue
           mergeProvider(providerID, {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -121,6 +121,14 @@ it.instance("provider loaded from env variable", () =>
   }),
 )
 
+it.instance("GITHUB_TOKEN does not activate github-copilot", () =>
+  Effect.gen(function* () {
+    yield* setProcessEnv("GITHUB_TOKEN", "test-github-token")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.githubCopilot]).toBeUndefined()
+  }),
+)
+
 it.instance(
   "provider loaded from config with apiKey option",
   Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #44113

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The models.dev catalog lists `GITHUB_TOKEN` as an env var for `github-copilot`, so the generic env activation loop treats any `GITHUB_TOKEN` (often set for GitHub tooling) as a Copilot credential and loads the provider with source env. That bypasses the Copilot OAuth plugin, model discovery, and endpoint routing, which sends models like `gpt-5.6-sol` to `/chat/completions` where they fail.

This skips `github-copilot` in the env activation loop so the provider only activates through its OAuth plugin flow. Generic env activation for all other providers is unchanged.

### How did you verify your code works?

- Added a regression test: with `GITHUB_TOKEN` set, `github-copilot` no longer appears in loaded providers (`bun test test/provider/provider.test.ts -t GITHUB_TOKEN` passes; it fails without the fix).
- Ran `bun run typecheck` and the full `test/provider/provider.test.ts` suite locally.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR