### PR TITLE
fix(tui): clear answer editing state when selecting other options

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -98,6 +98,8 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   }
 
   function selectTab(index: number) {
+    // Re-clicking the active tab must not disturb an open custom-answer editor.
+    if (index === store.tab) return
     setStore("tab", index)
     setStore("selected", 0)
     // Mouse handlers switch tabs while the custom-answer editor is open; stale editing
@@ -107,6 +109,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
 
   function selectOption() {
     if (other()) {
+      // Opens the editor; must return before any unconditional editing reset below.
       if (!multi()) {
         setStore("editing", true)
         return

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -100,6 +100,9 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   function selectTab(index: number) {
     setStore("tab", index)
     setStore("selected", 0)
+    // Mouse handlers switch tabs while the custom-answer editor is open; stale editing
+    // state would keep Return bound to the editor on the new tab.
+    setStore("editing", false)
   }
 
   function selectOption() {
@@ -118,6 +121,9 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     }
     const opt = options()[store.selected]
     if (!opt) return
+    // Mouse handlers reach this while the custom-answer editor is open; leaving it enabled
+    // keeps Return bound to the editor instead of submit/confirm.
+    setStore("editing", false)
     if (multi()) {
       toggle(opt.label)
       return


### PR DESCRIPTION
### Issue for this PR

Closes #44192

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Mouse handlers call `selectOption()`/`selectTab()` directly and bypass the `enabled: !store.editing` gate on the keybindings. So after selecting "Type your own answer" (editing mode), clicking a preset option (or another question tab) picks it but leaves `store.editing` stuck on `true`. At the confirm tab both binding sets then refuse Return - the editing set requires `!confirm()` and the normal set requires `!store.editing` - so the answers can never be submitted.

This clears `editing` when a preset option is picked or the tab changes. Selecting the custom row still enters edit mode as before; keyboard-only flows are unchanged since those keys are already gated off while editing.

### How did you verify your code works?

- Reproduced the flow locally in the TUI: select "Type your own answer", click a preset option, advance to confirm, Enter does nothing before this change and submits after.
- Keyboard-only flow (escape out of editor, arrows, enter) behaves as before.
- `bun run typecheck` clean in `packages/tui`; existing tui test suite shows no new failures.

### Screenshots / recordings

Not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
