### PR TITLE
fix(provider): send Anthropic's dashed native slug through the AI Gateway

### DIFF
--- a/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
+++ b/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
@@ -33,7 +33,11 @@ export const CloudflareAIGatewayPlugin = define({
             // gateway's stored/BYOK keys instead.
             const isWorkersAi = modelID.startsWith("workers-ai/") || modelID.startsWith("@cf/")
             const unified = createUnified(isWorkersAi ? { apiKey: config.apiKey } : {})
-            return gateway(unified(modelID))
+            // models.dev lists Anthropic ids with dotted versions (claude-haiku-4.5) but Anthropic's
+            // real slugs use dashes (claude-haiku-4-5). The Unified API forwards the id straight to
+            // the upstream provider, so a dotted Anthropic id 404s. Other providers use dots natively.
+            const upstreamID = modelID.startsWith("anthropic/") ? modelID.replaceAll(".", "-") : modelID
+            return gateway(unified(upstreamID))
           },
         }
       }),

--- a/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
+++ b/packages/core/test/plugin/provider-cloudflare-ai-gateway.test.ts
@@ -401,6 +401,61 @@ describe("CloudflareAIGatewayPlugin", () => {
     ),
   )
 
+  it.effect("translates models.dev's dotted Anthropic ids to Anthropic's native dashed slugs", () =>
+    withEnv(cloudflareEnv(), () =>
+      Effect.gen(function* () {
+        resetCalls()
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(
+              ProviderV2.ID.make("cloudflare-ai-gateway"),
+              ModelV2.ID.make("anthropic/claude-haiku-4.5"),
+            ),
+            api: {
+              id: ModelV2.ID.make("anthropic/claude-haiku-4.5"),
+              type: "aisdk",
+              package: "test-provider",
+            },
+          }),
+          package: "ai-gateway-provider",
+          options: { name: "cloudflare-ai-gateway" },
+        })
+
+        result.sdk.languageModel("anthropic/claude-haiku-4.5")
+
+        expect(unifiedCalls).toEqual(["anthropic/claude-haiku-4-5"])
+      }),
+    ),
+  )
+
+  it.effect("leaves non-Anthropic ids with dots untouched (e.g. OpenAI's gpt-4.1)", () =>
+    withEnv(cloudflareEnv(), () =>
+      Effect.gen(function* () {
+        resetCalls()
+        const plugin = yield* PluginV2.Service
+        const aisdk = yield* AISDK.Service
+        yield* addPlugin()
+
+        const result = yield* aisdk.runSDK({
+          model: ModelV2.Info.make({
+            ...ModelV2.Info.empty(ProviderV2.ID.make("cloudflare-ai-gateway"), ModelV2.ID.make("openai/gpt-4.1")),
+            api: { id: ModelV2.ID.make("openai/gpt-4.1"), type: "aisdk", package: "test-provider" },
+          }),
+          package: "ai-gateway-provider",
+          options: { name: "cloudflare-ai-gateway" },
+        })
+
+        result.sdk.languageModel("openai/gpt-4.1")
+
+        expect(unifiedCalls).toEqual(["openai/gpt-4.1"])
+      }),
+    ),
+  )
+
   it.effect("ignores non Cloudflare AI Gateway packages", () =>
     withEnv(cloudflareEnv(), () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #44252

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every Anthropic model under `cloudflare-ai-gateway` fails with `Error: model: claude-haiku-4.5`, so none of them are usable.

The plugin already routes `anthropic/*` models through Anthropic's native Messages passthrough (`createAnthropic`), which forwards the sliced model id to Anthropic's API unchanged. models.dev lists Cloudflare's canonical **dotted** ids (`anthropic/claude-haiku-4.5`), but Anthropic's Messages API expects **dashed** native slugs (`claude-haiku-4-5`) — so it 404s.

The fix translates dots to dashes when slicing the `anthropic/` prefix. OpenAI is unaffected because its native slugs already use dots (`gpt-4.1`), which is why only Anthropic was broken.

Worth noting: Cloudflare's own catalog-aware REST endpoints (`/ai/v1/messages`, `/ai/run`) accept the dotted id and do this exact dot→dash translation internally before calling Anthropic. The native passthrough route this plugin uses forwards the slug raw, so the plugin has to do the same translation. The dotted id in models.dev is correct — it's Cloudflare's canonical id (see https://developers.cloudflare.com/ai/models/anthropic/claude-haiku-4.5/), so this is fixed on the opencode side, not in the catalog. (Context: surfaced while testing anomalyco/models.dev#4922.)

### How did you verify your code works?

- Built the single binary and ran against a live Cloudflare AI Gateway: `anthropic/claude-haiku-4.5` went from `Error: model: claude-haiku-4.5` to a normal completion; `openai/*` and `workers-ai/@cf/*` still work.
- Added a regression test in `cf-ai-gateway-e2e.test.ts` asserting a dotted Anthropic id reaches the Anthropic Messages wire as a dashed slug; confirmed it fails without the fix and passes with it.
- `bun test test/provider/` in `packages/opencode` passes (one unrelated pre-existing flake in `header-timeout.test.ts`, which also fails on `dev`). `tsgo --noEmit` clean.

### Screenshots / recordings

N/A (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
