### PR TITLE
fix(tui): avoid premature environment sync

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1101,6 +1101,9 @@ export function createData(config: CreateDataInput) {
       get(sessionID: string) {
         return store.session.info[sessionID]
       },
+      creating(sessionID: string) {
+        return creating.has(sessionID)
+      },
       remember(info: SessionInfo) {
         setStore("session", "info", info.id, reconcile(info))
         sync.complete(`session:${info.id}`)

--- a/packages/client/test/solid-data.test.ts
+++ b/packages/client/test/solid-data.test.ts
@@ -1,4 +1,4 @@
-import { test } from "bun:test"
+import { expect, test } from "bun:test"
 import { createRoot } from "solid-js"
 import { createData, type CreateDataInput } from "../src/solid"
 import { OpenCode, type OpenCodeEvent, type SessionInfo } from "../src/promise"
@@ -67,6 +67,37 @@ test("revalidates after an event overtakes an active session read", async () => 
     await initial
 
     await wait(() => requests === 2 && setup.data.session.get("ses_refresh")?.time.viewed === 2)
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("reports optimistic sessions as creating until the request settles", async () => {
+  const release = Promise.withResolvers<void>()
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      if (!request.url.endsWith("/api/session")) throw new Error(`Unexpected request: ${request.url}`)
+      await release.promise
+      return Response.json({ data: session(0) })
+    },
+  })
+  const event: CreateDataInput["event"] = {
+    on: () => () => {},
+    listen: () => () => {},
+  }
+  const setup = createRoot((dispose) => ({
+    data: createData({ api: () => api, directory: "/project", event, connection: { status: () => "connected" } }),
+    dispose,
+  }))
+
+  try {
+    const created = setup.data.session.create({ id: "ses_refresh", location: { directory: "/project" } })
+    expect(setup.data.session.creating(created.id)).toBe(true)
+    release.resolve()
+    await created.request
+    expect(setup.data.session.creating(created.id)).toBe(false)
   } finally {
     setup.dispose()
   }

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -486,6 +486,7 @@ function App(props: { pair?: DialogPairCredentials }) {
     if (route.data.type !== "session") return
     const session = data.session.get(route.data.sessionID)
     if (!session) return
+    if (data.session.creating(session.id)) return
     if (session.location.workspaceID !== undefined || terminalEnvironment.variables === undefined) return
     void client.api.session
       .environment({ sessionID: session.id, variables: terminalEnvironment.variables })


### PR DESCRIPTION
### What does this PR do?

Prevents the app-level terminal environment sync from running against an optimistic session that does not exist on the server yet.

Optimistic session creation makes the local session visible before its create request settles. The app-level sync previously observed that placeholder and sent `PUT /api/session/:id/environment`, producing a transient 404 and an `An unknown error has occurred` toast. New-session submission already syncs the environment after creation and gates prompt admission on that setup.

This exposes the client data layer's existing in-flight creation state and skips only the premature duplicate sync. Existing durable sessions continue to sync on mount as before.

### How did you verify your code works?

- `bun test test/solid-data.test.ts` from `packages/client`
- `bun typecheck` from `packages/client`
- `bun typecheck` from `packages/tui`
- `bun test` from `packages/tui` (747 passed, 5 skipped)