### PR TITLE
fix(core): skip models.dev refresh event when the catalog is unchanged

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -541,6 +541,9 @@ const decodeCatalog = (text: string) =>
   Schema.decodeUnknownEffect(CatalogJson)(text).pipe(Effect.map((catalog) => catalog as Record<string, SourceProvider>))
 const Cache = Schema.Struct({
   updatedAt: Schema.Number,
+  // Digest of the raw body, persisted so refresh() can skip republishing a
+  // byte-identical catalog. Optional for entries written before it existed.
+  digest: Schema.optional(Schema.String),
   body: CatalogJson,
 })
 const defaultSource = "https://models.opencode.ai"
@@ -566,6 +569,10 @@ const bundledSnapshot = Effect.suspend(() =>
 function cacheKey(source: string) {
   if (source === defaultSource) return "models-dev:catalog"
   return `models-dev:catalog:${Hash.fast(source)}`
+}
+
+export function bodyDigest(text: string) {
+  return new Bun.CryptoHasher("sha256").update(text).digest("hex")
 }
 
 export const layer = (options?: Options) =>
@@ -600,14 +607,9 @@ export const layer = (options?: Options) =>
           return {
             catalog: cached.value.body as Record<string, SourceProvider>,
             updatedAt: cached.value.updatedAt,
+            digest: cached.value.digest,
           }
         if (value !== undefined) yield* kv.remove(key)
-      })
-
-      const fresh = Effect.fnUntraced(function* () {
-        const cached = yield* loadFromCache()
-        if (!cached) return false
-        return Date.now() - cached.updatedAt < Duration.toMillis(ttl)
       })
 
       const fetchApi = Effect.fn("ModelsDev.fetchApi")(function* () {
@@ -630,19 +632,23 @@ export const layer = (options?: Options) =>
       // periodic fetch below still refreshes on top.
       const loadSnapshot = options?.snapshot === false ? Effect.undefined : bundledSnapshot
 
-      const fetchAndWrite = Effect.fn("ModelsDev.fetchAndWrite")(function* () {
-        const text = yield* fetchApi()
-        const catalog = yield* decodeCatalog(text)
-        // Best-effort: a cache-write failure must never kill catalog
-        // population. The payload has outgrown some KV backends' per-value
-        // limits (Durable Object SQLite caps values at 2 MB and api.json
-        // passed it in Aug 2026); a boot without a cache hit just refetches.
-        yield* kv.set(key, { updatedAt: Date.now(), body: text }).pipe(
+      // Best-effort: a cache-write failure must never kill catalog
+      // population. The payload has outgrown some KV backends' per-value
+      // limits (Durable Object SQLite caps values at 2 MB and api.json
+      // passed it in Aug 2026); a boot without a cache hit just refetches.
+      const writeCache = Effect.fn("ModelsDev.writeCache")(function* (text: string) {
+        yield* kv.set(key, { updatedAt: Date.now(), digest: bodyDigest(text), body: text }).pipe(
           Effect.catchCauseIf(
             (cause) => !Cause.hasInterruptsOnly(cause),
             (cause) => Effect.logWarning("Failed to cache models.dev catalog", { cause }),
           ),
         )
+      })
+
+      const fetchAndWrite = Effect.fn("ModelsDev.fetchAndWrite")(function* () {
+        const text = yield* fetchApi()
+        const catalog = yield* decodeCatalog(text)
+        yield* writeCache(text)
         return catalog
       })
 
@@ -672,8 +678,15 @@ export const layer = (options?: Options) =>
         yield* lock
           .withPermit(
             Effect.gen(function* () {
-              if (!force && (yield* fresh())) return
-              yield* fetchAndWrite()
+              const stored = yield* loadFromCache()
+              if (!force && stored && Date.now() - stored.updatedAt < Duration.toMillis(ttl)) return
+              const text = yield* fetchApi()
+              // models.dev rarely changes between polls; skip the cache write,
+              // invalidation, and Refreshed event for a byte-identical body so
+              // downstream catalog.updated listeners stay quiet.
+              if (!force && stored?.digest === bodyDigest(text)) return
+              yield* decodeCatalog(text)
+              yield* writeCache(text)
               yield* invalidate
               yield* bus.publish(ModelsDev.Event.Refreshed, {})
             }),

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test"
 import { Money } from "@opencode-ai/schema/money"
-import { Effect, Layer, Ref } from "effect"
+import { Effect, Fiber, Layer, Ref, Scope, Stream } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNodePlatform } from "@opencode-ai/util/effect/app-node-platform"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Bus } from "@opencode-ai/core/bus"
 import { KV } from "@opencode-ai/core/kv"
 import { Model } from "@opencode-ai/core/model"
-import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { bodyDigest, ModelsDev } from "@opencode-ai/core/models-dev"
 import { Provider } from "@opencode-ai/core/provider"
 import { it } from "./lib/effect"
 
@@ -180,7 +181,7 @@ const buildLayer = (state: Ref.Ref<MockState>, cache: MockCache, options: Models
   // and Effect.provide uses a process-global MemoMap by default — without fresh,
   // every test would reuse the cachedInvalidateWithTTL state from the first run.
   Layer.fresh(
-    AppNodeBuilder.build(ModelsDev.node, [
+    AppNodeBuilder.build(LayerNode.group([ModelsDev.node, Bus.node]), [
       [ModelsDev.node, ModelsDev.configured(options)],
       [LayerNodePlatform.httpClient, Layer.succeed(HttpClient.HttpClient, makeMockClient(state))],
       [KV.node, makeMockKV(cache)],
@@ -199,13 +200,16 @@ const makeFailingWriteKV = (cache: MockCache) =>
 const makeCache = (): MockCache => ({ values: new Map() })
 
 const writeCacheText = (cache: MockCache, text: string, updatedAt = Date.now()) =>
-  cache.values.set(cacheKey, { updatedAt, body: text })
+  cache.values.set(cacheKey, { updatedAt, digest: bodyDigest(text), body: text })
 
 const writeCache = (cache: MockCache, data: object, updatedAt?: number) =>
   writeCacheText(cache, JSON.stringify(data), updatedAt)
 
-const provided = <A, E>(state: Ref.Ref<MockState>, cache: MockCache, eff: Effect.Effect<A, E, ModelsDev.Service>) =>
-  eff.pipe(Effect.provide(buildLayer(state, cache)))
+const provided = <A, E>(
+  state: Ref.Ref<MockState>,
+  cache: MockCache,
+  eff: Effect.Effect<A, E, ModelsDev.Service | Bus.Service | Scope.Scope>,
+) => eff.pipe(Effect.provide(buildLayer(state, cache)))
 
 const initialState: MockState = {
   body: JSON.stringify(fixture),
@@ -391,13 +395,92 @@ describe("ModelsDev Service", () => {
         cache,
         Effect.gen(function* () {
           const svc = yield* ModelsDev.Service
-          yield* svc.refresh(false)
+          const bus = yield* Bus.Service
+          const refreshed = yield* bus.subscribe(ModelsDev.Event.Refreshed).pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkScoped,
+            Effect.flatMap((fiber) =>
+              Effect.gen(function* () {
+                yield* Effect.yieldNow
+                yield* svc.refresh(false)
+                return yield* Fiber.join(fiber)
+              }),
+            ),
+          )
+          expect(refreshed.length).toBe(1)
           return yield* svc.get()
         }),
       )
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBe(1)
       expect(after).toEqual(fixture2Snapshot)
+    }),
+  )
+
+  it.live("refresh(false) stays quiet when the fetched body matches the cached digest", () =>
+    Effect.gen(function* () {
+      const cache = makeCache()
+      writeCache(cache, fixture, Date.now() - 10 * 60 * 1000)
+      const seeded = structuredClone(cache.values.get(cacheKey))
+      // The server serves a byte-identical body, so the refresh still hits
+      // the network but must not rewrite the cache or publish Refreshed.
+      const state = yield* Ref.make(initialState)
+      yield* provided(
+        state,
+        cache,
+        Effect.gen(function* () {
+          const svc = yield* ModelsDev.Service
+          const bus = yield* Bus.Service
+          const event = yield* bus.subscribe(ModelsDev.Event.Refreshed).pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkScoped,
+            Effect.flatMap((fiber) =>
+              Effect.gen(function* () {
+                yield* Effect.yieldNow
+                yield* svc.refresh(false)
+                return yield* Fiber.join(fiber).pipe(Effect.timeoutOption("50 millis"))
+              }),
+            ),
+          )
+          expect(event._tag).toBe("None")
+        }),
+      )
+      const final = yield* Ref.get(state)
+      expect(final.calls.length).toBe(1)
+      expect(cache.values.get(cacheKey)).toEqual(seeded)
+    }),
+  )
+
+  it.live("refresh(false) republishes once for legacy cache entries without a digest", () =>
+    Effect.gen(function* () {
+      const cache = makeCache()
+      cache.values.set(cacheKey, { updatedAt: Date.now() - 10 * 60 * 1000, body: JSON.stringify(fixture) })
+      const state = yield* Ref.make(initialState)
+      yield* provided(
+        state,
+        cache,
+        Effect.gen(function* () {
+          const svc = yield* ModelsDev.Service
+          const bus = yield* Bus.Service
+          const refreshed = yield* bus.subscribe(ModelsDev.Event.Refreshed).pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkScoped,
+            Effect.flatMap((fiber) =>
+              Effect.gen(function* () {
+                yield* Effect.yieldNow
+                yield* svc.refresh(false)
+                return yield* Fiber.join(fiber)
+              }),
+            ),
+          )
+          expect(refreshed.length).toBe(1)
+        }),
+      )
+      // The rewritten entry now carries a digest, so later identical bodies stay quiet.
+      expect(cache.values.get(cacheKey)).toMatchObject({ digest: bodyDigest(JSON.stringify(fixture)) })
     }),
   )
 


### PR DESCRIPTION
## Problem

The models.dev service repeats `refresh()` every 5 minutes (`Schedule.spaced(ttl)`), and because the repeat interval equals the freshness TTL, every cycle fetched a new body, rewrote the multi-MB KV entry, invalidated the memoized catalog, and published `ModelsDev.Event.Refreshed` — **even when api.json was byte-identical**.

That triggered the full downstream chain on every cycle with no content change:

1. `Refreshed` → the `opencode.models.dev` plugin re-runs its integration/catalog transforms (`ctx.catalog.reload()`)
2. `Catalog.finalize` publishes `catalog.updated` unconditionally (no diffing)
3. Every listener churns: the TUI subscribes to `catalog.updated`, and the event logger writes it

## Fix

Persist a sha256 digest of the raw response body alongside the KV cache entry. `refresh()` still fetches each cycle (same cadence as before), but when the new body is byte-identical to the cached one it now skips:

- the cache rewrite (saves a multi-MB KV write per cycle — notable given Durable Object SQLite's 2 MB value cap noted in the existing comment)
- the catalog invalidation
- the `Refreshed` publish

`refresh(true)` (explicit force) bypasses both the freshness check and the digest skip, preserving its "reload now" semantics for callers like tests/CLI.

Legacy cache entries written before this change have no digest; they decode fine via the optional schema field and publish once before self-correcting.

## Notes

- The server does serve an ETag (`models.opencode.ai/api.json`, Cloudflare), so conditional `If-None-Match` requests could additionally save bandwidth. That is left out of scope here: 304 handling would need special-casing around `HttpClient.filterStatusOk` + `retryTransient` (304 is not an ok status and would be retried). The digest comparison achieves the behavioral goal with no protocol complexity.
- Only subscriber of `Refreshed` is the models-dev plugin, so no other call sites are affected.

## Testing

- Extended `refresh(false) fetches when stale` to assert one `Refreshed` event is published on a real content change
- New: unchanged byte-identical body → HTTP still hit once, but no `Refreshed` event and cache entry untouched
- New: legacy entry without digest → republishes exactly once and persists the digest
- All 15 tests in `packages/core/test/models.test.ts` pass; `bun typecheck` clean in `packages/core`