### PR TITLE
fix(client): tolerate slow event connections

### DIFF
--- a/packages/client/src/solid/connection.ts
+++ b/packages/client/src/solid/connection.ts
@@ -24,7 +24,7 @@ export type ClientConnectionOptions = {
   }
 }
 
-const connectTimeout = 2_000
+const connectTimeout = 30_000
 const reconnectDelay = 1_000
 const connectionHistoryLimit = 50
 


### PR DESCRIPTION
## Summary

- extend the initial SSE handshake timeout from 2 seconds to 30 seconds
- prevent slow or high-latency connections from repeatedly cancelling `/api/event` before `server.connected` arrives
- retain the existing reconnect behavior for failed streams

## Testing

- `bun typecheck` (`packages/client`)
- `bun typecheck` (`packages/app`)
- pre-push workspace typecheck
- `bun test` (`packages/client`): 61 passed; one unrelated generated-client surface assertion fails because `question` is absent