### PR TITLE
fix(app): skip service worker in development

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -42,7 +42,7 @@ const clearAuthToken = () => {
 
 const web = createWebPlatform(pkg.version)
 
-if ("serviceWorker" in navigator) {
+if (import.meta.env.PROD && "serviceWorker" in navigator) {
   window.addEventListener("load", () => void navigator.serviceWorker.register("/sw.js"), { once: true })
 }
 


### PR DESCRIPTION
## Summary
- register `/sw.js` only in production
- keep development and Playwright on the PWA plugin's default `devOptions.enabled: false` path

## Root cause
#44294 switched to manual registration but registered the production `/sw.js` URL during Vite development. The development server has no generated worker at that URL and returns the HTML fallback, which Chromium rejects as an unsupported service-worker MIME type.

The plugin's manual-registration documentation requires either production-only `/sw.js` registration or the generated `/dev-sw.js?dev-sw` path when development workers are explicitly enabled.

## Testing
- failing timeline smoke test passes locally
- `bun typecheck` in `packages/app` passes
- no service-worker MIME error is emitted in development