### PR TITLE
docs(providers): fix OAuth wording in self-hosted GitLab setup

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1009,7 +1009,7 @@ Your GitLab administrator must:
 
 ##### OAuth for Self-Hosted instances
 
-In order to make Oauth working for your self-hosted instance, you need to create
+In order to make OAuth work for your self-hosted instance, you need to create
 a new application (Settings → Applications) with the
 callback URL `http://127.0.0.1:8080/callback` and following scopes:
 


### PR DESCRIPTION
### Issue for this PR

Closes #44308

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Corrects the OAuth casing and grammar in the self-hosted GitLab setup instructions. The wording now matches the heading directly above it and the other OAuth references on the page.

### How did you verify your code works?

- `bun run --cwd packages/web build` (Bun 1.3.14)
- `git diff --check`
- Verified the generated Providers page contains the corrected sentence

### Screenshots / recordings

Not applicable — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR