### PR TITLE
fix(app): synchronize composer model controls

### DIFF
--- a/packages/app/src/composer/composer.tsx
+++ b/packages/app/src/composer/composer.tsx
@@ -29,7 +29,7 @@ export function Composer(props: {
         accentSubmit={props.accentSubmit}
         borderUnderlay={props.borderUnderlay}
         class={props.class}
-        variantControlVisible={!props.model.model.loading}
+        modelControlsVisible={!props.model.model.loading}
         attachKeybind={command.keybindParts("file.attach")}
         attachShortcut={command.keybind("file.attach")}
         modelControl={

--- a/packages/app/src/composer/editor/editor.tsx
+++ b/packages/app/src/composer/editor/editor.tsx
@@ -42,7 +42,7 @@ export type ComposerEditorProps = {
   borderUnderlay?: boolean
   class?: string
   modelControl?: JSX.Element
-  variantControlVisible?: boolean
+  modelControlsVisible?: boolean
   attachKeybind?: string[]
   attachShortcut?: string
 }
@@ -233,17 +233,19 @@ export function ComposerEditor(props: ComposerEditorProps) {
                 />
               )}
             </Show>
-            {props.modelControl}
-            <Show when={(props.variantControlVisible ?? true) && view.variant} keyed>
-              {(control) => (
-                <Show when={control.options().length > 1}>
-                  <ComposerEditorConfiguredSelect
-                    title={i18n.t("ui.promptInput.chooseVariant")}
-                    keybind={["Shift", "Mod", "D"]}
-                    control={control}
-                  />
-                </Show>
-              )}
+            <Show when={props.modelControlsVisible ?? true}>
+              {props.modelControl}
+              <Show when={view.variant} keyed>
+                {(control) => (
+                  <Show when={control.options().length > 1}>
+                    <ComposerEditorConfiguredSelect
+                      title={i18n.t("ui.promptInput.chooseVariant")}
+                      keybind={["Shift", "Mod", "D"]}
+                      control={control}
+                    />
+                  </Show>
+                )}
+              </Show>
             </Show>
           </div>
           <ComposerEditorSubmitButton


### PR DESCRIPTION
## Summary
- Gate the model selector and variant selector behind the same loading state.
- Prevent the variant selector from appearing before the model list.

## Validation
- `bun typecheck` in `packages/app`