### PR TITLE
fix(session-ui): reduce tool error spacing

### DIFF
--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -1,6 +1,6 @@
 [data-component="card"][data-kind="tool-error-card"] {
-  --card-pad-y: 8px;
-  --card-line-pad: 12px;
+  --card-pad-y: 0px;
+  --card-line-pad: 4px;
 
   [data-slot="basic-tool-tool-title"] {
     color: var(--v2-text-text-base);


### PR DESCRIPTION
## Summary
- Remove excess card padding around single-line tool failures.
- Align failed tool row spacing with the originating tool call.

## Validation
- `bun typecheck` in `packages/session-ui`.