### PR TITLE
fix(app): reuse global model state

### DIFF
--- a/packages/app/e2e/performance/timeline/first-navigation-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/first-navigation-benchmark.spec.ts
@@ -53,6 +53,37 @@ benchmark.describe("performance: first navigation paint", () => {
     expect(result.summary.unknownSamples).toBe(0)
   })
 
+  benchmark("opens a session from the new session page without a blank frame", async ({ page, report }) => {
+    await mockStressTimeline(page)
+    await installTimelineSettings(page)
+    await installStressSessionTabs(page, { draftID })
+    await page.goto("/")
+
+    const draftHref = stressDraftHref(draftID)
+    const draftTab = page.locator(`[data-slot="titlebar-tabs"] a[href="${draftHref}"]`)
+    await expect(draftTab).toHaveCount(1)
+    await draftTab.click()
+    await expect(page.locator('[data-component="new-session"]')).toBeVisible()
+
+    const href = stressSessionHref(fixture.targetID)
+    const sessionTab = page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`)
+    await expect(sessionTab).toHaveCount(1)
+    const result = await measureFirstNavigation(page, {
+      href,
+      destinationPath: href,
+      sourceSelector: '[data-component="new-session"]',
+      destinationSelector: messageSelector(fixture.expected.targetMessageIDs.at(-1)!),
+      contentSelector,
+      navigate: async () => {
+        await sessionTab.click()
+        await expectSessionTitle(page, fixture.expected.targetTitle)
+      },
+    })
+    report(result)
+    expect(result.summary.blankSamples).toBe(0)
+    expect(result.summary.unknownSamples).toBe(0)
+  })
+
   benchmark("opens a child session without a blank frame", async ({ page, report }) => {
     await setup(page)
     const href = stressSessionHref(fixture.childID)

--- a/packages/app/src/providers/models/models.tsx
+++ b/packages/app/src/providers/models/models.tsx
@@ -1,44 +1,24 @@
-import { type Accessor, createMemo, createResource } from "solid-js"
-import { createStore } from "solid-js/store"
+import { type Accessor, createMemo } from "solid-js"
 import { DateTime } from "luxon"
 import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/providers/catalog/providers"
-import { Persist, persisted } from "@/runtime/persistence/storage"
+import { useGlobal } from "@/runtime/server/runtime"
 
 export type ModelKey = { providerID: string; modelID: string }
 
 type Visibility = "show" | "hide"
-type User = ModelKey & { visibility: Visibility; favorite?: boolean }
-type Store = {
-  user: User[]
-  recent: ModelKey[]
-  variant?: Record<string, string | undefined>
-}
-
 const RECENT_LIMIT = 5
 
 function modelKey(model: ModelKey) {
   return `${model.providerID}:${model.modelID}`
 }
 
-const createModelsPersistedState = () => {
-  const [store, setStore, _, ready] = persisted(
-    Persist.global("model"),
-    createStore<Store>({
-      user: [],
-      recent: [],
-      variant: {},
-    }),
-  )
-
-  return [store, setStore, ready] as const
-}
-
 const createModelsController = (directory: Accessor<string | undefined>) => {
   const providers = useProviders(() => directory())
-
-  const [store, setStore, ready] = createModelsPersistedState()
+  const models = useGlobal().models
+  const store = models.store
+  const setStore = models.set
 
   const available = createMemo(() =>
     providers.connected().flatMap((p) =>
@@ -148,23 +128,14 @@ const createModelsController = (directory: Accessor<string | undefined>) => {
     setStore("variant", key, value)
   }
 
-  const [recentModels] = createResource(
-    async () => {
-      const recent = store.recent
-      await ready.promise
-      return recent
-    },
-    (p) => p,
-    { initialValue: [] },
-  )
   return {
-    ready,
+    ready: models.ready,
     list,
     find,
     visible,
     setVisibility,
     recent: {
-      list: () => recentModels()!,
+      list: models.recent,
       push,
     },
     variant: {

--- a/packages/app/src/runtime/server/runtime.tsx
+++ b/packages/app/src/runtime/server/runtime.tsx
@@ -1,5 +1,5 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
-import { Accessor, createEffect, createMemo, createRoot, getOwner } from "solid-js"
+import { Accessor, createEffect, createMemo, createResource, createRoot, getOwner } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createServerProjects, RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServers } from "./registry"
 import { pathKey } from "@/workspaces/path-key"
@@ -10,6 +10,7 @@ import { createData } from "@opencode-ai/client/solid"
 import type { ServerScope } from "@/runtime/server/scope"
 import { createServerPermissionState } from "@/session/requests/server-permission"
 import { createServerNotificationState } from "@/shell/notifications/notification"
+import { Persist, persisted } from "@/runtime/persistence/storage"
 
 export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext({
   name: "Global",
@@ -24,6 +25,7 @@ export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext(
         serverKey: undefined as ServerConnection.Key | undefined,
       },
     })
+    const models = createGlobalModels()
 
     const settingsServer = createMemo(() => {
       const list = server.list
@@ -86,12 +88,44 @@ export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext(
           },
         },
       },
+      models,
       ensureServerCtx(conn: ServerConnection.Any) {
         return ensureServerCtx(conn)
       },
     }
   },
 })
+
+function createGlobalModels() {
+  const [store, setStore, _, ready] = persisted(
+    Persist.global("model"),
+    createStore<{
+      user: Array<{ providerID: string; modelID: string; visibility: "show" | "hide"; favorite?: boolean }>
+      recent: Array<{ providerID: string; modelID: string }>
+      variant?: Record<string, string | undefined>
+    }>({
+      user: [],
+      recent: [],
+      variant: {},
+    }),
+  )
+  const [recent] = createResource(
+    async () => {
+      const value = store.recent
+      await ready.promise
+      return value
+    },
+    (value) => value,
+    { initialValue: [] },
+  )
+
+  return {
+    store,
+    set: setStore,
+    ready,
+    recent: () => recent()!,
+  }
+}
 
 function createServerController(
   conn: ServerConnection.Any,


### PR DESCRIPTION
## Summary
- Create persisted model state once in the global runtime.
- Reuse model readiness and recent-model state across route transitions.
- Cover new-session to session navigation in the first-paint benchmark.

## Validation
- `bun typecheck` in `packages/app`