### PR TITLE
fix(app): align background hint spacing

### DIFF
--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -505,7 +505,7 @@ function MessageTimelineView(
               ref={setBackgroundHintRef}
               class="duration-150 motion-reduce:animate-none"
               classList={{
-                [`flex h-8 items-start pt-2 ${turnPadding()}`]: true,
+                [`flex h-9 items-start pt-3 ${turnPadding()}`]: true,
                 "animate-in fade-in": backgroundHintVisibility().animate && backgroundHintVisibility().show,
                 "animate-out fade-out fill-mode-forwards":
                   backgroundHintVisibility().animate && !backgroundHintVisibility().show,


### PR DESCRIPTION
## Summary

- align the bottom-spacer background hint with the 12px tool/step spacing rhythm
- preserve the hint content height while moving it down 4px

## Before / After

| Before | After |
| --- | --- |
| ![Before: background hint with 8px spacing](https://github.com/user-attachments/assets/6c6ee191-aef7-45c3-a338-e0da5718d084) | ![After: background hint aligned to 12px step spacing](https://github.com/user-attachments/assets/40382ad4-f0ca-4228-b5fe-aa34d05147e1) |

## Validation

- `bun typecheck` in `packages/app`
- repository pre-push typecheck
- deterministic before/after Playwright fixture capture at 960x540

## Benchmark

- attempted the production cached timeline repaint benchmark before and after the change
- the harness rendered a blank page and timed out waiting for the fixture session title in both runs, so no metrics were emitted
