### PR TITLE
fix(app): stabilize initial timeline rendering

### DIFF
--- a/packages/app/src/session/timeline/interaction.ts
+++ b/packages/app/src/session/timeline/interaction.ts
@@ -1,7 +1,7 @@
 import type { SessionMessageUser } from "@opencode-ai/client/promise"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLocation } from "@solidjs/router"
-import { createEffect, createSignal, on, onCleanup } from "solid-js"
+import { createEffect, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLayout } from "@/shell/state/layout"
 import type { SessionModel } from "../model"
@@ -19,6 +19,10 @@ export function createSessionTimelineInteraction(session: SessionModel) {
       overflow: false,
       jump: false,
     },
+    follow: {
+      sessionKey: session.identity.sessionKey(),
+      pinned: true,
+    },
     refs: {
       content: undefined as HTMLDivElement | undefined,
       dock: undefined as HTMLDivElement | undefined,
@@ -26,11 +30,11 @@ export function createSessionTimelineInteraction(session: SessionModel) {
   })
   // The single source of truth for "follow the newest content". The virtualizer pins and unpins
   // it from scroll geometry; everything else only expresses explicit intent.
-  const [pinned, setPinned] = createSignal(true)
-  const pin = () => setPinned(true)
+  const pinned = () => state.follow.sessionKey !== session.identity.sessionKey() || state.follow.pinned
+  const pin = () => setState("follow", { sessionKey: session.identity.sessionKey(), pinned: true })
   const unpin = () => {
     if (!scroller || scroller.scrollHeight - scroller.clientHeight <= 1) return
-    setPinned(false)
+    setState("follow", { sessionKey: session.identity.sessionKey(), pinned: false })
   }
   let scroller: HTMLDivElement | undefined
   let dockHeight = 0
@@ -209,8 +213,10 @@ export function createSessionTimelineInteraction(session: SessionModel) {
     on(
       session.identity.sessionKey,
       () => {
+        pin()
         setState("messageID", undefined)
         setState("pendingMessage", undefined)
+        setState("scroll", { overflow: false, jump: false })
       },
       { defer: true },
     ),

--- a/packages/app/src/session/timeline/model.ts
+++ b/packages/app/src/session/timeline/model.ts
@@ -13,6 +13,7 @@ export {
 
 export function createTimelineModel(input: { session: Pick<SessionModel, "identity" | "history"> }) {
   const data = useData()
+  const prepared = new Set<string>()
 
   const [resource] = createResource(
     () => input.session.identity.sessionID(),
@@ -29,9 +30,15 @@ export function createTimelineModel(input: { session: Pick<SessionModel, "identi
         pause: () => new Promise((resolve) => setTimeout(resolve, leadingTurnPageDelay)),
         maxPages: leadingTurnPageLimit,
       }).catch(() => undefined)
+      if (input.session.identity.sessionKey() === key) prepared.add(key)
     },
   )
-  const ready = createMemo(() => !input.session.identity.sessionID() || !resource.loading)
+  const ready = createMemo(() => {
+    const id = input.session.identity.sessionID()
+    if (!id || prepared.has(input.session.identity.sessionKey()) || !resource.loading) return true
+    const messages = data.session.message.list(id)
+    return messages.length > 0 && !leadingTurnNeedsParent(messages)
+  })
   const more = () => {
     const id = input.session.identity.sessionID()
     return id ? data.session.message.more(id) : false

--- a/packages/app/src/session/timeline/model.ts
+++ b/packages/app/src/session/timeline/model.ts
@@ -20,7 +20,7 @@ export function createTimelineModel(input: { session: Pick<SessionModel, "identi
       if (!id) return
       const key = input.session.identity.sessionKey()
       await Promise.all([data.session.message.sync(id), data.session.pending.sync(id)])
-      void enrichLeadingTurn({
+      await enrichLeadingTurn({
         current: () => input.session.identity.sessionKey() === key,
         messages: () => data.session.message.list(id),
         more: () => data.session.message.more(id),

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -20,6 +20,7 @@ import { observeElementOffsetReconnectAware } from "./observe-element-offset"
 import { filterVirtualIndexes } from "./virtual-items"
 
 const fallbackItemSize = 60
+const pendingMarkdown = '[data-component="markdown"]:not([data-markdown-ready])'
 // Distance from the bottom that counts as "at the end". Deliberately tight: a collapse clamps
 // exactly to the end, while a one-pixel nudge upward is a deliberate move away from it.
 const endEpsilon = 0.5
@@ -177,6 +178,22 @@ export function createTimelineVirtualizer(input: Input) {
   })
 
   let overscanFrame: number | undefined
+  const settleColdBottom = () => {
+    if (input.pinned()) virtualizer.scrollToEnd()
+    if (virtualContent?.querySelector(pendingMarkdown)) {
+      overscanFrame = requestAnimationFrame(settleColdBottom)
+      return
+    }
+    overscanFrame = requestAnimationFrame(() => {
+      if (input.pinned()) virtualizer.scrollToEnd()
+      if (virtualContent?.querySelector(pendingMarkdown)) {
+        settleColdBottom()
+        return
+      }
+      overscanFrame = undefined
+      virtualContent?.style.removeProperty("visibility")
+    })
+  }
   onMount(() => {
     overscanFrame = requestAnimationFrame(() => {
       if (renderOverscan() < 20) setRenderOverscan(20)
@@ -184,13 +201,7 @@ export function createTimelineVirtualizer(input: Input) {
         overscanFrame = undefined
         return
       }
-      if (input.pinned()) virtualizer.scrollToEnd()
-      // Let newly overscanned rows measure before exposing the estimated cold viewport.
-      overscanFrame = requestAnimationFrame(() => {
-        overscanFrame = undefined
-        if (input.pinned()) virtualizer.scrollToEnd()
-        virtualContent?.style.removeProperty("visibility")
-      })
+      settleColdBottom()
     })
   })
 

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -191,8 +191,22 @@ export function createTimelineVirtualizer(input: Input) {
         return
       }
       overscanFrame = undefined
-      virtualContent?.classList.add("animate-in", "fade-in", "duration-150")
-      virtualContent?.style.removeProperty("visibility")
+      const content = virtualContent
+      if (!content) return
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+        content.style.removeProperty("visibility")
+        return
+      }
+      const animation = ["animate-in", "fade-in", "duration-150"]
+      const clearAnimation = () => {
+        content.removeEventListener("animationend", clearAnimation)
+        content.removeEventListener("animationcancel", clearAnimation)
+        content.classList.remove(...animation)
+      }
+      content.addEventListener("animationend", clearAnimation)
+      content.addEventListener("animationcancel", clearAnimation)
+      content.classList.add(...animation)
+      content.style.removeProperty("visibility")
     })
   }
   onMount(() => {

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -191,6 +191,7 @@ export function createTimelineVirtualizer(input: Input) {
         return
       }
       overscanFrame = undefined
+      virtualContent?.classList.add("animate-in", "fade-in", "duration-150")
       virtualContent?.style.removeProperty("visibility")
     })
   }
@@ -388,6 +389,7 @@ export function createTimelineVirtualizer(input: Input) {
           <Show when={input.showHeader()}>{props.header}</Show>
           <div
             data-timeline-virtual-content
+            class="motion-reduce:animate-none"
             ref={(element) => {
               virtualContent = element
               input.setContentRef(element)

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -179,8 +179,18 @@ export function createTimelineVirtualizer(input: Input) {
   let overscanFrame: number | undefined
   onMount(() => {
     overscanFrame = requestAnimationFrame(() => {
-      overscanFrame = undefined
       if (renderOverscan() < 20) setRenderOverscan(20)
+      if (!coldBottomMount) {
+        overscanFrame = undefined
+        return
+      }
+      if (input.pinned()) virtualizer.scrollToEnd()
+      // Let newly overscanned rows measure before exposing the estimated cold viewport.
+      overscanFrame = requestAnimationFrame(() => {
+        overscanFrame = undefined
+        if (input.pinned()) virtualizer.scrollToEnd()
+        virtualContent?.style.removeProperty("visibility")
+      })
     })
   })
 
@@ -371,7 +381,12 @@ export function createTimelineVirtualizer(input: Input) {
               virtualContent = element
               input.setContentRef(element)
             }}
-            style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative", width: "100%" }}
+            style={{
+              height: `${virtualizer.getTotalSize()}px`,
+              position: "relative",
+              width: "100%",
+              visibility: coldBottomMount ? "hidden" : undefined,
+            }}
           >
             <For each={virtualRowKeys()}>{(rowKey) => <VirtualRow rowKey={rowKey} />}</For>
             <Show when={rows().length > 0}>

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -178,15 +178,17 @@ export function createTimelineVirtualizer(input: Input) {
   })
 
   let overscanFrame: number | undefined
+  const pendingMeasurements = () =>
+    virtualizer.getVirtualItems().some((item) => !virtualizer.itemSizeCache.has(item.key))
   const settleColdBottom = () => {
     if (input.pinned()) virtualizer.scrollToEnd()
-    if (virtualContent?.querySelector(pendingMarkdown)) {
+    if (virtualContent?.querySelector(pendingMarkdown) || pendingMeasurements()) {
       overscanFrame = requestAnimationFrame(settleColdBottom)
       return
     }
     overscanFrame = requestAnimationFrame(() => {
       if (input.pinned()) virtualizer.scrollToEnd()
-      if (virtualContent?.querySelector(pendingMarkdown)) {
+      if (virtualContent?.querySelector(pendingMarkdown) || pendingMeasurements()) {
         settleColdBottom()
         return
       }
@@ -198,7 +200,8 @@ export function createTimelineVirtualizer(input: Input) {
         return
       }
       const animation = ["animate-in", "fade-in", "duration-150"]
-      const clearAnimation = () => {
+      const clearAnimation = (event: AnimationEvent) => {
+        if (event.target !== content) return
         content.removeEventListener("animationend", clearAnimation)
         content.removeEventListener("animationcancel", clearAnimation)
         content.classList.remove(...animation)

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -50,6 +50,7 @@ type RenderedBlock =
 type RenderResult = {
   text: string
   blocks: RenderedBlock[]
+  ready: boolean
 }
 
 const renderedCodeTokens = new WeakMap<HTMLDivElement, RenderedCodeState>()
@@ -374,7 +375,7 @@ function initialResult(
   owner: string,
   deferUntilReady: boolean | undefined,
 ): RenderResult {
-  if (!text) return { text, blocks: [] }
+  if (!text) return { text, blocks: [], ready: true }
   const base = key ?? checksum(text)
   if (base) {
     const blocks = projection.blocks.flatMap((block, index) => {
@@ -384,11 +385,12 @@ function initialResult(
       if (cached?.raw !== block.raw) return []
       return [{ key: `${owner}:${cacheKey}`, mode: block.mode, ...cached }]
     })
-    if (blocks.length === projection.blocks.length) return { text, blocks }
+    if (blocks.length === projection.blocks.length) return { text, blocks, ready: true }
   }
-  if (deferUntilReady) return { text, blocks: [] }
+  if (deferUntilReady) return { text, blocks: [], ready: false }
   return {
     text,
+    ready: false,
     blocks: [
       {
         key: "initial",
@@ -456,10 +458,11 @@ export function Markdown(
         projection: value,
       }
     },
-    async (src) => {
+    async (src): Promise<RenderResult> => {
       if (isServer)
         return {
           text: src.text,
+          ready: true,
           blocks: [
             {
               key: "server",
@@ -470,7 +473,7 @@ export function Markdown(
             },
           ],
         } satisfies RenderResult
-      if (!src.text) return { text: src.text, blocks: [] } satisfies RenderResult
+      if (!src.text) return { text: src.text, blocks: [], ready: true } satisfies RenderResult
 
       const base = src.key ?? checksum(src.text)
       return Promise.all(
@@ -508,11 +511,12 @@ export function Markdown(
           return { key: blockKey, mode: block.mode, raw: block.raw, hash: hash ?? "", html: safe }
         }),
       )
-        .then((blocks) => ({ text: src.text, blocks }) satisfies RenderResult)
+        .then((blocks) => ({ text: src.text, blocks, ready: true }) satisfies RenderResult)
         .catch(
           () =>
             ({
               text: src.text,
+              ready: true,
               blocks: [
                 {
                   key: base ?? "fallback",
@@ -545,9 +549,11 @@ export function Markdown(
     const content = local.text ? pendingBlocks(result, projected, local.cacheKey, owner, local.deferUntilReady) : []
     if (!container) return
     if (isServer) return
+    delete container.dataset.markdownReady
     if (content.length === 0) {
       disposeCopyButtons(container)
       container.innerHTML = ""
+      if (result?.ready && result.text === local.text) container.dataset.markdownReady = ""
       return
     }
 
@@ -576,6 +582,7 @@ export function Markdown(
         copy: i18n.t("ui.message.copy"),
         copied: i18n.t("ui.message.copied"),
       }))
+    if (result?.ready && result.text === local.text) container.dataset.markdownReady = ""
   })
 
   onCleanup(() => {
@@ -588,7 +595,6 @@ export function Markdown(
   return (
     <div
       data-component="markdown"
-      data-markdown-ready={html.loading ? undefined : ""}
       dir="auto"
       classList={{
         ...local.classList,

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -367,7 +367,13 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   }
 }
 
-function initialResult(text: string, key: string | undefined, projection: Projection, owner: string): RenderResult {
+function initialResult(
+  text: string,
+  key: string | undefined,
+  projection: Projection,
+  owner: string,
+  deferUntilReady: boolean | undefined,
+): RenderResult {
   if (!text) return { text, blocks: [] }
   const base = key ?? checksum(text)
   if (base) {
@@ -380,6 +386,7 @@ function initialResult(text: string, key: string | undefined, projection: Projec
     })
     if (blocks.length === projection.blocks.length) return { text, blocks }
   }
+  if (deferUntilReady) return { text, blocks: [] }
   return {
     text,
     blocks: [
@@ -403,11 +410,12 @@ export function Markdown(
     text: string
     cacheKey?: string
     streaming?: boolean
+    deferUntilReady?: boolean
     class?: string
     classList?: Record<string, boolean>
   },
 ) {
-  const [local, others] = splitProps(props, ["text", "cacheKey", "streaming", "class", "classList"])
+  const [local, others] = splitProps(props, ["text", "cacheKey", "streaming", "deferUntilReady", "class", "classList"])
   const i18n = useI18n()
   const [root, setRoot] = createSignal<HTMLDivElement>()
   const owner = createUniqueId()
@@ -523,6 +531,7 @@ export function Markdown(
         local.cacheKey,
         local.streaming ? pendingProjection(local.text) : completedProjection(local.text),
         owner,
+        local.deferUntilReady,
       ),
     },
   )
@@ -533,7 +542,7 @@ export function Markdown(
     const container = root()
     const result = html.latest ?? html()
     const projected = currentProjection()
-    const content = local.text ? pendingBlocks(result, projected, local.cacheKey, owner) : []
+    const content = local.text ? pendingBlocks(result, projected, local.cacheKey, owner, local.deferUntilReady) : []
     if (!container) return
     if (isServer) return
     if (content.length === 0) {
@@ -596,9 +605,11 @@ function pendingBlocks(
   projection: Projection | undefined,
   cacheKey: string | undefined,
   owner: string,
+  deferUntilReady: boolean | undefined,
 ) {
   if (!result) return []
   if (!projection || result.text === projection.text) return result.blocks
+  if (deferUntilReady) return result.blocks
   const initial = result.blocks.length === 1 && result.blocks[0]?.key === "initial"
   return projection.blocks.map((block, index) => {
     const current = initial ? undefined : result.blocks[index]

--- a/packages/session-ui/src/message/message-content.tsx
+++ b/packages/session-ui/src/message/message-content.tsx
@@ -159,7 +159,7 @@ function PacedMarkdown(props: { text: string; cacheKey: string; streaming: boole
 
   return (
     <Show when={value()}>
-      <Markdown text={value()} cacheKey={props.cacheKey} streaming={props.streaming} />
+      <Markdown text={value()} cacheKey={props.cacheKey} streaming={props.streaming} deferUntilReady />
     </Show>
   )
 }


### PR DESCRIPTION
## Summary

- defer timeline Markdown until converted HTML is applied, retaining the last rendered HTML while streaming
- include orphan leading-turn history enrichment in initial readiness instead of prepending rows after reveal
- render cached complete timeline pages immediately while their refresh finishes
- hide cold pinned timelines until mounted Markdown and virtual row measurements settle
- reveal cold timelines with a one-time reduced-motion-aware fade
- isolate follow, overflow, and jump state per session before virtualizer remounts
- clear entrance animation classes after completion so later layout changes cannot replay the fade

## Validation

- `bun typecheck` (`packages/session-ui`)
- `bun test src --only-failures` (`packages/session-ui`): 95 passed
- `bun typecheck` (`packages/app`)
- `bun test --conditions=solid --only-failures --preload ./happydom.ts src/session/timeline/model.test.ts`: 7 passed
- cached and cold session-tab smoke tests: 2 passed
- `bunx playwright test e2e/regression/session-timeline-history-root.spec.ts e2e/regression/session-timeline-transport.spec.ts`: 10 passed
- `bunx playwright test e2e/regression/session-timeline-tool-projection.spec.ts`: 6 passed
- live Desktop CDP probe: one timeline node and stable row range throughout fade
- push hook: full monorepo typecheck
