### PR TITLE
fix(core): serialize prompt settlement around event publication

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -217,32 +217,40 @@ const layer = Layer.effect(
       ),
     )
 
+    // Settlement claims the pending entry before publishing so a concurrent
+    // reply cannot observe it as pending while listeners delay the publish; a
+    // failed publish restores the entry. Cascade loops re-claim each entry the
+    // same way because every publish is a suspension point.
     const reply = EffectRuntime.fn("PermissionV2.reply")((input: ReplyInput) =>
       EffectRuntime.uninterruptible(
         EffectRuntime.gen(function* () {
           const existing = pending.get(input.requestID)
           if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
-          yield* events.publish(Event.Replied, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-            reply: input.reply,
-          })
+          pending.delete(input.requestID)
+          yield* events
+            .publish(Event.Replied, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+              reply: input.reply,
+            })
+            .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(input.requestID, existing))))
 
           if (input.reply === "reject") {
             yield* Deferred.fail(
               existing.deferred,
               input.message ? new CorrectedError({ feedback: input.message }) : new DeclinedError(),
             )
-            pending.delete(input.requestID)
-            for (const [id, item] of pending) {
+            for (const [id, item] of Array.from(pending)) {
               if (item.request.sessionID !== existing.request.sessionID) continue
-              yield* events.publish(Event.Replied, {
-                sessionID: item.request.sessionID,
-                requestID: item.request.id,
-                reply: "reject",
-              })
+              if (!pending.delete(id)) continue
+              yield* events
+                .publish(Event.Replied, {
+                  sessionID: item.request.sessionID,
+                  requestID: item.request.id,
+                  reply: "reject",
+                })
+                .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(id, item))))
               yield* Deferred.fail(item.deferred, new DeclinedError())
-              pending.delete(id)
             }
             return
           }
@@ -255,11 +263,10 @@ const layer = Layer.effect(
             })
           }
           yield* Deferred.succeed(existing.deferred, undefined)
-          pending.delete(input.requestID)
           if (input.reply !== "always" || !existing.request.save?.length) return
 
           const rememberedRules = yield* savedRules()
-          for (const [id, item] of pending) {
+          for (const [id, item] of Array.from(pending)) {
             const input = { ...item.request }
             const rules = yield* configured(item.request.sessionID, item.agent).pipe(
               EffectRuntime.catchTag("Session.NotFoundError", () => EffectRuntime.succeed(undefined)),
@@ -273,13 +280,15 @@ const layer = Layer.effect(
               )
             )
               continue
-            yield* events.publish(Event.Replied, {
-              sessionID: item.request.sessionID,
-              requestID: item.request.id,
-              reply: "always",
-            })
+            if (!pending.delete(id)) continue
+            yield* events
+              .publish(Event.Replied, {
+                sessionID: item.request.sessionID,
+                requestID: item.request.id,
+                reply: "always",
+              })
+              .pipe(EffectRuntime.onError(() => EffectRuntime.sync(() => pending.set(id, item))))
             yield* Deferred.succeed(item.deferred, undefined)
-            pending.delete(id)
           }
         }),
       ),

--- a/packages/core/src/question.ts
+++ b/packages/core/src/question.ts
@@ -109,18 +109,23 @@ const layer = Layer.effect(
       ),
     )
 
+    // Settlement claims the pending entry before publishing so a concurrent
+    // reply/reject cannot observe it as pending while listeners delay the
+    // publish; a failed publish restores the entry.
     const reply = Effect.fn("QuestionV2.reply")((input: ReplyInput) =>
       Effect.uninterruptible(
         Effect.gen(function* () {
           const existing = pending.get(input.requestID)
           if (!existing) return yield* new NotFoundError({ requestID: input.requestID })
-          yield* events.publish(Event.Replied, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-            answers: input.answers.map((answer) => [...answer]),
-          })
-          yield* Deferred.succeed(existing.deferred, input.answers)
           pending.delete(input.requestID)
+          yield* events
+            .publish(Event.Replied, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+              answers: input.answers.map((answer) => [...answer]),
+            })
+            .pipe(Effect.onError(() => Effect.sync(() => pending.set(input.requestID, existing))))
+          yield* Deferred.succeed(existing.deferred, input.answers)
         }),
       ),
     )
@@ -130,12 +135,14 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const existing = pending.get(requestID)
           if (!existing) return yield* new NotFoundError({ requestID })
-          yield* events.publish(Event.Rejected, {
-            sessionID: existing.request.sessionID,
-            requestID: existing.request.id,
-          })
-          yield* Deferred.fail(existing.deferred, new RejectedError())
           pending.delete(requestID)
+          yield* events
+            .publish(Event.Rejected, {
+              sessionID: existing.request.sessionID,
+              requestID: existing.request.id,
+            })
+            .pipe(Effect.onError(() => Effect.sync(() => pending.set(requestID, existing))))
+          yield* Deferred.fail(existing.deferred, new RejectedError())
         }),
       ),
     )

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -283,6 +283,40 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("settles a pending request exactly once under concurrent replies", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const events = yield* EventV2.Service
+      const gate = yield* Deferred.make<void>()
+      const entered = yield* Deferred.make<void>()
+      const replied: unknown[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === PermissionV2.Event.Replied.type
+          ? Effect.gen(function* () {
+              replied.push(event.data)
+              yield* Deferred.succeed(entered, undefined)
+              yield* Deferred.await(gate)
+            })
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const { service, fiber, request } = yield* waitForRequest()
+
+      const winner = yield* service.reply({ requestID: request.id, reply: "once" }).pipe(Effect.forkScoped)
+      yield* Deferred.await(entered)
+
+      expect(yield* service.reply({ requestID: request.id, reply: "reject" }).pipe(Effect.flip)).toEqual(
+        new PermissionV2.NotFoundError({ requestID: request.id }),
+      )
+
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.join(winner)
+      yield* Fiber.join(fiber)
+      expect(replied).toEqual([{ sessionID: request.sessionID, requestID: request.id, reply: "once" }])
+      expect(yield* service.list()).toEqual([])
+    }),
+  )
+
   it.effect("stores and removes saved resources for a project", () =>
     Effect.gen(function* () {
       yield* setup()

--- a/packages/core/test/question.test.ts
+++ b/packages/core/test/question.test.ts
@@ -89,6 +89,44 @@ describe("QuestionV2", () => {
     }),
   )
 
+  it.effect("settles a pending request exactly once under concurrent settlement", () =>
+    Effect.gen(function* () {
+      const service = yield* QuestionV2.Service
+      const events = yield* EventV2.Service
+      const gate = yield* Deferred.make<void>()
+      const entered = yield* Deferred.make<void>()
+      const settled: EventV2.Payload[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === QuestionV2.Event.Replied.type || event.type === QuestionV2.Event.Rejected.type
+          ? Effect.gen(function* () {
+              settled.push(event)
+              yield* Deferred.succeed(entered, undefined)
+              yield* Deferred.await(gate)
+            })
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const { fiber, request } = yield* waitForAsk(service, { sessionID, questions: [question] })
+
+      const winner = yield* service.reply({ requestID: request.id, answers: [["One"]] }).pipe(Effect.forkScoped)
+      yield* Deferred.await(entered)
+
+      expect(yield* service.reply({ requestID: request.id, answers: [["Two"]] }).pipe(Effect.flip)).toEqual(
+        new QuestionV2.NotFoundError({ requestID: request.id }),
+      )
+      expect(yield* service.reject(request.id).pipe(Effect.flip)).toEqual(
+        new QuestionV2.NotFoundError({ requestID: request.id }),
+      )
+
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.join(winner)
+      expect(yield* Fiber.join(fiber)).toEqual([["One"]])
+      expect(settled.map((event) => [event.type, event.data])).toEqual([
+        [QuestionV2.Event.Replied.type, { sessionID, requestID: request.id, answers: [["One"]] }],
+      ])
+    }),
+  )
+
   it.effect("isolates pending requests by location-layer instance and rejects them on finalization", () =>
     Effect.gen(function* () {
       const firstScope = yield* Scope.make()


### PR DESCRIPTION
### Issue for this PR

Closes #34853

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`QuestionV2.reply`, `QuestionV2.reject`, and `PermissionV2.reply` published their settlement event before removing the pending entry. Since `EventV2.publish` runs listeners inline, a slow listener suspends the first reply while the entry still looks pending. A second concurrent reply then also passes the pending check, publishes a conflicting settlement event, and both callers get success.

The fix claims the pending entry synchronously before publishing, so the second caller gets `NotFoundError` instead of double settling. If the publish fails, the entry is restored, which keeps the rollback behavior these services already used on the create side. The cascade loops in `PermissionV2.reply` (reject all in session, auto allow after "always") now re-claim each entry with `pending.delete(id)` before publishing, since every publish is a suspension point where another reply can win the race.

This works because the claim happens with no yield point between the pending check and the delete, so only one settlement can ever proceed per request.

### How did you verify your code works?

Added regression tests that block a settlement listener on a deferred and race a second reply. Both tests fail on the current code (double publish or timeout) and pass with the fix. `bun test test/question.test.ts test/permission.test.ts` in packages/core: 16 pass. Typecheck and oxlint are clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
