### PR TITLE
fix(server): release SSE streams when a Bun client disconnects

### DIFF
--- a/packages/cli/src/commands/handlers/serve.ts
+++ b/packages/cli/src/commands/handlers/serve.ts
@@ -7,6 +7,7 @@ import { Context, Layer, Option } from "effect"
 import * as Effect from "effect/Effect"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
 import { createServer } from "node:http"
+import { bridgeClientDisconnect } from "@opencode-ai/core/util/http-server"
 import { createRoutes } from "@opencode-ai/server/routes"
 import { Commands } from "../commands"
 import { Runtime } from "../../framework/runtime"
@@ -39,7 +40,7 @@ function listen(hostname: string, port: Option.Option<number>, password: string)
 function bind(hostname: string, port: number, password: string) {
   return Layer.build(
     HttpRouter.serve(createRoutes(password), { disableListenLog: true, disableLogger: true }).pipe(
-      Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { port, host: hostname })),
+      Layer.provideMerge(NodeHttpServer.layer(() => bridgeClientDisconnect(createServer()), { port, host: hostname })),
       Layer.provide(AppNodeBuilder.build(LayerNode.group([Credential.node, PermissionSaved.node]))),
     ),
   ).pipe(Effect.map((context) => Context.get(context, HttpServer.HttpServer).address))

--- a/packages/core/src/util/http-server.ts
+++ b/packages/core/src/util/http-server.ts
@@ -1,0 +1,19 @@
+import type { Server } from "node:http"
+
+/**
+ * Bun's node:http compatibility layer does not emit ServerResponse "close"
+ * when the client disconnects mid-response (oven-sh/bun#14697). Hosts that
+ * interrupt request work from that event, such as @effect/platform-node,
+ * therefore never release long-lived streams like SSE, and the abandoned
+ * stream keeps writing into a dead socket. Destroying the response from the
+ * request "aborted" event makes Bun emit the missing "close".
+ */
+export function bridgeClientDisconnect<T extends Server>(server: T): T {
+  if (!process.versions.bun) return server
+  server.on("request", (request, response) => {
+    request.once("aborted", () => {
+      if (!response.writableEnded && !response.destroyed) response.destroy()
+    })
+  })
+  return server
+}

--- a/packages/core/test/util/http-server.test.ts
+++ b/packages/core/test/util/http-server.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { createServer } from "node:http"
+import { bridgeClientDisconnect } from "@opencode-ai/core/util/http-server"
+
+function listen(server: ReturnType<typeof createServer>) {
+  return new Promise<number>((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (address && typeof address === "object") return resolve(address.port)
+      reject(new Error("expected a TCP address"))
+    })
+  })
+}
+
+describe("bridgeClientDisconnect", () => {
+  test("emits response close after an SSE client disconnects", async () => {
+    const closed = Promise.withResolvers<void>()
+    const server = bridgeClientDisconnect(
+      createServer((request, response) => {
+        request.on("error", () => {})
+        response.on("close", () => closed.resolve())
+        response.writeHead(200, { "content-type": "text/event-stream" })
+        response.write("data: ready\n\n")
+      }),
+    )
+    const port = await listen(server)
+
+    const abort = new AbortController()
+    const response = await fetch(`http://127.0.0.1:${port}/`, { signal: abort.signal })
+    const reader = response.body!.getReader()
+    await reader.read()
+    abort.abort()
+
+    const timeout = new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 5000))
+    expect(await Promise.race([closed.promise.then(() => "closed"), timeout])).toBe("closed")
+    server.close()
+    server.closeAllConnections()
+  })
+
+  test("leaves completed responses untouched", async () => {
+    let destroyed = false
+    const server = bridgeClientDisconnect(
+      createServer((request, response) => {
+        response.on("close", () => {
+          destroyed = response.destroyed && !response.writableEnded
+        })
+        response.writeHead(200, { "content-type": "text/plain" })
+        response.end("ok")
+      }),
+    )
+    const port = await listen(server)
+
+    const response = await fetch(`http://127.0.0.1:${port}/`)
+    expect(await response.text()).toBe("ok")
+    expect(destroyed).toBe(false)
+    server.close()
+    server.closeAllConnections()
+  })
+})

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -6,6 +6,7 @@ import { ConfigProvider, Context, Effect, Exit, Layer, Scope } from "effect"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
 import { OpenApi } from "effect/unstable/httpapi"
 import { createServer } from "node:http"
+import { bridgeClientDisconnect } from "@opencode-ai/core/util/http-server"
 import { MDNS } from "./mdns"
 import { HttpApiApp } from "./routes/instance/httpapi/server"
 import { disposeMiddleware } from "./routes/instance/httpapi/lifecycle"
@@ -197,7 +198,7 @@ function forceClose(state: ListenerState) {
 }
 
 function serverLayer(opts: { port: number; hostname: string }) {
-  const server = createServer()
+  const server = bridgeClientDisconnect(createServer())
   const serverRef = { closeStarted: false, forceStop: false }
   const close = server.close.bind(server)
   // Keep shutdown owned by NodeHttpServer, but honor listener.stop(true) by


### PR DESCRIPTION
### Issue for this PR

Closes #36311

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On the pinned Bun (1.3.14), `node:http` does not emit `ServerResponse` "close" when the client disconnects (oven-sh/bun#14697). `@effect/platform-node` interrupts the request fiber from exactly that event, so when a TUI drops its `/api/event` SSE connection the server side event stream never gets released. It keeps writing heartbeats into a dead socket, which is the state captured in the issue: server alive, listener open, health unresponsive, one core pinned in the native write path.

The fix is the bridge suggested in the issue: on Bun only, destroy the response from the request "aborted" event, which makes Bun emit the missing "close" so Effect can interrupt the stream and release its event subscription. The helper lives in core and is applied to both places we create a `node:http` server, the V1 server layer and the V2 `serve` command.

### How did you verify your code works?

Added a test that opens an SSE response, aborts the client, and asserts the response "close" event fires. Without the bridge the event never fires on Bun 1.3.14 (verified with a copy of the test against a raw `createServer`), with the bridge it fires immediately. A second test confirms normally completed responses are not destroyed. `bun test test/util/http-server.test.ts` in packages/core: 2 pass. Typecheck passes for core, cli, and opencode.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
