### PR TITLE
fix(tui): reconcile pending prompts with the live server

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -55,6 +55,14 @@ function compareMessage(a: Message, b: Message) {
   return a.time.created - b.time.created || a.id.localeCompare(b.id)
 }
 
+function groupBySession<T extends { id: string; sessionID: string }>(requests: T[]) {
+  const grouped: Record<string, T[]> = {}
+  for (const request of requests.toSorted((a, b) => a.id.localeCompare(b.id))) {
+    ;(grouped[request.sessionID] ??= []).push(request)
+  }
+  return grouped
+}
+
 const messageKey = (message: Message) => message.time.created + message.id
 
 export const {
@@ -532,6 +540,15 @@ export const {
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            // Pending prompts are process-local on the server, so hydrate them
+            // from the live service instead of trusting event-fed state that a
+            // restart may have orphaned.
+            sdk.client.permission
+              .list({ workspace })
+              .then((x) => setStore("permission", reconcile(groupBySession(x.data ?? [])))),
+            sdk.client.question
+              .list({ workspace })
+              .then((x) => setStore("question", reconcile(groupBySession(x.data ?? [])))),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")
@@ -664,6 +681,21 @@ export const {
           })
           syncingSessions.set(sessionID, task)
           return task
+        },
+      },
+      question: {
+        dismiss(sessionID: string, requestID: string) {
+          const requests = store.question[sessionID]
+          if (!requests) return
+          const match = search(requests, requestID, (r) => r.id)
+          if (!match.found) return
+          setStore(
+            "question",
+            sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 1)
+            }),
+          )
         },
       },
       bootstrap,

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -5,6 +5,7 @@ import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
+import { useSync } from "../../context/sync"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
@@ -13,6 +14,7 @@ const QUESTION_MODE = "question"
 
 export function QuestionPrompt(props: { request: QuestionRequest; directory?: string }) {
   const sdk = useSDK()
+  const sync = useSync()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
@@ -45,20 +47,36 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     return store.answers[store.tab]?.includes(value) ?? false
   })
 
+  // A restarted service loses its pending questions, so a failed settlement is
+  // rechecked against the live list and a request the server no longer knows
+  // is dismissed instead of rendering forever as an unanswerable prompt.
+  async function settle(request: Promise<{ error?: unknown }>) {
+    const result = await request
+    if (!result.error) return
+    const pending = await sdk.client.question.list({ directory: props.directory }).catch(() => undefined)
+    if (!pending?.data) return
+    if (pending.data.some((item) => item.id === props.request.id)) return
+    sync.question.dismiss(props.request.sessionID, props.request.id)
+  }
+
   function submit() {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
-    void sdk.client.question.reply({
-      requestID: props.request.id,
-      directory: props.directory,
-      answers,
-    })
+    void settle(
+      sdk.client.question.reply({
+        requestID: props.request.id,
+        directory: props.directory,
+        answers,
+      }),
+    )
   }
 
   function reject() {
-    void sdk.client.question.reject({
-      requestID: props.request.id,
-      directory: props.directory,
-    })
+    void settle(
+      sdk.client.question.reject({
+        requestID: props.request.id,
+        directory: props.directory,
+      }),
+    )
   }
 
   function pick(answer: string, custom: boolean = false) {
@@ -71,11 +89,13 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       setStore("custom", inputs)
     }
     if (single()) {
-      void sdk.client.question.reply({
-        requestID: props.request.id,
-        directory: props.directory,
-        answers: [[answer]],
-      })
+      void settle(
+        sdk.client.question.reply({
+          requestID: props.request.id,
+          directory: props.directory,
+          answers: [[answer]],
+        }),
+      )
       return
     }
     setStore("tab", store.tab + 1)

--- a/packages/tui/test/cli/cmd/tui/sync-pending-prompts.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-pending-prompts.test.tsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import type { PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2"
+import { tmpdir } from "../../../fixture/fixture"
+import { json, mount, wait } from "./sync-fixture"
+
+const question: QuestionRequest = {
+  id: "que_pending",
+  sessionID: "ses_test",
+  questions: [{ question: "Proceed?", header: "Q", options: [{ label: "Yes", description: "Continue" }] }],
+}
+
+const permission: PermissionRequest = {
+  id: "per_pending",
+  sessionID: "ses_test",
+  permission: "read",
+  patterns: ["src/index.ts"],
+  metadata: {},
+  always: ["*"],
+}
+
+describe("tui sync pending prompts", () => {
+  test("hydrates pending prompts on bootstrap and drops entries a restarted server no longer knows", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let questions: QuestionRequest[] = [question]
+    let permissions: PermissionRequest[] = [permission]
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === "/question") return json(questions)
+      if (url.pathname === "/permission") return json(permissions)
+      return undefined
+    }, tmp.path)
+
+    try {
+      await wait(() => (sync.data.question["ses_test"]?.length ?? 0) === 1)
+      await wait(() => (sync.data.permission["ses_test"]?.length ?? 0) === 1)
+      expect(sync.data.question["ses_test"]?.[0]?.id).toBe("que_pending")
+      expect(sync.data.permission["ses_test"]?.[0]?.id).toBe("per_pending")
+
+      questions = []
+      permissions = []
+      await sync.bootstrap()
+      await wait(() => (sync.data.question["ses_test"]?.length ?? 0) === 0)
+      await wait(() => (sync.data.permission["ses_test"]?.length ?? 0) === 0)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("dismisses a question the server can no longer answer", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit({
+        directory: "/tmp/opencode/packages/tui",
+        project: "proj_test",
+        payload: { id: "evt_question", type: "question.asked", properties: question },
+      })
+      await wait(() => (sync.data.question["ses_test"]?.length ?? 0) === 1)
+
+      sync.question.dismiss("ses_test", "que_pending")
+      expect(sync.data.question["ses_test"]).toEqual([])
+      sync.question.dismiss("ses_test", "que_pending")
+      expect(sync.data.question["ses_test"]).toEqual([])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/tui/test/fixture/tui-sdk.ts
+++ b/packages/tui/test/fixture/tui-sdk.ts
@@ -78,6 +78,8 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
         "/experimental/workspace/status",
         "/formatter",
         "/lsp",
+        "/permission",
+        "/question",
       ].includes(url.pathname)
     )
       return json([])


### PR DESCRIPTION
### Issue for this PR

Closes #36585

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pending questions and permissions live in a process local map on the server, so a managed service restart destroys them. The TUI only learns about pending prompts through live events, so after a restart it keeps rendering a form the replacement server has never heard of. Submitting fails with a not found error that was silently ignored, leaving a form that can never be answered.

Two changes:

1. Bootstrap now hydrates pending questions and permissions from the live server (`GET /question` and `GET /permission`) and replaces the event fed state. Prompts that survived appear, prompts the server no longer knows are dropped.
2. When a question reply or reject fails, the TUI rechecks the live pending list. If the request is gone from the server, the form is dismissed instead of rendering forever. If the recheck fails too (for example the server is briefly unreachable), the form stays, so a transient network error cannot eat a real question.

The durable fix for keeping prompts alive across restarts is tracked in #36347. This is the client side escape hatch so users are never stuck looking at an unanswerable form.

### How did you verify your code works?

Added TUI tests: one mounts with pending prompts served by the mock and asserts they hydrate, then simulates a restart by emptying the server lists and re-running bootstrap and asserts the stale entries are dropped. Another covers dismissal of an event fed question. `bun test test/cli/cmd/tui/` in packages/tui: 25 pass. Typecheck and oxlint are clean.

### Screenshots / recordings

The change removes a stuck form after a service restart. No visual change in the normal flow.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
