### PR TITLE
fix(opencode): let a pinned websearch provider enable the tool for any provider

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -37,6 +37,10 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
     enabled: bool("OPENCODE_ENABLE_PARALLEL"),
     legacy: bool("OPENCODE_EXPERIMENTAL_PARALLEL"),
   }).pipe(Config.map((flags) => flags.enabled || flags.legacy)),
+  websearchProvider: Config.string("OPENCODE_WEBSEARCH_PROVIDER").pipe(
+    Config.map((value) => (value === "exa" || value === "parallel" ? value : undefined)),
+    Config.orElse(() => Config.succeed(undefined)),
+  ),
   enableExperimentalModels: bool("OPENCODE_ENABLE_EXPERIMENTAL_MODELS"),
   enableQuestionTool: bool("OPENCODE_ENABLE_QUESTION_TOOL"),
   experimentalReferences: enabledByExperimental("OPENCODE_EXPERIMENTAL_REFERENCES"),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -25,7 +25,7 @@ import z from "zod"
 import { Plugin } from "../plugin"
 import { Provider } from "@/provider/provider"
 
-import { WebSearchTool } from "./websearch"
+import { WebSearchTool, type WebSearchProvider } from "./websearch"
 import { LspTool } from "./lsp"
 import * as Truncate from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
@@ -55,12 +55,16 @@ import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { McpCatalog } from "@/mcp/catalog"
 
-export function webSearchEnabled(providerID: ProviderV2.ID, flags = { exa: false, parallel: false }) {
+export function webSearchEnabled(
+  providerID: ProviderV2.ID,
+  flags: { exa: boolean; parallel: boolean; provider?: WebSearchProvider } = { exa: false, parallel: false },
+) {
   return (
     providerID === ProviderV2.ID.opencode ||
     providerID === ProviderV2.ID.make("opencode-go") ||
     flags.exa ||
-    flags.parallel
+    flags.parallel ||
+    flags.provider !== undefined
   )
 }
 
@@ -291,7 +295,11 @@ const layer = Layer.effect(
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
       const filtered = (yield* all()).filter((tool) => {
         if (tool.id === WebSearchTool.id) {
-          return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
+          return webSearchEnabled(input.providerID, {
+            exa: flags.enableExa,
+            parallel: flags.enableParallel,
+            provider: flags.websearchProvider,
+          })
         }
 
         const usePatch =

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -27,9 +27,11 @@ export const Parameters = Schema.Struct({
 const WebSearchProviderSchema = Schema.Literals(["exa", "parallel"])
 export type WebSearchProvider = Schema.Schema.Type<typeof WebSearchProviderSchema>
 
-export function selectWebSearchProvider(sessionID: string, flags = { exa: false, parallel: false }): WebSearchProvider {
-  const override = process.env.OPENCODE_WEBSEARCH_PROVIDER
-  if (override === "exa" || override === "parallel") return override
+export function selectWebSearchProvider(
+  sessionID: string,
+  flags: { exa: boolean; parallel: boolean; provider?: WebSearchProvider } = { exa: false, parallel: false },
+): WebSearchProvider {
+  if (flags.provider) return flags.provider
   if (flags.parallel) return "parallel"
   if (flags.exa) return "exa"
 
@@ -112,6 +114,7 @@ export const WebSearchTool = Tool.define(
           const provider = selectWebSearchProvider(ctx.sessionID, {
             exa: flags.enableExa,
             parallel: flags.enableParallel,
+            provider: flags.websearchProvider,
           })
           const title = webSearchProviderLabel(provider)
           yield* ctx.metadata({ title: `${title} "${params.query}"`, metadata: { provider } })

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -15,18 +15,9 @@ describe("websearch provider", () => {
   })
 
   test("supports an operational override", () => {
-    const original = process.env.OPENCODE_WEBSEARCH_PROVIDER
-
-    try {
-      process.env.OPENCODE_WEBSEARCH_PROVIDER = "parallel"
-      expect(selectWebSearchProvider(SESSION_ID)).toBe("parallel")
-
-      process.env.OPENCODE_WEBSEARCH_PROVIDER = "exa"
-      expect(selectWebSearchProvider(SESSION_ID)).toBe("exa")
-    } finally {
-      if (original === undefined) delete process.env.OPENCODE_WEBSEARCH_PROVIDER
-      else process.env.OPENCODE_WEBSEARCH_PROVIDER = original
-    }
+    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: false, provider: "parallel" })).toBe("parallel")
+    expect(selectWebSearchProvider(SESSION_ID, { exa: true, parallel: false, provider: "parallel" })).toBe("parallel")
+    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: false, provider: "exa" })).toBe("exa")
   })
 
   test("routes to Exa when the Exa flag is enabled", () => {
@@ -43,6 +34,16 @@ describe("websearch provider", () => {
     expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: false })).toBe(false)
     expect(webSearchEnabled(ProviderV2.ID.openai, { exa: true, parallel: false })).toBe(true)
     expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: true })).toBe(true)
+  })
+
+  test("is enabled for any provider when a websearch provider is pinned", () => {
+    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: false, provider: "exa" })).toBe(true)
+    expect(webSearchEnabled(ProviderV2.ID.make("ollama"), { exa: false, parallel: false, provider: "parallel" })).toBe(
+      true,
+    )
+    expect(webSearchEnabled(ProviderV2.ID.make("ollama"), { exa: false, parallel: false, provider: undefined })).toBe(
+      false,
+    )
   })
 
   test("uses branded labels", () => {

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -257,13 +257,15 @@ Allows the LLM to fetch and read web pages. Useful for looking up documentation 
 Search the web for information.
 
 :::note
-This tool is only available when using the OpenCode or OpenCode Go provider, or when the `OPENCODE_ENABLE_EXA` environment variable is set to any truthy value (e.g., `true` or `1`).
+This tool is only available when using the OpenCode or OpenCode Go provider, or when a websearch backend is selected through an environment variable. Any provider, including local models through Ollama or LM Studio, can use it once a backend is enabled.
 
-To enable when launching OpenCode:
+To enable it for any provider when launching OpenCode, pin a search backend:
 
 ```bash
-OPENCODE_ENABLE_EXA=1 opencode
+OPENCODE_WEBSEARCH_PROVIDER=exa opencode
 ```
+
+Valid values are `exa` and `parallel`. Alternatively, set `OPENCODE_ENABLE_EXA` or `OPENCODE_ENABLE_PARALLEL` to any truthy value (e.g., `true` or `1`) to enable the tool and let OpenCode pick the backend.
 
 :::
 


### PR DESCRIPTION
### Issue for this PR

Closes #44307

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The websearch tool is stripped from the tool list for every provider that is not opencode or opencode-go, unless `OPENCODE_ENABLE_EXA` or `OPENCODE_ENABLE_PARALLEL` is set. `OPENCODE_WEBSEARCH_PROVIDER` already pins the search backend, but it did not count as an enablement signal, so custom and local providers (Ollama, LM Studio, anything openai-compatible) could pin a backend and still never receive the tool.

This makes a pinned `OPENCODE_WEBSEARCH_PROVIDER=exa|parallel` also enable the tool, which gives custom providers one documented env var to turn websearch on. The env read moves out of `selectWebSearchProvider` into `RuntimeFlags` next to the existing exa and parallel flags, so validation happens in one place and the function is testable without touching `process.env`. Defaults are unchanged: without any of the three env vars, only opencode and opencode-go get the tool.

Also updates the tools doc, which only mentioned `OPENCODE_ENABLE_EXA` and did not mention that this works for any provider.

### How did you verify your code works?

Extended the existing websearch tests: `webSearchEnabled` returns true for non opencode providers when a backend is pinned and stays false otherwise, and `selectWebSearchProvider` honors the pinned backend over the exa and parallel flags. `bun test test/tool/` in packages/opencode: 341 pass. Typecheck and oxlint are clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
