### PR TITLE
fix(app): preserve session header while loading

### DIFF
--- a/packages/app/src/session/route.tsx
+++ b/packages/app/src/session/route.tsx
@@ -16,6 +16,7 @@ import { useTabs } from "@/shell/tabs/tabs"
 import { requireServerKey } from "@/shell/routes/session"
 import { useSessionModel } from "./model"
 import { SessionPanelFrame } from "./session-frame"
+import { SessionIdentityHeader } from "./session-identity-header"
 import { IncompatibleServerPanel } from "./incompatible-server-panel"
 import { SessionErrorFallback } from "./route-error"
 import { createSessionResolution } from "./session-resolution"
@@ -83,7 +84,7 @@ function ResolvedTargetSessionRoute() {
         </SessionStatePanel>
       }
     >
-      <Show when={directory()} fallback={<SessionStatePanel />}>
+      <Show when={directory()} fallback={<PendingSessionState sessionID={params.id} />}>
         {(value) => (
           <LocationProvider directory={value()}>
             <SessionUIProvider directory={value()} server={server.key}>
@@ -93,6 +94,14 @@ function ResolvedTargetSessionRoute() {
         )}
       </Show>
     </Show>
+  )
+}
+
+function PendingSessionState(props: { sessionID: string }) {
+  return (
+    <SessionStatePanel>
+      <SessionIdentityHeader sessionID={props.sessionID} />
+    </SessionStatePanel>
   )
 }
 

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -17,6 +17,7 @@ import { createSessionReview } from "./review/model"
 import { SessionDesktopReview, SessionMobileReview, SessionMobileTabs } from "./review/view"
 import { createSessionTimelineInteraction } from "./timeline/interaction"
 import { ActiveSessionComposerRegion, createActiveSessionRegion } from "./composer/region"
+import { SessionIdentityHeader } from "./session-identity-header"
 
 export function SessionScreen(props: { session: SessionModel }) {
   const session = props.session
@@ -73,7 +74,16 @@ export function SessionScreen(props: { session: SessionModel }) {
             <SessionMobileReview review={review} />
           </Match>
           <Match when={session.identity.params.id}>
-            <Show when={messagesReady() ? session.identity.params.id : undefined} keyed>
+            <Show when={!messagesReady()}>
+              <SessionIdentityHeader
+                sessionID={session.identity.params.id ?? ""}
+                session={session.data.info()}
+              />
+            </Show>
+            <Show
+              when={messagesReady() ? session.identity.params.id : undefined}
+              keyed
+            >
               {(_id) => (
                 <MessageTimeline
                   session={session}

--- a/packages/app/src/session/session-identity-header.tsx
+++ b/packages/app/src/session/session-identity-header.tsx
@@ -1,0 +1,88 @@
+import type { SessionInfo } from "@opencode-ai/client/promise"
+import { Icon } from "@opencode-ai/ui/icon"
+import { ProjectAvatar } from "@opencode-ai/ui/project-avatar"
+import { createMemo, Show, type ParentProps } from "solid-js"
+import { useServer } from "@/runtime/server/current"
+import { displayName, getProjectAvatarSource, projectForSession } from "@/shell/layout/helpers"
+import { getProjectAvatarVariant } from "@/shell/state/layout"
+import { tabKey, useTabs } from "@/shell/tabs/tabs"
+import { useSettings } from "@/settings/model"
+import { pathKey } from "@/workspaces/path-key"
+import { isWorkspaceDirectory } from "@/workspaces/paths"
+import { sessionTitle } from "./title"
+
+export function SessionTitleHeader(props: ParentProps) {
+  return (
+    <div
+      data-session-title
+      class="sticky top-0 z-30 w-full bg-[linear-gradient(to_bottom,var(--v2-background-bg-base)_48px,transparent)] pb-4 pe-3 ps-2.5"
+    >
+      {props.children}
+    </div>
+  )
+}
+
+export function SessionIdentityHeader(props: { sessionID: string; session?: SessionInfo }) {
+  const server = useServer()
+  const tabs = useTabs()
+  const settings = useSettings()
+  const info = createMemo(
+    () => tabs.info[tabKey({ type: "session", server: server.key, sessionId: props.sessionID })],
+  )
+  const directory = createMemo(() => props.session?.location.directory ?? info()?.directory)
+  const title = createMemo(() => sessionTitle(props.session?.title ?? info()?.title))
+  const project = createMemo(() => {
+    const projects = server.ctx.projects.list()
+    if (props.session) return projectForSession(props.session, projects)
+    const value = directory()
+    if (!value) return undefined
+    const key = pathKey(value)
+    return projects.find(
+      (item) => pathKey(item.worktree) === key || item.sandboxes?.some((sandbox) => pathKey(sandbox) === key),
+    )
+  })
+  const showProjectIcon = () =>
+    import.meta.env.VITE_OPENCODE_CHANNEL !== "prod" && settings.general.showProjectIcon() && !!directory()
+  const workspaceSession = createMemo(() => isWorkspaceDirectory(project(), directory() ?? ""))
+
+  return (
+    <Show when={title() || showProjectIcon()}>
+      <SessionTitleHeader>
+        <div class="flex h-12 w-full items-center justify-between gap-2">
+          <div class="flex min-w-0 flex-1 items-center gap-1">
+            <div class="flex min-w-0 w-full flex-1 items-center">
+              <span
+                classList={{
+                  "flex size-6 shrink-0 items-center justify-center": true,
+                  "text-v2-icon-icon-accent": workspaceSession() && !showProjectIcon(),
+                  "text-v2-icon-icon-muted": !workspaceSession() && !showProjectIcon(),
+                }}
+              >
+                <Show
+                  when={showProjectIcon()}
+                  fallback={<Icon name={workspaceSession() ? "workspace-isolated" : "monitor"} />}
+                >
+                  <ProjectAvatar
+                    fallback={displayName(project() ?? { worktree: directory() ?? "" })}
+                    src={getProjectAvatarSource(project()?.id, project()?.icon)}
+                    variant={getProjectAvatarVariant(project()?.icon?.color)}
+                  />
+                </Show>
+              </span>
+              <Show when={title()}>
+                {(value) => (
+                  <h1
+                    dir="auto"
+                    class="w-fit truncate rounded-[6px] px-2 py-1 text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base"
+                  >
+                    {value()}
+                  </h1>
+                )}
+              </Show>
+            </div>
+          </div>
+        </div>
+      </SessionTitleHeader>
+    </Show>
+  )
+}

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -30,6 +30,7 @@ import { displayName, getProjectAvatarSource, projectForSession } from "@/shell/
 import { parseCommentNote, readPromptPresentation } from "@/composer/comment-note"
 import { useCommand } from "@/shell/commands/command"
 import { useSettings } from "@/settings/model"
+import { SessionTitleHeader } from "../session-identity-header"
 
 type BackgroundTask = {
   id: string
@@ -523,10 +524,7 @@ function MessageTimelineView(
       }}
       renderRow={(row, onSizeChange) => <rowRenderer.Row row={row} onSizeChange={onSizeChange} />}
       header={
-        <div
-          data-session-title
-          class="sticky top-0 z-30 bg-[linear-gradient(to_bottom,var(--v2-background-bg-base)_48px,transparent)] w-full pb-4 pr-3 pl-2.5"
-        >
+        <SessionTitleHeader>
           <div class="h-12 w-full flex items-center justify-between gap-2">
             <div class="flex items-center gap-1 min-w-0 flex-1">
               <div class="flex items-center min-w-0 flex-1 w-full">
@@ -716,7 +714,7 @@ function MessageTimelineView(
               )}
             </Show>
           </div>
-        </div>
+        </SessionTitleHeader>
       }
     />
   )


### PR DESCRIPTION
## Summary

- keep the session title row visible while session metadata or messages are loading
- reuse the production header wrapper so loading and loaded states have identical spacing
- derive the loading title and project/workspace icon from live session data or persisted tab metadata

## Validation

- `bun typecheck` (`packages/app`)
- `bun test --conditions=solid --only-failures --preload ./happydom.ts ./src/session`: 136 passed
- `bun run build` (`packages/app`)
- push hook: full monorepo typecheck
