### PR TITLE
feat(app): add word-level diff highlighting

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/solid"
 import { I18nProvider } from "@opencode-ai/ui/context"
 import { DialogProvider } from "@opencode-ai/ui/context/dialog"
 import { FileComponentProvider } from "@opencode-ai/ui/context/file"
-import { File } from "@opencode-ai/session-ui/file"
+import { File, type FileProps } from "@opencode-ai/session-ui/file"
 import { Font } from "@opencode-ai/ui/font"
 import { Splash } from "@opencode-ai/ui/logo"
 import { ThemeProvider } from "@opencode-ai/ui/theme/context"
@@ -415,7 +415,7 @@ export function AppBaseProviders(
               <QueryProvider>
                 <WslServersProvider>
                   <DialogProvider>
-                    <FileComponentProvider component={File}>{props.children}</FileComponentProvider>
+                    <FileComponentProvider component={SettingsFile}>{props.children}</FileComponentProvider>
                   </DialogProvider>
                 </WslServersProvider>
               </QueryProvider>
@@ -424,6 +424,19 @@ export function AppBaseProviders(
         </LanguageProvider>
       </ThemeProvider>
     </MetaProvider>
+  )
+}
+
+function SettingsFile(props: FileProps) {
+  const settings = useSettings()
+  if (props.mode === "text") return <File {...props} />
+  return (
+    <File
+      {...props}
+      lineDiffType={
+        settings.appearance.wordDiffHighlighting() ? (props.diffStyle === "split" ? "word-alt" : "word") : "none"
+      }
+    />
   )
 }
 

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -503,6 +503,18 @@ export const SettingsGeneral: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.general.row.wordDiffHighlighting.title")}
+          description={language.t("settings.general.row.wordDiffHighlighting.description")}
+        >
+          <div data-action="settings-word-diff-highlighting">
+            <Switch
+              checked={settings.appearance.wordDiffHighlighting()}
+              onChange={(checked) => settings.appearance.setWordDiffHighlighting(checked)}
+            />
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.general.row.uiFont.title")}
           description={language.t("settings.general.row.uiFont.description")}
         >

--- a/packages/app/src/components/settings-v2/general-controllers.ts
+++ b/packages/app/src/components/settings-v2/general-controllers.ts
@@ -89,6 +89,8 @@ export function createAppearanceSettingsController() {
       current: createMemo(() => themes().find((option) => option.id === theme.themeId())),
       select: (option: { id: string } | null) => option && theme.setTheme(option.id),
     },
+    wordDiffHighlighting: settings.appearance.wordDiffHighlighting,
+    setWordDiffHighlighting: settings.appearance.setWordDiffHighlighting,
     fonts: {
       ui: createMemo(() => ({
         value: sansInput(settings.appearance.uiFont()),

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -169,6 +169,18 @@ const AppearanceSection: Component<{ controller: AppearanceSettingsController }>
           />
         </SettingsRowV2>
 
+        <SettingsRowV2
+          title={language.t("settings.general.row.wordDiffHighlighting.title")}
+          description={language.t("settings.general.row.wordDiffHighlighting.description")}
+        >
+          <div data-action="settings-word-diff-highlighting">
+            <Switch
+              checked={props.controller.wordDiffHighlighting()}
+              onChange={props.controller.setWordDiffHighlighting}
+            />
+          </div>
+        </SettingsRowV2>
+
         <FontSetting kind="ui" fonts={props.controller.fonts} />
         <FontSetting kind="code" fonts={props.controller.fonts} />
         <FontSetting kind="terminal" fonts={props.controller.fonts} />

--- a/packages/app/src/context/settings.test.ts
+++ b/packages/app/src/context/settings.test.ts
@@ -10,7 +10,12 @@ import {
   resolveNewLayoutDesigns,
   shouldDisplayTabsToast,
   shouldEnableNewLayout,
+  wordDiffHighlightingDefault,
 } from "./settings"
+
+test("word-level diff highlighting is opt-in", () => {
+  expect(wordDiffHighlightingDefault).toBe(false)
+})
 
 describe("agent visibility", () => {
   test("shows the picker for existing profiles and hides it for first-time installs", () => {

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -45,6 +45,7 @@ export interface Settings {
     mono: string
     sans: string
     terminal: string
+    wordDiffHighlighting: boolean
   }
   keybinds: Record<string, string>
   permissions: {
@@ -57,6 +58,7 @@ export interface Settings {
 export const monoDefault = "System Mono"
 export const sansDefault = "System Sans"
 export const terminalDefault = "JetBrainsMono Nerd Font Mono"
+export const wordDiffHighlightingDefault = false
 const legacyNewLayoutDesignsDefault = import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"
 export const newLayoutDesignsDefault = true
 // Existing users can switch layouts until local midnight on this date. Set new Date(YYYY, M-1, D) to show.
@@ -201,6 +203,7 @@ const defaultSettings: Settings = {
     mono: "",
     sans: "",
     terminal: "",
+    wordDiffHighlighting: wordDiffHighlightingDefault,
   },
   keybinds: {},
   permissions: {
@@ -474,6 +477,13 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         terminalFont: withFallback(() => store.appearance?.terminal, defaultSettings.appearance.terminal),
         setTerminalFont(value: string) {
           setStore("appearance", "terminal", value.trim() ? value : "")
+        },
+        wordDiffHighlighting: withFallback(
+          () => store.appearance?.wordDiffHighlighting,
+          defaultSettings.appearance.wordDiffHighlighting,
+        ),
+        setWordDiffHighlighting(value: boolean) {
+          setStore("appearance", "wordDiffHighlighting", value)
         },
       },
       keybinds: {

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -916,6 +916,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "OpenCode ስርዓቱን፣ ብርሃንን ወይም ጨለማውን ገጽታ የሚከተል እንደሆነ ምረጥ",
   "settings.general.row.theme.title": "ገጽታ",
   "settings.general.row.theme.description": "OpenCode ገጽታ እንዴት እንደሆነ አብጅ።",
+  "settings.general.row.wordDiffHighlighting.title": "በቃል ደረጃ የልዩነት ማድመቅ",
+  "settings.general.row.wordDiffHighlighting.description": "በታከሉ እና በተወገዱ መስመሮች ውስጥ የተቀየሩ ቃላትን አድምቅ",
   "settings.general.row.font.title": "የኮድ ቅርጸ ቁምፊ",
   "settings.general.row.font.description": "በኮድ ብሎኮች ውስጥ ጥቅም ላይ የዋለውን ቅርጸ-ቁምፊ አብጅ",
   "settings.general.row.terminalFont.title": "ተርሚናል ፊደል",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -855,6 +855,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "اختر ما إذا كان OpenCode يتبع سمة النظام أو الفاتح أو الداكن",
   "settings.general.row.theme.title": "السمة",
   "settings.general.row.theme.description": "تخصيص سمة OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "إبراز الفروق على مستوى الكلمات",
+  "settings.general.row.wordDiffHighlighting.description": "أبرِز الكلمات المتغيّرة داخل الأسطر المضافة والمحذوفة",
   "settings.general.row.font.title": "خط الكود",
   "settings.general.row.font.description": "خصّص الخط المستخدم في كتل التعليمات البرمجية",
   "settings.general.row.terminalFont.title": "خط الطرفية",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -945,6 +945,9 @@ export const dict = {
     "OpenCode-un sistem, açıq və ya tünd mövzudan istifadə etməsini seçin",
   "settings.general.row.theme.title": "Mövzu",
   "settings.general.row.theme.description": "OpenCode-un mövzusunu fərdiləşdirin.",
+  "settings.general.row.wordDiffHighlighting.title": "Söz səviyyəsində fərqlərin vurğulanması",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Əlavə edilmiş və silinmiş sətirlərdə dəyişdirilmiş sözləri vurğulayın",
   "settings.general.row.font.title": "Kod şrifti",
   "settings.general.row.font.description": "Kod bloklarında istifadə olunan mono şrifti fərdiləşdirin",
   "settings.general.row.terminalFont.title": "Terminal şrifti",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -941,6 +941,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Изберете дали OpenCode следва системната, светла или тъмна тема",
   "settings.general.row.theme.title": "Тема",
   "settings.general.row.theme.description": "Персонализирайте как е тематично OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Открояване на разликите на ниво дума",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Откроява променените думи в добавените и премахнатите редове",
   "settings.general.row.font.title": "Шрифт на кода",
   "settings.general.row.font.description": "Персонализирайте шрифта, използван в кодовите блокове",
   "settings.general.row.terminalFont.title": "Терминален шрифт",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -933,6 +933,8 @@ export const dict: Record<string, string> = {
   "settings.general.row.colorScheme.description": "OpenCode সিস্টেম, হালকা বা অন্ধকার থিম অনুসরণ করে কিনা তা বেছে নিন",
   "settings.general.row.theme.title": "থিম",
   "settings.general.row.theme.description": "কিভাবে OpenCode থিম করা হয় তা কাস্টমাইজ করুন।",
+  "settings.general.row.wordDiffHighlighting.title": "শব্দ-স্তরের পার্থক্য হাইলাইটকরণ",
+  "settings.general.row.wordDiffHighlighting.description": "যোগ করা ও সরানো লাইনের পরিবর্তিত শব্দগুলো হাইলাইট করুন",
   "settings.general.row.font.title": "কোড ফন্ট",
   "settings.general.row.font.description": "কোড ব্লকে ব্যবহৃত ফন্ট কাস্টমাইজ করুন",
   "settings.general.row.terminalFont.title": "টার্মিনাল ফন্ট",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -858,6 +858,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Escolha se o OpenCode segue o tema do sistema, claro ou escuro",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Personalize como o OpenCode é tematizado.",
+  "settings.general.row.wordDiffHighlighting.title": "Realce de diferenças no nível da palavra",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Realçar palavras alteradas em linhas adicionadas e removidas",
   "settings.general.row.font.title": "Fonte de código",
   "settings.general.row.font.description": "Personalize a fonte usada em blocos de código",
   "settings.general.row.terminalFont.title": "Fonte do terminal",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -923,6 +923,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Odaberi da li OpenCode prati sistemsku, svijetlu ili tamnu temu",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Prilagodi temu OpenCode-a.",
+  "settings.general.row.wordDiffHighlighting.title": "Isticanje razlika na nivou riječi",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Istakni promijenjene riječi u dodanim i uklonjenim redovima",
   "settings.general.row.font.title": "Font za kod",
   "settings.general.row.font.description": "Prilagodi font koji se koristi u blokovima koda",
   "settings.general.row.terminalFont.title": "Font terminala",

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -944,6 +944,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Trieu si OpenCode segueix el tema del sistema, clar o fosc",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Personalitza la temàtica de OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Ressaltat de diferències paraula per paraula",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Ressalta les paraules modificades a les línies afegides i suprimides",
   "settings.general.row.font.title": "Font del codi",
   "settings.general.row.font.description": "Personalitzeu el tipus de lletra utilitzat als blocs de codi",
   "settings.general.row.terminalFont.title": "Tipus de lletra terminal",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -941,6 +941,8 @@ export const dict = {
     "Zvolte, zda bude OpenCode následovat systémové, světlé nebo tmavé téma",
   "settings.general.row.theme.title": "téma",
   "settings.general.row.theme.description": "Přizpůsobte, jak je téma OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Zvýraznění rozdílů na úrovni slov",
+  "settings.general.row.wordDiffHighlighting.description": "Zvýrazní změněná slova v přidaných a odstraněných řádcích",
   "settings.general.row.font.title": "Písmo kódu",
   "settings.general.row.font.description": "Přizpůsobte písmo používané v blocích kódu",
   "settings.general.row.terminalFont.title": "Terminálové písmo",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -800,6 +800,8 @@ export const dict = {
     "Vælg, om OpenCode skal følge systemtemaet eller bruge et lyst eller mørkt tema",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Tilpas OpenCodes tema.",
+  "settings.general.row.wordDiffHighlighting.title": "Fremhævning af forskelle på ordniveau",
+  "settings.general.row.wordDiffHighlighting.description": "Fremhæv ændrede ord i tilføjede og fjernede linjer",
   "settings.general.row.font.title": "Kode-skrifttype",
   "settings.general.row.font.description": "Tilpas skrifttypen, der bruges i kodeblokke",
   "settings.general.row.terminalFont.title": "Terminalskrifttype",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -750,6 +750,9 @@ export const dict = {
     "Wählen Sie, ob OpenCode dem System-, hellen oder dunklen Thema folgt",
   "settings.general.row.theme.title": "Thema",
   "settings.general.row.theme.description": "Das Thema von OpenCode anpassen.",
+  "settings.general.row.wordDiffHighlighting.title": "Hervorhebung von Unterschieden auf Wortebene",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Geänderte Wörter in hinzugefügten und entfernten Zeilen hervorheben",
   "settings.general.row.font.title": "Code-Schriftart",
   "settings.general.row.font.description": "Die in Codeblöcken verwendete Schriftart anpassen",
   "settings.general.row.terminalFont.title": "Terminalschriftart",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -950,6 +950,9 @@ export const dict = {
     "OpenCode އިން ސިސްޓަމް، ލައިޓް، ނުވަތަ ޑާކް ތީމް އަށް ތަބާވާތޯ ހޮވާށެވެ",
   "settings.general.row.theme.title": "ތީމް",
   "settings.general.row.theme.description": "OpenCode ތީމް ކުރެވިފައިވާ ގޮތް ކަސްޓަމައިޒް ކުރުން.",
+  "settings.general.row.wordDiffHighlighting.title": "ބަހުގެ ފެންވަރުގައި ތަފާތު ހައިލައިޓް ކުރުން",
+  "settings.general.row.wordDiffHighlighting.description":
+    "އިތުރުކޮށްފައިވާ އަދި ނައްތާލާފައިވާ ލައިންތަކުގައި ބަދަލުވެފައިވާ ބަސްތައް ހައިލައިޓް ކުރުން",
   "settings.general.row.font.title": "ކޯޑް ފޮންޓެވެ",
   "settings.general.row.font.description": "ކޯޑް ބްލޮކްތަކުގައި ބޭނުންކުރާ ފޮންޓް ކަސްޓަމައިޒް ކުރުން",
   "settings.general.row.terminalFont.title": "ޓާމިނަލް ފޮންޓެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -952,6 +952,9 @@ export const dict: Record<string, string> = {
     "OpenCode གིས་ རིམ་ལུགས་དང་ འོད་ ཡང་ན་ གནགཔོ་གི་བརྗོད་དོན་ལུ་ རྗེས་སུ་འཇུག་ནི་ཨིན་ན་ གདམ་ཁ་རྐྱབས།",
   "settings.general.row.theme.title": "བརྗོད༌དོན",
   "settings.general.row.theme.description": "OpenCodeའདི་བརྗོད་དོན་ག་དེ་སྦེ་ཡོདཔ་ཨིན་ན་སྲོལ་སྒྲིག་འབད།",
+  "settings.general.row.wordDiffHighlighting.title": "མིང་ཚིག་གི་གནས་རིམ་གྱི་ཁྱད་པར་གཙོ་དམིགས།",
+  "settings.general.row.wordDiffHighlighting.description":
+    "ཁ་སྐོང་དང་བཏོན་གཏང་འབད་ཡོད་པའི་གྲལ་ཐིག་ཚུ་ནང་ བསྒྱུར་བཅོས་འབད་ཡོད་པའི་མིང་ཚིག་ཚུ་གཙོ་དམིགས་འབད།",
   "settings.general.row.font.title": "ཨང་རྟགས་ཡིག་གཟུགས།",
   "settings.general.row.font.description": "གསང་གྲངས་སྡེབ་ཚན་ཚུ་ནང་ལག་ལེན་འཐབ་མི་ཡིག་གཟུགས་སྲོལ་སྒྲིག་འབད།",
   "settings.general.row.terminalFont.title": "ཊར་མི་ནཱལ་ཡིག་གཟུགས།",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -946,6 +946,9 @@ export const dict = {
     "Επιλέξτε εάν το OpenCode ακολουθεί το σύστημα, το ανοιχτό ή το σκοτεινό θέμα",
   "settings.general.row.theme.title": "Θέμα",
   "settings.general.row.theme.description": "Προσαρμογή του τρόπου με τον οποίο έχει θέμα το OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Επισήμανση διαφορών σε επίπεδο λέξης",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Επισημάνετε τις τροποποιημένες λέξεις στις γραμμές που προστέθηκαν και αφαιρέθηκαν",
   "settings.general.row.font.title": "Γραμματοσειρά κώδικα",
   "settings.general.row.font.description": "Προσαρμογή της γραμματοσειράς που χρησιμοποιείται στα μπλοκ κώδικα",
   "settings.general.row.terminalFont.title": "Τερματική γραμματοσειρά",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -917,6 +917,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Choose whether OpenCode follows the system, light, or dark theme",
   "settings.general.row.theme.title": "Theme",
   "settings.general.row.theme.description": "Customise how OpenCode is themed.",
+  "settings.general.row.wordDiffHighlighting.title": "Word-level diff highlighting",
+  "settings.general.row.wordDiffHighlighting.description": "Highlight changed words within added and removed lines",
   "settings.general.row.font.title": "Code Font",
   "settings.general.row.font.description": "Customise the font used in code blocks",
   "settings.general.row.terminalFont.title": "Terminal Font",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -927,6 +927,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Elige si OpenCode sigue el tema del sistema, claro u oscuro",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Personaliza el tema de OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Resaltado de diferencias a nivel de palabra",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Resaltar las palabras modificadas en las líneas añadidas y eliminadas",
   "settings.general.row.font.title": "Fuente de código",
   "settings.general.row.font.description": "Personaliza la fuente usada en bloques de código",
   "settings.general.row.terminalFont.title": "Fuente del terminal",

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -931,6 +931,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Valige, kas OpenCode järgib süsteemi, heledat või tumedat teemat",
   "settings.general.row.theme.title": "Teema",
   "settings.general.row.theme.description": "Kohandage, kuidas OpenCode on teemastatud.",
+  "settings.general.row.wordDiffHighlighting.title": "Sõnatasemel erinevuste esiletõstmine",
+  "settings.general.row.wordDiffHighlighting.description": "Tõstke muudetud sõnad lisatud ja eemaldatud ridadel esile",
   "settings.general.row.font.title": "Koodi font",
   "settings.general.row.font.description": "Kohandage koodiplokkides kasutatavat fonti",
   "settings.general.row.terminalFont.title": "Terminali font",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -932,6 +932,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "انتخاب کنید که آیا OpenCode از تم سیستمی، روشن یا تیره پیروی می کند",
   "settings.general.row.theme.title": "موضوع",
   "settings.general.row.theme.description": "نحوه مضمون سازی OpenCode را سفارشی کنید.",
+  "settings.general.row.wordDiffHighlighting.title": "برجسته‌سازی تفاوت‌ها در سطح واژه",
+  "settings.general.row.wordDiffHighlighting.description":
+    "واژه‌های تغییریافته را در خط‌های افزوده و حذف‌شده برجسته کنید",
   "settings.general.row.font.title": "فونت کد",
   "settings.general.row.font.description": "فونت مورد استفاده در بلوک های کد را سفارشی کنید",
   "settings.general.row.terminalFont.title": "فونت ترمینال",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -835,6 +835,8 @@ export const dict = {
     "Valitse, käyttääkö OpenCode järjestelmän mukaista, vaaleaa vai tummaa teemaa",
   "settings.general.row.theme.title": "Teema",
   "settings.general.row.theme.description": "Mukauta OpenCoden teemaa.",
+  "settings.general.row.wordDiffHighlighting.title": "Sanatason erojen korostus",
+  "settings.general.row.wordDiffHighlighting.description": "Korosta muutetut sanat lisätyillä ja poistetuilla riveillä",
   "settings.general.row.font.title": "Koodifontti",
   "settings.general.row.font.description": "Mukauta koodilohkoissa käytettyä fonttia",
   "settings.general.row.terminalFont.title": "Terminaalin fontti",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -934,6 +934,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Vel um OpenCode fylgir skipanini, ljósa ella myrka temanum",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Tillaga hvussu OpenCode er tema.",
+  "settings.general.row.wordDiffHighlighting.title": "Markering av munum á orðastigi",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Markera broytt orð í linjum, sum eru lagdar afturat ella strikaðar",
   "settings.general.row.font.title": "Koda skriftslag",
   "settings.general.row.font.description": "Tillaga skriftslagið, sum verður brúkt í kodublokkum",
   "settings.general.row.terminalFont.title": "Terminalskriftslag",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -863,6 +863,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Choisissez si OpenCode suit le thème système, clair ou sombre",
   "settings.general.row.theme.title": "Thème",
   "settings.general.row.theme.description": "Personnaliser le thème d'OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Mise en évidence des différences au niveau des mots",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Mettre en évidence les mots modifiés dans les lignes ajoutées et supprimées",
   "settings.general.row.font.title": "Police de code",
   "settings.general.row.font.description": "Personnaliser la police utilisée dans les blocs de code",
   "settings.general.row.terminalFont.title": "Police du terminal",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -943,6 +943,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "चुनें कि OpenCode सिस्टम, हल्की या गहरी थीम में से किसका उपयोग करे",
   "settings.general.row.theme.title": "थीम",
   "settings.general.row.theme.description": "अनुकूलित करें कि OpenCode की थीम कैसी है।",
+  "settings.general.row.wordDiffHighlighting.title": "शब्द-स्तरीय अंतर को हाइलाइट करना",
+  "settings.general.row.wordDiffHighlighting.description":
+    "जोड़ी गई और हटाई गई पंक्तियों में बदले हुए शब्दों को हाइलाइट करें",
   "settings.general.row.font.title": "कोड फ़ॉन्ट",
   "settings.general.row.font.description": "कोड ब्लॉक में प्रयुक्त फ़ॉन्ट को अनुकूलित करें",
   "settings.general.row.terminalFont.title": "टर्मिनल फ़ॉन्ट",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -944,6 +944,9 @@ export const dict = {
     "Odaberite hoće li OpenCode slijediti sistemsku, svijetlu ili tamnu temu",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Prilagodite način na koji je OpenCode tematiziran.",
+  "settings.general.row.wordDiffHighlighting.title": "Isticanje razlika na razini riječi",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Istaknite promijenjene riječi u dodanim i uklonjenim recima",
   "settings.general.row.font.title": "Font koda",
   "settings.general.row.font.description": "Prilagodite font koji se koristi u blokovima koda",
   "settings.general.row.terminalFont.title": "Font Terminal",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -944,6 +944,9 @@ export const dict = {
     "Válassza ki, hogy a OpenCode a rendszer, a világos vagy a sötét témát követi-e",
   "settings.general.row.theme.title": "Téma",
   "settings.general.row.theme.description": "Szabja személyre a OpenCode témáját.",
+  "settings.general.row.wordDiffHighlighting.title": "Szószintű eltérések kiemelése",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Emelje ki a módosított szavakat a hozzáadott és eltávolított sorokban",
   "settings.general.row.font.title": "Kód betűtípus",
   "settings.general.row.font.description": "Testreszabhatja a kódblokkban használt betűtípust",
   "settings.general.row.terminalFont.title": "Terminal betűtípus",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -942,6 +942,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Ընտրեք՝ OpenCode-ը հետևում է համակարգին, թեթև թե մուգ թեմային",
   "settings.general.row.theme.title": "Թեմա",
   "settings.general.row.theme.description": "Անհատականացրեք, թե ինչպես է OpenCode-ի թեմատիկությունը։",
+  "settings.general.row.wordDiffHighlighting.title": "Տարբերությունների գունանշում բառերի մակարդակով",
+  "settings.general.row.wordDiffHighlighting.description": "Գունանշեք ավելացված և հեռացված տողերում փոփոխված բառերը",
   "settings.general.row.font.title": "Կոդի տառատեսակ",
   "settings.general.row.font.description": "Անհատականացրեք կոդերի բլոկներում օգտագործվող տառատեսակը",
   "settings.general.row.terminalFont.title": "Տերմինալ տառատեսակ",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -1015,6 +1015,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Pilih apakah OpenCode mengikuti tema sistem, terang, atau gelap",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Sesuaikan tema OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Penyorotan perbedaan pada tingkat kata",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Sorot kata yang berubah dalam baris yang ditambahkan dan dihapus",
   "settings.general.row.font.title": "Font kode",
   "settings.general.row.font.description": "Sesuaikan font yang digunakan di blok kode",
   "settings.general.row.terminalFont.title": "Font terminal",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -937,6 +937,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Veldu hvort OpenCode fylgir kerfis-, ljósu eða dökku þema",
   "settings.general.row.theme.title": "Þema",
   "settings.general.row.theme.description": "Sérsníddu hvernig OpenCode er þema.",
+  "settings.general.row.wordDiffHighlighting.title": "Áherslulitun mismunar á orðastigi",
+  "settings.general.row.wordDiffHighlighting.description": "Áherslulita breytt orð í viðbættum og fjarlægðum línum",
   "settings.general.row.font.title": "Kóða leturgerð",
   "settings.general.row.font.description": "Sérsníddu leturgerðina sem notuð er í kóðablokkum",
   "settings.general.row.terminalFont.title": "Leturgerð skjáhermis",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -855,6 +855,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Scegli se OpenCode segue il tema di sistema, chiaro o scuro",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Personalizza il tema di OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Evidenziazione delle differenze a livello di parola",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Evidenzia le parole modificate nelle righe aggiunte e rimosse",
   "settings.general.row.font.title": "Carattere del codice",
   "settings.general.row.font.description": "Personalizza il carattere utilizzato nei blocchi di codice",
   "settings.general.row.terminalFont.title": "Carattere terminale",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -843,6 +843,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "OpenCodeがシステム、ライト、またはダークテーマに従うかを選択します",
   "settings.general.row.theme.title": "テーマ",
   "settings.general.row.theme.description": "OpenCodeのテーマをカスタマイズします。",
+  "settings.general.row.wordDiffHighlighting.title": "単語単位の差分強調表示",
+  "settings.general.row.wordDiffHighlighting.description": "追加行と削除行内で変更された単語を強調表示します",
   "settings.general.row.font.title": "コードフォント",
   "settings.general.row.font.description": "コードブロックで使用するフォントをカスタマイズします",
   "settings.general.row.terminalFont.title": "ターミナルのフォント",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -934,6 +934,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "აირჩიეთ, მიჰყვება თუ არა OpenCode სისტემას, ღია თუ ბნელ თემას",
   "settings.general.row.theme.title": "თემა",
   "settings.general.row.theme.description": "მორგება, თუ როგორ არის OpenCode თემატური.",
+  "settings.general.row.wordDiffHighlighting.title": "სიტყვის დონეზე განსხვავებების გამოკვეთა",
+  "settings.general.row.wordDiffHighlighting.description": "გამოკვეთეთ დამატებულ და წაშლილ ხაზებში შეცვლილი სიტყვები",
   "settings.general.row.font.title": "კოდის შრიფტი",
   "settings.general.row.font.description": "მორგეთ კოდის ბლოკებში გამოყენებული შრიფტი",
   "settings.general.row.terminalFont.title": "ტერმინალის შრიფტი",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -932,6 +932,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "ជ្រើសរើសថាតើ OpenCode ធ្វើតាមប្រព័ន្ធ ពន្លឺ ឬរូបរាងងងឹត",
   "settings.general.row.theme.title": "ស្បែក",
   "settings.general.row.theme.description": "ប្ដូរតាមបំណងពីរបៀបដែល OpenCode មានប្រធានបទ។",
+  "settings.general.row.wordDiffHighlighting.title": "ការរំលេចភាពខុសគ្នានៅកម្រិតពាក្យ",
+  "settings.general.row.wordDiffHighlighting.description":
+    "រំលេចពាក្យដែលបានផ្លាស់ប្ដូរនៅក្នុងបន្ទាត់ដែលបានបន្ថែម និងដកចេញ",
   "settings.general.row.font.title": "ពុម្ពអក្សរកូដ",
   "settings.general.row.font.description": "ប្ដូរពុម្ពអក្សរដែលប្រើក្នុងប្លុកកូដតាមបំណង",
   "settings.general.row.terminalFont.title": "ពុម្ពអក្សរស្ថានីយ",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -598,6 +598,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "OpenCode가 시스템, 라이트 또는 다크 테마를 따를지 선택하세요",
   "settings.general.row.theme.title": "테마",
   "settings.general.row.theme.description": "OpenCode 테마 사용자 지정",
+  "settings.general.row.wordDiffHighlighting.title": "단어 단위 diff 강조 표시",
+  "settings.general.row.wordDiffHighlighting.description": "추가되거나 삭제된 줄에서 변경된 단어를 강조 표시합니다",
   "settings.general.row.font.title": "코드 글꼴",
   "settings.general.row.font.description": "코드 블록에 사용되는 글꼴을 사용자 지정",
   "settings.general.row.terminalFont.title": "터미널 글꼴",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -929,6 +929,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "ເລືອກວ່າ OpenCode ປະຕິບັດຕາມລະບົບ, ແສງສະຫວ່າງ, ຫຼືຮູບແບບຊ້ໍາ",
   "settings.general.row.theme.title": "ຫົວຂໍ້",
   "settings.general.row.theme.description": "ປັບແຕ່ງວິທີ OpenCode ເປັນຫົວຂໍ້.",
+  "settings.general.row.wordDiffHighlighting.title": "ການເນັ້ນຄວາມແຕກຕ່າງໃນລະດັບຄຳ",
+  "settings.general.row.wordDiffHighlighting.description": "ເນັ້ນຄຳທີ່ປ່ຽນແປງໃນບັນທັດທີ່ເພີ່ມ ແລະ ລຶບອອກ",
   "settings.general.row.font.title": "ຕົວອັກສອນລະຫັດ",
   "settings.general.row.font.description": "ປັບແຕ່ງຕົວອັກສອນທີ່ໃຊ້ໃນບລັອກລະຫັດ",
   "settings.general.row.terminalFont.title": "ຕົວອັກສອນປາຍ",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -949,6 +949,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Pasirinkite, ar OpenCode seka sistemos, šviesios ar tamsios temos",
   "settings.general.row.theme.title": "tema",
   "settings.general.row.theme.description": "Tinkinkite OpenCode temą.",
+  "settings.general.row.wordDiffHighlighting.title": "Žodžių lygmens skirtumų paryškinimas",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Paryškinkite pakeistus žodžius pridėtose ir pašalintose eilutėse",
   "settings.general.row.font.title": "Kodo šriftas",
   "settings.general.row.font.description": "Tinkinkite kodo blokuose naudojamą šriftą",
   "settings.general.row.terminalFont.title": "Šriftas Terminal",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -941,6 +941,9 @@ export const dict = {
     "Izvēlieties, vai OpenCode sekos sistēmas, gaišajai vai tumšajai tēmai",
   "settings.general.row.theme.title": "Tēma",
   "settings.general.row.theme.description": "Pielāgojiet OpenCode tēmu.",
+  "settings.general.row.wordDiffHighlighting.title": "Vārdu līmeņa atšķirību izcelšana",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Izceliet mainītos vārdus pievienotajās un noņemtajās rindās",
   "settings.general.row.font.title": "Koda fonts",
   "settings.general.row.font.description": "Pielāgojiet fontu, kas tiek izmantots koda blokos",
   "settings.general.row.terminalFont.title": "Termināļa fonts",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -939,6 +939,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Изберете дали OpenCode ја следи системската, светла или темна тема",
   "settings.general.row.theme.title": "Тема",
   "settings.general.row.theme.description": "Приспособете како OpenCode е тематизирана.",
+  "settings.general.row.wordDiffHighlighting.title": "Истакнување на разликите на ниво на збор",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Истакнете ги изменетите зборови во додадените и отстранетите редови",
   "settings.general.row.font.title": "Фонт на код",
   "settings.general.row.font.description": "Приспособете го фонтот што се користи во блоковите со кодови",
   "settings.general.row.terminalFont.title": "Терминален фонт",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -943,6 +943,9 @@ export const dict = {
     "OpenCode нь систем, цайвар эсвэл бараан загварт тохирох эсэхийг сонгоно уу",
   "settings.general.row.theme.title": "Сэдэв",
   "settings.general.row.theme.description": "OpenCode-г хэрхэн загварчлахыг тохируулна уу.",
+  "settings.general.row.wordDiffHighlighting.title": "Үгийн түвшний ялгааг тодруулах",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Нэмэгдсэн болон устгагдсан мөрүүд дэх өөрчлөгдсөн үгсийг тодруулах",
   "settings.general.row.font.title": "Кодын фонт",
   "settings.general.row.font.description": "Кодын блокуудад ашигладаг фонтыг тохируулна уу",
   "settings.general.row.terminalFont.title": "Терминал фонт",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -934,6 +934,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Pilih sama ada OpenCode mengikut sistem, tema cerah, atau gelap",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Sesuaikan tema OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Penyerlahan perbezaan pada aras perkataan",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Serlahkan perkataan yang berubah dalam baris yang ditambah dan dialih keluar",
   "settings.general.row.font.title": "Fon Kod",
   "settings.general.row.font.description": "Sesuaikan fon yang digunakan dalam blok kod",
   "settings.general.row.terminalFont.title": "Fon Terminal",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -948,6 +948,9 @@ export const dict = {
     "OpenCode သည် စနစ်၊ အလင်း သို့မဟုတ် အမှောင် အပြင်အဆင်ကို လိုက်နာခြင်း ရှိ၊ မရှိကို ရွေးပါ။",
   "settings.general.row.theme.title": "အပြင်အဆင်",
   "settings.general.row.theme.description": "OpenCode ကို ဘယ်လိုပုံစံနဲ့ စိတ်ကြိုက်လုပ်မလဲ။",
+  "settings.general.row.wordDiffHighlighting.title": "စကားလုံးအဆင့် ကွာခြားချက်များကို အသားပေးဖော်ပြခြင်း",
+  "settings.general.row.wordDiffHighlighting.description":
+    "ထည့်သွင်းထားသော စာကြောင်းများနှင့် ဖယ်ရှားထားသော စာကြောင်းများအတွင်းရှိ ပြောင်းလဲထားသည့် စကားလုံးများကို အသားပေးဖော်ပြပါ",
   "settings.general.row.font.title": "ကုဒ်ဖောင့်",
   "settings.general.row.font.description": "ကုဒ်တုံးများတွင် အသုံးပြုသည့် ဖောင့်ကို စိတ်ကြိုက်ပြင်ဆင်ပါ။",
   "settings.general.row.terminalFont.title": "Terminal ဖောင့်",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -935,6 +935,9 @@ export const dict: Record<string, string> = {
     "OpenCode ले प्रणाली, उज्यालो वा गाढा विषयवस्तुलाई फलो गर्छ कि गर्दैन भन्ने छनौट गर्नुहोस्",
   "settings.general.row.theme.title": "विषयवस्तु",
   "settings.general.row.theme.description": "कसरी OpenCode विषयवस्तुलाई अनुकूलित गर्नुहोस्।",
+  "settings.general.row.wordDiffHighlighting.title": "शब्द-स्तरीय भिन्नता हाइलाइटिङ",
+  "settings.general.row.wordDiffHighlighting.description":
+    "थपिएका र हटाइएका लाइनहरूमा परिवर्तित शब्दहरू हाइलाइट गर्नुहोस्",
   "settings.general.row.font.title": "कोड फन्ट",
   "settings.general.row.font.description": "कोड ब्लकहरूमा प्रयोग गरिएको फन्ट अनुकूलित गर्नुहोस्",
   "settings.general.row.terminalFont.title": "टर्मिनल फन्ट",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -945,6 +945,9 @@ export const dict = {
     "Kies of OpenCode het systeemthema, het lichte thema of het donkere thema gebruikt",
   "settings.general.row.theme.title": "Thema",
   "settings.general.row.theme.description": "Pas het thema van OpenCode aan.",
+  "settings.general.row.wordDiffHighlighting.title": "Verschillen op woordniveau markeren",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Gewijzigde woorden in toegevoegde en verwijderde regels markeren",
   "settings.general.row.font.title": "Codelettertype",
   "settings.general.row.font.description": "Pas het lettertype aan dat in codeblokken wordt gebruikt",
   "settings.general.row.terminalFont.title": "Terminal-lettertype",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -781,6 +781,8 @@ export const dict = {
     "Velg om OpenCode skal følge systeminnstillingen eller bruke lyst eller mørkt tema",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Tilpass temaet i OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Utheving av forskjeller på ordnivå",
+  "settings.general.row.wordDiffHighlighting.description": "Uthev endrede ord i linjer som er lagt til eller fjernet",
   "settings.general.row.font.title": "Kodefont",
   "settings.general.row.font.description": "Tilpass skrifttypen som brukes i kodeblokker",
   "settings.general.row.terminalFont.title": "Terminalskrift",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -941,6 +941,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "چنو کہ آیا OpenCode سسٹم، لائٹ، یا ڈارک تھیم دی پیروی کردا اے",
   "settings.general.row.theme.title": "تھیم",
   "settings.general.row.theme.description": "OpenCode نوں کس طرح تھیم کیتا گیا اے، اپنی مرضی دے مطابق بناؤ۔",
+  "settings.general.row.wordDiffHighlighting.title": "لفظاں دے پدھر تے فرق نوں نمایاں کرنا",
+  "settings.general.row.wordDiffHighlighting.description":
+    "شامل کیتیاں تے ہٹائیاں گئیاں لائناں وچ بدلے ہوئے لفظ نمایاں کرو",
   "settings.general.row.font.title": "کوڈ فونٹ",
   "settings.general.row.font.description": "کوڈ بلاکس وچ استعمال ہون آلے فونٹ نو اپنی مرضی دے مطابق بناؤ",
   "settings.general.row.terminalFont.title": "Terminal فونٹ",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -860,6 +860,8 @@ export const dict = {
     "Wybierz, czy OpenCode ma używać motywu systemowego, jasnego czy ciemnego",
   "settings.general.row.theme.title": "Motyw",
   "settings.general.row.theme.description": "Dostosuj motyw OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Wyróżnianie różnic na poziomie słów",
+  "settings.general.row.wordDiffHighlighting.description": "Wyróżnia zmienione słowa w dodanych i usuniętych wierszach",
   "settings.general.row.font.title": "Czcionka kodu",
   "settings.general.row.font.description": "Dostosuj czcionkę używaną w blokach kodu",
   "settings.general.row.terminalFont.title": "Czcionka terminala",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -939,6 +939,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Alege dacă OpenCode urmează sistemul, tema deschisă sau închisă",
   "settings.general.row.theme.title": "Temă",
   "settings.general.row.theme.description": "Personalizează tema OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Evidențierea diferențelor la nivel de cuvânt",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Evidențiază cuvintele modificate din liniile adăugate și eliminate",
   "settings.general.row.font.title": "Font cod",
   "settings.general.row.font.description": "Personalizează fontul folosit în blocurile de cod",
   "settings.general.row.terminalFont.title": "Font terminal",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -925,6 +925,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Выберите, следует ли OpenCode системной, светлой или тёмной теме",
   "settings.general.row.theme.title": "Тема",
   "settings.general.row.theme.description": "Настройте оформление OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Подсветка различий на уровне слов",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Подсвечивать изменённые слова в добавленных и удалённых строках",
   "settings.general.row.font.title": "Шрифт кода",
   "settings.general.row.font.description": "Настройте шрифт, используемый в блоках кода",
   "settings.general.row.terminalFont.title": "Шрифт терминала",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -931,6 +931,8 @@ export const dict: Record<string, string> = {
   "settings.general.row.colorScheme.description": "OpenCode පද්ධතිය, ආලෝකය හෝ අඳුරු තේමාව අනුගමනය කරන්නේද යන්න තෝරන්න",
   "settings.general.row.theme.title": "තේමාව",
   "settings.general.row.theme.description": "OpenCode තේමා කර ඇති ආකාරය අභිරුචිකරණය කරන්න.",
+  "settings.general.row.wordDiffHighlighting.title": "වචන මට්ටමේ වෙනස්කම් උද්දීපනය කිරීම",
+  "settings.general.row.wordDiffHighlighting.description": "එකතු කළ සහ ඉවත් කළ පේළිවල වෙනස් වූ වචන උද්දීපනය කරන්න",
   "settings.general.row.font.title": "කේත අකුරු",
   "settings.general.row.font.description": "කේත බ්ලොක් වල භාවිතා කරන අකුරු අභිරුචිකරණය කරන්න",
   "settings.general.row.terminalFont.title": "ටර්මිනල් අකුරු",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -939,6 +939,8 @@ export const dict = {
     "Vyberte, či má OpenCode nasledovať systémovú, svetlú alebo tmavú tému",
   "settings.general.row.theme.title": "Téma",
   "settings.general.row.theme.description": "Prispôsobte tému OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Zvýraznenie rozdielov na úrovni slov",
+  "settings.general.row.wordDiffHighlighting.description": "Zvýrazní zmenené slová v pridaných a odstránených riadkoch",
   "settings.general.row.font.title": "Písmo kódu",
   "settings.general.row.font.description": "Prispôsobte písmo používané v blokoch kódu",
   "settings.general.row.terminalFont.title": "Písmo terminálu",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -939,6 +939,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Izberite, ali OpenCode sledi sistemski, svetli ali temni temi",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Prilagodite temo OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Označevanje razlik na ravni besed",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Označi spremenjene besede v dodanih in odstranjenih vrsticah",
   "settings.general.row.font.title": "Pisava kode",
   "settings.general.row.font.description": "Prilagodite pisavo, uporabljeno v blokih kode",
   "settings.general.row.terminalFont.title": "Pisava terminala",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -939,6 +939,9 @@ export const dict = {
     "Zgjidhni nëse OpenCode ndjek temën e sistemit, të lehtë ose të errët",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Personalizojeni se si është tema e OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Theksimi i dallimeve në nivel fjale",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Theksoni fjalët e ndryshuara brenda rreshtave të shtuar dhe të hequr",
   "settings.general.row.font.title": "Fonti i kodit",
   "settings.general.row.font.description": "Personalizoni fontin e përdorur në blloqet e kodit",
   "settings.general.row.terminalFont.title": "Fonti i Terminalit",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -938,6 +938,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Одаберите да ли OpenCode прати системску, светлу или тамну тему",
   "settings.general.row.theme.title": "Тема",
   "settings.general.row.theme.description": "Прилагодите како је OpenCode тематски.",
+  "settings.general.row.wordDiffHighlighting.title": "Истицање разлика на нивоу речи",
+  "settings.general.row.wordDiffHighlighting.description": "Истакните измењене речи у додатим и уклоњеним редовима",
   "settings.general.row.font.title": "Фонт кода",
   "settings.general.row.font.description": "Прилагодите фонт који се користи у блоковима кода",
   "settings.general.row.terminalFont.title": "Фонт терминала",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -940,6 +940,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Välj om OpenCode följer system-, ljus- eller mörktemat",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "Anpassa OpenCodes tema.",
+  "settings.general.row.wordDiffHighlighting.title": "Markering av skillnader på ordnivå",
+  "settings.general.row.wordDiffHighlighting.description": "Markera ändrade ord i tillagda och borttagna rader",
   "settings.general.row.font.title": "Kodtypsnitt",
   "settings.general.row.font.description": "Anpassa teckensnittet som används i kodblock",
   "settings.general.row.terminalFont.title": "Terminaltypsnitt",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -940,6 +940,9 @@ export const dict = {
     "Интихоб кунед, ки OpenCode аз рӯи система, равшанӣ ё мавзӯи торик пайравӣ мекунад",
   "settings.general.row.theme.title": "Мавзӯъ",
   "settings.general.row.theme.description": "Чӣ тавр OpenCode мавзӯъро танзим кунед.",
+  "settings.general.row.wordDiffHighlighting.title": "Рангнишонии фарқиятҳо дар сатҳи калима",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Калимаҳои тағйирёфтаро дар сатрҳои иловашуда ва хориҷшуда рангнишонӣ кунед",
   "settings.general.row.font.title": "Шрифти код",
   "settings.general.row.font.description": "Ҳарферо, ки дар блокҳои код истифода мешавад, танзим кунед",
   "settings.general.row.terminalFont.title": "Шрифти терминал",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -910,6 +910,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "เลือกว่าจะให้ OpenCode ใช้ธีมตามระบบ สว่าง หรือมืด",
   "settings.general.row.theme.title": "ธีม",
   "settings.general.row.theme.description": "ปรับแต่งธีมของ OpenCode",
+  "settings.general.row.wordDiffHighlighting.title": "การเน้นความแตกต่างระดับคำ",
+  "settings.general.row.wordDiffHighlighting.description": "เน้นคำที่เปลี่ยนแปลงภายในบรรทัดที่เพิ่มและลบ",
   "settings.general.row.font.title": "แบบอักษรโค้ด",
   "settings.general.row.font.description": "ปรับแต่งแบบอักษรที่ใช้ในบล็อกโค้ด",
   "settings.general.row.terminalFont.title": "แบบอักษรเทอร์มินัล",

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -936,6 +936,9 @@ export const dict = {
     "OpenCode ulgamy, ýagtylygy ýa-da garaňky temany yzarlaýandygyny saýlaň",
   "settings.general.row.theme.title": "Mowzuk",
   "settings.general.row.theme.description": "OpenCode-iň mowzuklydygyny düzüň.",
+  "settings.general.row.wordDiffHighlighting.title": "Söz derejesindäki tapawutlary aýratyn görkezmek",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Goşulan we aýrylan setirlerdäki üýtgedilen sözleri aýratyn görkezmek",
   "settings.general.row.font.title": "Kod şrifti",
   "settings.general.row.font.description": "Kod bloklarynda ulanylýan şrifti düzüň",
   "settings.general.row.terminalFont.title": "Terminal şrifti",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -929,6 +929,9 @@ export const dict = {
     "OpenCode'un sistem, açık veya koyu temayı takip etip etmeyeceğini seçin",
   "settings.general.row.theme.title": "Tema",
   "settings.general.row.theme.description": "OpenCode'un temasını özelleştirin.",
+  "settings.general.row.wordDiffHighlighting.title": "Sözcük düzeyinde fark vurgulama",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Eklenen ve kaldırılan satırlardaki değişen sözcükleri vurgulayın",
   "settings.general.row.font.title": "Kod yazı tipi",
   "settings.general.row.font.description": "Kod bloklarında kullanılan yazı tipini özelleştirin",
   "settings.general.row.terminalFont.title": "Terminal yazı tipi",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -1030,6 +1030,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Виберіть, чи OpenCode використовує системну, світлу або темну тему",
   "settings.general.row.theme.title": "Тема",
   "settings.general.row.theme.description": "Налаштуйте тему OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Підсвічення відмінностей на рівні слів",
+  "settings.general.row.wordDiffHighlighting.description": "Підсвічувати змінені слова в доданих і вилучених рядках",
   "settings.general.row.font.title": "Шрифт коду",
   "settings.general.row.font.description": "Налаштуйте шрифт, який використовується в блоках коду",
   "settings.general.row.terminalFont.title": "Шрифт термінала",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -945,6 +945,9 @@ export const dict = {
     "منتخب کریں کہ آیا OpenCode سسٹم، لائٹ یا ڈارک تھیم کی پیروی کرتا ہے۔",
   "settings.general.row.theme.title": "تھیم",
   "settings.general.row.theme.description": "OpenCode کی تھیم حسب ضرورت بنائیں۔",
+  "settings.general.row.wordDiffHighlighting.title": "لفظ کی سطح پر فرق نمایاں کرنا",
+  "settings.general.row.wordDiffHighlighting.description":
+    "شامل کی گئی اور حذف کی گئی لائنوں میں تبدیل شدہ الفاظ نمایاں کریں",
   "settings.general.row.font.title": "کوڈ فونٹ",
   "settings.general.row.font.description": "کوڈ بلاکس میں استعمال ہونے والے فونٹ کو حسب ضرورت بنائیں",
   "settings.general.row.terminalFont.title": "ٹرمینل فونٹ",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -943,6 +943,9 @@ export const dict = {
     "OpenCode tizimga, yorugʻlik yoki qorongʻi mavzuga amal qilishini tanlang",
   "settings.general.row.theme.title": "Mavzu",
   "settings.general.row.theme.description": "OpenCode mavzusini sozlash.",
+  "settings.general.row.wordDiffHighlighting.title": "So‘z darajasidagi farqlarni ajratib ko‘rsatish",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Qo‘shilgan va olib tashlangan satrlardagi o‘zgargan so‘zlarni ajratib ko‘rsatish",
   "settings.general.row.font.title": "Kod shrifti",
   "settings.general.row.font.description": "Kod bloklarida ishlatiladigan shriftni moslashtiring",
   "settings.general.row.terminalFont.title": "Terminal shrifti",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -946,6 +946,9 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Chọn xem OpenCode tuân theo hệ thống, chủ đề sáng hay tối",
   "settings.general.row.theme.title": "Chủ đề",
   "settings.general.row.theme.description": "Tùy chỉnh chủ đề của OpenCode.",
+  "settings.general.row.wordDiffHighlighting.title": "Làm nổi bật khác biệt ở cấp độ từ",
+  "settings.general.row.wordDiffHighlighting.description":
+    "Làm nổi bật các từ đã thay đổi trong những dòng được thêm và xóa",
   "settings.general.row.font.title": "Phông chữ mã",
   "settings.general.row.font.description": "Tùy chỉnh phông chữ được sử dụng trong khối mã",
   "settings.general.row.terminalFont.title": "Phông chữ terminal",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -906,6 +906,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "选择 OpenCode 跟随系统、浅色或深色主题",
   "settings.general.row.theme.title": "主题",
   "settings.general.row.theme.description": "自定义 OpenCode 的主题。",
+  "settings.general.row.wordDiffHighlighting.title": "字词级差异突出显示",
+  "settings.general.row.wordDiffHighlighting.description": "突出显示新增行和删除行中已更改的字词",
   "settings.general.row.font.title": "代码字体",
   "settings.general.row.font.description": "自定义代码块使用的字体",
   "settings.general.row.terminalFont.title": "终端字体",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -901,6 +901,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "選擇 OpenCode 要跟隨系統、淺色或深色主題",
   "settings.general.row.theme.title": "主題",
   "settings.general.row.theme.description": "自訂 OpenCode 的主題。",
+  "settings.general.row.wordDiffHighlighting.title": "字詞層級差異醒目提示",
+  "settings.general.row.wordDiffHighlighting.description": "醒目提示新增行與移除行中已變更的字詞",
   "settings.general.row.font.title": "程式碼字型",
   "settings.general.row.font.description": "自訂程式碼區塊使用的字型",
   "settings.general.row.terminalFont.title": "終端機字型",

--- a/packages/session-ui/src/components/file.tsx
+++ b/packages/session-ui/src/components/file.tsx
@@ -906,7 +906,7 @@ function TextViewer<T>(props: TextFileProps<T>) {
 
   createEffect(() => {
     const opts = options()
-    const workerPool = getWorkerPool("unified")
+    const workerPool = getWorkerPool("none")
     const virtualizer = virtuals.get()
 
     renderViewer({
@@ -1111,7 +1111,7 @@ function DiffViewer<T>(props: DiffFileProps<T>) {
 
   createEffect(() => {
     const opts = options()
-    const workerPool = large() ? getWorkerPool("unified") : getWorkerPool(props.diffStyle)
+    const workerPool = getWorkerPool(opts.lineDiffType)
     const virtualizer = virtuals.get()
     const beforeContents = typeof local.before?.contents === "string" ? local.before.contents : ""
     const afterContents = typeof local.after?.contents === "string" ? local.after.contents : ""

--- a/packages/session-ui/src/pierre/worker.ts
+++ b/packages/session-ui/src/pierre/worker.ts
@@ -1,16 +1,15 @@
+import type { LineDiffTypes } from "@pierre/diffs"
 import { WorkerPoolManager } from "@pierre/diffs/worker"
 import ShikiWorkerUrl from "@pierre/diffs/worker/worker.js?worker&url"
 import { registerOpenCodeTheme } from "@opencode-ai/ui/context/marked-theme-register"
 
 registerOpenCodeTheme()
 
-export type WorkerPoolStyle = "unified" | "split"
-
 export function workerFactory(): Worker {
   return new Worker(ShikiWorkerUrl, { type: "module" })
 }
 
-function createPool(lineDiffType: "none" | "word-alt") {
+function createPool(lineDiffType: LineDiffTypes) {
   const pool = new WorkerPoolManager(
     {
       workerFactory,
@@ -32,24 +31,23 @@ function createPool(lineDiffType: "none" | "word-alt") {
   return pool
 }
 
-let unified: WorkerPoolManager | undefined
-let split: WorkerPoolManager | undefined
+const pools = new Map<LineDiffTypes, WorkerPoolManager>()
 
-export function getWorkerPool(style: WorkerPoolStyle | undefined): WorkerPoolManager | undefined {
+export function getWorkerPool(lineDiffType: LineDiffTypes | undefined): WorkerPoolManager | undefined {
   if (typeof window === "undefined") return
 
-  if (style === "split") {
-    if (!split) split = createPool("word-alt")
-    return split
-  }
+  const type = lineDiffType ?? "none"
+  const existing = pools.get(type)
+  if (existing) return existing
 
-  if (!unified) unified = createPool("none")
-  return unified
+  const pool = createPool(type)
+  pools.set(type, pool)
+  return pool
 }
 
 export function getWorkerPools() {
   return {
-    unified: getWorkerPool("unified"),
-    split: getWorkerPool("split"),
+    unified: getWorkerPool("none"),
+    split: getWorkerPool("word-alt"),
   }
 }

--- a/packages/session-ui/src/v2/components/session-review-v2.tsx
+++ b/packages/session-ui/src/v2/components/session-review-v2.tsx
@@ -153,7 +153,7 @@ export function SessionReviewV2(props: SessionReviewV2Props) {
   const locale = useLocale()
 
   createEffect(() => {
-    getWorkerPool(props.diffStyle)
+    getWorkerPool(props.diffStyle === "split" ? "word-alt" : "none")
   })
 
   const fileIndex = () => {


### PR DESCRIPTION
### Issue for this PR

Closes #36824

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an opt-in Appearance setting for the desktop app that emphasizes changed words inside added and removed lines. It defaults off and selects a matching diff worker pool so disabled users keep the existing rendering path.

### How did you verify your code works?

- Tested the toggle in the desktop app and confirmed open diffs rerender immediately.
- Ran app and session-ui typechecks.
- Ran session-ui, settings, and i18n parity tests.
- The push hook passed typechecking across all 30 packages.

### Screenshots / recordings

Example:
<img width="857" height="348" alt="image" src="https://github.com/user-attachments/assets/8159efb3-f1c9-43b9-9522-e31b5c375ab1" />

Setting:
<img width="698" height="273" alt="image" src="https://github.com/user-attachments/assets/9ab1da10-bdaa-4bdd-9409-2def9a2746b6" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR