### PR TITLE
docs: fix internal section links

### DIFF
--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -60,7 +60,7 @@ OpenCode config.
 
 Here the full ID is `provider_id/model_id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
-If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
+If you've configured a [custom provider](/docs/providers#custom-provider), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
 
 ---
 

--- a/packages/web/src/content/docs/network.mdx
+++ b/packages/web/src/content/docs/network.mdx
@@ -26,7 +26,7 @@ export NO_PROXY=localhost,127.0.0.1
 The TUI communicates with a local HTTP server. You must bypass the proxy for this connection to prevent routing loops.
 :::
 
-You can configure the server's port and hostname using [CLI flags](/docs/cli#run).
+You can configure the server's port and hostname using [CLI flags](/docs/cli#tui).
 
 ---
 

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -27,7 +27,7 @@ Start OpenCode with `--auto` to automatically approve permission requests that a
 opencode --auto
 ```
 
-You can also use auto mode with [`opencode run`](/docs/cli#run).
+You can also use auto mode with [`opencode run`](/docs/cli#run-1).
 
 ```bash
 opencode run --auto "Refactor this module"


### PR DESCRIPTION
### Issue for this PR

Closes #44335

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Fixes three English documentation links that target missing or incorrect generated section IDs:

- Links custom-provider configuration to `#custom-provider`.
- Links the Network page's port and hostname flags to the TUI section.
- Links `opencode run` permission guidance to the top-level run command rather than the GitHub agent subcommand.

### How did you verify your code works?

- `bun run --cwd packages/web build`
- `bun typecheck` (Ubuntu 24.04, Bun 1.3.14; 30/30 packages passed)
- Verified the generated HTML contains each corrected `href` and matching target `id`
- `git diff --check`

### Screenshots / recordings

Not applicable; documentation-only link fixes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR