### PR TITLE
fix(tui): guard Object.entries against null MCP/theme/input

### DIFF
--- a/packages/opencode/src/cli/cmd/run/theme.ts
+++ b/packages/opencode/src/cli/cmd/run/theme.ts
@@ -308,7 +308,7 @@ export function resolveTheme(theme: ThemeJson, pick: "dark" | "light"): TuiTheme
   }
 
   const resolved = Object.fromEntries(
-    Object.entries(theme.theme)
+    Object.entries(theme.theme ?? {})
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => [key, resolveColor(value as ColorValue)]),
   ) as Partial<Record<ThemeColor, RGBA>>
@@ -316,12 +316,12 @@ export function resolveTheme(theme: ThemeJson, pick: "dark" | "light"): TuiTheme
   return {
     ...(resolved as Record<ThemeColor, RGBA>),
     selectedListItemText:
-      theme.theme.selectedListItemText === undefined
+      theme.theme?.selectedListItemText === undefined
         ? resolved.background!
         : resolveColor(theme.theme.selectedListItemText),
     backgroundMenu:
-      theme.theme.backgroundMenu === undefined ? resolved.backgroundElement! : resolveColor(theme.theme.backgroundMenu),
-    thinkingOpacity: theme.theme.thinkingOpacity ?? 0.6,
+      theme.theme?.backgroundMenu === undefined ? resolved.backgroundElement! : resolveColor(theme.theme.backgroundMenu),
+    thinkingOpacity: theme.theme?.thinkingOpacity ?? 0.6,
   }
 }
 
@@ -475,7 +475,7 @@ function quantizeColor(indexed: RGBA[], rgba: RGBA): RGBA {
 
 function quantizeTheme(theme: TuiThemeCurrent, indexed: RGBA[]): TuiThemeCurrent {
   const resolved = Object.fromEntries(
-    Object.entries(theme)
+    Object.entries(theme ?? {})
       .filter(([key]) => key !== "thinkingOpacity")
       .map(([key, value]) => [key, quantizeColor(indexed, value as RGBA)]),
   ) as Partial<Record<ThemeColor, RGBA>>

--- a/packages/tui/src/attention.ts
+++ b/packages/tui/src/attention.ts
@@ -96,7 +96,7 @@ function normalizePack(pack: TuiAttentionSoundPack): RegisteredSoundPack | undef
     name: pack.name?.trim() || undefined,
     builtin: false,
     sounds: Object.fromEntries(
-      Object.entries(pack.sounds).filter(
+      Object.entries(pack.sounds ?? {}).filter(
         (item): item is [TuiAttentionSoundName, string] =>
           Schema.is(AttentionSoundName)(item[0]) && typeof item[1] === "string" && item[1].trim().length > 0,
       ),

--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -50,10 +50,10 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={Object.keys(sync.data.mcp ?? {}).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
-          <For each={Object.entries(sync.data.mcp)}>
+          <text fg={theme.text}>{Object.keys(sync.data.mcp ?? {}).length} MCP Servers</text>
+          <For each={Object.entries(sync.data.mcp ?? {})}>
             {([key, item]) => (
               <box flexDirection="row" gap={1}>
                 <text

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -369,7 +369,7 @@ export function Autocomplete(props: {
     const options: AutocompleteOption[] = []
     const width = props.anchor().width - 4
 
-    for (const res of Object.values(sync.data.mcp_resource)) {
+    for (const res of Object.values(sync.data.mcp_resource ?? {})) {
       options.push({
         display: Locale.truncateMiddle(res.name, width),
         // Match the name only; matching the URI caused unrelated fuzzy hits.

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -504,11 +504,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const mcp = {
       isEnabled(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         return status?.status === "connected"
       },
       async toggle(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         if (status?.status === "connected") {
           // Disable: disconnect the MCP
           await sdk.client.mcp.disconnect({ name })

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -134,7 +134,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         .discover()
         .then((themes) => {
           setCustomThemes(
-            Object.entries(themes).reduce<Record<string, ThemeJson>>((result, [name, theme]) => {
+            Object.entries(themes ?? {}).reduce<Record<string, ThemeJson>>((result, [name, theme]) => {
               if (isTheme(theme)) result[name] = theme
               return result
             }, {}),
@@ -263,7 +263,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         if (theme) return resolveTheme(theme, store.mode)
       }
 
-      return resolveTheme(store.themes.opencode, store.mode)
+      return resolveTheme(store.themes.opencode ?? DEFAULT_THEMES.opencode, store.mode)
     })
 
     createEffect(() => renderer.setBackgroundColor(values().background))

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -151,7 +151,7 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       return sync.data.lsp.map((item) => ({ id: item.id, root: item.root, status: item.status }))
     },
     mcp() {
-      return Object.entries(sync.data.mcp)
+      return Object.entries(sync.data.mcp ?? {})
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([name, item]) => ({
           name,

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -10,8 +10,8 @@ export function Footer() {
   const { theme } = useTheme()
   const sync = useSync()
   const route = useRoute()
-  const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
-  const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
+  const mcp = createMemo(() => Object.values(sync.data.mcp ?? {}).filter((x) => x.status === "connected").length)
+  const mcpError = createMemo(() => Object.values(sync.data.mcp ?? {}).some((x) => x.status === "failed"))
   const lsp = createMemo(() => Object.keys(sync.data.lsp))
   const permissions = createMemo(() => {
     if (route.data.type !== "session") return []

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2618,8 +2618,8 @@ function Diagnostics(props: { diagnostics: unknown; filePath: string }) {
   )
 }
 
-function input(input: Record<string, unknown>, omit?: string[]): string {
-  const primitives = Object.entries(input).filter(([key, value]) => {
+function input(input: Record<string, unknown> | null | undefined, omit?: string[]): string {
+  const primitives = Object.entries(input ?? {}).filter(([key, value]) => {
     if (omit?.includes(key)) return false
     return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
   })

--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -264,7 +264,7 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   }
 
   const resolved = Object.fromEntries(
-    Object.entries(theme.theme)
+    Object.entries(theme.theme ?? {})
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => {
         return [key, resolveColor(value as ColorValue)]
@@ -272,7 +272,7 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   ) as Partial<Record<ThemeColor, RGBA>>
 
   // Handle selectedListItemText separately since it's optional
-  const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
+  const hasSelectedListItemText = theme.theme?.selectedListItemText !== undefined
   if (hasSelectedListItemText) {
     resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
   } else {
@@ -282,14 +282,14 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   }
 
   // Handle backgroundMenu - optional with fallback to backgroundElement
-  if (theme.theme.backgroundMenu !== undefined) {
+  if (theme.theme?.backgroundMenu !== undefined) {
     resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
   } else {
     resolved.backgroundMenu = resolved.backgroundElement
   }
 
   // Handle thinkingOpacity - optional with default of 0.6
-  const thinkingOpacity = theme.theme.thinkingOpacity ?? 0.6
+  const thinkingOpacity = theme.theme?.thinkingOpacity ?? 0.6
 
   return {
     ...resolved,

--- a/packages/tui/test/theme.test.ts
+++ b/packages/tui/test/theme.test.ts
@@ -37,6 +37,11 @@ test("hasTheme checks theme presence", () => {
   expect(hasTheme(name)).toBe(true)
 })
 
+test("resolveTheme does not crash when theme colors are missing", () => {
+  const resolved = resolveTheme({} as (typeof DEFAULT_THEMES)["opencode"], "dark")
+  expect(resolved.thinkingOpacity).toBe(0.6)
+})
+
 test("resolveTheme rejects circular color refs", () => {
   const item = structuredClone(DEFAULT_THEMES.opencode)
   item.defs = { ...item.defs, one: "two", two: "one" }


### PR DESCRIPTION
### Issue for this PR

Closes #44100

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TUI dies with `TypeError: Object.entries requires that input parameter not be null or undefined` on 0.0.0-beta-17823 (same stack as #44100). Solid is iterating a value that is still null: theme colors, MCP status, tool `input`, attention sounds.

This PR passes `?? {}` (or optional chaining) at those call sites, falls back to the built-in `opencode` theme if the active one is missing, and adds a test that `resolveTheme({})` does not throw.

### How did you verify your code works?

Added `packages/tui/test/theme.test.ts` coverage for a theme object with no `theme` key.

### Screenshots / recordings

N/A (crash guard, no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR