### PR TITLE
docs: fix OAuth typo and internal links to missing/incorrect anchors

### DIFF
--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -60,7 +60,7 @@ OpenCode config.
 
 Here the full ID is `provider_id/model_id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
-If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
+If you've configured a [custom provider](/docs/providers#custom-provider), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
 
 ---
 

--- a/packages/web/src/content/docs/network.mdx
+++ b/packages/web/src/content/docs/network.mdx
@@ -26,7 +26,7 @@ export NO_PROXY=localhost,127.0.0.1
 The TUI communicates with a local HTTP server. You must bypass the proxy for this connection to prevent routing loops.
 :::
 
-You can configure the server's port and hostname using [CLI flags](/docs/cli#run).
+You can configure the server's port and hostname using [CLI flags](/docs/cli#tui).
 
 ---
 

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -27,7 +27,7 @@ Start OpenCode with `--auto` to automatically approve permission requests that a
 opencode --auto
 ```
 
-You can also use auto mode with [`opencode run`](/docs/cli#run).
+You can also use auto mode with [`opencode run`](/docs/cli#run-1).
 
 ```bash
 opencode run --auto "Refactor this module"

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1009,7 +1009,7 @@ Your GitLab administrator must:
 
 ##### OAuth for Self-Hosted instances
 
-In order to make Oauth working for your self-hosted instance, you need to create
+In order to make OAuth work for your self-hosted instance, you need to create
 a new application (Settings → Applications) with the
 callback URL `http://127.0.0.1:8080/callback` and following scopes:
 


### PR DESCRIPTION
Fixes #44308 and #44335

**docs(providers): fix OAuth typo**
- `Oauth` → `OAuth` (consistent with all other mentions on the page)
- `make Oauth working` → `make OAuth work` (grammatically correct)

**docs: fix internal links to missing/incorrect anchors**
- `models.mdx`: `/docs/providers#custom` → `/docs/providers#custom-provider`
- `network.mdx`: `/docs/cli#run` → `/docs/cli#tui` (port/hostname flags are in the TUI section)
- `permissions.mdx`: `/docs/cli#run` → `/docs/cli#run-1` (the `opencode run` command section)