### PR TITLE
fix(tui): use grapheme-based display width for truncate functions

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -43,7 +43,7 @@ export function duration(input: number) {
   if (input < 60000) {
     return `${(input / 1000).toFixed(1)}s`
   }
-  if (input < 3600000) {
+  if (input <= 3600000) {
     const minutes = Math.floor(input / 60000)
     const seconds = Math.floor((input % 60000) / 1000)
     return `${minutes}m ${seconds}s`

--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -1,3 +1,17 @@
+import { promptOffsetWidth, displaySlice } from "../prompt/display"
+
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+function fitWidth(str: string, budget: number) {
+  let width = 0
+  for (const part of graphemes.segment(str)) {
+    const next = width + (part.segment === "\n" ? 1 : Bun.stringWidth(part.segment))
+    if (next > budget) return str.slice(0, part.index)
+    width = next
+  }
+  return str
+}
+
 export function titlecase(str: string) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
 }
@@ -59,23 +73,25 @@ export function duration(input: number) {
 }
 
 export function truncate(str: string, len: number): string {
-  if (str.length <= len) return str
-  return str.slice(0, len - 1) + "…"
+  const width = promptOffsetWidth(str)
+  if (width <= len) return str
+  return fitWidth(str, len - 1) + "…"
 }
 
 export function truncateLeft(str: string, len: number): string {
-  if (str.length <= len) return str
-  return "…" + str.slice(-(len - 1))
+  const width = promptOffsetWidth(str)
+  if (width <= len) return str
+  return "…" + displaySlice(str, width - (len - 1))
 }
 
 export function truncateMiddle(str: string, maxLength: number = 35): string {
-  if (str.length <= maxLength) return str
+  const width = promptOffsetWidth(str)
+  if (width <= maxLength) return str
 
-  const ellipsis = "…"
-  const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
-  const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
+  const keepStart = Math.ceil((maxLength - 1) / 2)
+  const keepEnd = Math.floor((maxLength - 1) / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  return displaySlice(str, 0, keepStart) + "…" + displaySlice(str, width - keepEnd)
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -60,7 +60,7 @@ OpenCode config.
 
 Here the full ID is `provider_id/model_id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
-If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
+If you've configured a [custom provider](/docs/providers#custom-provider), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
 
 ---
 

--- a/packages/web/src/content/docs/network.mdx
+++ b/packages/web/src/content/docs/network.mdx
@@ -26,7 +26,7 @@ export NO_PROXY=localhost,127.0.0.1
 The TUI communicates with a local HTTP server. You must bypass the proxy for this connection to prevent routing loops.
 :::
 
-You can configure the server's port and hostname using [CLI flags](/docs/cli#run).
+You can configure the server's port and hostname using [CLI flags](/docs/cli#tui).
 
 ---
 

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -27,7 +27,7 @@ Start OpenCode with `--auto` to automatically approve permission requests that a
 opencode --auto
 ```
 
-You can also use auto mode with [`opencode run`](/docs/cli#run).
+You can also use auto mode with [`opencode run`](/docs/cli#run-1).
 
 ```bash
 opencode run --auto "Refactor this module"

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1009,7 +1009,7 @@ Your GitLab administrator must:
 
 ##### OAuth for Self-Hosted instances
 
-In order to make Oauth working for your self-hosted instance, you need to create
+In order to make OAuth work for your self-hosted instance, you need to create
 a new application (Settings → Applications) with the
 callback URL `http://127.0.0.1:8080/callback` and following scopes:
 


### PR DESCRIPTION
Fixes #44338

The `truncate`, `truncateLeft`, and `truncateMiddle` functions used `str.length` (UTF-16 code units) to measure string length, causing two issues:

1. **Split surrogate pairs → mojibake**: The slice could cut an emoji in half, leaving a lone surrogate that renders as a broken glyph.
2. **Column budgets ignored for wide characters**: CJK characters count as 1 in UTF-16 but render as 2 columns, causing dialog rows to overflow.

The fix reuses the existing grapheme-based width helpers from `packages/tui/src/prompt/display.ts` (`promptOffsetWidth`, `displaySlice`) to ensure truncation respects display width and never splits grapheme clusters.