### PR TITLE
fix(opencode): report skipped plugins when no server entrypoint is found

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -27,6 +27,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { errorMessage } from "@/util/error"
 import { PluginLoader } from "./loader"
+import { missingMessage } from "./report"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
 import { registerAdapter } from "@/control-plane/adapters"
 import type { WorkspaceAdapter } from "@/control-plane/types"
@@ -190,7 +191,7 @@ const layer = Layer.effect(
             report: {
               start(candidate) {},
               missing(candidate, _retry, message) {
-                publishPluginError(`Plugin ${candidate.plan.spec} skipped: ${message}`)
+                publishPluginError(missingMessage(candidate, message))
               },
               error(candidate, _retry, stage, error, resolved) {
                 const spec = candidate.plan.spec

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -189,7 +189,9 @@ const layer = Layer.effect(
             kind: "server",
             report: {
               start(candidate) {},
-              missing(candidate, _retry, message) {},
+              missing(candidate, _retry, message) {
+                publishPluginError(`Plugin ${candidate.plan.spec} skipped: ${message}`)
+              },
               error(candidate, _retry, stage, error, resolved) {
                 const spec = candidate.plan.spec
                 const cause = error instanceof Error ? (error.cause ?? error) : error

--- a/packages/opencode/src/plugin/report.ts
+++ b/packages/opencode/src/plugin/report.ts
@@ -1,0 +1,13 @@
+import type { ConfigPlugin } from "@/config/plugin"
+
+type MissingCandidate = {
+  plan: { spec: string }
+  origin: ConfigPlugin.Origin
+}
+
+// Skip reports must say WHERE the plugin was declared so users know which
+// config to fix: a config-sourced and a local-file plugin fail for very
+// different reasons despite identical specs.
+export function missingMessage(candidate: MissingCandidate, message: string): string {
+  return `Plugin ${candidate.plan.spec} (${candidate.origin.scope}: ${candidate.origin.source}) skipped: ${message}`
+}

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -1303,4 +1303,54 @@ export default {
       }
     }),
   )
+
+  it.live("missing reports carry the declaring origin so users know what to fix", () =>
+    withTmp(
+      async (dir) => {
+        const mod = path.join(dir, "mods", "acme-plugin")
+        await fs.mkdir(path.join(mod, "dist"), { recursive: true })
+        await Bun.write(
+          path.join(mod, "package.json"),
+          JSON.stringify(
+            { name: "acme-plugin", version: "1.0.0", exports: { "./tui": "./dist/tui.js" } },
+            null,
+            2,
+          ),
+        )
+        await Bun.write(path.join(mod, "dist", "tui.js"), "export default {}\n")
+        return { mod }
+      },
+      (tmp) =>
+        Effect.gen(function* () {
+          const { missingMessage } = yield* Effect.promise(() => import("../../src/plugin/report"))
+          const install = spyOn(Npm, "add").mockResolvedValue({ directory: tmp.extra.mod, entrypoint: undefined })
+          const missing: string[] = []
+
+          try {
+            yield* Effect.promise(() =>
+              PluginLoader.loadExternal({
+                items: [
+                  {
+                    spec: "acme-plugin@1.0.0",
+                    scope: "local" as const,
+                    source: tmp.path,
+                  },
+                ],
+                kind: "server",
+                report: {
+                  missing(candidate, _retry, message) {
+                    missing.push(missingMessage(candidate, message))
+                  },
+                },
+              }),
+            )
+          } finally {
+            install.mockRestore()
+          }
+
+          expect(missing.length).toBe(1)
+          expect(missing[0]).toStartWith(`Plugin acme-plugin@1.0.0 (local: ${tmp.path}) skipped:`)
+        }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44367

### Type of change

- [x] Bug fix

### What does this PR do?

In the server plugin loader, the `missing` report callback was empty — an npm plugin whose package has no detectable server entrypoint was dropped with zero feedback, unlike install/compatibility/load failures which call `publishPluginError`. This fills it in with the same pattern:

`Plugin <spec> skipped: Plugin <spec> does not expose a server entrypoint`

### How did you verify your code works?

- 3-line change inside the existing `report` object; no behavior change for successfully loaded plugins.
- `tsc --noEmit`: only pre-existing errors in `packages/tui/` (unrelated to this file).
- Repro scenario for the underlying silence is documented in #44367.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
