### PR TITLE
docs: fix npm plugin cache path

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -45,7 +45,7 @@ Browse available plugins in the [ecosystem](/docs/ecosystem#plugins).
 
 ### How plugins are installed
 
-**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/node_modules/`.
+**npm plugins** are installed automatically at startup using npm's [Arborist](https://npm.github.io/arborist/). Packages and their dependencies are cached in `~/.cache/opencode/packages/<package-name>/`.
 
 **Local plugins** are loaded directly from the plugin directory. To use external packages, you must create a `package.json` within your config directory (see [Dependencies](#dependencies)), or publish the plugin to npm and [add it to your config](/docs/config#plugins).
 


### PR DESCRIPTION
### Issue for this PR

Closes #44367

### Type of change

- [x] Documentation

### What does this PR do?

The plugins docs say npm plugins are cached in `~/.cache/opencode/node_modules/`, but `packages/core/src/npm.ts` (`directory(pkg)`) actually installs into `~/.cache/opencode/packages/<pkg>/`, using npm Arborist rather than Bun. This aligns the docs with the code.

### How did you verify your code works?

Docs-only change; statement matches `directory()` and the `reify`/Arborist implementation in `core/npm.ts`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
