### PR TITLE
docs: add opencode-qoder-bridge to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-qoder-bridge](https://github.com/naoufalelbani/opencode-qoder-bridge)                    | Use Qoder AI models in OpenCode through the official Qoder Agent SDK with tools, MCP, sessions, and quota tracking |
 
 ---
 


### PR DESCRIPTION
Adds opencode-qoder-bridge to the OpenCode ecosystem plugin list.

opencode-qoder-bridge lets users access Qoder AI models from OpenCode through the official Qoder Agent SDK.

It supports:
- Dynamic Qoder model discovery
- Streaming and tool calling
- MCP integration
- Multimodal input
- Persistent sessions
- Quota and usage tracking

Repository:
https://github.com/naoufalelbani/opencode-qoder-bridge

npm:
https://www.npmjs.com/package/opencode-qoder-bridge