### PR TITLE
fix(tui): enable copy on select by default

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -5,7 +5,6 @@ export function truthy(key: string) {
   return value === "true" || value === "1"
 }
 
-const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
 const fff = process.env["OPENCODE_DISABLE_FFF"]
 
 function enabledByExperimental(key: string) {
@@ -40,8 +39,7 @@ export const Flag = {
   OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: Config.boolean("OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER").pipe(
     Config.withDefault(false),
   ),
-  OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT:
-    copy === undefined ? process.platform === "win32" : truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
+  OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT: truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
   OPENCODE_MODELS_URL: process.env["OPENCODE_MODELS_URL"],
   OPENCODE_MODELS_PATH: process.env["OPENCODE_MODELS_PATH"],
   OPENCODE_DB: process.env["OPENCODE_DB"],


### PR DESCRIPTION
### Issue for this PR

Closes #44392

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores copy-on-select as the default on Windows, matching the existing behavior on other platforms. Mouse-up now reaches the existing `Selection.copy` and clipboard path. Setting `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT=true` still preserves manual Ctrl+C and right-click copy.

### How did you verify your code works?

- Checked unset, `true`, `1`, and `false` flag behavior directly.
- Ran `bun typecheck` in `packages/core` and `packages/tui`.
- Built the Windows x64 standalone executable and passed its version smoke test.
- Sent an SGR mouse selection through Herdr; OpenCode showed the copy toast and the selected text reached the native Windows clipboard.
- Passed the repository pre-push typecheck across all 30 runnable tasks.

### Screenshots / recordings

N/A. No visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR