### PR TITLE
docs: add opencode-qoder-bridge to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-qoder-bridge](https://github.com/naoufalelbani/opencode-qoder-bridge)                    | Use Qoder AI models in OpenCode through the official Qoder Agent SDK with tools, MCP, sessions, and quota tracking |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #44407

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-qoder-bridge` to the community plugins listed on the OpenCode ecosystem page.

The plugin integrates Qoder models with OpenCode through the Qoder Agent SDK.

### How did you verify your code works?

Verified locally that the commit only adds one row to `packages/web/src/content/docs/ecosystem.mdx` and contains no unrelated changes.

### Screenshots / recordings

Not applicable — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR