### PR TITLE
docs(web): surface per-model monthly usage caps in Go docs

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -15,6 +15,13 @@ use OpenCode.
 
 It is designed primarily for international users and provides stable global access.
 
+:::note
+Monthly usage varies by model. While the Go plan includes up to **$60/month** of usage, some models are capped at
+**$15/month** — a separate limit from the plan's monthly allowance. Each model's included monthly usage is listed in
+the Usage column under [Usage limits](#usage-limits). Keep in mind that the **<a href={console}>console</a>** usage
+page shows your remaining usage against the per-model limit, not against the plan's $60 monthly limit.
+:::
+
 ---
 
 ## Background


### PR DESCRIPTION
### Issue for this PR

Closes #43651

### Type of change

- [x] Documentation

### What does this PR do?

The Go docs bury the per-model monthly cap: some models include only $15/month of usage even on the $60 plan, and the console usage page shows remaining quota per model, which reads as if you burned most of the subscription when you did not. This adds a short note near the top of packages/web/src/content/docs/go.mdx calling out both facts so people stop hitting the cap by surprise. Wording sticks to what the page already documents - no new numbers or policy.

### How did you verify your code works?

- bunx prettier --check packages/web/src/content/docs/go.mdx passes
- Docs-only change: 7 added lines in one MDX file, English source only (the 17 translation copies are generated separately)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR