### PR TITLE
fix(core): classify plain AI SDK stream errors

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,7 +3,7 @@ export { ImageClient } from "./image-client.js"
 export { Auth } from "./route/auth.js"
 export { Provider } from "./provider.js"
 export { ProviderPackage } from "./provider-package.js"
-export { isContextOverflow, isContextOverflowFailure } from "./provider-error.js"
+export { isContextOverflow, isContextOverflowFailure, classifyProviderFailure } from "./provider-error.js"
 export type {
   RouteLanguageModelInput,
   RouteRoutedLanguageModelInput,

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -75,6 +75,9 @@ const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?ma
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
 const NETWORK_ERROR_TEXT = /network[-_\s]error/i
+// Plain stream errors (no status, no code) often carry only transient-capacity
+// phrasing; these still belong on the retryable provider-internal path.
+const PROVIDER_CAPACITY_TEXT = /\bat capacity\b|\bhigh demand\b|\boverloaded\b/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -140,6 +143,8 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
       status: input.status,
       retryAfterMs: input.retryAfterMs,
     })
+  if (PROVIDER_CAPACITY_TEXT.test(text))
+    return new ProviderInternalReason({ ...common, status: input.status, retryAfterMs: input.retryAfterMs })
   if (input.status === 429) {
     return new RateLimitReason({
       ...common,

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -25,11 +25,11 @@ import {
   ProviderMetadata,
   TransportReason,
   ToolResultValue,
-  UnknownProviderReason,
   type ContentPart,
   type LLMRequest,
   type ToolDefinition,
   type UsageInput,
+  classifyProviderFailure,
 } from "@opencode-ai/ai"
 import { Auth, Endpoint, RequestExecutor, type AnyRoute } from "@opencode-ai/ai/route"
 import { ProviderShared } from "@opencode-ai/ai/protocols/shared"
@@ -791,7 +791,9 @@ function llmError(method: string, error: unknown) {
       ? new InvalidProviderOutputReason({ message: error.message })
       : APICallError.isInstance(error)
         ? apiCallErrorReason(error)
-        : new UnknownProviderReason({ message: unknownErrorMessage(error) })
+        : // Plain stream errors carry only a message; run the shared classifier so
+          // known transient text retries instead of falling straight to UnknownProvider.
+          classifyProviderFailure({ message: unknownErrorMessage(error) })
   return new AIError({
     module: "AISDK",
     method,

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -536,6 +536,18 @@ it.effect("preserves non-empty AI SDK error messages", () =>
   }),
 )
 
+it.effect("classifies plain AI SDK stream capacity errors as retryable", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      new Error("The model is currently at capacity due to high demand. Please try again in a few minutes."),
+    )
+    expect(error).toBeInstanceOf(AIError)
+    expect(error.reason).toMatchObject({ _tag: "ProviderInternal" })
+    const projected = toSessionError(error)
+    expect(projected.type).toBe("provider.internal")
+  }),
+)
+
 const apiCallError = (input: Partial<ConstructorParameters<typeof APICallError>[0]>) =>
   new APICallError({
     message: "",


### PR DESCRIPTION
### Issue for this PR

Closes #43791

### Type of change

- [x] Bug fix

### What does this PR do?

When an AI SDK model stream fails with a plain Error (no status, no code), llmError() used to drop it straight into UnknownProviderReason, so the shared classifier never ran and transient failures like "model is at capacity" were never retried. Plain errors now go through classifyProviderFailure like APICallErrors already did, and capacity/overload phrasing (at capacity / high demand / overloaded) classifies as retryable ProviderInternal. Truly unknown plain errors still land on UnknownProvider - the existing "Bad Request" test covers that.

### How did you verify your code works?

- packages/core: bun test test/aisdk.test.ts -> 24 pass / 0 fail (was 23; added a case where a plain stream error carrying capacity text becomes ProviderInternal and projects to provider.internal)
- packages/ai: bun test -> 551 pass / 6 fail, identical to the v2 baseline (those 6 are pre-existing OpenRouter reasoning failures)
- bun run typecheck clean in both packages

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR