### PR TITLE
fix(core): publish post-spawn info on shell.created

### DIFF
--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -370,7 +370,9 @@ const layer = () =>
                 ),
               )
 
-              yield* bus.publish(Shell.Event.Created, { info })
+              // Publish the post-spawn Info so subscribers see the attached pid; the
+              // outer `info` object predates the spawn and never carries one.
+              yield* bus.publish(Shell.Event.Created, { info: session.info })
               yield* Deferred.succeed(ready, session)
               // Hold the handle's scope open until the command terminates; closing it earlier would
               // release (kill) the process before its exit is observed.


### PR DESCRIPTION
### Issue for this PR

Closes #43078

### Type of change

- [x] Bug fix

### What does this PR do?

shell.created published the Info object built before the process spawned, so the pid field was always missing for event subscribers (the pid only ever landed on the session copy). The event now publishes session.info, i.e. the same post-spawn info that create() returns. One-line publish substitution, as suggested in the issue.

### How did you verify your code works?

- bun run typecheck in packages/core: clean
- No test asserts on this event today; there is no existing harness that builds the full Shell service stack (Bus/Location/Environment deps), so I kept the change to the exact substitution rather than adding a fixture for it.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR