### PR TITLE
fix(ai): recover cause-chain diagnostics for mid-stream read failures

### DIFF
--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -240,6 +240,33 @@ const nativeTransportFailure = (error: unknown) => {
   return failure
 }
 
+const maxCauseDepth = 4
+
+// A mid-stream rejection nests the native failure under Effect's decode wrapper,
+// sometimes beyond what nativeTransportFailure can see. Walk a bounded cause
+// chain and keep only stable class/code signals - never payloads - so surfaced
+// errors stay diagnosable.
+const describeCauseChain = (source: unknown) => {
+  const classes: string[] = []
+  let code: string | undefined
+  let message: string | undefined
+  let node: unknown = source
+  for (let depth = 0; depth < maxCauseDepth && node !== null && typeof node === "object"; depth += 1) {
+    const record = node as Record<string, unknown>
+    if (typeof record.name === "string" && record.name !== "Error") classes.push(record.name)
+    if (code === undefined && typeof record.code === "string") code = record.code
+    if (
+      message === undefined &&
+      typeof record.message === "string" &&
+      record.message.trim() !== "" &&
+      !record.message.startsWith("Decode error")
+    )
+      message = record.message
+    node = record.cause
+  }
+  return { classes, code, message }
+}
+
 const httpError = (input: {
   readonly error: unknown
   readonly request: HttpClientRequest.HttpClientRequest
@@ -256,7 +283,10 @@ const httpError = (input: {
         operation: input.operation,
         code: failure.code,
         url: request.url,
-        http: new HttpContext({ request: requestDetails(request) }),
+        http: new HttpContext({
+          request: requestDetails(request),
+          ...(failedResponse ? { response: responseDetails(failedResponse) } : {}),
+        }),
       }),
     })
 
@@ -265,10 +295,24 @@ const httpError = (input: {
       ? input.error.reason.cause
       : input.error
   const native = nativeTransportFailure(source)
-  const code = native?.code
-  const raw = native?.message ?? (input.error instanceof Error ? input.error.message : undefined)
+  // Shallow decode found no code: probe the bounded chain for the missing
+  // signals instead of surfacing only Effect's generic decode message.
+  const chain = native?.code === undefined ? describeCauseChain(source) : undefined
+  const code = native?.code ?? chain?.code ?? chain?.classes[chain.classes.length - 1]
+  const raw = native?.message ?? chain?.message ?? (input.error instanceof Error ? input.error.message : undefined)
   const detail = raw
   const message = code && detail && !detail.includes(code) ? `${code}: ${detail}` : detail
+
+  // Read failures carry the response that broke mid-stream; keep its safe
+  // metadata (status, headers) so callers can tell a truncated 200 apart.
+  const failedResponse =
+    input.operation === "read" &&
+    HttpClientError.isHttpClientError(input.error) &&
+    "response" in input.error.reason &&
+    input.error.reason.response !== null &&
+    typeof input.error.reason.response === "object"
+      ? (input.error.reason.response as HttpClientResponse.HttpClientResponse)
+      : undefined
 
   if (Cause.isTimeoutError(input.error) || Cause.isTimeoutError(source))
     return transportError({ message: message ?? "HTTP transport timed out", code: code ?? "Timeout" })

--- a/packages/ai/test/executor.test.ts
+++ b/packages/ai/test/executor.test.ts
@@ -125,6 +125,40 @@ describe("RequestExecutor", () => {
     ),
   )
 
+  it.effect("recovers cause-chain signals when the native failure does not decode", () =>
+    Effect.gen(function* () {
+      const executor = yield* RequestExecutor.Service
+      const error = yield* RequestExecutor.stream(executor, secretRequest).pipe(Stream.runDrain, Effect.flip)
+
+      expectAIError(error)
+      // The nested cause carries the code but a non-string message, so the
+      // shallow native decode misses it; the bounded chain probe recovers it.
+      expect(error.reason).toMatchObject({
+        _tag: "Transport",
+        message: "ECONNRESET: fetch failed",
+        operation: "read",
+        code: "ECONNRESET",
+      })
+      const http = errorHttp(error)
+      expect(http?.response?.status).toBe(200)
+    }).pipe(
+      Effect.provide(
+        responsesLayer([
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode('data: {"choices":[]}\n\n'))
+              },
+              pull(controller) {
+                controller.error(new TypeError("fetch failed", { cause: { code: "ECONNRESET", message: 42 } }))
+              },
+            }),
+          ),
+        ]),
+      ),
+    ),
+  )
+
   it.effect("preserves middleware error messages", () =>
     Effect.gen(function* () {
       const executor = yield* RequestExecutor.Service


### PR DESCRIPTION
### Issue for this PR

Closes #42482

### Type of change

- [x] Bug fix

### What does this PR do?

A 200 response whose body breaks mid-stream used to surface only as "Decode error (200 POST ...)" - httpError fell back to Effect's outer decode message and dropped the native cause entirely, and read-failure errors carried no response metadata. This change:

- probes a bounded (depth-4) cause chain when the shallow native decode finds no code, recovering class/code signals without retaining payloads
- attaches the failed response's status/headers to read-operation transport errors, so a truncated 200 is distinguishable from a connect failure

Deliberately not in this PR: chunk/byte counters and decoded-event accounting at the protocol boundary - that instrumentation spans every protocol and deserves its own change.

### How did you verify your code works?

- new regression test: a 200 stream that emits one valid SSE chunk then rejects with TypeError("fetch failed", {cause:{code:"ECONNRESET", message:42}}) now surfaces "ECONNRESET: fetch failed" with code ECONNRESET and http.response.status 200 (previously: opaque decode message, no code, no response)
- packages/ai: bun test -> 558 pass / 6 fail; the 6 failures are the pre-existing OpenRouter reasoning set, identical to baseline
- bun run typecheck (packages/ai): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
