### PR TITLE
fix(core): keep glob/grep permission metadata JSON-encodable

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -9,6 +9,7 @@ import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
 import { PermissionV2 } from "../permission"
+import { jsonMetadata } from "./metadata"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -59,15 +60,16 @@ const layer = Layer.effectDiscard(
           ],
           execute: (input, context) =>
             Effect.gen(function* () {
+              const metadata = jsonMetadata({
+                root: input.path ?? ".",
+                path: input.path,
+                limit: input.limit,
+              })
               yield* permission.assert({
                 action: name,
                 resources: [input.pattern],
                 save: ["*"],
-                metadata: {
-                  root: input.path ?? ".",
-                  path: input.path,
-                  limit: input.limit,
-                },
+                metadata,
                 sessionID: context.sessionID,
                 agent: context.agent,
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -10,6 +10,7 @@ import { Location } from "../location"
 import { PermissionV2 } from "../permission"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
+import { jsonMetadata } from "./metadata"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -78,16 +79,17 @@ const layer = Layer.effectDiscard(
           ],
           execute: (input, context) =>
             Effect.gen(function* () {
+              const metadata = jsonMetadata({
+                root: ".",
+                path: input.path,
+                include: input.include,
+                limit: input.limit,
+              })
               yield* permission.assert({
                 action: name,
                 resources: [input.pattern],
                 save: ["*"],
-                metadata: {
-                  root: ".",
-                  path: input.path,
-                  include: input.include,
-                  limit: input.limit,
-                },
+                metadata,
                 sessionID: context.sessionID,
                 agent: context.agent,
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },

--- a/packages/core/src/tool/metadata.ts
+++ b/packages/core/src/tool/metadata.ts
@@ -1,0 +1,9 @@
+/**
+ * Permission metadata is persisted and served as JSON, so absent optional
+ * fields must be omitted rather than stored as `undefined`.
+ */
+export function jsonMetadata(fields: Record<string, string | number | undefined>): Record<string, string | number> {
+  return Object.fromEntries(
+    Object.entries(fields).filter((entry): entry is [string, string | number] => entry[1] !== undefined),
+  )
+}

--- a/packages/core/test/tool-permission-metadata.test.ts
+++ b/packages/core/test/tool-permission-metadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { jsonMetadata } from "../src/tool/metadata"
+
+describe("jsonMetadata", () => {
+  test("drops absent optional fields so metadata stays JSON-encodable", () => {
+    const metadata = jsonMetadata({
+      root: ".",
+      path: undefined,
+      include: undefined,
+      limit: undefined,
+    })
+    expect(metadata).toEqual({ root: "." })
+    expect(JSON.parse(JSON.stringify(metadata))).toEqual(metadata)
+  })
+
+  test("keeps provided optional fields and required values", () => {
+    const metadata = jsonMetadata({
+      root: "src",
+      path: "src",
+      include: "*.ts",
+      limit: 10,
+    })
+    expect(metadata).toEqual({ root: "src", path: "src", include: "*.ts", limit: 10 })
+  })
+
+  test("matches the glob/grep pending-permission repro from #37650", () => {
+    // glob input without the optional `path`
+    expect(jsonMetadata({ root: ".", path: undefined, limit: undefined })).toEqual({ root: "." })
+    // grep input with `path` but absent `include`/`limit`
+    expect(jsonMetadata({ root: ".", path: "docs", include: undefined, limit: undefined })).toEqual({
+      root: ".",
+      path: "docs",
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #37650

### Type of change

- [x] Bug fix

### What does this PR do?

Pending `glob` and `grep` permissions store absent optional tool inputs (`path`, `include`, `limit`) as `undefined` inside JSON permission metadata, so when `session.permission.list` encodes its response, schema validation fails with `Expected JSON value, got undefined`.

This adds a small `jsonMetadata` helper in `packages/core/src/tool/metadata.ts` that omits `undefined` fields, and builds the glob/grep permission metadata through it: absent optional inputs are simply left out of the record, so permission listing stays schema-valid whether or not the model supplied them.

(Supersedes #44375, which was auto-closed before its description could be brought up to the PR template.)

### How did you verify your code works?

- New unit tests in `packages/core/test/tool-permission-metadata.test.ts` cover the all-optional-absent case from the issue, the fully-populated case, and the mixed path-only case: 3 pass.
- Existing related suites still pass: tool-bash, tool-edit, filesystem/search → 22 pass.
- `bun run typecheck` clean in @opencode-ai/core and across the monorepo.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR