### PR TITLE
fix(core): treat empty apiKey as no credential

### DIFF
--- a/packages/core/src/aisdk-native.ts
+++ b/packages/core/src/aisdk-native.ts
@@ -157,10 +157,12 @@ function mapBedrockSettings(
   settings: Readonly<Record<string, unknown>>,
   baseSettings: Readonly<Record<string, unknown>>,
 ) {
+  // Empty strings mean "no credential": forwarding one would suppress the
+  // SDK's own auth resolution for keyless setups (custom headers, gateways).
   const apiKey =
-    typeof settings.apiKey === "string"
+    typeof settings.apiKey === "string" && settings.apiKey !== ""
       ? settings.apiKey
-      : typeof settings.bearerToken === "string"
+      : typeof settings.bearerToken === "string" && settings.bearerToken !== ""
         ? settings.bearerToken
         : undefined
   const region = bedrockRegion(settings)
@@ -280,7 +282,7 @@ function mapBaseSettings(settings: Readonly<Record<string, unknown>>) {
 }
 
 function mapAPIKey(settings: Readonly<Record<string, unknown>>) {
-  return typeof settings.apiKey === "string" ? { apiKey: settings.apiKey } : {}
+  return typeof settings.apiKey === "string" && settings.apiKey !== "" ? { apiKey: settings.apiKey } : {}
 }
 
 function mapGoogleOptions(settings: Readonly<Record<string, unknown>>, extra: Readonly<Record<string, unknown>> = {}) {

--- a/packages/core/test/aisdk-native.test.ts
+++ b/packages/core/test/aisdk-native.test.ts
@@ -435,4 +435,13 @@ describe("AISDKNative", () => {
       settings: {},
     })
   })
+  test("treats empty-string apiKey as no credential", () => {
+    const mapped = map("@ai-sdk/openai", { apiKey: "", baseURL: "https://gateway.test/v1" })
+    expect(mapped?.settings.apiKey).toBeUndefined()
+    expect(mapped?.settings.baseURL).toBe("https://gateway.test/v1")
+  })
+
+  test("keeps non-empty apiKey", () => {
+    expect(map("@ai-sdk/openai", { apiKey: "secret" })?.settings.apiKey).toBe("secret")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #42790

### Type of change

- [x] Bug fix

### What does this PR do?

settings.apiKey set to an empty string was forwarded into the AI SDK facades verbatim, which suppresses their built-in auth resolution (env var / default chain). That is why keyless setups - a gateway with custom auth headers, for example - needed the apiKey: "" workaround from the issue. Both credential mappers (mapAPIKey and the Bedrock apiKey/bearerToken path) now treat only non-empty strings as credentials, matching how hasConfiguredAuth() in model-resolver already ignores empty strings. Availability itself needed no change: config-added providers are activated unconditionally on the current branch.

### How did you verify your code works?

- extended packages/core/test/aisdk-native.test.ts: {apiKey: ""} maps to no apiKey while baseURL is preserved; non-empty keys pass through; full file 19 pass / 0 fail
- bun run typecheck (packages/core): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
