### PR TITLE
fix(core): honor settings.maxOutputTokens as a generation default

### DIFF
--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -168,12 +168,13 @@ const resolveCatalogModel = Effect.fn("ModelResolver.resolveCatalogModel")(funct
   return yield* Effect.try({
     try: () => {
       const runtime = module.model(resolved.modelID ?? resolved.id, settings)
-      return LanguageModel.update(runtime, {
+      const model = LanguageModel.update(runtime, {
         provider: resolved.providerID,
         compatibility: resolved.compatibility
           ? Object.assign({}, runtime.compatibility, resolved.compatibility)
           : runtime.compatibility,
       })
+      return applyOutputTokenCap(model, outputTokenCapFrom(resolved.settings))
     },
     catch: () => unsupported(resolved),
   })
@@ -326,6 +327,19 @@ function hasConfiguredAuth(model: Info) {
   return [model.settings?.apiKey, model.settings?.authToken, model.settings?.accessToken].some(
     (value) => typeof value === "string" && value !== "",
   )
+}
+
+// Users can raise a provider/model's output ceiling with settings.maxOutputTokens
+// (number). Routes lower it per-API (max_tokens / maxOutputTokens); without it the
+// gateway picks its own cap, which thinking models truncate against.
+function outputTokenCapFrom(settings: Info["settings"] | undefined): number | undefined {
+  const value = settings?.maxOutputTokens
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function applyOutputTokenCap(model: LanguageModel, cap: number | undefined): LanguageModel {
+  if (cap === undefined) return model
+  return LanguageModel.update(model, { route: model.route.with({ generation: { maxTokens: cap } }) })
 }
 
 function usesAPIKeyAuth(packageName: string | undefined) {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -1237,4 +1237,26 @@ describe("ModelResolver", () => {
       expect(ModelResolver.supported(model(undefined))).toBe(false)
     }),
   )
+
+  it.effect("applies settings.maxOutputTokens as a route generation default", () =>
+    Effect.gen(function* () {
+      const resolved = yield* ModelResolver.fromCatalogModel(
+        model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+          settings: { baseURL: "https://gateway.test/v1", maxOutputTokens: 16384 },
+        }),
+      )
+      expect(resolved.route.defaults?.generation).toMatchObject({ maxTokens: 16384 })
+    }),
+  )
+
+  it.effect("ignores non-numeric maxOutputTokens", () =>
+    Effect.gen(function* () {
+      const resolved = yield* ModelResolver.fromCatalogModel(
+        model(Provider.aisdk("@ai-sdk/openai-compatible"), {
+          settings: { baseURL: "https://gateway.test/v1", maxOutputTokens: "big" },
+        }),
+      )
+      expect(resolved.route.defaults?.generation).toBeUndefined()
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR  Closes anomalyco/opencode#43945  ### Type of change  - [x] Bug fix  ### What does this PR do?  Session requests never set a max output size, so for thinking models served through gateways (hy3 in the issue) the gateway applies its own cap and long responses get severed mid-generation with no local escape hatch. Providers/models can now declare maxOutputTokens in their settings:      "provider": { "opencode-go": { "options": { "maxOutputTokens": 64000 } } }  The resolver applies it as a route generation default, and protocols already lower that per-API (max_tokens / maxOutputTokens / max_completion_tokens). Non-numeric or non-positive values are ignored. This is intentionally a route-level default, so anything that sets generation explicitly still wins.  ### How did you verify your code works?  - two new cases in packages/core/test/model-resolver.test.ts: numeric maxOutputTokens lands on route.defaults.generation.maxTokens; non-numeric value is ignored - bun test test/model-resolver.test.ts -> 41 pass / 0 fail - bun run typecheck (packages/core): clean  ### Screenshots / recordings  Not a UI change.  ### Checklist  - [x] I have tested my changes locally - [x] I have not included unrelated changes in this PR 