### PR TITLE
docs(web): explain projects and sessions in the TUI guide

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -27,6 +27,36 @@ Give me a quick summary of the codebase.
 
 ---
 
+## Projects and sessions
+
+OpenCode organizes your work into projects, and every conversation happens inside a session.
+
+A project is the codebase OpenCode is working in. When you start OpenCode, it looks upward from the starting directory until it finds a `.git` or `.hg` folder and treats that repository as the project. Starting from any subdirectory of the same repository therefore opens the same project, and separate clones of that repository count as one project too. Outside of version control, the directory you start in groups your sessions.
+
+Sessions belong to the project they were started in. Each session keeps its own messages, tool calls, and file changes, so different tasks stay separated.
+
+To begin a new task, run:
+
+```bash frame="none"
+/new
+```
+
+This starts a fresh session while your current one stays around. To return to an earlier session, run:
+
+```bash frame="none"
+/sessions
+```
+
+This lists recent sessions of the current project so you can pick up where you left off.
+
+To work on another codebase, start OpenCode in its directory instead. It becomes its own project with its own sessions.
+
+```bash
+opencode /path/to/project
+```
+
+---
+
 ## File references
 
 You can reference files in your messages using `@`. This does a fuzzy file search in the current working directory.


### PR DESCRIPTION
### Issue for this PR

Closes #40938

### Type of change

- [x] Documentation / docs

### What does this PR do?

Adds a "Projects and sessions" section to the TUI guide, placed right after the intro so newcomers get the mental model before the feature sections. It explains how OpenCode resolves the directory you start in into a project (walking up to the enclosing git/hg repository), that sessions belong to the project they were started in, and the common workflows: starting a separate task with `/new`, returning to an earlier session with `/sessions`, and opening another project with `opencode /path/to/project`.

### How did you verify your code works?

- Checked every claim against the source: `packages/core/src/project.ts` (`Project.root` walks up from the startup directory to the nearest `.git`/`.hg`; git repos are identified by remote/root commit) and the TUI session list (`packages/tui/src/component/dialog-session-list.tsx`, scoped per project by default).
- `cd packages/web && bun run build` — completed successfully ("[build] Complete!"), so the MDX compiles and the page builds.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
