### PR TITLE
fix(core): name inline image attachments in model context

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -26,6 +26,13 @@ const attachmentLocation = (file: FileAttachment) => {
   }
 }
 
+// Inline uploads (data: URIs from client paste/attach) carry the original
+// filename only in `name`; wire formats drop it, so surface it as a note.
+const inlineAttachmentName = (file: FileAttachment) => {
+  if (file.source.type !== "uri") return undefined
+  return URL.parse(file.source.uri)?.protocol === "data:" ? file.name : undefined
+}
+
 const textAttachment = (file: FileAttachment): ContentPart => ({
   type: "text",
   text: `\n\n${[
@@ -68,8 +75,8 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
   if (file.mime === "text/plain") return [textAttachment(file)]
   if (file.mime === "application/x-directory") return [directoryAttachment(file)]
   if (imageMimes.has(file.mime) || file.mime === "application/pdf") {
-    const location = attachmentLocation(file)
-    return [...(location === undefined ? [] : [Message.text(`Attached file: ${location}`)]), media(file)]
+    const origin = attachmentLocation(file) ?? inlineAttachmentName(file)
+    return [...(origin === undefined ? [] : [Message.text(`Attached file: ${origin}`)]), media(file)]
   }
   return []
 }

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -421,6 +421,35 @@ Recent work
     ])
   })
 
+  test("notes inline image attachments by name when no local path exists", () => {
+    const data = Base64.make("AAECAw==")
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-inline-image-name"),
+          type: "user",
+          text: "Inspect this image",
+          files: [
+            FileAttachment.make({
+              data,
+              mime: "image/png",
+              source: { type: "uri", uri: "data:image/png;base64,AAECAw==" },
+              name: "IMG_3480.JPG",
+            }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages[0]?.content).toEqual([
+      { type: "text", text: "Inspect this image" },
+      { type: "text", text: "Attached file: IMG_3480.JPG" },
+      { type: "media", mediaType: "image/png", data, filename: "IMG_3480.JPG" },
+    ])
+  })
+
   test("falls back to attachment names for invalid local source paths", () => {
     const data = Base64.make("AAECAw==")
     const messages = toLLMMessages(


### PR DESCRIPTION
### Issue for this PR

Closes #41454

### Type of change

- [x] Bug fix

### What does this PR do?

TUI image uploads reach the session as data: URIs, and attachmentContent only emitted the "Attached file: <path>" note for file:// sources - so inline images lowered to a bare media part and the model had no idea what the file was called or where it lived. Data-URI attachments now fall back to the attachment name (e.g. IMG_3480.JPG), giving the agent something to reference. Local-path images keep the existing location note, and remote provider media (https) stays silent on purpose - that case is covered by an existing test I did not change.

### How did you verify your code works?

- new test in packages/core/test/session-runner-message.test.ts: a data:-URI image with name IMG_3480.JPG lowers to text "Attached file: IMG_3480.JPG" + media part with filename
- bun test test/session-runner-message.test.ts -> 23 pass / 0 fail (18 pre-existing + 1 new + rest unchanged)
- bun run typecheck (packages/core): clean
- full core suite shows the same 7 environmental failures with and without this change (verified by stashing): Windows shell-spawn timeouts and plugin auto-discovery tests, unrelated files

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR