### PR TITLE
fix(app): hide empty terminal cursor

### DIFF
--- a/packages/app/e2e/regression/terminal-composer-focus.spec.ts
+++ b/packages/app/e2e/regression/terminal-composer-focus.spec.ts
@@ -10,11 +10,13 @@ const ptyID = "pty_terminal_composer_focus"
 const newPtyID = "pty_terminal_composer_focus_new"
 const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
 const ptyInput: string[] = []
+let sendPtyOutput: ((data: string) => void) | undefined
 
 test.use({ viewport: { width: 1440, height: 900 } })
 
 test.beforeEach(async ({ page }) => {
   ptyInput.length = 0
+  sendPtyOutput = undefined
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -74,6 +76,7 @@ test.beforeEach(async ({ page }) => {
   )
   await page.routeWebSocket(new RegExp(`/api/pty/${ptyID}/connect`), (ws) => {
     ws.onMessage((message) => ptyInput.push(message.toString()))
+    sendPtyOutput = (data) => ws.send(data)
   })
 })
 
@@ -88,6 +91,33 @@ test("clears the terminal line with Command+Delete", async ({ page }) => {
   await page.keyboard.press("Meta+Backspace")
 
   await expect.poll(() => ptyInput.join("")).toBe("\x15")
+})
+
+test("hides the native contenteditable caret", async ({ page }) => {
+  await page.goto(`/server/${base64Encode(server)}/session/${sessionID}`)
+  await expectSessionTitle(page, "Terminal composer focus")
+
+  await page.keyboard.press("Control+Backquote")
+  const terminal = page.locator('[data-component="terminal"]')
+  await expect(terminal).toHaveAttribute("contenteditable", "true")
+  await expect(terminal).toHaveCSS("caret-color", "rgba(0, 0, 0, 0)")
+})
+
+test("reveals the terminal after its first server output renders", async ({ page }) => {
+  await page.goto(`/server/${base64Encode(server)}/session/${sessionID}`)
+  await expectSessionTitle(page, "Terminal composer focus")
+
+  await page.keyboard.press("Control+Backquote")
+  const terminal = page.locator('[data-component="terminal"]')
+  await expect(terminal).toHaveAttribute("contenteditable", "true")
+  await expect(terminal).toHaveCSS("opacity", "0")
+  await expect.poll(() => sendPtyOutput).toBeDefined()
+
+  sendPtyOutput?.("\x1b[?25h")
+  await expect(terminal).toHaveCSS("opacity", "0")
+
+  sendPtyOutput?.("ready")
+  await expect(terminal).toHaveCSS("opacity", "1")
 })
 
 test("routes typing to the composer unless the open terminal is focused", async ({ page }) => {

--- a/packages/app/src/session/terminal/terminal.tsx
+++ b/packages/app/src/session/terminal/terminal.tsx
@@ -221,6 +221,14 @@ export const Terminal = (props: TerminalProps) => {
   let drop: VoidFunction | undefined
   let reconn: ReturnType<typeof setTimeout> | undefined
   let tries = 0
+  let revealed = false
+
+  const reveal = () => {
+    if (revealed) return
+    if (!serializeAddon.serializeAsText({ trimWhitespace: true })) return
+    revealed = true
+    container.style.opacity = "1"
+  }
 
   const cleanup = () => {
     if (!cleanups.length) return
@@ -500,6 +508,7 @@ export const Terminal = (props: TerminalProps) => {
 
       if (restore && restoreSize) {
         await write(restore)
+        reveal()
         fit.fit()
         scheduleSize(t.cols, t.rows)
         if (scrollY !== undefined) t.scrollToLine(scrollY)
@@ -509,6 +518,7 @@ export const Terminal = (props: TerminalProps) => {
         scheduleSize(t.cols, t.rows)
         if (restore) {
           await write(restore)
+          reveal()
           if (scrollY !== undefined) t.scrollToLine(scrollY)
         }
         startResize()
@@ -605,6 +615,7 @@ export const Terminal = (props: TerminalProps) => {
           const data = typeof event.data === "string" ? event.data : ""
           if (!data) return
           output?.push(data)
+          if (!revealed) output?.flush(reveal)
           cursor += data.length
           seek = cursor
         }
@@ -685,7 +696,7 @@ export const Terminal = (props: TerminalProps) => {
       dir="ltr"
       data-prevent-autofocus
       tabIndex={-1}
-      style={{ "background-color": terminalColors().background }}
+      style={{ "background-color": terminalColors().background, "caret-color": "transparent", opacity: 0 }}
       classList={{
         ...local.classList,
         "select-text": true,


### PR DESCRIPTION
## Summary

- hide Chromium's native contenteditable caret on terminal hosts
- keep new terminal surfaces transparent through cursor-only initialization frames
- reveal restored or server-rendered terminal content after visible buffer text is painted
- cover native-caret and first-output behavior with Playwright regressions

## Recording

The terminal remains blank through a cursor-only initialization frame, then reveals the first visible server output atomically.

https://github.com/user-attachments/assets/b446a18e-b982-49c1-9fe4-65a06090e9bc

## Validation

- `bun typecheck` (`packages/app`)
- `bun run typecheck:e2e` (`packages/app`)
- `PLAYWRIGHT_PORT=31856 bunx playwright test e2e/regression/terminal-composer-focus.spec.ts --workers=1` (7 passed)
- upstream push hook: 32 package typechecks passed

The production session benchmark was attempted before and after the change, but its fixture did not render the expected session headings and therefore reported no metrics in either run.
