### PR TITLE
fix(core): omit absent optional fields from glob/grep permission metadata

### DIFF
--- a/packages/core/src/tool/plugin/glob.ts
+++ b/packages/core/src/tool/plugin/glob.ts
@@ -73,10 +73,12 @@ export const Plugin = {
                 action: name,
                 resources: [input.pattern],
                 save: ["*"],
+                // Absent optional fields must stay absent: explicit undefined
+                // values break schema encoding when the permission is listed.
                 metadata: {
                   root: searchPath ?? ".",
-                  path: searchPath,
-                  limit: input.limit,
+                  ...(searchPath === undefined ? {} : { path: searchPath }),
+                  ...(input.limit === undefined ? {} : { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/src/tool/plugin/grep.ts
+++ b/packages/core/src/tool/plugin/grep.ts
@@ -90,9 +90,9 @@ export const Plugin = {
                 save: ["*"],
                 metadata: {
                   root: ".",
-                  path: input.path,
-                  include: input.include,
-                  limit: input.limit,
+                  ...(input.path === undefined ? {} : { path: input.path }),
+                  ...(input.include === undefined ? {} : { include: input.include }),
+                  ...(input.limit === undefined ? {} : { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,


### PR DESCRIPTION
### Issue for this PR

Closes #37650

### Type of change

- [x] Bug fix

### What does this PR do?

glob and grep built their permission metadata with every field always present, so a call that omitted the optional path/include/limit inputs stored explicit undefined values in the JSON metadata. Encoding the pending permission for session.permission.list then failed schema validation. The two tools now build the metadata conditionally so absent optional fields stay absent, exactly as the issue expects.

### How did you verify your code works?

- bun test ./test/tool-search.test.ts (packages/core - exercises both tools through Permission.node): 11 pass / 0 fail
- bun run typecheck (packages/core): clean
- end-to-end listing behavior is covered by the Drive reproduction linked in the issue; I kept the change to the two metadata builders rather than adding a blocking-ask fixture

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR