### PR TITLE
fix(cli): let open steps drain before breaking on session idle

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -705,11 +705,39 @@ export const RunCommand = effectCmd({
           // mid-step and losing the trailing events.
           let openSteps = 0
           let idlePending = false
-          let drainTimedOut = false
-          let drainTimer: ReturnType<typeof setTimeout> | undefined
 
-          for await (const event of events.stream) {
-            if (drainTimedOut) break
+          // While draining, each wait for the next event races a deadline that
+          // resets on every delivered part, so a stream that goes quiet after
+          // idle can't block exit. OPENCODE_RUN_DRAIN_TIMEOUT overrides (ms).
+          const drainTimeoutMs = () => {
+            const raw = Number(process.env.OPENCODE_RUN_DRAIN_TIMEOUT)
+            return Number.isFinite(raw) && raw > 0 ? raw : 3_000
+          }
+          const drain = { idle: false, timer: undefined as ReturnType<typeof setTimeout> | undefined }
+          async function* raced<T>(stream: AsyncIterable<T>): AsyncGenerator<T> {
+            const iterator = stream[Symbol.asyncIterator]()
+            try {
+              while (true) {
+                const pending = iterator.next()
+                const settled = drain.idle
+                  ? await Promise.race([
+                      pending,
+                      new Promise<undefined>((resolve) => {
+                        drain.timer = setTimeout(() => resolve(undefined), drainTimeoutMs())
+                      }),
+                    ])
+                  : await pending
+                clearTimeout(drain.timer)
+                if (settled === undefined || settled.done) return
+                yield settled.value
+              }
+            } finally {
+              clearTimeout(drain.timer)
+              void Promise.resolve(iterator.return?.()).catch(() => {})
+            }
+          }
+
+          for await (const event of raced(events.stream)) {
             if (event.type === "session.created" && event.properties.info.parentID) {
               if (sessions.has(event.properties.info.parentID)) sessions.add(event.properties.info.id)
             }
@@ -803,6 +831,10 @@ export const RunCommand = effectCmd({
                 err = String(props.error.data.message)
               }
               error = error ? error + EOL + err : err
+              // Unlike the happy path we stop as soon as an error lands instead
+              // of waiting out the drain window: the error is what the caller
+              // needs, and reporting it promptly matters more than a trailing
+              // step-finish.
               if (emit("error", { error: props.error })) {
                 if (idlePending) break
                 continue
@@ -818,7 +850,7 @@ export const RunCommand = effectCmd({
             ) {
               if (openSteps > 0) {
                 idlePending = true
-                drainTimer = setTimeout(() => (drainTimedOut = true), 3_000)
+                drain.idle = true
                 continue
               }
               break
@@ -846,7 +878,6 @@ export const RunCommand = effectCmd({
               }
             }
           }
-          clearTimeout(drainTimer)
           return error
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -699,7 +699,17 @@ export const RunCommand = effectCmd({
           const sessions = new Set([sessionID])
           let error: string | undefined
 
+          // session.status idle can arrive ahead of the remaining parts of an
+          // open step when event delivery lags (e.g. in containers/CI). Track
+          // open steps and keep draining until they settle rather than exiting
+          // mid-step and losing the trailing events.
+          let openSteps = 0
+          let idlePending = false
+          let drainTimedOut = false
+          let drainTimer: ReturnType<typeof setTimeout> | undefined
+
           for await (const event of events.stream) {
+            if (drainTimedOut) break
             if (event.type === "session.created" && event.properties.info.parentID) {
               if (sessions.has(event.properties.info.parentID)) sessions.add(event.properties.info.id)
             }
@@ -743,11 +753,18 @@ export const RunCommand = effectCmd({
               }
 
               if (part.type === "step-start") {
+                openSteps++
                 if (emit("step_start", { part })) continue
               }
 
               if (part.type === "step-finish") {
-                if (emit("step_finish", { part })) continue
+                openSteps = Math.max(0, openSteps - 1)
+                const drained = idlePending && openSteps <= 0
+                if (emit("step_finish", { part })) {
+                  if (drained) break
+                  continue
+                }
+                if (drained) break
               }
 
               if (part.type === "text" && part.time?.end) {
@@ -786,8 +803,12 @@ export const RunCommand = effectCmd({
                 err = String(props.error.data.message)
               }
               error = error ? error + EOL + err : err
-              if (emit("error", { error: props.error })) continue
+              if (emit("error", { error: props.error })) {
+                if (idlePending) break
+                continue
+              }
               UI.error(err)
+              if (idlePending) break
             }
 
             if (
@@ -795,6 +816,11 @@ export const RunCommand = effectCmd({
               event.properties.sessionID === sessionID &&
               event.properties.status.type === "idle"
             ) {
+              if (openSteps > 0) {
+                idlePending = true
+                drainTimer = setTimeout(() => (drainTimedOut = true), 3_000)
+                continue
+              }
               break
             }
 
@@ -820,6 +846,7 @@ export const RunCommand = effectCmd({
               }
             }
           }
+          clearTimeout(drainTimer)
           return error
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)


### PR DESCRIPTION
### Issue for this PR

Closes #31435

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --format json` sometimes exits before the final `text`/`step-finish` parts are delivered. The event loop breaks as soon as it sees `session.status = idle`, but in containers/CI the idle event can overtake the remaining message parts on the stream, so the JSONL ends at `step_start` with the answer missing. (An earlier attempt at this was #31446, which got cleaned up before anyone reviewed it.)

The loop now counts open steps from `step-start`/`step-finish` parts. When idle arrives while a step is still open it defers the break and keeps draining until the step settles. If the trailing events never arrive a 3 second timer breaks out so the CLI can't hang on a dead stream. When no step is open nothing changes - idle still exits immediately.

### How did you verify your code works?

- Replayed the race against both old and new loop logic using a synthetic SSE stream (idle injected between step-start and the trailing parts). Old output stops at `step_start`; new output emits every part in order.
- Confirmed the 3s timeout breaks the loop when `step-finish` never arrives.
- Ran a multi-step session with a tool call: full sequence comes through (`step_start`, `tool_use`, `step_finish`, `step_start`, `text`, `step_finish`). Non-JSON mode still exits on idle.
- `bun run typecheck` passes.

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
