### PR TITLE
fix(session-ui): avoid replaying thinking summary animation

### DIFF
--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -458,6 +458,7 @@ export function createSessionTimelineRowRenderer(input: {
         if (value._tag !== "Thinking") throw new Error("Expected a thinking timeline row")
         return value
       }
+      const animateHeading = createMemo<boolean>((previous) => previous ?? !current().reasoningHeading)
       return (
         <Frame row={current()}>
           <div data-slot="session-turn-message-container" class={`w-full ${padding()}`}>
@@ -480,8 +481,8 @@ export function createSessionTimelineRowRenderer(input: {
                             <TextReveal
                               text={current().reasoningHeading}
                               class="session-turn-thinking-heading"
-                              travel={25}
-                              duration={700}
+                              travel={animateHeading() ? 25 : 0}
+                              duration={animateHeading() ? 700 : 0}
                             />
                           </span>
                         </Show>


### PR DESCRIPTION
## Summary

- latch whether a thinking summary was absent when its row first rendered
- animate newly arriving summaries while rendering summaries already present on tab switches immediately

## Recording

The recording shows a newly arriving summary animate, then remounts the populated row without replaying the animation.

https://github.com/user-attachments/assets/098da92a-4ab1-4bc6-b9c5-631515b6fdc7

## Validation

- `bun typecheck` (`packages/session-ui`)
- `bun test src --only-failures` (`packages/session-ui`)
- `bun typecheck` (`packages/app`)
- `bun test ./e2e/performance/unit/session-tab-switch-metrics.test.ts ./e2e/performance/unit/session-tab-switch-probe.test.ts` (`packages/app`)
- pre-push repository typecheck
