### PR TITLE
fix(app): navigate parent with escape

### DIFF
--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -26,6 +26,16 @@ test("navigates to a subagent child session missing from the session list", asyn
   await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
 })
 
+test("returns to the parent session with Escape", async ({ page }) => {
+  await setup(page)
+  await openChildFromParent(page)
+  await expectSessionTitle(page, taskDescription)
+
+  await page.keyboard.press("Escape")
+
+  await Promise.all([expect(page).toHaveURL(sessionHref(parentID)), expectSessionTitle(page, parentTitle)])
+})
+
 test("shows parent lineage while the child timeline loads", async ({ page }) => {
   await setup(page)
   const requested = Promise.withResolvers<void>()

--- a/packages/app/src/session/composer/region.tsx
+++ b/packages/app/src/session/composer/region.tsx
@@ -101,6 +101,10 @@ export function createActiveSessionRegion(input: {
   const focus = () => {
     if (!input.session.data.isChild()) promptRef?.focus()
   }
+  const openParent = () => {
+    const id = input.session.data.parentID()
+    if (id) navigate(sessionHref(requireServerKey(input.session.identity.params.serverKey), id))
+  }
   const editable = (target: EventTarget | null | undefined) => {
     if (!(target instanceof HTMLElement)) return false
     return /^(INPUT|TEXTAREA|SELECT|BUTTON)$/.test(target.tagName) || target.isContentEditable
@@ -113,6 +117,7 @@ export function createActiveSessionRegion(input: {
     return current instanceof HTMLElement ? current : undefined
   }
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return
     const path = event.composedPath()
     const target = path.find((item): item is HTMLElement => item instanceof HTMLElement)
     const active = activeElement()
@@ -122,6 +127,11 @@ export function createActiveSessionRegion(input: {
       (active && (active.closest("[data-prevent-autofocus]") || editable(active))) ||
       dialog.active
     ) {
+      return
+    }
+    if (event.key === "Escape" && input.session.data.isChild()) {
+      event.preventDefault()
+      openParent()
       return
     }
     if (active === promptRef) {
@@ -172,10 +182,7 @@ export function createActiveSessionRegion(input: {
     },
     region: {
       centered: input.screen.centered,
-      openParent: () => {
-        const id = input.session.data.parentID()
-        if (id) navigate(sessionHref(requireServerKey(input.session.identity.params.serverKey), id))
-      },
+      openParent,
       prompt,
       setDockRef: input.timeline.view.setDockRef,
       setPromptRef: (element: HTMLDivElement) => {


### PR DESCRIPTION
## Summary

- navigate from a subagent session to its parent when Escape is otherwise unhandled
- preserve local Escape behavior for dialogs, editable controls, terminals, and request docks
- cover the child-to-parent shortcut with a regression test

## Recording

The recording opens a subagent session and returns to its parent with Escape.

https://github.com/user-attachments/assets/897c7db0-d06e-421b-87fb-cb682f87a794

## Validation

- `bun typecheck`
- `bun typecheck:e2e`
- `PLAYWRIGHT_PORT=3023 bunx playwright test e2e/regression/subagent-child-navigation.spec.ts` (6 passed)

## Performance

- attempted the production `session-parent-hydration-benchmark` before and after the change
- both runs hit the same existing blank initial render before metrics could be collected
