### PR TITLE
fix(cli): expose durable event persistence for packaged servers

### DIFF
--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -81,6 +81,11 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           port,
           password,
           simulation: truthy(process.env.OPENCODE_SIMULATE),
+          // Packaged servers default to in-memory event streams; this opts into
+          // durable event payload rows when a persistent database is attached.
+          events: {
+            persist: truthy(process.env.OPENCODE_EVENTS_PERSIST),
+          },
           database: {
             path:
               process.env.OPENCODE_DB ??


### PR DESCRIPTION
### Issue for this PR

Closes #42839

### Type of change

- [x] Bug fix

### What does this PR do?

ServerOptions has supported events.persist all along, but the packaged CLI server never passed it through, so `opencode serve` always ran with durable event payload rows off - even with OPENCODE_DB pointed at a file. This adds an OPENCODE_EVENTS_PERSIST environment knob wired into the same start() options, following the file's existing env-var conventions (OPENCODE_SIMULATE etc.).

### How did you verify your code works?

- bun run typecheck (packages/cli): clean
- the wiring is a direct pass-through of an existing ServerOptions field that routes.ts already consumes (Bus.configured({ persist: options.events?.persist })); there is no existing test harness that boots the packaged serve process

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR