### PR TITLE
fix(ai): revive stringified null tokens in tool call inputs

### DIFF
--- a/packages/ai/src/tool-runtime.ts
+++ b/packages/ai/src/tool-runtime.ts
@@ -34,8 +34,46 @@ export const dispatch = (tools: Tools, call: ToolCallPart): Effect.Effect<Dispat
   )
 }
 
+type Revived = { readonly value: unknown; readonly changed: boolean }
+
+// Some gateways serialize null as the literal string "null" inside tool
+// arguments. Revive those tokens before decoding: nullable fields then receive
+// real nulls, while schemas that reject the revived form fall back to the raw
+// payload - so a string field whose legitimate content is "null" still works.
+const reviveNullStrings = (value: unknown): Revived => {
+  if (value === "null") return { value: null, changed: true }
+  if (Array.isArray(value)) {
+    let changed = false
+    const items = value.map((item) => {
+      const revived = reviveNullStrings(item)
+      changed = changed || revived.changed
+      return revived.value
+    })
+    return { value: items, changed }
+  }
+  if (value !== null && typeof value === "object") {
+    let changed = false
+    const entries = Object.entries(value).map(([key, item]) => {
+      const revived = reviveNullStrings(item)
+      changed = changed || revived.changed
+      return [key, revived.value]
+    })
+    return { value: Object.fromEntries(entries), changed }
+  }
+  return { value, changed: false }
+}
+
+const decodeToolInput = (tool: AnyTool, input: ToolCallPart["input"]) => {
+  const salvaged = reviveNullStrings(input)
+  if (!salvaged.changed) return tool._decode(input)
+  // Gateways that serialize null as the string "null" hit every nullable field,
+  // so try the revived form first; fall back to the raw payload when the schema
+  // rejects it (e.g. a string field whose legitimate content is "null").
+  return tool._decode(salvaged.value).pipe(Effect.catch(() => tool._decode(input)))
+}
+
 const decodeAndExecute = (tool: AnyTool, call: ToolCallPart): Effect.Effect<ToolSettlement, ToolFailure> =>
-  tool._decode(call.input).pipe(
+  decodeToolInput(tool, call.input).pipe(
     Effect.mapError((error) => new ToolFailure({ message: `Invalid tool input: ${error.message}` })),
     Effect.flatMap((decoded) =>
       tool.execute!(decoded, { id: call.id, name: call.name }).pipe(

--- a/packages/ai/test/tool-runtime.test.ts
+++ b/packages/ai/test/tool-runtime.test.ts
@@ -863,4 +863,36 @@ describe("LLMClient tools", () => {
       expect(results.map((event) => event.id).toSorted()).toEqual(["c1", "c2"])
     }),
   )
+const nullable = Tool.make({
+  description: "Echoes a nullable string.",
+  parameters: Schema.Struct({ value: Schema.NullOr(Schema.String) }),
+  success: Schema.Struct({ received: Schema.NullOr(Schema.String) }),
+  execute: ({ value }) => Effect.succeed({ received: value }),
+})
+
+const strictString = Tool.make({
+  description: "Echoes a plain string.",
+  parameters: Schema.Struct({ value: Schema.String }),
+  success: Schema.Struct({ received: Schema.String }),
+  execute: ({ value }) => Effect.succeed({ received: value }),
+})
+  it.effect("revives stringified null tokens when the schema allows null", () =>
+    Effect.gen(function* () {
+      const settled = yield* ToolRuntime.dispatch(
+        { nullable },
+        LLMEvent.toolCall({ id: "call_null", name: "nullable", input: { value: "null" } }),
+      )
+      expect(settled.result).toMatchObject({ type: "json", value: { received: null } })
+    }),
+  )
+
+  it.effect("keeps literal null strings when the schema expects a string", () =>
+    Effect.gen(function* () {
+      const settled = yield* ToolRuntime.dispatch(
+        { strictString },
+        LLMEvent.toolCall({ id: "call_str", name: "strictString", input: { value: "null" } }),
+      )
+      expect(settled.result).toMatchObject({ type: "json", value: { received: "null" } })
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44262

### Type of change

- [x] Bug fix

### What does this PR do?

The Zen x-preview-f-free route serializes null as the literal string "null" inside tool arguments (confirmed against the raw SSE in the issue - the corruption happens upstream, before any client parses it). ToolRuntime.dispatch now decodes the arguments once with those tokens revived to real null, and falls back to the raw payload when the schema rejects the revived form:

- nullable fields receive a real null instead of a string, which is what every tool declaring `string | null` expects
- a string field whose legitimate content happens to be "null" still decodes unchanged, because the revived form fails its schema and the raw payload is used instead
- inputs without such tokens skip the salvage entirely (no behavioral change)

### How did you verify your code works?

- two new cases in packages/ai/test/tool-runtime.test.ts: NullOr(String) input {value: "null"} executes with received null; plain String input {value: "null"} still executes with the literal text
- bun test test/tool-runtime.test.ts -> 27 pass / 0 fail
- bun run typecheck (packages/ai): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR