### PR TITLE
fix(zen): echo stream identity on the oa-compat cost chunk

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -32,6 +32,7 @@ import {
   createBodyConverter,
   createStreamPartConverter,
   createResponseConverter,
+  parseChunkIdentity,
   UsageInfo,
 } from "./provider/provider"
 import { anthropicHelper } from "./provider/anthropic"
@@ -364,6 +365,9 @@ export async function handler(
         let buffer = ""
         let responseLength = 0
         let timestampFirstByte = 0
+        // Identity of the last forwarded chunk, echoed on the trailing cost
+        // frame so OpenAI-compatible clients can rebuild the response.
+        let lastChunkIdentity: ReturnType<typeof parseChunkIdentity> = undefined
 
         function pump(): Promise<void> {
           return (
@@ -397,7 +401,7 @@ export async function handler(
                   await trackUsage(sessionId, billingSource, authInfo, modelInfo, providerInfo, usageInfo, costInfo)
                   await reload(billingSource, authInfo, costInfo)
                   const cost = calculateOccurredCost(billingSource, costInfo)
-                  c.enqueue(encoder.encode(buildCostChunk(opts.format, cost)))
+                  c.enqueue(encoder.encode(buildCostChunk(opts.format, cost, lastChunkIdentity)))
                 }
                 c.close()
                 return
@@ -425,6 +429,11 @@ export async function handler(
 
                 part = part.trim()
                 usageParser.parse(part)
+
+                if (opts.format === "oa-compat") {
+                  const identity = parseChunkIdentity(part)
+                  if (identity) lastChunkIdentity = identity
+                }
 
                 if (providerInfo.format !== opts.format) {
                   part = streamConverter(part)

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import { ZenData } from "@opencode-ai/console-core/model.js"
 import {
   fromAnthropicChunk,
@@ -166,14 +167,50 @@ export interface CommonChunk {
   }
 }
 
-export function buildCostChunk(format: ZenData.Format, cost: string): string {
+export interface ChunkIdentity {
+  readonly id?: string
+  readonly model?: string
+  readonly created?: number
+}
+
+const identityJson = z.object({
+  id: z.string().optional(),
+  model: z.string().optional(),
+  created: z.number().optional(),
+})
+
+// Extract the stream-identity fields (id / model / created) from one SSE data
+// frame so a synthesized trailing chunk can echo them back to the client.
+export function parseChunkIdentity(part: string): ChunkIdentity | undefined {
+  const line = part.split("\n").find((line) => line.startsWith("data:"))
+  if (!line) return undefined
+  const payload = line.slice(5).trim()
+  if (!payload || payload === "[DONE]") return undefined
+  const decoded = identityJson.safeParse(JSON.parse(payload))
+  if (!decoded.success) return undefined
+  const { id, model, created } = decoded.data
+  if (id === undefined && model === undefined && created === undefined) return undefined
+  return { id, model, created }
+}
+
+export function buildCostChunk(format: ZenData.Format, cost: string, identity?: ChunkIdentity): string {
   switch (format) {
     case "anthropic":
       return `event: ping\ndata: ${JSON.stringify({ type: "ping", cost })}\n\n`
     case "openai":
       return `event: ping\ndata: ${JSON.stringify({ type: "ping", cost })}\n\n`
     case "oa-compat":
-      return `data: ${JSON.stringify({ choices: [], cost })}\n\n`
+      // OpenAI-compatible clients rebuild the response from these frames and
+      // expect the identity fields on every chunk, including the trailing
+      // usage/cost frame with empty choices.
+      return `data: ${JSON.stringify({
+        id: identity?.id ?? "",
+        object: "chat.completion.chunk",
+        created: identity?.created ?? 0,
+        model: identity?.model ?? "",
+        choices: [],
+        cost,
+      })}\n\n`
     default:
       return `data: ${JSON.stringify({ type: "ping", cost })}\n\n`
   }

--- a/packages/console/app/test/cost-chunk.test.ts
+++ b/packages/console/app/test/cost-chunk.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import { buildCostChunk, parseChunkIdentity } from "../src/routes/zen/util/provider/provider"
+
+describe("parseChunkIdentity", () => {
+  test("extracts id, model and created from a chat chunk frame", () => {
+    const part = 'data: {"id":"gen-1","object":"chat.completion.chunk","created":1755000000,"model":"gpt-5.6-luna","choices":[]}'
+    expect(parseChunkIdentity(part)).toEqual({
+      id: "gen-1",
+      model: "gpt-5.6-luna",
+      created: 1755000000,
+    })
+  })
+
+  test("ignores [DONE] and non-data lines", () => {
+    expect(parseChunkIdentity("data: [DONE]")).toBeUndefined()
+    expect(parseChunkIdentity("event: ping\ndata: {\"type\":\"ping\"}")).toBeUndefined()
+    expect(parseChunkIdentity("")).toBeUndefined()
+  })
+})
+
+describe("buildCostChunk", () => {
+  test("oa-compat cost chunk echoes stream identity", () => {
+    const chunk = buildCostChunk("oa-compat", "0.0001", {
+      id: "gen-1",
+      model: "gpt-5.6-luna",
+      created: 1755000000,
+    })
+    const payload = JSON.parse(chunk.replace(/^data: /, "").trim())
+    expect(payload).toEqual({
+      id: "gen-1",
+      object: "chat.completion.chunk",
+      created: 1755000000,
+      model: "gpt-5.6-luna",
+      choices: [],
+      cost: "0.0001",
+    })
+  })
+
+  test("oa-compat cost chunk keeps identity keys present when unknown", () => {
+    const payload = JSON.parse(buildCostChunk("oa-compat", "0").replace(/^data: /, "").trim())
+    expect(payload).toEqual({
+      id: "",
+      object: "chat.completion.chunk",
+      created: 0,
+      model: "",
+      choices: [],
+      cost: "0",
+    })
+  })
+
+  test("anthropic and openai formats keep the ping event shape", () => {
+    for (const format of ["anthropic", "openai"] as const) {
+      const chunk = buildCostChunk(format, "0.5", { id: "gen-1" })
+      expect(chunk).toContain("event: ping")
+      expect(JSON.parse(chunk.split("data: ")[1].trim())).toEqual({ type: "ping", cost: "0.5" })
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #42918

### Type of change

- [x] Bug fix

### What does this PR do?

With stream_options.include_usage, the trailing cost frame on /go/v1/chat/completions was emitted as {"choices":[],"cost":"..."} with no id/object/created/model. Strict OpenAI-compatible rebuilders (LiteLLM per the issue) fail on that frame because the identity fields are absent.

The streaming pump now remembers id/model/created from the last forwarded chunk and the oa-compat cost frame echoes them, matching the shape OpenAI itself uses for its usage chunk (identity fields present, empty choices array). The anthropic/openai ping-event cost frames are unchanged.

### How did you verify your code works?

- new packages/console/app/test/cost-chunk.test.ts: identity extraction from SSE data frames ([DONE]/ping frames ignored), oa-compat frame echoes known identity, identity keys stay present when unknown, other formats keep the ping shape - 5 pass / 0 fail
- bun run typecheck (packages/console/app): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR