### PR TITLE
fix(cli): attribute step events to their model in run json output

### DIFF
--- a/packages/cli/src/run/noninteractive.ts
+++ b/packages/cli/src/run/noninteractive.ts
@@ -90,6 +90,9 @@ export async function runNonInteractivePrompt(input: Input) {
   let finalizing = false
   let admission: AbortController | undefined
   let pendingStep: { timestamp: number; part: Record<string, unknown>; label: string } | undefined
+  // Model attribution for the in-flight step, stamped onto the JSON events so
+  // headless consumers can attribute tokens/cost per model across switches.
+  let currentStepModel: { providerID: string; modelID: string } | undefined
 
   const emit = (type: string, timestamp: number, data: Record<string, unknown>) => {
     if (input.format !== "json") return false
@@ -224,12 +227,15 @@ export async function runNonInteractivePrompt(input: Input) {
       if (finalizing && !event.type.startsWith("session.execution.")) continue
 
       if (event.type === "session.step.started") {
+        currentStepModel = { providerID: event.data.model.providerID, modelID: event.data.model.id }
         const part = {
           id: partID(event.id),
           sessionID: input.sessionID,
           messageID: event.data.assistantMessageID,
           type: "step-start",
           snapshot: event.data.snapshot,
+          providerID: event.data.model.providerID,
+          modelID: event.data.model.id,
         }
         if (input.compatibility === "v1") {
           pendingStep = {
@@ -463,8 +469,11 @@ export async function runNonInteractivePrompt(input: Input) {
           snapshot: event.data.snapshot,
           cost: event.data.cost,
           tokens: event.data.tokens,
+          providerID: currentStepModel?.providerID,
+          modelID: currentStepModel?.modelID,
         }
         emit("step_finish", time, { part })
+        currentStepModel = undefined
         continue
       }
       if (event.type === "session.step.failed") {


### PR DESCRIPTION
### Issue for this PR

Closes #40544

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode run --format json` emitted step_start/step_finish without any model reference, so a headless consumer could not attribute tokens or cost - especially across mid-session model switches or subagents running a different model. The core session.step.started event already carries the model (the human output prints it), so the JSON path now stamps providerID/modelID onto step_start from the event and onto step_finish from the in-flight capture, clearing it when the step ends.

### How did you verify your code works?

- bun run typecheck (packages/cli): clean
- additive keys on JSON events; the v1-compatibility pendingStep path inherits them through the same part object

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR