### PR TITLE
fix(zen): keep array-format assistant content in /v1/responses requests

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai.ts
@@ -150,8 +150,19 @@ export function fromOpenaiRequest(body: any): CommonRequest {
 
     if ((m as any).role === "assistant") {
       const c = (m as any).content
+      // Responses-style array content (output_text parts) must survive as text,
+      // otherwise the assistant message reaches upstream with neither content
+      // nor tool_calls and gets rejected.
+      const text = Array.isArray(c)
+        ? c
+            .filter(
+              (p: any) => p && typeof p.text === "string" && (p.type === "output_text" || p.type === "text"),
+            )
+            .map((p: any) => p.text)
+            .join("")
+        : c
       const out: any = { role: "assistant" }
-      if (typeof c === "string" && c.length > 0) out.content = c
+      if (typeof text === "string" && text.length > 0) out.content = text
       if (Array.isArray((m as any).tool_calls)) out.tool_calls = (m as any).tool_calls
       msgs.push(out)
       continue

--- a/packages/console/app/test/responses-assistant-content.test.ts
+++ b/packages/console/app/test/responses-assistant-content.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test"
+import { fromOpenaiRequest } from "../src/routes/zen/util/provider/openai"
+import { toOaCompatibleRequest } from "../src/routes/zen/util/provider/openai-compatible"
+
+describe("fromOpenaiRequest assistant content", () => {
+  test("flattens array-format assistant content into text", () => {
+    const common = fromOpenaiRequest({
+      model: "deepseek-v4-flash-free",
+      input: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello there" }],
+        },
+      ],
+    })
+
+    expect(common.messages).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello there" },
+    ])
+  })
+
+  test("survives the full openai -> oa-compat conversion without dropping the assistant message", () => {
+    const common = fromOpenaiRequest({
+      model: "deepseek-v4-flash-free",
+      stream: true,
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "hi" }] },
+        {
+          role: "assistant",
+          content: [{ type: "output_text", text: "partial answer" }],
+        },
+        { role: "user", content: "continue" },
+      ],
+    })
+    const compat = toOaCompatibleRequest(common)
+
+    const assistants = compat.messages.filter((m: any) => m.role === "assistant")
+    expect(assistants).toEqual([{ role: "assistant", content: "partial answer" }])
+  })
+
+  test("keeps tool_calls when array content is absent", () => {
+    const common = fromOpenaiRequest({
+      model: "m",
+      input: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "f", arguments: "{}" } }],
+        },
+      ],
+    })
+    expect(common.messages[0]).toMatchObject({ role: "assistant" })
+    expect((common.messages[0] as any).tool_calls).toHaveLength(1)
+    expect((common.messages[0] as any).content).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41766

### Type of change

- [x] Bug fix

### What does this PR do?

fromOpenaiRequest only copied assistant content when it was a string. Responses API clients legitimately send assistant messages with array content ([{type:"output_text",text:...}]), and after conversion those messages reached the upstream provider with neither content nor tool_calls, producing "Invalid assistant message: content or tool_calls must be set". output_text (and plain text) parts are now flattened into the text field; tool_calls handling is unchanged, and an assistant message with only tool_calls still emits no content.

### How did you verify your code works?

- new packages/console/app/test/responses-assistant-content.test.ts: array content flattens to text; the full openai -> oa-compat chain keeps the assistant message; tool_calls-only assistants stay content-less - 3 pass / 0 fail
- bun run typecheck (packages/console/app): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR