### PR TITLE
fix(core): trim whitespace in model references

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -38,10 +38,13 @@ export function compatibility(input: unknown): Compatibility | undefined {
 }
 
 export function parse(input: string): { providerID: Provider.ID; modelID: ID } {
-  const [providerID, ...modelID] = input.split("/")
+  // User-supplied references (config, CLI flags) occasionally carry stray
+  // whitespace, which upstream gateways reject with an opaque 400. Trim the
+  // reference and each segment; model IDs never legitimately contain them.
+  const [providerID, ...modelID] = input.trim().split("/")
   return {
-    providerID: Provider.ID.make(providerID),
-    modelID: ID.make(modelID.join("/")),
+    providerID: Provider.ID.make(providerID.trim()),
+    modelID: ID.make(modelID.join("/").trim()),
   }
 }
 

--- a/packages/core/test/model-parse.test.ts
+++ b/packages/core/test/model-parse.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { Model } from "@opencode-ai/core/model"
+
+describe("Model.parse", () => {
+  test("splits provider and model", () => {
+    const parsed = Model.parse("opencode/gpt-5")
+    expect(String(parsed.providerID)).toBe("opencode")
+    expect(String(parsed.modelID)).toBe("gpt-5")
+  })
+
+  test("keeps slashes inside multi-segment model ids", () => {
+    const parsed = Model.parse("@scope/pkg/gpt-5")
+    expect(String(parsed.providerID)).toBe("@scope")
+    expect(String(parsed.modelID)).toBe("pkg/gpt-5")
+  })
+
+  test("trims stray whitespace around the reference and segments", () => {
+    const padded = Model.parse(" opencode/ deepseek-v4-flash ")
+    expect(String(padded.providerID)).toBe("opencode")
+    expect(String(padded.modelID)).toBe("deepseek-v4-flash")
+
+    const tabbed = Model.parse("\topenai\n")
+    expect(String(tabbed.providerID)).toBe("openai")
+    expect(String(tabbed.modelID)).toBe("")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41719

### Type of change

- [x] Bug fix

### What does this PR do?

A model reference with stray whitespace - a leading space in opencode.json, a trailing newline in a shell flag - reached providers verbatim and failed with an opaque upstream 400. Model.parse now trims the whole reference and each segment before constructing the branded ids. Multi-slash ids (@scope/pkg/model) keep their inner slashes, and ids never legitimately contain leading/trailing whitespace.

Note: #41314 fixed the relay-side injection for deepseek-v4-flash; this covers the client-side variant where the whitespace comes from user config/flags.

### How did you verify your code works?

- new packages/core/test/model-parse.test.ts: plain split, multi-slash ids preserved, whitespace around reference and segments trimmed - 3 pass / 0 fail
- bun run typecheck (packages/core): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR