### PR TITLE
docs(ecosystem): add dejavu — cross-session error-gate plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                | Cross-session error gates: recurring tool-call failures promoted into enforced gates — remind first, hard-block on same-session repeat |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation addition for the community ecosystem plugins list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

dejavu mechanically detects recurring tool-call failures across sessions and promotes them into enforced gates: a reminder with the correction on the next attempt, a hard block if the same session repeats the call.

### How did you verify your code works?

Docs-only table row. Entry matches the Plugins table column alignment and links to the live, public repo: https://github.com/WhiteBite/opencode-dejavu

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
