### PR TITLE
fix(app): simplify session max width

### DIFF
--- a/packages/app/src/session/composer/session-composer-region.tsx
+++ b/packages/app/src/session/composer/session-composer-region.tsx
@@ -36,7 +36,7 @@ export function SessionComposerRegion(props: {
       <div
         classList={{
           "w-full px-3 pointer-events-auto": true,
-          "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": controller.centered(),
+          "md:max-w-[1000px] md:mx-auto": controller.centered(),
         }}
       >
         <Show when={controller.state.questionRequest()} keyed>

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -499,7 +499,7 @@ function MessageTimelineView(
             data-component="session-background-hint-row"
             classList={{
               "min-w-0 w-full max-w-full": true,
-              "md:max-w-200 2xl:max-w-[1000px] md:mx-auto": props.centered,
+              "md:max-w-[1000px] md:mx-auto": props.centered,
             }}
           >
             <div

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -233,7 +233,7 @@ export function createSessionTimelineRowRenderer(input: {
       data-timeline-row={props.row._tag}
       classList={{
         "min-w-0 w-full max-w-full": true,
-        "md:max-w-200 2xl:max-w-[1000px] md:mx-auto": input.centered?.(),
+        "md:max-w-[1000px] md:mx-auto": input.centered?.(),
         "pt-3": props.row._tag === "AssistantPart" && props.row.previousAssistantPart,
       }}
     >


### PR DESCRIPTION
## Summary

- replace the session's 800px/1000px responsive width tiers with one 1000px desktop cap
- keep timeline rows, background work hints, and the composer aligned to the same width

## Before / After

| Before | After |
| --- | --- |
| ![Before: session content capped at 800px](https://github.com/user-attachments/assets/b3ca3f6f-254d-4d99-a44a-3f2adea629ba) | ![After: session content uses the 1000px cap](https://github.com/user-attachments/assets/7fd42a44-f881-4aef-8b0e-6f3c87e92771) |

## Validation

- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/session-ui`
- pre-push `bun turbo typecheck --concurrency=3` (32 packages passed)
- production first-navigation benchmark attempted before and after; both runs are blocked before metric collection because the fixture does not render the expected session heading
