### PR TITLE
fix(core): keep signed thinking ahead of tool calls on errored replay

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -157,8 +157,19 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
           providerMetadata: reuseProviderMetadata ? providerMetadata(providerMetadataKey, item.state) : undefined,
         },
       ]
-    if (item.type === "reasoning")
-      return reuseProviderMetadata
+    if (item.type === "reasoning") {
+      // Anthropic requires every thinking block to precede its sibling tool_use
+      // blocks on replay. Demoting a signed/redacted block to plain text on an
+      // errored message that still replays tool calls breaks that invariant and
+      // fails the follow-up request with a 400 - so same-model proofs survive
+      // errors, while everything else keeps demoting.
+      const state = item.state as Record<string, unknown> | undefined
+      const proofed =
+        sameModel &&
+        state !== undefined &&
+        ((typeof state.signature === "string" && state.signature.length > 0) ||
+          typeof state.redactedData === "string")
+      return reuseProviderMetadata || proofed
         ? [
             {
               type: "reasoning",
@@ -169,6 +180,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
         : item.text.length > 0
           ? [{ type: "text", text: item.text }]
           : []
+    }
     // Call-side metadata is model-scoped proof of generation (Gemini thought
     // signatures, OpenAI encrypted reasoning): only the producing model may
     // replay it.

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -798,6 +798,59 @@ Recent work
     ])
   })
 
+  test("keeps signed reasoning ahead of tool calls when replaying an errored same-model message", () => {
+    const messages = toLLMMessages(
+      [
+        SessionMessage.Assistant.make({
+          id: id("assistant-failed-signed"),
+          type: "assistant",
+          agent: build,
+          model: { id: Model.ID.make("model"), providerID: Provider.ID.make("provider") },
+          content: [
+            SessionMessage.AssistantReasoning.make({
+              type: "reasoning",
+              text: "Signed thought",
+              state: { signature: "sig_failed" },
+            }),
+            SessionMessage.AssistantTool.make({
+              type: "tool",
+              id: "tool-failed",
+              name: "read",
+              executed: false,
+              state: SessionMessage.ToolStateError.make({
+                status: "error",
+                input: { path: "docs" },
+                error: { type: "unknown", message: "Step interrupted" },
+              }),
+              time: { created, completed: created },
+            }),
+          ],
+          finish: "error",
+          error: { type: "unknown", message: "Step interrupted" },
+          time: { created, completed: created },
+        }),
+      ],
+      model,
+      "anthropic",
+    )
+
+    expect(messages[0]?.content).toEqual([
+      {
+        type: "reasoning",
+        text: "Signed thought",
+        providerMetadata: { anthropic: { signature: "sig_failed" } },
+      },
+      {
+        type: "tool-call",
+        id: "tool-failed",
+        name: "read",
+        input: { path: "docs" },
+        providerExecuted: false,
+        providerMetadata: undefined,
+      },
+    ])
+  })
+
   test("lowers failed assistant reasoning to text", () => {
     const messages = toLLMMessages(
       [


### PR DESCRIPTION
### Issue for this PR

Closes #38620

### Type of change

- [x] Bug fix

### What does this PR do?

Replaying an errored assistant message stripped its reasoning provider metadata (signature / redactedData) while still replaying the same message's tool_use parts. Anthropic requires every thinking block to precede its sibling tool_use when thinking is enabled, so any interrupted-or-failed step in a thinking + tool session made the follow-up request fail with a 400.

The reuse gate now keeps signed/redacted reasoning blocks - with their metadata - when the producing model is the replay target, even if the message carries an error. Unsigned hosted-style reasoning (OpenAI itemId/encrypted content) keeps demoting to text as before, cross-model replay is unchanged, and the existing "lowers failed assistant reasoning to text" case still passes untouched since its fixture has no signature.

### How did you verify your code works?

- new test in packages/core/test/session-runner-message.test.ts: errored same-model message with signed reasoning + a tool call lowers to reasoning(with anthropic signature) followed by tool-call, instead of demoting
- bun test ./test/session-runner-message.test.ts -> 23 pass / 0 fail
- bun run typecheck (packages/core): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR