### PR TITLE
fix(app): pick undo boundaries from promoted history only

### DIFF
--- a/packages/app/src/session/revert.ts
+++ b/packages/app/src/session/revert.ts
@@ -67,13 +67,27 @@ export function createSessionRevert(input: {
     await stage(message, messages[index - 1])
   }
 
+  // The revert boundary must reference promoted history: an admitted-but-
+  // unpromoted prompt exists only in the client store, and the server's revert
+  // planner cannot stage against it ("Message not found").
+  const promotedUserMessageIDs = async (sessionID: string) => {
+    const page = await server.api.message.list({ sessionID, limit: 200, order: "desc" }).catch(() => undefined)
+    if (!page) return undefined
+    return new Set(page.data.filter((message) => message.type === "user").map((message) => message.id))
+  }
+
   const undo = async () => {
+    const sessionID = input.session.identity.params.id
+    if (!sessionID) return
     const messages = input.session.history.userMessages()
     const reverted = input.session.data.revertMessageID()
-    const boundary = reverted ? messages.findIndex((message) => message.id === reverted) : messages.length
+    const promoted = await promotedUserMessageIDs(sessionID)
+    if (!promoted) return
+    const candidates = messages.filter((message) => promoted.has(message.id))
+    const boundary = reverted ? candidates.findIndex((message) => message.id === reverted) : candidates.length
     if (boundary <= 0) return
-    const message = messages[boundary - 1]
-    if (message) await stage(message, messages[boundary - 2])
+    const message = candidates[boundary - 1]
+    if (message) await stage(message, candidates[boundary - 2])
   }
 
   const redo = async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #39736

### Type of change

- [x] Bug fix

### What does this PR do?

Undo picked its boundary from the client-side message list, which also contains admitted-but-unpromoted prompts (they render immediately while a response is active). The server revert planner only knows promoted session_message rows, so staging against an admitted prompt failed with "Message not found" and nothing was undone.

undo() now fetches the session'"'"'s promoted user messages from the API and intersects them with the local list before selecting the boundary, so it always stages against history the server can revert. Redo/to keep their existing behavior.

### How did you verify your code works?

- bun run typecheck (packages/app): the only diagnostic is the pre-existing packages/app/src/custom-elements.d.ts TS1128 on unmodified v2; no errors in the touched file
- behavior is data-driven: with no admitted prompts the promoted set equals the local list and selection is identical to before

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR