### PR TITLE
fix(core): skip unresolvable paths in the advisory shell scan

### DIFF
--- a/packages/core/src/tool/plugin/shell.ts
+++ b/packages/core/src/tool/plugin/shell.ts
@@ -209,9 +209,18 @@ export const Plugin = {
                       const parsed = yield* ShellParse.scan(invocation.command, invocation.shell, target.absolute, {
                         portable,
                       })
-                      const directories = yield* Effect.forEach(parsed.directories, (directory) =>
-                        mutation.resolve({ path: path.resolve(target.absolute, directory), kind: "directory" }),
-                      )
+                      const directories = (
+                        yield* Effect.forEach(parsed.directories, (directory) =>
+                          mutation
+                            .resolve({ path: path.resolve(target.absolute, directory), kind: "directory" })
+                            .pipe(
+                              // The argument scan is advisory: candidates can be
+                              // sockets, devices, or otherwise unresolvable paths.
+                              // Skip them instead of failing the whole command.
+                              Effect.catch(() => Effect.succeed(undefined)),
+                            ),
+                        )
+                      ).filter((item): item is NonNullable<typeof item> => item !== undefined)
                       const external = [target, ...directories]
                         .map((item) => item.externalDirectory)
                         .filter((item) => item !== undefined)

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -289,6 +289,37 @@ describe("ShellTool", () => {
     { timeout: 15_000 },
   )
 
+  productionIt.live(
+    "skips unresolvable socket arguments during the advisory scan",
+    () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withSession(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              if (process.platform === "win32") return
+              const net = yield* Effect.promise(() => import("node:net"))
+              const socketPath = path.join(tmp.path, "live.sock")
+              const server = net.createServer(() => undefined)
+              yield* Effect.promise(
+                () => new Promise<void>((resolve) => server.listen(socketPath, () => resolve())),
+              )
+              try {
+                const settled = yield* executeTool(registry, call({ command: `printf %s ${socketPath}` }))
+                expect(settled.status).toBe("completed")
+                expect(settled.content?.[0]).toMatchObject({ type: "text", text: socketPath })
+              } finally {
+                server.close()
+              }
+            }),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+      ),
+    { timeout: 15_000 },
+  )
+
   it.live("resolves a relative workdir from the active Location", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #38544

### Type of change

- [x] Bug fix

### What does this PR do?

The shell tool'"'"'s argument scan is documented as best-effort/advisory, but when one of the candidate paths failed to resolve (a live Unix-domain socket, per the issue), the FileSystem.realPath error propagated and killed the whole command before it ran. Unresolvable candidates are now skipped: the scan continues without them, and the command executes.

### How did you verify your code works?

- new case in packages/core/test/tool-shell.test.ts following the issue repro: live Unix-domain socket path passed to printf - asserts the tool completes and echoes the path. Guarded to non-Windows platforms (unix sockets), so it exercises on the macOS/Linux CI legs
- bun test ./test/tool-shell.test.ts -> 25 pass / 0 fail
- bun run typecheck (packages/core): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR