### PR TITLE
feat(cli): add disabled_plugins config and plugin management commands

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -71,6 +71,9 @@ export const Info = Schema.Struct({
   enabled_providers: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "When set, ONLY these providers will be enabled. All other providers will be ignored",
   }),
+  disabled_plugins: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+    description: "Disable plugins that are configured in the plugin array",
+  }),
   model: Schema.optional(Schema.String).annotate({
     description: "Model to use in the format of provider/model, eg anthropic/claude-2",
   }),

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -52,6 +52,7 @@ const InfoCommand = effectCmd({
   handler: Effect.fn("Cli.debug.info")(function* () {
     const { Config } = yield* Effect.promise(() => import("@/config/config"))
     const { ConfigPlugin } = yield* Effect.promise(() => import("@/config/plugin"))
+    const { parsePluginSpecifier } = yield* Effect.promise(() => import("@/plugin/shared"))
     const config = yield* Config.Service.use((cfg) => cfg.get())
     const termProgram = process.env.TERM_PROGRAM
       ? `${process.env.TERM_PROGRAM}${process.env.TERM_PROGRAM_VERSION ? ` ${process.env.TERM_PROGRAM_VERSION}` : ""}`
@@ -70,11 +71,11 @@ const InfoCommand = effectCmd({
       console.log("none")
       return
     }
-    const disabledPlugins = new Set(config.disabled_plugins ?? [])
+    const disabledPlugins = new Set((config.disabled_plugins ?? []).map((spec) => parsePluginSpecifier(spec).pkg))
     for (const plugin of config.plugin_origins) {
-      const spec = ConfigPlugin.pluginSpecifier(plugin.spec)
-      const suffix = disabledPlugins.has(spec) ? " (disabled)" : ""
-      console.log(`- ${spec}${suffix}`)
+      const name = parsePluginSpecifier(ConfigPlugin.pluginSpecifier(plugin.spec)).pkg
+      const suffix = disabledPlugins.has(name) ? " (disabled)" : ""
+      console.log(`- ${name}${suffix}`)
     }
   }),
 })

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -70,8 +70,11 @@ const InfoCommand = effectCmd({
       console.log("none")
       return
     }
+    const disabledPlugins = new Set(config.disabled_plugins ?? [])
     for (const plugin of config.plugin_origins) {
-      console.log(`- ${ConfigPlugin.pluginSpecifier(plugin.spec)}`)
+      const spec = ConfigPlugin.pluginSpecifier(plugin.spec)
+      const suffix = disabledPlugins.has(spec) ? " (disabled)" : ""
+      console.log(`- ${spec}${suffix}`)
     }
   }),
 })

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,16 +1,23 @@
 import { intro, log, outro, spinner } from "@clack/prompts"
 import { Effect } from "effect"
+import path from "path"
+import { applyEdits, modify, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
+import type { ParseError as JsoncParseError } from "jsonc-parser"
 
 import { ConfigPaths } from "@/config/paths"
 import { Global } from "@opencode-ai/core/global"
 import { installPlugin, patchPluginConfig, readPluginManifest } from "../../plugin/install"
 import { resolvePluginTarget } from "../../plugin/shared"
+import * as ConfigPlugin from "@/config/plugin"
 import { errorMessage } from "../../util/error"
 import { Filesystem } from "@/util/filesystem"
+import { Flock } from "@opencode-ai/core/util/flock"
 import { Process } from "@/util/process"
 import { UI } from "../ui"
+import { cmd } from "./cmd"
 import { effectCmd } from "../effect-cmd"
 import { InstanceRef } from "@/effect/instance-ref"
+import { Config } from "@/config/config"
 
 type Spin = {
   start: (msg: string) => void
@@ -175,9 +182,10 @@ export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps
   }
 }
 
-export const PluginCommand = effectCmd({
-  command: "plugin <module>",
-  aliases: ["plug"],
+// --- Install subcommand ---
+
+const PluginInstallCommand = effectCmd({
+  command: "install <module>",
   describe: "install plugin and update config",
   builder: (yargs) =>
     yargs
@@ -197,7 +205,7 @@ export const PluginCommand = effectCmd({
         default: false,
         describe: "replace existing plugin version",
       }),
-  handler: Effect.fn("Cli.plug")(function* (args) {
+  handler: Effect.fn("Cli.plug.install")(function* (args) {
     const mod = String(args.module ?? "").trim()
     if (!mod) {
       UI.error("module is required")
@@ -227,4 +235,242 @@ export const PluginCommand = effectCmd({
     outro("Done")
     if (!ok) process.exitCode = 1
   }),
+})
+
+// --- List subcommand ---
+
+const PluginListCommand = effectCmd({
+  command: "list",
+  aliases: ["ls"],
+  describe: "list configured plugins and their status",
+  handler: Effect.fn("Cli.plug.list")(function* () {
+    const cfgSvc = yield* Config.Service
+    const config = yield* cfgSvc.get()
+
+    UI.empty()
+    intro("Plugins")
+
+    const plugins = config.plugin ?? []
+    const disabledPlugins = new Set(config.disabled_plugins ?? [])
+
+    if (plugins.length === 0) {
+      log.warn("No plugins configured")
+      outro("Install plugins with: opencode plugin install <module>")
+      return
+    }
+
+    for (const spec of plugins) {
+      const name = ConfigPlugin.pluginSpecifier(spec)
+      const disabled = disabledPlugins.has(name)
+      const icon = disabled ? "✗" : "✓"
+      const status = disabled ? "disabled" : "enabled"
+      log.info(`${icon} ${name} (${status})`)
+    }
+
+    outro(`${plugins.length} plugin(s) configured`)
+  }),
+})
+
+// --- Disable subcommand ---
+
+async function findConfigFile(global: boolean, directory: string): Promise<string> {
+  const dir = global ? Global.Path.config : directory
+  const files = ConfigPaths.fileInDirectory(dir, "opencode")
+  for (const file of files) {
+    if (await Filesystem.exists(file)) return file
+  }
+  // Default to first path if none exist
+  return files[0]
+}
+
+async function readConfigText(file: string): Promise<string> {
+  try {
+    const text = await Filesystem.readText(file)
+    return text.trim() ? text : "{}"
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return "{}"
+    throw err
+  }
+}
+
+function patchConfigDisabledPlugins(text: string, module: string, action: "add" | "remove"): { text: string; changed: boolean } {
+  const errs: JsoncParseError[] = []
+  const data = parseJsonc(text, errs, { allowTrailingComma: true })
+  if (errs.length) {
+    const err = errs[0]
+    const lines = text.substring(0, err.offset).split("\n")
+    throw new Error(`Invalid JSON at line ${lines.length}, column ${lines[lines.length - 1].length + 1}: ${printParseErrorCode(err.error)}`)
+  }
+
+  const current: string[] = Array.isArray(data?.disabled_plugins) ? data.disabled_plugins : []
+
+  if (action === "add") {
+    if (current.includes(module)) return { text, changed: false }
+    const next = [...current, module]
+    const updated = applyEdits(
+      text,
+      modify(text, ["disabled_plugins"], next, {
+        formattingOptions: { tabSize: 2, insertSpaces: true },
+      }),
+    )
+    return { text: updated, changed: true }
+  }
+
+  // remove
+  if (!current.includes(module)) return { text, changed: false }
+  const next = current.filter((item: string) => item !== module)
+  const value = next.length > 0 ? next : undefined
+  const updated = applyEdits(
+    text,
+    modify(text, ["disabled_plugins"], value, {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    }),
+  )
+  return { text: updated, changed: true }
+}
+
+const PluginDisableCommand = effectCmd({
+  command: "disable <module>",
+  describe: "disable a configured plugin without removing it",
+  builder: (yargs) =>
+    yargs
+      .positional("module", {
+        type: "string",
+        describe: "plugin module name to disable",
+      })
+      .option("global", {
+        alias: ["g"],
+        type: "boolean",
+        default: false,
+        describe: "modify global config",
+      }),
+  handler: Effect.fn("Cli.plug.disable")(function* (args) {
+    const mod = String(args.module ?? "").trim()
+    if (!mod) {
+      UI.error("module is required")
+      process.exitCode = 1
+      return
+    }
+
+    const ctx = yield* InstanceRef
+    if (!ctx) return
+
+    const cfgSvc = yield* Config.Service
+    const config = yield* cfgSvc.get()
+    const global = Boolean(args.global)
+
+    UI.empty()
+    intro(`Disable plugin ${mod}`)
+
+    // Check that plugin is configured
+    const plugins = config.plugin ?? []
+    const pluginNames = plugins.map((spec) => ConfigPlugin.pluginSpecifier(spec))
+    if (!pluginNames.includes(mod)) {
+      log.error(`Plugin "${mod}" is not configured`)
+      log.info(`Available plugins: ${pluginNames.join(", ") || "none"}`)
+      outro("Done")
+      process.exitCode = 1
+      return
+    }
+
+    const dir = global ? Global.Path.config : ctx.directory
+
+    yield* Effect.acquireUseRelease(
+      Effect.promise(() => Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, "opencode"))}`)),
+      (lock) =>
+        Effect.gen(function* () {
+          const file = yield* Effect.promise(() => findConfigFile(global, dir))
+          const text = yield* Effect.promise(() => readConfigText(file))
+          const result = patchConfigDisabledPlugins(text, mod, "add")
+          if (!result.changed) {
+            log.info(`Plugin "${mod}" is already disabled`)
+            return
+          }
+          yield* Effect.promise(() => Filesystem.write(file, result.text))
+          log.success(`Plugin "${mod}" disabled in ${file}`)
+        }),
+      (lock) => Effect.promise(() => lock.release()),
+    )
+    outro("Done")
+  }),
+})
+
+// --- Enable subcommand ---
+
+const PluginEnableCommand = effectCmd({
+  command: "enable <module>",
+  describe: "re-enable a previously disabled plugin",
+  builder: (yargs) =>
+    yargs
+      .positional("module", {
+        type: "string",
+        describe: "plugin module name to enable",
+      })
+      .option("global", {
+        alias: ["g"],
+        type: "boolean",
+        default: false,
+        describe: "modify global config",
+      }),
+  handler: Effect.fn("Cli.plug.enable")(function* (args) {
+    const mod = String(args.module ?? "").trim()
+    if (!mod) {
+      UI.error("module is required")
+      process.exitCode = 1
+      return
+    }
+
+    const ctx = yield* InstanceRef
+    if (!ctx) return
+
+    const cfgSvc = yield* Config.Service
+    const config = yield* cfgSvc.get()
+    const global = Boolean(args.global)
+
+    UI.empty()
+    intro(`Enable plugin ${mod}`)
+
+    const disabledPlugins = config.disabled_plugins ?? []
+    if (!disabledPlugins.includes(mod)) {
+      log.info(`Plugin "${mod}" is not disabled`)
+      outro("Done")
+      return
+    }
+
+    const dir = global ? Global.Path.config : ctx.directory
+
+    yield* Effect.acquireUseRelease(
+      Effect.promise(() => Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, "opencode"))}`)),
+      (lock) =>
+        Effect.gen(function* () {
+          const file = yield* Effect.promise(() => findConfigFile(global, dir))
+          const text = yield* Effect.promise(() => readConfigText(file))
+          const result = patchConfigDisabledPlugins(text, mod, "remove")
+          if (!result.changed) {
+            log.info(`Plugin "${mod}" is not disabled in ${file}`)
+            return
+          }
+          yield* Effect.promise(() => Filesystem.write(file, result.text))
+          log.success(`Plugin "${mod}" enabled in ${file}`)
+        }),
+      (lock) => Effect.promise(() => lock.release()),
+    )
+    outro("Done")
+  }),
+})
+
+// --- Parent command ---
+
+export const PluginCommand = cmd({
+  command: "plugin",
+  aliases: ["plug"],
+  describe: "manage plugins (install, list, disable, enable)",
+  builder: (yargs) =>
+    yargs
+      .command(PluginInstallCommand)
+      .command(PluginListCommand)
+      .command(PluginDisableCommand)
+      .command(PluginEnableCommand)
+      .demandCommand(),
+  async handler() {},
 })

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -9,6 +9,7 @@ import { Global } from "@opencode-ai/core/global"
 import { installPlugin, patchPluginConfig, readPluginManifest } from "../../plugin/install"
 import { resolvePluginTarget } from "../../plugin/shared"
 import * as ConfigPlugin from "@/config/plugin"
+import { parsePluginSpecifier } from "../../plugin/shared"
 import { errorMessage } from "../../util/error"
 import { Filesystem } from "@/util/filesystem"
 import { Flock } from "@opencode-ai/core/util/flock"
@@ -251,7 +252,7 @@ const PluginListCommand = effectCmd({
     intro("Plugins")
 
     const plugins = config.plugin ?? []
-    const disabledPlugins = new Set(config.disabled_plugins ?? [])
+    const disabledPlugins = new Set((config.disabled_plugins ?? []).map(pluginPackageName))
 
     if (plugins.length === 0) {
       log.warn("No plugins configured")
@@ -260,7 +261,7 @@ const PluginListCommand = effectCmd({
     }
 
     for (const spec of plugins) {
-      const name = ConfigPlugin.pluginSpecifier(spec)
+      const name = pluginPackageName(spec)
       const disabled = disabledPlugins.has(name)
       const icon = disabled ? "✗" : "✓"
       const status = disabled ? "disabled" : "enabled"
@@ -291,6 +292,19 @@ async function readConfigText(file: string): Promise<string> {
     if (err?.code === "ENOENT") return "{}"
     throw err
   }
+}
+
+function pluginPackageName(spec: string | readonly [string, unknown]): string {
+  const str = Array.isArray(spec) ? spec[0] : spec
+  return parsePluginSpecifier(str).pkg
+}
+
+function parseFilePlugins(text: string): string[] {
+  const errs: JsoncParseError[] = []
+  const data = parseJsonc(text, errs, { allowTrailingComma: true })
+  if (errs.length) return []
+  const plugins = Array.isArray(data?.plugin) ? data.plugin : []
+  return plugins.map((spec: unknown) => pluginPackageName(String(spec)))
 }
 
 function patchConfigDisabledPlugins(text: string, module: string, action: "add" | "remove"): { text: string; changed: boolean } {
@@ -355,25 +369,12 @@ const PluginDisableCommand = effectCmd({
     const ctx = yield* InstanceRef
     if (!ctx) return
 
-    const cfgSvc = yield* Config.Service
-    const config = yield* cfgSvc.get()
     const global = Boolean(args.global)
+    const dir = global ? Global.Path.config : ctx.directory
+    const normalizedMod = parsePluginSpecifier(mod).pkg
 
     UI.empty()
     intro(`Disable plugin ${mod}`)
-
-    // Check that plugin is configured
-    const plugins = config.plugin ?? []
-    const pluginNames = plugins.map((spec) => ConfigPlugin.pluginSpecifier(spec))
-    if (!pluginNames.includes(mod)) {
-      log.error(`Plugin "${mod}" is not configured`)
-      log.info(`Available plugins: ${pluginNames.join(", ") || "none"}`)
-      outro("Done")
-      process.exitCode = 1
-      return
-    }
-
-    const dir = global ? Global.Path.config : ctx.directory
 
     yield* Effect.acquireUseRelease(
       Effect.promise(() => Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, "opencode"))}`)),
@@ -381,7 +382,17 @@ const PluginDisableCommand = effectCmd({
         Effect.gen(function* () {
           const file = yield* Effect.promise(() => findConfigFile(global, dir))
           const text = yield* Effect.promise(() => readConfigText(file))
-          const result = patchConfigDisabledPlugins(text, mod, "add")
+
+          // Validate against the target file, not merged config
+          const filePluginNames = parseFilePlugins(text)
+          if (!filePluginNames.includes(normalizedMod)) {
+            log.error(`Plugin "${mod}" is not configured in ${file}`)
+            log.info(`Available plugins: ${filePluginNames.join(", ") || "none"}`)
+            process.exitCode = 1
+            return
+          }
+
+          const result = patchConfigDisabledPlugins(text, normalizedMod, "add")
           if (!result.changed) {
             log.info(`Plugin "${mod}" is already disabled`)
             return
@@ -423,21 +434,12 @@ const PluginEnableCommand = effectCmd({
     const ctx = yield* InstanceRef
     if (!ctx) return
 
-    const cfgSvc = yield* Config.Service
-    const config = yield* cfgSvc.get()
     const global = Boolean(args.global)
+    const dir = global ? Global.Path.config : ctx.directory
+    const normalizedMod = parsePluginSpecifier(mod).pkg
 
     UI.empty()
     intro(`Enable plugin ${mod}`)
-
-    const disabledPlugins = config.disabled_plugins ?? []
-    if (!disabledPlugins.includes(mod)) {
-      log.info(`Plugin "${mod}" is not disabled`)
-      outro("Done")
-      return
-    }
-
-    const dir = global ? Global.Path.config : ctx.directory
 
     yield* Effect.acquireUseRelease(
       Effect.promise(() => Flock.acquire(`plug-config:${Filesystem.resolve(path.join(dir, "opencode"))}`)),
@@ -445,7 +447,7 @@ const PluginEnableCommand = effectCmd({
         Effect.gen(function* () {
           const file = yield* Effect.promise(() => findConfigFile(global, dir))
           const text = yield* Effect.promise(() => readConfigText(file))
-          const result = patchConfigDisabledPlugins(text, mod, "remove")
+          const result = patchConfigDisabledPlugins(text, normalizedMod, "remove")
           if (!result.changed) {
             log.info(`Plugin "${mod}" is not disabled in ${file}`)
             return
@@ -462,7 +464,7 @@ const PluginEnableCommand = effectCmd({
 // --- Parent command ---
 
 export const PluginCommand = cmd({
-  command: "plugin",
+  command: "plugin [module]",
   aliases: ["plug"],
   describe: "manage plugins (install, list, disable, enable)",
   builder: (yargs) =>
@@ -471,6 +473,17 @@ export const PluginCommand = cmd({
       .command(PluginListCommand)
       .command(PluginDisableCommand)
       .command(PluginEnableCommand)
-      .demandCommand(),
-  async handler() {},
+      .positional("module", {
+        type: "string",
+        describe: "npm module name (shorthand for install)",
+      }),
+  async handler(args) {
+    const mod = String(args.module ?? "").trim()
+    if (!mod) {
+      // No subcommand and no module → show help
+      return
+    }
+    // Backward compat: `opencode plugin <module>` → hint to use install
+    log.info(`To install a plugin, use: opencode plugin install ${mod}`)
+  },
 })

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -36,6 +36,7 @@ export type Resolved = TuiConfig.Resolved
 
 export type HostMetadata = {
   plugin_origins?: ConfigPlugin.Origin[]
+  disabled_plugins?: string[]
 }
 
 export interface Interface {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -179,14 +179,12 @@ const layer = Layer.effect(
           if (init._tag === "Some") hooks.push(init.value)
         }
 
-        const disabledPlugins = new Set(cfg.disabled_plugins ?? [])
+        const disabledPlugins = new Set((cfg.disabled_plugins ?? []).map((spec) => parsePluginSpecifier(spec).pkg))
         const plugins = flags.pure
           ? []
           : (cfg.plugin_origins ?? []).filter(
-              (origin) => !disabledPlugins.has(ConfigPlugin.pluginSpecifier(origin.spec)),
+              (origin) => !disabledPlugins.has(parsePluginSpecifier(ConfigPlugin.pluginSpecifier(origin.spec)).pkg),
             )
-        if (flags.pure && cfg.plugin_origins?.length) {
-        }
         if (plugins.length) yield* config.waitForDependencies()
 
         const loaded = yield* Effect.promise(() =>

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -28,6 +28,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { errorMessage } from "@/util/error"
 import { PluginLoader } from "./loader"
 import { parsePluginSpecifier, readPluginId, readV1Plugin, resolvePluginId } from "./shared"
+import * as ConfigPlugin from "@/config/plugin"
 import { registerAdapter } from "@/control-plane/adapters"
 import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -178,7 +179,12 @@ const layer = Layer.effect(
           if (init._tag === "Some") hooks.push(init.value)
         }
 
-        const plugins = flags.pure ? [] : (cfg.plugin_origins ?? [])
+        const disabledPlugins = new Set(cfg.disabled_plugins ?? [])
+        const plugins = flags.pure
+          ? []
+          : (cfg.plugin_origins ?? []).filter(
+              (origin) => !disabledPlugins.has(ConfigPlugin.pluginSpecifier(origin.spec)),
+            )
         if (flags.pure && cfg.plugin_origins?.length) {
         }
         if (plugins.length) yield* config.waitForDependencies()

--- a/packages/opencode/src/plugin/tui/runtime.ts
+++ b/packages/opencode/src/plugin/tui/runtime.ts
@@ -1086,7 +1086,10 @@ async function load(input: {
       }).pipe(Effect.provide(AppNodeBuilder.build(RuntimeFlags.node))),
     )
     const pluginOrigins = config.plugin_origins ?? (await TuiConfig.pluginOrigins())
-    const records = Flag.OPENCODE_PURE ? [] : pluginOrigins
+    const disabledPlugins = new Set(config.disabled_plugins ?? [])
+    const records = Flag.OPENCODE_PURE
+      ? []
+      : pluginOrigins.filter((origin) => !disabledPlugins.has(ConfigPlugin.pluginSpecifier(origin.spec)))
     if (Flag.OPENCODE_PURE && pluginOrigins.length) {
     }
 

--- a/packages/opencode/src/plugin/tui/runtime.ts
+++ b/packages/opencode/src/plugin/tui/runtime.ts
@@ -39,6 +39,7 @@ import { internalTuiPlugins, type InternalTuiPlugin } from "./internal"
 import type { HostPluginApi, HostSlots } from "@opencode-ai/tui/plugin/slots"
 import { ConfigPlugin } from "@/config/plugin"
 import { ConfigPluginV1 } from "@opencode-ai/core/v1/config/plugin"
+import { parsePluginSpecifier } from "../shared"
 import { createCommandShim } from "@opencode-ai/tui/plugin/command-shim"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Effect } from "effect"
@@ -1086,12 +1087,12 @@ async function load(input: {
       }).pipe(Effect.provide(AppNodeBuilder.build(RuntimeFlags.node))),
     )
     const pluginOrigins = config.plugin_origins ?? (await TuiConfig.pluginOrigins())
-    const disabledPlugins = new Set(config.disabled_plugins ?? [])
+    const disabledPlugins = new Set((config.disabled_plugins ?? []).map((spec) => parsePluginSpecifier(spec).pkg))
     const records = Flag.OPENCODE_PURE
       ? []
-      : pluginOrigins.filter((origin) => !disabledPlugins.has(ConfigPlugin.pluginSpecifier(origin.spec)))
-    if (Flag.OPENCODE_PURE && pluginOrigins.length) {
-    }
+      : pluginOrigins.filter(
+          (origin) => !disabledPlugins.has(parsePluginSpecifier(ConfigPlugin.pluginSpecifier(origin.spec)).pkg),
+        )
 
     for (const item of internalTuiPlugins(flags)) {
       const entry = loadInternalPlugin(item)


### PR DESCRIPTION
### Issue for this PR

Closes #7687

Related: #12490 — This PR is a fresh implementation against the current codebase. That PR has been open and unmerged since before the recent refactors.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Users currently have to remove a plugin from the `plugin` array to stop it from loading. This PR adds `disabled_plugins` to the config schema so plugins can be temporarily disabled while keeping their config entry.

Changes:
- Added `disabled_plugins: string[]` to config schema (mirrors `disabled_providers` pattern)
- Filter disabled plugins in server (`plugin/index.ts`) and TUI (`tui/runtime.ts`) loading
- Restructured `plugin` CLI into subcommands: `install`, `list`, `disable`, `enable`
- Updated `debug info` to show disabled status

Example config:
```json
{
  "plugin": ["opencode-lmstudio"],
  "disabled_plugins": ["opencode-lmstudio"]
}
```

### How did you verify your code works?

1. Added `"plugin": ["fake-test-plugin"], "disabled_plugins": []` to opencode.json
2. Ran `opencode plugin list` → showed `✓ fake-test-plugin (enabled)`
3. Ran `opencode plugin disable fake-test-plugin` → list showed `✗ fake-test-plugin (disabled)`
4. Ran `opencode plugin enable fake-test-plugin` → list showed `✓ fake-test-plugin (enabled)`
5. Typecheck passes for both core and opencode packages

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
