### PR TITLE
fix(core): reject fish for v2 bash tool

### DIFF
--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -11,6 +11,7 @@ import { LocationMutation } from "../location-mutation"
 import { AppProcess } from "../process"
 import { PermissionV2 } from "../permission"
 import { PositiveInt } from "../schema"
+import { Shell } from "../shell"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -45,8 +46,6 @@ const Output = Schema.Struct({
 })
 
 type Output = typeof Output.Type
-
-const defaultShell = () => (process.platform === "win32" ? (process.env.COMSPEC ?? "cmd.exe") : "/bin/sh")
 
 const modelOutput = (output: Output) => {
   const warnings = output.warnings?.length
@@ -151,10 +150,7 @@ const layer = Layer.effectDiscard(
               if ((yield* fs.stat(target.canonical)).type !== "Directory")
                 return yield* Effect.fail(new Error(`Working directory is not a directory: ${target.canonical}`))
 
-              const entries = yield* config.entries()
-              const shell =
-                Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
-                  .shell ?? defaultShell()
+              const shell = Shell.acceptable(Config.latest(yield* config.entries(), "shell"))
               const command = ChildProcess.make(input.command, [], {
                 cwd: target.canonical,
                 shell,

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -14,6 +14,7 @@ import { PermissionV2 } from "@opencode-ai/core/permission"
 import { AppProcess } from "@opencode-ai/core/process"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
+import { Shell } from "@opencode-ai/core/shell"
 import { BashTool } from "@opencode-ai/core/tool/bash"
 import { ToolRegistry } from "@opencode-ai/core/tool/registry"
 import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
@@ -72,16 +73,19 @@ const appProcess = Layer.succeed(
       }),
   } as unknown as AppProcess.Interface),
 )
+let configEntries: Config.Entry[] = []
+
 const config = Layer.succeed(
   Config.Service,
   Config.Service.of({
-    entries: () => Effect.succeed([]),
+    entries: () => Effect.succeed(configEntries),
   }),
 )
 
 const reset = () => {
   assertions.length = 0
   runs.length = 0
+  configEntries = []
   denyAction = undefined
   runFailure = undefined
   afterPermission = () => Effect.void
@@ -413,6 +417,43 @@ describe("BashTool", () => {
           ),
         )
       },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("rejects terminal-only shells from config and $SHELL", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.acquireUseRelease(
+          Effect.sync(() => {
+            const prev = process.env.SHELL
+            process.env.SHELL = "/usr/bin/fish"
+            Shell.acceptable.reset()
+            Shell.preferred.reset()
+            return prev
+          }),
+          (prev) =>
+            Effect.gen(function* () {
+              reset()
+              yield* withTool(tmp.path, (registry) => executeTool(registry, call({ command: "pwd" })))
+              expect(runs).toHaveLength(1)
+              expect(Shell.name(String(runs[0]?.shell))).not.toBe("fish")
+
+              reset()
+              configEntries = [new Config.Document({ type: "document", info: new Config.Info({ shell: "fish" }) })]
+              yield* withTool(tmp.path, (registry) => executeTool(registry, call({ command: "pwd" })))
+              expect(runs).toHaveLength(1)
+              expect(Shell.name(String(runs[0]?.shell))).not.toBe("fish")
+            }),
+          (prev) =>
+            Effect.sync(() => {
+              if (prev === undefined) delete process.env.SHELL
+              else process.env.SHELL = prev
+              Shell.acceptable.reset()
+              Shell.preferred.reset()
+            }),
+        ),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #44434

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V1's bash/shell tool rejects fish and nu via `Shell.acceptable()` and falls back to a POSIX shell. V2's bash tool skipped that helper and used raw `config.shell` (or `/bin/sh`). With Auto selected, a fish `$SHELL` or `shell: "fish"` in config could run agent scripts in fish, so bash-only syntax failed.

This routes the V2 bash tool through `Shell.acceptable()` so fish/nu stay terminal-only. Interactive PTY still uses `Shell.preferred()` and can remain fish.

Replaces #44437, which was auto-closed for a missing PR template.

### How did you verify your code works?

From `packages/core`:

- `bun typecheck`
- `bun test test/tool-bash.test.ts test/shell.test.ts`

The new test sets `$SHELL` to fish and `config.shell` to fish, then checks the spawned runner is not fish.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
