### PR TITLE
fix clicking

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1282,7 +1282,9 @@ function App(props: { pair?: DialogPairCredentials }) {
         evt.preventDefault()
         evt.stopPropagation()
       }}
-      onMouseUp={copyOnSelectEnabled() ? () => Selection.copy(renderer, toast, clipboard) : undefined}
+      onMouseUp={
+        copyOnSelectEnabled() ? (event) => Selection.copyOnSelectRelease(event, renderer, toast, clipboard) : undefined
+      }
     >
       <box
         flexGrow={1}

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -211,10 +211,6 @@ export function DialogProvider(props: ParentProps) {
   const copyOnSelectEnabled = () =>
     (config.data.terminal?.copy ?? (process.platform === "win32" ? "manual" : "select")) === "select"
 
-  function copySelection() {
-    return copy(renderer, toast, clipboard)
-  }
-
   return (
     <ctx.Provider value={value}>
       {props.children}
@@ -225,11 +221,11 @@ export function DialogProvider(props: ParentProps) {
           if (copyOnSelectEnabled()) return
           if (evt.button !== MouseButton.RIGHT) return
 
-          if (!copySelection()) return
+          if (!copy(renderer, toast, clipboard)) return
           evt.preventDefault()
           evt.stopPropagation()
         }}
-        onMouseUp={copyOnSelectEnabled() ? copySelection : undefined}
+        onMouseUp={copyOnSelectEnabled() ? () => copy(renderer, toast, clipboard) : undefined}
       >
         <Show when={value.stack.length}>
           <Dialog onClose={() => value.clear()} size={value.size} centered={value.centered}>

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -7,6 +7,7 @@ import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { useClipboard } from "../context/clipboard"
 import { useConfig } from "../config"
+import { copy } from "../util/selection"
 
 export type DialogSize = "medium" | "large" | "xlarge"
 
@@ -211,14 +212,7 @@ export function DialogProvider(props: ParentProps) {
     (config.data.terminal?.copy ?? (process.platform === "win32" ? "manual" : "select")) === "select"
 
   function copySelection() {
-    const text = renderer.getSelection()?.getSelectedText()
-    if (!text) return false
-    void clipboard.write(text).then(
-      () => toast.show({ message: "Copied to clipboard", variant: "info" }),
-      (error) => toast.error(error),
-    )
-    renderer.clearSelection()
-    return true
+    return copy(renderer, toast, clipboard)
   }
 
   return (

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -7,7 +7,7 @@ import { createStore } from "solid-js/store"
 import { useToast } from "./toast"
 import { useClipboard } from "../context/clipboard"
 import { useConfig } from "../config"
-import { copy } from "../util/selection"
+import { copy, copyOnSelectRelease } from "../util/selection"
 
 export type DialogSize = "medium" | "large" | "xlarge"
 
@@ -225,7 +225,7 @@ export function DialogProvider(props: ParentProps) {
           evt.preventDefault()
           evt.stopPropagation()
         }}
-        onMouseUp={copyOnSelectEnabled() ? () => copy(renderer, toast, clipboard) : undefined}
+        onMouseUp={copyOnSelectEnabled() ? (event) => copyOnSelectRelease(event, renderer, toast, clipboard) : undefined}
       >
         <Show when={value.stack.length}>
           <Dialog onClose={() => value.clear()} size={value.size} centered={value.centered}>

--- a/packages/tui/src/util/selection.ts
+++ b/packages/tui/src/util/selection.ts
@@ -39,7 +39,8 @@ export function copy(renderer: Renderer, toast: Toast, clipboard: ClipboardServi
     .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
     .catch(toast.error)
 
-  renderer.clearSelection()
+  // Keep the highlight. clearSelection() also resets OpenTUI's click
+  // counter, so clearing here would turn a triple-click into a new single-click.
   return true
 }
 

--- a/packages/tui/src/util/selection.ts
+++ b/packages/tui/src/util/selection.ts
@@ -23,6 +23,16 @@ type SelectionKeyEvent = {
   stopPropagation: () => void
 }
 
+export function copyOnSelectRelease(
+  event: { isDragging?: boolean },
+  renderer: Renderer,
+  toast: Toast,
+  clipboard: ClipboardService,
+): boolean {
+  if (!event.isDragging) return false
+  return copy(renderer, toast, clipboard)
+}
+
 export function copy(renderer: Renderer, toast: Toast, clipboard: ClipboardService): boolean {
   const selection = renderer.getSelection()
   if (!selection) return false

--- a/packages/tui/test/util/selection-copy-on-select.test.tsx
+++ b/packages/tui/test/util/selection-copy-on-select.test.tsx
@@ -2,7 +2,7 @@
 import { expect, test } from "bun:test"
 import { testRender, useRenderer } from "@opentui/solid"
 import { useClipboard } from "../../src/context/clipboard"
-import { copy } from "../../src/util/selection"
+import { copyOnSelectRelease } from "../../src/util/selection"
 import { TestTuiContexts } from "../fixture/tui-environment"
 
 function CopyOnSelectText() {
@@ -13,7 +13,7 @@ function CopyOnSelectText() {
     error: () => {},
   }
   return (
-    <box onMouseUp={() => copy(renderer, toast, clipboard)}>
+    <box onMouseUp={(event) => copyOnSelectRelease(event, renderer, toast, clipboard)}>
       <text>alpha beta gamma</text>
     </box>
   )

--- a/packages/tui/test/util/selection-copy-on-select.test.tsx
+++ b/packages/tui/test/util/selection-copy-on-select.test.tsx
@@ -1,0 +1,59 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender, useRenderer } from "@opentui/solid"
+import { useClipboard } from "../../src/context/clipboard"
+import { copy } from "../../src/util/selection"
+import { TestTuiContexts } from "../fixture/tui-environment"
+
+function CopyOnSelectText() {
+  const renderer = useRenderer()
+  const clipboard = useClipboard()
+  const toast = {
+    show: () => {},
+    error: () => {},
+  }
+  return (
+    <box onMouseUp={() => copy(renderer, toast, clipboard)}>
+      <text>alpha beta gamma</text>
+    </box>
+  )
+}
+
+test("copy-on-select keeps a word highlight so a third click can select the line", async () => {
+  const writes: string[] = []
+  const app = await testRender(
+    () => (
+      <TestTuiContexts
+        clipboard={{
+          async read() {
+            return undefined
+          },
+          async write(text) {
+            writes.push(text)
+          },
+        }}
+      >
+        <CopyOnSelectText />
+      </TestTuiContexts>
+    ),
+    { width: 20, height: 2 },
+  )
+
+  try {
+    app.renderer.start()
+    await app.waitForFrame((frame) => frame.includes("beta"))
+
+    await app.mockMouse.click(6, 0)
+    expect(app.renderer.getSelection()?.getSelectedText() ?? "").toBe("")
+
+    await app.mockMouse.click(6, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("beta")
+    expect(writes).toEqual(["beta"])
+
+    await app.mockMouse.click(6, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("alpha beta gamma")
+    expect(writes).toEqual(["beta", "alpha beta gamma"])
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/tui/test/util/selection.test.ts
+++ b/packages/tui/test/util/selection.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "bun:test"
+import { copy, handleSelectionKey } from "../../src/util/selection"
+
+function createCopyHarness(text: string | null) {
+  const writes: string[] = []
+  const toasts: string[] = []
+  let cleared = false
+  const renderer = {
+    getSelection: () =>
+      text === null
+        ? null
+        : {
+            getSelectedText: () => text,
+            selectedRenderables: [],
+          },
+    clearSelection: () => {
+      cleared = true
+    },
+  }
+  const toast = {
+    show: (input: { message: string }) => toasts.push(input.message),
+    error: () => {},
+  }
+  const clipboard = {
+    async read() {
+      return undefined
+    },
+    async write(value: string) {
+      writes.push(value)
+    },
+  }
+  return { renderer, toast, clipboard, writes, toasts, cleared: () => cleared }
+}
+
+async function flushCopy(harness: ReturnType<typeof createCopyHarness>) {
+  await Promise.resolve()
+  await Promise.resolve()
+  return harness
+}
+
+test("copy writes selected text without clearing the highlight", async () => {
+  const harness = createCopyHarness("beta")
+  expect(copy(harness.renderer, harness.toast, harness.clipboard)).toBe(true)
+  await flushCopy(harness)
+  expect(harness.writes).toEqual(["beta"])
+  expect(harness.toasts).toEqual(["Copied to clipboard"])
+  expect(harness.cleared()).toBe(false)
+})
+
+test("copy returns false when nothing is selected", () => {
+  const harness = createCopyHarness(null)
+  expect(copy(harness.renderer, harness.toast, harness.clipboard)).toBe(false)
+  expect(harness.writes).toEqual([])
+  expect(harness.cleared()).toBe(false)
+})
+
+test("ctrl+c copies without clearing and escape still dismisses", async () => {
+  const harness = createCopyHarness("beta")
+  const prevented: string[] = []
+  handleSelectionKey(
+    harness.renderer,
+    harness.toast,
+    {
+      ctrl: true,
+      name: "c",
+      preventDefault: () => prevented.push("prevent"),
+      stopPropagation: () => prevented.push("stop"),
+    },
+    harness.clipboard,
+  )
+  await flushCopy(harness)
+  expect(harness.writes).toEqual(["beta"])
+  expect(harness.cleared()).toBe(false)
+  expect(prevented).toEqual(["prevent", "stop"])
+
+  handleSelectionKey(
+    harness.renderer,
+    harness.toast,
+    {
+      name: "escape",
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    },
+    harness.clipboard,
+  )
+  expect(harness.cleared()).toBe(true)
+})

--- a/packages/tui/test/util/selection.test.ts
+++ b/packages/tui/test/util/selection.test.ts
@@ -1,87 +1,26 @@
 import { expect, test } from "bun:test"
-import { copy, handleSelectionKey } from "../../src/util/selection"
+import { copy } from "../../src/util/selection"
 
-function createCopyHarness(text: string | null) {
-  const writes: string[] = []
-  const toasts: string[] = []
+test("copy writes selected text without clearing the highlight", () => {
   let cleared = false
-  const renderer = {
-    getSelection: () =>
-      text === null
-        ? null
-        : {
-            getSelectedText: () => text,
-            selectedRenderables: [],
-          },
-    clearSelection: () => {
-      cleared = true
-    },
-  }
-  const toast = {
-    show: (input: { message: string }) => toasts.push(input.message),
-    error: () => {},
-  }
-  const clipboard = {
-    async read() {
-      return undefined
-    },
-    async write(value: string) {
-      writes.push(value)
-    },
-  }
-  return { renderer, toast, clipboard, writes, toasts, cleared: () => cleared }
-}
-
-async function flushCopy(harness: ReturnType<typeof createCopyHarness>) {
-  await Promise.resolve()
-  await Promise.resolve()
-  return harness
-}
-
-test("copy writes selected text without clearing the highlight", async () => {
-  const harness = createCopyHarness("beta")
-  expect(copy(harness.renderer, harness.toast, harness.clipboard)).toBe(true)
-  await flushCopy(harness)
-  expect(harness.writes).toEqual(["beta"])
-  expect(harness.toasts).toEqual(["Copied to clipboard"])
-  expect(harness.cleared()).toBe(false)
-})
-
-test("copy returns false when nothing is selected", () => {
-  const harness = createCopyHarness(null)
-  expect(copy(harness.renderer, harness.toast, harness.clipboard)).toBe(false)
-  expect(harness.writes).toEqual([])
-  expect(harness.cleared()).toBe(false)
-})
-
-test("ctrl+c copies without clearing and escape still dismisses", async () => {
-  const harness = createCopyHarness("beta")
-  const prevented: string[] = []
-  handleSelectionKey(
-    harness.renderer,
-    harness.toast,
+  const copied = copy(
     {
-      ctrl: true,
-      name: "c",
-      preventDefault: () => prevented.push("prevent"),
-      stopPropagation: () => prevented.push("stop"),
+      getSelection: () => ({
+        getSelectedText: () => "beta",
+        selectedRenderables: [],
+      }),
+      clearSelection: () => {
+        cleared = true
+      },
     },
-    harness.clipboard,
-  )
-  await flushCopy(harness)
-  expect(harness.writes).toEqual(["beta"])
-  expect(harness.cleared()).toBe(false)
-  expect(prevented).toEqual(["prevent", "stop"])
-
-  handleSelectionKey(
-    harness.renderer,
-    harness.toast,
+    { show: () => {}, error: () => {} },
     {
-      name: "escape",
-      preventDefault: () => {},
-      stopPropagation: () => {},
+      async read() {
+        return undefined
+      },
+      async write() {},
     },
-    harness.clipboard,
   )
-  expect(harness.cleared()).toBe(true)
+  expect(copied).toBe(true)
+  expect(cleared).toBe(false)
 })

--- a/packages/tui/test/util/selection.test.ts
+++ b/packages/tui/test/util/selection.test.ts
@@ -1,5 +1,15 @@
 import { expect, test } from "bun:test"
-import { copy } from "../../src/util/selection"
+import { copy, copyOnSelectRelease } from "../../src/util/selection"
+
+function renderer() {
+  return {
+    getSelection: () => ({
+      getSelectedText: () => "beta",
+      selectedRenderables: [],
+    }),
+    clearSelection: () => {},
+  }
+}
 
 test("copy writes selected text without clearing the highlight", () => {
   let cleared = false
@@ -23,4 +33,21 @@ test("copy writes selected text without clearing the highlight", () => {
   )
   expect(copied).toBe(true)
   expect(cleared).toBe(false)
+})
+
+test("copy-on-select ignores a later non-drag release", () => {
+  const writes: string[] = []
+  const clipboard = {
+    async read() {
+      return undefined
+    },
+    async write(value: string) {
+      writes.push(value)
+    },
+  }
+  const toast = { show: () => {}, error: () => {} }
+  expect(copyOnSelectRelease({}, renderer(), toast, clipboard)).toBe(false)
+  expect(copyOnSelectRelease({ isDragging: false }, renderer(), toast, clipboard)).toBe(false)
+  expect(copyOnSelectRelease({ isDragging: true }, renderer(), toast, clipboard)).toBe(true)
+  expect(writes).toEqual(["beta"])
 })


### PR DESCRIPTION
Copy-on-select reset the click counter, so a third click could not select the full line. Keep the selection after copying to preserve multi-click input.