### PR TITLE
docs: add gutchapa-opencode-telegram plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [gutchapa-opencode-telegram](https://github.com/gutchapa/opencode-telegram)                        | Telegram bot for opencode: chat with your local AI assistant over Telegram with 90+ slash commands |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [gutchapa-opencode-telegram](https://github.com/gutchapa/opencode-telegram)                        | Telegram bot for opencode: chat with your local AI assistant over Telegram with 90+ slash commands |
+| [gutchapa-opencode-telegram](https://github.com/gutchapa/opencode-telegram)                        | Telegram bot for opencode: chat with your local AI assistant over Telegram with 70+ slash commands |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation-only change (adds a row to the ecosystem Plugins table).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [gutchapa-opencode-telegram](https://github.com/gutchapa/opencode-telegram) to the Plugins table of the ecosystem docs. The plugin is an opencode server plugin that turns opencode into a Telegram bot: chat with your local AI assistant over Telegram with 70+ slash commands, with agentic replies running through the hosting opencode server. Telegram polling is opt-in, so installing the plugin never starts a second poller or conflicts with an existing standalone bot.

### How did you verify your code works?

- The new row matches the existing table format and both the repo and npm links resolve (HTTP 200).
- The published npm package (`gutchapa-opencode-telegram@1.0.0`) installs in a fresh project and loads in `opencode serve` with zero errors — `server()` logs "Telegram polling disabled" with polling opt-in by default.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

