### PR TITLE
fix(ai): handle anthropic error events and ping frames

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -41,6 +41,7 @@ const SSE_EVENTS = new Set([
   "content_block_start",
   "content_block_delta",
   "content_block_stop",
+  "ping",
   "error",
 ])
 export const framing = Framing.sseEvents(SSE_EVENTS)
@@ -1004,11 +1005,13 @@ const providerErrorMessage = (event: AnthropicEvent): string => {
 }
 
 const onError = (event: AnthropicEvent) =>
-  new AIError({
-    module: ADAPTER,
-    method: "stream",
-    reason: classifyProviderFailure({ message: providerErrorMessage(event), code: event.error?.type }),
-  })
+  Effect.fail(
+    new AIError({
+      module: ADAPTER,
+      method: "stream",
+      reason: classifyProviderFailure({ message: providerErrorMessage(event), code: event.error?.type }),
+    }),
+  )
 
 const step = (state: ParserState, event: AnthropicEvent) => {
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))


### PR DESCRIPTION
Parity fixes for Anthropic Messages protocol:

- **error handling:** `onError` previously returned bare `AIError` from `step` (`protocol.stream.step` expects `Effect<E, AIError>`) — the error was swallowed instead of failing the stream. Now returns `Effect.fail(AIError)` so `Route.streamPrepared` correctly routes via `Stream.catchCause -> AIError` and `requireTerminalEvent`. Matches SDK `Stream.fromSSEResponse:139 throws APIError` behavior.

- **ping:** Adds `ping` to `SSE_EVENTS` allowlist (`Framing.sseEvents`). Previously filtered implicitly at framing; now passes through to `step` where it falls through to `NO_EVENTS` (explicit `continue` like SDK `streaming.ts:135`). Preserves `sseFraming` empty-data filter so `event: ping\n\n` (empty data per SDK `streaming.test.ts:68`) remains dropped.

Keeps ID scrubbing as requested.