### PR TITLE
fix(core): settle overlapping reasoning fragments instead of dying

### DIFF
--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -137,12 +137,18 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
     const chunks = new Map<string, Fragment>()
     let nextOrdinal = 0
     const start = (id: string, state?: Record<string, unknown>) =>
-      Effect.suspend(() => {
-        if (chunks.has(id)) return Effect.die(new Error(`Duplicate ${name} start: ${id}`))
-        if (single && chunks.size > 0) return Effect.die(new Error(`${name} start before end: ${id}`))
+      Effect.gen(function* () {
+        if (single && chunks.size > 0) {
+          // Providers occasionally open a new fragment before closing the
+          // previous one (e.g. overlapping reasoning summaries). Force-settle
+          // open fragments so a malformed boundary degrades to merged output
+          // instead of failing the whole execution as an untyped defect.
+          yield* flush()
+        }
+        if (chunks.has(id)) yield* end(id)
         const ordinal = nextOrdinal++
         chunks.set(id, { ordinal, values: [], pending: "", state })
-        return Effect.succeed(ordinal)
+        return ordinal
       })
     const publishDelta = Effect.fnUntraced(function* (id: string, force = false) {
       if (!delta) return undefined

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -176,6 +176,22 @@ test("provider metadata is flattened using the route key", async () => {
   })
 })
 
+test("overlapping reasoning starts settle the open fragment instead of dying", async () => {
+  const { published, publisher } = capture("openai")
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningStart({ id: "rs_a:0" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningDelta({ id: "rs_a:0", text: "first" })))
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningStart({ id: "rs_b:0" })))
+  await Effect.runPromise(
+    publisher.publish(LLMEvent.reasoningEnd({ id: "rs_b:0", providerMetadata: { openai: { itemId: "rs_b" } } })),
+  )
+
+  const started = published.filter((event) => event.type === "session.reasoning.started.1")
+  const ended = published.filter((event) => event.type === "session.reasoning.ended.1")
+  expect(started).toHaveLength(2)
+  expect(ended).toHaveLength(2)
+  expect((ended[0]?.data as any).text).toBe("first")
+})
+
 test("reasoning state from start, empty delta, and end is merged", async () => {
   const { published, publisher } = capture()
   await Effect.runPromise(


### PR DESCRIPTION
### Issue for this PR

Closes #36892

### Type of change

- [x] Bug fix

### What does this PR do?

The reasoning fragment tracker runs in single-fragment mode, and a provider opening a new reasoning summary before closing the previous one hit `Effect.die("reasoning start before end")` - an untyped defect that failed the entire execution as "unknown". Overlapping starts now force-settle every open fragment first (publishing its accumulated text as a normal reasoning.ended), then open the new one, so a malformed provider boundary degrades to slightly merged output instead of killing the turn. Duplicate ids under single mode settle the same way; non-single trackers (text/tool input) keep their strict dies.

### How did you verify your code works?

- new test in packages/core/test/session-runner-tool-events.test.ts: rs_a:0 started + delta, then rs_b:0 start/end -> two reasoning.started and two reasoning.ended events, first ending with text "first"; previously this died
- bun test ./test/session-runner-tool-events.test.ts -> 18 pass / 0 fail
- bun run typecheck (packages/core): clean

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR