### PR TITLE
docs(ecosystem): add dejavu — cross-session error-gate plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                | Cross-session error gates: recurring tool-call failures promoted into enforced gates — remind first, hard-block on same-session repeat |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                | Cross-session error gates: recurring tool-call failures promoted into enforced gates — remind first, hard-block on same-session repeat |
+| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                    | Cross-session error gates for recurring tool-call failures — remind first, hard-block on same-session repeat |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                    | Cross-session error gates for recurring tool-call failures — remind first, hard-block on same-session repeat |
+| [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu)                                    | Cross-session memory of recurring tool failures — reminds first, hard-blocks on repeat             |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — adding my plugin to the ecosystem list.

### Type of change

- [x] Documentation

### What does this PR do?

Adds a row for [opencode-dejavu](https://github.com/WhiteBite/opencode-dejavu) to the Plugins table (replaces my earlier #44467 that the compliance bot auto-closed on the 2h timer). The plugin reminds the agent about previously failed tool calls and blocks same-session repeats; published on npm as `opencode-dejavu`. Row is padded to match the table's column alignment and the description trimmed per review feedback.

### How did you verify your code works?

Docs-only table row: the link resolves to the live public repo, and I checked the row against the table's pipe alignment in raw MDX.

### Screenshots / recordings

N/A — docs table row.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR