### PR TITLE
fix(desktop): use PATH for WSL probe

### DIFF
--- a/packages/desktop/src/main/wsl/runtime.test.ts
+++ b/packages/desktop/src/main/wsl/runtime.test.ts
@@ -1,0 +1,35 @@
+import { EventEmitter } from "node:events"
+import { expect, mock, test } from "bun:test"
+
+const calls: string[][] = []
+
+mock.module("node:child_process", () => ({
+  spawn: (_command: string, args: string[]) => {
+    calls.push(args)
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    })
+    queueMicrotask(() => child.emit("close", 0, null))
+    return child
+  },
+}))
+
+mock.module("@lydell/node-pty", () => ({
+  spawn: () => {
+    throw new Error("unexpected interactive command")
+  },
+}))
+
+const { probeWslDistro } = await import("./runtime")
+
+test("probes distro execution through true on PATH", async () => {
+  calls.length = 0
+
+  await expect(probeWslDistro("Alpine")).resolves.toMatchObject({
+    name: "Alpine",
+    canExecute: true,
+  })
+
+  expect(calls[0]).toEqual(["-d", "Alpine", "--", "true"])
+})

--- a/packages/desktop/src/main/wsl/runtime.ts
+++ b/packages/desktop/src/main/wsl/runtime.ts
@@ -277,7 +277,7 @@ export async function installWslOpencode(version: string, distro: string, opts?:
 }
 
 export async function probeWslDistro(name: string, opts?: RunWslOptions): Promise<WslDistroProbe> {
-  const executable = await runWslInDistro(["/bin/true"], name, opts).catch((error) => ({
+  const executable = await runWslInDistro(["true"], name, opts).catch((error) => ({
     code: 1,
     signal: null,
     stdout: "",


### PR DESCRIPTION
### Issue for this PR

Closes #44508

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The WSL probe assumes every distro has `/bin/true`. NixOS does not, so Desktop reports that the distro still needs first-run setup. This uses `true` from the distro PATH instead and adds a test for the exact WSL arguments.

### How did you verify your code works?

- Ran `bun test src/main/wsl/runtime.test.ts` and `bun typecheck` from `packages/desktop`.
- Ran the repository pre-push typecheck (30 tasks passed).
- Confirmed `wsl.exe -d nixos -- true` exits 0 on the affected system.

### Screenshots / recordings

Not applicable; this is a WSL probe fix with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR