### PR TITLE
fix(desktop): resolve WSL OpenCode from PATH

### DIFF
--- a/packages/desktop/src/main/wsl/runtime.test.ts
+++ b/packages/desktop/src/main/wsl/runtime.test.ts
@@ -1,0 +1,54 @@
+import { EventEmitter } from "node:events"
+import { expect, mock, test } from "bun:test"
+
+const calls: string[][] = []
+let stdout = ""
+
+mock.module("node:child_process", () => ({
+  spawn: (_command: string, args: string[]) => {
+    calls.push(args)
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    })
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(stdout))
+      child.stdout.emit("end")
+      child.stderr.emit("end")
+      child.emit("close", 0, null)
+    })
+    return child
+  },
+}))
+
+mock.module("@lydell/node-pty", () => ({
+  spawn: () => {
+    throw new Error("unexpected interactive command")
+  },
+}))
+
+const { resolveWslOpencode } = await import("./runtime")
+
+test("resolves OpenCode from the distro PATH", async () => {
+  calls.length = 0
+  stdout = "/home/alice/.local/bin/opencode\n"
+
+  await expect(resolveWslOpencode("Debian")).resolves.toBe("/home/alice/.local/bin/opencode")
+  expect(calls).toEqual([
+    [
+      "-d",
+      "Debian",
+      "--",
+      "sh",
+      "-c",
+      'command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
+    ],
+  ])
+})
+
+test("falls back to the fixed OpenCode path when it is absent from PATH", async () => {
+  calls.length = 0
+  stdout = "/home/alice/.opencode/bin/opencode\n"
+
+  await expect(resolveWslOpencode("Debian")).resolves.toBe("/home/alice/.opencode/bin/opencode")
+})

--- a/packages/desktop/src/main/wsl/runtime.test.ts
+++ b/packages/desktop/src/main/wsl/runtime.test.ts
@@ -29,7 +29,7 @@ mock.module("@lydell/node-pty", () => ({
 
 const { resolveWslOpencode } = await import("./runtime")
 
-test("resolves OpenCode from the distro PATH", async () => {
+test("resolves OpenCode from the distro PATH without Windows interop entries", async () => {
   calls.length = 0
   stdout = "/home/alice/.local/bin/opencode\n"
 
@@ -41,7 +41,7 @@ test("resolves OpenCode from the distro PATH", async () => {
       "--",
       "sh",
       "-c",
-      'command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
+      'PATH=$(printf "%s" "$PATH" | awk -v RS=: -v ORS=: \'$0 !~ /^\\/mnt\\//\' | sed "s/:$//"); export PATH; command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
     ],
   ])
 })

--- a/packages/desktop/src/main/wsl/runtime.ts
+++ b/packages/desktop/src/main/wsl/runtime.ts
@@ -310,8 +310,12 @@ export async function probeWslDistro(name: string, opts?: RunWslOptions): Promis
 export async function resolveWslOpencode(distro: string, opts?: RunWslOptions) {
   return firstLine(
     (
-      await runWslSh(
-        'if [ -x "$HOME/.opencode/bin/opencode" ]; then printf "%s\\n" "$HOME/.opencode/bin/opencode"; fi',
+      await runWslInDistro(
+        [
+          "sh",
+          "-c",
+          'command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
+        ],
         distro,
         opts,
       )

--- a/packages/desktop/src/main/wsl/runtime.ts
+++ b/packages/desktop/src/main/wsl/runtime.ts
@@ -314,7 +314,7 @@ export async function resolveWslOpencode(distro: string, opts?: RunWslOptions) {
         [
           "sh",
           "-c",
-          'command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
+          'PATH=$(printf "%s" "$PATH" | awk -v RS=: -v ORS=: \'$0 !~ /^\\/mnt\\//\' | sed "s/:$//"); export PATH; command -v opencode || { [ -x "$HOME/.opencode/bin/opencode" ] && printf "%s\\n" "$HOME/.opencode/bin/opencode"; }',
         ],
         distro,
         opts,


### PR DESCRIPTION
### Issue for this PR

Closes #38309

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The WSL setup only recognized `$HOME/.opencode/bin/opencode`, so installations from global npm, Nix, or Home Manager appeared missing even when `opencode` was available. Resolve `opencode` from the distro PATH first, then retain the existing fixed path as a fallback.

### How did you verify your code works?

- `bun test src/main/wsl/runtime.test.ts` from `packages/desktop` (2 passed)
- `bun typecheck` from `packages/desktop`
- pre-push repository typecheck (30/30 tasks)
- verified the command resolves `/etc/profiles/per-user/ming/bin/opencode` on NixOS WSL

### Screenshots / recordings

N/A (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR