### PR TITLE
fix(tui): recover from terminal forms

### DIFF
--- a/.changeset/terminal-form-recovery.md
+++ b/.changeset/terminal-form-recovery.md
@@ -1,0 +1,6 @@
+---
+"@opencode-ai/client": patch
+"@opencode-ai/plugin": patch
+---
+
+Add form reply and cancellation operations that reconcile terminal forms in the local TUI projection.

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -6,7 +6,9 @@
 import type {
   AgentInfo,
   CommandInfo,
+  FormCancelInput,
   FormInfo,
+  FormReplyInput,
   IntegrationInfo,
   LocationRef,
   LocationGetOutput,
@@ -37,7 +39,12 @@ import type {
 import { Worktree } from "@opencode-ai/schema/worktree"
 import { SessionID } from "@opencode-ai/schema/session-id"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
-import { isPermissionNotFoundError, type SessionPromptInput } from "../promise"
+import {
+  isFormAlreadySettledError,
+  isFormNotFoundError,
+  isPermissionNotFoundError,
+  type SessionPromptInput,
+} from "../promise"
 import { createStore, produce, reconcile } from "solid-js/store"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import { batch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
@@ -118,6 +125,16 @@ export function locationKey(location: LocationRef) {
 
 function locationQuery(ref?: LocationRef) {
   return ref ? { directory: ref.directory, workspace: ref.workspaceID } : undefined
+}
+
+function formRequestOptions(sessionID: string, ref?: LocationRef) {
+  if (sessionID !== "global" || !ref) return undefined
+  return {
+    headers: {
+      "x-opencode-directory": encodeURIComponent(ref.directory),
+      ...(ref.workspaceID ? { "x-opencode-workspace": ref.workspaceID } : {}),
+    },
+  }
 }
 
 function createSync() {
@@ -226,6 +243,32 @@ export function createData(config: CreateDataInput) {
       sessionID,
       requests.filter((request) => request.id !== requestID),
     )
+  }
+
+  function removeForm(sessionID: string, formID: string, ref?: LocationRef) {
+    const forms = store.session.form[sessionID]
+    if (!forms) return false
+    const location = ref && locationKey(ref)
+    const next = forms.filter((form) => {
+      if (form.id !== formID) return true
+      if (sessionID !== "global" || !location) return false
+      return !form.location || locationKey(form.location) !== location
+    })
+    if (next.length === forms.length) return false
+    setStore("session", "form", sessionID, next)
+    return true
+  }
+
+  function settleForm(input: FormCancelInput, ref: LocationRef | undefined, request: Promise<void>) {
+    return request
+      .catch((error: unknown) => {
+        if ((!isFormNotFoundError(error) && !isFormAlreadySettledError(error)) || error.id !== input.formID) throw error
+      })
+      .then(() => {
+        if (!removeForm(input.sessionID, input.formID, ref)) return
+        result.session.form.invalidate(input.sessionID, ref)
+        void result.session.form.sync(input.sessionID, ref).catch(() => undefined)
+      })
   }
 
   function updatePending(sessionID: string, inboxID: string, delivery: SessionInbox.Delivery) {
@@ -998,12 +1041,7 @@ export function createData(config: CreateDataInput) {
         return
       case "form.replied":
       case "form.cancelled":
-        setStore(
-          "session",
-          "form",
-          event.data.sessionID,
-          (store.session.form[event.data.sessionID] ?? []).filter((form) => form.id !== event.data.id),
-        )
+        removeForm(event.data.sessionID, event.data.id, event.location)
         return
     }
 
@@ -1419,6 +1457,12 @@ export function createData(config: CreateDataInput) {
           sync.invalidate(
             `session.form:${sessionID}:${sessionID === "global" ? locationKey(ref ?? defaultLocation()) : ""}`,
           )
+        },
+        reply(input: FormReplyInput, ref?: LocationRef) {
+          return settleForm(input, ref, api().form.reply(input, formRequestOptions(input.sessionID, ref)))
+        },
+        cancel(input: FormCancelInput, ref?: LocationRef) {
+          return settleForm(input, ref, api().form.cancel(input, formRequestOptions(input.sessionID, ref)))
         },
       },
     },

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -1,7 +1,9 @@
 import type {
   AgentInfo,
   CommandInfo,
+  FormCancelInput,
   FormInfo,
+  FormReplyInput,
   IntegrationInfo,
   LocationRef,
   McpResource,
@@ -91,6 +93,8 @@ export interface Data {
       list(sessionID: string, location?: LocationRef): Array<FormInfo & { readonly location?: LocationRef }> | undefined
       sync(sessionID: string, location?: LocationRef): Promise<void>
       invalidate(sessionID: string, location?: LocationRef): void
+      reply(input: FormReplyInput, location?: LocationRef): Promise<void>
+      cancel(input: FormCancelInput, location?: LocationRef): Promise<void>
     }
   }
   readonly project: {

--- a/packages/tui/src/routes/session/form.tsx
+++ b/packages/tui/src/routes/session/form.tsx
@@ -12,8 +12,7 @@ import {
 import open from "open"
 import { useTheme, useThemes } from "../../context/theme"
 import type { FormAnswer, FormField, FormValue } from "@opencode-ai/client"
-import type { FormWithLocation } from "../../context/data"
-import { useClient } from "../../context/client"
+import { useData, type FormWithLocation } from "../../context/data"
 import { useClipboard } from "../../context/clipboard"
 import { SplitBorder } from "../../ui/border"
 import { useToast } from "../../ui/toast"
@@ -41,22 +40,8 @@ function truncate(label: string, max: number) {
   return label.length > max ? label.slice(0, max - 1).trimEnd() + "…" : label
 }
 
-function requestOptions(form: FormWithLocation) {
-  if (form.sessionID !== "global" || !form.location) return undefined
-  return {
-    headers: {
-      "x-opencode-directory": encodeURIComponent(form.location.directory),
-      ...(form.location.workspaceID ? { "x-opencode-workspace": form.location.workspaceID } : {}),
-    },
-  }
-}
-
-export function FormPrompt(props: {
-  form: FormWithLocation
-  onReply?: (answer: FormAnswer) => void | Promise<void>
-  onCancel?: () => void | Promise<void>
-}) {
-  const client = useClient()
+export function FormPrompt(props: { form: FormWithLocation }) {
+  const data = useData()
   const themes = useThemes()
   const theme = useTheme("elevated")
   const themeMode = themes.mode
@@ -258,16 +243,9 @@ export function FormPrompt(props: {
   }
 
   function reply(answer: FormAnswer) {
-    void Promise.resolve()
-      .then(() =>
-        props.onReply
-          ? props.onReply(answer)
-          : client.api.form.reply(
-              { sessionID: props.form.sessionID, formID: props.form.id, answer },
-              requestOptions(props.form),
-            ),
-      )
-      .catch((error: unknown) => setStore("error", errorMessage(error)))
+    void data.session.form
+      .reply({ sessionID: props.form.sessionID, formID: props.form.id, answer }, props.form.location)
+      .catch(showError)
   }
 
   function replySingle(field: FormAnswerField, value: FormValue) {
@@ -457,11 +435,13 @@ export function FormPrompt(props: {
   }
 
   function cancel() {
-    if (props.onCancel) {
-      void props.onCancel()
-      return
-    }
-    void client.api.form.cancel({ sessionID: props.form.sessionID, formID: props.form.id }, requestOptions(props.form))
+    void data.session.form
+      .cancel({ sessionID: props.form.sessionID, formID: props.form.id }, props.form.location)
+      .catch(showError)
+  }
+
+  function showError(error: unknown) {
+    setStore("error", errorMessage(error))
   }
 
   function openExternal() {

--- a/packages/tui/test/cli/tui/form.test.tsx
+++ b/packages/tui/test/cli/tui/form.test.tsx
@@ -3,7 +3,8 @@ import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import type { FormWithLocation } from "../../../src/context/data"
+import { onMount, Show } from "solid-js"
+import { DataProvider, useData, type FormWithLocation } from "../../../src/context/data"
 import { ClientProvider } from "../../../src/context/client"
 import { ThemeProvider } from "../../../src/context/theme"
 import { Keymap } from "../../../src/context/keymap"
@@ -12,7 +13,7 @@ import { ToastProvider } from "../../../src/ui/toast"
 import { emptyThemeSource, tmpdir } from "../../fixture/fixture"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
-import { createApi, createEventStream, createFetch } from "../../fixture/tui-client"
+import { createApi, createEventStream, createFetch, json } from "../../fixture/tui-client"
 
 async function mountForm(
   root: string,
@@ -20,23 +21,17 @@ async function mountForm(
   fields?: FormWithLocation["fields"],
   height = 20,
   clipboardText?: string,
+  response?: { reply?: 404 | 409; cancel?: 404 | 409; syncFailure?: boolean },
 ) {
   const state = path.join(root, "state")
   await mkdir(state, { recursive: true })
 
   const replies: unknown[] = []
+  const cancellations: unknown[] = []
   const copied: string[] = []
+  let terminal = false
+  let formLists = 0
   const events = createEventStream()
-  const transport = createFetch(
-    (url, request) =>
-      url.pathname === "/api/session/ses_test/form/frm_test/reply"
-        ? request.json().then((answer) => {
-            replies.push(answer)
-            return new Response(null, { status: 204 })
-          })
-        : undefined,
-    events,
-  )
   const config = createTuiResolvedConfig()
   const form = {
     id: "frm_test",
@@ -51,7 +46,43 @@ async function mountForm(
       },
     ],
   } satisfies FormWithLocation
+  const failure = (status: 404 | 409) => {
+    terminal = true
+    return json(
+      {
+        _tag: status === 404 ? "FormNotFoundError" : "FormAlreadySettledError",
+        id: form.id,
+        message: status === 404 ? `Form not found: ${form.id}` : `Form already settled: ${form.id}`,
+      },
+      { status },
+    )
+  }
+  const transport = createFetch((url, request) => {
+    if (url.pathname === "/api/session/ses_test/form" && request.method === "GET")
+      return response?.syncFailure && formLists++ > 0
+        ? json({ message: "Could not refresh forms" }, { status: 500 })
+        : json({ data: terminal ? [] : [form] })
+    if (url.pathname === "/api/session/ses_test/form/frm_test/reply")
+      return request.json().then((answer) => {
+        replies.push(answer)
+        return response?.reply ? failure(response.reply) : new Response(null, { status: 204 })
+      })
+    if (url.pathname === "/api/session/ses_test/form/frm_test/cancel") {
+      cancellations.push(true)
+      return response?.cancel ? failure(response.cancel) : new Response(null, { status: 204 })
+    }
+  }, events)
   const { FormPrompt } = await import("../../../src/routes/session/form")
+
+  function CurrentForm() {
+    const data = useData()
+    onMount(() => void data.session.form.sync(form.sessionID))
+    return (
+      <Show when={data.session.form.list(form.sessionID)?.[0]} keyed fallback={<text>Composer ready</text>}>
+        {(current) => <FormPrompt form={current} />}
+      </Show>
+    )
+  }
 
   function Harness() {
     return (
@@ -75,11 +106,11 @@ async function mountForm(
         <ConfigProvider config={config}>
           <Keymap.Provider>
             <ClientProvider api={createApi(transport.fetch)}>
-              <ThemeProvider mode="dark" source={emptyThemeSource}>
-                <ToastProvider>
-                  <FormPrompt form={form} />
-                </ToastProvider>
-              </ThemeProvider>
+              <DataProvider>
+                <ThemeProvider mode="dark" source={emptyThemeSource}>
+                  <ToastProvider>{response ? <CurrentForm /> : <FormPrompt form={form} />}</ToastProvider>
+                </ThemeProvider>
+              </DataProvider>
             </ClientProvider>
           </Keymap.Provider>
         </ConfigProvider>
@@ -90,7 +121,63 @@ async function mountForm(
   const app = await testRender(() => <Harness />, { width, height, kittyKeyboard: true })
   app.renderer.start()
   await app.waitForFrame((frame) => frame.includes("Authorization required"))
-  return { app, copied, replies }
+  return { app, cancellations, copied, replies }
+}
+
+function mountRecoveringForm(root: string, response: { reply?: 404 | 409; cancel?: 404 | 409; syncFailure?: boolean }) {
+  return mountForm(
+    root,
+    80,
+    [{ key: "target", type: "string", options: [{ value: "staging", label: "Staging" }] }],
+    20,
+    undefined,
+    response,
+  )
+}
+
+test("restores the composer when terminal-form revalidation fails", async () => {
+  await using tmp = await tmpdir()
+  const prompt = await mountRecoveringForm(tmp.path, { reply: 404, syncFailure: true })
+  try {
+    prompt.app.mockInput.pressEnter()
+    await prompt.app.waitForFrame((frame) => frame.includes("Composer ready"))
+
+    expect(prompt.replies).toHaveLength(1)
+  } finally {
+    prompt.app.renderer.destroy()
+  }
+})
+
+for (const status of [404, 409] as const) {
+  test(`restores the composer after a terminal ${status} reply`, async () => {
+    await using tmp = await tmpdir()
+    const prompt = await mountRecoveringForm(tmp.path, { reply: status })
+    try {
+      prompt.app.mockInput.pressEnter()
+      await prompt.app.waitForFrame((frame) => frame.includes("Composer ready"))
+
+      expect(prompt.replies).toHaveLength(1)
+      expect(prompt.app.captureCharFrame()).not.toContain("Form not found")
+      expect(prompt.app.captureCharFrame()).not.toContain("Form already settled")
+    } finally {
+      prompt.app.renderer.destroy()
+    }
+  })
+
+  test(`restores the composer after a terminal ${status} cancellation`, async () => {
+    await using tmp = await tmpdir()
+    const prompt = await mountRecoveringForm(tmp.path, { cancel: status })
+    try {
+      prompt.app.mockInput.pressEscape()
+      await prompt.app.waitForFrame((frame) => frame.includes("Composer ready"))
+
+      expect(prompt.cancellations).toHaveLength(1)
+      expect(prompt.app.captureCharFrame()).not.toContain("Form not found")
+      expect(prompt.app.captureCharFrame()).not.toContain("Form already settled")
+    } finally {
+      prompt.app.renderer.destroy()
+    }
+  })
 }
 
 test("requires explicit acknowledgement before submitting an external field", async () => {


### PR DESCRIPTION
## What

Recover the normal TUI composer when a cached form has already disappeared or been settled elsewhere. Replying or cancelling a stale form now treats both `FormNotFoundError` and `FormAlreadySettledError` as terminal outcomes and removes the matching form from the local projection immediately.

This supersedes #44507 with the review findings addressed.

## Before / After

**Before:** If the TUI missed a form settlement event, the stale prompt remained active. A reply or cancellation returned 404 or 409, displayed an error, and continued blocking the normal composer. The previous fix hid the component while waiting for a list refresh, which could leave a blank blocked footer when refresh failed.

**After:** Form settlement lives in the client data layer. Successful, missing, and already-settled outcomes remove the matching projected form synchronously, so the keyed form component unmounts and normal keymap/composer cleanup runs immediately. Revalidation is advisory; a failed refresh cannot re-block the composer.

## How

- `packages/client/src/solid/data.ts` adds projection-aware form `reply` and `cancel` operations, preserving global-form location headers and accepting 404/409 as terminal only when the error identifies the submitted form.
- `packages/tui/src/routes/session/form.tsx` delegates settlement to the data layer instead of coordinating API errors and cache state itself.
- `packages/plugin/src/tui/context.ts` exposes the domain-level form operations to TUI data consumers.
- `packages/tui/test/cli/tui/form.test.tsx` covers reply and cancellation recovery for 404 and 409, plus failed background revalidation.

## Scope

This does not change form protocol or server behavior. Duplicate in-flight form submissions remain outside this stale-projection recovery fix.

## Testing

- `bun run test test/cli/tui/form.test.tsx` from `packages/tui` (25 passed)
- `bun run test test/solid-data.test.ts` from `packages/client` (3 passed)
- `bun typecheck` from `packages/tui`, `packages/client`, and `packages/plugin`
- Push hook: repository-wide Turbo typecheck (32 packages passed)
- `bun run lint` (0 errors; pre-existing warnings remain)

## Flow

```mermaid
sequenceDiagram
  participant TUI as FormPrompt
  participant Data as Client data
  participant API as Form API

  TUI->>Data: reply or cancel
  Data->>API: settle form
  API-->>Data: success, 404, or 409
  Data->>Data: remove matching projected form
  Data-->>TUI: terminal completion
  Note over TUI: Form unmounts; composer resumes
  Data->>API: revalidate forms in background
```
