### PR TITLE
feat: make the session retry policy configurable

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -185,6 +185,34 @@ export const Info = Schema.Struct({
       policies: Schema.optional(Schema.mutable(Schema.Array(ConfigExperimental.Policy))).annotate({
         description: "Policy statements applied to supported resources, such as provider access",
       }),
+      retry: Schema.optional(
+        Schema.Struct({
+          maxRetries: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(-1))).annotate({
+            description:
+              "Maximum retry attempts for a retryable provider error. Use -1 to keep retrying for as long as the error stays retryable (default: 5)",
+          }),
+          initialDelayMs: Schema.optional(PositiveInt).annotate({
+            description: "Delay before the first retry, in milliseconds (default: 2000)",
+          }),
+          backoffFactor: Schema.optional(Schema.Finite.check(Schema.isGreaterThanOrEqualTo(1))).annotate({
+            description:
+              "Multiplier applied to the delay after each attempt. 1 keeps the delay flat instead of doubling (default: 2)",
+          }),
+          jitterFactor: Schema.optional(Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))).annotate({
+            description: "Fraction of the delay added back as random jitter (default: 0.25)",
+          }),
+          maxDelayMs: Schema.optional(PositiveInt).annotate({
+            description: "Absolute ceiling on any retry delay, in milliseconds (default: 2147483647)",
+          }),
+          maxDelayNoHeadersMs: Schema.optional(PositiveInt).annotate({
+            description:
+              "Ceiling on the backoff delay when the error carries no retry-after headers, in milliseconds (default: 30000)",
+          }),
+        }),
+      ).annotate({
+        description:
+          "Retry policy for retryable provider errors. Omitted fields keep their defaults, so the schedule is unchanged unless you set them.",
+      }),
     }),
   ),
 }).annotate({ identifier: "Config" })

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -201,8 +201,9 @@ export const Info = Schema.Struct({
           jitterFactor: Schema.optional(Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))).annotate({
             description: "Fraction of the delay added back as random jitter (default: 0.25)",
           }),
-          maxDelayMs: Schema.optional(PositiveInt).annotate({
-            description: "Absolute ceiling on any retry delay, in milliseconds (default: 2147483647)",
+          maxDelayMs: Schema.optional(PositiveInt.check(Schema.isLessThanOrEqualTo(2_147_483_647))).annotate({
+            description:
+              "Absolute ceiling on any retry delay, in milliseconds. Cannot exceed 2147483647, the largest value setTimeout can represent (default: 2147483647)",
           }),
           maxDelayNoHeadersMs: Schema.optional(PositiveInt).annotate({
             description:

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -660,6 +660,7 @@ const layer = Layer.effect(
             Effect.retry(
               SessionRetry.policy({
                 provider: input.model.providerID,
+                tuning: (yield* config.get()).experimental?.retry,
                 parse,
                 set: (info) => {
                   return status.set(ctx.sessionID, {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -50,7 +50,10 @@ function resolve(tuning?: Tuning) {
     initialDelayMs: tuning?.initialDelayMs ?? RETRY_INITIAL_DELAY,
     backoffFactor: tuning?.backoffFactor ?? RETRY_BACKOFF_FACTOR,
     jitterFactor: tuning?.jitterFactor ?? RETRY_JITTER_FACTOR,
-    maxDelayMs: tuning?.maxDelayMs ?? RETRY_MAX_DELAY,
+    // Normalized here so policy() and delay() read the same ceiling. Config
+    // validation also bounds this, but a plugin config hook mutates the loaded
+    // config without revalidation, so it cannot be the only guard.
+    maxDelayMs: Math.min(tuning?.maxDelayMs ?? RETRY_MAX_DELAY, RETRY_MAX_DELAY),
     maxDelayNoHeadersMs: tuning?.maxDelayNoHeadersMs ?? RETRY_MAX_DELAY_NO_HEADERS,
   }
 }
@@ -68,7 +71,12 @@ const RETRYABLE_MESSAGE_PATTERNS = [
 ]
 
 function cap(ms: number, limits: Limits) {
-  return Math.min(ms, limits.maxDelayMs)
+  // A tuned backoffFactor or jitterFactor can overflow the exponential to
+  // Infinity, and Infinity * 0 jitter is NaN. Duration.millis turns NaN and
+  // negatives alike into an immediate retry, so every delay is pinned to a
+  // finite, non-negative value here rather than at each return site.
+  if (!Number.isFinite(ms)) return limits.maxDelayMs
+  return Math.min(Math.max(ms, 0), limits.maxDelayMs)
 }
 
 export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random(), tuning?: Tuning) {

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -30,6 +30,33 @@ export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 export const RETRY_MAX_RETRIES = 5
 
+/**
+ * Overrides for the retry schedule, supplied by `experimental.retry` in the
+ * config. Every field falls back to the constant above, so an absent or empty
+ * object reproduces the default schedule exactly.
+ */
+export type Tuning = {
+  maxRetries?: number
+  initialDelayMs?: number
+  backoffFactor?: number
+  jitterFactor?: number
+  maxDelayMs?: number
+  maxDelayNoHeadersMs?: number
+}
+
+function resolve(tuning?: Tuning) {
+  return {
+    maxRetries: tuning?.maxRetries ?? RETRY_MAX_RETRIES,
+    initialDelayMs: tuning?.initialDelayMs ?? RETRY_INITIAL_DELAY,
+    backoffFactor: tuning?.backoffFactor ?? RETRY_BACKOFF_FACTOR,
+    jitterFactor: tuning?.jitterFactor ?? RETRY_JITTER_FACTOR,
+    maxDelayMs: tuning?.maxDelayMs ?? RETRY_MAX_DELAY,
+    maxDelayNoHeadersMs: tuning?.maxDelayNoHeadersMs ?? RETRY_MAX_DELAY_NO_HEADERS,
+  }
+}
+
+type Limits = ReturnType<typeof resolve>
+
 const RETRYABLE_MESSAGE_PATTERNS = [
   /429|500|502|503|504|524/i,
   /rate increased too quickly|rate limit|rate-limit|rate_limit|too many requests/i,
@@ -40,11 +67,12 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   /\btry again (?:later|in\b)|\b(?:currently|temporarily) at capacity\b/i,
 ]
 
-function cap(ms: number) {
-  return Math.min(ms, RETRY_MAX_DELAY)
+function cap(ms: number, limits: Limits) {
+  return Math.min(ms, limits.maxDelayMs)
 }
 
-export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random()) {
+export function delay(attempt: number, error?: SessionV1.APIError, random = Math.random(), tuning?: Tuning) {
+  const limits = resolve(tuning)
   if (error) {
     const headers = error.data.responseHeaders
     if (headers) {
@@ -52,7 +80,7 @@ export function delay(attempt: number, error?: SessionV1.APIError, random = Math
       if (retryAfterMs) {
         const parsedMs = Number.parseFloat(retryAfterMs)
         if (!Number.isNaN(parsedMs)) {
-          return cap(parsedMs)
+          return cap(parsedMs, limits)
         }
       }
 
@@ -61,25 +89,25 @@ export function delay(attempt: number, error?: SessionV1.APIError, random = Math
         const parsedSeconds = Number.parseFloat(retryAfter)
         if (!Number.isNaN(parsedSeconds)) {
           // convert seconds to milliseconds
-          return cap(Math.ceil(parsedSeconds * 1000))
+          return cap(Math.ceil(parsedSeconds * 1000), limits)
         }
         // Try parsing as HTTP date format
         const parsed = Date.parse(retryAfter) - Date.now()
         if (!Number.isNaN(parsed) && parsed > 0) {
-          return cap(Math.ceil(parsed))
+          return cap(Math.ceil(parsed), limits)
         }
       }
 
-      return cap(exponential(attempt, random))
+      return cap(exponential(attempt, random, limits), limits)
     }
   }
 
-  return cap(Math.min(exponential(attempt, random), RETRY_MAX_DELAY_NO_HEADERS))
+  return cap(Math.min(exponential(attempt, random, limits), limits.maxDelayNoHeadersMs), limits)
 }
 
-function exponential(attempt: number, random: number) {
-  const base = RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1)
-  return Math.ceil(base + base * RETRY_JITTER_FACTOR * random)
+function exponential(attempt: number, random: number, limits: Limits) {
+  const base = limits.initialDelayMs * Math.pow(limits.backoffFactor, attempt - 1)
+  return Math.ceil(base + base * limits.jitterFactor * random)
 }
 
 export function retryable(error: Err, provider: string) {
@@ -182,17 +210,25 @@ function parseJSON(value: unknown) {
 
 export function policy(opts: {
   provider: string
+  tuning?: Tuning
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
 }) {
+  const limits = resolve(opts.tuning)
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
-      if (meta.attempt > RETRY_MAX_RETRIES) return Cause.done(meta.attempt)
+      // A negative limit means retry for as long as the error stays retryable.
+      if (limits.maxRetries >= 0 && meta.attempt > limits.maxRetries) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
-        const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
+        const wait = delay(
+          meta.attempt,
+          SessionV1.APIError.isInstance(error) ? error : undefined,
+          Math.random(),
+          opts.tuning,
+        )
         const now = yield* Clock.currentTimeMillis
         yield* opts.set({
           attempt: meta.attempt,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -176,6 +176,36 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(1, error, 0, { maxDelayMs: 60_000 })).toBe(60_000)
   })
 
+  test("clamps a maxDelayMs that setTimeout cannot represent", () => {
+    const tuning = { maxDelayMs: 4_294_967_296, initialDelayMs: 4_294_967_296, maxDelayNoHeadersMs: 4_294_967_296 }
+    expect(SessionRetry.delay(1, undefined, 0, tuning)).toBe(SessionRetry.RETRY_MAX_DELAY)
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "4294967296" }), 0, tuning)).toBe(
+      SessionRetry.RETRY_MAX_DELAY,
+    )
+  })
+
+  test("never returns a non-finite delay when the exponential overflows", () => {
+    // base * jitter reaches Infinity, and Infinity * 0 jitter is NaN
+    expect(SessionRetry.delay(1, undefined, 0, { jitterFactor: 1e306 })).toBe(SessionRetry.RETRY_MAX_DELAY)
+    expect(SessionRetry.delay(320, undefined, 0, { backoffFactor: 10 })).toBe(SessionRetry.RETRY_MAX_DELAY)
+    expect(SessionRetry.delay(10, undefined, 0, { initialDelayMs: 1e300, backoffFactor: 10 })).toBe(
+      SessionRetry.RETRY_MAX_DELAY,
+    )
+  })
+
+  test("never returns a negative delay from a malformed retry-after", () => {
+    expect(SessionRetry.delay(1, apiError({ "retry-after-ms": "-5000" }), 0)).toBe(0)
+    expect(SessionRetry.delay(1, apiError({ "retry-after": "-100" }), 0)).toBe(0)
+  })
+
+  test("pins the jitter ceiling for a tuned schedule", () => {
+    const error = apiError()
+    const tuning = { initialDelayMs: 500, backoffFactor: 1, jitterFactor: 0.2 }
+    expect(SessionRetry.delay(1, error, 0, tuning)).toBe(500)
+    expect(SessionRetry.delay(1, error, 1, tuning)).toBe(600)
+    expect(SessionRetry.delay(9, error, 1, tuning)).toBe(600)
+  })
+
   it.instance("policy stops after a configured maxRetries", () =>
     Effect.gen(function* () {
       const attempts: number[] = []

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -146,6 +146,80 @@ describe("session.retry.delay", () => {
       expect(attempts).toStrictEqual([1, 2, 3, 4, 5])
     }),
   )
+
+  test("keeps the default schedule when tuning is absent or empty", () => {
+    const error = apiError()
+    const base = Array.from({ length: 6 }, (_, index) => SessionRetry.delay(index + 1, error, 0))
+    const empty = Array.from({ length: 6 }, (_, index) => SessionRetry.delay(index + 1, error, 0, {}))
+    expect(base).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000])
+    expect(empty).toStrictEqual(base)
+  })
+
+  test("flattens the schedule when backoffFactor is 1", () => {
+    const error = apiError()
+    const delays = Array.from({ length: 5 }, (_, index) =>
+      SessionRetry.delay(index + 1, error, 0, { initialDelayMs: 500, backoffFactor: 1 }),
+    )
+    expect(delays).toStrictEqual([500, 500, 500, 500, 500])
+  })
+
+  test("honours a lower ceiling when headers are missing", () => {
+    const error = apiError()
+    const delays = Array.from({ length: 4 }, (_, index) =>
+      SessionRetry.delay(index + 1, error, 0, { maxDelayNoHeadersMs: 2000 }),
+    )
+    expect(delays).toStrictEqual([2000, 2000, 2000, 2000])
+  })
+
+  test("honours a lower absolute ceiling for header delays", () => {
+    const error = apiError({ "retry-after": "600" })
+    expect(SessionRetry.delay(1, error, 0, { maxDelayMs: 60_000 })).toBe(60_000)
+  })
+
+  it.instance("policy stops after a configured maxRetries", () =>
+    Effect.gen(function* () {
+      const attempts: number[] = []
+      const error = apiError({ "retry-after-ms": "0" })
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          tuning: { maxRetries: 2 },
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: (info) =>
+            Effect.sync(() => {
+              attempts.push(info.attempt)
+            }),
+        }),
+      )
+
+      yield* Effect.forEach(Array.from({ length: 5 }), () => Effect.ignore(step(error)))
+
+      expect(attempts).toStrictEqual([1, 2])
+    }),
+  )
+
+  it.instance("policy keeps retrying when maxRetries is negative", () =>
+    Effect.gen(function* () {
+      const attempts: number[] = []
+      const error = apiError({ "retry-after-ms": "0" })
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          tuning: { maxRetries: -1 },
+          parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+          set: (info) =>
+            Effect.sync(() => {
+              attempts.push(info.attempt)
+            }),
+        }),
+      )
+
+      yield* Effect.forEach(Array.from({ length: 20 }), () => Effect.ignore(step(error)))
+
+      expect(attempts).toHaveLength(20)
+      expect(attempts.at(-1)).toBe(20)
+    }),
+  )
 })
 
 describe("session.retry.retryable", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #43596

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The retry constants in `session/retry.ts` are compiled in, so a turn is dropped after 5 attempts and there is no way to change that. This adds an optional `experimental.retry` block and passes it into `SessionRetry.policy`. Each field falls back to the constant it replaces, so nothing moves unless you set one.

I exposed `backoffFactor` as well as `maxRetries`, because the attempt count alone barely helps. With no response headers the delay is already clamped at 30s from attempt 5 on, so more attempts is mostly more waiting. With headers but no `retry-after` it isn't clamped at all (#33728), so attempt 10 waits ~17 min. `retry-after` handling is untouched.

`maxRetries: -1` retries while the error stays retryable, which is the long quota window case in the issue. That does hand back the unbounded retry the cap was added to stop (#41848). It's opt-in and off by default, but say the word and I'll drop it and keep only the finite knobs.

### How did you verify your code works?

`bun test test/session/` (417 pass), `bun test test/config` (183 pass), `bun turbo typecheck` on core and opencode.

Six new tests in `retry.test.ts`. The one that matters: absent and empty tuning both still produce `[2000, 4000, 8000, 16000, 30000, 30000]`, so the default schedule is unchanged.

I also ran `script/schema.ts` to look at the generated schema. That's why the two float fields use `Schema.Finite` and not `Schema.Number`, which was emitting `"NaN"` and `"Infinity"` string enums into the public schema.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
