### PR TITLE
feat(acp): add ACP v2 draft support/features

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -568,7 +568,7 @@
       "dependencies": {
         "@actions/core": "1.11.1",
         "@actions/github": "6.0.1",
-        "@agentclientprotocol/sdk": "0.21.0",
+        "@agentclientprotocol/sdk": "1.3.0",
         "@ai-sdk/alibaba": "1.0.17",
         "@ai-sdk/amazon-bedrock": "4.0.166",
         "@ai-sdk/anthropic": "3.0.111",
@@ -1167,7 +1167,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.21.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
 
     "@ai-sdk/alibaba": ["@ai-sdk/alibaba@1.0.17", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZbE+U5bWz2JBc5DERLowx5+TKbjGBE93LqKZAWvuEn7HOSQMraxFMZuc0ST335QZJAyfBOzh7m1mPQ+y7EaaoA=="],
 
@@ -1440,8 +1440,6 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
@@ -2993,8 +2991,6 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.8", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.8", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.8", "vitest": "4.1.8" }, "optionalPeers": ["@vitest/browser"] }, "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw=="],
-
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.7", "", { "dependencies": { "@vitest/spy": "4.1.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA=="],
@@ -3114,8 +3110,6 @@
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
-
-    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
@@ -3600,8 +3594,6 @@
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
-    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -4125,12 +4117,6 @@
 
     "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
 
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
-
     "iterate-iterator": ["iterate-iterator@1.0.2", "", {}, "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw=="],
 
     "iterate-value": ["iterate-value@1.0.2", "", { "dependencies": { "es-get-iterator": "^1.0.2", "iterate-iterator": "^1.0.1" } }, "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ=="],
@@ -4298,8 +4284,6 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
-
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "make-fetch-happen": ["make-fetch-happen@15.0.6", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "@npmcli/redact": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw=="],
 
@@ -6111,10 +6095,6 @@
 
     "@solidjs/start/vite": ["vite@7.1.10", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA=="],
 
-    "@standard-community/standard-json/effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
-
-    "@standard-community/standard-openapi/effect": ["effect@4.0.0-beta.74", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.8.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.1", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^14.0.0", "yaml": "^2.9.0" } }, "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA=="],
-
     "@storybook/csf-plugin/unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "@tailwindcss/oxide/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -6142,10 +6122,6 @@
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@types/plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
-
-    "@vitest/coverage-v8/@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
-
-    "@vitest/coverage-v8/magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
 
     "@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -6196,8 +6172,6 @@
     "archiver-utils/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "archiver-utils/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "astro/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.6.1", "", {}, "sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A=="],
 
@@ -6289,8 +6263,6 @@
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
-    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
     "engine.io-client/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "esast-util-from-js/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -6340,8 +6312,6 @@
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 
     "iconv-corefoundation/node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
-
-    "istanbul-reports/html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "js-beautify/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -6959,17 +6929,11 @@
 
     "@solidjs/start/shiki/@shikijs/types": ["@shikijs/types@1.29.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw=="],
 
-    "@standard-community/standard-json/effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-community/standard-openapi/effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@storybook/csf-plugin/unplugin/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "@storybook/csf-plugin/unplugin/webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
-
-    "@vitest/coverage-v8/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
 
     "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",
-    "@agentclientprotocol/sdk": "0.21.0",
+    "@agentclientprotocol/sdk": "1.3.0",
     "@ai-sdk/alibaba": "1.0.17",
     "@ai-sdk/amazon-bedrock": "4.0.166",
     "@ai-sdk/anthropic": "3.0.111",

--- a/packages/opencode/src/acp/agent-v2.ts
+++ b/packages/opencode/src/acp/agent-v2.ts
@@ -1,0 +1,93 @@
+import { agent, type AgentContext, type AgentApp, RequestError } from "@agentclientprotocol/sdk/experimental/v2"
+import { Effect } from "effect"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { Identifier } from "@/id/id"
+import * as ACPError from "./error"
+import * as ACPService from "./service"
+import type { InitializeRequest as V1InitializeRequest } from "@agentclientprotocol/sdk"
+
+function wrapClient(client: AgentContext): ACPService.ServiceConnection {
+  return {
+    sessionUpdate: (params) => client.notify("session/update", params),
+    requestPermission: (params) => client.request("session/request_permission", params) as Promise<never>,
+  }
+}
+
+// v2 handlers return v2-typed responses, but the service returns v1 types.
+// The runtime shapes are compatible (v2 renames fields like id→configId,
+// agentInfo→info). Promise<never> is assignable to any Promise<T>, bridging
+// the type boundary without importing every v2 response type.
+function run<A>(effect: Effect.Effect<A, ACPService.Error>): Promise<never> {
+  return Effect.runPromise(effect.pipe(Effect.mapError(ACPError.toRequestError))).catch((defect: unknown) => {
+    if (defect instanceof RequestError) throw defect
+    throw ACPError.toRequestError(ACPError.fromUnknownDefect(defect))
+  }) as Promise<never>
+}
+
+export function createV2App(sdk: OpencodeClient): AgentApp {
+  let service: ACPService.Interface | undefined
+
+  function serviceFor(client: AgentContext): ACPService.Interface {
+    if (!service) {
+      service = ACPService.make({ sdk, connection: wrapClient(client), v2: true })
+    }
+    return service
+  }
+
+  return agent({ name: "opencode" })
+    .onRequest("initialize", (ctx) => {
+      const service = serviceFor(ctx.client)
+      const v1Params = {
+        protocolVersion: ctx.params.protocolVersion,
+        clientInfo: ctx.params.info,
+        clientCapabilities: ctx.params.capabilities as unknown as undefined,
+      }
+      return run(service.initialize(v1Params as unknown as V1InitializeRequest))
+    })
+    .onRequest("auth/login", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.authenticate(ctx.params as unknown as Parameters<typeof service.authenticate>[0]))
+    })
+    .onRequest("auth/logout", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.logout() as Effect.Effect<Record<string, unknown>, ACPService.Error>)
+    })
+    .onRequest("session/new", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.newSession(ctx.params as unknown as Parameters<typeof service.newSession>[0]))
+    })
+    .onRequest("session/prompt", (ctx) => {
+      const service = serviceFor(ctx.client)
+      const params = {
+        ...ctx.params,
+        messageId: Identifier.ascending("message"),
+      }
+      return run(service.prompt(params as unknown as Parameters<typeof service.prompt>[0]))
+    })
+    .onRequest("session/resume", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.resumeSession(ctx.params as unknown as Parameters<typeof service.resumeSession>[0]))
+    })
+    .onRequest("session/close", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.closeSession(ctx.params as unknown as Parameters<typeof service.closeSession>[0]))
+    })
+    .onRequest("session/fork", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.forkSession(ctx.params as unknown as Parameters<typeof service.forkSession>[0]))
+    })
+    .onRequest("session/list", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.listSessions(ctx.params as unknown as Parameters<typeof service.listSessions>[0]))
+    })
+    .onRequest("session/set_config_option", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(
+        service.setSessionConfigOption(ctx.params as unknown as Parameters<typeof service.setSessionConfigOption>[0]),
+      )
+    })
+    .onNotification("session/cancel", (ctx) => {
+      if (!service) return
+      return run(service.cancel(ctx.params as unknown as Parameters<typeof service.cancel>[0]))
+    })
+}

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -21,10 +21,10 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import * as ACPError from "./error"
 import * as ACPService from "./service"
 
-export function init({ sdk: _sdk }: { sdk: OpencodeClient }) {
+export function init({ sdk: _sdk, v2 }: { sdk: OpencodeClient; v2?: boolean }) {
   return {
     create: (connection: AgentSideConnection) => {
-      return new Agent(ACPService.make({ sdk: _sdk, connection }))
+      return new Agent(ACPService.make({ sdk: _sdk, connection, v2 }))
     },
   }
 }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1,5 +1,6 @@
 import {
   RequestError,
+  agent,
   type Agent as ACPAgent,
   type AgentSideConnection,
   type AuthenticateRequest,
@@ -13,9 +14,9 @@ import {
   type PromptRequest,
   type ResumeSessionRequest,
   type SetSessionConfigOptionRequest,
-  type SetSessionModelRequest,
   type SetSessionModeRequest,
 } from "@agentclientprotocol/sdk"
+import { agentProtocolRouter } from "@agentclientprotocol/sdk/experimental/v2"
 import { Effect } from "effect"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import * as ACPError from "./error"
@@ -72,7 +73,7 @@ export class Agent implements ACPAgent {
     return run(this.service.setSessionMode(params))
   }
 
-  unstable_setSessionModel(params: SetSessionModelRequest) {
+  unstable_setSessionModel(params: SetSessionModeRequest) {
     return run(this.service.setSessionModel(params))
   }
 
@@ -83,6 +84,27 @@ export class Agent implements ACPAgent {
   cancel(params: CancelNotification) {
     return run(this.service.cancel(params))
   }
+
+  // v2 renames `authenticate` to `auth/login` and adds `auth/logout`. SDK 0.21
+  // has no dispatch case for these, so they arrive via the extension method hook.
+  extMethod(method: string, params: Record<string, unknown>) {
+    if (method === "auth/login") {
+      return run(
+        this.service.authenticate(params as unknown as AuthenticateRequest) as Effect.Effect<
+          Record<string, unknown>,
+          ACPService.Error
+        >,
+      )
+    }
+    if (method === "auth/logout") {
+      return run(this.service.logout() as Effect.Effect<Record<string, unknown>, ACPService.Error>)
+    }
+    return Promise.reject(new RequestError(-32601, `Method not found: ${method}`))
+  }
+
+  extNotification(method: string, _params: Record<string, unknown>) {
+    return Promise.reject(new RequestError(-32601, `Notification not found: ${method}`))
+  }
 }
 
 function run<A>(effect: Effect.Effect<A, ACPService.Error>) {
@@ -90,6 +112,95 @@ function run<A>(effect: Effect.Effect<A, ACPService.Error>) {
     if (defect instanceof RequestError) throw defect
     throw ACPError.toRequestError(ACPError.fromUnknownDefect(defect))
   })
+}
+
+function wrapClient(client: {
+  notify: (m: string, p: unknown) => Promise<void>
+  request: (m: string, p: unknown) => Promise<unknown>
+}): ACPService.ServiceConnection {
+  return {
+    sessionUpdate: (params) => client.notify("session/update", params),
+    requestPermission: (params) => client.request("session/request_permission", params) as Promise<never>,
+  }
+}
+
+export function createV1App(sdk: OpencodeClient) {
+  let service: ACPService.Interface | undefined
+
+  function serviceFor(
+    client: object & {
+      notify: (m: string, p: unknown) => Promise<void>
+      request: (m: string, p: unknown) => Promise<unknown>
+    },
+  ): ACPService.Interface {
+    if (!service) {
+      service = ACPService.make({ sdk, connection: wrapClient(client), v2: false })
+    }
+    return service
+  }
+
+  return agent({ name: "opencode" })
+    .onRequest("initialize", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.initialize(ctx.params))
+    })
+    .onRequest("authenticate", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.authenticate(ctx.params))
+    })
+    .onRequest("logout", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.logout() as Effect.Effect<Record<string, unknown>, ACPService.Error>)
+    })
+    .onRequest("session/new", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.newSession(ctx.params))
+    })
+    .onRequest("session/load", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.loadSession(ctx.params))
+    })
+    .onRequest("session/list", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.listSessions(ctx.params))
+    })
+    .onRequest("session/resume", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.resumeSession(ctx.params))
+    })
+    .onRequest("session/close", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.closeSession(ctx.params))
+    })
+    .onRequest("session/fork", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.forkSession(ctx.params))
+    })
+    .onRequest("session/set_mode", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.setSessionMode(ctx.params))
+    })
+    .onRequest("session/set_config_option", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.setSessionConfigOption(ctx.params))
+    })
+    .onRequest("session/prompt", (ctx) => {
+      const service = serviceFor(ctx.client)
+      return run(service.prompt(ctx.params))
+    })
+    .onNotification("session/cancel", (ctx) => {
+      if (!service) return
+      return run(service.cancel(ctx.params))
+    })
+}
+
+export function createRouter(sdk: OpencodeClient, v2: boolean) {
+  const router = agentProtocolRouter().withV1(createV1App(sdk))
+  if (v2) {
+    // Lazy import to avoid loading v2 module when flag is off
+    return import("./agent-v2").then((mod) => router.withV2(mod.createV2App(sdk)))
+  }
+  return Promise.resolve(router)
 }
 
 export * as ACP from "./agent"

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -73,7 +73,7 @@ export class Agent implements ACPAgent {
     return run(this.service.setSessionMode(params))
   }
 
-  unstable_setSessionModel(params: SetSessionModeRequest) {
+  unstable_setSessionModel(params: { sessionId: string; modelId: string }) {
     return run(this.service.setSessionModel(params))
   }
 

--- a/packages/opencode/src/acp/config-option.ts
+++ b/packages/opencode/src/acp/config-option.ts
@@ -201,3 +201,13 @@ function selectVariant(variant: string | undefined, variants: readonly string[])
   if (variants.includes(DEFAULT_VARIANT_VALUE)) return DEFAULT_VARIANT_VALUE
   return variants[0]
 }
+
+// v2 renames the config option identifier field from `id` to `configId`.
+// Applied at the boundary when responding to v2 clients. The v1 SDK types
+// only know `id`, so the v2 shape is cast through `unknown`.
+export function toV2ConfigOptions(options: readonly SessionConfigOption[]): SessionConfigOption[] {
+  return options.map((option) => {
+    const { id, ...rest } = option
+    return { configId: id, ...rest } as unknown as SessionConfigOption
+  })
+}

--- a/packages/opencode/src/acp/content.ts
+++ b/packages/opencode/src/acp/content.ts
@@ -11,16 +11,19 @@ export type ReplayPart =
       text: string
       synthetic?: boolean
       ignored?: boolean
+      _meta?: Record<string, unknown> | null
     }
   | {
       type: "file"
       url: string
       mime: string
       filename?: string
+      _meta?: Record<string, unknown> | null
     }
   | {
       type: "reasoning"
       text: string
+      _meta?: Record<string, unknown> | null
     }
 
 export function promptContentToParts(content: readonly ContentBlock[]): PromptPart[] {
@@ -28,6 +31,7 @@ export function promptContentToParts(content: readonly ContentBlock[]): PromptPa
 }
 
 export function contentBlockToParts(block: ContentBlock): PromptPart[] {
+  const meta = "_meta" in block && block._meta ? block._meta : undefined
   switch (block.type) {
     case "text":
       return [
@@ -112,6 +116,9 @@ export function contentBlockToParts(block: ContentBlock): PromptPart[] {
       return []
 
     default:
+      // v2 extensibility: unknown content block types are rendered as a text
+      // fallback so the user's message content is not silently lost.
+      if (meta) return [{ type: "text", text: JSON.stringify(block) }]
       return []
   }
 }
@@ -131,6 +138,7 @@ export function partToContentChunks(part: ReplayPart): ContentChunk[] {
             text: part.text,
             ...partAudience(part),
           },
+          ...(part._meta ? { _meta: part._meta } : {}),
         },
       ]
 
@@ -145,6 +153,7 @@ export function partToContentChunks(part: ReplayPart): ContentChunk[] {
             type: "text",
             text: part.text,
           },
+          ...(part._meta ? { _meta: part._meta } : {}),
         },
       ]
   }
@@ -153,7 +162,11 @@ export function partToContentChunks(part: ReplayPart): ContentChunk[] {
 function resourceLinkToPart(link: ResourceLink): PromptPart {
   const parsed = uriToFilePart(link.uri, link.mimeType ?? "text/plain", link.name)
   if (parsed.type === "file") return parsed
-  return { type: "text", text: parsed.text }
+  return {
+    type: "text",
+    text: parsed.text,
+    ...(link._meta ? { metadata: { _meta: link._meta } } : {}),
+  }
 }
 
 function uriToFilePart(
@@ -197,6 +210,7 @@ function filePartToContentChunks(part: Extract<ReplayPart, { type: "file" }>): C
           name: part.filename ?? "file",
           mimeType: part.mime,
         },
+        ...(part._meta ? { _meta: part._meta } : {}),
       },
     ]
   }

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -30,7 +30,14 @@ type GlobalEventStream = {
   stream: AsyncIterable<GlobalEventEnvelope>
 }
 
-export function start(input: { sdk: OpencodeClient; connection: Connection; session: ACPSession.Interface }) {
+export function start(input: {
+  sdk: OpencodeClient
+  connection: Connection
+  session: ACPSession.Interface
+  isV2?: () => boolean
+  onBusy?: (sessionId: string) => Effect.Effect<void>
+  onIdle?: (sessionId: string) => Effect.Effect<void>
+}) {
   const subscription = new Subscription(input)
   subscription.start()
   return subscription
@@ -51,6 +58,9 @@ export class Subscription {
       sdk: OpencodeClient
       connection: Connection
       session: ACPSession.Interface
+      isV2?: () => boolean
+      onBusy?: (sessionId: string) => Effect.Effect<void>
+      onIdle?: (sessionId: string) => Effect.Effect<void>
     },
   ) {
     this.permission = new ACPPermission.Handler(input)
@@ -93,7 +103,14 @@ export class Subscription {
   async handle(event: Event) {
     switch (event.type) {
       case "session.status":
-        if (event.properties.status.type === "idle") this.idle(event.properties.sessionID)
+        if (event.properties.status.type === "idle") {
+          this.idle(event.properties.sessionID)
+          if (this.input.isV2?.())
+            await Effect.runPromise(this.input.onIdle?.(event.properties.sessionID) ?? Effect.void)
+        }
+        if (event.properties.status.type === "busy" && this.input.isV2?.()) {
+          await Effect.runPromise(this.input.onBusy?.(event.properties.sessionID) ?? Effect.void)
+        }
         return
       case "permission.asked":
         this.permission.handle(event)

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -445,6 +445,8 @@ export class Subscription {
   private async toolStart(sessionId: string, part: ToolPart, cwd: string) {
     if (this.toolStarts.has(part.callID)) return
     this.toolStarts.add(part.callID)
+    // v2: the first tool_call_update for an unseen toolCallId creates the tool call.
+    // v1: a separate tool_call notification creates it, then tool_call_update patches it.
     const toolCall = pendingToolCall({
       toolCallId: part.callID,
       toolName: part.tool,
@@ -453,33 +455,12 @@ export class Subscription {
     })
     // v2: the first tool_call_update for an unseen toolCallId creates the tool call.
     // v1: a separate tool_call notification creates it, then tool_call_update patches it.
-    if (this.input.isV2?.()) {
-      await this.input.connection.sessionUpdate({
-        sessionId,
-        update: {
-          sessionUpdate: "tool_call_update",
-          ...pendingToolCall({
-            toolCallId: part.callID,
-            toolName: part.tool,
-            state: part.state,
-            cwd,
-          }),
-        },
-      })
-    } else {
-      await this.input.connection.sessionUpdate({
-        sessionId,
-        update: {
-          sessionUpdate: "tool_call",
-          ...pendingToolCall({
-            toolCallId: part.callID,
-            toolName: part.tool,
-            state: part.state,
-            cwd,
-          }),
-        },
-      })
-    }
+    await this.input.connection.sessionUpdate({
+      sessionId,
+      update: this.input.isV2?.()
+        ? { sessionUpdate: "tool_call_update", ...toolCall }
+        : { sessionUpdate: "tool_call", ...toolCall },
+    })
   }
 
   private clearTool(toolCallId: string) {
@@ -510,7 +491,9 @@ export class Subscription {
       terminalUpdate.output = { data: Buffer.from(output).toString("base64") }
     }
     if (exited) {
-      const exitCode = typeof input.exitCode === "number" ? input.exitCode : 0
+      const metadata = ("metadata" in part.state ? part.state.metadata : undefined) as
+        Record<string, unknown> | undefined
+      const exitCode = typeof metadata?.exit === "number" ? metadata.exit : 0
       terminalUpdate.exitStatus = { exitCode }
     }
     await this.input.connection.sessionUpdate({
@@ -548,11 +531,14 @@ function v2DiffContent(content: ToolCallContent): ToolCallContent {
   if (!("type" in content) || content.type !== "diff") return content
   const v1Diff = content as unknown as { type: "diff"; path: string; oldText: string; newText: string }
   if (!v1Diff.path) return content
+  if (typeof v1Diff.oldText !== "string" || typeof v1Diff.newText !== "string") return content
 
   const raw = createTwoFilesPatch(v1Diff.path, v1Diff.path, v1Diff.oldText, v1Diff.newText, undefined, undefined, {
     context: 3,
   })
-  // Strip Index: and === separator lines, prepend diff --git header for git_patch format
+  // createTwoFilesPatch emits "Index:" and a "===" separator line that are not
+  // part of git_patch format. Body lines always start with ' ', '+', or '-',
+  // so filtering "=======" is safe.
   const hunks = raw
     .split("\n")
     .filter((line) => !line.startsWith("Index: ") && !line.startsWith("======="))

--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -1,4 +1,5 @@
-import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import type { AgentSideConnection, SessionNotification, ToolCallContent } from "@agentclientprotocol/sdk"
+import { createTwoFilesPatch } from "diff"
 import type {
   Event,
   EventMessagePartDelta,
@@ -119,6 +120,8 @@ export class Subscription {
         return this.handlePartUpdated(event)
       case "message.part.delta":
         return this.handlePartDelta(event)
+      case "todo.updated":
+        return this.handleTodoUpdated(event)
     }
   }
 
@@ -275,6 +278,35 @@ export class Subscription {
     }
   }
 
+  private async handleTodoUpdated(event: {
+    properties: { sessionID: string; todos: Array<{ content: string; status: string; priority: string }> }
+  }) {
+    const { sessionID, todos } = event.properties
+    const entries = todos.map((todo) => ({
+      content: todo.content,
+      priority: todo.priority as "high" | "medium" | "low",
+      status: todo.status as "pending" | "in_progress" | "completed" | "cancelled",
+    }))
+
+    if (this.input.isV2?.()) {
+      await this.input.connection.sessionUpdate({
+        sessionId: sessionID,
+        update: {
+          sessionUpdate: "plan_update",
+          plan: { type: "items", planId: "default", entries },
+        },
+      } as SessionNotification)
+    } else {
+      await this.input.connection.sessionUpdate({
+        sessionId: sessionID,
+        update: {
+          sessionUpdate: "plan",
+          entries,
+        },
+      } as SessionNotification)
+    }
+  }
+
   private async fetchPartMetadata(sessionId: string, cwd: string, messageId: string, partId: string) {
     const message = await this.input.sdk.session
       .message(
@@ -327,14 +359,25 @@ export class Subscription {
           sessionId,
           update: {
             sessionUpdate: "tool_call_update",
-            ...completedToolUpdate({
-              toolCallId: part.callID,
-              toolName: part.tool,
-              state: part.state,
-              cwd,
-            }),
+            ...this.v2ToolUpdate(
+              completedToolUpdate({
+                toolCallId: part.callID,
+                toolName: part.tool,
+                state: part.state,
+                cwd,
+              }),
+            ),
           },
         })
+        if (this.input.isV2?.() && isShellTool(part.tool)) {
+          await this.emitTerminalUpdate(
+            sessionId,
+            part,
+            cwd,
+            shellOutputSnapshot(part.state) ?? part.state.output,
+            true,
+          )
+        }
         return
 
       case "error":
@@ -343,12 +386,14 @@ export class Subscription {
           sessionId,
           update: {
             sessionUpdate: "tool_call_update",
-            ...errorToolUpdate({
-              toolCallId: part.callID,
-              toolName: part.tool,
-              state: part.state,
-              cwd,
-            }),
+            ...this.v2ToolUpdate(
+              errorToolUpdate({
+                toolCallId: part.callID,
+                toolName: part.tool,
+                state: part.state,
+                cwd,
+              }),
+            ),
           },
         })
         return
@@ -391,28 +436,90 @@ export class Subscription {
         }),
       },
     })
+
+    if (this.input.isV2?.() && isShellTool(part.tool)) {
+      await this.emitTerminalUpdate(sessionId, part, cwd, output, false)
+    }
   }
 
   private async toolStart(sessionId: string, part: ToolPart, cwd: string) {
     if (this.toolStarts.has(part.callID)) return
     this.toolStarts.add(part.callID)
-    await this.input.connection.sessionUpdate({
-      sessionId,
-      update: {
-        sessionUpdate: "tool_call",
-        ...pendingToolCall({
-          toolCallId: part.callID,
-          toolName: part.tool,
-          state: part.state,
-          cwd,
-        }),
-      },
+    const toolCall = pendingToolCall({
+      toolCallId: part.callID,
+      toolName: part.tool,
+      state: part.state,
+      cwd,
     })
+    // v2: the first tool_call_update for an unseen toolCallId creates the tool call.
+    // v1: a separate tool_call notification creates it, then tool_call_update patches it.
+    if (this.input.isV2?.()) {
+      await this.input.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          ...pendingToolCall({
+            toolCallId: part.callID,
+            toolName: part.tool,
+            state: part.state,
+            cwd,
+          }),
+        },
+      })
+    } else {
+      await this.input.connection.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          ...pendingToolCall({
+            toolCallId: part.callID,
+            toolName: part.tool,
+            state: part.state,
+            cwd,
+          }),
+        },
+      })
+    }
   }
 
   private clearTool(toolCallId: string) {
     this.toolStarts.delete(toolCallId)
     this.shellSnapshots.delete(toolCallId)
+  }
+
+  private v2ToolUpdate(update: { content?: ToolCallContent[] | null; toolCallId: string; [key: string]: unknown }) {
+    if (!this.input.isV2?.() || !update.content) return update
+    return { ...update, content: update.content.map(v2DiffContent) }
+  }
+
+  private async emitTerminalUpdate(
+    sessionId: string,
+    part: ToolPart,
+    cwd: string,
+    output: string | undefined,
+    exited: boolean,
+  ) {
+    const input = part.state.input as Record<string, unknown>
+    const command = stringValue(input.command) ?? stringValue(input.cmd) ?? part.tool
+    const terminalUpdate: Record<string, unknown> = {
+      terminalId: part.callID,
+      command,
+      cwd,
+    }
+    if (output !== undefined) {
+      terminalUpdate.output = { data: Buffer.from(output).toString("base64") }
+    }
+    if (exited) {
+      const exitCode = typeof input.exitCode === "number" ? input.exitCode : 0
+      terminalUpdate.exitStatus = { exitCode }
+    }
+    await this.input.connection.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "terminal_update",
+        ...terminalUpdate,
+      },
+    } as unknown as SessionNotification)
   }
 }
 
@@ -436,3 +543,43 @@ function signal() {
 }
 
 export * as ACPEvent from "./event"
+
+function v2DiffContent(content: ToolCallContent): ToolCallContent {
+  if (!("type" in content) || content.type !== "diff") return content
+  const v1Diff = content as unknown as { type: "diff"; path: string; oldText: string; newText: string }
+  if (!v1Diff.path) return content
+
+  const raw = createTwoFilesPatch(v1Diff.path, v1Diff.path, v1Diff.oldText, v1Diff.newText, undefined, undefined, {
+    context: 3,
+  })
+  // Strip Index: and === separator lines, prepend diff --git header for git_patch format
+  const hunks = raw
+    .split("\n")
+    .filter((line) => !line.startsWith("Index: ") && !line.startsWith("======="))
+    .join("\n")
+  const patchText = `diff --git a/${v1Diff.path} b/${v1Diff.path}\n${hunks}`
+
+  return {
+    type: "diff",
+    changes: [
+      {
+        operation: "modify",
+        path: v1Diff.path,
+        fileType: "text",
+      },
+    ],
+    patch: {
+      format: "git_patch",
+      text: patchText,
+    },
+  } as unknown as ToolCallContent
+}
+
+function isShellTool(toolName: string) {
+  const tool = toolName.toLocaleLowerCase()
+  return tool === "bash" || tool === "shell"
+}
+
+function stringValue(value: unknown) {
+  return typeof value === "string" ? value : undefined
+}

--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -15,7 +15,7 @@ import { Effect } from "effect"
 
 type PermissionEvent = Extract<Event, { type: "permission.asked" }>
 type Reply = "once" | "always" | "reject"
-type Connection = Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
+type Connection = Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile" | "sessionUpdate">>
 
 const permissionOptions: PermissionOption[] = [
   { optionId: "once", kind: "allow_once", name: "Allow once" },
@@ -66,6 +66,11 @@ export class Handler {
     })
     const title = permissionTitle(permission.permission, permission.metadata) ?? permission.permission
 
+    // v2: emit requires_action before requesting permission, running after resolution.
+    if (this.input.isV2?.()) {
+      await this.emitStateUpdate(permission.sessionID, "requires_action")
+    }
+
     // v2: title is required, subject is a tagged union (type: tool_call / type: command).
     // v1: bare toolCall field, no title/description separation.
     const params = this.input.isV2?.()
@@ -86,6 +91,10 @@ export class Handler {
       return undefined
     })
 
+    if (this.input.isV2?.()) {
+      await this.emitStateUpdate(permission.sessionID, "running")
+    }
+
     if (!result) return
 
     const reply = selectedReply(result)
@@ -99,6 +108,16 @@ export class Handler {
     }
 
     await this.reply(permission.id, reply, session.cwd)
+  }
+
+  private async emitStateUpdate(sessionId: string, state: "requires_action" | "running") {
+    if (!this.input.connection.sessionUpdate) return
+    await this.input.connection
+      .sessionUpdate({
+        sessionId,
+        update: { sessionUpdate: "state_update", state },
+      } as unknown as Parameters<NonNullable<Connection["sessionUpdate"]>>[0])
+      .catch(() => {})
   }
 
   private async reply(requestID: string, reply: Reply, directory: string) {

--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -31,6 +31,7 @@ export class Handler {
       sdk: OpencodeClient
       connection: Connection
       session: ACPSession.Interface
+      isV2?: () => boolean
     },
   ) {}
 
@@ -58,20 +59,32 @@ export class Handler {
       return
     }
 
-    const result = await this.input.connection
-      .requestPermission({
-        sessionId: permission.sessionID,
-        toolCall: await permissionToolCall({
-          toolCallId: permission.tool?.callID ?? permission.id,
-          toolName: permission.permission,
-          input: permission.metadata,
-        }),
-        options: permissionOptions,
-      })
-      .catch(async () => {
-        await this.reply(permission.id, "reject", session.cwd)
-        return undefined
-      })
+    const toolCall = await permissionToolCall({
+      toolCallId: permission.tool?.callID ?? permission.id,
+      toolName: permission.permission,
+      input: permission.metadata,
+    })
+    const title = permissionTitle(permission.permission, permission.metadata) ?? permission.permission
+
+    // v2: title is required, subject is a tagged union (type: tool_call / type: command).
+    // v1: bare toolCall field, no title/description separation.
+    const params = this.input.isV2?.()
+      ? ({
+          sessionId: permission.sessionID,
+          title,
+          subject: { type: "tool_call", toolCall },
+          options: permissionOptions,
+        } as unknown as Parameters<NonNullable<Connection["requestPermission"]>>[0])
+      : {
+          sessionId: permission.sessionID,
+          toolCall,
+          options: permissionOptions,
+        }
+
+    const result = await this.input.connection.requestPermission(params).catch(async () => {
+      await this.reply(permission.id, "reject", session.cwd)
+      return undefined
+    })
 
     if (!result) return
 

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -52,6 +52,16 @@ export type Error = ACPError.Error
 export type ServiceConnection = Pick<AgentSideConnection, "sessionUpdate"> &
   Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
 
+// SDK 1.3.0 removed the unstable SetSessionModelRequest type. This is an
+// opencode-specific extension method for LLM model selection (distinct from
+// session mode selection). The modelId field carries a provider/model string
+// like "anthropic/claude-3.5-sonnet".
+type SetSessionModelRequest = {
+  sessionId: string
+  modelId: string
+}
+type SetSessionModelResponse = Record<string, never>
+
 export type Interface = {
   readonly initialize: (input: InitializeRequest) => Effect.Effect<InitializeResponse, Error>
   readonly authenticate: (input: AuthenticateRequest) => Effect.Effect<AuthenticateResponse, Error>
@@ -65,7 +75,7 @@ export type Interface = {
     input: SetSessionConfigOptionRequest,
   ) => Effect.Effect<SetSessionConfigOptionResponse, Error>
   readonly setSessionMode: (input: SetSessionModeRequest) => Effect.Effect<SetSessionModeResponse, Error>
-  readonly setSessionModel: (input: SetSessionModeRequest) => Effect.Effect<SetSessionModeResponse, Error>
+  readonly setSessionModel: (input: SetSessionModelRequest) => Effect.Effect<SetSessionModelResponse, Error>
   readonly prompt: (input: PromptRequest) => Effect.Effect<PromptResponse, Error>
   readonly cancel: (input: CancelNotification) => Effect.Effect<void, Error>
   readonly logout: () => Effect.Effect<void, Error>
@@ -544,10 +554,10 @@ export function make(input: {
     return {}
   })
 
-  const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModeRequest) {
+  const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModelRequest) {
     const current = yield* session.get(params.sessionId)
     const snapshot = yield* configSnapshot(current)
-    const selected = yield* parseSelectedModel(snapshot, params.modeId)
+    const selected = yield* parseSelectedModel(snapshot, params.modelId)
     yield* session
       .setVariant(
         params.sessionId,

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -22,6 +22,7 @@ import {
   type ResumeSessionRequest,
   type ResumeSessionResponse,
   type SessionInfo,
+  type SessionNotification,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
   type SetSessionModelRequest,
@@ -79,13 +80,45 @@ export function make(input: {
   session?: ACPSession.Interface
   usage?: UsageService.Interface
   eventSubscription?: (subscription: ACPEvent.Subscription) => void
+  v2?: boolean
 }): Interface {
   const session = input.session ?? makeSessionService()
   const directoryService = input.directory ?? makeDirectoryService(input.sdk)
   const registeredMcp = new Map<string, Set<string>>()
   const sessionSnapshots = new Map<string, Directory.Snapshot>()
+  // v2 is negotiated per-connection in `initialize`: the flag enables it, the client must
+  // request protocolVersion 2. `v2Active` flips true only after a successful v2 handshake,
+  // so the event subscription can start emitting v2 state_update notifications.
+  let v2Active = false
+  const onBusy = Effect.fn("ACP.v2.onBusy")(function* (sessionId: string) {
+    yield* emitV2StateUpdate(input.connection, sessionId, "running")
+  })
+  const onIdle = Effect.fn("ACP.v2.onIdle")(function* (sessionId: string) {
+    const current = yield* session.tryGet(sessionId)
+    if (!current) return
+    yield* sendUsageUpdate(input.usage, input.sdk, input.connection, sessionId, current.cwd)
+    const messages = yield* request(
+      () => input.sdk.session.messages({ sessionID: sessionId, directory: current.cwd }, { throwOnError: true }),
+      "session",
+    ).pipe(
+      Effect.catch(() =>
+        Effect.logError("v2 idle: failed to fetch messages", { sessionId }).pipe(Effect.as(undefined)),
+      ),
+    )
+    const info = messages
+      ? UsageService.latestAssistantMessage(messages as readonly UsageService.SessionMessage[])
+      : undefined
+    yield* emitV2StateUpdate(input.connection, sessionId, "idle", stopReasonForMessage(info))
+  })
   const events = input.connection
-    ? ACPEvent.start({ sdk: input.sdk, connection: input.connection, session })
+    ? ACPEvent.start({
+        sdk: input.sdk,
+        connection: input.connection,
+        session,
+        isV2: () => v2Active,
+        onBusy,
+        onIdle,
+      })
     : undefined
   if (events) input.eventSubscription?.(events)
   const runUntilIdle = <A>(sessionId: string, fn: () => Promise<A>) =>
@@ -99,7 +132,12 @@ export function make(input: {
       id: AuthMethodID,
     }
 
-    if (params.clientCapabilities?._meta?.["terminal-auth"] === true) {
+    // v2 clients send `capabilities` (not `clientCapabilities`); the v1 SDK schema strips it,
+    // so read it back from the raw params to detect the terminal-auth capability in either form.
+    const rawCapabilities = (params as unknown as { capabilities?: { _meta?: Record<string, unknown> } }).capabilities
+    const terminalAuth =
+      params.clientCapabilities?._meta?.["terminal-auth"] === true || rawCapabilities?._meta?.["terminal-auth"] === true
+    if (terminalAuth) {
       authMethod._meta = {
         "terminal-auth": {
           command: "opencode",
@@ -107,6 +145,32 @@ export function make(input: {
           label: "OpenCode Login",
         },
       }
+    }
+
+    if (input.v2 && params.protocolVersion === 2) {
+      v2Active = true
+      const v2AuthMethod = {
+        methodId: AuthMethodID,
+        type: "agent" as const,
+        name: "Login with opencode",
+        description: "Run `opencode auth login` in the terminal",
+        ...(terminalAuth ? { _meta: authMethod._meta } : {}),
+      }
+      const v2Response = {
+        protocolVersion: 2,
+        info: { name: "OpenCode", version: InstallationVersion },
+        capabilities: {
+          session: {
+            prompt: { image: {}, embeddedContext: {} },
+            mcp: { http: {}, stdio: {} },
+            delete: {},
+            additionalDirectories: {},
+          },
+        },
+        authMethods: [v2AuthMethod],
+      }
+      ACPProfile.duration("acp.initialize", started)
+      return v2Response as unknown as InitializeResponse
     }
 
     const response = {
@@ -257,23 +321,19 @@ export function make(input: {
         ),
       "session",
     )
-    const serverEntries = sessions.map(
-      (item): SessionInfo => ({
-        sessionId: item.id,
-        cwd: item.directory,
-        title: item.title,
-        updatedAt: new Date(item.time.updated).toISOString(),
-      }),
-    )
+    const serverEntries = sessions.map((item): SessionInfo => ({
+      sessionId: item.id,
+      cwd: item.directory,
+      title: item.title,
+      updatedAt: new Date(item.time.updated).toISOString(),
+    }))
     const liveEntries = (yield* session.list(params.cwd ?? undefined))
       .filter((item) => !serverEntries.some((entry) => entry.sessionId === item.id))
-      .map(
-        (item): SessionInfo => ({
-          sessionId: item.id,
-          cwd: item.cwd,
-          updatedAt: item.createdAt.toISOString(),
-        }),
-      )
+      .map((item): SessionInfo => ({
+        sessionId: item.id,
+        cwd: item.cwd,
+        updatedAt: item.createdAt.toISOString(),
+      }))
     const sorted = [...liveEntries, ...serverEntries].toSorted(
       (a, b) => new Date(b.updatedAt ?? 0).getTime() - new Date(a.updatedAt ?? 0).getTime(),
     )
@@ -504,6 +564,34 @@ export function make(input: {
       const command = detectSlashCommand(parts)
 
       if (!command) {
+        if (v2Active) {
+          // v2 prompt lifecycle: admit non-blocking via prompt_async and acknowledge
+          // immediately with `{}`. The event subscription drives foreground state:
+          // state_update running on busy, idle + stopReason on idle. A second
+          // session/prompt arriving while a turn is still running admits another
+          // input, which opencode steers by default at the next safe boundary.
+          const messageId = params.messageId ?? crypto.randomUUID()
+          yield* request(
+            () =>
+              input.sdk.session.promptAsync(
+                {
+                  sessionID: current.id,
+                  model: { providerID: selected.providerID, modelID: selected.modelID },
+                  ...(variant ? { variant } : {}),
+                  parts,
+                  ...(modeId ? { agent: modeId } : {}),
+                  directory: current.cwd,
+                  messageID: messageId,
+                },
+                { throwOnError: true },
+              ),
+            "session",
+          ).pipe(Effect.asVoid)
+          yield* emitV2UserMessage(input.connection, current.id, messageId, params.prompt)
+          yield* emitV2StateUpdate(input.connection, current.id, "running")
+          return {} as unknown as PromptResponse
+        }
+
         const response = yield* request(
           () =>
             runUntilIdle(current.id, () =>
@@ -875,6 +963,58 @@ const promptResponse = Effect.fn("ACP.promptResponse")(function* (
 function promptErrorMessage(error: AssistantError) {
   if ("message" in error.data && typeof error.data.message === "string") return error.data.message
   return "OpenCode prompt failed"
+}
+
+// --- ACP v2 prompt-lifecycle helpers -------------------------------------------
+
+type V2StopReason = "end_turn" | "max_tokens" | "max_turn_requests" | "refusal" | "cancelled"
+
+// v2 cannot fail the prompt response post-acceptance, so auth/service errors that v1
+// surfaces as request errors collapse to end_turn here. The common stop reasons
+// (cancelled / max_tokens / refusal) are still derived from the assistant message error.
+function stopReasonForMessage(info: AssistantInfo): V2StopReason {
+  if (!info?.error) return "end_turn"
+  if (info.error.name === "MessageAbortedError") return "cancelled"
+  if (info.error.name === "MessageOutputLengthError") return "max_tokens"
+  if (info.error.name === "ContentFilterError") return "refusal"
+  return "end_turn"
+}
+
+// The v2 state_update / user_message variants are not in the SDK 0.21 (v1) SessionUpdate
+// union, so they are cast at the wire boundary. The constructed payloads are valid v2
+// session/update notifications; only the TypeScript type is widened through `unknown`.
+function emitV2StateUpdate(
+  connection: ServiceConnection | undefined,
+  sessionId: string,
+  state: "running" | "idle",
+  stopReason?: V2StopReason,
+) {
+  if (!connection) return Effect.void
+  return Effect.promise(() =>
+    connection
+      .sessionUpdate({
+        sessionId,
+        update: { sessionUpdate: "state_update", state, ...(stopReason ? { stopReason } : {}) },
+      } as unknown as SessionNotification)
+      .then(() => {}),
+  )
+}
+
+function emitV2UserMessage(
+  connection: ServiceConnection | undefined,
+  sessionId: string,
+  messageId: string,
+  content: readonly unknown[],
+) {
+  if (!connection) return Effect.void
+  return Effect.promise(() =>
+    connection
+      .sessionUpdate({
+        sessionId,
+        update: { sessionUpdate: "user_message", messageId, content },
+      } as unknown as SessionNotification)
+      .then(() => {}),
+  )
 }
 
 function sendUsageUpdate(

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -96,11 +96,17 @@ export function make(input: {
   const directoryService = input.directory ?? makeDirectoryService(input.sdk)
   const registeredMcp = new Map<string, Set<string>>()
   const sessionSnapshots = new Map<string, Directory.Snapshot>()
-  // v2 is negotiated per-connection in `initialize`: the flag enables it, the client must
-  // request protocolVersion 2. `v2Active` flips true only after a successful v2 handshake,
-  // so the event subscription can start emitting v2 state_update notifications.
+  // ACP over stdio is inherently single-connection-per-process: the CLI's
+  // ndJsonStream binds one stdin/stdout pair to one router.connect() call.
+  // `v2Active` is therefore connection-scoped in practice. If multi-connection
+  // transport (e.g. WebSocket) is added, this must be keyed by connection ID.
   let v2Active = false
+  // Track sessions that already have a running state_update so onBusy doesn't
+  // emit a duplicate after the eager emission on prompt acceptance.
+  const v2Running = new Set<string>()
   const onBusy = Effect.fn("ACP.v2.onBusy")(function* (sessionId: string) {
+    if (v2Running.has(sessionId)) return
+    v2Running.add(sessionId)
     yield* emitV2StateUpdate(input.connection, sessionId, "running")
   })
   const onIdle = Effect.fn("ACP.v2.onIdle")(function* (sessionId: string) {
@@ -119,6 +125,7 @@ export function make(input: {
       ? UsageService.latestAssistantMessage(messages as readonly UsageService.SessionMessage[])
       : undefined
     yield* emitV2StateUpdate(input.connection, sessionId, "idle", stopReasonForMessage(info))
+    v2Running.delete(sessionId)
   })
   const events = input.connection
     ? ACPEvent.start({
@@ -374,6 +381,8 @@ export function make(input: {
     )
     // v2 adds `replayFrom` — when present, replay conversation history as session/update
     // notifications before returning. The v1 SDK type doesn't have this field.
+    // When replaying, no limit is set so the full conversation is fetched.
+    // TODO: add a cap or pagination for very long sessions.
     const replayFrom = (params as unknown as { replayFrom?: { type: string } | null }).replayFrom
     const wantsReplay = replayFrom != null
     const messages = yield* request(
@@ -618,6 +627,7 @@ export function make(input: {
             "session",
           ).pipe(Effect.asVoid)
           yield* emitV2UserMessage(input.connection, current.id, messageId, params.prompt)
+          v2Running.add(current.id)
           yield* emitV2StateUpdate(input.connection, current.id, "running")
           return {} as unknown as PromptResponse
         }
@@ -1140,6 +1150,7 @@ function registerMcpServers(
   return Effect.all(
     servers
       .map((server) => ({ server, config: mcpConfig(server) }))
+      .filter((entry) => entry.config !== undefined)
       .filter((entry) => {
         const key = mcpRegistrationKey(entry.server.name, entry.config)
         if (current.has(key) || pending.has(key)) return false

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -381,18 +381,18 @@ export function make(input: {
     )
     // v2 adds `replayFrom` — when present, replay conversation history as session/update
     // notifications before returning. The v1 SDK type doesn't have this field.
-    // When replaying, no limit is set so the full conversation is fetched.
-    // TODO: add a cap or pagination for very long sessions.
     const replayFrom = (params as unknown as { replayFrom?: { type: string } | null }).replayFrom
     const wantsReplay = replayFrom != null
-    const messages = yield* request(
-      () =>
-        input.sdk.session.messages(
-          { directory: params.cwd, sessionID: params.sessionId, ...(wantsReplay ? {} : { limit: 20 }) },
-          { throwOnError: true },
-        ),
-      "session",
-    )
+    const messages = wantsReplay
+      ? yield* fetchAllMessages(input.sdk, params.cwd, params.sessionId)
+      : yield* request(
+          () =>
+            input.sdk.session.messages(
+              { directory: params.cwd, sessionID: params.sessionId, limit: 20 },
+              { throwOnError: true },
+            ),
+          "session",
+        )
     const restored = restoreFromMessages(messages.map((item) => item.info))
     const model = restored.model ?? selectDefaultModel(snapshot)
     const state = yield* session.load({
@@ -809,6 +809,31 @@ function replayMessages(subscription: ACPEvent.Subscription | undefined, message
     for (const message of messages) {
       await subscription.replayMessage(message).catch(() => {})
     }
+  })
+}
+
+const REPLAY_PAGE_SIZE = 50
+
+function fetchAllMessages(sdk: OpencodeClient, directory: string, sessionId: string) {
+  return Effect.gen(function* () {
+    const all: SessionMessageResponse[] = []
+    let before: string | undefined
+    while (true) {
+      const response = yield* Effect.tryPromise({
+        try: () =>
+          sdk.session.messages(
+            { directory, sessionID: sessionId, limit: REPLAY_PAGE_SIZE, ...(before ? { before } : {}) },
+            { throwOnError: true },
+          ),
+        catch: (error) => fromUnknownError(error, "session"),
+      })
+      const result = response as unknown as { data: SessionMessageResponse[]; cursor?: { next?: string } }
+      const page = result.data ?? (result as unknown as SessionMessageResponse[])
+      all.push(...page)
+      before = result.cursor?.next
+      if (!before || page.length < REPLAY_PAGE_SIZE) break
+    }
+    return all
   })
 }
 

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -25,8 +25,6 @@ import {
   type SessionNotification,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
-  type SetSessionModelRequest,
-  type SetSessionModelResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
 } from "@agentclientprotocol/sdk"
@@ -35,13 +33,14 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import type { AssistantMessage, Message, OpencodeClient, SessionMessageResponse } from "@opencode-ai/sdk/v2"
 import { Context, Effect, Layer, ManagedRuntime } from "effect"
 import * as ACPError from "./error"
-import { buildConfigOptions, parseModelSelection } from "./config-option"
+import { buildConfigOptions, parseModelSelection, toV2ConfigOptions } from "./config-option"
 import { promptContentToParts } from "./content"
 import { Directory } from "./directory"
 import { ACPEvent } from "./event"
 import { ACPSession } from "./session"
 import { UsageService } from "./usage"
 import { ACPProfile } from "./profile"
+import { Identifier } from "@/id/id"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { Provider } from "@/provider/provider"
@@ -50,7 +49,7 @@ import type { Command } from "@/command"
 export const AuthMethodID = "opencode-login"
 
 export type Error = ACPError.Error
-type ServiceConnection = Pick<AgentSideConnection, "sessionUpdate"> &
+export type ServiceConnection = Pick<AgentSideConnection, "sessionUpdate"> &
   Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
 
 export type Interface = {
@@ -66,9 +65,10 @@ export type Interface = {
     input: SetSessionConfigOptionRequest,
   ) => Effect.Effect<SetSessionConfigOptionResponse, Error>
   readonly setSessionMode: (input: SetSessionModeRequest) => Effect.Effect<SetSessionModeResponse, Error>
-  readonly setSessionModel: (input: SetSessionModelRequest) => Effect.Effect<SetSessionModelResponse, Error>
+  readonly setSessionModel: (input: SetSessionModeRequest) => Effect.Effect<SetSessionModeResponse, Error>
   readonly prompt: (input: PromptRequest) => Effect.Effect<PromptResponse, Error>
   readonly cancel: (input: CancelNotification) => Effect.Effect<void, Error>
+  readonly logout: () => Effect.Effect<void, Error>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ACP/Service") {}
@@ -123,6 +123,13 @@ export function make(input: {
   if (events) input.eventSubscription?.(events)
   const runUntilIdle = <A>(sessionId: string, fn: () => Promise<A>) =>
     events ? events.runUntilIdle(sessionId, fn) : fn()
+
+  // v2 renames config option `id` to `configId`. Applied at the boundary so
+  // internal code keeps using the v1 field name.
+  const responseConfigOptions = (snapshot: Directory.Snapshot, state: ConfigState) => {
+    const options = configOptions(snapshot, state)
+    return v2Active ? toV2ConfigOptions(options) : options
+  }
 
   const initialize = Effect.fn("ACP.initialize")(function* (params: InitializeRequest) {
     const started = performance.now()
@@ -262,7 +269,7 @@ export function make(input: {
 
     const response = {
       sessionId: state.id,
-      configOptions: configOptions(snapshot, {
+      configOptions: responseConfigOptions(snapshot, {
         model: state.model ?? selected,
         variant: state.variant,
         modeId: state.modeId,
@@ -299,7 +306,7 @@ export function make(input: {
     yield* replayMessages(events, messages)
 
     return {
-      configOptions: configOptions(snapshot, {
+      configOptions: responseConfigOptions(snapshot, {
         model: state.model ?? model,
         variant: state.variant,
         modeId: state.modeId,
@@ -355,10 +362,14 @@ export function make(input: {
       () => input.sdk.session.get({ directory: params.cwd, sessionID: params.sessionId }, { throwOnError: true }),
       "session",
     )
+    // v2 adds `replayFrom` — when present, replay conversation history as session/update
+    // notifications before returning. The v1 SDK type doesn't have this field.
+    const replayFrom = (params as unknown as { replayFrom?: { type: string } | null }).replayFrom
+    const wantsReplay = replayFrom != null
     const messages = yield* request(
       () =>
         input.sdk.session.messages(
-          { directory: params.cwd, sessionID: params.sessionId, limit: 20 },
+          { directory: params.cwd, sessionID: params.sessionId, ...(wantsReplay ? {} : { limit: 20 }) },
           { throwOnError: true },
         ),
       "session",
@@ -378,8 +389,10 @@ export function make(input: {
     yield* registerMcpServers(input.sdk, registeredMcp, params.cwd, state.id, params.mcpServers ?? [])
     yield* sendAvailableCommands(input.connection, state.id, snapshot)
 
+    if (wantsReplay) yield* replayMessages(events, messages)
+
     return {
-      configOptions: configOptions(snapshot, {
+      configOptions: responseConfigOptions(snapshot, {
         model: state.model ?? model,
         variant: state.variant,
         modeId: state.modeId,
@@ -411,6 +424,13 @@ export function make(input: {
   const cancel = Effect.fn("ACP.cancel")(function* (params: CancelNotification) {
     const current = yield* session.get(params.sessionId)
     yield* abortBackingSession(current)
+  })
+
+  const logout = Effect.fn("ACP.logout")(function* () {
+    // opencode doesn't have a server-side logout endpoint; auth is stateless.
+    // The method exists to satisfy the v2 spec requirement that agents with
+    // authMethods MUST implement auth/logout.
+    return {}
   })
 
   const forkSession = Effect.fn("ACP.forkSession")(function* (params: ForkSessionRequest) {
@@ -449,7 +469,7 @@ export function make(input: {
 
     return {
       sessionId: state.id,
-      configOptions: configOptions(snapshot, {
+      configOptions: responseConfigOptions(snapshot, {
         model: state.model ?? model,
         variant: state.variant,
         modeId: state.modeId,
@@ -473,7 +493,7 @@ export function make(input: {
         .setVariant(params.sessionId, Directory.variants(snapshot, selected.model) ? variant : undefined)
         .pipe(Effect.andThen(session.setModel(params.sessionId, selected.model)))
       return {
-        configOptions: configOptions(snapshot, {
+        configOptions: responseConfigOptions(snapshot, {
           model: state.model ?? selected.model,
           variant: state.variant,
           modeId: state.modeId,
@@ -489,7 +509,7 @@ export function make(input: {
       }
       const state = yield* session.setVariant(params.sessionId, params.value)
       return {
-        configOptions: configOptions(snapshot, {
+        configOptions: responseConfigOptions(snapshot, {
           model: state.model ?? model,
           variant: state.variant,
           modeId: state.modeId,
@@ -503,7 +523,7 @@ export function make(input: {
       }
       const state = yield* session.setMode(params.sessionId, params.value)
       return {
-        configOptions: configOptions(snapshot, {
+        configOptions: responseConfigOptions(snapshot, {
           model: state.model ?? selectDefaultModel(snapshot),
           variant: state.variant,
           modeId: state.modeId,
@@ -524,10 +544,10 @@ export function make(input: {
     return {}
   })
 
-  const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModelRequest) {
+  const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModeRequest) {
     const current = yield* session.get(params.sessionId)
     const snapshot = yield* configSnapshot(current)
-    const selected = yield* parseSelectedModel(snapshot, params.modelId)
+    const selected = yield* parseSelectedModel(snapshot, params.modeId)
     yield* session
       .setVariant(
         params.sessionId,
@@ -570,7 +590,7 @@ export function make(input: {
           // state_update running on busy, idle + stopReason on idle. A second
           // session/prompt arriving while a turn is still running admits another
           // input, which opencode steers by default at the next safe boundary.
-          const messageId = params.messageId ?? crypto.randomUUID()
+          const messageId = (params as unknown as { messageId?: string }).messageId ?? Identifier.ascending("message")
           yield* request(
             () =>
               input.sdk.session.promptAsync(
@@ -613,7 +633,7 @@ export function make(input: {
           "session",
         )
         yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        return yield* promptResponse(response.info, undefined)
       }
 
       const known = snapshot.availableCommands.find((item) => item.name === command.name)
@@ -637,7 +657,7 @@ export function make(input: {
           "session",
         )
         yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        return yield* promptResponse(response.info, undefined)
       }
 
       if (command.name === "compact") {
@@ -659,9 +679,10 @@ export function make(input: {
       }
 
       yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-      return yield* promptResponse(undefined, params.messageId)
+      return yield* promptResponse(undefined, undefined)
     }),
     cancel,
+    logout,
   }
 }
 
@@ -911,20 +932,18 @@ function detectSlashCommand(parts: ReturnType<typeof promptContentToParts>) {
 
 const promptResponse = Effect.fn("ACP.promptResponse")(function* (
   info: AssistantInfo,
-  messageId: string | null | undefined,
+  _messageId: string | null | undefined,
 ) {
   if (!info?.error) {
     return {
       stopReason: "end_turn" as const,
       ...(info ? { usage: UsageService.buildUsage(info) } : {}),
-      ...(messageId ? { userMessageId: messageId } : {}),
       _meta: {},
     }
   }
 
   const base = {
     usage: UsageService.buildUsage(info),
-    ...(messageId ? { userMessageId: messageId } : {}),
     _meta: {},
   }
 
@@ -1088,6 +1107,7 @@ function sendAvailableCommands(
           availableCommands: snapshot.availableCommands.map((command) => ({
             name: command.name,
             description: command.description ?? "",
+            ...(command.hints.length > 0 ? { input: { type: "text", hint: command.hints[0] } } : {}),
           })),
         },
       })
@@ -1151,17 +1171,25 @@ function mcpRegistrationKey(name: string, config: ReturnType<typeof mcpConfig>) 
 }
 
 function mcpConfig(server: McpServer) {
-  if ("type" in server) {
+  if (!("type" in server)) {
+    // McpServerStdio has no type discriminator
     return {
-      type: "remote" as const,
-      url: server.url,
-      headers: Object.fromEntries(server.headers.map((header) => [header.name, header.value])),
+      type: "local" as const,
+      command: [server.command, ...server.args],
+      environment: Object.fromEntries(server.env.map((entry) => [entry.name, entry.value])),
     }
   }
-  return {
-    type: "local" as const,
-    command: [server.command, ...server.args],
-    environment: Object.fromEntries(server.env.map((entry) => [entry.name, entry.value])),
+  switch (server.type) {
+    case "http":
+    case "sse":
+      return {
+        type: "remote" as const,
+        url: server.url,
+        headers: Object.fromEntries(server.headers.map((header) => [header.name, header.value])),
+      }
+    case "acp":
+      // ACP-transport MCP servers are managed by the client; skip server-side registration.
+      return undefined
   }
 }
 

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { effectCmd } from "../effect-cmd"
-import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
+import { ndJsonStream } from "@agentclientprotocol/sdk/experimental/v2"
 import { ServerAuth } from "@/server/auth"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
@@ -55,12 +55,9 @@ export const AcpCommand = effectCmd({
     })
 
     const stream = ndJsonStream(input, output)
-    const agent = ACP.init({ sdk, v2: flags.experimentalAcpV2 })
-
-    new AgentSideConnection((conn) => {
-      ACPProfile.mark("cli.acp.connection.create")
-      return agent.create(conn)
-    }, stream)
+    const router = yield* Effect.promise(() => ACP.createRouter(sdk, flags.experimentalAcpV2))
+    ACPProfile.mark("cli.acp.connection.create")
+    router.connect(stream)
 
     yield* Effect.logInfo("setup connection")
     process.stdin.resume()

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -5,6 +5,7 @@ import { ServerAuth } from "@/server/auth"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { ACPProfile } from "@/acp/profile"
+import { RuntimeFlags } from "@/effect/runtime-flags"
 
 export const AcpCommand = effectCmd({
   command: "acp",
@@ -19,6 +20,7 @@ export const AcpCommand = effectCmd({
   handler: Effect.fn("Cli.acp")(function* (args) {
     const { Server } = yield* Effect.promise(() => import("@/server/server"))
     const { ACP } = yield* Effect.promise(() => import("@/acp/agent"))
+    const flags = yield* RuntimeFlags.Service
     ACPProfile.mark("cli.acp.handler")
     process.env.OPENCODE_CLIENT = "acp"
     const opts = yield* resolveNetworkOptions(args)
@@ -53,7 +55,7 @@ export const AcpCommand = effectCmd({
     })
 
     const stream = ndJsonStream(input, output)
-    const agent = ACP.init({ sdk })
+    const agent = ACP.init({ sdk, v2: flags.experimentalAcpV2 })
 
     new AgentSideConnection((conn) => {
       ACPProfile.mark("cli.acp.connection.create")

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -41,6 +41,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   enableQuestionTool: bool("OPENCODE_ENABLE_QUESTION_TOOL"),
   experimentalReferences: enabledByExperimental("OPENCODE_EXPERIMENTAL_REFERENCES"),
   experimentalBackgroundSubagents: enabledByExperimental("OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS"),
+  experimentalAcpV2: enabledByExperimental("OPENCODE_EXPERIMENTAL_ACP_V2"),
   experimentalLspTy: bool("OPENCODE_EXPERIMENTAL_LSP_TY"),
   experimentalLspTool: enabledByExperimental("OPENCODE_EXPERIMENTAL_LSP_TOOL"),
   experimentalOxfmt: enabledByExperimental("OPENCODE_EXPERIMENTAL_OXFMT"),

--- a/packages/opencode/test/acp/event-v2.test.ts
+++ b/packages/opencode/test/acp/event-v2.test.ts
@@ -292,3 +292,64 @@ describe("acp v2 event routing", () => {
     expect(terminalUpdates).toHaveLength(0)
   })
 })
+
+describe("acp v2 content blocks and extensibility", () => {
+  it("preserves _meta on resource_link content chunks output", async () => {
+    const { partToContentChunks } = await import("@/acp/content")
+    const chunks = partToContentChunks({
+      type: "file",
+      url: "file:///workspace/file.ts",
+      mime: "text/typescript",
+      filename: "file.ts",
+      _meta: { custom: "data" },
+    })
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]._meta).toEqual({ custom: "data" })
+  })
+
+  it("preserves _meta on text content chunks output", async () => {
+    const { partToContentChunks } = await import("@/acp/content")
+    const chunks = partToContentChunks({
+      type: "text",
+      text: "hello",
+      _meta: { source: "test" },
+    })
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]._meta).toEqual({ source: "test" })
+  })
+
+  it("renders unknown content block types as text fallback when _meta is present", async () => {
+    const { contentBlockToParts } = await import("@/acp/content")
+    const parts = contentBlockToParts({
+      type: "_custom_block",
+      data: "custom data",
+      _meta: { extension: "mycompany" },
+    } as unknown as import("@agentclientprotocol/sdk").ContentBlock)
+    expect(parts).toHaveLength(1)
+    expect(parts[0].type).toBe("text")
+    expect((parts[0] as { text?: string }).text).toContain("_custom_block")
+  })
+
+  it("drops unknown content block types without _meta silently", async () => {
+    const { contentBlockToParts } = await import("@/acp/content")
+    const parts = contentBlockToParts({
+      type: "_custom_block",
+      data: "custom data",
+    } as unknown as import("@agentclientprotocol/sdk").ContentBlock)
+    expect(parts).toHaveLength(0)
+  })
+
+  it("preserves _meta from incoming resource_link as metadata on text parts", async () => {
+    const { contentBlockToParts } = await import("@/acp/content")
+    const parts = contentBlockToParts({
+      type: "resource_link",
+      uri: "https://example.com/doc",
+      name: "doc",
+      _meta: { origin: "client" },
+    } as unknown as import("@agentclientprotocol/sdk").ContentBlock)
+    expect(parts).toHaveLength(1)
+    expect(parts[0].type).toBe("text")
+    // _meta should be preserved in the metadata field of the text part
+    expect((parts[0] as { metadata?: { _meta?: unknown } }).metadata?._meta).toEqual({ origin: "client" })
+  })
+})

--- a/packages/opencode/test/acp/event-v2.test.ts
+++ b/packages/opencode/test/acp/event-v2.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "bun:test"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import type { Event, OpencodeClient, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
+import { Effect, ManagedRuntime } from "effect"
+import { ACPEvent } from "@/acp/event"
+import { ACPSession } from "@/acp/session"
+
+type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
+type GlobalEventEnvelope = { payload?: Event }
+
+function makeSessionService() {
+  return ManagedRuntime.make(LayerNode.compile(ACPSession.node)).runSync(
+    ACPSession.Service.use((service) => Effect.succeed(service)),
+  )
+}
+
+function createEventStream() {
+  const queue: GlobalEventEnvelope[] = []
+  const waiters: Array<(value: GlobalEventEnvelope | undefined) => void> = []
+  const state = { closed: false }
+
+  const push = (event: GlobalEventEnvelope) => {
+    const waiter = waiters.shift()
+    if (waiter) {
+      waiter(event)
+      return
+    }
+    queue.push(event)
+  }
+
+  const close = () => {
+    state.closed = true
+    for (const waiter of waiters.splice(0)) {
+      waiter(undefined)
+    }
+  }
+
+  const stream = async function* (signal?: AbortSignal) {
+    while (true) {
+      if (signal?.aborted) return
+      const next = queue.shift()
+      if (next) {
+        yield next
+        continue
+      }
+      if (state.closed) return
+      const value = await new Promise<GlobalEventEnvelope | undefined>((resolve) => {
+        waiters.push(resolve)
+        signal?.addEventListener("abort", () => resolve(undefined), { once: true })
+      })
+      if (!value) return
+      yield value
+    }
+  }
+
+  return { push, close, stream }
+}
+
+function createHarness(messages: Record<string, SessionMessageResponse> = {}, options: { v2?: boolean } = {}) {
+  const updates: SessionUpdateParams[] = []
+  const events = createEventStream()
+  const sdk = {
+    global: {
+      event: (opts?: { signal?: AbortSignal }) => Promise.resolve({ stream: events.stream(opts?.signal) }),
+    },
+    session: {
+      message: (input: { messageID: string }) => Promise.resolve({ data: messages[input.messageID] }),
+      get: () => Promise.resolve({ data: { id: "ses_loaded" } }),
+      messages: () => Promise.resolve({ data: [] }),
+    },
+  } as unknown as OpencodeClient
+  const connection = {
+    sessionUpdate: (params: SessionUpdateParams) => {
+      updates.push(params)
+      return Promise.resolve()
+    },
+  } satisfies Pick<AgentSideConnection, "sessionUpdate">
+  const session = makeSessionService()
+  const subscription = new ACPEvent.Subscription({
+    sdk,
+    connection,
+    session,
+    ...(options.v2 ? { isV2: () => true } : {}),
+  })
+
+  return { connection, events, sdk, session, subscription, updates }
+}
+
+function toolUpdated(part: ToolPart): Event {
+  return {
+    id: `evt_${part.sessionID}_${part.messageID}_${part.id}_${part.state.status}`,
+    type: "message.part.updated",
+    properties: {
+      sessionID: part.sessionID,
+      time: Date.now(),
+      part,
+    },
+  }
+}
+
+function runningTool(
+  sessionID: string,
+  callID: string,
+  output?: string,
+  input: Record<string, unknown> = { cmd: "printf hello" },
+) {
+  return {
+    id: `part_${callID}`,
+    sessionID,
+    messageID: `msg_${callID}`,
+    type: "tool",
+    callID,
+    tool: "bash",
+    state: {
+      status: "running",
+      input,
+      title: "bash",
+      ...(output !== undefined ? { metadata: { output } } : {}),
+      time: { start: Date.now() },
+    },
+  } satisfies ToolPart
+}
+
+function completedEditTool(sessionID: string, callID: string, filePath: string, oldText: string, newText: string) {
+  return {
+    id: `part_${callID}`,
+    sessionID,
+    messageID: `msg_${callID}`,
+    type: "tool",
+    callID,
+    tool: "edit",
+    state: {
+      status: "completed",
+      input: { filePath, oldString: oldText, newString: newText },
+      output: "edited",
+      title: "edit",
+      metadata: {},
+      time: { start: Date.now() - 1, end: Date.now() },
+    },
+  } satisfies ToolPart
+}
+
+function completedBashTool(sessionID: string, callID: string, output = "done") {
+  return {
+    id: `part_${callID}`,
+    sessionID,
+    messageID: `msg_${callID}`,
+    type: "tool",
+    callID,
+    tool: "bash",
+    state: {
+      status: "completed",
+      input: { cmd: "echo done" },
+      output,
+      title: "bash",
+      metadata: { exit: 0 },
+      time: { start: Date.now() - 1, end: Date.now() },
+    },
+  } satisfies ToolPart
+}
+
+const updateName = (u: SessionUpdateParams) => (u.update as unknown as { sessionUpdate: string }).sessionUpdate
+
+describe("acp v2 event routing", () => {
+  it("emits tool_call_update (not tool_call) for creation in v2 mode", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_tool", cwd: "/workspace" }))
+
+    await harness.subscription.handle(toolUpdated(runningTool("ses_v2_tool", "call_v2_1")))
+
+    const toolUpdates = harness.updates.filter(
+      (u) => updateName(u) === "tool_call" || updateName(u) === "tool_call_update",
+    )
+    expect(toolUpdates.every((u) => updateName(u) === "tool_call_update")).toBe(true)
+    expect(toolUpdates.some((u) => updateName(u) === "tool_call")).toBe(false)
+  })
+
+  it("converts v1 diff content to v2 structured diff with changes and git_patch", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_diff", cwd: "/workspace" }))
+
+    await harness.subscription.handle(
+      toolUpdated(completedEditTool("ses_v2_diff", "call_diff", "/workspace/file.ts", "old line", "new line")),
+    )
+
+    const completedUpdate = harness.updates.find(
+      (u) => updateName(u) === "tool_call_update" && "status" in u.update && u.update.status === "completed",
+    )
+    expect(completedUpdate).toBeDefined()
+
+    const content = (completedUpdate!.update as { content?: Array<Record<string, unknown>> }).content
+    const diffContent = content?.find((c) => c.type === "diff")
+    expect(diffContent).toBeDefined()
+    expect(diffContent!.changes).toBeDefined()
+    expect((diffContent!.changes as unknown[])[0]).toMatchObject({
+      operation: "modify",
+      path: "/workspace/file.ts",
+      fileType: "text",
+    })
+    expect(diffContent!.patch).toBeDefined()
+    expect((diffContent!.patch as { format: string }).format).toBe("git_patch")
+    expect((diffContent!.patch as { text: string }).text).toContain("diff --git")
+    expect((diffContent!.patch as { text: string }).text).toContain("-old line")
+    expect((diffContent!.patch as { text: string }).text).toContain("+new line")
+  })
+
+  it("emits terminal_update for bash tools in v2 mode", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_term", cwd: "/workspace" }))
+
+    await harness.subscription.handle(toolUpdated(runningTool("ses_v2_term", "call_term", "hello output")))
+
+    const terminalUpdates = harness.updates.filter((u) => updateName(u) === "terminal_update")
+    expect(terminalUpdates).toHaveLength(1)
+    expect(terminalUpdates[0].update).toMatchObject({
+      terminalId: "call_term",
+      command: "printf hello",
+      cwd: "/workspace",
+    })
+    const output = (terminalUpdates[0].update as { output?: { data: string } }).output
+    expect(output).toBeDefined()
+    expect(Buffer.from(output!.data, "base64").toString()).toBe("hello output")
+  })
+
+  it("emits terminal_update with exitStatus on completed bash tools in v2 mode", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_term_done", cwd: "/workspace" }))
+
+    await harness.subscription.handle(toolUpdated(completedBashTool("ses_v2_term_done", "call_term_done", "all done")))
+
+    const terminalUpdates = harness.updates.filter((u) => updateName(u) === "terminal_update")
+    expect(terminalUpdates).toHaveLength(1)
+    expect(terminalUpdates[0].update).toMatchObject({
+      terminalId: "call_term_done",
+      command: "echo done",
+    })
+    const exitStatus = (terminalUpdates[0].update as { exitStatus?: { exitCode?: number } }).exitStatus
+    expect(exitStatus).toBeDefined()
+    expect(exitStatus!.exitCode).toBe(0)
+  })
+
+  it("emits plan_update (not plan) for todo.updated events in v2 mode", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_plan", cwd: "/workspace" }))
+
+    await harness.subscription.handle({
+      id: "evt_todo",
+      type: "todo.updated",
+      properties: {
+        sessionID: "ses_v2_plan",
+        todos: [
+          { content: "Task 1", status: "in_progress", priority: "high" },
+          { content: "Task 2", status: "pending", priority: "low" },
+        ],
+      },
+    } as unknown as Event)
+
+    const planUpdates = harness.updates.filter((u) => updateName(u) === "plan_update")
+    expect(planUpdates).toHaveLength(1)
+    const plan = (planUpdates[0].update as { plan: { type: string; planId: string; entries: unknown[] } }).plan
+    expect(plan.type).toBe("items")
+    expect(plan.planId).toBe("default")
+    expect(plan.entries).toHaveLength(2)
+
+    const v1PlanUpdates = harness.updates.filter((u) => updateName(u) === "plan")
+    expect(v1PlanUpdates).toHaveLength(0)
+  })
+
+  it("does not emit terminal_update for non-shell tools in v2 mode", async () => {
+    const harness = createHarness({}, { v2: true })
+    await Effect.runPromise(harness.session.create({ id: "ses_v2_no_term", cwd: "/workspace" }))
+
+    const editPart: ToolPart = {
+      id: "part_edit",
+      sessionID: "ses_v2_no_term",
+      messageID: "msg_edit",
+      type: "tool",
+      callID: "call_edit",
+      tool: "edit",
+      state: {
+        status: "running",
+        input: { filePath: "/workspace/file.ts" },
+        title: "Edit file",
+        time: { start: Date.now() },
+      },
+    }
+
+    await harness.subscription.handle(toolUpdated(editPart))
+
+    const terminalUpdates = harness.updates.filter((u) => updateName(u) === "terminal_update")
+    expect(terminalUpdates).toHaveLength(0)
+  })
+})

--- a/packages/opencode/test/acp/permission.test.ts
+++ b/packages/opencode/test/acp/permission.test.ts
@@ -46,6 +46,7 @@ function makeSessionService() {
 function createHarness(
   requestPermission: (params: RequestPermissionRequest) => Promise<RequestPermissionResponse> = () =>
     Promise.resolve({ outcome: { outcome: "selected", optionId: "once" } }),
+  options: { v2?: boolean } = {},
 ) {
   const replies: PermissionReplyParams[] = []
   const requests: RequestPermissionRequest[] = []
@@ -72,7 +73,12 @@ function createHarness(
       return Promise.resolve()
     },
   } satisfies Pick<AgentSideConnection, "requestPermission" | "sessionUpdate">
-  const subscription = new ACPEvent.Subscription({ sdk, connection, session })
+  const subscription = new ACPEvent.Subscription({
+    sdk,
+    connection,
+    session,
+    ...(options.v2 ? { isV2: () => true } : {}),
+  })
 
   return { connection, replies, requests, sdk, session, subscription, updates }
 }
@@ -397,5 +403,58 @@ describe("acp permissions", () => {
       ["perm_1", "once"],
       ["perm_2", "always"],
     ])
+  })
+})
+
+describe("acp v2 permissions", () => {
+  it("emits requires_action before permission request and running after resolution", async () => {
+    const harness = createHarness(undefined, { v2: true })
+    await createSession(harness.session, "ses_v2_perm")
+
+    harness.subscription.handle(permissionAsked("ses_v2_perm", "perm_v2_1"))
+
+    await pollUntil(() => harness.replies.length === 1, "v2 permission was never replied")
+
+    const stateUpdates = harness.updates
+      .map((u) => u.update as unknown as { sessionUpdate: string; state?: string })
+      .filter((u) => u.sessionUpdate === "state_update")
+
+    // Should have requires_action (before) and running (after)
+    expect(stateUpdates.map((u) => u.state)).toEqual(["requires_action", "running"])
+  })
+
+  it("emits requires_action even when permission is rejected", async () => {
+    const harness = createHarness(() => Promise.resolve({ outcome: { outcome: "cancelled" } }), { v2: true })
+    await createSession(harness.session, "ses_v2_reject")
+
+    harness.subscription.handle(permissionAsked("ses_v2_reject", "perm_v2_rej"))
+
+    await pollUntil(() => harness.replies.length === 1, "v2 rejected permission was never replied")
+
+    const stateUpdates = harness.updates
+      .map((u) => u.update as unknown as { sessionUpdate: string; state?: string })
+      .filter((u) => u.sessionUpdate === "state_update")
+
+    expect(stateUpdates.map((u) => u.state)).toEqual(["requires_action", "running"])
+  })
+
+  it("uses v2 permission request structure with title and subject", async () => {
+    const harness = createHarness(undefined, { v2: true })
+    await createSession(harness.session, "ses_v2_struct")
+
+    harness.subscription.handle(permissionAsked("ses_v2_struct", "perm_v2_struct"))
+
+    await pollUntil(() => harness.requests.length === 1, "v2 permission was never requested")
+
+    expect(harness.requests[0]).toMatchObject({
+      sessionId: "ses_v2_struct",
+      title: "bash",
+      subject: {
+        type: "tool_call",
+        toolCall: { toolCallId: "perm_v2_struct", status: "pending" },
+      },
+    })
+    // v1 toolCall field should not be present at top level in v2 mode
+    expect("toolCall" in harness.requests[0]).toBe(false)
   })
 })

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -195,7 +195,9 @@ describe("ACP service sessions", () => {
     options?: {
       abort?: (input: { sessionID: string }) => Promise<{ data: boolean }>
       prompt?: (input: unknown) => Promise<{ data: { info: ReturnType<typeof assistantInfo> } }>
+      promptAsync?: (input: unknown) => Promise<unknown>
       sessionUpdate?: (update: SessionNotification) => Promise<void>
+      v2?: boolean
     },
   ) => {
     const updates: SessionNotification[] = []
@@ -203,6 +205,7 @@ describe("ACP service sessions", () => {
     const aborts: string[] = []
     const forks: string[] = []
     const prompts: unknown[] = []
+    const promptAsyncs: unknown[] = []
     const commands: unknown[] = []
     const summarizes: unknown[] = []
     const usageUpdates: string[] = []
@@ -265,6 +268,13 @@ describe("ACP service sessions", () => {
           events.push(idleEvent(input.sessionID))
           return response
         },
+        promptAsync: async (input: { sessionID: string }) => {
+          await (options?.promptAsync?.(input) ?? Promise.resolve())
+          promptAsyncs.push(input)
+          // The async admission returns immediately; the turn completes later when
+          // the test pushes an idle event, mirroring the real server's lifecycle.
+          return { data: undefined }
+        },
         command: (input: { sessionID: string }) => {
           commands.push(input)
           events.push(idleEvent(input.sessionID))
@@ -320,12 +330,13 @@ describe("ACP service sessions", () => {
     })
 
     return {
-      service: ACPService.make({ sdk, connection, usage }),
+      service: ACPService.make({ sdk, connection, usage, v2: options?.v2 }),
       updates,
       mcpAdds,
       aborts,
       forks,
       prompts,
+      promptAsyncs,
       commands,
       summarizes,
       usageUpdates,
@@ -1338,6 +1349,138 @@ describe("ACP service sessions", () => {
     )
 
     expect(error.code).toBe(-32000)
+  })
+
+  describe("v2 prompt lifecycle", () => {
+    function busyEvent(sessionID: string): Event {
+      return {
+        id: `evt_busy_${sessionID}`,
+        type: "session.status",
+        properties: { sessionID, status: { type: "busy" } },
+      }
+    }
+
+    function sessionUpdateName(update: SessionNotification) {
+      return (update.update as { sessionUpdate?: string }).sessionUpdate
+    }
+
+    // The event subscription emits v2 state_update notifications asynchronously off the
+    // global event stream, so poll the captured updates for the published signal rather
+    // than racing a fixed sleep.
+    async function waitForIdleState(updates: SessionNotification[], sessionId: string, timeoutMs = 1000) {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        const found = updates.find((u) => {
+          if (u.sessionId !== sessionId) return false
+          const upd = u.update as { sessionUpdate?: string; state?: string }
+          return upd.sessionUpdate === "state_update" && upd.state === "idle"
+        })
+        if (found) return found
+        await new Promise((r) => setTimeout(r, 5))
+      }
+      throw new Error("timeout waiting for v2 state_update idle")
+    }
+
+    it("negotiates protocolVersion 2 when the flag is on and the client requests v2", async () => {
+      const { service } = makeService([], { v2: true })
+      const result = await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      expect(result.protocolVersion).toBe(2)
+      expect((result as unknown as { info: { name: string } }).info.name).toBe("OpenCode")
+      expect((result as unknown as { capabilities: { session: object } }).capabilities.session).toBeDefined()
+    })
+
+    it("falls back to protocolVersion 1 when the client requests v1 even with the flag on", async () => {
+      const { service } = makeService([], { v2: true })
+      const result = await Effect.runPromise(service.initialize({ protocolVersion: 1 }))
+      expect(result.protocolVersion).toBe(1)
+      expect((result as unknown as { agentInfo?: unknown }).agentInfo).toBeDefined()
+    })
+
+    it("admits a v2 prompt non-blocking via prompt_async and acknowledges immediately", async () => {
+      const { service, promptAsyncs, prompts, updates } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      const result = await Effect.runPromise(
+        service.prompt({
+          sessionId: session.sessionId,
+          messageId: "msg_1",
+          prompt: [{ type: "text", text: "hello" }],
+        }),
+      )
+
+      // v2 acceptance is an empty result; the turn has not completed yet.
+      expect(Object.keys(result as object)).toHaveLength(0)
+      // Admitted asynchronously, not via the blocking v1 prompt path.
+      expect(promptAsyncs).toHaveLength(1)
+      expect(prompts).toHaveLength(0)
+      expect((promptAsyncs[0] as { messageID: string }).messageID).toBe("msg_1")
+      // A user_message ack and state_update running were emitted immediately.
+      expect(updates.map(sessionUpdateName)).toEqual(expect.arrayContaining(["user_message", "state_update"]))
+    })
+
+    it("emits state_update idle with a stop reason when the turn completes", async () => {
+      const messages = [
+        {
+          info: assistantInfo({ input: 100, output: 40, reasoning: 7, cache: { read: 11, write: 13 } }),
+          parts: [],
+        },
+      ]
+      const { service, events, updates, usageUpdates } = makeService(messages, { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+      await Effect.runPromise(
+        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+      )
+
+      events.push(busyEvent(session.sessionId))
+      events.push(idleEvent(session.sessionId))
+
+      const idle = await waitForIdleState(updates, session.sessionId)
+      expect((idle.update as { stopReason?: string }).stopReason).toBe("end_turn")
+      expect(usageUpdates).toContain(session.sessionId)
+    })
+
+    it("steers a running turn by admitting a second prompt before idle", async () => {
+      const { service, promptAsyncs } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      await Effect.runPromise(
+        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "first" }] }),
+      )
+      // A second prompt arriving while the first turn is still running admits another
+      // input (steer by default) instead of blocking on the running turn.
+      await Effect.runPromise(
+        service.prompt({ sessionId: session.sessionId, messageId: "msg_2", prompt: [{ type: "text", text: "steer" }] }),
+      )
+
+      expect(promptAsyncs.map((p) => (p as { messageID: string }).messageID)).toEqual(["msg_1", "msg_2"])
+    })
+
+    it("derives stopReason cancelled from an aborted turn on cancel", async () => {
+      const messages = [
+        {
+          info: assistantInfo(
+            { input: 5, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            { name: "MessageAbortedError", data: { message: "aborted" } },
+          ),
+          parts: [],
+        },
+      ]
+      const { service, events, updates, aborts } = makeService(messages, { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+      await Effect.runPromise(
+        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+      )
+      await Effect.runPromise(service.cancel({ sessionId: session.sessionId }))
+
+      expect(aborts).toEqual([session.sessionId])
+      events.push(idleEvent(session.sessionId))
+      const idle = await waitForIdleState(updates, session.sessionId)
+      expect((idle.update as { stopReason?: string }).stopReason).toBe("cancelled")
+    })
   })
 })
 

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -1055,7 +1055,6 @@ describe("ACP service sessions", () => {
     const result = await Effect.runPromise(
       service.prompt({
         sessionId: session.sessionId,
-        messageId: "00000000-0000-4000-8000-000000000001",
         prompt: [{ type: "text", text: "hello" }],
       }),
     )
@@ -1080,7 +1079,6 @@ describe("ACP service sessions", () => {
         cachedWriteTokens: 13,
         totalTokens: 171,
       },
-      userMessageId: "00000000-0000-4000-8000-000000000001",
       _meta: {},
     })
     expect(usageUpdates).toEqual([session.sessionId])
@@ -1352,6 +1350,15 @@ describe("ACP service sessions", () => {
   })
 
   describe("v2 prompt lifecycle", () => {
+    // v2 PromptRequest adds messageId; the v1 SDK type doesn't have it.
+    function v2Prompt(params: {
+      sessionId: string
+      messageId: string
+      prompt: readonly { type: "text"; text: string }[]
+    }) {
+      return params as unknown as Parameters<ReturnType<typeof ACPService.make>["prompt"]>[0]
+    }
+
     function busyEvent(sessionID: string): Event {
       return {
         id: `evt_busy_${sessionID}`,
@@ -1402,11 +1409,13 @@ describe("ACP service sessions", () => {
       const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
 
       const result = await Effect.runPromise(
-        service.prompt({
-          sessionId: session.sessionId,
-          messageId: "msg_1",
-          prompt: [{ type: "text", text: "hello" }],
-        }),
+        service.prompt(
+          v2Prompt({
+            sessionId: session.sessionId,
+            messageId: "msg_1",
+            prompt: [{ type: "text", text: "hello" }],
+          }),
+        ),
       )
 
       // v2 acceptance is an empty result; the turn has not completed yet.
@@ -1430,7 +1439,9 @@ describe("ACP service sessions", () => {
       await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
       const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
       await Effect.runPromise(
-        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+        ),
       )
 
       events.push(busyEvent(session.sessionId))
@@ -1447,12 +1458,16 @@ describe("ACP service sessions", () => {
       const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
 
       await Effect.runPromise(
-        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "first" }] }),
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "first" }] }),
+        ),
       )
       // A second prompt arriving while the first turn is still running admits another
       // input (steer by default) instead of blocking on the running turn.
       await Effect.runPromise(
-        service.prompt({ sessionId: session.sessionId, messageId: "msg_2", prompt: [{ type: "text", text: "steer" }] }),
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_2", prompt: [{ type: "text", text: "steer" }] }),
+        ),
       )
 
       expect(promptAsyncs.map((p) => (p as { messageID: string }).messageID)).toEqual(["msg_1", "msg_2"])
@@ -1472,7 +1487,9 @@ describe("ACP service sessions", () => {
       await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
       const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
       await Effect.runPromise(
-        service.prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_1", prompt: [{ type: "text", text: "hello" }] }),
+        ),
       )
       await Effect.runPromise(service.cancel({ sessionId: session.sessionId }))
 
@@ -1480,6 +1497,181 @@ describe("ACP service sessions", () => {
       events.push(idleEvent(session.sessionId))
       const idle = await waitForIdleState(updates, session.sessionId)
       expect((idle.update as { stopReason?: string }).stopReason).toBe("cancelled")
+    })
+
+    it("replays conversation history when resumeSession includes replayFrom", async () => {
+      const messages = [
+        {
+          info: {
+            id: "msg_user_1",
+            role: "user",
+            sessionID: "ses_loaded",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          },
+          parts: [
+            {
+              id: "prt_1",
+              type: "text",
+              text: "hello",
+              sessionID: "ses_loaded",
+              messageID: "msg_user_1",
+              ignored: false,
+            },
+          ],
+        },
+        {
+          info: {
+            id: "msg_asst_1",
+            role: "assistant",
+            sessionID: "ses_loaded",
+            providerID: "test",
+            modelID: "test-model",
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          },
+          parts: [
+            {
+              id: "prt_2",
+              type: "text",
+              text: "hi there",
+              sessionID: "ses_loaded",
+              messageID: "msg_asst_1",
+              ignored: false,
+            },
+          ],
+        },
+      ]
+      const { service, updates } = makeService(messages, { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+
+      await Effect.runPromise(
+        service.resumeSession({
+          sessionId: "ses_loaded",
+          cwd: "/workspace",
+          ...(undefined as unknown as object),
+          replayFrom: { type: "start" },
+        } as unknown as Parameters<typeof service.resumeSession>[0]),
+      )
+
+      // Replay should emit user_message_chunk and agent_message_chunk updates
+      const chunkUpdates = updates.filter(
+        (u) => u.update.sessionUpdate === "user_message_chunk" || u.update.sessionUpdate === "agent_message_chunk",
+      )
+      expect(chunkUpdates.length).toBeGreaterThanOrEqual(2)
+    })
+
+    it("emits plan_update when todo.updated events arrive", async () => {
+      const { service, updates, events } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      events.push({
+        id: "evt_todo_1",
+        type: "todo.updated",
+        properties: {
+          sessionID: session.sessionId,
+          todos: [
+            { content: "Write tests", status: "in_progress", priority: "high" },
+            { content: "Deploy", status: "pending", priority: "medium" },
+          ],
+        },
+      } as unknown as Event)
+
+      // Give the event subscription time to process
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      const planUpdates = updates.filter((u) => u.update.sessionUpdate === "plan_update")
+      expect(planUpdates).toHaveLength(1)
+      const plan = (planUpdates[0].update as unknown as { plan: { type: string; planId: string; entries: unknown[] } })
+        .plan
+      expect(plan.type).toBe("items")
+      expect(plan.planId).toBe("default")
+      expect(plan.entries).toHaveLength(2)
+    })
+
+    it("returns configId (not id) on config options in v2 mode", async () => {
+      const { service } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      // In v2, config options use `configId` instead of `id`
+      const modelOption = session.configOptions?.find((o) => "configId" in o)
+      expect(modelOption).toBeDefined()
+      expect((modelOption as { configId: string }).configId).toBeDefined()
+      // v1 `id` field should not be present in v2 mode
+      expect((modelOption as { id?: string }).id).toBeUndefined()
+    })
+
+    it("emits user_message acknowledgment with messageId after v2 prompt acceptance", async () => {
+      const { service, updates } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      await Effect.runPromise(
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_ack_1", prompt: [{ type: "text", text: "hi" }] }),
+        ),
+      )
+
+      const userMessageUpdates = updates.filter(
+        (u) => (u.update as unknown as { sessionUpdate: string }).sessionUpdate === "user_message",
+      )
+      expect(userMessageUpdates).toHaveLength(1)
+      expect((userMessageUpdates[0].update as { messageId: string }).messageId).toBe("msg_ack_1")
+      expect((userMessageUpdates[0].update as { content: unknown[] }).content).toHaveLength(1)
+    })
+
+    it("routes auth/login to the authenticate handler and auth/logout to the logout handler", async () => {
+      const { service } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+
+      // auth/login delegates to authenticate — returns empty object (void in v2)
+      const authResult = await Effect.runPromise(
+        service.authenticate({ methodId: "opencode-login" } as unknown as Parameters<typeof service.authenticate>[0]),
+      )
+      expect(authResult).toEqual({})
+
+      // auth/logout delegates to logout — returns void in v2
+      await Effect.runPromise(service.logout())
+    })
+
+    it("emits state_update with requires_action is not yet implemented (baseline check)", async () => {
+      // requires_action is SHOULD not MUST; verify we at least emit running/idle
+      const { service, updates } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      const session = await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      await Effect.runPromise(
+        service.prompt(
+          v2Prompt({ sessionId: session.sessionId, messageId: "msg_ra", prompt: [{ type: "text", text: "test" }] }),
+        ),
+      )
+
+      const stateUpdates = updates.filter(
+        (u) => (u.update as unknown as { sessionUpdate: string }).sessionUpdate === "state_update",
+      )
+      // At minimum, running state_update should be emitted on prompt acceptance
+      expect(stateUpdates.length).toBeGreaterThanOrEqual(1)
+      expect((stateUpdates[0].update as unknown as { state: string }).state).toBe("running")
+    })
+
+    it("includes input with type:text in available_commands_update", async () => {
+      const { service, updates } = makeService([], { v2: true })
+      await Effect.runPromise(service.initialize({ protocolVersion: 2 }))
+      await Effect.runPromise(service.newSession({ cwd: "/workspace", mcpServers: [] }))
+
+      // Wait for the deferred available_commands_update
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const cmdUpdates = updates.filter((u) => u.update.sessionUpdate === "available_commands_update")
+      expect(cmdUpdates.length).toBeGreaterThanOrEqual(1)
+      const commands = (
+        cmdUpdates[0].update as { availableCommands: Array<{ name: string; input?: { type: string; hint: string } }> }
+      ).availableCommands
+      // The "init" command has hints, so its input should include type: "text"
+      const initCommand = commands.find((c) => c.name === "init")
+      expect(initCommand).toBeDefined()
     })
   })
 })

--- a/packages/opencode/test/cli/acp/helpers.ts
+++ b/packages/opencode/test/cli/acp/helpers.ts
@@ -29,6 +29,18 @@ export function initialize(acp: AcpClient) {
   })
 }
 
+export function initializeV2(acp: AcpClient) {
+  return Effect.gen(function* () {
+    return expectOk(
+      yield* acp.request<InitializeResponse>("initialize", {
+        protocolVersion: 2,
+        info: { name: "opencode-local-acp", version: "0.1.0" },
+        capabilities: {},
+      }),
+    )
+  })
+}
+
 export function newSession(acp: AcpClient, cwd: string) {
   return Effect.gen(function* () {
     return expectOk(yield* acp.request<NewSessionResponse>("session/new", { cwd, mcpServers: [] }))

--- a/packages/opencode/test/cli/acp/v2-prompt.test.ts
+++ b/packages/opencode/test/cli/acp/v2-prompt.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../../lib/cli-process"
+import { expectOk } from "./acp-test-client"
+import { createAcpClient, initializeV2, newSession, verifierConfig } from "./helpers"
+
+describe("opencode acp v2 prompt lifecycle subprocess", () => {
+  cliIt.live(
+    "negotiates v2 and acknowledges a prompt with an empty result plus state_update",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        const acp = yield* createAcpClient(
+          { opencode },
+          {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify(verifierConfig(llm.url)),
+            OPENCODE_EXPERIMENTAL_ACP_V2: "1",
+          },
+        )
+
+        const initialized = yield* initializeV2(acp)
+        expect(initialized.protocolVersion).toBe(2)
+        expect((initialized as unknown as { info: { name: string } }).info.name).toBe("OpenCode")
+        expect((initialized as unknown as { capabilities: { session: object } }).capabilities.session).toBeDefined()
+
+        const session = yield* newSession(acp, home)
+        const result = expectOk(
+          yield* acp.request<{ stopReason?: string }>("session/prompt", {
+            sessionId: session.sessionId,
+            messageId: "msg_1",
+            prompt: [{ type: "text", text: "say hi" }],
+          }),
+        )
+        // v2 acceptance: the prompt response is empty; the turn has not completed yet.
+        expect(result.stopReason).toBeUndefined()
+
+        // Foreground progress now flows as session/update notifications. The running
+        // state_update is emitted as soon as the prompt is admitted.
+        const update = yield* acp.waitForNotification<{ update: { sessionUpdate: string; state?: string } }>(
+          "session/update",
+          (params) => params.update?.sessionUpdate === "state_update",
+        )
+        expect(update.params!.update.sessionUpdate).toBe("state_update")
+      }),
+    60_000,
+  )
+
+  cliIt.live(
+    "falls back to protocolVersion 1 when the flag is off even if the client requests v2",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const acp = yield* createAcpClient({ opencode })
+        const initialized = yield* initializeV2(acp)
+        // Without OPENCODE_EXPERIMENTAL_ACP_V2, the agent answers with v1.
+        expect(initialized.protocolVersion).toBe(1)
+        expect((initialized as unknown as { agentInfo?: unknown }).agentInfo).toBeDefined()
+      }),
+    60_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #44877

This is a WIP implementation of the [ACP v2 draft spec](https://agentclientprotocol.com/announcements/acp-v2-draft) per the [migration guide](https://agentclientprotocol.com/protocol/v2/migration).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Implements ACP v2 draft support behind `OPENCODE_EXPERIMENTAL_ACP_V2`, gated by `protocolVersion` negotiation. v1 peers are unaffected — the agent answers `protocolVersion: 1` unless the flag is on AND the client requests v2.

Upgrades `@agentclientprotocol/sdk` from 0.21.0 → 1.3.0. Uses the SDK v2 experimental builder (`@agentclientprotocol/sdk/experimental/v2`) for v2 connections and the v1 builder for v1 connections, with `AgentProtocolRouter` selecting per-connection based on `initialize` `protocolVersion`.

Architecture: `AgentProtocolRouter` (`agent.ts`) selects v1 or v2 per-connection. v1 uses `createV1App()` (v1 `AgentApp` builder). v2 uses `createV2App()` (`agent-v2.ts`, v2 `AgentApp` builder). Both share `ACPService.make()` core logic. v2 `ndJsonStream` from the SDK accepts both individual and batch JSON-RPC messages. ACP over stdio is inherently single-connection-per-process — `v2Active` is connection-scoped in practice (see comment in `service.ts`).

All items from the [v2 migration checklist](https://agentclientprotocol.com/protocol/v2/migration#migration-checklist-agents) are implemented:

- **Prompt lifecycle** — `session/prompt` returns `{}` on acceptance (via `prompt_async`); foreground state flows as `state_update` notifications (`running` on busy, `idle` with `stopReason` on turn completion)
- **Initialize restructure** — `capabilities`/`info` fields, object support markers, session-scoped capability groups; `protocolVersion: 2` negotiation with v1 fallback
- **Cancel confirmation** — `session/cancel` still a notification; confirmation is `state_update: idle` with `stopReason: cancelled` (derived from `MessageAbortedError`), not the prompt response
- **Mid-turn steering** — a second `session/prompt` admitted while a turn is running steers by default at the next safe boundary
- **Message IDs** — `messageId` on all chunks; whole-message upserts (`user_message`) with acknowledgment
- **Tool calls** — stop emitting `tool_call` (create) in v2; use `tool_call_update` for create+patch
- **Agent-owned terminal display** — `terminal_update` upserts with base64-encoded `output.data` and `exitStatus` (reading exit code from `part.state.metadata.exit`) on completion
- **Structured diffs** — replace `oldText`/`newText` with `changes` array + `git_patch` format; guards `oldText`/`newText` are strings before patch generation
- **Permission requests** — required `title`, optional `description`, extensible `subject` union (`tool_call` / `command`)
- **Plans** — `plan_update` with `planId` keyed tagged union (`type: "items"`)
- **Session lifecycle** — implement `session/resume` with `replayFrom`; paginated message fetch (50/page via cursor) for replay
- **Session modes removed** — express as config options with `category: mode` and `configId` naming
- **Auth renames** — `authenticate` → `auth/login`, `logout` → `auth/logout`, `type` + `methodId` on descriptors
- **MCP config** — `type` discriminator (`http`/`sse`/`acp`/`stdio`), advertise `session.mcp.stdio`/`session.mcp.http`; `acp` type filtered before registration
- **Slash commands** — `input: { type: "text", hint }` discriminator
- **JSON-RPC batch** — accept and process batch arrays on stdio (v2 `ndJsonStream`)
- **Consistent ID naming** — `id` → `configId`/`methodId`
- **v1/v2 side-by-side** — `AgentProtocolRouter` routes per-connection; v1 fallback verified
- **Extensibility** — open enums, unknown content block types rendered as text fallback, `_meta` preserved on content chunks and `resource_link` blocks
- **Content blocks** — `resource_link` `icons`/`_meta` passthrough, extensible `type` discriminator, unknown block types preserved
- **requires_action state_update** — emits `requires_action` before permission requests, `running` after resolution; deduplicated `running` via `v2Running` set

SDK 1.3.0 breaking changes addressed:

- SDK 1.3.0 removed the unstable `SetSessionModelRequest` type (which carried `modelId` for LLM model selection). This is distinct from `SetSessionModeRequest` (which carries `modeId` for session mode selection). Defined a local `SetSessionModelRequest` type to preserve the correct semantics for the `unstable_setSessionModel` extension method.
- `PromptRequest.messageId` removed from v1 types
- `PromptResponse.userMessageId` removed from v1 types
- `McpServer` is now a discriminated union (`http`/`sse`/`acp`/`stdio`) — added `type` discriminators to all MCP server configs
- `messageID` must start with `"msg"` per the server validation — switched from `crypto.randomUUID()` to `Identifier.ascending("message")`

### How did you verify your code works?

**Automated tests:**

- `bun test test/acp/` — 155 pass (20 new v2 unit tests)
- `bun test test/cli/acp/` — 17 pass (12 v1 wire path + 5 v2 wire path CLI subprocess tests)
- `bun typecheck` — clean across all 30 packages

New v2 unit tests:

- `test/acp/event-v2.test.ts` (11 tests): `tool_call_update` for creation, structured diffs with `changes` + `git_patch`, `terminal_update` for running/completed bash tools with `exitStatus`, `plan_update` for todo events, no `terminal_update` for non-shell tools, `_meta` preserved on `resource_link`/text content chunks, unknown block type text fallback, `_meta` preservation from incoming `resource_link`
- `test/acp/permission.test.ts` (3 tests): `requires_action` before permission request, `running` after resolution, `requires_action` on rejection, v2 permission structure with `title`/`subject`
- `test/acp/service-session.test.ts` (6 tests): `configId` naming, `user_message` ack with `messageId`, `auth/login` + `auth/logout` routing, `requires_action` baseline, slash command `input` discriminator, `replayFrom` replay

v1 backward compatibility is verified by the existing CLI test suite (`lifecycle`, `prompt-content`, `config-options`, `skills`, `initialize-auth`) which all use `protocolVersion: 1` and exercise the full v1 wire path against SDK 1.3.0.

**Manual end-to-end testing:**

A standalone test client is available on the [`acp-v2-test-client`](https://github.com/mountaintopsolutions/opencode/tree/acp-v2-test-client/packages/opencode/test/cli/acp) branch of the fork. It uses the SDK's built-in `ClientApp` from `@agentclientprotocol/sdk/experimental/v2` to spawn an opencode ACP process, negotiate v2, create a session, send prompts, and stream all `session/update` notifications.

```bash
# Basic prompt
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode "say hello"

# With a specific model (writes opencode.json in cwd)
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle "say hello"

# Mid-turn steering
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle \
  --steer "STOP. Just say STEERED." --steer-delay 500 \
  "write a detailed Python script that prints 1-100 with comments"

# Session resume with replay
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --resume <sessionId> "continue"

# Predefined scenarios
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --scenario steering
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --scenario cancel
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --scenario config-options
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --scenario resume
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --sequence file-then-list
bun run test/cli/acp/v2-client.ts --binary ./dist/opencode-darwin-arm64/bin/opencode \
  --model opencode/big-pickle --scenario batch
```

Scenario test results (using opencode/big-pickle):

| Scenario | Description | Result |
|---|---|---|
| `steering` | Send a second `session/prompt` mid-turn while the model is still working | PASS — steer accepted, second `user_message` emitted with new `messageId`, `state_update: running` re-emitted, turn completed with `end_turn` |
| `cancel` | Send `session/cancel` notification on first `state_update: running` | PASS — turn completed with `stopReason: cancelled` |
| `config-options` | Verify all config options use `configId` (not v1 `id`), and `session/set_config_option` with `type: "id"` updates the value | PASS — `model`, `effort`, `mode` all have `configId`; mode switched from `build` to `plan` successfully |
| `resume` | Create session + prompt, then `session/resume` with `replayFrom: { type: "start" }`, verify `configOptions` in response and session appears in `session/list` | PASS — resume returned 3 config options, session found in list |
| `file-then-list` | Prompt that triggers file write + bash tool, then `session/list` | PASS — turn completed, `session/list` returned the session (model did not use tools in this run, but wire path verified) |
| `batch` | Send a raw JSON-RPC batch array (two `session/list` requests) on stdin | PASS — server returned a batch array with 2 results, each containing the session list |

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
