### PR TITLE
fix(core): avoid stale MCP OAuth snapshots destroying rotated credentials

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -273,28 +273,53 @@ export const layer = (options?: Options) =>
           return MCPOAuth.provider({ ...base, store: MCPOAuth.memoryStore() })
         const credentialID = found.id
         const methodID = found.value.methodID
-        let current: Credential.OAuth | undefined = found.value
+        const integrationID = entry.integrationID
+        // Tracks the refresh token this provider last presented, so invalidate can tell whether the SDK
+        // rejected the currently-stored credential or a snapshot another connection has already rotated past.
+        let presented = found.value.refresh
+        const readOAuthCredential = async () => {
+          const stored = await Effect.runPromise(credentials.list(integrationID))
+          const match = stored.find((credential) => credential.id === credentialID)
+          return match && match.value.type === "oauth" ? match.value : undefined
+        }
         return MCPOAuth.provider({
           ...base,
-          // Drop a credential the SDK rejected so the next connect cleanly reports needs_auth. Uses the raw
-          // credential service (no integration event) to avoid re-triggering the reconnect subscriber mid-connect.
+          // Drop a credential the SDK rejected so the next connect cleanly reports needs_auth — but only if it is
+          // still the stored one. Rotating servers hand out a fresh refresh token per use, so a concurrent
+          // connection may have already replaced ours; deleting then would discard the newer valid credential and
+          // strand every connection in needs_auth until a manual re-auth. Uses the raw credential service (no
+          // integration event) to avoid re-triggering the reconnect subscriber mid-connect.
           invalidate: async (scope) => {
             if (scope === "verifier" || scope === "discovery") return
-            current = undefined
+            const oauth = await readOAuthCredential()
+            if (!oauth || oauth.refresh !== presented) return
             await Effect.runPromise(credentials.remove(credentialID))
           },
+          // Always read the latest stored tokens instead of caching at connect time: with refresh-token rotation,
+          // a cached snapshot goes stale the moment another connection refreshes, and re-presenting the consumed
+          // token fails with invalid_grant.
           store: {
-            tokens: async () => (current ? MCPOAuth.toTokens(current) : undefined),
+            tokens: async () => {
+              const oauth = await readOAuthCredential()
+              if (!oauth) return undefined
+              presented = oauth.refresh
+              return MCPOAuth.toTokens(oauth)
+            },
             saveTokens: async (tokens) => {
-              current = MCPOAuth.toCredential({
+              const previous = await readOAuthCredential()
+              const value = MCPOAuth.toCredential({
                 methodID,
                 serverUrl: remote.url,
                 tokens,
-                client: current ? MCPOAuth.clientFromCredential(current) : undefined,
+                client: previous ? MCPOAuth.clientFromCredential(previous) : undefined,
               })
-              await Effect.runPromise(credentials.update(credentialID, { value: current }))
+              presented = value.refresh
+              await Effect.runPromise(credentials.update(credentialID, { value }))
             },
-            clientInformation: async () => (current ? MCPOAuth.clientFromCredential(current) : undefined),
+            clientInformation: async () => {
+              const oauth = await readOAuthCredential()
+              return oauth ? MCPOAuth.clientFromCredential(oauth) : undefined
+            },
             saveClientInformation: async () => {},
             codeVerifier: async () => undefined,
             saveCodeVerifier: async () => {},


### PR DESCRIPTION
## Problem

Remote MCP OAuth credentials (e.g. Stripe) are lost roughly daily, flipping the server to `needs_auth` until a manual re-login.

`connectProvider` snapshotted the OAuth credential into a closure variable at connect time. Every Location graph boots its own MCP layer, so multiple connections share one stored credential while each holds its own snapshot. Rotating authorization servers (Stripe included) invalidate the previous refresh token on every use, so once the access token expired:

1. Connection A refreshes `R0 → R1` and persists it
2. Connection B still presents its stale `R0`; the in-flight dedupe from #43074 cannot help because A's refresh already completed
3. The server answers `invalid_grant`, the SDK calls `invalidateCredentials('tokens')`, and our `invalidate` deleted the entire credential row — including the valid `R1` another connection had just stored

Every subsequent connect then finds no credential and reports `needs_auth`. Log evidence from 2026-08-22/23: five concurrent stripe connections boot at 23:40, `Unauthorized` on resource listing at 00:22 after access-token expiry, first permanent `needs_auth` at 00:46:58, repeating every ~15 minutes afterward.

## Fix

In `connectProvider` (`packages/core/src/mcp/index.ts`):

- `tokens()`, `saveTokens()`, and `clientInformation()` now read the latest stored credential on every call instead of a connect-time snapshot, so every connection always presents the current rotated token
- `invalidate()` re-reads the stored credential and only removes it when its refresh token matches the one this provider last presented; if another connection already rotated past it, the newer valid credential is kept

The SDK-level singleflight from #43074 remains in place for genuinely simultaneous refreshes; this closes the sequential staleness gap it could not cover.

## Testing

- `bun typecheck` in `packages/core`
- `bun test test/mcp.test.ts test/mcp-oauth.test.ts` — 35 passed

A full regression test for the rotation race would require an auth-gating stub MCP server plus functional Integration/Credential service mocks beyond the existing harness; happy to add one if reviewers want it.