### PR TITLE
feat: open VS Code native diff for edit/write permission approvals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -231,7 +231,8 @@ export const TuiThreadCommand = cmd({
       const config = await TuiConfig.get()
 
       const network = resolveNetworkOptionsNoConfig(args)
-      const external = hasArg("--port") || hasArg("--hostname") || network.mdns === true
+      const external =
+        hasArg("--port") || hasArg("--hostname") || network.mdns === true || !!process.env.OPENCODE_VSCODE_IPC_PORT
 
       const headers = external ? ServerAuth.headers() : undefined
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -6,18 +6,19 @@ import { Deferred, Effect, Layer, Context } from "effect"
 import os from "os"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { isConnected as isVscodeConnected, forwardDiff, forwardReply, fetchEditedContent } from "@/server/connection"
 
 export const Event = PermissionV1.Event
 
 export interface Interface {
-  readonly ask: (input: PermissionV1.AskInput) => Effect.Effect<void, PermissionV1.Error>
+  readonly ask: (input: PermissionV1.AskInput) => Effect.Effect<string | undefined, PermissionV1.Error>
   readonly reply: (input: PermissionV1.ReplyInput) => Effect.Effect<void, PermissionV1.NotFoundError>
   readonly list: () => Effect.Effect<ReadonlyArray<PermissionV1.Request>>
 }
 
 interface PendingEntry {
   info: PermissionV1.Request
-  deferred: Deferred.Deferred<void, PermissionV1.RejectedError | PermissionV1.CorrectedError>
+  deferred: Deferred.Deferred<string | undefined, PermissionV1.RejectedError | PermissionV1.CorrectedError>
 }
 
 interface State {
@@ -95,9 +96,20 @@ const layer = Layer.effect(
       }
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
 
-      const deferred = yield* Deferred.make<void, PermissionV1.RejectedError | PermissionV1.CorrectedError>()
+      const deferred = yield* Deferred.make<
+        string | undefined,
+        PermissionV1.RejectedError | PermissionV1.CorrectedError
+      >()
       pending.set(id, { info, deferred })
       yield* events.publish(Event.Asked, info)
+      if (isVscodeConnected() && info.metadata && typeof info.metadata === "object") {
+        const meta = info.metadata as { filepath?: string; oldText?: string; newText?: string }
+        if (meta.oldText !== undefined && meta.newText !== undefined) {
+          yield* Effect.sync(() =>
+            forwardDiff(String(id), meta.filepath ?? "", meta.oldText as string, meta.newText as string),
+          )
+        }
+      }
       return yield* Effect.ensuring(
         Deferred.await(deferred),
         Effect.sync(() => {
@@ -119,6 +131,7 @@ const layer = Layer.effect(
       })
 
       if (input.reply === "reject") {
+        yield* Effect.sync(() => forwardReply(existing.info.id))
         yield* Deferred.fail(
           existing.deferred,
           input.message
@@ -134,12 +147,17 @@ const layer = Layer.effect(
             requestID: item.info.id,
             reply: "reject",
           })
+          yield* Effect.sync(() => forwardReply(item.info.id))
           yield* Deferred.fail(item.deferred, new PermissionV1.RejectedError())
         }
         return
       }
 
-      yield* Deferred.succeed(existing.deferred, undefined)
+      const content =
+        input.content ??
+        (isVscodeConnected() ? yield* Effect.promise(() => fetchEditedContent(existing.info.id)) : undefined)
+      yield* Deferred.succeed(existing.deferred, content)
+      yield* Effect.sync(() => forwardReply(existing.info.id))
       if (input.reply === "once") return
 
       for (const pattern of existing.info.always) {
@@ -162,6 +180,7 @@ const layer = Layer.effect(
           requestID: item.info.id,
           reply: "always",
         })
+        yield* Effect.sync(() => forwardReply(item.info.id))
         yield* Deferred.succeed(item.deferred, undefined)
       }
     })

--- a/packages/opencode/src/server/connection.ts
+++ b/packages/opencode/src/server/connection.ts
@@ -1,0 +1,57 @@
+let connected = false
+
+export function setConnected(value: boolean) {
+  connected = value
+}
+
+export function isConnected() {
+  return connected
+}
+
+function vscodePort() {
+  return process.env.OPENCODE_VSCODE_IPC_PORT
+}
+
+export function forwardDiff(requestID: string, filepath: string, oldText: string, newText: string) {
+  const port = vscodePort()
+  if (!port) return
+  fetch(`http://localhost:${port}/diff`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ requestID, filepath, oldText, newText }),
+  }).catch((e) => console.error("Failed to forward diff to VS Code:", e))
+}
+
+export function forwardReply(requestID: string) {
+  const port = vscodePort()
+  if (!port) return
+  fetch(`http://localhost:${port}/reply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ requestID }),
+  }).catch((e) => console.error("Failed to forward reply to VS Code:", e))
+}
+
+export function fetchEditedContent(requestID: string): Promise<string | undefined> {
+  const port = vscodePort()
+  if (!port) return Promise.resolve(undefined)
+  return fetch(`http://localhost:${port}/diff-content/${requestID}`)
+    .then((res) => (res.ok ? res.json() : undefined))
+    .then((data) => (typeof data?.content === "string" ? data.content : undefined))
+    .catch(() => undefined)
+}
+
+export function register(serverURL: URL): Promise<boolean> {
+  const port = vscodePort()
+  if (!port) return Promise.resolve(false)
+  return fetch(`http://localhost:${port}/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ port: serverURL.port }),
+  })
+    .then((res) => res.ok)
+    .catch((e) => {
+      console.error("Failed to register with VS Code:", e)
+      return false
+    })
+}

--- a/packages/opencode/src/server/connection.ts
+++ b/packages/opencode/src/server/connection.ts
@@ -12,12 +12,24 @@ function vscodePort() {
   return process.env.OPENCODE_VSCODE_IPC_PORT
 }
 
+function vscodeToken() {
+  return process.env.OPENCODE_VSCODE_IPC_TOKEN
+}
+
+function ipcHeaders() {
+  const token = vscodeToken()
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { "x-opencode-token": token } : {}),
+  }
+}
+
 export function forwardDiff(requestID: string, filepath: string, oldText: string, newText: string) {
   const port = vscodePort()
   if (!port) return
   fetch(`http://localhost:${port}/diff`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: ipcHeaders(),
     body: JSON.stringify({ requestID, filepath, oldText, newText }),
   }).catch((e) => console.error("Failed to forward diff to VS Code:", e))
 }
@@ -27,7 +39,7 @@ export function forwardReply(requestID: string) {
   if (!port) return
   fetch(`http://localhost:${port}/reply`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: ipcHeaders(),
     body: JSON.stringify({ requestID }),
   }).catch((e) => console.error("Failed to forward reply to VS Code:", e))
 }
@@ -35,7 +47,10 @@ export function forwardReply(requestID: string) {
 export function fetchEditedContent(requestID: string): Promise<string | undefined> {
   const port = vscodePort()
   if (!port) return Promise.resolve(undefined)
-  return fetch(`http://localhost:${port}/diff-content/${requestID}`)
+  const token = vscodeToken()
+  return fetch(`http://localhost:${port}/diff-content/${requestID}`, {
+    headers: token ? { "x-opencode-token": token } : undefined,
+  })
     .then((res) => (res.ok ? res.json() : undefined))
     .then((data) => (typeof data?.content === "string" ? data.content : undefined))
     .catch(() => undefined)
@@ -46,7 +61,7 @@ export function register(serverURL: URL): Promise<boolean> {
   if (!port) return Promise.resolve(false)
   return fetch(`http://localhost:${port}/register`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: ipcHeaders(),
     body: JSON.stringify({ port: serverURL.port }),
   })
     .then((res) => res.ok)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -9,10 +9,7 @@ import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware
 import { described } from "./metadata"
 
 const root = "/permission"
-const ReplyPayload = Schema.Struct({
-  reply: PermissionV1.Reply,
-  message: Schema.optional(Schema.String),
-})
+const ReplyPayload = PermissionV1.ReplyBody
 
 export const PermissionApi = HttpApi.make("permission")
   .add(

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -22,6 +22,7 @@ export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permiss
           requestID: ctx.params.requestID,
           reply: ctx.payload.reply,
           message: ctx.payload.message,
+          content: ctx.payload.content,
         })
         .pipe(
           Effect.catchTag("Permission.NotFoundError", (error) =>

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -13,6 +13,7 @@ import { WebSocketTracker } from "./routes/instance/httpapi/websocket-tracker"
 import { PublicApi } from "./routes/instance/httpapi/public"
 import type { CorsOptions } from "@opencode-ai/server/cors"
 import { lazy } from "@/util/lazy"
+import { register, setConnected } from "./connection"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -72,6 +73,7 @@ export let url: URL | undefined
 
 export async function listen(opts: ListenOptions): Promise<Listener> {
   const listener = await Effect.runPromise(listenEffect(opts))
+  register(listener.url).then((ok) => ok && setConnected(true))
   return {
     hostname: listener.hostname,
     port: listener.port,

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -56,38 +56,50 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const truncate = yield* Truncate.Service
   const flags = yield* RuntimeFlags.Service
 
-  const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
-    sessionID: input.session.id,
-    abort: options.abortSignal!,
-    messageID: input.processor.message.id,
-    callID: options.toolCallId,
-    extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck, promptOps: input.promptOps },
-    agent: input.agent.name,
-    messages: input.messages,
-    metadata: (val) =>
-      input.processor.updateToolCall(options.toolCallId, (match) => {
-        if (!["running", "pending"].includes(match.state.status)) return match
-        return {
-          ...match,
-          state: {
-            title: val.title,
-            metadata: val.metadata,
-            status: "running",
-            input: args,
-            time: { start: Date.now() },
-          },
-        }
-      }),
-    ask: (req) =>
-      permission
-        .ask({
-          ...req,
-          sessionID: input.session.id,
-          tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-          ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
-        })
-        .pipe(Effect.orDie),
-  })
+  const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => {
+    const extra: { [key: string]: unknown } = {
+      model: input.model,
+      bypassAgentCheck: input.bypassAgentCheck,
+      promptOps: input.promptOps,
+    }
+    return {
+      sessionID: input.session.id,
+      abort: options.abortSignal!,
+      messageID: input.processor.message.id,
+      callID: options.toolCallId,
+      extra,
+      agent: input.agent.name,
+      messages: input.messages,
+      metadata: (val) =>
+        input.processor.updateToolCall(options.toolCallId, (match) => {
+          if (!["running", "pending"].includes(match.state.status)) return match
+          return {
+            ...match,
+            state: {
+              title: val.title,
+              metadata: val.metadata,
+              status: "running",
+              input: args,
+              time: { start: Date.now() },
+            },
+          }
+        }),
+      ask: (req) =>
+        permission
+          .ask({
+            ...req,
+            sessionID: input.session.id,
+            tool: { messageID: input.processor.message.id, callID: options.toolCallId },
+            ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+          })
+          .pipe(
+            Effect.map((content) => {
+              if (content !== undefined) extra[Tool.EditedContentKey] = content
+            }),
+            Effect.orDie,
+          ),
+    }
+  }
 
   for (const item of yield* registry.tools({
     modelID: ModelV2.ID.make(input.model.api.id),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -106,12 +106,17 @@ export const EditTool = Tool.define(
                   metadata: {
                     filepath: filePath,
                     diff,
+                    oldText: contentOld,
+                    newText: contentNew,
                   },
                 })
+                const edited = ctx.extra?.[Tool.EditedContentKey]
+                if (typeof edited === "string") contentNew = edited
                 yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
                 if (yield* format.file(filePath)) {
                   contentNew = yield* Bom.syncFile(afs, filePath, desiredBom)
                 }
+                diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
                 yield* events.publish(FileSystem.Event.Edited, { file: filePath })
                 yield* events.publish(Watcher.Event.Updated, {
                   file: filePath,
@@ -149,8 +154,12 @@ export const EditTool = Tool.define(
                 metadata: {
                   filepath: filePath,
                   diff,
+                  oldText: contentOld,
+                  newText: contentNew,
                 },
               })
+              const edited = ctx.extra?.[Tool.EditedContentKey]
+              if (typeof edited === "string") contentNew = edited
 
               yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
               if (yield* format.file(filePath)) {

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -45,6 +45,8 @@ export type Context<M extends Metadata = Metadata> = {
   ask(input: Omit<PermissionV1.Request, "id" | "sessionID" | "tool">): Effect.Effect<void>
 }
 
+export const EditedContentKey = "editedContent"
+
 export interface ExecuteResult<M extends Metadata = Metadata> {
   title: string
   metadata: M

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -3,7 +3,7 @@ import * as path from "path"
 import { Effect } from "effect"
 import * as Tool from "./tool"
 import { LSP } from "@/lsp/lsp"
-import { createTwoFilesPatch } from "diff"
+import { createTwoFilesPatch, diffLines } from "diff"
 import DESCRIPTION from "./write.txt"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { FileSystem } from "@opencode-ai/core/filesystem"
@@ -13,6 +13,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceState } from "@/effect/instance-state"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
+import { Snapshot } from "@/snapshot"
 import * as Bom from "@/util/bom"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
@@ -58,17 +59,42 @@ export const WriteTool = Tool.define(
             metadata: {
               filepath,
               diff,
+              oldText: contentOld,
+              newText: contentNew,
             },
           })
+          const edited = ctx.extra?.[Tool.EditedContentKey]
+          let finalContent = typeof edited === "string" ? edited : contentNew
 
-          yield* fs.writeWithDirs(filepath, Bom.join(contentNew, desiredBom))
+          yield* fs.writeWithDirs(filepath, Bom.join(finalContent, desiredBom))
           if (yield* format.file(filepath)) {
-            yield* Bom.syncFile(fs, filepath, desiredBom)
+            finalContent = yield* Bom.syncFile(fs, filepath, desiredBom)
           }
+          const finalDiff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, finalContent))
           yield* events.publish(FileSystem.Event.Edited, { file: filepath })
           yield* events.publish(Watcher.Event.Updated, {
             file: filepath,
             event: exists ? "change" : "add",
+          })
+
+          let additions = 0
+          let deletions = 0
+          for (const change of diffLines(contentOld, finalContent)) {
+            if (change.added) additions += change.count || 0
+            if (change.removed) deletions += change.count || 0
+          }
+          const filediff: Snapshot.FileDiff = {
+            file: filepath,
+            patch: finalDiff,
+            additions,
+            deletions,
+          }
+          yield* ctx.metadata({
+            metadata: {
+              diff: finalDiff,
+              filediff,
+              diagnostics: {},
+            },
           })
 
           let output = "Wrote file successfully."
@@ -93,6 +119,8 @@ export const WriteTool = Tool.define(
             title: path.relative(instance.worktree, filepath),
             metadata: {
               diagnostics,
+              diff: finalDiff,
+              filediff,
               filepath,
               exists: exists,
             },

--- a/packages/schema/src/v1/permission.ts
+++ b/packages/schema/src/v1/permission.ts
@@ -38,7 +38,11 @@ export type Request = typeof Request.Type
 export const Reply = Schema.Literals(["once", "always", "reject"])
 export type Reply = typeof Reply.Type
 
-export const ReplyBody = Schema.Struct({ reply: Reply, message: Schema.optional(Schema.String) }).annotate({
+export const ReplyBody = Schema.Struct({
+  reply: Reply,
+  message: Schema.optional(Schema.String),
+  content: Schema.optional(Schema.String),
+}).annotate({
   identifier: "PermissionReplyBody",
 })
 export type ReplyBody = typeof ReplyBody.Type

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2104,14 +2104,29 @@ function Shell(props: ToolProps) {
 }
 
 function Write(props: ToolProps) {
+  const ctx = use()
   const { theme, syntax } = useTheme()
   const pathFormatter = usePathFormatter()
   const code = createMemo(() => {
     return stringValue(props.input.content) ?? ""
   })
 
+  const diff = createMemo(() => stringValue(props.metadata.diff))
+
+  const view = createMemo(() => {
+    const diffStyle = ctx.tui.diff_style
+    if (diffStyle === "stacked") return "unified"
+    return ctx.width > 120 ? "split" : "unified"
+  })
+
   return (
     <Switch>
+      <Match when={diff() !== undefined}>
+        <BlockTool title={"# Wrote " + pathFormatter.format(stringValue(props.input.filePath))} part={props.part}>
+          <DiffView diff={diff() ?? ""} filePath={stringValue(props.input.filePath) ?? ""} view={view()} />
+          <Diagnostics diagnostics={props.metadata.diagnostics} filePath={stringValue(props.input.filePath) ?? ""} />
+        </BlockTool>
+      </Match>
       <Match when={props.metadata.diagnostics !== undefined}>
         <BlockTool title={"# Wrote " + pathFormatter.format(stringValue(props.input.filePath))} part={props.part}>
           <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
@@ -2393,9 +2408,36 @@ function Execute(props: ToolProps) {
   )
 }
 
+function DiffView(p: { diff: string; filePath: string; view: "unified" | "split" }) {
+  const { theme, syntax } = useTheme()
+  const ctx = use()
+  return (
+    <box paddingLeft={1}>
+      <diff
+        diff={p.diff}
+        view={p.view}
+        filetype={filetype(p.filePath)}
+        syntaxStyle={syntax()}
+        showLineNumbers={true}
+        width="100%"
+        wrapMode={ctx.diffWrapMode()}
+        fg={theme.text}
+        addedBg={theme.diffAddedBg}
+        removedBg={theme.diffRemovedBg}
+        contextBg={theme.diffContextBg}
+        addedSignColor={theme.diffHighlightAdded}
+        removedSignColor={theme.diffHighlightRemoved}
+        lineNumberFg={theme.diffLineNumber}
+        lineNumberBg={theme.diffContextBg}
+        addedLineNumberBg={theme.diffAddedLineNumberBg}
+        removedLineNumberBg={theme.diffRemovedLineNumberBg}
+      />
+    </box>
+  )
+}
+
 function Edit(props: ToolProps) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
   const pathFormatter = usePathFormatter()
 
   const view = createMemo(() => {
@@ -2405,35 +2447,13 @@ function Edit(props: ToolProps) {
     return ctx.width > 120 ? "split" : "unified"
   })
 
-  const ft = createMemo(() => filetype(stringValue(props.input.filePath)))
-
   const diffContent = createMemo(() => stringValue(props.metadata.diff) ?? "")
 
   return (
     <Switch>
       <Match when={stringValue(props.metadata.diff) !== undefined}>
         <BlockTool title={"← Edit " + pathFormatter.format(stringValue(props.input.filePath))} part={props.part}>
-          <box paddingLeft={1}>
-            <diff
-              diff={diffContent()}
-              view={view()}
-              filetype={ft()}
-              syntaxStyle={syntax()}
-              showLineNumbers={true}
-              width="100%"
-              wrapMode={ctx.diffWrapMode()}
-              fg={theme.text}
-              addedBg={theme.diffAddedBg}
-              removedBg={theme.diffRemovedBg}
-              contextBg={theme.diffContextBg}
-              addedSignColor={theme.diffHighlightAdded}
-              removedSignColor={theme.diffHighlightRemoved}
-              lineNumberFg={theme.diffLineNumber}
-              lineNumberBg={theme.diffContextBg}
-              addedLineNumberBg={theme.diffAddedLineNumberBg}
-              removedLineNumberBg={theme.diffRemovedLineNumberBg}
-            />
-          </box>
+          <DiffView diff={diffContent()} filePath={stringValue(props.input.filePath) ?? ""} view={view()} />
           <Diagnostics diagnostics={props.metadata.diagnostics} filePath={stringValue(props.input.filePath) ?? ""} />
         </BlockTool>
       </Match>
@@ -2448,7 +2468,7 @@ function Edit(props: ToolProps) {
 
 function ApplyPatch(props: ToolProps) {
   const ctx = use()
-  const { theme, syntax } = useTheme()
+  const { theme } = useTheme()
   const pathFormatter = usePathFormatter()
 
   const files = createMemo(() => parseApplyPatchFiles(props.metadata.files))
@@ -2460,29 +2480,7 @@ function ApplyPatch(props: ToolProps) {
   })
 
   function Diff(p: { diff: string; filePath: string }) {
-    return (
-      <box paddingLeft={1}>
-        <diff
-          diff={p.diff}
-          view={view()}
-          filetype={filetype(p.filePath)}
-          syntaxStyle={syntax()}
-          showLineNumbers={true}
-          width="100%"
-          wrapMode={ctx.diffWrapMode()}
-          fg={theme.text}
-          addedBg={theme.diffAddedBg}
-          removedBg={theme.diffRemovedBg}
-          contextBg={theme.diffContextBg}
-          addedSignColor={theme.diffHighlightAdded}
-          removedSignColor={theme.diffHighlightRemoved}
-          lineNumberFg={theme.diffLineNumber}
-          lineNumberBg={theme.diffContextBg}
-          addedLineNumberBg={theme.diffAddedLineNumberBg}
-          removedLineNumberBg={theme.diffRemovedLineNumberBg}
-        />
-      </box>
-    )
+    return <DiffView diff={p.diff} filePath={p.filePath} view={view()} />
   }
 
   function title(file: { type: string; relativePath: string; filePath: string; deletions: number }) {

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -20,7 +20,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -43,12 +45,32 @@
       {
         "command": "opencode.addFilepathToTerminal",
         "title": "Add Filepath to Terminal"
+      },
+      {
+        "command": "opencode.diff.accept",
+        "title": "Accept Diff",
+        "icon": "$(check)"
+      },
+      {
+        "command": "opencode.diff.reject",
+        "title": "Reject Diff",
+        "icon": "$(x)"
       }
     ],
     "menus": {
       "editor/title": [
         {
           "command": "opencode.openNewTerminal",
+          "group": "navigation"
+        },
+        {
+          "command": "opencode.diff.accept",
+          "when": "resourceScheme == opencode-diff",
+          "group": "navigation"
+        },
+        {
+          "command": "opencode.diff.reject",
+          "when": "resourceScheme == opencode-diff",
           "group": "navigation"
         }
       ]

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -61,14 +61,16 @@ class MemFS implements vscode.FileSystemProvider {
 
 const memfs = new MemFS()
 
-export function activate(context: vscode.ExtensionContext) {
-  const ipcPort = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
-  context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_PORT", String(ipcPort))
-  output.appendLine(`[opencode] extension activated, IPC_PORT=${ipcPort}`)
-
+export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.registerFileSystemProvider(SCHEME, memfs, { isCaseSensitive: true }))
 
-  startIpcServer(context, ipcPort)
+  const ipcPort = await startIpcServer(context)
+  if (!ipcPort) {
+    output.appendLine("[opencode] failed to start IPC server")
+    return
+  }
+  context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_PORT", String(ipcPort))
+  output.appendLine(`[opencode] extension activated, IPC_PORT=${ipcPort}`)
 
   const openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
     await openTerminal()
@@ -185,7 +187,6 @@ export function activate(context: vscode.ExtensionContext) {
       },
       env: {
         OPENCODE_CALLER: "vscode",
-        OPENCODE_VSCODE_IPC_PORT: port.toString(),
       },
     })
 
@@ -260,9 +261,9 @@ export function activate(context: vscode.ExtensionContext) {
   }
 }
 
-function startIpcServer(context: vscode.ExtensionContext, port: number) {
-  ipcServer = http.createServer(async (req, res) => {
-    const url = new URL(req.url ?? "/", `http://localhost:${port}`)
+function startIpcServer(context: vscode.ExtensionContext): Promise<number | undefined> {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost")
 
     if (req.method === "POST" && url.pathname === "/register") {
       let body = ""
@@ -340,14 +341,27 @@ function startIpcServer(context: vscode.ExtensionContext, port: number) {
     res.end()
   })
 
-  ipcServer.listen(port, () => {
-    output.appendLine(`[opencode] IPC server listening on ${port}`)
-  })
-
-  context.subscriptions.push({
-    dispose: () => {
-      ipcServer?.close()
-    },
+  return new Promise((resolve) => {
+    server.once("error", (e) => {
+      output.appendLine(`[opencode] IPC server error: ${String(e)}`)
+      resolve(undefined)
+    })
+    server.listen(0, () => {
+      ipcServer = server
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        output.appendLine("[opencode] IPC server failed to resolve port")
+        resolve(undefined)
+        return
+      }
+      output.appendLine(`[opencode] IPC server listening on ${address.port}`)
+      context.subscriptions.push({
+        dispose: () => {
+          server.close()
+        },
+      })
+      resolve(address.port)
+    })
   })
 }
 

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -2,10 +2,74 @@
 export function deactivate() {}
 
 import * as vscode from "vscode"
+import http from "http"
 
 const TERMINAL_NAME = "opencode"
+const SCHEME = "opencode-diff"
+
+let opencodePort: number | undefined
+let ipcServer: http.Server | undefined
+
+type PendingDiff = {
+  resolve: (content: string | null) => void
+}
+
+const pendingDiffs = new Map<string, PendingDiff>()
+
+const output = vscode.window.createOutputChannel("opencode")
+
+class MemFS implements vscode.FileSystemProvider {
+  private files = new Map<string, Uint8Array>()
+  private _emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>()
+
+  readonly onDidChangeFile = this._emitter.event
+
+  stat(uri: vscode.Uri): vscode.FileStat {
+    const data = this.files.get(uri.toString())
+    if (!data) throw vscode.FileSystemError.FileNotFound(uri)
+    return { type: vscode.FileType.File, ctime: 0, mtime: 0, size: data.length }
+  }
+
+  readFile(uri: vscode.Uri): Uint8Array {
+    const data = this.files.get(uri.toString())
+    if (!data) throw vscode.FileSystemError.FileNotFound(uri)
+    return data
+  }
+
+  writeFile(uri: vscode.Uri, content: Uint8Array, _options: { create: boolean; overwrite: boolean }): void {
+    this.files.set(uri.toString(), content)
+    this._emitter.fire([{ type: vscode.FileChangeType.Changed, uri }])
+  }
+
+  readDirectory(): [string, vscode.FileType][] {
+    return []
+  }
+
+  createDirectory(): void {}
+
+  rename(): void {}
+
+  delete(uri: vscode.Uri): void {
+    this.files.delete(uri.toString())
+    this._emitter.fire([{ type: vscode.FileChangeType.Deleted, uri }])
+  }
+
+  watch(): vscode.Disposable {
+    return new vscode.Disposable(() => {})
+  }
+}
+
+const memfs = new MemFS()
 
 export function activate(context: vscode.ExtensionContext) {
+  const ipcPort = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
+  context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_PORT", String(ipcPort))
+  output.appendLine(`[opencode] extension activated, IPC_PORT=${ipcPort}`)
+
+  context.subscriptions.push(vscode.workspace.registerFileSystemProvider(SCHEME, memfs, { isCaseSensitive: true }))
+
+  startIpcServer(context, ipcPort)
+
   const openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
     await openTerminal()
   })
@@ -33,14 +97,78 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     if (terminal.name === TERMINAL_NAME) {
-      // @ts-ignore
-      const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
-      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef, false)
+      opencodePort ? await appendPrompt(fileRef) : terminal.sendText(fileRef, false)
       terminal.show()
     }
   })
 
-  context.subscriptions.push(openNewTerminalDisposable, openTerminalDisposable, addFilepathDisposable)
+  const diffAcceptDisposable = vscode.commands.registerCommand(
+    "opencode.diff.accept",
+    async () => {
+      const requestID = activeDiffRequestID()
+      output.appendLine(`[opencode] accept clicked, requestID=${requestID ?? "none"}`)
+      if (!requestID) return
+      const pending = pendingDiffs.get(requestID)
+      if (!pending) return
+      pendingDiffs.delete(requestID)
+      const edited = readNewDocument(requestID)
+      if (opencodePort) {
+        await fetch(`http://localhost:${opencodePort}/permission/${requestID}/reply`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reply: "once", content: edited }),
+        }).catch((e) => output.appendLine(`[opencode] failed to reply: ${String(e)}`))
+      }
+      await cleanupDiff(requestID)
+      pending.resolve(edited)
+    },
+  )
+
+  const diffRejectDisposable = vscode.commands.registerCommand(
+    "opencode.diff.reject",
+    async () => {
+      const requestID = activeDiffRequestID()
+      output.appendLine(`[opencode] reject clicked, requestID=${requestID ?? "none"}`)
+      if (!requestID) return
+      const pending = pendingDiffs.get(requestID)
+      if (!pending) return
+      pendingDiffs.delete(requestID)
+      await cleanupDiff(requestID)
+      if (opencodePort) {
+        await fetch(`http://localhost:${opencodePort}/permission/${requestID}/reply`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reply: "reject" }),
+        }).catch((e) => output.appendLine(`[opencode] failed to reply: ${String(e)}`))
+      }
+      pending.resolve(null)
+    },
+  )
+
+  const diffCloseDisposable = vscode.workspace.onDidCloseTextDocument((doc: vscode.TextDocument) => {
+    const requestID = requestIDFromUri(doc.uri)
+    if (!requestID) return
+    const pending = pendingDiffs.get(requestID)
+    if (!pending) return
+    pendingDiffs.delete(requestID)
+    if (opencodePort) {
+      fetch(`http://localhost:${opencodePort}/permission/${requestID}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reply: "reject" }),
+      }).catch((e) => output.appendLine(`[opencode] failed to reply: ${String(e)}`))
+    }
+    pending.resolve(null)
+  })
+
+  context.subscriptions.push(
+    openNewTerminalDisposable,
+    openTerminalDisposable,
+    addFilepathDisposable,
+    diffAcceptDisposable,
+    diffRejectDisposable,
+    diffCloseDisposable,
+  )
 
   async function openTerminal() {
     // Create a new terminal in split screen
@@ -56,48 +184,44 @@ export function activate(context: vscode.ExtensionContext) {
         preserveFocus: false,
       },
       env: {
-        _EXTENSION_OPENCODE_PORT: port.toString(),
         OPENCODE_CALLER: "vscode",
+        OPENCODE_VSCODE_IPC_PORT: port.toString(),
       },
     })
 
     terminal.show()
     terminal.sendText(`opencode --port ${port}`)
 
+    // Wait for opencode to start and connect to our IPC server
+    let tries = 10
+    while (tries > 0 && !opencodePort) {
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      tries--
+    }
+
     const fileRef = getActiveFile()
     if (!fileRef) {
       return
     }
 
-    // Wait for the terminal to be ready
-    let tries = 10
-    let connected = false
-    do {
-      await new Promise((resolve) => setTimeout(resolve, 200))
-      try {
-        await fetch(`http://localhost:${port}/app`)
-        connected = true
-        break
-      } catch {}
-
-      tries--
-    } while (tries > 0)
-
     // If connected, append the prompt to the terminal
-    if (connected) {
-      await appendPrompt(port, `In ${fileRef}`)
+    if (opencodePort) {
+      await appendPrompt(`In ${fileRef}`)
       terminal.show()
     }
   }
 
-  async function appendPrompt(port: number, text: string) {
-    await fetch(`http://localhost:${port}/tui/append-prompt`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ text }),
-    })
+  async function appendPrompt(text: string) {
+    if (!opencodePort) return
+    try {
+      await fetch(`http://localhost:${opencodePort}/tui/append-prompt`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ text }),
+      })
+    } catch {}
   }
 
   function getActiveFile() {
@@ -134,4 +258,149 @@ export function activate(context: vscode.ExtensionContext) {
 
     return filepathWithAt
   }
+}
+
+function startIpcServer(context: vscode.ExtensionContext, port: number) {
+  ipcServer = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost:${port}`)
+
+    if (req.method === "POST" && url.pathname === "/register") {
+      let body = ""
+      req.on("data", (chunk) => (body += chunk))
+      req.on("end", () => {
+        try {
+          const data = JSON.parse(body)
+          opencodePort = data.port
+          output.appendLine(`[opencode] registered with VS Code, opencode port = ${data.port}`)
+          res.writeHead(200, { "Content-Type": "application/json" })
+          res.end(JSON.stringify({ ok: true }))
+        } catch {
+          res.writeHead(400)
+          res.end()
+        }
+      })
+      return
+    }
+
+    if (req.method === "POST" && url.pathname === "/diff") {
+      let body = ""
+      req.on("data", (chunk) => (body += chunk))
+      req.on("end", async () => {
+        try {
+          const { requestID, filepath, oldText, newText } = JSON.parse(body)
+          output.appendLine(`[opencode] received diff request for ${filepath}, showing diff`)
+          await showDiff(requestID, filepath, oldText, newText)
+          res.writeHead(200, { "Content-Type": "application/json" })
+          res.end(JSON.stringify({ ok: true }))
+        } catch (e) {
+          output.appendLine(`Failed to show diff: ${String(e)}`)
+          res.writeHead(500)
+          res.end()
+        }
+      })
+      return
+    }
+
+    if (req.method === "GET" && url.pathname.startsWith("/diff-content/")) {
+      const requestID = url.pathname.split("/")[2]
+      try {
+        const content = readNewDocument(requestID)
+        res.writeHead(200, { "Content-Type": "application/json" })
+        res.end(JSON.stringify({ content }))
+      } catch {
+        res.writeHead(404)
+        res.end()
+      }
+      return
+    }
+
+    if (req.method === "POST" && url.pathname === "/reply") {
+      let body = ""
+      req.on("data", (chunk) => (body += chunk))
+      req.on("end", async () => {
+        try {
+          const { requestID } = JSON.parse(body)
+          const pending = pendingDiffs.get(requestID)
+          if (pending) {
+            pendingDiffs.delete(requestID)
+            await cleanupDiff(requestID)
+            pending.resolve(null)
+          }
+          res.writeHead(200, { "Content-Type": "application/json" })
+          res.end(JSON.stringify({ ok: true }))
+        } catch {
+          res.writeHead(400)
+          res.end()
+        }
+      })
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  ipcServer.listen(port, () => {
+    output.appendLine(`[opencode] IPC server listening on ${port}`)
+  })
+
+  context.subscriptions.push({
+    dispose: () => {
+      ipcServer?.close()
+    },
+  })
+}
+
+function requestIDFromUri(uri: vscode.Uri | undefined): string | undefined {
+  if (!uri || uri.scheme !== SCHEME) return undefined
+  return uri.authority
+}
+
+function activeDiffRequestID(): string | undefined {
+  for (const doc of vscode.workspace.textDocuments) {
+    const requestID = requestIDFromUri(doc.uri)
+    if (requestID) return requestID
+  }
+  return undefined
+}
+
+function oldUri(requestID: string): vscode.Uri {
+  return vscode.Uri.parse(`${SCHEME}://${requestID}/old`)
+}
+
+function newUri(requestID: string): vscode.Uri {
+  return vscode.Uri.parse(`${SCHEME}://${requestID}/new`)
+}
+
+function readNewDocument(requestID: string): string {
+  const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === newUri(requestID).toString())
+  if (doc) return doc.getText()
+  return Buffer.from(memfs.readFile(newUri(requestID))).toString()
+}
+
+async function showDiff(
+  requestID: string,
+  filepath: string,
+  oldText: string,
+  newText: string,
+): Promise<void> {
+  memfs.writeFile(oldUri(requestID), Buffer.from(oldText), { create: true, overwrite: true })
+  memfs.writeFile(newUri(requestID), Buffer.from(newText), { create: true, overwrite: true })
+
+  const viewColumn = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.Beside
+
+  await vscode.commands.executeCommand("vscode.diff", oldUri(requestID), newUri(requestID), `${filepath} (Diff)`, {
+    viewColumn,
+    preserveFocus: false,
+  })
+
+  await new Promise<string | null>((resolve) => {
+    pendingDiffs.set(requestID, { resolve })
+  })
+}
+
+async function cleanupDiff(requestID: string) {
+  await vscode.commands.executeCommand("workbench.action.revertAndCloseActiveEditor")
+  memfs.delete(oldUri(requestID))
+  memfs.delete(newUri(requestID))
 }

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -3,6 +3,7 @@ export function deactivate() {}
 
 import * as vscode from "vscode"
 import http from "http"
+import { randomUUID } from "crypto"
 
 const TERMINAL_NAME = "opencode"
 const SCHEME = "opencode-diff"
@@ -64,13 +65,15 @@ const memfs = new MemFS()
 export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.registerFileSystemProvider(SCHEME, memfs, { isCaseSensitive: true }))
 
-  const ipcPort = await startIpcServer(context)
-  if (!ipcPort) {
+  const ipcToken = randomUUID()
+  const ipcPort = await startIpcServer(context, ipcToken)
+  if (ipcPort) {
+    context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_PORT", String(ipcPort))
+    context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_TOKEN", ipcToken)
+    output.appendLine(`[opencode] extension activated, IPC_PORT=${ipcPort}`)
+  } else {
     output.appendLine("[opencode] failed to start IPC server")
-    return
   }
-  context.environmentVariableCollection.replace("OPENCODE_VSCODE_IPC_PORT", String(ipcPort))
-  output.appendLine(`[opencode] extension activated, IPC_PORT=${ipcPort}`)
 
   const openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
     await openTerminal()
@@ -261,8 +264,14 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 }
 
-function startIpcServer(context: vscode.ExtensionContext): Promise<number | undefined> {
+function startIpcServer(context: vscode.ExtensionContext, token: string): Promise<number | undefined> {
   const server = http.createServer(async (req, res) => {
+    if (req.headers["x-opencode-token"] !== token) {
+      res.writeHead(401)
+      res.end()
+      return
+    }
+
     const url = new URL(req.url ?? "/", "http://localhost")
 
     if (req.method === "POST" && url.pathname === "/register") {
@@ -401,7 +410,7 @@ async function showDiff(
   memfs.writeFile(oldUri(requestID), Buffer.from(oldText), { create: true, overwrite: true })
   memfs.writeFile(newUri(requestID), Buffer.from(newText), { create: true, overwrite: true })
 
-  const viewColumn = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.Beside
+  const viewColumn = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.Active
 
   await vscode.commands.executeCommand("vscode.diff", oldUri(requestID), newUri(requestID), `${filepath} (Diff)`, {
     viewColumn,
@@ -414,7 +423,15 @@ async function showDiff(
 }
 
 async function cleanupDiff(requestID: string) {
-  await vscode.commands.executeCommand("workbench.action.revertAndCloseActiveEditor")
+  const uris = [oldUri(requestID).toString(), newUri(requestID).toString()]
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input
+      if (input instanceof vscode.TabInputTextDiff && (uris.includes(input.original.toString()) || uris.includes(input.modified.toString()))) {
+        await vscode.window.tabGroups.close(tab)
+      }
+    }
+  }
   memfs.delete(oldUri(requestID))
   memfs.delete(newUri(requestID))
 }


### PR DESCRIPTION
### Issue for this PR

Closes #9370

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode runs in a VS Code integrated terminal, edit/write permission requests now open the native VS Code diff editor. The user can adjust the proposed change directly in the diff buffer and approve or reject from VS Code or from the opencode TUI.

How it works:
- The extension starts an IPC server on an OS-assigned port and exposes it via `OPENCODE_VSCODE_IPC_PORT` for new terminals.
- opencode registers its own server port with the extension on startup.
- `edit`/`write` permission requests carry `oldText`/`newText` in metadata; the extension renders them in a native diff editor backed by an in-memory file system.
- Accept/reject buttons in the diff editor title bar reply to opencode with the edited content.
- opencode applies the edited content as the final file content and the TUI shows the resulting diff.

### How did you verify your code works?

Tested end-to-end locally: edit existing files, create new files via write, edit the diff in VS Code and accept from both the TUI and the diff editor buttons. In all cases the file is saved with the manually edited content and the chat shows the final diff.

### Screenshots / recordings

Demo: https://github.com/iamseb4s/opencode/releases/download/vscode-diff-assets/vscode-diff-demo.mov

VS Code diff editor:
https://github.com/iamseb4s/opencode/releases/download/vscode-diff-assets/vscode-diff.png

TUI showing the edited diff:
https://github.com/iamseb4s/opencode/releases/download/vscode-diff-assets/tui-diff.png

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR