### PR TITLE
fix(session-ui): align tool error card with figma

### DIFF
--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -1,13 +1,91 @@
+/* Metrics, colors, and states come from the Figma "Test Error Card" fixtures
+   (closed 1845:15508, open 1845:15482): a full-height 2px fg-danger rail,
+   10px left inset, a 24px header row (16px ban icon + 8px gap + 13px text with
+   6px gaps), a 13px/440 fg-danger summary, and a faint detail body when open. */
 [data-component="card"][data-kind="tool-error-card"] {
   --card-pad-y: 0px;
-  --card-line-pad: 4px;
+  /* Figma draws the rail as a square full-height border-left, not an inset bar. */
+  --card-line-pad: 0px;
+  --card-pad-r: 0px;
 
+  &::before {
+    border-radius: 0;
+  }
+
+  /* Inter 13px at Figma weights 530/440 with -0.04px tracking. Figma's
+     leading-none becomes the 16px compact metric because solid 13px line
+     boxes clip Inter descenders. */
   [data-slot="basic-tool-tool-title"] {
+    font-family: var(--v2-font-family-sans);
+    font-size: 13px;
+    font-weight: 530;
+    line-height: var(--line-height-compact);
+    letter-spacing: -0.04px;
     color: var(--v2-text-text-base);
   }
 
   [data-slot="basic-tool-tool-subtitle"] {
+    font-family: var(--v2-font-family-sans);
+    font-size: 13px;
+    font-weight: 440;
+    line-height: var(--line-height-compact);
+    letter-spacing: -0.04px;
     color: var(--v2-text-text-muted);
+  }
+
+  /* Figma separator: size/sm 11px at weight/medium 530, +0.05px tracking,
+     line-height/tight, text-muted. */
+  [data-slot="tool-error-card-dot"] {
+    flex-shrink: 0;
+    font-family: var(--v2-font-family-sans);
+    font-size: 11px;
+    font-weight: 530;
+    line-height: var(--line-height-tight);
+    letter-spacing: 0.05px;
+    color: var(--v2-text-text-muted);
+  }
+
+  [data-slot="tool-error-card-summary"],
+  [data-slot="tool-error-card-message"] {
+    font-family: var(--v2-font-family-sans);
+    font-size: 13px;
+    font-weight: 440;
+    line-height: var(--line-height-compact);
+    letter-spacing: -0.04px;
+    color: var(--v2-state-fg-danger);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  [data-slot="tool-error-card-summary"] {
+    flex-shrink: 1;
+    min-width: 0;
+  }
+
+  /* Closed state: the summary sits on its own line, indented to the 24px
+     text column (16px icon + 8px gap). */
+  [data-slot="tool-error-card-message"] {
+    padding-inline-start: 24px;
+  }
+
+  /* Figma row: flex gap-6 items-center inside a 24px-tall header. */
+  [data-slot="basic-tool-tool-info-main"] {
+    align-items: center;
+    gap: 6px;
+  }
+
+  /* The 14px triangle follows the text with the row's 6px gap and is visible
+     in both Figma states rather than hover-revealed. */
+  [data-slot="basic-tool-tool-trigger-content"] {
+    max-width: calc(100% - 20px);
+  }
+
+  [data-slot="collapsible-arrow"] {
+    width: 14px;
+    height: 14px;
+    margin-inline-start: 6px;
+    opacity: 1;
   }
 
   [data-slot="collapsible-arrow"],
@@ -16,7 +94,14 @@
   }
 
   > [data-component="collapsible"].tool-collapsible {
-    gap: 0px;
+    /* Figma: 4px between the 24px header box and the 13px summary row. The
+       summary's 16px compact line box centers the 13px em, so the box gap
+       shrinks by 1.5px to keep the em at Figma's 28px offset. */
+    gap: 2.5px;
+
+    > [data-slot="collapsible-trigger"] {
+      height: 24px;
+    }
 
     > [data-slot="collapsible-content"] {
       border-inline-start: none;
@@ -31,7 +116,10 @@
   }
 
   > [data-component="collapsible"].tool-collapsible[data-open="true"] {
-    gap: 4px;
+    /* Open detail: Figma places the detail em 1px under the 24px header (6px
+       under the header's text row); the compact line box already contributes
+       1.5px, so no extra gap. */
+    gap: 0px;
   }
 
   [data-component="tool-error-card-icon"] [data-slot="icon-svg"] {
@@ -41,9 +129,18 @@
   [data-slot="tool-error-card-content"] {
     position: relative;
     padding-left: 24px;
-    margin-bottom: 8px;
     -webkit-user-select: text;
     user-select: text;
+  }
+
+  /* Figma detail body: Inter 13px/440 in text-faint ("502 Bad Gateway"). */
+  [data-slot="tool-error-card-content"] [data-slot="card-description"] {
+    font-family: var(--v2-font-family-sans);
+    font-size: 13px;
+    font-weight: 440;
+    line-height: var(--line-height-compact);
+    letter-spacing: -0.04px;
+    color: var(--v2-text-text-faint);
   }
 
   > [data-component="collapsible"].tool-collapsible[data-open="true"] [data-slot="tool-error-card-content"] {

--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -1,10 +1,6 @@
-/* Metrics, colors, and states come from the Figma "Test Error Card" fixtures
-   (closed 1845:15508, open 1845:15482): a full-height 2px fg-danger rail,
-   10px left inset, a 24px header row (16px ban icon + 8px gap + 13px text with
-   6px gaps), a 13px/440 fg-danger summary, and a faint detail body when open. */
+/* Values match the Figma "Test Error Card" fixtures: closed 1845:15508, open 1845:15482. */
 [data-component="card"][data-kind="tool-error-card"] {
   --card-pad-y: 0px;
-  /* Figma draws the rail as a square full-height border-left, not an inset bar. */
   --card-line-pad: 0px;
   --card-pad-r: 0px;
 
@@ -12,9 +8,7 @@
     border-radius: 0;
   }
 
-  /* Inter 13px at Figma weights 530/440 with -0.04px tracking. Figma's
-     leading-none becomes the 16px compact metric because solid 13px line
-     boxes clip Inter descenders. */
+  /* Figma's leading-none would clip Inter descenders at 13px; keep the compact metric. */
   [data-slot="basic-tool-tool-title"] {
     font-family: var(--v2-font-family-sans);
     font-size: 13px;
@@ -33,8 +27,6 @@
     color: var(--v2-text-text-muted);
   }
 
-  /* Figma separator: size/sm 11px at weight/medium 530, +0.05px tracking,
-     line-height/tight, text-muted. */
   [data-slot="tool-error-card-dot"] {
     flex-shrink: 0;
     font-family: var(--v2-font-family-sans);
@@ -63,21 +55,18 @@
     min-width: 0;
   }
 
-  /* Closed state: the summary sits on its own line, indented to the 24px
-     text column (16px icon + 8px gap). */
   [data-slot="tool-error-card-message"] {
+    /* Text column indent: 16px icon + 8px gap. */
     padding-inline-start: 24px;
   }
 
-  /* Figma row: flex gap-6 items-center inside a 24px-tall header. */
   [data-slot="basic-tool-tool-info-main"] {
     align-items: center;
     gap: 6px;
   }
 
-  /* The 14px triangle follows the text with the row's 6px gap and is visible
-     in both Figma states rather than hover-revealed. */
   [data-slot="basic-tool-tool-trigger-content"] {
+    /* Reserve the 14px arrow + 6px gap. */
     max-width: calc(100% - 20px);
   }
 
@@ -85,6 +74,7 @@
     width: 14px;
     height: 14px;
     margin-inline-start: 6px;
+    /* Always visible; the base collapsible reveals arrows only on hover. */
     opacity: 1;
   }
 
@@ -94,9 +84,7 @@
   }
 
   > [data-component="collapsible"].tool-collapsible {
-    /* Figma: 4px between the 24px header box and the 13px summary row. The
-       summary's 16px compact line box centers the 13px em, so the box gap
-       shrinks by 1.5px to keep the em at Figma's 28px offset. */
+    /* Figma's 4px gap minus the 1.5px the compact line box adds above the summary em. */
     gap: 2.5px;
 
     > [data-slot="collapsible-trigger"] {
@@ -116,9 +104,7 @@
   }
 
   > [data-component="collapsible"].tool-collapsible[data-open="true"] {
-    /* Open detail: Figma places the detail em 1px under the 24px header (6px
-       under the header's text row); the compact line box already contributes
-       1.5px, so no extra gap. */
+    /* The compact line box alone yields Figma's spacing under the header. */
     gap: 0px;
   }
 
@@ -133,7 +119,6 @@
     user-select: text;
   }
 
-  /* Figma detail body: Inter 13px/440 in text-faint ("502 Bad Gateway"). */
   [data-slot="tool-error-card-content"] [data-slot="card-description"] {
     font-family: var(--v2-font-family-sans);
     font-size: 13px;

--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -1,4 +1,3 @@
-/* Values match the Figma "Test Error Card" fixtures: closed 1845:15508, open 1845:15482. */
 [data-component="card"][data-kind="tool-error-card"] {
   --card-pad-y: 0px;
   --card-line-pad: 0px;

--- a/packages/session-ui/src/components/tool-error-card.stories.tsx
+++ b/packages/session-ui/src/components/tool-error-card.stories.tsx
@@ -12,7 +12,18 @@ Tool call failure summary styled like a tool trigger.
 - Collapsible; click header to expand/collapse.
 `
 
-const samples = [
+const samples: { tool: string; error: string; subtitle?: string; defaultOpen?: boolean }[] = [
+  {
+    tool: "shell",
+    subtitle: "sleep 30",
+    error: "Tool execution interrupted",
+  },
+  {
+    tool: "shell",
+    subtitle: "sleep 30",
+    error: "Tool execution interrupted",
+    defaultOpen: true,
+  },
   {
     tool: "patch",
     error:
@@ -62,8 +73,9 @@ export default {
     },
   },
   args: {
-    tool: "patch",
+    tool: samples[0].tool,
     error: samples[0].error,
+    subtitle: samples[0].subtitle,
   },
   argTypes: {
     tool: {
@@ -73,9 +85,12 @@ export default {
     error: {
       control: "text",
     },
+    subtitle: {
+      control: "text",
+    },
   },
-  render: (props: { tool: string; error: string }) => {
-    return <ToolErrorCard tool={props.tool} error={props.error} />
+  render: (props: { tool: string; error: string; subtitle?: string }) => {
+    return <ToolErrorCard tool={props.tool} error={props.error} subtitle={props.subtitle} />
   },
 }
 
@@ -83,7 +98,16 @@ export const All = {
   render: () => {
     return (
       <div style="display: flex; flex-direction: column; gap: 12px; max-width: 720px;">
-        <For each={samples}>{(item) => <ToolErrorCard tool={item.tool} error={item.error} />}</For>
+        <For each={samples}>
+          {(item) => (
+            <ToolErrorCard
+              tool={item.tool}
+              error={item.error}
+              subtitle={item.subtitle}
+              defaultOpen={item.defaultOpen}
+            />
+          )}
+        </For>
       </div>
     )
   },

--- a/packages/session-ui/src/components/tool-error-card.tsx
+++ b/packages/session-ui/src/components/tool-error-card.tsx
@@ -70,8 +70,6 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
     return value
   })
 
-  // The danger summary is the message head before the first ": "; the rest is
-  // the faint detail body revealed by the open state.
   const summary = createMemo(() => {
     const head = (tail().split(": ")[0] ?? "").trim()
     if (!head) return i18n.t("ui.toolErrorCard.failed")
@@ -99,8 +97,7 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
           <div data-component="tool-trigger">
             <div data-slot="basic-tool-tool-trigger-content">
               <span data-slot="basic-tool-tool-indicator" data-component="tool-error-card-icon">
-                {/* Figma renders the ban glyph with a 1px stroke at 16px; the icon
-                    path lives in a 20px viewBox, so author 20/16 = 1.25. */}
+                {/* 20px-viewBox path at 16px: 1.25 renders the 1px stroke Figma specifies. */}
                 <Icon name="circle-ban-sign" style={{ "stroke-width": 1.25 }} />
               </span>
               <div data-slot="basic-tool-tool-info">

--- a/packages/session-ui/src/components/tool-error-card.tsx
+++ b/packages/session-ui/src/components/tool-error-card.tsx
@@ -70,19 +70,18 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
     return value
   })
 
-  const subtitle = createMemo(() => {
-    if (split.subtitle) return split.subtitle
-    const parts = tail().split(": ")
-    if (parts.length <= 1) return i18n.t("ui.toolErrorCard.failed")
-    const head = (parts[0] ?? "").trim()
+  // The danger summary is the message head before the first ": "; the rest is
+  // the faint detail body revealed by the open state.
+  const summary = createMemo(() => {
+    const head = (tail().split(": ")[0] ?? "").trim()
     if (!head) return i18n.t("ui.toolErrorCard.failed")
-    return head[0] ? head[0].toUpperCase() + head.slice(1) : i18n.t("ui.toolErrorCard.failed")
+    return head[0].toUpperCase() + head.slice(1)
   })
 
-  const body = createMemo(() => {
+  const detail = createMemo(() => {
     const parts = tail().split(": ")
-    if (parts.length <= 1) return cleaned()
-    return parts.slice(1).join(": ").trim() || cleaned()
+    if (parts.length <= 1) return ""
+    return parts.slice(1).join(": ").trim()
   })
 
   const copy = async () => {
@@ -100,27 +99,37 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
           <div data-component="tool-trigger">
             <div data-slot="basic-tool-tool-trigger-content">
               <span data-slot="basic-tool-tool-indicator" data-component="tool-error-card-icon">
-                <Icon name="circle-ban-sign" size="small" style={{ "stroke-width": 1.5 }} />
+                {/* Figma renders the ban glyph with a 1px stroke at 16px; the icon
+                    path lives in a 20px viewBox, so author 20/16 = 1.25. */}
+                <Icon name="circle-ban-sign" style={{ "stroke-width": 1.25 }} />
               </span>
               <div data-slot="basic-tool-tool-info">
                 <div data-slot="basic-tool-tool-info-structured">
                   <div data-slot="basic-tool-tool-info-main">
                     <span data-slot="basic-tool-tool-title">{name()}</span>
-                    <Show
-                      when={split.href && split.subtitle}
-                      fallback={<span data-slot="basic-tool-tool-subtitle">{subtitle()}</span>}
-                    >
-                      <a
-                        data-slot="basic-tool-tool-subtitle"
-                        class="clickable subagent-link"
-                        href={split.href!}
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          split.onSubtitleClick?.(event)
-                        }}
+                    <Show when={split.subtitle}>
+                      <Show
+                        when={split.href}
+                        fallback={<span data-slot="basic-tool-tool-subtitle">{split.subtitle}</span>}
                       >
-                        {subtitle()}
-                      </a>
+                        <a
+                          data-slot="basic-tool-tool-subtitle"
+                          class="clickable subagent-link"
+                          href={split.href!}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            split.onSubtitleClick?.(event)
+                          }}
+                        >
+                          {split.subtitle}
+                        </a>
+                      </Show>
+                    </Show>
+                    <Show when={open()}>
+                      <span data-slot="tool-error-card-dot" aria-hidden="true">
+                        ·
+                      </span>
+                      <span data-slot="tool-error-card-summary">{summary()}</span>
                     </Show>
                   </div>
                 </div>
@@ -129,33 +138,38 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
             <Collapsible.Arrow />
           </div>
         </Collapsible.Trigger>
-        <Collapsible.Content>
-          <div data-slot="tool-error-card-content">
-            <Show when={open()}>
-              <div data-slot="tool-error-card-copy">
-                <Tooltip
-                  appearance="standard"
-                  value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.toolErrorCard.copyError")}
-                  placement="top"
-                  gutter={4}
-                >
-                  <IconButton
-                    icon={<Icon name={copied() ? "check" : "copy"} />}
-                    size="normal"
-                    variant="ghost"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      void copy()
-                    }}
-                    aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.toolErrorCard.copyError")}
-                  />
-                </Tooltip>
-              </div>
-            </Show>
-            <Show when={body()}>{(value) => <CardDescription>{value()}</CardDescription>}</Show>
-          </div>
-        </Collapsible.Content>
+        <Show when={!open()}>
+          <div data-slot="tool-error-card-message">{summary()}</div>
+        </Show>
+        <Show when={detail()}>
+          <Collapsible.Content>
+            <div data-slot="tool-error-card-content">
+              <Show when={open()}>
+                <div data-slot="tool-error-card-copy">
+                  <Tooltip
+                    appearance="standard"
+                    value={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.toolErrorCard.copyError")}
+                    placement="top"
+                    gutter={4}
+                  >
+                    <IconButton
+                      icon={<Icon name={copied() ? "check" : "copy"} />}
+                      size="normal"
+                      variant="ghost"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        void copy()
+                      }}
+                      aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.toolErrorCard.copyError")}
+                    />
+                  </Tooltip>
+                </div>
+              </Show>
+              <CardDescription>{detail()}</CardDescription>
+            </div>
+          </Collapsible.Content>
+        </Show>
       </Collapsible>
     </Card>
   )

--- a/packages/session-ui/src/message/current-message.test.ts
+++ b/packages/session-ui/src/message/current-message.test.ts
@@ -29,20 +29,23 @@ describe("current content default open", () => {
     expect(currentContentDefaultOpen(tool("patch"), false, false)).toBe(true)
   })
 
-  test("collapses failed patches", () => {
-    const patch: SessionMessageAssistantTool = {
+  test("collapses errored tools regardless of disclosure preferences", () => {
+    const errored = (name: string): SessionMessageAssistantTool => ({
       type: "tool",
-      id: "tool_patch",
-      name: "patch",
+      id: `tool_${name}`,
+      name,
       state: {
         status: "error",
         input: {},
-        error: { type: "ToolError", message: "Verification failed" },
+        error: { type: "ToolError", message: "Tool execution interrupted" },
         metadata: {},
       },
       time: { created: 1, completed: 2 },
-    }
-    expect(currentContentDefaultOpen(patch, false, false)).toBe(false)
+    })
+    expect(currentContentDefaultOpen(errored("shell"), true, true)).toBe(false)
+    expect(currentContentDefaultOpen(errored("execute"), true, true)).toBe(false)
+    expect(currentContentDefaultOpen(errored("edit"), true, true)).toBe(false)
+    expect(currentContentDefaultOpen(errored("patch"), false, false)).toBe(false)
   })
 
   test("opens deletion-only patches", () => {

--- a/packages/session-ui/src/message/current-tool-state.ts
+++ b/packages/session-ui/src/message/current-tool-state.ts
@@ -35,8 +35,10 @@ export function currentContentDefaultOpen(
   editExpanded: boolean,
 ) {
   if (content.type !== "tool") return undefined
+  // Errored tools render the error card, which starts collapsed.
+  if (content.state.status === "error") return false
   if (content.name === "shell" || content.name === "execute") return shellExpanded
-  if (content.name === "patch") return content.state.status !== "error"
+  if (content.name === "patch") return true
   if (content.name !== "edit" && content.name !== "write") return undefined
   if (!editExpanded) return false
   const files = currentToolMetadata(content).files

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -772,6 +772,14 @@ export function ToolDisplay(
     if (typeof value === "string" && value) return value
     return taskId()
   })
+  // The Figma error card shows the shell command as the muted subtitle
+  // ("Shell sleep 30"), mirroring the shell tool trigger.
+  const shellSubtitle = createMemo(() => {
+    if (props.tool !== "shell") return undefined
+    if (typeof props.input.command === "string" && props.input.command) return props.input.command
+    if (typeof props.metadata.command === "string" && props.metadata.command) return props.metadata.command
+    return undefined
+  })
   const error = createMemo(() => toolDisplayError(props, i18n.t("ui.toolErrorCard.failed")))
   const render = createMemo(() => ToolRegistry.render(props.tool) ?? GenericTool)
 
@@ -799,7 +807,7 @@ export function ToolDisplay(
                   defaultOpen={props.defaultOpen}
                   open={props.open}
                   onOpenChange={props.onOpenChange}
-                  subtitle={taskSubtitle()}
+                  subtitle={taskSubtitle() ?? shellSubtitle()}
                   href={taskHref()}
                   onSubtitleClick={(event) => {
                     if (!data.navigateToSession) return

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -772,14 +772,7 @@ export function ToolDisplay(
     if (typeof value === "string" && value) return value
     return taskId()
   })
-  // The Figma error card shows the shell command as the muted subtitle
-  // ("Shell sleep 30"), mirroring the shell tool trigger.
-  const shellSubtitle = createMemo(() => {
-    if (props.tool !== "shell") return undefined
-    if (typeof props.input.command === "string" && props.input.command) return props.input.command
-    if (typeof props.metadata.command === "string" && props.metadata.command) return props.metadata.command
-    return undefined
-  })
+  const errorSubtitle = createMemo(() => toolErrorSubtitle(props, i18n))
   const error = createMemo(() => toolDisplayError(props, i18n.t("ui.toolErrorCard.failed")))
   const render = createMemo(() => ToolRegistry.render(props.tool) ?? GenericTool)
 
@@ -807,7 +800,7 @@ export function ToolDisplay(
                   defaultOpen={props.defaultOpen}
                   open={props.open}
                   onOpenChange={props.onOpenChange}
-                  subtitle={taskSubtitle() ?? shellSubtitle()}
+                  subtitle={taskSubtitle() ?? errorSubtitle()}
                   href={taskHref()}
                   onSubtitleClick={(event) => {
                     if (!data.navigateToSession) return
@@ -828,6 +821,32 @@ export function ToolDisplay(
       </div>
     </Show>
   )
+}
+
+// The error card mirrors each tool trigger's muted subtitle so failed rows
+// read like their non-error counterparts ("Shell sleep 30", "Read index.ts").
+function toolErrorSubtitle(props: ToolProps, i18n: UiI18n) {
+  const text = (value: unknown) => (typeof value === "string" && value ? value : undefined)
+  if (props.tool === "shell") return text(props.input.command) ?? text(props.metadata.command)
+  if (props.tool === "execute") return text(props.input.code)
+  if (props.tool === "read") return getFilename(readToolPath(props.input) ?? "")
+  if (props.tool === "edit" || props.tool === "write") return getFilename(text(props.input.path) ?? "")
+  if (props.tool === "list" || props.tool === "glob" || props.tool === "grep")
+    return displayDirectory(text(props.input.path) ?? "/")
+  if (props.tool === "webfetch") return text(props.input.url)
+  if (props.tool === "websearch") return text(props.input.query)
+  if (props.tool === "skill") return skillToolName(props.input, props.metadata)
+  if (props.tool === "patch") {
+    const count = patchFileGroups(props.metadata.files).length
+    if (count === 0) return undefined
+    return `${count} ${i18n.plural("ui.common.file", count)}`
+  }
+  if (props.tool === "question") {
+    const count = Array.isArray(props.input.questions) ? props.input.questions.filter(questionInfo).length : 0
+    if (count === 0) return undefined
+    return `${count} ${i18n.plural("ui.common.question", count)}`
+  }
+  return undefined
 }
 
 function toolDisplayError(props: ToolProps & { error?: string }, fallback: string) {

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -823,8 +823,8 @@ export function ToolDisplay(
   )
 }
 
-// The error card mirrors each tool trigger's muted subtitle so failed rows
-// read like their non-error counterparts ("Shell sleep 30", "Read index.ts").
+// Each branch must stay in sync with its tool trigger's subtitle expression so
+// failed rows read like their non-error counterparts ("Shell sleep 30").
 function toolErrorSubtitle(props: ToolProps, i18n: UiI18n) {
   const text = (value: unknown) => (typeof value === "string" && value ? value : undefined)
   if (props.tool === "shell") return text(props.input.command) ?? text(props.metadata.command)


### PR DESCRIPTION
Aligns the timeline tool error card with the Figma `Test Error Card` design (shown for an interrupted shell, applied to every error rendered by `ToolErrorCard`).

## Figma mapping

All values read from the Figma node (`1845:15508` closed, `1845:15482` open), including the exported SVG assets:

- Full-height square 2px `fg-danger` rail, 10px left inset, no right/vertical padding
- 24px header row: 16px ban icon (1px danger stroke) + 8px gap + 13px Inter text with 6px gaps
- Title 13px/530, subtitle 13px/440 muted, separator dot 11px/530 (+0.05px, tight), error text 13px/440 `fg-danger`
- 14px `fill-triangle-right`/`-down` arrow in `text-faint`, always visible
- Closed: danger summary on its own line, 4px below the header, indented to the 24px text column
- Open: summary moves inline after the dot; detail after the first `": "` renders as the faint body
- Figma's `leading-none` translated to the 16px compact metric per package typography rules, with box gaps compensated so em positions land on Figma's offsets

## Behavior

- Errored tools now default to the collapsed error card regardless of the shell/edit disclosure preferences (generalizes the existing failed-patch rule)
- The error card's muted subtitle mirrors each tool trigger's subtitle (`Shell sleep 30`, `Read index.ts`, webfetch URL, websearch query, patch/question counts, etc.)
- Detail body and copy control only render when the error has detail after the summary, matching the 24px-tall open Figma state for `Tool execution interrupted`

## Testing

- `bun typecheck` and full `bun test src` in `packages/session-ui` (100 pass)
- Storybook fixtures added for the exact Figma states (closed + open interrupted shell)
