### PR TITLE
fix(core): skip local liveness check for workspace locations

### DIFF
--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -147,7 +147,14 @@ export function buildLocationServiceMap(
             Layer.provide(LayerNode.compile(location.hoisted)),
           )
         },
-        { idleTimeToLive: (ref) => (existsSync(ref.directory) ? Duration.infinity : Duration.zero) },
+        {
+          // Workspace-placed directories exist only inside the workspace, so a
+          // local stat consults the wrong filesystem. Workspace liveness is
+          // owned by placement; do not probe the sandbox here, which would
+          // provision lazily-idle workspaces.
+          idleTimeToLive: (ref) =>
+            ref.workspaceID !== undefined || existsSync(ref.directory) ? Duration.infinity : Duration.zero,
+        },
       ),
       (inner) => ({
         ...inner,

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -3,7 +3,20 @@ import path from "path"
 import { describe, expect } from "bun:test"
 import { Config } from "@opencode-ai/schema/config"
 import { Money } from "@opencode-ai/schema/money"
-import { DateTime, Deferred, Duration, Effect, Equal, Fiber, Hash, Layer, LayerMap, RcMap, Schema, Stream } from "effect"
+import {
+  DateTime,
+  Deferred,
+  Duration,
+  Effect,
+  Equal,
+  Fiber,
+  Hash,
+  Layer,
+  LayerMap,
+  RcMap,
+  Schema,
+  Stream,
+} from "effect"
 import { TestClock } from "effect/testing"
 import { Plugin as EffectPlugin } from "@opencode-ai/plugin/effect"
 import { Agent } from "@opencode-ai/core/agent"
@@ -23,6 +36,7 @@ import { Project } from "@opencode-ai/core/project"
 import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
+import { Workspace } from "@opencode-ai/core/workspace"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { tmpdir } from "./fixture/tmpdir"
@@ -61,10 +75,9 @@ const activityLocations = Layer.effect(
   ),
 )
 const itWithActivity = testEffect(
-  AppNodeBuilder.build(
-    LayerNode.group([Database.node, Bus.node, LocationServiceMap.node, LocationActivity.node]),
-    [[LocationServiceMap.node, activityLocations]],
-  ),
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, LocationServiceMap.node, LocationActivity.node]), [
+    [LocationServiceMap.node, activityLocations],
+  ]),
 )
 
 describe("LocationServiceMap", () => {
@@ -110,6 +123,35 @@ describe("LocationServiceMap", () => {
           yield* Effect.promise(() => fs.mkdir(directory))
           const location = yield* Location.Service.pipe(Effect.provide(locations.get(ref)), Effect.scoped)
           expect(location.directory).toBe(ref.directory)
+        }),
+      ),
+    ),
+  )
+
+  it.live("keeps a workspace location admitted when its directory does not exist locally", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const directory = AbsolutePath.make(path.join(dir.path, "workspace-only"))
+          const workspaceRef = Location.Ref.make({ directory, workspaceID: Workspace.ID.make("wrk_liveness") })
+          const localRef = Location.Ref.make({ directory })
+
+          // The directory only exists inside the workspace, so liveness must
+          // not consult the local filesystem. Boot outcome is not the subject
+          // here: parts of the location graph still read the host filesystem,
+          // so only assert that the entry survives release instead of being
+          // evicted by a zero idle time-to-live.
+          yield* Location.Service.pipe(Effect.provide(locations.get(workspaceRef)), Effect.scoped, Effect.exit)
+          expect(Array.from(yield* RcMap.keys(locations.rcMap))).toEqual([workspaceRef])
+
+          // A local ref with the same missing directory keeps the existing
+          // behavior: dropped as soon as it goes idle so a retry can rebuild it.
+          yield* Location.Service.pipe(Effect.provide(locations.get(localRef)), Effect.scoped, Effect.exit)
+          expect(Array.from(yield* RcMap.keys(locations.rcMap))).toEqual([workspaceRef])
         }),
       ),
     ),


### PR DESCRIPTION
## What

`LocationServiceMap` decided a Location's idle time-to-live with a process-local `existsSync(ref.directory)`. For a Location with `workspaceID` set (remote workspace placement), the directory only exists inside the workspace, so the check consulted the wrong filesystem: the entry got a zero TTL and was evicted the moment it went idle, even though placement was healthy. Fixes #44554.

## How

- `packages/core/src/location-services.ts:150`: the `idleTimeToLive` policy now returns `Duration.infinity` when `ref.workspaceID` is set, and keeps the `existsSync` check only for local refs. The policy is captured once per RcMap entry at admission and consumed at release, so this single site covers both admission and idle eviction.
- `packages/core/test/location-layer.test.ts:131`: new test through the real `buildLocationServiceMap`: a workspace ref whose directory does not exist locally survives release of its last handle, while a local ref with the same missing directory is still dropped immediately (the existing "retries a location after its missing directory is recreated" test continues to cover the local rebuild path). The assertion is exit-agnostic because parts of the location graph still read the host filesystem during boot (e.g. `FileSystem` root resolution), which is a separate seam from liveness.

## Scope

- No sandbox probing for liveness: probing would provision lazily-idle workspaces. Workspace liveness stays owned by placement (the workspace row and provider binding).
- No change to local Location admission, eviction, or retry-after-recreate behavior.
- No clustered ownership or placement semantics; `LocationActivity`'s idle sweep still invalidates idle workspace locations like any other.

## Testing

```sh
cd packages/core
bun run test test/location-layer.test.ts   # 22 pass
bun typecheck
cd .. && bunx prettier --check core/src/location-services.ts core/test/location-layer.test.ts
```

The new test fails on `origin/v2` without the fix (workspace ref evicted at release) and passes with it.