### PR TITLE
fix(core): never build fff index for workspace locations

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -187,7 +187,7 @@ export const layer = (options?: Options) =>
       const location = yield* Location.Service
       // Workspace-backed Locations resolve in a remote sandbox; fff would index the local server directory
       // in-process and serve wrong results. Ripgrep routes through the Location environment spawner.
-      if (location.workspaceID !== undefined) return ripgrepLayer
+      if (location.workspaceID) return ripgrepLayer
       if (options?.fff === false || (options?.fff === undefined && process.platform === "win32") || !Fff.available())
         return ripgrepLayer
       // Non-VCS locations can contain many repositories, so avoid eagerly content-indexing the entire aggregate tree.

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -184,9 +184,12 @@ export const fffLayer = Layer.effect(
 export const layer = (options?: Options) =>
   Layer.unwrap(
     Effect.gen(function* () {
+      const location = yield* Location.Service
+      // Workspace-backed Locations resolve in a remote sandbox; fff would index the local server directory
+      // in-process and serve wrong results. Ripgrep routes through the Location environment spawner.
+      if (location.workspaceID !== undefined) return ripgrepLayer
       if (options?.fff === false || (options?.fff === undefined && process.platform === "win32") || !Fff.available())
         return ripgrepLayer
-      const location = yield* Location.Service
       // Non-VCS locations can contain many repositories, so avoid eagerly content-indexing the entire aggregate tree.
       return location.vcs && !Protected.isHome(location.directory) ? fffLayer : ripgrepLayer
     }),

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -15,6 +15,22 @@ import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { Workspace } from "@opencode-ai/core/workspace"
 import { location } from "../fixture/location"
 
+const ripgrepStub = (entry: string, onFind: (input: Ripgrep.FindInput) => void) =>
+  Layer.succeed(
+    Ripgrep.Service,
+    Ripgrep.Service.of({
+      find: (input) =>
+        Effect.gen(function* () {
+          onFind(input)
+          if (input.onEntry)
+            yield* input.onEntry(FileSystem.Entry.make({ path: RelativePath.make(entry), type: "file" }))
+          return []
+        }),
+      glob: () => Effect.succeed([]),
+      grep: () => Effect.succeed([]),
+    }),
+  )
+
 describe("FileSystemSearch", () => {
   test("honors wildcard directory rules from .gitignore", async () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-fff-ignore-"))
@@ -55,6 +71,8 @@ describe("FileSystemSearch", () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-search-workspace-"))
     try {
       // A local file that only an fff index of the server directory could surface.
+      // The fff-vs-ripgrep discrimination only bites where Fff.available() is
+      // true; elsewhere the layer choice already falls back to ripgrep.
       await Bun.write(path.join(directory, "server-local.ts"), "server local")
       let observed: Ripgrep.FindInput | undefined
       const ref = Location.Ref.make({
@@ -71,23 +89,7 @@ describe("FileSystemSearch", () => {
             ),
           ),
         ],
-        [
-          Ripgrep.node,
-          Layer.succeed(
-            Ripgrep.Service,
-            Ripgrep.Service.of({
-              find: (input) =>
-                Effect.gen(function* () {
-                  observed = input
-                  if (input.onEntry)
-                    yield* input.onEntry(FileSystem.Entry.make({ path: RelativePath.make("remote.ts"), type: "file" }))
-                  return []
-                }),
-              glob: () => Effect.succeed([]),
-              grep: () => Effect.succeed([]),
-            }),
-          ),
-        ],
+        [Ripgrep.node, ripgrepStub("remote.ts", (input) => (observed = input))],
       ])
 
       await Effect.runPromise(
@@ -116,23 +118,7 @@ describe("FileSystemSearch", () => {
           ),
         ),
       ],
-      [
-        Ripgrep.node,
-        Layer.succeed(
-          Ripgrep.Service,
-          Ripgrep.Service.of({
-            find: (input) =>
-              Effect.gen(function* () {
-                observed = input
-                if (input.onEntry)
-                  yield* input.onEntry(FileSystem.Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" }))
-                return []
-              }),
-            glob: () => Effect.succeed([]),
-            grep: () => Effect.succeed([]),
-          }),
-        ),
-      ],
+      [Ripgrep.node, ripgrepStub("src/index.ts", (input) => (observed = input))],
     ])
 
     await Effect.runPromise(

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -12,6 +12,7 @@ import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
 import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
+import { Workspace } from "@opencode-ai/core/workspace"
 import { location } from "../fixture/location"
 
 describe("FileSystemSearch", () => {
@@ -45,6 +46,58 @@ describe("FileSystemSearch", () => {
       )
 
       expect(entries.every((entry) => !entry.path.startsWith("rust/target/"))).toBe(true)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test("selects the ripgrep layer for workspace-backed locations even when vcs would pick fff", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-search-workspace-"))
+    try {
+      // A local file that only an fff index of the server directory could surface.
+      await Bun.write(path.join(directory, "server-local.ts"), "server local")
+      let observed: Ripgrep.FindInput | undefined
+      const ref = Location.Ref.make({
+        directory: AbsolutePath.make(directory),
+        workspaceID: Workspace.ID.make("wrk_test"),
+      })
+      const layer = AppNodeBuilder.build(FileSystemSearch.node, [
+        [
+          Location.node,
+          Layer.succeed(
+            Location.Service,
+            Location.Service.of(
+              location(ref, { vcs: { type: "git", store: AbsolutePath.make(path.join(directory, ".git")) } }),
+            ),
+          ),
+        ],
+        [
+          Ripgrep.node,
+          Layer.succeed(
+            Ripgrep.Service,
+            Ripgrep.Service.of({
+              find: (input) =>
+                Effect.gen(function* () {
+                  observed = input
+                  if (input.onEntry)
+                    yield* input.onEntry(FileSystem.Entry.make({ path: RelativePath.make("remote.ts"), type: "file" }))
+                  return []
+                }),
+              glob: () => Effect.succeed([]),
+              grep: () => Effect.succeed([]),
+            }),
+          ),
+        ],
+      ])
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const search = yield* FileSystemSearch.Service
+          const entries = yield* search.find({ query: "ts", type: "file" })
+          expect(observed?.cwd).toBe(directory)
+          expect(entries.map((entry) => entry.path)).toEqual([RelativePath.make("remote.ts")])
+        }).pipe(Effect.provide(layer), Effect.scoped),
+      )
     } finally {
       await rm(directory, { recursive: true, force: true })
     }


### PR DESCRIPTION
## What

`FileSystemSearch` chose its implementation from process-local facts only (platform, `location.vcs`, `Protected.isHome`), ignoring workspace placement. For a Location with `workspaceID` set, the fff layer built an in-process native index of `location.directory` on the server (packages/core/src/filesystem/search.ts:122-127) — an empty or foreign local directory — and served silently wrong search results while the real files live in the remote sandbox.

## How

- `layer` in packages/core/src/filesystem/search.ts:184-196 now resolves `Location.Service` first and forces `ripgrepLayer` whenever `location.workspaceID` is set, before the platform/option/vcs checks. Ripgrep routes through the Location environment spawner (packages/core/src/ripgrep.ts:117-118), so it is the placement-correct seam.
- Added a focused test in packages/core/test/filesystem/search.test.ts that places a workspace-backed Location on a vcs+non-home directory (the combination that would otherwise pick fff on this platform), plants a server-local file, and asserts search results come from the ripgrep seam — not from an fff index of the server directory. The test fails without the guard.

## Scope

This is the mechanical guard half of #44553 only. Until #44552 (executable identity) lands, remote ripgrep spawns can fail — this PR converts silently wrong results into an honest spawn failure, which is a strict improvement. Explicitly deferred:

- Placement-aware VCS detection (remains in #44553).
- Making remote ripgrep spawns actually succeed (#44552 owns executable identity).

Refs #44553

## Testing

From `packages/core`:

```
bun run test test/filesystem/search.test.ts
bun typecheck
bunx prettier --check src/filesystem/search.ts test/filesystem/search.test.ts
```

All pass; the new test was verified to fail with the guard reverted.
