### PR TITLE
fix(codemode): package conditional transpilers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,11 @@ jobs:
         env:
           OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
 
+      - name: Verify published codemode package
+        if: runner.os == 'Linux'
+        working-directory: packages/codemode
+        run: bun run script/publish.ts --dry-run
+
       - name: Verify compiled service lifecycle
         if: always()
         timeout-minutes: 10

--- a/packages/codemode/script/publish.ts
+++ b/packages/codemode/script/publish.ts
@@ -2,20 +2,26 @@
 
 import { Script } from "@opencode-ai/script"
 import { $ } from "bun"
-import { rm } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 process.chdir(fileURLToPath(new URL("..", import.meta.url)))
 
+const dryRun = Bun.argv.includes("--dry-run")
 const originalText = await Bun.file("package.json").text()
 const pkg = JSON.parse(originalText) as {
   name: string
   version: string
   exports: Record<string, string | { import: string; types: string }>
+  imports: Record<string, Record<string, string>>
 }
 const tarball = `${pkg.name.replace("@", "").replace("/", "-")}-${pkg.version}.tgz`
+const output = (value: string, types = false) =>
+  value.replace("./src/", "./dist/").replace(/\.ts$/, types ? ".d.ts" : ".js")
 
-if ((await $`npm view ${pkg.name}@${pkg.version} version`.nothrow()).exitCode === 0) {
+if (!dryRun && (await $`npm view ${pkg.name}@${pkg.version} version`.nothrow()).exitCode === 0) {
   console.log(`already published ${pkg.name}@${pkg.version}`)
   process.exit(0)
 }
@@ -29,16 +35,38 @@ try {
       return [
         key,
         {
-          import: value.replace("./src/", "./dist/").replace(/\.ts$/, ".js"),
-          types: value.replace("./src/", "./dist/").replace(/\.ts$/, ".d.ts"),
+          import: output(value),
+          types: output(value, true),
         },
       ]
     }),
   )
+  pkg.imports = Object.fromEntries(
+    Object.entries(pkg.imports).map(([key, conditions]) => [
+      key,
+      Object.fromEntries(Object.entries(conditions).map(([condition, value]) => [condition, output(value)])),
+    ]),
+  )
   await Bun.write("package.json", JSON.stringify(pkg, null, 2) + "\n")
   await rm(tarball, { force: true })
   await $`bun pm pack`
-  await $`npm publish ${tarball} --tag ${Script.channel} --access public`
+  const consumer = await mkdtemp(join(tmpdir(), "opencode-codemode-"))
+  try {
+    await Bun.write(
+      join(consumer, "package.json"),
+      JSON.stringify({
+        private: true,
+        type: "module",
+        dependencies: { [pkg.name]: `file:${join(process.cwd(), tarball)}` },
+      }),
+    )
+    await $`bun install --ignore-scripts`.cwd(consumer)
+    await $`bun -e ${`await import(${JSON.stringify(pkg.name)})`}`.cwd(consumer)
+    await $`bun --conditions=workerd -e ${`await import(${JSON.stringify(pkg.name)})`}`.cwd(consumer)
+  } finally {
+    await rm(consumer, { recursive: true, force: true })
+  }
+  if (!dryRun) await $`npm publish ${tarball} --tag ${Script.channel} --access public`
 } finally {
   await Bun.write("package.json", originalText)
   await rm(tarball, { force: true })

--- a/packages/codemode/script/publish.ts
+++ b/packages/codemode/script/publish.ts
@@ -60,8 +60,8 @@ try {
         dependencies: { [pkg.name]: `file:${join(process.cwd(), tarball)}` },
       }),
     )
-    await $`bun install --ignore-scripts`.cwd(consumer)
-    await $`bun -e ${`await import(${JSON.stringify(pkg.name)})`}`.cwd(consumer)
+    await $`npm install --ignore-scripts --no-audit --no-fund`.cwd(consumer)
+    await $`node --input-type=module -e ${`await import(${JSON.stringify(pkg.name)})`}`.cwd(consumer)
     await $`bun --conditions=workerd -e ${`await import(${JSON.stringify(pkg.name)})`}`.cwd(consumer)
   } finally {
     await rm(consumer, { recursive: true, force: true })


### PR DESCRIPTION
## What

Make published `@opencode-ai/codemode` packages loadable again by rewriting the package's conditional `#transpile` imports to their compiled `dist` targets.

The publish step now verifies the exact packed artifact from an isolated npm consumer with Node's default resolver and Bun's `workerd` condition before sending it to npm. The same dry-run runs in Linux PR CI.

## Before / After

**Before:** `beta-17963` included `dist/interpreter/transpile.node.js` and `dist/interpreter/transpile.workerd.js`, but its published `package.json` still mapped `#transpile` to excluded `src/interpreter/*.ts` files. A clean package import failed with Bun's `Cannot find package '#transpile'` or Node's `ERR_MODULE_NOT_FOUND`; the failure also made `@opencode-ai/sdk/workerd` unusable through its transitive core dependency.

**After:** publication rewrites both conditional targets from `src/*.ts` to `dist/*.js`. The publish command installs its own tarball into a fresh temporary project and imports it under both resolver conditions, blocking publication if package contents and manifest resolution diverge again.

## How

- `packages/codemode/script/publish.ts` applies the same source-to-dist mapping to `imports` that it already applied to `exports`. This matches the existing `@opencode-ai/util` and core package publishers.
- The script supports `--dry-run` for release validation without npm publication.
- The packed-artifact smoke check uses npm installation, Node default resolution, and Bun workerd resolution.
- `.github/workflows/test.yml` runs the dry-run on Linux PR builds, before the release workflow can encounter the defect.

## Scope

This changes only codemode package assembly and validation. It does not change interpreter behavior, conditional selection, or the contents of either transpiler implementation. Already-published prereleases remain immutable and require a new cohort.

## Testing

- `bun run typecheck` from `packages/codemode`
- `bun run test` from `packages/codemode` (`1,089` passed)
- `bun run script/publish.ts --dry-run` from `packages/codemode`
  - built and packed the package
  - installed the tarball into a clean npm consumer
  - imported successfully with Node's default condition
  - imported successfully with Bun's `workerd` condition
- Inspected the tarball: 72 files, no `src/`, both compiled transpilers present, and both manifest targets point to `dist/*.js`
- Executed a codemode program from the npm-installed tarball under Node
- Bundled the installed tarball with Bun's `workerd` condition; only `transpile.workerd.js` entered the graph
- Wrangler dry-run and local Worker execution passed against the installed tarball
- Repository pre-push typecheck (`32` packages passed)
- `bun run lint` (no errors; existing repository warnings remain)
