### PR TITLE
fix(tui): show the effective default model

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -1,7 +1,7 @@
 import { createStore } from "solid-js/store"
 import { dedupeWith } from "effect/Array"
 import { createSimpleContext } from "./helper"
-import { batch, createMemo, onCleanup } from "solid-js"
+import { batch, createMemo, createResource, onCleanup } from "solid-js"
 import { useEvent } from "./event"
 import path from "path"
 import { useTuiPaths } from "./runtime"
@@ -30,6 +30,22 @@ export function parseModel(model: string) {
     providerID: providerID,
     modelID: rest.join("/"),
   }
+}
+
+/**
+ * A session stored without a model runs on the server's default model, so the
+ * status line shows that effective model instead of claiming no provider is
+ * selected. "No provider selected" remains only when no usable default exists.
+ */
+export function withDefaultModelFallback(options: {
+  selection: (ModelPreferenceModel & { variant?: string }) | undefined
+  defaultModel: ModelPreferenceModel | undefined
+  isValid: (model: ModelPreferenceModel) => boolean
+  variantPreference: (model: ModelPreferenceModel) => string | undefined
+}) {
+  if (options.selection) return options.selection
+  if (!options.defaultModel || !options.isValid(options.defaultModel)) return undefined
+  return { ...options.defaultModel, variant: normalizeModelVariant(options.variantPreference(options.defaultModel)) }
 }
 
 export function recentModels(model: ModelPreferenceModel, recent: ModelPreferenceModel[]) {
@@ -217,8 +233,30 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         )
       })
 
+      const [serverDefaultModel] = createResource(
+        () => {
+          const ref = location.ref ?? data.location.default()
+          // Refetch when the catalog changes, such as a provider connecting.
+          return JSON.stringify([ref.directory, ref.workspaceID, models()?.length ?? -1])
+        },
+        async () => {
+          const ref = location.ref ?? data.location.default()
+          const response = await client.api.model
+            .default({ location: { directory: ref.directory, workspace: ref.workspaceID } })
+            .catch(() => undefined)
+          if (!response?.data) return undefined
+          return { providerID: response.data.providerID, modelID: response.data.id }
+        },
+      )
+
       const currentSelection = createMemo<ModelSelection | undefined>(() => {
-        if (route.data.type === "session") return sessionSelection(route.data.sessionID)
+        if (route.data.type === "session")
+          return withDefaultModelFallback({
+            selection: sessionSelection(route.data.sessionID),
+            defaultModel: serverDefaultModel(),
+            isValid: isModelValid,
+            variantPreference: (model) => preferences.variant[modelPreferenceKey(model)],
+          })
         const model = newSessionModel()
         if (!model) return
         return { ...model, variant: normalizeModelVariant(preferences.variant[modelPreferenceKey(model)]) }

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { parseModel, recentModels, withDefaultModelFallback } from "../../src/context/local"
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({
@@ -19,4 +19,46 @@ test("moves a model to the front, deduplicates, and limits recents", () => {
     ...recent.slice(0, 5),
     ...recent.slice(6, 10),
   ])
+})
+
+test("session selection wins over the default model", () => {
+  const selection = { providerID: "openai", modelID: "gpt", variant: "high" }
+  expect(
+    withDefaultModelFallback({
+      selection,
+      defaultModel: { providerID: "opencode", modelID: "fable" },
+      isValid: () => true,
+      variantPreference: () => undefined,
+    }),
+  ).toBe(selection)
+})
+
+test("sessions without a stored model fall back to the server default", () => {
+  expect(
+    withDefaultModelFallback({
+      selection: undefined,
+      defaultModel: { providerID: "opencode", modelID: "fable" },
+      isValid: () => true,
+      variantPreference: (model) => (model.modelID === "fable" ? "max" : undefined),
+    }),
+  ).toEqual({ providerID: "opencode", modelID: "fable", variant: "max" })
+})
+
+test("no provider is reported only without a usable default", () => {
+  expect(
+    withDefaultModelFallback({
+      selection: undefined,
+      defaultModel: undefined,
+      isValid: () => true,
+      variantPreference: () => undefined,
+    }),
+  ).toBeUndefined()
+  expect(
+    withDefaultModelFallback({
+      selection: undefined,
+      defaultModel: { providerID: "gone", modelID: "model" },
+      isValid: () => false,
+      variantPreference: () => undefined,
+    }),
+  ).toBeUndefined()
 })

--- a/packages/tui/test/fixture/tui-client.ts
+++ b/packages/tui/test/fixture/tui-client.ts
@@ -152,6 +152,11 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
         location: { directory, project: { id: "proj_test", directory: worktree, canonical: worktree } },
         data: [],
       })
+    if (url.pathname === "/api/model/default")
+      return json({
+        location: { directory, project: { id: "proj_test", directory: worktree, canonical: worktree } },
+        data: null,
+      })
     if (url.pathname === "/api/reference")
       return json({ location: { directory, project: { id: "proj_test", directory, canonical: directory } }, data: [] })
     if (url.pathname === "/api/websearch/provider") {


### PR DESCRIPTION
## What

Shows the server's effective default model in the TUI when a session was stored without an explicit model.

## Before / After

**Before:** opening a session created through the API with `model: null` showed `No provider selected` and offered to connect a provider, even though the server could run the session using its configured default model.

**After:** the session status line falls back to `GET /api/model/default`, validates that model against the current catalog, and applies the user's variant preference. `No provider selected` remains only when no usable default exists.

## How

- `packages/tui/src/context/local.tsx` loads the server default for the active location and applies it only when the session has no stored selection.
- `packages/tui/test/context/local.test.ts` covers explicit-selection precedence, valid fallback, variant preference, and missing/stale defaults.
- The TUI client fixture now serves the existing `model.default` endpoint.

## Scope

- No server or protocol changes; the endpoint already exists.
- Stored session model selection is unchanged.
- Cross-instance plugin schemas and null tool inputs are handled separately in #43535 and #44567.

## Testing

- `bun run test test/context/local.test.ts` in `packages/tui`: 5 passed.
- `bun typecheck` in `packages/tui`: passed.
- Repository pre-push typecheck: 32 package tasks passed.

## Demo

Session stored with `model: null`, before:

![Before: TUI incorrectly reports no provider](https://github.com/user-attachments/assets/7e84ab64-32c2-4374-b1e0-19f876d766e4)

After, showing the effective server default:

![After: TUI shows the server default model](https://github.com/user-attachments/assets/da2f1052-cf1c-4507-bb58-b2816a93f38d)
