### PR TITLE
fix(ai): fail loudly on missing anthropic tool_use id

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -795,7 +795,8 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
   const block = event.content_block
   if (!block) return [state, NO_EVENTS]
 
-  if ((block.type === "tool_use" || block.type === "server_tool_use") && event.index !== undefined) {
+  if (block.type === "tool_use" || block.type === "server_tool_use") {
+    if (event.index === undefined || !block.id) return [state, NO_EVENTS]
     const events: LLMEvent[] = []
     const lifecycle = Lifecycle.stepStart(state.lifecycle, events)
     return [
@@ -803,7 +804,7 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
         ...state,
         lifecycle,
         tools: ToolStream.start(state.tools, event.index, {
-          id: block.id ?? String(event.index),
+          id: block.id,
           name: block.name ?? "",
           input:
             block.input !== undefined && (!ProviderShared.isRecord(block.input) || Object.keys(block.input).length > 0)
@@ -815,7 +816,7 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
       [
         ...events,
         LLMEvent.toolInputStart({
-          id: block.id ?? String(event.index),
+          id: block.id,
           name: block.name ?? "",
           providerExecuted: block.type === "server_tool_use" ? true : undefined,
         }),
@@ -1015,7 +1016,18 @@ const onError = (event: AnthropicEvent) =>
 
 const step = (state: ParserState, event: AnthropicEvent) => {
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))
-  if (event.type === "content_block_start") return Effect.succeed(onContentBlockStart(state, event))
+  if (event.type === "content_block_start") {
+    const block = event.content_block
+    if (block && (block.type === "tool_use" || block.type === "server_tool_use")) {
+      if (event.index === undefined)
+        return Effect.fail(ProviderShared.eventError(ADAPTER, `Anthropic ${block.type} missing index`))
+      if (!block.id)
+        return Effect.fail(
+          ProviderShared.eventError(ADAPTER, `Anthropic tool_use missing id at index ${event.index}`),
+        )
+    }
+    return Effect.succeed(onContentBlockStart(state, event))
+  }
   if (event.type === "content_block_delta") return onContentBlockDelta(state, event)
   if (event.type === "content_block_stop") return onContentBlockStop(state, event)
   if (event.type === "message_delta") return Effect.succeed(onMessageDelta(state, event))


### PR DESCRIPTION
Previously `onContentBlockStart` fabricated `String(event.index)` when `block.id` was missing (`packages/ai/src/protocols/anthropic-messages.ts:805`), hiding provider/gateway bugs and risking mis-wired `tool_result`s.

Now fails the stream with `invalidRequest` if `index` or `id` is missing for `tool_use`/`server_tool_use`, surfacing malformed events instead of silently inventing an id. Matches SDK behavior which preserves `undefined` and lets validation surface.

Minimal change: convert `onContentBlockStart` to `Effect.fn` to allow `yield* invalid(...)` and wire `step` directly.