### PR TITLE
fix: stream Bun runtime downloads to disk to avoid Bun.write GC hang

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -185,7 +185,11 @@ async function compileExecutable(item: (typeof allTargets)[number]) {
     headers: { Accept: "application/octet-stream", ...(token ? { Authorization: `Bearer ${token}` } : {}) },
   })
   if (!response.ok) throw new Error(`Failed to download ${name} from Bun release ${release}: ${response.status}`)
-  await Bun.write(archive, response)
+  // Stream to disk instead of `Bun.write(archive, response)`: passing the Response object
+  // hangs forever if it gets GC'd mid-download (https://github.com/oven-sh/bun/issues/40278).
+  const sink = Bun.file(archive).writer()
+  for await (const chunk of response.body!) await sink.write(chunk)
+  await sink.end()
   await $`unzip -oq ${archive} -d ${cache}`
   await rm(archive)
   return executable


### PR DESCRIPTION
## Problem

`build-cli` jobs intermittently hang until the workflow's 30-minute timeout, with no output after the PWA build step:

- https://github.com/anomalyco/opencode/actions/runs/32667950653/job/97264439367 (cancelled at 30m16s)
- https://github.com/anomalyco/opencode/actions/runs/32668247343/job/97270013692 (cancelled at 30m15s)

Root cause is a Bun runtime bug, reported upstream with full trace and repro: https://github.com/oven-sh/bun/issues/40278

`compileExecutable()` downloads the Bun runtime archive with `await Bun.write(archive, response)`. That call is `response`'s last use, so the Response wrapper is dead to liveness-based GC the moment the write starts. If a GC collects it mid-download, Bun's fetch finalizer classifies the body as unobserved (it only checks the promise set by `arrayBuffer()`-style consumers, not `Bun.write`'s waiter), discards the transfer, and the write promise never settles. No error, and `AbortSignal` cannot cancel it. Latent in Bun ≤1.3.x; Bun 1.4.0's GC timing makes it fire near-deterministically on this workload (5/5 hangs in isolation testing).

## Fix

Stream the response body to disk through a `FileSink` instead of handing the Response object to `Bun.write`:

```ts
const sink = Bun.file(archive).writer()
for await (const chunk of response.body!) await sink.write(chunk)
await sink.end()
```

- Materializing `response.body` pins the stream source, which puts the fetch finalizer on its "streaming — keep loading" path, so GC of the Response can no longer discard the transfer.
- Disk writes start with the first chunk and overlap with the download, instead of buffering the full ~30 MB archive in memory first. On Bun 1.4 the native-stream fetch path also applies socket backpressure automatically.

## Validation

Against a local server with a controlled GC kill-test (Response made unreachable, `Bun.gc(true)` forced mid-download):

| Pattern | Bun 1.4.0 | Bun 1.3.14 |
| --- | --- | --- |
| `Bun.write(archive, response)` (old) | hangs | hangs (forced GC) |
| `FileSink` pump (this PR) | completes 3/3 | completes 2/2 |

Also verified byte-exact output (52,428,800 / 52,428,800 bytes) on both versions. `prettier --check` passes on the touched file.
