### PR TITLE
fix: add DOM.AsyncIterable lib so ReadableStream iteration typechecks

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "jsxImportSource": "@opentui/solid",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "noUncheckedIndexedAccess": false
   },
   "exclude": ["dist", "dist-node"]


### PR DESCRIPTION
#44572 merged with `for await (const chunk of response.body!)` in `script/build.ts`, which broke `typecheck` on `v2` (https://github.com/anomalyco/opencode/actions/runs/32679589332/job/97293790984):

```text
script/build.ts(191,29): error TS2504: Type 'ReadableStream<Uint8Array<ArrayBuffer>>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
```

The code is valid at runtime (Bun implements async iteration of `ReadableStream`); the failure is types-only. `packages/cli/tsconfig.json` pins `"lib": ["ESNext", "DOM", "DOM.Iterable"]`, and TypeScript ships `ReadableStream[Symbol.asyncIterator]` in `lib.dom.asynciterable.d.ts`, which only loads via `DOM.AsyncIterable`. `@types/bun` intentionally defers to the DOM declaration when the DOM lib is loaded (`LibDomIsLoaded extends true ? {} : import("node:stream/web").ReadableStream`), so nothing else supplies the method.

This adds the one missing lib entry. Verified locally against the `v2` tip with the same checker CI uses: `tsgo --noEmit -p packages/cli` fails with TS2504 before, exits 0 after.
